### PR TITLE
ext: Import Atmel SAMV71 header files from ASF library

### DIFF
--- a/asf/sam/include/CMakeLists.txt
+++ b/asf/sam/include/CMakeLists.txt
@@ -1,5 +1,6 @@
-if(CONFIG_SOC_ATMEL_SAME70_REVB)
-  zephyr_include_directories(same70b)
+if(CONFIG_SOC_ATMEL_SAME70_REVB OR
+   CONFIG_SOC_ATMEL_SAMV71_REVB)
+  zephyr_include_directories(${CONFIG_SOC_SERIES}b)
 else()
   zephyr_include_directories(${CONFIG_SOC_SERIES})
 endif()

--- a/asf/sam/include/samv71/README
+++ b/asf/sam/include/samv71/README
@@ -1,0 +1,49 @@
+Atmel SAM V71
+#############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMV71 Series Device Support (2.4.182)
+   http://packs.download.atmel.com/Atmel.SAMV71_DFP.2.4.182.atpack
+
+Status:
+   version 2.4.182
+
+Purpose:
+   Official package for SAM V71.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMV71_DFP.2.4.182.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch Lst:
+   * Core IRQ and interrupt handler names changed to alligne with CMSIS names.
+     Old names mapped as aliases to new names. Several errors in SVD files
+     corrected. Missing TC1 and TC2 to instance definitions added to header
+     files. TC, USART and USBHS module changed (for revB devices) to reflect
+     the modes according to the datasheet.
+   * Updated device XML for rev. B devices. Updated/added SVD files.
+   * Renamed some Cortex-M interrupt handlers. Added TCM configuration fuses.
+   * Corrected number of TC channels.
+   * Fixed ECF parameters.
+   * Added rev B devices. Added core peripherals. Updated headers, startup
+     code and linker scripts.

--- a/asf/sam/include/samv71/component-version.h
+++ b/asf/sam/include/samv71/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2019 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 2
+#define COMPONENT_VERSION_MINOR 4
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 20004
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 182
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "2.4"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2019-01-31 14:15:03"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/asf/sam/include/samv71/component/acc.h
+++ b/asf/sam/include/samv71/component/acc.h
@@ -1,0 +1,421 @@
+/**
+ * \file
+ *
+ * \brief Component description for ACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ACC_COMPONENT_H_
+#define _SAMV71_ACC_COMPONENT_H_
+#define _SAMV71_ACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Analog Comparator Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ACC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ACC_6490                       /**< (ACC) Module ID */
+#define REV_ACC H                      /**< (ACC) Module revision */
+
+/* -------- ACC_CR : (ACC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_CR_OFFSET                       (0x00)                                        /**<  (ACC_CR) Control Register  Offset */
+
+#define ACC_CR_SWRST_Pos                    0                                              /**< (ACC_CR) Software Reset Position */
+#define ACC_CR_SWRST_Msk                    (_U_(0x1) << ACC_CR_SWRST_Pos)                 /**< (ACC_CR) Software Reset Mask */
+#define ACC_CR_SWRST                        ACC_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_CR_SWRST_Msk instead */
+#define ACC_CR_MASK                         _U_(0x01)                                      /**< \deprecated (ACC_CR) Register MASK  (Use ACC_CR_Msk instead)  */
+#define ACC_CR_Msk                          _U_(0x01)                                      /**< (ACC_CR) Register Mask  */
+
+
+/* -------- ACC_MR : (ACC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SELMINUS:3;                /**< bit:   0..2  Selection for Minus Comparator Input     */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SELPLUS:3;                 /**< bit:   4..6  Selection For Plus Comparator Input      */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACEN:1;                    /**< bit:      8  Analog Comparator Enable                 */
+    uint32_t EDGETYP:2;                 /**< bit:  9..10  Edge Type                                */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t INV:1;                     /**< bit:     12  Invert Comparator Output                 */
+    uint32_t SELFS:1;                   /**< bit:     13  Selection Of Fault Source                */
+    uint32_t FE:1;                      /**< bit:     14  Fault Enable                             */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_MR_OFFSET                       (0x04)                                        /**<  (ACC_MR) Mode Register  Offset */
+
+#define ACC_MR_SELMINUS_Pos                 0                                              /**< (ACC_MR) Selection for Minus Comparator Input Position */
+#define ACC_MR_SELMINUS_Msk                 (_U_(0x7) << ACC_MR_SELMINUS_Pos)              /**< (ACC_MR) Selection for Minus Comparator Input Mask */
+#define ACC_MR_SELMINUS(value)              (ACC_MR_SELMINUS_Msk & ((value) << ACC_MR_SELMINUS_Pos))
+#define   ACC_MR_SELMINUS_TS_Val            _U_(0x0)                                       /**< (ACC_MR) Select TS  */
+#define   ACC_MR_SELMINUS_VREFP_Val         _U_(0x1)                                       /**< (ACC_MR) Select VREFP  */
+#define   ACC_MR_SELMINUS_DAC0_Val          _U_(0x2)                                       /**< (ACC_MR) Select DAC0  */
+#define   ACC_MR_SELMINUS_DAC1_Val          _U_(0x3)                                       /**< (ACC_MR) Select DAC1  */
+#define   ACC_MR_SELMINUS_AFE0_AD0_Val      _U_(0x4)                                       /**< (ACC_MR) Select AFE0_AD0  */
+#define   ACC_MR_SELMINUS_AFE0_AD1_Val      _U_(0x5)                                       /**< (ACC_MR) Select AFE0_AD1  */
+#define   ACC_MR_SELMINUS_AFE0_AD2_Val      _U_(0x6)                                       /**< (ACC_MR) Select AFE0_AD2  */
+#define   ACC_MR_SELMINUS_AFE0_AD3_Val      _U_(0x7)                                       /**< (ACC_MR) Select AFE0_AD3  */
+#define ACC_MR_SELMINUS_TS                  (ACC_MR_SELMINUS_TS_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select TS Position  */
+#define ACC_MR_SELMINUS_VREFP               (ACC_MR_SELMINUS_VREFP_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select VREFP Position  */
+#define ACC_MR_SELMINUS_DAC0                (ACC_MR_SELMINUS_DAC0_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select DAC0 Position  */
+#define ACC_MR_SELMINUS_DAC1                (ACC_MR_SELMINUS_DAC1_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select DAC1 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD0            (ACC_MR_SELMINUS_AFE0_AD0_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD0 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD1            (ACC_MR_SELMINUS_AFE0_AD1_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD1 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD2            (ACC_MR_SELMINUS_AFE0_AD2_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD2 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD3            (ACC_MR_SELMINUS_AFE0_AD3_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD3 Position  */
+#define ACC_MR_SELPLUS_Pos                  4                                              /**< (ACC_MR) Selection For Plus Comparator Input Position */
+#define ACC_MR_SELPLUS_Msk                  (_U_(0x7) << ACC_MR_SELPLUS_Pos)               /**< (ACC_MR) Selection For Plus Comparator Input Mask */
+#define ACC_MR_SELPLUS(value)               (ACC_MR_SELPLUS_Msk & ((value) << ACC_MR_SELPLUS_Pos))
+#define   ACC_MR_SELPLUS_AFE0_AD0_Val       _U_(0x0)                                       /**< (ACC_MR) Select AFE0_AD0  */
+#define   ACC_MR_SELPLUS_AFE0_AD1_Val       _U_(0x1)                                       /**< (ACC_MR) Select AFE0_AD1  */
+#define   ACC_MR_SELPLUS_AFE0_AD2_Val       _U_(0x2)                                       /**< (ACC_MR) Select AFE0_AD2  */
+#define   ACC_MR_SELPLUS_AFE0_AD3_Val       _U_(0x3)                                       /**< (ACC_MR) Select AFE0_AD3  */
+#define   ACC_MR_SELPLUS_AFE0_AD4_Val       _U_(0x4)                                       /**< (ACC_MR) Select AFE0_AD4  */
+#define   ACC_MR_SELPLUS_AFE0_AD5_Val       _U_(0x5)                                       /**< (ACC_MR) Select AFE0_AD5  */
+#define   ACC_MR_SELPLUS_AFE1_AD0_Val       _U_(0x6)                                       /**< (ACC_MR) Select AFE1_AD0  */
+#define   ACC_MR_SELPLUS_AFE1_AD1_Val       _U_(0x7)                                       /**< (ACC_MR) Select AFE1_AD1  */
+#define ACC_MR_SELPLUS_AFE0_AD0             (ACC_MR_SELPLUS_AFE0_AD0_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD0 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD1             (ACC_MR_SELPLUS_AFE0_AD1_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD1 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD2             (ACC_MR_SELPLUS_AFE0_AD2_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD2 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD3             (ACC_MR_SELPLUS_AFE0_AD3_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD3 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD4             (ACC_MR_SELPLUS_AFE0_AD4_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD4 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD5             (ACC_MR_SELPLUS_AFE0_AD5_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD5 Position  */
+#define ACC_MR_SELPLUS_AFE1_AD0             (ACC_MR_SELPLUS_AFE1_AD0_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE1_AD0 Position  */
+#define ACC_MR_SELPLUS_AFE1_AD1             (ACC_MR_SELPLUS_AFE1_AD1_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE1_AD1 Position  */
+#define ACC_MR_ACEN_Pos                     8                                              /**< (ACC_MR) Analog Comparator Enable Position */
+#define ACC_MR_ACEN_Msk                     (_U_(0x1) << ACC_MR_ACEN_Pos)                  /**< (ACC_MR) Analog Comparator Enable Mask */
+#define ACC_MR_ACEN                         ACC_MR_ACEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_ACEN_Msk instead */
+#define   ACC_MR_ACEN_DIS_Val               _U_(0x0)                                       /**< (ACC_MR) Analog comparator disabled.  */
+#define   ACC_MR_ACEN_EN_Val                _U_(0x1)                                       /**< (ACC_MR) Analog comparator enabled.  */
+#define ACC_MR_ACEN_DIS                     (ACC_MR_ACEN_DIS_Val << ACC_MR_ACEN_Pos)       /**< (ACC_MR) Analog comparator disabled. Position  */
+#define ACC_MR_ACEN_EN                      (ACC_MR_ACEN_EN_Val << ACC_MR_ACEN_Pos)        /**< (ACC_MR) Analog comparator enabled. Position  */
+#define ACC_MR_EDGETYP_Pos                  9                                              /**< (ACC_MR) Edge Type Position */
+#define ACC_MR_EDGETYP_Msk                  (_U_(0x3) << ACC_MR_EDGETYP_Pos)               /**< (ACC_MR) Edge Type Mask */
+#define ACC_MR_EDGETYP(value)               (ACC_MR_EDGETYP_Msk & ((value) << ACC_MR_EDGETYP_Pos))
+#define   ACC_MR_EDGETYP_RISING_Val         _U_(0x0)                                       /**< (ACC_MR) Only rising edge of comparator output  */
+#define   ACC_MR_EDGETYP_FALLING_Val        _U_(0x1)                                       /**< (ACC_MR) Falling edge of comparator output  */
+#define   ACC_MR_EDGETYP_ANY_Val            _U_(0x2)                                       /**< (ACC_MR) Any edge of comparator output  */
+#define ACC_MR_EDGETYP_RISING               (ACC_MR_EDGETYP_RISING_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Only rising edge of comparator output Position  */
+#define ACC_MR_EDGETYP_FALLING              (ACC_MR_EDGETYP_FALLING_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Falling edge of comparator output Position  */
+#define ACC_MR_EDGETYP_ANY                  (ACC_MR_EDGETYP_ANY_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Any edge of comparator output Position  */
+#define ACC_MR_INV_Pos                      12                                             /**< (ACC_MR) Invert Comparator Output Position */
+#define ACC_MR_INV_Msk                      (_U_(0x1) << ACC_MR_INV_Pos)                   /**< (ACC_MR) Invert Comparator Output Mask */
+#define ACC_MR_INV                          ACC_MR_INV_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_INV_Msk instead */
+#define   ACC_MR_INV_DIS_Val                _U_(0x0)                                       /**< (ACC_MR) Analog comparator output is directly processed.  */
+#define   ACC_MR_INV_EN_Val                 _U_(0x1)                                       /**< (ACC_MR) Analog comparator output is inverted prior to being processed.  */
+#define ACC_MR_INV_DIS                      (ACC_MR_INV_DIS_Val << ACC_MR_INV_Pos)         /**< (ACC_MR) Analog comparator output is directly processed. Position  */
+#define ACC_MR_INV_EN                       (ACC_MR_INV_EN_Val << ACC_MR_INV_Pos)          /**< (ACC_MR) Analog comparator output is inverted prior to being processed. Position  */
+#define ACC_MR_SELFS_Pos                    13                                             /**< (ACC_MR) Selection Of Fault Source Position */
+#define ACC_MR_SELFS_Msk                    (_U_(0x1) << ACC_MR_SELFS_Pos)                 /**< (ACC_MR) Selection Of Fault Source Mask */
+#define ACC_MR_SELFS                        ACC_MR_SELFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_SELFS_Msk instead */
+#define   ACC_MR_SELFS_CE_Val               _U_(0x0)                                       /**< (ACC_MR) The CE flag is used to drive the FAULT output.  */
+#define   ACC_MR_SELFS_OUTPUT_Val           _U_(0x1)                                       /**< (ACC_MR) The output of the analog comparator flag is used to drive the FAULT output.  */
+#define ACC_MR_SELFS_CE                     (ACC_MR_SELFS_CE_Val << ACC_MR_SELFS_Pos)      /**< (ACC_MR) The CE flag is used to drive the FAULT output. Position  */
+#define ACC_MR_SELFS_OUTPUT                 (ACC_MR_SELFS_OUTPUT_Val << ACC_MR_SELFS_Pos)  /**< (ACC_MR) The output of the analog comparator flag is used to drive the FAULT output. Position  */
+#define ACC_MR_FE_Pos                       14                                             /**< (ACC_MR) Fault Enable Position */
+#define ACC_MR_FE_Msk                       (_U_(0x1) << ACC_MR_FE_Pos)                    /**< (ACC_MR) Fault Enable Mask */
+#define ACC_MR_FE                           ACC_MR_FE_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_FE_Msk instead */
+#define   ACC_MR_FE_DIS_Val                 _U_(0x0)                                       /**< (ACC_MR) The FAULT output is tied to 0.  */
+#define   ACC_MR_FE_EN_Val                  _U_(0x1)                                       /**< (ACC_MR) The FAULT output is driven by the signal defined by SELFS.  */
+#define ACC_MR_FE_DIS                       (ACC_MR_FE_DIS_Val << ACC_MR_FE_Pos)           /**< (ACC_MR) The FAULT output is tied to 0. Position  */
+#define ACC_MR_FE_EN                        (ACC_MR_FE_EN_Val << ACC_MR_FE_Pos)            /**< (ACC_MR) The FAULT output is driven by the signal defined by SELFS. Position  */
+#define ACC_MR_MASK                         _U_(0x7777)                                    /**< \deprecated (ACC_MR) Register MASK  (Use ACC_MR_Msk instead)  */
+#define ACC_MR_Msk                          _U_(0x7777)                                    /**< (ACC_MR) Register Mask  */
+
+
+/* -------- ACC_IER : (ACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IER_OFFSET                      (0x24)                                        /**<  (ACC_IER) Interrupt Enable Register  Offset */
+
+#define ACC_IER_CE_Pos                      0                                              /**< (ACC_IER) Comparison Edge Position */
+#define ACC_IER_CE_Msk                      (_U_(0x1) << ACC_IER_CE_Pos)                   /**< (ACC_IER) Comparison Edge Mask */
+#define ACC_IER_CE                          ACC_IER_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IER_CE_Msk instead */
+#define ACC_IER_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IER) Register MASK  (Use ACC_IER_Msk instead)  */
+#define ACC_IER_Msk                         _U_(0x01)                                      /**< (ACC_IER) Register Mask  */
+
+
+/* -------- ACC_IDR : (ACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IDR_OFFSET                      (0x28)                                        /**<  (ACC_IDR) Interrupt Disable Register  Offset */
+
+#define ACC_IDR_CE_Pos                      0                                              /**< (ACC_IDR) Comparison Edge Position */
+#define ACC_IDR_CE_Msk                      (_U_(0x1) << ACC_IDR_CE_Pos)                   /**< (ACC_IDR) Comparison Edge Mask */
+#define ACC_IDR_CE                          ACC_IDR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IDR_CE_Msk instead */
+#define ACC_IDR_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IDR) Register MASK  (Use ACC_IDR_Msk instead)  */
+#define ACC_IDR_Msk                         _U_(0x01)                                      /**< (ACC_IDR) Register Mask  */
+
+
+/* -------- ACC_IMR : (ACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IMR_OFFSET                      (0x2C)                                        /**<  (ACC_IMR) Interrupt Mask Register  Offset */
+
+#define ACC_IMR_CE_Pos                      0                                              /**< (ACC_IMR) Comparison Edge Position */
+#define ACC_IMR_CE_Msk                      (_U_(0x1) << ACC_IMR_CE_Pos)                   /**< (ACC_IMR) Comparison Edge Mask */
+#define ACC_IMR_CE                          ACC_IMR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IMR_CE_Msk instead */
+#define ACC_IMR_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IMR) Register MASK  (Use ACC_IMR_Msk instead)  */
+#define ACC_IMR_Msk                         _U_(0x01)                                      /**< (ACC_IMR) Register Mask  */
+
+
+/* -------- ACC_ISR : (ACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge (cleared on read)        */
+    uint32_t SCO:1;                     /**< bit:      1  Synchronized Comparator Output           */
+    uint32_t :29;                       /**< bit:  2..30  Reserved */
+    uint32_t MASK:1;                    /**< bit:     31  Flag Mask                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_ISR_OFFSET                      (0x30)                                        /**<  (ACC_ISR) Interrupt Status Register  Offset */
+
+#define ACC_ISR_CE_Pos                      0                                              /**< (ACC_ISR) Comparison Edge (cleared on read) Position */
+#define ACC_ISR_CE_Msk                      (_U_(0x1) << ACC_ISR_CE_Pos)                   /**< (ACC_ISR) Comparison Edge (cleared on read) Mask */
+#define ACC_ISR_CE                          ACC_ISR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_CE_Msk instead */
+#define ACC_ISR_SCO_Pos                     1                                              /**< (ACC_ISR) Synchronized Comparator Output Position */
+#define ACC_ISR_SCO_Msk                     (_U_(0x1) << ACC_ISR_SCO_Pos)                  /**< (ACC_ISR) Synchronized Comparator Output Mask */
+#define ACC_ISR_SCO                         ACC_ISR_SCO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_SCO_Msk instead */
+#define ACC_ISR_MASK_Pos                    31                                             /**< (ACC_ISR) Flag Mask Position */
+#define ACC_ISR_MASK_Msk                    (_U_(0x1) << ACC_ISR_MASK_Pos)                 /**< (ACC_ISR) Flag Mask Mask */
+#define ACC_ISR_MASK                        ACC_ISR_MASK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_MASK_Msk instead */
+#define ACC_ISR_Msk                         _U_(0x80000003)                                /**< (ACC_ISR) Register Mask  */
+
+
+/* -------- ACC_ACR : (ACC Offset: 0x94) (R/W 32) Analog Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISEL:1;                    /**< bit:      0  Current Selection                        */
+    uint32_t HYST:2;                    /**< bit:   1..2  Hysteresis Selection                     */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_ACR_OFFSET                      (0x94)                                        /**<  (ACC_ACR) Analog Control Register  Offset */
+
+#define ACC_ACR_ISEL_Pos                    0                                              /**< (ACC_ACR) Current Selection Position */
+#define ACC_ACR_ISEL_Msk                    (_U_(0x1) << ACC_ACR_ISEL_Pos)                 /**< (ACC_ACR) Current Selection Mask */
+#define ACC_ACR_ISEL                        ACC_ACR_ISEL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ACR_ISEL_Msk instead */
+#define   ACC_ACR_ISEL_LOPW_Val             _U_(0x0)                                       /**< (ACC_ACR) Low-power option.  */
+#define   ACC_ACR_ISEL_HISP_Val             _U_(0x1)                                       /**< (ACC_ACR) High-speed option.  */
+#define ACC_ACR_ISEL_LOPW                   (ACC_ACR_ISEL_LOPW_Val << ACC_ACR_ISEL_Pos)    /**< (ACC_ACR) Low-power option. Position  */
+#define ACC_ACR_ISEL_HISP                   (ACC_ACR_ISEL_HISP_Val << ACC_ACR_ISEL_Pos)    /**< (ACC_ACR) High-speed option. Position  */
+#define ACC_ACR_HYST_Pos                    1                                              /**< (ACC_ACR) Hysteresis Selection Position */
+#define ACC_ACR_HYST_Msk                    (_U_(0x3) << ACC_ACR_HYST_Pos)                 /**< (ACC_ACR) Hysteresis Selection Mask */
+#define ACC_ACR_HYST(value)                 (ACC_ACR_HYST_Msk & ((value) << ACC_ACR_HYST_Pos))
+#define ACC_ACR_MASK                        _U_(0x07)                                      /**< \deprecated (ACC_ACR) Register MASK  (Use ACC_ACR_Msk instead)  */
+#define ACC_ACR_Msk                         _U_(0x07)                                      /**< (ACC_ACR) Register Mask  */
+
+
+/* -------- ACC_WPMR : (ACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_WPMR_OFFSET                     (0xE4)                                        /**<  (ACC_WPMR) Write Protection Mode Register  Offset */
+
+#define ACC_WPMR_WPEN_Pos                   0                                              /**< (ACC_WPMR) Write Protection Enable Position */
+#define ACC_WPMR_WPEN_Msk                   (_U_(0x1) << ACC_WPMR_WPEN_Pos)                /**< (ACC_WPMR) Write Protection Enable Mask */
+#define ACC_WPMR_WPEN                       ACC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_WPMR_WPEN_Msk instead */
+#define ACC_WPMR_WPKEY_Pos                  8                                              /**< (ACC_WPMR) Write Protection Key Position */
+#define ACC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << ACC_WPMR_WPKEY_Pos)          /**< (ACC_WPMR) Write Protection Key Mask */
+#define ACC_WPMR_WPKEY(value)               (ACC_WPMR_WPKEY_Msk & ((value) << ACC_WPMR_WPKEY_Pos))
+#define   ACC_WPMR_WPKEY_PASSWD_Val         _U_(0x414343)                                  /**< (ACC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define ACC_WPMR_WPKEY_PASSWD               (ACC_WPMR_WPKEY_PASSWD_Val << ACC_WPMR_WPKEY_Pos)  /**< (ACC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define ACC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (ACC_WPMR) Register MASK  (Use ACC_WPMR_Msk instead)  */
+#define ACC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (ACC_WPMR) Register Mask  */
+
+
+/* -------- ACC_WPSR : (ACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_WPSR_OFFSET                     (0xE8)                                        /**<  (ACC_WPSR) Write Protection Status Register  Offset */
+
+#define ACC_WPSR_WPVS_Pos                   0                                              /**< (ACC_WPSR) Write Protection Violation Status Position */
+#define ACC_WPSR_WPVS_Msk                   (_U_(0x1) << ACC_WPSR_WPVS_Pos)                /**< (ACC_WPSR) Write Protection Violation Status Mask */
+#define ACC_WPSR_WPVS                       ACC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_WPSR_WPVS_Msk instead */
+#define ACC_WPSR_MASK                       _U_(0x01)                                      /**< \deprecated (ACC_WPSR) Register MASK  (Use ACC_WPSR_Msk instead)  */
+#define ACC_WPSR_Msk                        _U_(0x01)                                      /**< (ACC_WPSR) Register Mask  */
+
+
+/* -------- ACC_VER : (ACC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_VER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_VER_OFFSET                      (0xFC)                                        /**<  (ACC_VER) Version Register  Offset */
+
+#define ACC_VER_VERSION_Pos                 0                                              /**< (ACC_VER) Version of the Hardware Module Position */
+#define ACC_VER_VERSION_Msk                 (_U_(0xFFF) << ACC_VER_VERSION_Pos)            /**< (ACC_VER) Version of the Hardware Module Mask */
+#define ACC_VER_VERSION(value)              (ACC_VER_VERSION_Msk & ((value) << ACC_VER_VERSION_Pos))
+#define ACC_VER_MFN_Pos                     16                                             /**< (ACC_VER) Metal Fix Number Position */
+#define ACC_VER_MFN_Msk                     (_U_(0x7) << ACC_VER_MFN_Pos)                  /**< (ACC_VER) Metal Fix Number Mask */
+#define ACC_VER_MFN(value)                  (ACC_VER_MFN_Msk & ((value) << ACC_VER_MFN_Pos))
+#define ACC_VER_MASK                        _U_(0x70FFF)                                   /**< \deprecated (ACC_VER) Register MASK  (Use ACC_VER_Msk instead)  */
+#define ACC_VER_Msk                         _U_(0x70FFF)                                   /**< (ACC_VER) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ACC hardware registers */
+typedef struct {  
+  __O  uint32_t ACC_CR;         /**< (ACC Offset: 0x00) Control Register */
+  __IO uint32_t ACC_MR;         /**< (ACC Offset: 0x04) Mode Register */
+  __I  uint8_t                        Reserved1[28];
+  __O  uint32_t ACC_IER;        /**< (ACC Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t ACC_IDR;        /**< (ACC Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t ACC_IMR;        /**< (ACC Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t ACC_ISR;        /**< (ACC Offset: 0x30) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO uint32_t ACC_ACR;        /**< (ACC Offset: 0x94) Analog Control Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO uint32_t ACC_WPMR;       /**< (ACC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t ACC_WPSR;       /**< (ACC Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  uint32_t ACC_VER;        /**< (ACC Offset: 0xFC) Version Register */
+} Acc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ACC hardware registers */
+typedef struct {  
+  __O  ACC_CR_Type                    ACC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO ACC_MR_Type                    ACC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  uint8_t                        Reserved1[28];
+  __O  ACC_IER_Type                   ACC_IER;        /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  ACC_IDR_Type                   ACC_IDR;        /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  ACC_IMR_Type                   ACC_IMR;        /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  ACC_ISR_Type                   ACC_ISR;        /**< Offset: 0x30 (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO ACC_ACR_Type                   ACC_ACR;        /**< Offset: 0x94 (R/W  32) Analog Control Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO ACC_WPMR_Type                  ACC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  ACC_WPSR_Type                  ACC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  ACC_VER_Type                   ACC_VER;        /**< Offset: 0xFC (R/   32) Version Register */
+} Acc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Comparator Controller */
+
+#endif /* _SAMV71_ACC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/aes.h
+++ b/asf/sam/include/samv71/component/aes.h
@@ -1,0 +1,673 @@
+/**
+ * \file
+ *
+ * \brief Component description for AES
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_AES_COMPONENT_H_
+#define _SAMV71_AES_COMPONENT_H_
+#define _SAMV71_AES_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Advanced Encryption Standard
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AES */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define AES_6149                       /**< (AES) Module ID */
+#define REV_AES U                      /**< (AES) Module revision */
+
+/* -------- AES_CR : (AES Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t START:1;                   /**< bit:      0  Start Processing                         */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      8  Software Reset                           */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t LOADSEED:1;                /**< bit:     16  Random Number Generator Seed Loading     */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CR_OFFSET                       (0x00)                                        /**<  (AES_CR) Control Register  Offset */
+
+#define AES_CR_START_Pos                    0                                              /**< (AES_CR) Start Processing Position */
+#define AES_CR_START_Msk                    (_U_(0x1) << AES_CR_START_Pos)                 /**< (AES_CR) Start Processing Mask */
+#define AES_CR_START                        AES_CR_START_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_START_Msk instead */
+#define AES_CR_SWRST_Pos                    8                                              /**< (AES_CR) Software Reset Position */
+#define AES_CR_SWRST_Msk                    (_U_(0x1) << AES_CR_SWRST_Pos)                 /**< (AES_CR) Software Reset Mask */
+#define AES_CR_SWRST                        AES_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_SWRST_Msk instead */
+#define AES_CR_LOADSEED_Pos                 16                                             /**< (AES_CR) Random Number Generator Seed Loading Position */
+#define AES_CR_LOADSEED_Msk                 (_U_(0x1) << AES_CR_LOADSEED_Pos)              /**< (AES_CR) Random Number Generator Seed Loading Mask */
+#define AES_CR_LOADSEED                     AES_CR_LOADSEED_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_LOADSEED_Msk instead */
+#define AES_CR_MASK                         _U_(0x10101)                                   /**< \deprecated (AES_CR) Register MASK  (Use AES_CR_Msk instead)  */
+#define AES_CR_Msk                          _U_(0x10101)                                   /**< (AES_CR) Register Mask  */
+
+
+/* -------- AES_MR : (AES Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CIPHER:1;                  /**< bit:      0  Processing Mode                          */
+    uint32_t GTAGEN:1;                  /**< bit:      1  GCM Automatic Tag Generation Enable      */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t DUALBUFF:1;                /**< bit:      3  Dual Input Buffer                        */
+    uint32_t PROCDLY:4;                 /**< bit:   4..7  Processing Delay                         */
+    uint32_t SMOD:2;                    /**< bit:   8..9  Start Mode                               */
+    uint32_t KEYSIZE:2;                 /**< bit: 10..11  Key Size                                 */
+    uint32_t OPMOD:3;                   /**< bit: 12..14  Operating Mode                           */
+    uint32_t LOD:1;                     /**< bit:     15  Last Output Data Mode                    */
+    uint32_t CFBS:3;                    /**< bit: 16..18  Cipher Feedback Data Size                */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t CKEY:4;                    /**< bit: 20..23  Countermeasure Key                       */
+    uint32_t CMTYP1:1;                  /**< bit:     24  Countermeasure Type 1                    */
+    uint32_t CMTYP2:1;                  /**< bit:     25  Countermeasure Type 2                    */
+    uint32_t CMTYP3:1;                  /**< bit:     26  Countermeasure Type 3                    */
+    uint32_t CMTYP4:1;                  /**< bit:     27  Countermeasure Type 4                    */
+    uint32_t CMTYP5:1;                  /**< bit:     28  Countermeasure Type 5                    */
+    uint32_t CMTYP6:1;                  /**< bit:     29  Countermeasure Type 6                    */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :24;                       /**< bit:  0..23  Reserved */
+    uint32_t CMTYP:6;                   /**< bit: 24..29  Countermeasure Type 6                    */
+    uint32_t :2;                        /**< bit: 30..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_MR_OFFSET                       (0x04)                                        /**<  (AES_MR) Mode Register  Offset */
+
+#define AES_MR_CIPHER_Pos                   0                                              /**< (AES_MR) Processing Mode Position */
+#define AES_MR_CIPHER_Msk                   (_U_(0x1) << AES_MR_CIPHER_Pos)                /**< (AES_MR) Processing Mode Mask */
+#define AES_MR_CIPHER                       AES_MR_CIPHER_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CIPHER_Msk instead */
+#define AES_MR_GTAGEN_Pos                   1                                              /**< (AES_MR) GCM Automatic Tag Generation Enable Position */
+#define AES_MR_GTAGEN_Msk                   (_U_(0x1) << AES_MR_GTAGEN_Pos)                /**< (AES_MR) GCM Automatic Tag Generation Enable Mask */
+#define AES_MR_GTAGEN                       AES_MR_GTAGEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_GTAGEN_Msk instead */
+#define AES_MR_DUALBUFF_Pos                 3                                              /**< (AES_MR) Dual Input Buffer Position */
+#define AES_MR_DUALBUFF_Msk                 (_U_(0x1) << AES_MR_DUALBUFF_Pos)              /**< (AES_MR) Dual Input Buffer Mask */
+#define AES_MR_DUALBUFF                     AES_MR_DUALBUFF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_DUALBUFF_Msk instead */
+#define   AES_MR_DUALBUFF_INACTIVE_Val      _U_(0x0)                                       /**< (AES_MR) AES_IDATARx cannot be written during processing of previous block.  */
+#define   AES_MR_DUALBUFF_ACTIVE_Val        _U_(0x1)                                       /**< (AES_MR) AES_IDATARx can be written during processing of previous block when SMOD = 2. It speeds up the overall runtime of large files.  */
+#define AES_MR_DUALBUFF_INACTIVE            (AES_MR_DUALBUFF_INACTIVE_Val << AES_MR_DUALBUFF_Pos)  /**< (AES_MR) AES_IDATARx cannot be written during processing of previous block. Position  */
+#define AES_MR_DUALBUFF_ACTIVE              (AES_MR_DUALBUFF_ACTIVE_Val << AES_MR_DUALBUFF_Pos)  /**< (AES_MR) AES_IDATARx can be written during processing of previous block when SMOD = 2. It speeds up the overall runtime of large files. Position  */
+#define AES_MR_PROCDLY_Pos                  4                                              /**< (AES_MR) Processing Delay Position */
+#define AES_MR_PROCDLY_Msk                  (_U_(0xF) << AES_MR_PROCDLY_Pos)               /**< (AES_MR) Processing Delay Mask */
+#define AES_MR_PROCDLY(value)               (AES_MR_PROCDLY_Msk & ((value) << AES_MR_PROCDLY_Pos))
+#define AES_MR_SMOD_Pos                     8                                              /**< (AES_MR) Start Mode Position */
+#define AES_MR_SMOD_Msk                     (_U_(0x3) << AES_MR_SMOD_Pos)                  /**< (AES_MR) Start Mode Mask */
+#define AES_MR_SMOD(value)                  (AES_MR_SMOD_Msk & ((value) << AES_MR_SMOD_Pos))
+#define   AES_MR_SMOD_MANUAL_START_Val      _U_(0x0)                                       /**< (AES_MR) Manual Mode  */
+#define   AES_MR_SMOD_AUTO_START_Val        _U_(0x1)                                       /**< (AES_MR) Auto Mode  */
+#define   AES_MR_SMOD_IDATAR0_START_Val     _U_(0x2)                                       /**< (AES_MR) AES_IDATAR0 access only Auto Mode (DMA)  */
+#define AES_MR_SMOD_MANUAL_START            (AES_MR_SMOD_MANUAL_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) Manual Mode Position  */
+#define AES_MR_SMOD_AUTO_START              (AES_MR_SMOD_AUTO_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) Auto Mode Position  */
+#define AES_MR_SMOD_IDATAR0_START           (AES_MR_SMOD_IDATAR0_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) AES_IDATAR0 access only Auto Mode (DMA) Position  */
+#define AES_MR_KEYSIZE_Pos                  10                                             /**< (AES_MR) Key Size Position */
+#define AES_MR_KEYSIZE_Msk                  (_U_(0x3) << AES_MR_KEYSIZE_Pos)               /**< (AES_MR) Key Size Mask */
+#define AES_MR_KEYSIZE(value)               (AES_MR_KEYSIZE_Msk & ((value) << AES_MR_KEYSIZE_Pos))
+#define   AES_MR_KEYSIZE_AES128_Val         _U_(0x0)                                       /**< (AES_MR) AES Key Size is 128 bits  */
+#define   AES_MR_KEYSIZE_AES192_Val         _U_(0x1)                                       /**< (AES_MR) AES Key Size is 192 bits  */
+#define   AES_MR_KEYSIZE_AES256_Val         _U_(0x2)                                       /**< (AES_MR) AES Key Size is 256 bits  */
+#define AES_MR_KEYSIZE_AES128               (AES_MR_KEYSIZE_AES128_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 128 bits Position  */
+#define AES_MR_KEYSIZE_AES192               (AES_MR_KEYSIZE_AES192_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 192 bits Position  */
+#define AES_MR_KEYSIZE_AES256               (AES_MR_KEYSIZE_AES256_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 256 bits Position  */
+#define AES_MR_OPMOD_Pos                    12                                             /**< (AES_MR) Operating Mode Position */
+#define AES_MR_OPMOD_Msk                    (_U_(0x7) << AES_MR_OPMOD_Pos)                 /**< (AES_MR) Operating Mode Mask */
+#define AES_MR_OPMOD(value)                 (AES_MR_OPMOD_Msk & ((value) << AES_MR_OPMOD_Pos))
+#define   AES_MR_OPMOD_ECB_Val              _U_(0x0)                                       /**< (AES_MR) ECB: Electronic Code Book mode  */
+#define   AES_MR_OPMOD_CBC_Val              _U_(0x1)                                       /**< (AES_MR) CBC: Cipher Block Chaining mode  */
+#define   AES_MR_OPMOD_OFB_Val              _U_(0x2)                                       /**< (AES_MR) OFB: Output Feedback mode  */
+#define   AES_MR_OPMOD_CFB_Val              _U_(0x3)                                       /**< (AES_MR) CFB: Cipher Feedback mode  */
+#define   AES_MR_OPMOD_CTR_Val              _U_(0x4)                                       /**< (AES_MR) CTR: Counter mode (16-bit internal counter)  */
+#define   AES_MR_OPMOD_GCM_Val              _U_(0x5)                                       /**< (AES_MR) GCM: Galois/Counter mode  */
+#define AES_MR_OPMOD_ECB                    (AES_MR_OPMOD_ECB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) ECB: Electronic Code Book mode Position  */
+#define AES_MR_OPMOD_CBC                    (AES_MR_OPMOD_CBC_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CBC: Cipher Block Chaining mode Position  */
+#define AES_MR_OPMOD_OFB                    (AES_MR_OPMOD_OFB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) OFB: Output Feedback mode Position  */
+#define AES_MR_OPMOD_CFB                    (AES_MR_OPMOD_CFB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CFB: Cipher Feedback mode Position  */
+#define AES_MR_OPMOD_CTR                    (AES_MR_OPMOD_CTR_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CTR: Counter mode (16-bit internal counter) Position  */
+#define AES_MR_OPMOD_GCM                    (AES_MR_OPMOD_GCM_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) GCM: Galois/Counter mode Position  */
+#define AES_MR_LOD_Pos                      15                                             /**< (AES_MR) Last Output Data Mode Position */
+#define AES_MR_LOD_Msk                      (_U_(0x1) << AES_MR_LOD_Pos)                   /**< (AES_MR) Last Output Data Mode Mask */
+#define AES_MR_LOD                          AES_MR_LOD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_LOD_Msk instead */
+#define AES_MR_CFBS_Pos                     16                                             /**< (AES_MR) Cipher Feedback Data Size Position */
+#define AES_MR_CFBS_Msk                     (_U_(0x7) << AES_MR_CFBS_Pos)                  /**< (AES_MR) Cipher Feedback Data Size Mask */
+#define AES_MR_CFBS(value)                  (AES_MR_CFBS_Msk & ((value) << AES_MR_CFBS_Pos))
+#define   AES_MR_CFBS_SIZE_128BIT_Val       _U_(0x0)                                       /**< (AES_MR) 128-bit  */
+#define   AES_MR_CFBS_SIZE_64BIT_Val        _U_(0x1)                                       /**< (AES_MR) 64-bit  */
+#define   AES_MR_CFBS_SIZE_32BIT_Val        _U_(0x2)                                       /**< (AES_MR) 32-bit  */
+#define   AES_MR_CFBS_SIZE_16BIT_Val        _U_(0x3)                                       /**< (AES_MR) 16-bit  */
+#define   AES_MR_CFBS_SIZE_8BIT_Val         _U_(0x4)                                       /**< (AES_MR) 8-bit  */
+#define AES_MR_CFBS_SIZE_128BIT             (AES_MR_CFBS_SIZE_128BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 128-bit Position  */
+#define AES_MR_CFBS_SIZE_64BIT              (AES_MR_CFBS_SIZE_64BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 64-bit Position  */
+#define AES_MR_CFBS_SIZE_32BIT              (AES_MR_CFBS_SIZE_32BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 32-bit Position  */
+#define AES_MR_CFBS_SIZE_16BIT              (AES_MR_CFBS_SIZE_16BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 16-bit Position  */
+#define AES_MR_CFBS_SIZE_8BIT               (AES_MR_CFBS_SIZE_8BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 8-bit Position  */
+#define AES_MR_CKEY_Pos                     20                                             /**< (AES_MR) Countermeasure Key Position */
+#define AES_MR_CKEY_Msk                     (_U_(0xF) << AES_MR_CKEY_Pos)                  /**< (AES_MR) Countermeasure Key Mask */
+#define AES_MR_CKEY(value)                  (AES_MR_CKEY_Msk & ((value) << AES_MR_CKEY_Pos))
+#define   AES_MR_CKEY_PASSWD_Val            _U_(0xE)                                       /**< (AES_MR) This field must be written with 0xE to allow CMTYPx bit configuration changes. Any other values will abort the write operation in CMTYPx bits.Always reads as 0.  */
+#define AES_MR_CKEY_PASSWD                  (AES_MR_CKEY_PASSWD_Val << AES_MR_CKEY_Pos)    /**< (AES_MR) This field must be written with 0xE to allow CMTYPx bit configuration changes. Any other values will abort the write operation in CMTYPx bits.Always reads as 0. Position  */
+#define AES_MR_CMTYP1_Pos                   24                                             /**< (AES_MR) Countermeasure Type 1 Position */
+#define AES_MR_CMTYP1_Msk                   (_U_(0x1) << AES_MR_CMTYP1_Pos)                /**< (AES_MR) Countermeasure Type 1 Mask */
+#define AES_MR_CMTYP1                       AES_MR_CMTYP1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP1_Msk instead */
+#define   AES_MR_CMTYP1_NOPROT_EXTKEY_Val   _U_(0x0)                                       /**< (AES_MR) Countermeasure type 1 is disabled.  */
+#define   AES_MR_CMTYP1_PROT_EXTKEY_Val     _U_(0x1)                                       /**< (AES_MR) Countermeasure type 1 is enabled.  */
+#define AES_MR_CMTYP1_NOPROT_EXTKEY         (AES_MR_CMTYP1_NOPROT_EXTKEY_Val << AES_MR_CMTYP1_Pos)  /**< (AES_MR) Countermeasure type 1 is disabled. Position  */
+#define AES_MR_CMTYP1_PROT_EXTKEY           (AES_MR_CMTYP1_PROT_EXTKEY_Val << AES_MR_CMTYP1_Pos)  /**< (AES_MR) Countermeasure type 1 is enabled. Position  */
+#define AES_MR_CMTYP2_Pos                   25                                             /**< (AES_MR) Countermeasure Type 2 Position */
+#define AES_MR_CMTYP2_Msk                   (_U_(0x1) << AES_MR_CMTYP2_Pos)                /**< (AES_MR) Countermeasure Type 2 Mask */
+#define AES_MR_CMTYP2                       AES_MR_CMTYP2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP2_Msk instead */
+#define   AES_MR_CMTYP2_NO_PAUSE_Val        _U_(0x0)                                       /**< (AES_MR) Countermeasure type 2 is disabled.  */
+#define   AES_MR_CMTYP2_PAUSE_Val           _U_(0x1)                                       /**< (AES_MR) Countermeasure type 2 is enabled.  */
+#define AES_MR_CMTYP2_NO_PAUSE              (AES_MR_CMTYP2_NO_PAUSE_Val << AES_MR_CMTYP2_Pos)  /**< (AES_MR) Countermeasure type 2 is disabled. Position  */
+#define AES_MR_CMTYP2_PAUSE                 (AES_MR_CMTYP2_PAUSE_Val << AES_MR_CMTYP2_Pos)  /**< (AES_MR) Countermeasure type 2 is enabled. Position  */
+#define AES_MR_CMTYP3_Pos                   26                                             /**< (AES_MR) Countermeasure Type 3 Position */
+#define AES_MR_CMTYP3_Msk                   (_U_(0x1) << AES_MR_CMTYP3_Pos)                /**< (AES_MR) Countermeasure Type 3 Mask */
+#define AES_MR_CMTYP3                       AES_MR_CMTYP3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP3_Msk instead */
+#define   AES_MR_CMTYP3_NO_DUMMY_Val        _U_(0x0)                                       /**< (AES_MR) Countermeasure type 3 is disabled.  */
+#define   AES_MR_CMTYP3_DUMMY_Val           _U_(0x1)                                       /**< (AES_MR) Countermeasure type 3 is enabled.  */
+#define AES_MR_CMTYP3_NO_DUMMY              (AES_MR_CMTYP3_NO_DUMMY_Val << AES_MR_CMTYP3_Pos)  /**< (AES_MR) Countermeasure type 3 is disabled. Position  */
+#define AES_MR_CMTYP3_DUMMY                 (AES_MR_CMTYP3_DUMMY_Val << AES_MR_CMTYP3_Pos)  /**< (AES_MR) Countermeasure type 3 is enabled. Position  */
+#define AES_MR_CMTYP4_Pos                   27                                             /**< (AES_MR) Countermeasure Type 4 Position */
+#define AES_MR_CMTYP4_Msk                   (_U_(0x1) << AES_MR_CMTYP4_Pos)                /**< (AES_MR) Countermeasure Type 4 Mask */
+#define AES_MR_CMTYP4                       AES_MR_CMTYP4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP4_Msk instead */
+#define   AES_MR_CMTYP4_NO_RESTART_Val      _U_(0x0)                                       /**< (AES_MR) Countermeasure type 4 is disabled.  */
+#define   AES_MR_CMTYP4_RESTART_Val         _U_(0x1)                                       /**< (AES_MR) Countermeasure type 4 is enabled.  */
+#define AES_MR_CMTYP4_NO_RESTART            (AES_MR_CMTYP4_NO_RESTART_Val << AES_MR_CMTYP4_Pos)  /**< (AES_MR) Countermeasure type 4 is disabled. Position  */
+#define AES_MR_CMTYP4_RESTART               (AES_MR_CMTYP4_RESTART_Val << AES_MR_CMTYP4_Pos)  /**< (AES_MR) Countermeasure type 4 is enabled. Position  */
+#define AES_MR_CMTYP5_Pos                   28                                             /**< (AES_MR) Countermeasure Type 5 Position */
+#define AES_MR_CMTYP5_Msk                   (_U_(0x1) << AES_MR_CMTYP5_Pos)                /**< (AES_MR) Countermeasure Type 5 Mask */
+#define AES_MR_CMTYP5                       AES_MR_CMTYP5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP5_Msk instead */
+#define   AES_MR_CMTYP5_NO_ADDACCESS_Val    _U_(0x0)                                       /**< (AES_MR) Countermeasure type 5 is disabled.  */
+#define   AES_MR_CMTYP5_ADDACCESS_Val       _U_(0x1)                                       /**< (AES_MR) Countermeasure type 5 is enabled.  */
+#define AES_MR_CMTYP5_NO_ADDACCESS          (AES_MR_CMTYP5_NO_ADDACCESS_Val << AES_MR_CMTYP5_Pos)  /**< (AES_MR) Countermeasure type 5 is disabled. Position  */
+#define AES_MR_CMTYP5_ADDACCESS             (AES_MR_CMTYP5_ADDACCESS_Val << AES_MR_CMTYP5_Pos)  /**< (AES_MR) Countermeasure type 5 is enabled. Position  */
+#define AES_MR_CMTYP6_Pos                   29                                             /**< (AES_MR) Countermeasure Type 6 Position */
+#define AES_MR_CMTYP6_Msk                   (_U_(0x1) << AES_MR_CMTYP6_Pos)                /**< (AES_MR) Countermeasure Type 6 Mask */
+#define AES_MR_CMTYP6                       AES_MR_CMTYP6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CMTYP6_Msk instead */
+#define   AES_MR_CMTYP6_NO_IDLECURRENT_Val  _U_(0x0)                                       /**< (AES_MR) Countermeasure type 6 is disabled.  */
+#define   AES_MR_CMTYP6_IDLECURRENT_Val     _U_(0x1)                                       /**< (AES_MR) Countermeasure type 6 is enabled.  */
+#define AES_MR_CMTYP6_NO_IDLECURRENT        (AES_MR_CMTYP6_NO_IDLECURRENT_Val << AES_MR_CMTYP6_Pos)  /**< (AES_MR) Countermeasure type 6 is disabled. Position  */
+#define AES_MR_CMTYP6_IDLECURRENT           (AES_MR_CMTYP6_IDLECURRENT_Val << AES_MR_CMTYP6_Pos)  /**< (AES_MR) Countermeasure type 6 is enabled. Position  */
+#define AES_MR_MASK                         _U_(0x3FF7FFFB)                                /**< \deprecated (AES_MR) Register MASK  (Use AES_MR_Msk instead)  */
+#define AES_MR_Msk                          _U_(0x3FF7FFFB)                                /**< (AES_MR) Register Mask  */
+
+#define AES_MR_CMTYP_Pos                    24                                             /**< (AES_MR Position) Countermeasure Type 6 */
+#define AES_MR_CMTYP_Msk                    (_U_(0x3F) << AES_MR_CMTYP_Pos)                /**< (AES_MR Mask) CMTYP */
+#define AES_MR_CMTYP(value)                 (AES_MR_CMTYP_Msk & ((value) << AES_MR_CMTYP_Pos))  
+
+/* -------- AES_IER : (AES Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Enable */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Enable           */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IER_OFFSET                      (0x10)                                        /**<  (AES_IER) Interrupt Enable Register  Offset */
+
+#define AES_IER_DATRDY_Pos                  0                                              /**< (AES_IER) Data Ready Interrupt Enable Position */
+#define AES_IER_DATRDY_Msk                  (_U_(0x1) << AES_IER_DATRDY_Pos)               /**< (AES_IER) Data Ready Interrupt Enable Mask */
+#define AES_IER_DATRDY                      AES_IER_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_DATRDY_Msk instead */
+#define AES_IER_URAD_Pos                    8                                              /**< (AES_IER) Unspecified Register Access Detection Interrupt Enable Position */
+#define AES_IER_URAD_Msk                    (_U_(0x1) << AES_IER_URAD_Pos)                 /**< (AES_IER) Unspecified Register Access Detection Interrupt Enable Mask */
+#define AES_IER_URAD                        AES_IER_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_URAD_Msk instead */
+#define AES_IER_TAGRDY_Pos                  16                                             /**< (AES_IER) GCM Tag Ready Interrupt Enable Position */
+#define AES_IER_TAGRDY_Msk                  (_U_(0x1) << AES_IER_TAGRDY_Pos)               /**< (AES_IER) GCM Tag Ready Interrupt Enable Mask */
+#define AES_IER_TAGRDY                      AES_IER_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_TAGRDY_Msk instead */
+#define AES_IER_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IER) Register MASK  (Use AES_IER_Msk instead)  */
+#define AES_IER_Msk                         _U_(0x10101)                                   /**< (AES_IER) Register Mask  */
+
+
+/* -------- AES_IDR : (AES Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Disable */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Disable          */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IDR_OFFSET                      (0x14)                                        /**<  (AES_IDR) Interrupt Disable Register  Offset */
+
+#define AES_IDR_DATRDY_Pos                  0                                              /**< (AES_IDR) Data Ready Interrupt Disable Position */
+#define AES_IDR_DATRDY_Msk                  (_U_(0x1) << AES_IDR_DATRDY_Pos)               /**< (AES_IDR) Data Ready Interrupt Disable Mask */
+#define AES_IDR_DATRDY                      AES_IDR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_DATRDY_Msk instead */
+#define AES_IDR_URAD_Pos                    8                                              /**< (AES_IDR) Unspecified Register Access Detection Interrupt Disable Position */
+#define AES_IDR_URAD_Msk                    (_U_(0x1) << AES_IDR_URAD_Pos)                 /**< (AES_IDR) Unspecified Register Access Detection Interrupt Disable Mask */
+#define AES_IDR_URAD                        AES_IDR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_URAD_Msk instead */
+#define AES_IDR_TAGRDY_Pos                  16                                             /**< (AES_IDR) GCM Tag Ready Interrupt Disable Position */
+#define AES_IDR_TAGRDY_Msk                  (_U_(0x1) << AES_IDR_TAGRDY_Pos)               /**< (AES_IDR) GCM Tag Ready Interrupt Disable Mask */
+#define AES_IDR_TAGRDY                      AES_IDR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_TAGRDY_Msk instead */
+#define AES_IDR_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IDR) Register MASK  (Use AES_IDR_Msk instead)  */
+#define AES_IDR_Msk                         _U_(0x10101)                                   /**< (AES_IDR) Register Mask  */
+
+
+/* -------- AES_IMR : (AES Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Mask */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Mask             */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IMR_OFFSET                      (0x18)                                        /**<  (AES_IMR) Interrupt Mask Register  Offset */
+
+#define AES_IMR_DATRDY_Pos                  0                                              /**< (AES_IMR) Data Ready Interrupt Mask Position */
+#define AES_IMR_DATRDY_Msk                  (_U_(0x1) << AES_IMR_DATRDY_Pos)               /**< (AES_IMR) Data Ready Interrupt Mask Mask */
+#define AES_IMR_DATRDY                      AES_IMR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_DATRDY_Msk instead */
+#define AES_IMR_URAD_Pos                    8                                              /**< (AES_IMR) Unspecified Register Access Detection Interrupt Mask Position */
+#define AES_IMR_URAD_Msk                    (_U_(0x1) << AES_IMR_URAD_Pos)                 /**< (AES_IMR) Unspecified Register Access Detection Interrupt Mask Mask */
+#define AES_IMR_URAD                        AES_IMR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_URAD_Msk instead */
+#define AES_IMR_TAGRDY_Pos                  16                                             /**< (AES_IMR) GCM Tag Ready Interrupt Mask Position */
+#define AES_IMR_TAGRDY_Msk                  (_U_(0x1) << AES_IMR_TAGRDY_Pos)               /**< (AES_IMR) GCM Tag Ready Interrupt Mask Mask */
+#define AES_IMR_TAGRDY                      AES_IMR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_TAGRDY_Msk instead */
+#define AES_IMR_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IMR) Register MASK  (Use AES_IMR_Msk instead)  */
+#define AES_IMR_Msk                         _U_(0x10101)                                   /**< (AES_IMR) Register Mask  */
+
+
+/* -------- AES_ISR : (AES Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t URAT:4;                    /**< bit: 12..15  Unspecified Register Access (cleared by writing SWRST in AES_CR) */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready                            */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_ISR_OFFSET                      (0x1C)                                        /**<  (AES_ISR) Interrupt Status Register  Offset */
+
+#define AES_ISR_DATRDY_Pos                  0                                              /**< (AES_ISR) Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) Position */
+#define AES_ISR_DATRDY_Msk                  (_U_(0x1) << AES_ISR_DATRDY_Pos)               /**< (AES_ISR) Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) Mask */
+#define AES_ISR_DATRDY                      AES_ISR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_DATRDY_Msk instead */
+#define AES_ISR_URAD_Pos                    8                                              /**< (AES_ISR) Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) Position */
+#define AES_ISR_URAD_Msk                    (_U_(0x1) << AES_ISR_URAD_Pos)                 /**< (AES_ISR) Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) Mask */
+#define AES_ISR_URAD                        AES_ISR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_URAD_Msk instead */
+#define AES_ISR_URAT_Pos                    12                                             /**< (AES_ISR) Unspecified Register Access (cleared by writing SWRST in AES_CR) Position */
+#define AES_ISR_URAT_Msk                    (_U_(0xF) << AES_ISR_URAT_Pos)                 /**< (AES_ISR) Unspecified Register Access (cleared by writing SWRST in AES_CR) Mask */
+#define AES_ISR_URAT(value)                 (AES_ISR_URAT_Msk & ((value) << AES_ISR_URAT_Pos))
+#define   AES_ISR_URAT_IDR_WR_PROCESSING_Val _U_(0x0)                                       /**< (AES_ISR) Input Data register written during the data processing when SMOD = 0x2 mode.  */
+#define   AES_ISR_URAT_ODR_RD_PROCESSING_Val _U_(0x1)                                       /**< (AES_ISR) Output Data register read during the data processing.  */
+#define   AES_ISR_URAT_MR_WR_PROCESSING_Val _U_(0x2)                                       /**< (AES_ISR) Mode register written during the data processing.  */
+#define   AES_ISR_URAT_ODR_RD_SUBKGEN_Val   _U_(0x3)                                       /**< (AES_ISR) Output Data register read during the sub-keys generation.  */
+#define   AES_ISR_URAT_MR_WR_SUBKGEN_Val    _U_(0x4)                                       /**< (AES_ISR) Mode register written during the sub-keys generation.  */
+#define   AES_ISR_URAT_WOR_RD_ACCESS_Val    _U_(0x5)                                       /**< (AES_ISR) Write-only register read access.  */
+#define AES_ISR_URAT_IDR_WR_PROCESSING      (AES_ISR_URAT_IDR_WR_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Input Data register written during the data processing when SMOD = 0x2 mode. Position  */
+#define AES_ISR_URAT_ODR_RD_PROCESSING      (AES_ISR_URAT_ODR_RD_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Output Data register read during the data processing. Position  */
+#define AES_ISR_URAT_MR_WR_PROCESSING       (AES_ISR_URAT_MR_WR_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Mode register written during the data processing. Position  */
+#define AES_ISR_URAT_ODR_RD_SUBKGEN         (AES_ISR_URAT_ODR_RD_SUBKGEN_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Output Data register read during the sub-keys generation. Position  */
+#define AES_ISR_URAT_MR_WR_SUBKGEN          (AES_ISR_URAT_MR_WR_SUBKGEN_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Mode register written during the sub-keys generation. Position  */
+#define AES_ISR_URAT_WOR_RD_ACCESS          (AES_ISR_URAT_WOR_RD_ACCESS_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Write-only register read access. Position  */
+#define AES_ISR_TAGRDY_Pos                  16                                             /**< (AES_ISR) GCM Tag Ready Position */
+#define AES_ISR_TAGRDY_Msk                  (_U_(0x1) << AES_ISR_TAGRDY_Pos)               /**< (AES_ISR) GCM Tag Ready Mask */
+#define AES_ISR_TAGRDY                      AES_ISR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_TAGRDY_Msk instead */
+#define AES_ISR_MASK                        _U_(0x1F101)                                   /**< \deprecated (AES_ISR) Register MASK  (Use AES_ISR_Msk instead)  */
+#define AES_ISR_Msk                         _U_(0x1F101)                                   /**< (AES_ISR) Register Mask  */
+
+
+/* -------- AES_KEYWR : (AES Offset: 0x20) (/W 32) Key Word Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEYW:32;                   /**< bit:  0..31  Key Word                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_KEYWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_KEYWR_OFFSET                    (0x20)                                        /**<  (AES_KEYWR) Key Word Register 0  Offset */
+
+#define AES_KEYWR_KEYW_Pos                  0                                              /**< (AES_KEYWR) Key Word Position */
+#define AES_KEYWR_KEYW_Msk                  (_U_(0xFFFFFFFF) << AES_KEYWR_KEYW_Pos)        /**< (AES_KEYWR) Key Word Mask */
+#define AES_KEYWR_KEYW(value)               (AES_KEYWR_KEYW_Msk & ((value) << AES_KEYWR_KEYW_Pos))
+#define AES_KEYWR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_KEYWR) Register MASK  (Use AES_KEYWR_Msk instead)  */
+#define AES_KEYWR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_KEYWR) Register Mask  */
+
+
+/* -------- AES_IDATAR : (AES Offset: 0x40) (/W 32) Input Data Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDATA:32;                  /**< bit:  0..31  Input Data Word                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IDATAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IDATAR_OFFSET                   (0x40)                                        /**<  (AES_IDATAR) Input Data Register 0  Offset */
+
+#define AES_IDATAR_IDATA_Pos                0                                              /**< (AES_IDATAR) Input Data Word Position */
+#define AES_IDATAR_IDATA_Msk                (_U_(0xFFFFFFFF) << AES_IDATAR_IDATA_Pos)      /**< (AES_IDATAR) Input Data Word Mask */
+#define AES_IDATAR_IDATA(value)             (AES_IDATAR_IDATA_Msk & ((value) << AES_IDATAR_IDATA_Pos))
+#define AES_IDATAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_IDATAR) Register MASK  (Use AES_IDATAR_Msk instead)  */
+#define AES_IDATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_IDATAR) Register Mask  */
+
+
+/* -------- AES_ODATAR : (AES Offset: 0x50) (R/ 32) Output Data Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_ODATAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_ODATAR_OFFSET                   (0x50)                                        /**<  (AES_ODATAR) Output Data Register 0  Offset */
+
+#define AES_ODATAR_ODATA_Pos                0                                              /**< (AES_ODATAR) Output Data Position */
+#define AES_ODATAR_ODATA_Msk                (_U_(0xFFFFFFFF) << AES_ODATAR_ODATA_Pos)      /**< (AES_ODATAR) Output Data Mask */
+#define AES_ODATAR_ODATA(value)             (AES_ODATAR_ODATA_Msk & ((value) << AES_ODATAR_ODATA_Pos))
+#define AES_ODATAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_ODATAR) Register MASK  (Use AES_ODATAR_Msk instead)  */
+#define AES_ODATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_ODATAR) Register Mask  */
+
+
+/* -------- AES_IVR : (AES Offset: 0x60) (/W 32) Initialization Vector Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IV:32;                     /**< bit:  0..31  Initialization Vector                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IVR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IVR_OFFSET                      (0x60)                                        /**<  (AES_IVR) Initialization Vector Register 0  Offset */
+
+#define AES_IVR_IV_Pos                      0                                              /**< (AES_IVR) Initialization Vector Position */
+#define AES_IVR_IV_Msk                      (_U_(0xFFFFFFFF) << AES_IVR_IV_Pos)            /**< (AES_IVR) Initialization Vector Mask */
+#define AES_IVR_IV(value)                   (AES_IVR_IV_Msk & ((value) << AES_IVR_IV_Pos))
+#define AES_IVR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (AES_IVR) Register MASK  (Use AES_IVR_Msk instead)  */
+#define AES_IVR_Msk                         _U_(0xFFFFFFFF)                                /**< (AES_IVR) Register Mask  */
+
+
+/* -------- AES_AADLENR : (AES Offset: 0x70) (R/W 32) Additional Authenticated Data Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AADLEN:32;                 /**< bit:  0..31  Additional Authenticated Data Length     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_AADLENR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_AADLENR_OFFSET                  (0x70)                                        /**<  (AES_AADLENR) Additional Authenticated Data Length Register  Offset */
+
+#define AES_AADLENR_AADLEN_Pos              0                                              /**< (AES_AADLENR) Additional Authenticated Data Length Position */
+#define AES_AADLENR_AADLEN_Msk              (_U_(0xFFFFFFFF) << AES_AADLENR_AADLEN_Pos)    /**< (AES_AADLENR) Additional Authenticated Data Length Mask */
+#define AES_AADLENR_AADLEN(value)           (AES_AADLENR_AADLEN_Msk & ((value) << AES_AADLENR_AADLEN_Pos))
+#define AES_AADLENR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (AES_AADLENR) Register MASK  (Use AES_AADLENR_Msk instead)  */
+#define AES_AADLENR_Msk                     _U_(0xFFFFFFFF)                                /**< (AES_AADLENR) Register Mask  */
+
+
+/* -------- AES_CLENR : (AES Offset: 0x74) (R/W 32) Plaintext/Ciphertext Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLEN:32;                   /**< bit:  0..31  Plaintext/Ciphertext Length              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CLENR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CLENR_OFFSET                    (0x74)                                        /**<  (AES_CLENR) Plaintext/Ciphertext Length Register  Offset */
+
+#define AES_CLENR_CLEN_Pos                  0                                              /**< (AES_CLENR) Plaintext/Ciphertext Length Position */
+#define AES_CLENR_CLEN_Msk                  (_U_(0xFFFFFFFF) << AES_CLENR_CLEN_Pos)        /**< (AES_CLENR) Plaintext/Ciphertext Length Mask */
+#define AES_CLENR_CLEN(value)               (AES_CLENR_CLEN_Msk & ((value) << AES_CLENR_CLEN_Pos))
+#define AES_CLENR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_CLENR) Register MASK  (Use AES_CLENR_Msk instead)  */
+#define AES_CLENR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_CLENR) Register Mask  */
+
+
+/* -------- AES_GHASHR : (AES Offset: 0x78) (R/W 32) GCM Intermediate Hash Word Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GHASH:32;                  /**< bit:  0..31  Intermediate GCM Hash Word x             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_GHASHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_GHASHR_OFFSET                   (0x78)                                        /**<  (AES_GHASHR) GCM Intermediate Hash Word Register 0  Offset */
+
+#define AES_GHASHR_GHASH_Pos                0                                              /**< (AES_GHASHR) Intermediate GCM Hash Word x Position */
+#define AES_GHASHR_GHASH_Msk                (_U_(0xFFFFFFFF) << AES_GHASHR_GHASH_Pos)      /**< (AES_GHASHR) Intermediate GCM Hash Word x Mask */
+#define AES_GHASHR_GHASH(value)             (AES_GHASHR_GHASH_Msk & ((value) << AES_GHASHR_GHASH_Pos))
+#define AES_GHASHR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_GHASHR) Register MASK  (Use AES_GHASHR_Msk instead)  */
+#define AES_GHASHR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_GHASHR) Register Mask  */
+
+
+/* -------- AES_TAGR : (AES Offset: 0x88) (R/ 32) GCM Authentication Tag Word Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TAG:32;                    /**< bit:  0..31  GCM Authentication Tag x                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_TAGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_TAGR_OFFSET                     (0x88)                                        /**<  (AES_TAGR) GCM Authentication Tag Word Register 0  Offset */
+
+#define AES_TAGR_TAG_Pos                    0                                              /**< (AES_TAGR) GCM Authentication Tag x Position */
+#define AES_TAGR_TAG_Msk                    (_U_(0xFFFFFFFF) << AES_TAGR_TAG_Pos)          /**< (AES_TAGR) GCM Authentication Tag x Mask */
+#define AES_TAGR_TAG(value)                 (AES_TAGR_TAG_Msk & ((value) << AES_TAGR_TAG_Pos))
+#define AES_TAGR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AES_TAGR) Register MASK  (Use AES_TAGR_Msk instead)  */
+#define AES_TAGR_Msk                        _U_(0xFFFFFFFF)                                /**< (AES_TAGR) Register Mask  */
+
+
+/* -------- AES_CTRR : (AES Offset: 0x98) (R/ 32) GCM Encryption Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CTR:32;                    /**< bit:  0..31  GCM Encryption Counter                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CTRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CTRR_OFFSET                     (0x98)                                        /**<  (AES_CTRR) GCM Encryption Counter Value Register  Offset */
+
+#define AES_CTRR_CTR_Pos                    0                                              /**< (AES_CTRR) GCM Encryption Counter Position */
+#define AES_CTRR_CTR_Msk                    (_U_(0xFFFFFFFF) << AES_CTRR_CTR_Pos)          /**< (AES_CTRR) GCM Encryption Counter Mask */
+#define AES_CTRR_CTR(value)                 (AES_CTRR_CTR_Msk & ((value) << AES_CTRR_CTR_Pos))
+#define AES_CTRR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AES_CTRR) Register MASK  (Use AES_CTRR_Msk instead)  */
+#define AES_CTRR_Msk                        _U_(0xFFFFFFFF)                                /**< (AES_CTRR) Register Mask  */
+
+
+/* -------- AES_GCMHR : (AES Offset: 0x9c) (R/W 32) GCM H Word Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t H:32;                      /**< bit:  0..31  GCM H Word x                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_GCMHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_GCMHR_OFFSET                    (0x9C)                                        /**<  (AES_GCMHR) GCM H Word Register 0  Offset */
+
+#define AES_GCMHR_H_Pos                     0                                              /**< (AES_GCMHR) GCM H Word x Position */
+#define AES_GCMHR_H_Msk                     (_U_(0xFFFFFFFF) << AES_GCMHR_H_Pos)           /**< (AES_GCMHR) GCM H Word x Mask */
+#define AES_GCMHR_H(value)                  (AES_GCMHR_H_Msk & ((value) << AES_GCMHR_H_Pos))
+#define AES_GCMHR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_GCMHR) Register MASK  (Use AES_GCMHR_Msk instead)  */
+#define AES_GCMHR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_GCMHR) Register Mask  */
+
+
+/* -------- AES_VERSION : (AES Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_VERSION_OFFSET                  (0xFC)                                        /**<  (AES_VERSION) Version Register  Offset */
+
+#define AES_VERSION_VERSION_Pos             0                                              /**< (AES_VERSION) Version of the Hardware Module Position */
+#define AES_VERSION_VERSION_Msk             (_U_(0xFFF) << AES_VERSION_VERSION_Pos)        /**< (AES_VERSION) Version of the Hardware Module Mask */
+#define AES_VERSION_VERSION(value)          (AES_VERSION_VERSION_Msk & ((value) << AES_VERSION_VERSION_Pos))
+#define AES_VERSION_MFN_Pos                 16                                             /**< (AES_VERSION) Metal Fix Number Position */
+#define AES_VERSION_MFN_Msk                 (_U_(0x7) << AES_VERSION_MFN_Pos)              /**< (AES_VERSION) Metal Fix Number Mask */
+#define AES_VERSION_MFN(value)              (AES_VERSION_MFN_Msk & ((value) << AES_VERSION_MFN_Pos))
+#define AES_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (AES_VERSION) Register MASK  (Use AES_VERSION_Msk instead)  */
+#define AES_VERSION_Msk                     _U_(0x70FFF)                                   /**< (AES_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief AES hardware registers */
+typedef struct {  
+  __O  uint32_t AES_CR;         /**< (AES Offset: 0x00) Control Register */
+  __IO uint32_t AES_MR;         /**< (AES Offset: 0x04) Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __O  uint32_t AES_IER;        /**< (AES Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t AES_IDR;        /**< (AES Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t AES_IMR;        /**< (AES Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t AES_ISR;        /**< (AES Offset: 0x1C) Interrupt Status Register */
+  __O  uint32_t AES_KEYWR[8];   /**< (AES Offset: 0x20) Key Word Register 0 */
+  __O  uint32_t AES_IDATAR[4];  /**< (AES Offset: 0x40) Input Data Register 0 */
+  __I  uint32_t AES_ODATAR[4];  /**< (AES Offset: 0x50) Output Data Register 0 */
+  __O  uint32_t AES_IVR[4];     /**< (AES Offset: 0x60) Initialization Vector Register 0 */
+  __IO uint32_t AES_AADLENR;    /**< (AES Offset: 0x70) Additional Authenticated Data Length Register */
+  __IO uint32_t AES_CLENR;      /**< (AES Offset: 0x74) Plaintext/Ciphertext Length Register */
+  __IO uint32_t AES_GHASHR[4];  /**< (AES Offset: 0x78) GCM Intermediate Hash Word Register 0 */
+  __I  uint32_t AES_TAGR[4];    /**< (AES Offset: 0x88) GCM Authentication Tag Word Register 0 */
+  __I  uint32_t AES_CTRR;       /**< (AES Offset: 0x98) GCM Encryption Counter Value Register */
+  __IO uint32_t AES_GCMHR[4];   /**< (AES Offset: 0x9C) GCM H Word Register 0 */
+  __I  uint8_t                        Reserved2[80];
+  __I  uint32_t AES_VERSION;    /**< (AES Offset: 0xFC) Version Register */
+} Aes;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief AES hardware registers */
+typedef struct {  
+  __O  AES_CR_Type                    AES_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO AES_MR_Type                    AES_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __O  AES_IER_Type                   AES_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  AES_IDR_Type                   AES_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  AES_IMR_Type                   AES_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  AES_ISR_Type                   AES_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __O  AES_KEYWR_Type                 AES_KEYWR[8];   /**< Offset: 0x20 ( /W  32) Key Word Register 0 */
+  __O  AES_IDATAR_Type                AES_IDATAR[4];  /**< Offset: 0x40 ( /W  32) Input Data Register 0 */
+  __I  AES_ODATAR_Type                AES_ODATAR[4];  /**< Offset: 0x50 (R/   32) Output Data Register 0 */
+  __O  AES_IVR_Type                   AES_IVR[4];     /**< Offset: 0x60 ( /W  32) Initialization Vector Register 0 */
+  __IO AES_AADLENR_Type               AES_AADLENR;    /**< Offset: 0x70 (R/W  32) Additional Authenticated Data Length Register */
+  __IO AES_CLENR_Type                 AES_CLENR;      /**< Offset: 0x74 (R/W  32) Plaintext/Ciphertext Length Register */
+  __IO AES_GHASHR_Type                AES_GHASHR[4];  /**< Offset: 0x78 (R/W  32) GCM Intermediate Hash Word Register 0 */
+  __I  AES_TAGR_Type                  AES_TAGR[4];    /**< Offset: 0x88 (R/   32) GCM Authentication Tag Word Register 0 */
+  __I  AES_CTRR_Type                  AES_CTRR;       /**< Offset: 0x98 (R/   32) GCM Encryption Counter Value Register */
+  __IO AES_GCMHR_Type                 AES_GCMHR[4];   /**< Offset: 0x9C (R/W  32) GCM H Word Register 0 */
+  __I  uint8_t                        Reserved2[80];
+  __I  AES_VERSION_Type               AES_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+} Aes;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Advanced Encryption Standard */
+
+#endif /* _SAMV71_AES_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/afec.h
+++ b/asf/sam/include/samv71/component/afec.h
@@ -1,0 +1,1741 @@
+/**
+ * \file
+ *
+ * \brief Component description for AFEC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_AFEC_COMPONENT_H_
+#define _SAMV71_AFEC_COMPONENT_H_
+#define _SAMV71_AFEC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Analog Front-End Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AFEC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define AFEC_11147                      /**< (AFEC) Module ID */
+#define REV_AFEC O                      /**< (AFEC) Module revision */
+
+/* -------- AFEC_CR : (AFEC Offset: 0x00) (/W 32) AFEC Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t START:1;                   /**< bit:      1  Start Conversion                         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CR_OFFSET                      (0x00)                                        /**<  (AFEC_CR) AFEC Control Register  Offset */
+
+#define AFEC_CR_SWRST_Pos                   0                                              /**< (AFEC_CR) Software Reset Position */
+#define AFEC_CR_SWRST_Msk                   (_U_(0x1) << AFEC_CR_SWRST_Pos)                /**< (AFEC_CR) Software Reset Mask */
+#define AFEC_CR_SWRST                       AFEC_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CR_SWRST_Msk instead */
+#define AFEC_CR_START_Pos                   1                                              /**< (AFEC_CR) Start Conversion Position */
+#define AFEC_CR_START_Msk                   (_U_(0x1) << AFEC_CR_START_Pos)                /**< (AFEC_CR) Start Conversion Mask */
+#define AFEC_CR_START                       AFEC_CR_START_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CR_START_Msk instead */
+#define AFEC_CR_MASK                        _U_(0x03)                                      /**< \deprecated (AFEC_CR) Register MASK  (Use AFEC_CR_Msk instead)  */
+#define AFEC_CR_Msk                         _U_(0x03)                                      /**< (AFEC_CR) Register Mask  */
+
+
+/* -------- AFEC_MR : (AFEC Offset: 0x04) (R/W 32) AFEC Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRGEN:1;                   /**< bit:      0  Trigger Enable                           */
+    uint32_t TRGSEL:3;                  /**< bit:   1..3  Trigger Selection                        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t SLEEP:1;                   /**< bit:      5  Sleep Mode                               */
+    uint32_t FWUP:1;                    /**< bit:      6  Fast Wakeup                              */
+    uint32_t FREERUN:1;                 /**< bit:      7  Free Run Mode                            */
+    uint32_t PRESCAL:8;                 /**< bit:  8..15  Prescaler Rate Selection                 */
+    uint32_t STARTUP:4;                 /**< bit: 16..19  Startup Time                             */
+    uint32_t :3;                        /**< bit: 20..22  Reserved */
+    uint32_t ONE:1;                     /**< bit:     23  One                                      */
+    uint32_t TRACKTIM:4;                /**< bit: 24..27  Tracking Time                            */
+    uint32_t TRANSFER:2;                /**< bit: 28..29  Transfer Period                          */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t USEQ:1;                    /**< bit:     31  User Sequence Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_MR_OFFSET                      (0x04)                                        /**<  (AFEC_MR) AFEC Mode Register  Offset */
+
+#define AFEC_MR_TRGEN_Pos                   0                                              /**< (AFEC_MR) Trigger Enable Position */
+#define AFEC_MR_TRGEN_Msk                   (_U_(0x1) << AFEC_MR_TRGEN_Pos)                /**< (AFEC_MR) Trigger Enable Mask */
+#define AFEC_MR_TRGEN                       AFEC_MR_TRGEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_TRGEN_Msk instead */
+#define   AFEC_MR_TRGEN_DIS_Val             _U_(0x0)                                       /**< (AFEC_MR) Hardware triggers are disabled. Starting a conversion is only possible by software.  */
+#define   AFEC_MR_TRGEN_EN_Val              _U_(0x1)                                       /**< (AFEC_MR) Hardware trigger selected by TRGSEL field is enabled.  */
+#define AFEC_MR_TRGEN_DIS                   (AFEC_MR_TRGEN_DIS_Val << AFEC_MR_TRGEN_Pos)   /**< (AFEC_MR) Hardware triggers are disabled. Starting a conversion is only possible by software. Position  */
+#define AFEC_MR_TRGEN_EN                    (AFEC_MR_TRGEN_EN_Val << AFEC_MR_TRGEN_Pos)    /**< (AFEC_MR) Hardware trigger selected by TRGSEL field is enabled. Position  */
+#define AFEC_MR_TRGSEL_Pos                  1                                              /**< (AFEC_MR) Trigger Selection Position */
+#define AFEC_MR_TRGSEL_Msk                  (_U_(0x7) << AFEC_MR_TRGSEL_Pos)               /**< (AFEC_MR) Trigger Selection Mask */
+#define AFEC_MR_TRGSEL(value)               (AFEC_MR_TRGSEL_Msk & ((value) << AFEC_MR_TRGSEL_Pos))
+#define   AFEC_MR_TRGSEL_AFEC_TRIG0_Val     _U_(0x0)                                       /**< (AFEC_MR) AFE0_ADTRG for AFEC0 / AFE1_ADTRG for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG1_Val     _U_(0x1)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 0 for AFEC0/TIOA Output of the Timer Counter Channel 3 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG2_Val     _U_(0x2)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 1 for AFEC0/TIOA Output of the Timer Counter Channel 4 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG3_Val     _U_(0x3)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 2 for AFEC0/TIOA Output of the Timer Counter Channel 5 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG4_Val     _U_(0x4)                                       /**< (AFEC_MR) PWM0 event line 0 for AFEC0 / PWM1 event line 0 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG5_Val     _U_(0x5)                                       /**< (AFEC_MR) PWM0 event line 1 for AFEC0 / PWM1 event line 1 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG6_Val     _U_(0x6)                                       /**< (AFEC_MR) Analog Comparator  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG0           (AFEC_MR_TRGSEL_AFEC_TRIG0_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) AFE0_ADTRG for AFEC0 / AFE1_ADTRG for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG1           (AFEC_MR_TRGSEL_AFEC_TRIG1_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 0 for AFEC0/TIOA Output of the Timer Counter Channel 3 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG2           (AFEC_MR_TRGSEL_AFEC_TRIG2_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 1 for AFEC0/TIOA Output of the Timer Counter Channel 4 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG3           (AFEC_MR_TRGSEL_AFEC_TRIG3_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 2 for AFEC0/TIOA Output of the Timer Counter Channel 5 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG4           (AFEC_MR_TRGSEL_AFEC_TRIG4_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) PWM0 event line 0 for AFEC0 / PWM1 event line 0 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG5           (AFEC_MR_TRGSEL_AFEC_TRIG5_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) PWM0 event line 1 for AFEC0 / PWM1 event line 1 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG6           (AFEC_MR_TRGSEL_AFEC_TRIG6_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) Analog Comparator Position  */
+#define AFEC_MR_SLEEP_Pos                   5                                              /**< (AFEC_MR) Sleep Mode Position */
+#define AFEC_MR_SLEEP_Msk                   (_U_(0x1) << AFEC_MR_SLEEP_Pos)                /**< (AFEC_MR) Sleep Mode Mask */
+#define AFEC_MR_SLEEP                       AFEC_MR_SLEEP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_SLEEP_Msk instead */
+#define   AFEC_MR_SLEEP_NORMAL_Val          _U_(0x0)                                       /**< (AFEC_MR) Normal mode: The AFE and reference voltage circuitry are kept ON between conversions.  */
+#define   AFEC_MR_SLEEP_SLEEP_Val           _U_(0x1)                                       /**< (AFEC_MR) Sleep mode: The AFE and reference voltage circuitry are OFF between conversions.  */
+#define AFEC_MR_SLEEP_NORMAL                (AFEC_MR_SLEEP_NORMAL_Val << AFEC_MR_SLEEP_Pos)  /**< (AFEC_MR) Normal mode: The AFE and reference voltage circuitry are kept ON between conversions. Position  */
+#define AFEC_MR_SLEEP_SLEEP                 (AFEC_MR_SLEEP_SLEEP_Val << AFEC_MR_SLEEP_Pos)  /**< (AFEC_MR) Sleep mode: The AFE and reference voltage circuitry are OFF between conversions. Position  */
+#define AFEC_MR_FWUP_Pos                    6                                              /**< (AFEC_MR) Fast Wakeup Position */
+#define AFEC_MR_FWUP_Msk                    (_U_(0x1) << AFEC_MR_FWUP_Pos)                 /**< (AFEC_MR) Fast Wakeup Mask */
+#define AFEC_MR_FWUP                        AFEC_MR_FWUP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_FWUP_Msk instead */
+#define   AFEC_MR_FWUP_OFF_Val              _U_(0x0)                                       /**< (AFEC_MR) Normal Sleep mode: The sleep mode is defined by the SLEEP bit.  */
+#define   AFEC_MR_FWUP_ON_Val               _U_(0x1)                                       /**< (AFEC_MR) Fast akeup Sleep mode: The voltage reference is ON between conversions and AFE is OFF.  */
+#define AFEC_MR_FWUP_OFF                    (AFEC_MR_FWUP_OFF_Val << AFEC_MR_FWUP_Pos)     /**< (AFEC_MR) Normal Sleep mode: The sleep mode is defined by the SLEEP bit. Position  */
+#define AFEC_MR_FWUP_ON                     (AFEC_MR_FWUP_ON_Val << AFEC_MR_FWUP_Pos)      /**< (AFEC_MR) Fast akeup Sleep mode: The voltage reference is ON between conversions and AFE is OFF. Position  */
+#define AFEC_MR_FREERUN_Pos                 7                                              /**< (AFEC_MR) Free Run Mode Position */
+#define AFEC_MR_FREERUN_Msk                 (_U_(0x1) << AFEC_MR_FREERUN_Pos)              /**< (AFEC_MR) Free Run Mode Mask */
+#define AFEC_MR_FREERUN                     AFEC_MR_FREERUN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_FREERUN_Msk instead */
+#define   AFEC_MR_FREERUN_OFF_Val           _U_(0x0)                                       /**< (AFEC_MR) Normal mode  */
+#define   AFEC_MR_FREERUN_ON_Val            _U_(0x1)                                       /**< (AFEC_MR) Free Run mode: Never wait for any trigger.  */
+#define AFEC_MR_FREERUN_OFF                 (AFEC_MR_FREERUN_OFF_Val << AFEC_MR_FREERUN_Pos)  /**< (AFEC_MR) Normal mode Position  */
+#define AFEC_MR_FREERUN_ON                  (AFEC_MR_FREERUN_ON_Val << AFEC_MR_FREERUN_Pos)  /**< (AFEC_MR) Free Run mode: Never wait for any trigger. Position  */
+#define AFEC_MR_PRESCAL_Pos                 8                                              /**< (AFEC_MR) Prescaler Rate Selection Position */
+#define AFEC_MR_PRESCAL_Msk                 (_U_(0xFF) << AFEC_MR_PRESCAL_Pos)             /**< (AFEC_MR) Prescaler Rate Selection Mask */
+#define AFEC_MR_PRESCAL(value)              (AFEC_MR_PRESCAL_Msk & ((value) << AFEC_MR_PRESCAL_Pos))
+#define AFEC_MR_STARTUP_Pos                 16                                             /**< (AFEC_MR) Startup Time Position */
+#define AFEC_MR_STARTUP_Msk                 (_U_(0xF) << AFEC_MR_STARTUP_Pos)              /**< (AFEC_MR) Startup Time Mask */
+#define AFEC_MR_STARTUP(value)              (AFEC_MR_STARTUP_Msk & ((value) << AFEC_MR_STARTUP_Pos))
+#define   AFEC_MR_STARTUP_SUT0_Val          _U_(0x0)                                       /**< (AFEC_MR) 0 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT8_Val          _U_(0x1)                                       /**< (AFEC_MR) 8 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT16_Val         _U_(0x2)                                       /**< (AFEC_MR) 16 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT24_Val         _U_(0x3)                                       /**< (AFEC_MR) 24 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT64_Val         _U_(0x4)                                       /**< (AFEC_MR) 64 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT80_Val         _U_(0x5)                                       /**< (AFEC_MR) 80 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT96_Val         _U_(0x6)                                       /**< (AFEC_MR) 96 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT112_Val        _U_(0x7)                                       /**< (AFEC_MR) 112 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT512_Val        _U_(0x8)                                       /**< (AFEC_MR) 512 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT576_Val        _U_(0x9)                                       /**< (AFEC_MR) 576 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT640_Val        _U_(0xA)                                       /**< (AFEC_MR) 640 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT704_Val        _U_(0xB)                                       /**< (AFEC_MR) 704 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT768_Val        _U_(0xC)                                       /**< (AFEC_MR) 768 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT832_Val        _U_(0xD)                                       /**< (AFEC_MR) 832 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT896_Val        _U_(0xE)                                       /**< (AFEC_MR) 896 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT960_Val        _U_(0xF)                                       /**< (AFEC_MR) 960 periods of AFE clock  */
+#define AFEC_MR_STARTUP_SUT0                (AFEC_MR_STARTUP_SUT0_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 0 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT8                (AFEC_MR_STARTUP_SUT8_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 8 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT16               (AFEC_MR_STARTUP_SUT16_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 16 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT24               (AFEC_MR_STARTUP_SUT24_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 24 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT64               (AFEC_MR_STARTUP_SUT64_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 64 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT80               (AFEC_MR_STARTUP_SUT80_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 80 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT96               (AFEC_MR_STARTUP_SUT96_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 96 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT112              (AFEC_MR_STARTUP_SUT112_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 112 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT512              (AFEC_MR_STARTUP_SUT512_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 512 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT576              (AFEC_MR_STARTUP_SUT576_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 576 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT640              (AFEC_MR_STARTUP_SUT640_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 640 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT704              (AFEC_MR_STARTUP_SUT704_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 704 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT768              (AFEC_MR_STARTUP_SUT768_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 768 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT832              (AFEC_MR_STARTUP_SUT832_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 832 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT896              (AFEC_MR_STARTUP_SUT896_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 896 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT960              (AFEC_MR_STARTUP_SUT960_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 960 periods of AFE clock Position  */
+#define AFEC_MR_ONE_Pos                     23                                             /**< (AFEC_MR) One Position */
+#define AFEC_MR_ONE_Msk                     (_U_(0x1) << AFEC_MR_ONE_Pos)                  /**< (AFEC_MR) One Mask */
+#define AFEC_MR_ONE                         AFEC_MR_ONE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_ONE_Msk instead */
+#define AFEC_MR_TRACKTIM_Pos                24                                             /**< (AFEC_MR) Tracking Time Position */
+#define AFEC_MR_TRACKTIM_Msk                (_U_(0xF) << AFEC_MR_TRACKTIM_Pos)             /**< (AFEC_MR) Tracking Time Mask */
+#define AFEC_MR_TRACKTIM(value)             (AFEC_MR_TRACKTIM_Msk & ((value) << AFEC_MR_TRACKTIM_Pos))
+#define AFEC_MR_TRANSFER_Pos                28                                             /**< (AFEC_MR) Transfer Period Position */
+#define AFEC_MR_TRANSFER_Msk                (_U_(0x3) << AFEC_MR_TRANSFER_Pos)             /**< (AFEC_MR) Transfer Period Mask */
+#define AFEC_MR_TRANSFER(value)             (AFEC_MR_TRANSFER_Msk & ((value) << AFEC_MR_TRANSFER_Pos))
+#define AFEC_MR_USEQ_Pos                    31                                             /**< (AFEC_MR) User Sequence Enable Position */
+#define AFEC_MR_USEQ_Msk                    (_U_(0x1) << AFEC_MR_USEQ_Pos)                 /**< (AFEC_MR) User Sequence Enable Mask */
+#define AFEC_MR_USEQ                        AFEC_MR_USEQ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_USEQ_Msk instead */
+#define   AFEC_MR_USEQ_NUM_ORDER_Val        _U_(0x0)                                       /**< (AFEC_MR) Normal mode: The controller converts channels in a simple numeric order.  */
+#define   AFEC_MR_USEQ_REG_ORDER_Val        _U_(0x1)                                       /**< (AFEC_MR) User Sequence mode: The sequence respects what is defined in AFEC_SEQ1R and AFEC_SEQ1R.  */
+#define AFEC_MR_USEQ_NUM_ORDER              (AFEC_MR_USEQ_NUM_ORDER_Val << AFEC_MR_USEQ_Pos)  /**< (AFEC_MR) Normal mode: The controller converts channels in a simple numeric order. Position  */
+#define AFEC_MR_USEQ_REG_ORDER              (AFEC_MR_USEQ_REG_ORDER_Val << AFEC_MR_USEQ_Pos)  /**< (AFEC_MR) User Sequence mode: The sequence respects what is defined in AFEC_SEQ1R and AFEC_SEQ1R. Position  */
+#define AFEC_MR_MASK                        _U_(0xBF8FFFEF)                                /**< \deprecated (AFEC_MR) Register MASK  (Use AFEC_MR_Msk instead)  */
+#define AFEC_MR_Msk                         _U_(0xBF8FFFEF)                                /**< (AFEC_MR) Register Mask  */
+
+
+/* -------- AFEC_EMR : (AFEC Offset: 0x08) (R/W 32) AFEC Extended Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMPMODE:2;                 /**< bit:   0..1  Comparison Mode                          */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t CMPSEL:5;                  /**< bit:   3..7  Comparison Selected Channel              */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t CMPALL:1;                  /**< bit:      9  Compare All Channels                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t CMPFILTER:2;               /**< bit: 12..13  Compare Event Filtering                  */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RES:3;                     /**< bit: 16..18  Resolution                               */
+    uint32_t :5;                        /**< bit: 19..23  Reserved */
+    uint32_t TAG:1;                     /**< bit:     24  TAG of the AFEC_LDCR                     */
+    uint32_t STM:1;                     /**< bit:     25  Single Trigger Mode                      */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t SIGNMODE:2;                /**< bit: 28..29  Sign Mode                                */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_EMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_EMR_OFFSET                     (0x08)                                        /**<  (AFEC_EMR) AFEC Extended Mode Register  Offset */
+
+#define AFEC_EMR_CMPMODE_Pos                0                                              /**< (AFEC_EMR) Comparison Mode Position */
+#define AFEC_EMR_CMPMODE_Msk                (_U_(0x3) << AFEC_EMR_CMPMODE_Pos)             /**< (AFEC_EMR) Comparison Mode Mask */
+#define AFEC_EMR_CMPMODE(value)             (AFEC_EMR_CMPMODE_Msk & ((value) << AFEC_EMR_CMPMODE_Pos))
+#define   AFEC_EMR_CMPMODE_LOW_Val          _U_(0x0)                                       /**< (AFEC_EMR) Generates an event when the converted data is lower than the low threshold of the window.  */
+#define   AFEC_EMR_CMPMODE_HIGH_Val         _U_(0x1)                                       /**< (AFEC_EMR) Generates an event when the converted data is higher than the high threshold of the window.  */
+#define   AFEC_EMR_CMPMODE_IN_Val           _U_(0x2)                                       /**< (AFEC_EMR) Generates an event when the converted data is in the comparison window.  */
+#define   AFEC_EMR_CMPMODE_OUT_Val          _U_(0x3)                                       /**< (AFEC_EMR) Generates an event when the converted data is out of the comparison window.  */
+#define AFEC_EMR_CMPMODE_LOW                (AFEC_EMR_CMPMODE_LOW_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is lower than the low threshold of the window. Position  */
+#define AFEC_EMR_CMPMODE_HIGH               (AFEC_EMR_CMPMODE_HIGH_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is higher than the high threshold of the window. Position  */
+#define AFEC_EMR_CMPMODE_IN                 (AFEC_EMR_CMPMODE_IN_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is in the comparison window. Position  */
+#define AFEC_EMR_CMPMODE_OUT                (AFEC_EMR_CMPMODE_OUT_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is out of the comparison window. Position  */
+#define AFEC_EMR_CMPSEL_Pos                 3                                              /**< (AFEC_EMR) Comparison Selected Channel Position */
+#define AFEC_EMR_CMPSEL_Msk                 (_U_(0x1F) << AFEC_EMR_CMPSEL_Pos)             /**< (AFEC_EMR) Comparison Selected Channel Mask */
+#define AFEC_EMR_CMPSEL(value)              (AFEC_EMR_CMPSEL_Msk & ((value) << AFEC_EMR_CMPSEL_Pos))
+#define AFEC_EMR_CMPALL_Pos                 9                                              /**< (AFEC_EMR) Compare All Channels Position */
+#define AFEC_EMR_CMPALL_Msk                 (_U_(0x1) << AFEC_EMR_CMPALL_Pos)              /**< (AFEC_EMR) Compare All Channels Mask */
+#define AFEC_EMR_CMPALL                     AFEC_EMR_CMPALL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_CMPALL_Msk instead */
+#define AFEC_EMR_CMPFILTER_Pos              12                                             /**< (AFEC_EMR) Compare Event Filtering Position */
+#define AFEC_EMR_CMPFILTER_Msk              (_U_(0x3) << AFEC_EMR_CMPFILTER_Pos)           /**< (AFEC_EMR) Compare Event Filtering Mask */
+#define AFEC_EMR_CMPFILTER(value)           (AFEC_EMR_CMPFILTER_Msk & ((value) << AFEC_EMR_CMPFILTER_Pos))
+#define AFEC_EMR_RES_Pos                    16                                             /**< (AFEC_EMR) Resolution Position */
+#define AFEC_EMR_RES_Msk                    (_U_(0x7) << AFEC_EMR_RES_Pos)                 /**< (AFEC_EMR) Resolution Mask */
+#define AFEC_EMR_RES(value)                 (AFEC_EMR_RES_Msk & ((value) << AFEC_EMR_RES_Pos))
+#define   AFEC_EMR_RES_NO_AVERAGE_Val       _U_(0x0)                                       /**< (AFEC_EMR) 12-bit resolution, AFE sample rate is maximum (no averaging).  */
+#define   AFEC_EMR_RES_OSR4_Val             _U_(0x2)                                       /**< (AFEC_EMR) 13-bit resolution, AFE sample rate divided by 4 (averaging).  */
+#define   AFEC_EMR_RES_OSR16_Val            _U_(0x3)                                       /**< (AFEC_EMR) 14-bit resolution, AFE sample rate divided by 16 (averaging).  */
+#define   AFEC_EMR_RES_OSR64_Val            _U_(0x4)                                       /**< (AFEC_EMR) 15-bit resolution, AFE sample rate divided by 64 (averaging).  */
+#define   AFEC_EMR_RES_OSR256_Val           _U_(0x5)                                       /**< (AFEC_EMR) 16-bit resolution, AFE sample rate divided by 256 (averaging).  */
+#define AFEC_EMR_RES_NO_AVERAGE             (AFEC_EMR_RES_NO_AVERAGE_Val << AFEC_EMR_RES_Pos)  /**< (AFEC_EMR) 12-bit resolution, AFE sample rate is maximum (no averaging). Position  */
+#define AFEC_EMR_RES_OSR4                   (AFEC_EMR_RES_OSR4_Val << AFEC_EMR_RES_Pos)    /**< (AFEC_EMR) 13-bit resolution, AFE sample rate divided by 4 (averaging). Position  */
+#define AFEC_EMR_RES_OSR16                  (AFEC_EMR_RES_OSR16_Val << AFEC_EMR_RES_Pos)   /**< (AFEC_EMR) 14-bit resolution, AFE sample rate divided by 16 (averaging). Position  */
+#define AFEC_EMR_RES_OSR64                  (AFEC_EMR_RES_OSR64_Val << AFEC_EMR_RES_Pos)   /**< (AFEC_EMR) 15-bit resolution, AFE sample rate divided by 64 (averaging). Position  */
+#define AFEC_EMR_RES_OSR256                 (AFEC_EMR_RES_OSR256_Val << AFEC_EMR_RES_Pos)  /**< (AFEC_EMR) 16-bit resolution, AFE sample rate divided by 256 (averaging). Position  */
+#define AFEC_EMR_TAG_Pos                    24                                             /**< (AFEC_EMR) TAG of the AFEC_LDCR Position */
+#define AFEC_EMR_TAG_Msk                    (_U_(0x1) << AFEC_EMR_TAG_Pos)                 /**< (AFEC_EMR) TAG of the AFEC_LDCR Mask */
+#define AFEC_EMR_TAG                        AFEC_EMR_TAG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_TAG_Msk instead */
+#define AFEC_EMR_STM_Pos                    25                                             /**< (AFEC_EMR) Single Trigger Mode Position */
+#define AFEC_EMR_STM_Msk                    (_U_(0x1) << AFEC_EMR_STM_Pos)                 /**< (AFEC_EMR) Single Trigger Mode Mask */
+#define AFEC_EMR_STM                        AFEC_EMR_STM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_STM_Msk instead */
+#define AFEC_EMR_SIGNMODE_Pos               28                                             /**< (AFEC_EMR) Sign Mode Position */
+#define AFEC_EMR_SIGNMODE_Msk               (_U_(0x3) << AFEC_EMR_SIGNMODE_Pos)            /**< (AFEC_EMR) Sign Mode Mask */
+#define AFEC_EMR_SIGNMODE(value)            (AFEC_EMR_SIGNMODE_Msk & ((value) << AFEC_EMR_SIGNMODE_Pos))
+#define   AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN_Val _U_(0x0)                                       /**< (AFEC_EMR) Single-Ended channels: Unsigned conversions.Differential channels: Signed conversions.  */
+#define   AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG_Val _U_(0x1)                                       /**< (AFEC_EMR) Single-Ended channels: Signed conversions.Differential channels: Unsigned conversions.  */
+#define   AFEC_EMR_SIGNMODE_ALL_UNSIGNED_Val _U_(0x2)                                       /**< (AFEC_EMR) All channels: Unsigned conversions.  */
+#define   AFEC_EMR_SIGNMODE_ALL_SIGNED_Val  _U_(0x3)                                       /**< (AFEC_EMR) All channels: Signed conversions.  */
+#define AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN   (AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) Single-Ended channels: Unsigned conversions.Differential channels: Signed conversions. Position  */
+#define AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG   (AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) Single-Ended channels: Signed conversions.Differential channels: Unsigned conversions. Position  */
+#define AFEC_EMR_SIGNMODE_ALL_UNSIGNED      (AFEC_EMR_SIGNMODE_ALL_UNSIGNED_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) All channels: Unsigned conversions. Position  */
+#define AFEC_EMR_SIGNMODE_ALL_SIGNED        (AFEC_EMR_SIGNMODE_ALL_SIGNED_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) All channels: Signed conversions. Position  */
+#define AFEC_EMR_MASK                       _U_(0x330732FB)                                /**< \deprecated (AFEC_EMR) Register MASK  (Use AFEC_EMR_Msk instead)  */
+#define AFEC_EMR_Msk                        _U_(0x330732FB)                                /**< (AFEC_EMR) Register Mask  */
+
+
+/* -------- AFEC_SEQ1R : (AFEC Offset: 0x0c) (R/W 32) AFEC Channel Sequence 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USCH0:4;                   /**< bit:   0..3  User Sequence Number 0                   */
+    uint32_t USCH1:4;                   /**< bit:   4..7  User Sequence Number 1                   */
+    uint32_t USCH2:4;                   /**< bit:  8..11  User Sequence Number 2                   */
+    uint32_t USCH3:4;                   /**< bit: 12..15  User Sequence Number 3                   */
+    uint32_t USCH4:4;                   /**< bit: 16..19  User Sequence Number 4                   */
+    uint32_t USCH5:4;                   /**< bit: 20..23  User Sequence Number 5                   */
+    uint32_t USCH6:4;                   /**< bit: 24..27  User Sequence Number 6                   */
+    uint32_t USCH7:4;                   /**< bit: 28..31  User Sequence Number 7                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SEQ1R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SEQ1R_OFFSET                   (0x0C)                                        /**<  (AFEC_SEQ1R) AFEC Channel Sequence 1 Register  Offset */
+
+#define AFEC_SEQ1R_USCH0_Pos                0                                              /**< (AFEC_SEQ1R) User Sequence Number 0 Position */
+#define AFEC_SEQ1R_USCH0_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH0_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 0 Mask */
+#define AFEC_SEQ1R_USCH0(value)             (AFEC_SEQ1R_USCH0_Msk & ((value) << AFEC_SEQ1R_USCH0_Pos))
+#define AFEC_SEQ1R_USCH1_Pos                4                                              /**< (AFEC_SEQ1R) User Sequence Number 1 Position */
+#define AFEC_SEQ1R_USCH1_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH1_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 1 Mask */
+#define AFEC_SEQ1R_USCH1(value)             (AFEC_SEQ1R_USCH1_Msk & ((value) << AFEC_SEQ1R_USCH1_Pos))
+#define AFEC_SEQ1R_USCH2_Pos                8                                              /**< (AFEC_SEQ1R) User Sequence Number 2 Position */
+#define AFEC_SEQ1R_USCH2_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH2_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 2 Mask */
+#define AFEC_SEQ1R_USCH2(value)             (AFEC_SEQ1R_USCH2_Msk & ((value) << AFEC_SEQ1R_USCH2_Pos))
+#define AFEC_SEQ1R_USCH3_Pos                12                                             /**< (AFEC_SEQ1R) User Sequence Number 3 Position */
+#define AFEC_SEQ1R_USCH3_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH3_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 3 Mask */
+#define AFEC_SEQ1R_USCH3(value)             (AFEC_SEQ1R_USCH3_Msk & ((value) << AFEC_SEQ1R_USCH3_Pos))
+#define AFEC_SEQ1R_USCH4_Pos                16                                             /**< (AFEC_SEQ1R) User Sequence Number 4 Position */
+#define AFEC_SEQ1R_USCH4_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH4_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 4 Mask */
+#define AFEC_SEQ1R_USCH4(value)             (AFEC_SEQ1R_USCH4_Msk & ((value) << AFEC_SEQ1R_USCH4_Pos))
+#define AFEC_SEQ1R_USCH5_Pos                20                                             /**< (AFEC_SEQ1R) User Sequence Number 5 Position */
+#define AFEC_SEQ1R_USCH5_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH5_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 5 Mask */
+#define AFEC_SEQ1R_USCH5(value)             (AFEC_SEQ1R_USCH5_Msk & ((value) << AFEC_SEQ1R_USCH5_Pos))
+#define AFEC_SEQ1R_USCH6_Pos                24                                             /**< (AFEC_SEQ1R) User Sequence Number 6 Position */
+#define AFEC_SEQ1R_USCH6_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH6_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 6 Mask */
+#define AFEC_SEQ1R_USCH6(value)             (AFEC_SEQ1R_USCH6_Msk & ((value) << AFEC_SEQ1R_USCH6_Pos))
+#define AFEC_SEQ1R_USCH7_Pos                28                                             /**< (AFEC_SEQ1R) User Sequence Number 7 Position */
+#define AFEC_SEQ1R_USCH7_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH7_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 7 Mask */
+#define AFEC_SEQ1R_USCH7(value)             (AFEC_SEQ1R_USCH7_Msk & ((value) << AFEC_SEQ1R_USCH7_Pos))
+#define AFEC_SEQ1R_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_SEQ1R) Register MASK  (Use AFEC_SEQ1R_Msk instead)  */
+#define AFEC_SEQ1R_Msk                      _U_(0xFFFFFFFF)                                /**< (AFEC_SEQ1R) Register Mask  */
+
+
+/* -------- AFEC_SEQ2R : (AFEC Offset: 0x10) (R/W 32) AFEC Channel Sequence 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USCH8:4;                   /**< bit:   0..3  User Sequence Number 8                   */
+    uint32_t USCH9:4;                   /**< bit:   4..7  User Sequence Number 9                   */
+    uint32_t USCH10:4;                  /**< bit:  8..11  User Sequence Number 10                  */
+    uint32_t USCH11:4;                  /**< bit: 12..15  User Sequence Number 11                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SEQ2R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SEQ2R_OFFSET                   (0x10)                                        /**<  (AFEC_SEQ2R) AFEC Channel Sequence 2 Register  Offset */
+
+#define AFEC_SEQ2R_USCH8_Pos                0                                              /**< (AFEC_SEQ2R) User Sequence Number 8 Position */
+#define AFEC_SEQ2R_USCH8_Msk                (_U_(0xF) << AFEC_SEQ2R_USCH8_Pos)             /**< (AFEC_SEQ2R) User Sequence Number 8 Mask */
+#define AFEC_SEQ2R_USCH8(value)             (AFEC_SEQ2R_USCH8_Msk & ((value) << AFEC_SEQ2R_USCH8_Pos))
+#define AFEC_SEQ2R_USCH9_Pos                4                                              /**< (AFEC_SEQ2R) User Sequence Number 9 Position */
+#define AFEC_SEQ2R_USCH9_Msk                (_U_(0xF) << AFEC_SEQ2R_USCH9_Pos)             /**< (AFEC_SEQ2R) User Sequence Number 9 Mask */
+#define AFEC_SEQ2R_USCH9(value)             (AFEC_SEQ2R_USCH9_Msk & ((value) << AFEC_SEQ2R_USCH9_Pos))
+#define AFEC_SEQ2R_USCH10_Pos               8                                              /**< (AFEC_SEQ2R) User Sequence Number 10 Position */
+#define AFEC_SEQ2R_USCH10_Msk               (_U_(0xF) << AFEC_SEQ2R_USCH10_Pos)            /**< (AFEC_SEQ2R) User Sequence Number 10 Mask */
+#define AFEC_SEQ2R_USCH10(value)            (AFEC_SEQ2R_USCH10_Msk & ((value) << AFEC_SEQ2R_USCH10_Pos))
+#define AFEC_SEQ2R_USCH11_Pos               12                                             /**< (AFEC_SEQ2R) User Sequence Number 11 Position */
+#define AFEC_SEQ2R_USCH11_Msk               (_U_(0xF) << AFEC_SEQ2R_USCH11_Pos)            /**< (AFEC_SEQ2R) User Sequence Number 11 Mask */
+#define AFEC_SEQ2R_USCH11(value)            (AFEC_SEQ2R_USCH11_Msk & ((value) << AFEC_SEQ2R_USCH11_Pos))
+#define AFEC_SEQ2R_MASK                     _U_(0xFFFF)                                    /**< \deprecated (AFEC_SEQ2R) Register MASK  (Use AFEC_SEQ2R_Msk instead)  */
+#define AFEC_SEQ2R_Msk                      _U_(0xFFFF)                                    /**< (AFEC_SEQ2R) Register Mask  */
+
+
+/* -------- AFEC_CHER : (AFEC Offset: 0x14) (/W 32) AFEC Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Enable                         */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Enable                         */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Enable                         */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Enable                         */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Enable                         */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Enable                         */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Enable                         */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Enable                         */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Enable                         */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Enable                        */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Enable                        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Enable                        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHER_OFFSET                    (0x14)                                        /**<  (AFEC_CHER) AFEC Channel Enable Register  Offset */
+
+#define AFEC_CHER_CH0_Pos                   0                                              /**< (AFEC_CHER) Channel 0 Enable Position */
+#define AFEC_CHER_CH0_Msk                   (_U_(0x1) << AFEC_CHER_CH0_Pos)                /**< (AFEC_CHER) Channel 0 Enable Mask */
+#define AFEC_CHER_CH0                       AFEC_CHER_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH0_Msk instead */
+#define AFEC_CHER_CH1_Pos                   1                                              /**< (AFEC_CHER) Channel 1 Enable Position */
+#define AFEC_CHER_CH1_Msk                   (_U_(0x1) << AFEC_CHER_CH1_Pos)                /**< (AFEC_CHER) Channel 1 Enable Mask */
+#define AFEC_CHER_CH1                       AFEC_CHER_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH1_Msk instead */
+#define AFEC_CHER_CH2_Pos                   2                                              /**< (AFEC_CHER) Channel 2 Enable Position */
+#define AFEC_CHER_CH2_Msk                   (_U_(0x1) << AFEC_CHER_CH2_Pos)                /**< (AFEC_CHER) Channel 2 Enable Mask */
+#define AFEC_CHER_CH2                       AFEC_CHER_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH2_Msk instead */
+#define AFEC_CHER_CH3_Pos                   3                                              /**< (AFEC_CHER) Channel 3 Enable Position */
+#define AFEC_CHER_CH3_Msk                   (_U_(0x1) << AFEC_CHER_CH3_Pos)                /**< (AFEC_CHER) Channel 3 Enable Mask */
+#define AFEC_CHER_CH3                       AFEC_CHER_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH3_Msk instead */
+#define AFEC_CHER_CH4_Pos                   4                                              /**< (AFEC_CHER) Channel 4 Enable Position */
+#define AFEC_CHER_CH4_Msk                   (_U_(0x1) << AFEC_CHER_CH4_Pos)                /**< (AFEC_CHER) Channel 4 Enable Mask */
+#define AFEC_CHER_CH4                       AFEC_CHER_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH4_Msk instead */
+#define AFEC_CHER_CH5_Pos                   5                                              /**< (AFEC_CHER) Channel 5 Enable Position */
+#define AFEC_CHER_CH5_Msk                   (_U_(0x1) << AFEC_CHER_CH5_Pos)                /**< (AFEC_CHER) Channel 5 Enable Mask */
+#define AFEC_CHER_CH5                       AFEC_CHER_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH5_Msk instead */
+#define AFEC_CHER_CH6_Pos                   6                                              /**< (AFEC_CHER) Channel 6 Enable Position */
+#define AFEC_CHER_CH6_Msk                   (_U_(0x1) << AFEC_CHER_CH6_Pos)                /**< (AFEC_CHER) Channel 6 Enable Mask */
+#define AFEC_CHER_CH6                       AFEC_CHER_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH6_Msk instead */
+#define AFEC_CHER_CH7_Pos                   7                                              /**< (AFEC_CHER) Channel 7 Enable Position */
+#define AFEC_CHER_CH7_Msk                   (_U_(0x1) << AFEC_CHER_CH7_Pos)                /**< (AFEC_CHER) Channel 7 Enable Mask */
+#define AFEC_CHER_CH7                       AFEC_CHER_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH7_Msk instead */
+#define AFEC_CHER_CH8_Pos                   8                                              /**< (AFEC_CHER) Channel 8 Enable Position */
+#define AFEC_CHER_CH8_Msk                   (_U_(0x1) << AFEC_CHER_CH8_Pos)                /**< (AFEC_CHER) Channel 8 Enable Mask */
+#define AFEC_CHER_CH8                       AFEC_CHER_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH8_Msk instead */
+#define AFEC_CHER_CH9_Pos                   9                                              /**< (AFEC_CHER) Channel 9 Enable Position */
+#define AFEC_CHER_CH9_Msk                   (_U_(0x1) << AFEC_CHER_CH9_Pos)                /**< (AFEC_CHER) Channel 9 Enable Mask */
+#define AFEC_CHER_CH9                       AFEC_CHER_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH9_Msk instead */
+#define AFEC_CHER_CH10_Pos                  10                                             /**< (AFEC_CHER) Channel 10 Enable Position */
+#define AFEC_CHER_CH10_Msk                  (_U_(0x1) << AFEC_CHER_CH10_Pos)               /**< (AFEC_CHER) Channel 10 Enable Mask */
+#define AFEC_CHER_CH10                      AFEC_CHER_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH10_Msk instead */
+#define AFEC_CHER_CH11_Pos                  11                                             /**< (AFEC_CHER) Channel 11 Enable Position */
+#define AFEC_CHER_CH11_Msk                  (_U_(0x1) << AFEC_CHER_CH11_Pos)               /**< (AFEC_CHER) Channel 11 Enable Mask */
+#define AFEC_CHER_CH11                      AFEC_CHER_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH11_Msk instead */
+#define AFEC_CHER_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHER) Register MASK  (Use AFEC_CHER_Msk instead)  */
+#define AFEC_CHER_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHER) Register Mask  */
+
+#define AFEC_CHER_CH_Pos                    0                                              /**< (AFEC_CHER Position) Channel xx Enable */
+#define AFEC_CHER_CH_Msk                    (_U_(0xFFF) << AFEC_CHER_CH_Pos)               /**< (AFEC_CHER Mask) CH */
+#define AFEC_CHER_CH(value)                 (AFEC_CHER_CH_Msk & ((value) << AFEC_CHER_CH_Pos))  
+
+/* -------- AFEC_CHDR : (AFEC Offset: 0x18) (/W 32) AFEC Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Disable                        */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Disable                        */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Disable                        */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Disable                        */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Disable                        */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Disable                        */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Disable                        */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Disable                        */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Disable                        */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Disable                       */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Disable                       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Disable                       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHDR_OFFSET                    (0x18)                                        /**<  (AFEC_CHDR) AFEC Channel Disable Register  Offset */
+
+#define AFEC_CHDR_CH0_Pos                   0                                              /**< (AFEC_CHDR) Channel 0 Disable Position */
+#define AFEC_CHDR_CH0_Msk                   (_U_(0x1) << AFEC_CHDR_CH0_Pos)                /**< (AFEC_CHDR) Channel 0 Disable Mask */
+#define AFEC_CHDR_CH0                       AFEC_CHDR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH0_Msk instead */
+#define AFEC_CHDR_CH1_Pos                   1                                              /**< (AFEC_CHDR) Channel 1 Disable Position */
+#define AFEC_CHDR_CH1_Msk                   (_U_(0x1) << AFEC_CHDR_CH1_Pos)                /**< (AFEC_CHDR) Channel 1 Disable Mask */
+#define AFEC_CHDR_CH1                       AFEC_CHDR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH1_Msk instead */
+#define AFEC_CHDR_CH2_Pos                   2                                              /**< (AFEC_CHDR) Channel 2 Disable Position */
+#define AFEC_CHDR_CH2_Msk                   (_U_(0x1) << AFEC_CHDR_CH2_Pos)                /**< (AFEC_CHDR) Channel 2 Disable Mask */
+#define AFEC_CHDR_CH2                       AFEC_CHDR_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH2_Msk instead */
+#define AFEC_CHDR_CH3_Pos                   3                                              /**< (AFEC_CHDR) Channel 3 Disable Position */
+#define AFEC_CHDR_CH3_Msk                   (_U_(0x1) << AFEC_CHDR_CH3_Pos)                /**< (AFEC_CHDR) Channel 3 Disable Mask */
+#define AFEC_CHDR_CH3                       AFEC_CHDR_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH3_Msk instead */
+#define AFEC_CHDR_CH4_Pos                   4                                              /**< (AFEC_CHDR) Channel 4 Disable Position */
+#define AFEC_CHDR_CH4_Msk                   (_U_(0x1) << AFEC_CHDR_CH4_Pos)                /**< (AFEC_CHDR) Channel 4 Disable Mask */
+#define AFEC_CHDR_CH4                       AFEC_CHDR_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH4_Msk instead */
+#define AFEC_CHDR_CH5_Pos                   5                                              /**< (AFEC_CHDR) Channel 5 Disable Position */
+#define AFEC_CHDR_CH5_Msk                   (_U_(0x1) << AFEC_CHDR_CH5_Pos)                /**< (AFEC_CHDR) Channel 5 Disable Mask */
+#define AFEC_CHDR_CH5                       AFEC_CHDR_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH5_Msk instead */
+#define AFEC_CHDR_CH6_Pos                   6                                              /**< (AFEC_CHDR) Channel 6 Disable Position */
+#define AFEC_CHDR_CH6_Msk                   (_U_(0x1) << AFEC_CHDR_CH6_Pos)                /**< (AFEC_CHDR) Channel 6 Disable Mask */
+#define AFEC_CHDR_CH6                       AFEC_CHDR_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH6_Msk instead */
+#define AFEC_CHDR_CH7_Pos                   7                                              /**< (AFEC_CHDR) Channel 7 Disable Position */
+#define AFEC_CHDR_CH7_Msk                   (_U_(0x1) << AFEC_CHDR_CH7_Pos)                /**< (AFEC_CHDR) Channel 7 Disable Mask */
+#define AFEC_CHDR_CH7                       AFEC_CHDR_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH7_Msk instead */
+#define AFEC_CHDR_CH8_Pos                   8                                              /**< (AFEC_CHDR) Channel 8 Disable Position */
+#define AFEC_CHDR_CH8_Msk                   (_U_(0x1) << AFEC_CHDR_CH8_Pos)                /**< (AFEC_CHDR) Channel 8 Disable Mask */
+#define AFEC_CHDR_CH8                       AFEC_CHDR_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH8_Msk instead */
+#define AFEC_CHDR_CH9_Pos                   9                                              /**< (AFEC_CHDR) Channel 9 Disable Position */
+#define AFEC_CHDR_CH9_Msk                   (_U_(0x1) << AFEC_CHDR_CH9_Pos)                /**< (AFEC_CHDR) Channel 9 Disable Mask */
+#define AFEC_CHDR_CH9                       AFEC_CHDR_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH9_Msk instead */
+#define AFEC_CHDR_CH10_Pos                  10                                             /**< (AFEC_CHDR) Channel 10 Disable Position */
+#define AFEC_CHDR_CH10_Msk                  (_U_(0x1) << AFEC_CHDR_CH10_Pos)               /**< (AFEC_CHDR) Channel 10 Disable Mask */
+#define AFEC_CHDR_CH10                      AFEC_CHDR_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH10_Msk instead */
+#define AFEC_CHDR_CH11_Pos                  11                                             /**< (AFEC_CHDR) Channel 11 Disable Position */
+#define AFEC_CHDR_CH11_Msk                  (_U_(0x1) << AFEC_CHDR_CH11_Pos)               /**< (AFEC_CHDR) Channel 11 Disable Mask */
+#define AFEC_CHDR_CH11                      AFEC_CHDR_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH11_Msk instead */
+#define AFEC_CHDR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHDR) Register MASK  (Use AFEC_CHDR_Msk instead)  */
+#define AFEC_CHDR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHDR) Register Mask  */
+
+#define AFEC_CHDR_CH_Pos                    0                                              /**< (AFEC_CHDR Position) Channel xx Disable */
+#define AFEC_CHDR_CH_Msk                    (_U_(0xFFF) << AFEC_CHDR_CH_Pos)               /**< (AFEC_CHDR Mask) CH */
+#define AFEC_CHDR_CH(value)                 (AFEC_CHDR_CH_Msk & ((value) << AFEC_CHDR_CH_Pos))  
+
+/* -------- AFEC_CHSR : (AFEC Offset: 0x1c) (R/ 32) AFEC Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Status                         */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Status                         */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Status                         */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Status                         */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Status                         */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Status                         */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Status                         */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Status                         */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Status                         */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Status                        */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Status                        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Status                        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHSR_OFFSET                    (0x1C)                                        /**<  (AFEC_CHSR) AFEC Channel Status Register  Offset */
+
+#define AFEC_CHSR_CH0_Pos                   0                                              /**< (AFEC_CHSR) Channel 0 Status Position */
+#define AFEC_CHSR_CH0_Msk                   (_U_(0x1) << AFEC_CHSR_CH0_Pos)                /**< (AFEC_CHSR) Channel 0 Status Mask */
+#define AFEC_CHSR_CH0                       AFEC_CHSR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH0_Msk instead */
+#define AFEC_CHSR_CH1_Pos                   1                                              /**< (AFEC_CHSR) Channel 1 Status Position */
+#define AFEC_CHSR_CH1_Msk                   (_U_(0x1) << AFEC_CHSR_CH1_Pos)                /**< (AFEC_CHSR) Channel 1 Status Mask */
+#define AFEC_CHSR_CH1                       AFEC_CHSR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH1_Msk instead */
+#define AFEC_CHSR_CH2_Pos                   2                                              /**< (AFEC_CHSR) Channel 2 Status Position */
+#define AFEC_CHSR_CH2_Msk                   (_U_(0x1) << AFEC_CHSR_CH2_Pos)                /**< (AFEC_CHSR) Channel 2 Status Mask */
+#define AFEC_CHSR_CH2                       AFEC_CHSR_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH2_Msk instead */
+#define AFEC_CHSR_CH3_Pos                   3                                              /**< (AFEC_CHSR) Channel 3 Status Position */
+#define AFEC_CHSR_CH3_Msk                   (_U_(0x1) << AFEC_CHSR_CH3_Pos)                /**< (AFEC_CHSR) Channel 3 Status Mask */
+#define AFEC_CHSR_CH3                       AFEC_CHSR_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH3_Msk instead */
+#define AFEC_CHSR_CH4_Pos                   4                                              /**< (AFEC_CHSR) Channel 4 Status Position */
+#define AFEC_CHSR_CH4_Msk                   (_U_(0x1) << AFEC_CHSR_CH4_Pos)                /**< (AFEC_CHSR) Channel 4 Status Mask */
+#define AFEC_CHSR_CH4                       AFEC_CHSR_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH4_Msk instead */
+#define AFEC_CHSR_CH5_Pos                   5                                              /**< (AFEC_CHSR) Channel 5 Status Position */
+#define AFEC_CHSR_CH5_Msk                   (_U_(0x1) << AFEC_CHSR_CH5_Pos)                /**< (AFEC_CHSR) Channel 5 Status Mask */
+#define AFEC_CHSR_CH5                       AFEC_CHSR_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH5_Msk instead */
+#define AFEC_CHSR_CH6_Pos                   6                                              /**< (AFEC_CHSR) Channel 6 Status Position */
+#define AFEC_CHSR_CH6_Msk                   (_U_(0x1) << AFEC_CHSR_CH6_Pos)                /**< (AFEC_CHSR) Channel 6 Status Mask */
+#define AFEC_CHSR_CH6                       AFEC_CHSR_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH6_Msk instead */
+#define AFEC_CHSR_CH7_Pos                   7                                              /**< (AFEC_CHSR) Channel 7 Status Position */
+#define AFEC_CHSR_CH7_Msk                   (_U_(0x1) << AFEC_CHSR_CH7_Pos)                /**< (AFEC_CHSR) Channel 7 Status Mask */
+#define AFEC_CHSR_CH7                       AFEC_CHSR_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH7_Msk instead */
+#define AFEC_CHSR_CH8_Pos                   8                                              /**< (AFEC_CHSR) Channel 8 Status Position */
+#define AFEC_CHSR_CH8_Msk                   (_U_(0x1) << AFEC_CHSR_CH8_Pos)                /**< (AFEC_CHSR) Channel 8 Status Mask */
+#define AFEC_CHSR_CH8                       AFEC_CHSR_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH8_Msk instead */
+#define AFEC_CHSR_CH9_Pos                   9                                              /**< (AFEC_CHSR) Channel 9 Status Position */
+#define AFEC_CHSR_CH9_Msk                   (_U_(0x1) << AFEC_CHSR_CH9_Pos)                /**< (AFEC_CHSR) Channel 9 Status Mask */
+#define AFEC_CHSR_CH9                       AFEC_CHSR_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH9_Msk instead */
+#define AFEC_CHSR_CH10_Pos                  10                                             /**< (AFEC_CHSR) Channel 10 Status Position */
+#define AFEC_CHSR_CH10_Msk                  (_U_(0x1) << AFEC_CHSR_CH10_Pos)               /**< (AFEC_CHSR) Channel 10 Status Mask */
+#define AFEC_CHSR_CH10                      AFEC_CHSR_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH10_Msk instead */
+#define AFEC_CHSR_CH11_Pos                  11                                             /**< (AFEC_CHSR) Channel 11 Status Position */
+#define AFEC_CHSR_CH11_Msk                  (_U_(0x1) << AFEC_CHSR_CH11_Pos)               /**< (AFEC_CHSR) Channel 11 Status Mask */
+#define AFEC_CHSR_CH11                      AFEC_CHSR_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH11_Msk instead */
+#define AFEC_CHSR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHSR) Register MASK  (Use AFEC_CHSR_Msk instead)  */
+#define AFEC_CHSR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHSR) Register Mask  */
+
+#define AFEC_CHSR_CH_Pos                    0                                              /**< (AFEC_CHSR Position) Channel xx Status */
+#define AFEC_CHSR_CH_Msk                    (_U_(0xFFF) << AFEC_CHSR_CH_Pos)               /**< (AFEC_CHSR Mask) CH */
+#define AFEC_CHSR_CH(value)                 (AFEC_CHSR_CH_Msk & ((value) << AFEC_CHSR_CH_Pos))  
+
+/* -------- AFEC_LCDR : (AFEC Offset: 0x20) (R/ 32) AFEC Last Converted Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LDATA:16;                  /**< bit:  0..15  Last Data Converted                      */
+    uint32_t :8;                        /**< bit: 16..23  Reserved */
+    uint32_t CHNB:4;                    /**< bit: 24..27  Channel Number                           */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_LCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_LCDR_OFFSET                    (0x20)                                        /**<  (AFEC_LCDR) AFEC Last Converted Data Register  Offset */
+
+#define AFEC_LCDR_LDATA_Pos                 0                                              /**< (AFEC_LCDR) Last Data Converted Position */
+#define AFEC_LCDR_LDATA_Msk                 (_U_(0xFFFF) << AFEC_LCDR_LDATA_Pos)           /**< (AFEC_LCDR) Last Data Converted Mask */
+#define AFEC_LCDR_LDATA(value)              (AFEC_LCDR_LDATA_Msk & ((value) << AFEC_LCDR_LDATA_Pos))
+#define AFEC_LCDR_CHNB_Pos                  24                                             /**< (AFEC_LCDR) Channel Number Position */
+#define AFEC_LCDR_CHNB_Msk                  (_U_(0xF) << AFEC_LCDR_CHNB_Pos)               /**< (AFEC_LCDR) Channel Number Mask */
+#define AFEC_LCDR_CHNB(value)               (AFEC_LCDR_CHNB_Msk & ((value) << AFEC_LCDR_CHNB_Pos))
+#define AFEC_LCDR_MASK                      _U_(0xF00FFFF)                                 /**< \deprecated (AFEC_LCDR) Register MASK  (Use AFEC_LCDR_Msk instead)  */
+#define AFEC_LCDR_Msk                       _U_(0xF00FFFF)                                 /**< (AFEC_LCDR) Register Mask  */
+
+
+/* -------- AFEC_IER : (AFEC Offset: 0x24) (/W 32) AFEC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Enable 0     */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Enable 1     */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Enable 2     */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Enable 3     */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Enable 4     */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Enable 5     */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Enable 6     */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Enable 7     */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Enable 8     */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Enable 9     */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Enable 10    */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Enable 11    */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Enable              */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Enable   */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Enable        */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Enable      */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Enable x     */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IER_OFFSET                     (0x24)                                        /**<  (AFEC_IER) AFEC Interrupt Enable Register  Offset */
+
+#define AFEC_IER_EOC0_Pos                   0                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 0 Position */
+#define AFEC_IER_EOC0_Msk                   (_U_(0x1) << AFEC_IER_EOC0_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 0 Mask */
+#define AFEC_IER_EOC0                       AFEC_IER_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC0_Msk instead */
+#define AFEC_IER_EOC1_Pos                   1                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 1 Position */
+#define AFEC_IER_EOC1_Msk                   (_U_(0x1) << AFEC_IER_EOC1_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 1 Mask */
+#define AFEC_IER_EOC1                       AFEC_IER_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC1_Msk instead */
+#define AFEC_IER_EOC2_Pos                   2                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 2 Position */
+#define AFEC_IER_EOC2_Msk                   (_U_(0x1) << AFEC_IER_EOC2_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 2 Mask */
+#define AFEC_IER_EOC2                       AFEC_IER_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC2_Msk instead */
+#define AFEC_IER_EOC3_Pos                   3                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 3 Position */
+#define AFEC_IER_EOC3_Msk                   (_U_(0x1) << AFEC_IER_EOC3_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 3 Mask */
+#define AFEC_IER_EOC3                       AFEC_IER_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC3_Msk instead */
+#define AFEC_IER_EOC4_Pos                   4                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 4 Position */
+#define AFEC_IER_EOC4_Msk                   (_U_(0x1) << AFEC_IER_EOC4_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 4 Mask */
+#define AFEC_IER_EOC4                       AFEC_IER_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC4_Msk instead */
+#define AFEC_IER_EOC5_Pos                   5                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 5 Position */
+#define AFEC_IER_EOC5_Msk                   (_U_(0x1) << AFEC_IER_EOC5_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 5 Mask */
+#define AFEC_IER_EOC5                       AFEC_IER_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC5_Msk instead */
+#define AFEC_IER_EOC6_Pos                   6                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 6 Position */
+#define AFEC_IER_EOC6_Msk                   (_U_(0x1) << AFEC_IER_EOC6_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 6 Mask */
+#define AFEC_IER_EOC6                       AFEC_IER_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC6_Msk instead */
+#define AFEC_IER_EOC7_Pos                   7                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 7 Position */
+#define AFEC_IER_EOC7_Msk                   (_U_(0x1) << AFEC_IER_EOC7_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 7 Mask */
+#define AFEC_IER_EOC7                       AFEC_IER_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC7_Msk instead */
+#define AFEC_IER_EOC8_Pos                   8                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 8 Position */
+#define AFEC_IER_EOC8_Msk                   (_U_(0x1) << AFEC_IER_EOC8_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 8 Mask */
+#define AFEC_IER_EOC8                       AFEC_IER_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC8_Msk instead */
+#define AFEC_IER_EOC9_Pos                   9                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 9 Position */
+#define AFEC_IER_EOC9_Msk                   (_U_(0x1) << AFEC_IER_EOC9_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 9 Mask */
+#define AFEC_IER_EOC9                       AFEC_IER_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC9_Msk instead */
+#define AFEC_IER_EOC10_Pos                  10                                             /**< (AFEC_IER) End of Conversion Interrupt Enable 10 Position */
+#define AFEC_IER_EOC10_Msk                  (_U_(0x1) << AFEC_IER_EOC10_Pos)               /**< (AFEC_IER) End of Conversion Interrupt Enable 10 Mask */
+#define AFEC_IER_EOC10                      AFEC_IER_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC10_Msk instead */
+#define AFEC_IER_EOC11_Pos                  11                                             /**< (AFEC_IER) End of Conversion Interrupt Enable 11 Position */
+#define AFEC_IER_EOC11_Msk                  (_U_(0x1) << AFEC_IER_EOC11_Pos)               /**< (AFEC_IER) End of Conversion Interrupt Enable 11 Mask */
+#define AFEC_IER_EOC11                      AFEC_IER_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC11_Msk instead */
+#define AFEC_IER_DRDY_Pos                   24                                             /**< (AFEC_IER) Data Ready Interrupt Enable Position */
+#define AFEC_IER_DRDY_Msk                   (_U_(0x1) << AFEC_IER_DRDY_Pos)                /**< (AFEC_IER) Data Ready Interrupt Enable Mask */
+#define AFEC_IER_DRDY                       AFEC_IER_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_DRDY_Msk instead */
+#define AFEC_IER_GOVRE_Pos                  25                                             /**< (AFEC_IER) General Overrun Error Interrupt Enable Position */
+#define AFEC_IER_GOVRE_Msk                  (_U_(0x1) << AFEC_IER_GOVRE_Pos)               /**< (AFEC_IER) General Overrun Error Interrupt Enable Mask */
+#define AFEC_IER_GOVRE                      AFEC_IER_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_GOVRE_Msk instead */
+#define AFEC_IER_COMPE_Pos                  26                                             /**< (AFEC_IER) Comparison Event Interrupt Enable Position */
+#define AFEC_IER_COMPE_Msk                  (_U_(0x1) << AFEC_IER_COMPE_Pos)               /**< (AFEC_IER) Comparison Event Interrupt Enable Mask */
+#define AFEC_IER_COMPE                      AFEC_IER_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_COMPE_Msk instead */
+#define AFEC_IER_TEMPCHG_Pos                30                                             /**< (AFEC_IER) Temperature Change Interrupt Enable Position */
+#define AFEC_IER_TEMPCHG_Msk                (_U_(0x1) << AFEC_IER_TEMPCHG_Pos)             /**< (AFEC_IER) Temperature Change Interrupt Enable Mask */
+#define AFEC_IER_TEMPCHG                    AFEC_IER_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_TEMPCHG_Msk instead */
+#define AFEC_IER_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IER) Register MASK  (Use AFEC_IER_Msk instead)  */
+#define AFEC_IER_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IER) Register Mask  */
+
+#define AFEC_IER_EOC_Pos                    0                                              /**< (AFEC_IER Position) End of Conversion Interrupt Enable x */
+#define AFEC_IER_EOC_Msk                    (_U_(0xFFF) << AFEC_IER_EOC_Pos)               /**< (AFEC_IER Mask) EOC */
+#define AFEC_IER_EOC(value)                 (AFEC_IER_EOC_Msk & ((value) << AFEC_IER_EOC_Pos))  
+
+/* -------- AFEC_IDR : (AFEC Offset: 0x28) (/W 32) AFEC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Disable 0    */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Disable 1    */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Disable 2    */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Disable 3    */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Disable 4    */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Disable 5    */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Disable 6    */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Disable 7    */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Disable 8    */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Disable 9    */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Disable 10   */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Disable 11   */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Disable             */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Disable  */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Disable       */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Disable     */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Disable x    */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IDR_OFFSET                     (0x28)                                        /**<  (AFEC_IDR) AFEC Interrupt Disable Register  Offset */
+
+#define AFEC_IDR_EOC0_Pos                   0                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 0 Position */
+#define AFEC_IDR_EOC0_Msk                   (_U_(0x1) << AFEC_IDR_EOC0_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 0 Mask */
+#define AFEC_IDR_EOC0                       AFEC_IDR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC0_Msk instead */
+#define AFEC_IDR_EOC1_Pos                   1                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 1 Position */
+#define AFEC_IDR_EOC1_Msk                   (_U_(0x1) << AFEC_IDR_EOC1_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 1 Mask */
+#define AFEC_IDR_EOC1                       AFEC_IDR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC1_Msk instead */
+#define AFEC_IDR_EOC2_Pos                   2                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 2 Position */
+#define AFEC_IDR_EOC2_Msk                   (_U_(0x1) << AFEC_IDR_EOC2_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 2 Mask */
+#define AFEC_IDR_EOC2                       AFEC_IDR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC2_Msk instead */
+#define AFEC_IDR_EOC3_Pos                   3                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 3 Position */
+#define AFEC_IDR_EOC3_Msk                   (_U_(0x1) << AFEC_IDR_EOC3_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 3 Mask */
+#define AFEC_IDR_EOC3                       AFEC_IDR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC3_Msk instead */
+#define AFEC_IDR_EOC4_Pos                   4                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 4 Position */
+#define AFEC_IDR_EOC4_Msk                   (_U_(0x1) << AFEC_IDR_EOC4_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 4 Mask */
+#define AFEC_IDR_EOC4                       AFEC_IDR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC4_Msk instead */
+#define AFEC_IDR_EOC5_Pos                   5                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 5 Position */
+#define AFEC_IDR_EOC5_Msk                   (_U_(0x1) << AFEC_IDR_EOC5_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 5 Mask */
+#define AFEC_IDR_EOC5                       AFEC_IDR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC5_Msk instead */
+#define AFEC_IDR_EOC6_Pos                   6                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 6 Position */
+#define AFEC_IDR_EOC6_Msk                   (_U_(0x1) << AFEC_IDR_EOC6_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 6 Mask */
+#define AFEC_IDR_EOC6                       AFEC_IDR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC6_Msk instead */
+#define AFEC_IDR_EOC7_Pos                   7                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 7 Position */
+#define AFEC_IDR_EOC7_Msk                   (_U_(0x1) << AFEC_IDR_EOC7_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 7 Mask */
+#define AFEC_IDR_EOC7                       AFEC_IDR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC7_Msk instead */
+#define AFEC_IDR_EOC8_Pos                   8                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 8 Position */
+#define AFEC_IDR_EOC8_Msk                   (_U_(0x1) << AFEC_IDR_EOC8_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 8 Mask */
+#define AFEC_IDR_EOC8                       AFEC_IDR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC8_Msk instead */
+#define AFEC_IDR_EOC9_Pos                   9                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 9 Position */
+#define AFEC_IDR_EOC9_Msk                   (_U_(0x1) << AFEC_IDR_EOC9_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 9 Mask */
+#define AFEC_IDR_EOC9                       AFEC_IDR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC9_Msk instead */
+#define AFEC_IDR_EOC10_Pos                  10                                             /**< (AFEC_IDR) End of Conversion Interrupt Disable 10 Position */
+#define AFEC_IDR_EOC10_Msk                  (_U_(0x1) << AFEC_IDR_EOC10_Pos)               /**< (AFEC_IDR) End of Conversion Interrupt Disable 10 Mask */
+#define AFEC_IDR_EOC10                      AFEC_IDR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC10_Msk instead */
+#define AFEC_IDR_EOC11_Pos                  11                                             /**< (AFEC_IDR) End of Conversion Interrupt Disable 11 Position */
+#define AFEC_IDR_EOC11_Msk                  (_U_(0x1) << AFEC_IDR_EOC11_Pos)               /**< (AFEC_IDR) End of Conversion Interrupt Disable 11 Mask */
+#define AFEC_IDR_EOC11                      AFEC_IDR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC11_Msk instead */
+#define AFEC_IDR_DRDY_Pos                   24                                             /**< (AFEC_IDR) Data Ready Interrupt Disable Position */
+#define AFEC_IDR_DRDY_Msk                   (_U_(0x1) << AFEC_IDR_DRDY_Pos)                /**< (AFEC_IDR) Data Ready Interrupt Disable Mask */
+#define AFEC_IDR_DRDY                       AFEC_IDR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_DRDY_Msk instead */
+#define AFEC_IDR_GOVRE_Pos                  25                                             /**< (AFEC_IDR) General Overrun Error Interrupt Disable Position */
+#define AFEC_IDR_GOVRE_Msk                  (_U_(0x1) << AFEC_IDR_GOVRE_Pos)               /**< (AFEC_IDR) General Overrun Error Interrupt Disable Mask */
+#define AFEC_IDR_GOVRE                      AFEC_IDR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_GOVRE_Msk instead */
+#define AFEC_IDR_COMPE_Pos                  26                                             /**< (AFEC_IDR) Comparison Event Interrupt Disable Position */
+#define AFEC_IDR_COMPE_Msk                  (_U_(0x1) << AFEC_IDR_COMPE_Pos)               /**< (AFEC_IDR) Comparison Event Interrupt Disable Mask */
+#define AFEC_IDR_COMPE                      AFEC_IDR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_COMPE_Msk instead */
+#define AFEC_IDR_TEMPCHG_Pos                30                                             /**< (AFEC_IDR) Temperature Change Interrupt Disable Position */
+#define AFEC_IDR_TEMPCHG_Msk                (_U_(0x1) << AFEC_IDR_TEMPCHG_Pos)             /**< (AFEC_IDR) Temperature Change Interrupt Disable Mask */
+#define AFEC_IDR_TEMPCHG                    AFEC_IDR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_TEMPCHG_Msk instead */
+#define AFEC_IDR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IDR) Register MASK  (Use AFEC_IDR_Msk instead)  */
+#define AFEC_IDR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IDR) Register Mask  */
+
+#define AFEC_IDR_EOC_Pos                    0                                              /**< (AFEC_IDR Position) End of Conversion Interrupt Disable x */
+#define AFEC_IDR_EOC_Msk                    (_U_(0xFFF) << AFEC_IDR_EOC_Pos)               /**< (AFEC_IDR Mask) EOC */
+#define AFEC_IDR_EOC(value)                 (AFEC_IDR_EOC_Msk & ((value) << AFEC_IDR_EOC_Pos))  
+
+/* -------- AFEC_IMR : (AFEC Offset: 0x2c) (R/ 32) AFEC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Mask 0       */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Mask 1       */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Mask 2       */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Mask 3       */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Mask 4       */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Mask 5       */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Mask 6       */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Mask 7       */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Mask 8       */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Mask 9       */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Mask 10      */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Mask 11      */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Mask                */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Mask     */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Mask          */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Mask        */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Mask x       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IMR_OFFSET                     (0x2C)                                        /**<  (AFEC_IMR) AFEC Interrupt Mask Register  Offset */
+
+#define AFEC_IMR_EOC0_Pos                   0                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 0 Position */
+#define AFEC_IMR_EOC0_Msk                   (_U_(0x1) << AFEC_IMR_EOC0_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 0 Mask */
+#define AFEC_IMR_EOC0                       AFEC_IMR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC0_Msk instead */
+#define AFEC_IMR_EOC1_Pos                   1                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 1 Position */
+#define AFEC_IMR_EOC1_Msk                   (_U_(0x1) << AFEC_IMR_EOC1_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 1 Mask */
+#define AFEC_IMR_EOC1                       AFEC_IMR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC1_Msk instead */
+#define AFEC_IMR_EOC2_Pos                   2                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 2 Position */
+#define AFEC_IMR_EOC2_Msk                   (_U_(0x1) << AFEC_IMR_EOC2_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 2 Mask */
+#define AFEC_IMR_EOC2                       AFEC_IMR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC2_Msk instead */
+#define AFEC_IMR_EOC3_Pos                   3                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 3 Position */
+#define AFEC_IMR_EOC3_Msk                   (_U_(0x1) << AFEC_IMR_EOC3_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 3 Mask */
+#define AFEC_IMR_EOC3                       AFEC_IMR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC3_Msk instead */
+#define AFEC_IMR_EOC4_Pos                   4                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 4 Position */
+#define AFEC_IMR_EOC4_Msk                   (_U_(0x1) << AFEC_IMR_EOC4_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 4 Mask */
+#define AFEC_IMR_EOC4                       AFEC_IMR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC4_Msk instead */
+#define AFEC_IMR_EOC5_Pos                   5                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 5 Position */
+#define AFEC_IMR_EOC5_Msk                   (_U_(0x1) << AFEC_IMR_EOC5_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 5 Mask */
+#define AFEC_IMR_EOC5                       AFEC_IMR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC5_Msk instead */
+#define AFEC_IMR_EOC6_Pos                   6                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 6 Position */
+#define AFEC_IMR_EOC6_Msk                   (_U_(0x1) << AFEC_IMR_EOC6_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 6 Mask */
+#define AFEC_IMR_EOC6                       AFEC_IMR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC6_Msk instead */
+#define AFEC_IMR_EOC7_Pos                   7                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 7 Position */
+#define AFEC_IMR_EOC7_Msk                   (_U_(0x1) << AFEC_IMR_EOC7_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 7 Mask */
+#define AFEC_IMR_EOC7                       AFEC_IMR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC7_Msk instead */
+#define AFEC_IMR_EOC8_Pos                   8                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 8 Position */
+#define AFEC_IMR_EOC8_Msk                   (_U_(0x1) << AFEC_IMR_EOC8_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 8 Mask */
+#define AFEC_IMR_EOC8                       AFEC_IMR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC8_Msk instead */
+#define AFEC_IMR_EOC9_Pos                   9                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 9 Position */
+#define AFEC_IMR_EOC9_Msk                   (_U_(0x1) << AFEC_IMR_EOC9_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 9 Mask */
+#define AFEC_IMR_EOC9                       AFEC_IMR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC9_Msk instead */
+#define AFEC_IMR_EOC10_Pos                  10                                             /**< (AFEC_IMR) End of Conversion Interrupt Mask 10 Position */
+#define AFEC_IMR_EOC10_Msk                  (_U_(0x1) << AFEC_IMR_EOC10_Pos)               /**< (AFEC_IMR) End of Conversion Interrupt Mask 10 Mask */
+#define AFEC_IMR_EOC10                      AFEC_IMR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC10_Msk instead */
+#define AFEC_IMR_EOC11_Pos                  11                                             /**< (AFEC_IMR) End of Conversion Interrupt Mask 11 Position */
+#define AFEC_IMR_EOC11_Msk                  (_U_(0x1) << AFEC_IMR_EOC11_Pos)               /**< (AFEC_IMR) End of Conversion Interrupt Mask 11 Mask */
+#define AFEC_IMR_EOC11                      AFEC_IMR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC11_Msk instead */
+#define AFEC_IMR_DRDY_Pos                   24                                             /**< (AFEC_IMR) Data Ready Interrupt Mask Position */
+#define AFEC_IMR_DRDY_Msk                   (_U_(0x1) << AFEC_IMR_DRDY_Pos)                /**< (AFEC_IMR) Data Ready Interrupt Mask Mask */
+#define AFEC_IMR_DRDY                       AFEC_IMR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_DRDY_Msk instead */
+#define AFEC_IMR_GOVRE_Pos                  25                                             /**< (AFEC_IMR) General Overrun Error Interrupt Mask Position */
+#define AFEC_IMR_GOVRE_Msk                  (_U_(0x1) << AFEC_IMR_GOVRE_Pos)               /**< (AFEC_IMR) General Overrun Error Interrupt Mask Mask */
+#define AFEC_IMR_GOVRE                      AFEC_IMR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_GOVRE_Msk instead */
+#define AFEC_IMR_COMPE_Pos                  26                                             /**< (AFEC_IMR) Comparison Event Interrupt Mask Position */
+#define AFEC_IMR_COMPE_Msk                  (_U_(0x1) << AFEC_IMR_COMPE_Pos)               /**< (AFEC_IMR) Comparison Event Interrupt Mask Mask */
+#define AFEC_IMR_COMPE                      AFEC_IMR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_COMPE_Msk instead */
+#define AFEC_IMR_TEMPCHG_Pos                30                                             /**< (AFEC_IMR) Temperature Change Interrupt Mask Position */
+#define AFEC_IMR_TEMPCHG_Msk                (_U_(0x1) << AFEC_IMR_TEMPCHG_Pos)             /**< (AFEC_IMR) Temperature Change Interrupt Mask Mask */
+#define AFEC_IMR_TEMPCHG                    AFEC_IMR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_TEMPCHG_Msk instead */
+#define AFEC_IMR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IMR) Register MASK  (Use AFEC_IMR_Msk instead)  */
+#define AFEC_IMR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IMR) Register Mask  */
+
+#define AFEC_IMR_EOC_Pos                    0                                              /**< (AFEC_IMR Position) End of Conversion Interrupt Mask x */
+#define AFEC_IMR_EOC_Msk                    (_U_(0xFFF) << AFEC_IMR_EOC_Pos)               /**< (AFEC_IMR Mask) EOC */
+#define AFEC_IMR_EOC(value)                 (AFEC_IMR_EOC_Msk & ((value) << AFEC_IMR_EOC_Pos))  
+
+/* -------- AFEC_ISR : (AFEC Offset: 0x30) (R/ 32) AFEC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion 0 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion 1 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion 2 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion 3 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion 4 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion 5 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion 6 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion 7 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion 8 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion 9 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion 10 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion 11 (cleared by reading AFEC_CDRx) */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready (cleared by reading AFEC_LCDR) */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error (cleared by reading AFEC_ISR) */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Error (cleared by reading AFEC_ISR) */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change (cleared on read)     */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion x (cleared by reading AFEC_CDRx) */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_ISR_OFFSET                     (0x30)                                        /**<  (AFEC_ISR) AFEC Interrupt Status Register  Offset */
+
+#define AFEC_ISR_EOC0_Pos                   0                                              /**< (AFEC_ISR) End of Conversion 0 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC0_Msk                   (_U_(0x1) << AFEC_ISR_EOC0_Pos)                /**< (AFEC_ISR) End of Conversion 0 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC0                       AFEC_ISR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC0_Msk instead */
+#define AFEC_ISR_EOC1_Pos                   1                                              /**< (AFEC_ISR) End of Conversion 1 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC1_Msk                   (_U_(0x1) << AFEC_ISR_EOC1_Pos)                /**< (AFEC_ISR) End of Conversion 1 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC1                       AFEC_ISR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC1_Msk instead */
+#define AFEC_ISR_EOC2_Pos                   2                                              /**< (AFEC_ISR) End of Conversion 2 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC2_Msk                   (_U_(0x1) << AFEC_ISR_EOC2_Pos)                /**< (AFEC_ISR) End of Conversion 2 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC2                       AFEC_ISR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC2_Msk instead */
+#define AFEC_ISR_EOC3_Pos                   3                                              /**< (AFEC_ISR) End of Conversion 3 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC3_Msk                   (_U_(0x1) << AFEC_ISR_EOC3_Pos)                /**< (AFEC_ISR) End of Conversion 3 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC3                       AFEC_ISR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC3_Msk instead */
+#define AFEC_ISR_EOC4_Pos                   4                                              /**< (AFEC_ISR) End of Conversion 4 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC4_Msk                   (_U_(0x1) << AFEC_ISR_EOC4_Pos)                /**< (AFEC_ISR) End of Conversion 4 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC4                       AFEC_ISR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC4_Msk instead */
+#define AFEC_ISR_EOC5_Pos                   5                                              /**< (AFEC_ISR) End of Conversion 5 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC5_Msk                   (_U_(0x1) << AFEC_ISR_EOC5_Pos)                /**< (AFEC_ISR) End of Conversion 5 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC5                       AFEC_ISR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC5_Msk instead */
+#define AFEC_ISR_EOC6_Pos                   6                                              /**< (AFEC_ISR) End of Conversion 6 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC6_Msk                   (_U_(0x1) << AFEC_ISR_EOC6_Pos)                /**< (AFEC_ISR) End of Conversion 6 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC6                       AFEC_ISR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC6_Msk instead */
+#define AFEC_ISR_EOC7_Pos                   7                                              /**< (AFEC_ISR) End of Conversion 7 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC7_Msk                   (_U_(0x1) << AFEC_ISR_EOC7_Pos)                /**< (AFEC_ISR) End of Conversion 7 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC7                       AFEC_ISR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC7_Msk instead */
+#define AFEC_ISR_EOC8_Pos                   8                                              /**< (AFEC_ISR) End of Conversion 8 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC8_Msk                   (_U_(0x1) << AFEC_ISR_EOC8_Pos)                /**< (AFEC_ISR) End of Conversion 8 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC8                       AFEC_ISR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC8_Msk instead */
+#define AFEC_ISR_EOC9_Pos                   9                                              /**< (AFEC_ISR) End of Conversion 9 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC9_Msk                   (_U_(0x1) << AFEC_ISR_EOC9_Pos)                /**< (AFEC_ISR) End of Conversion 9 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC9                       AFEC_ISR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC9_Msk instead */
+#define AFEC_ISR_EOC10_Pos                  10                                             /**< (AFEC_ISR) End of Conversion 10 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC10_Msk                  (_U_(0x1) << AFEC_ISR_EOC10_Pos)               /**< (AFEC_ISR) End of Conversion 10 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC10                      AFEC_ISR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC10_Msk instead */
+#define AFEC_ISR_EOC11_Pos                  11                                             /**< (AFEC_ISR) End of Conversion 11 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC11_Msk                  (_U_(0x1) << AFEC_ISR_EOC11_Pos)               /**< (AFEC_ISR) End of Conversion 11 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC11                      AFEC_ISR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC11_Msk instead */
+#define AFEC_ISR_DRDY_Pos                   24                                             /**< (AFEC_ISR) Data Ready (cleared by reading AFEC_LCDR) Position */
+#define AFEC_ISR_DRDY_Msk                   (_U_(0x1) << AFEC_ISR_DRDY_Pos)                /**< (AFEC_ISR) Data Ready (cleared by reading AFEC_LCDR) Mask */
+#define AFEC_ISR_DRDY                       AFEC_ISR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_DRDY_Msk instead */
+#define AFEC_ISR_GOVRE_Pos                  25                                             /**< (AFEC_ISR) General Overrun Error (cleared by reading AFEC_ISR) Position */
+#define AFEC_ISR_GOVRE_Msk                  (_U_(0x1) << AFEC_ISR_GOVRE_Pos)               /**< (AFEC_ISR) General Overrun Error (cleared by reading AFEC_ISR) Mask */
+#define AFEC_ISR_GOVRE                      AFEC_ISR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_GOVRE_Msk instead */
+#define AFEC_ISR_COMPE_Pos                  26                                             /**< (AFEC_ISR) Comparison Error (cleared by reading AFEC_ISR) Position */
+#define AFEC_ISR_COMPE_Msk                  (_U_(0x1) << AFEC_ISR_COMPE_Pos)               /**< (AFEC_ISR) Comparison Error (cleared by reading AFEC_ISR) Mask */
+#define AFEC_ISR_COMPE                      AFEC_ISR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_COMPE_Msk instead */
+#define AFEC_ISR_TEMPCHG_Pos                30                                             /**< (AFEC_ISR) Temperature Change (cleared on read) Position */
+#define AFEC_ISR_TEMPCHG_Msk                (_U_(0x1) << AFEC_ISR_TEMPCHG_Pos)             /**< (AFEC_ISR) Temperature Change (cleared on read) Mask */
+#define AFEC_ISR_TEMPCHG                    AFEC_ISR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_TEMPCHG_Msk instead */
+#define AFEC_ISR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_ISR) Register MASK  (Use AFEC_ISR_Msk instead)  */
+#define AFEC_ISR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_ISR) Register Mask  */
+
+#define AFEC_ISR_EOC_Pos                    0                                              /**< (AFEC_ISR Position) End of Conversion x (cleared by reading AFEC_CDRx) */
+#define AFEC_ISR_EOC_Msk                    (_U_(0xFFF) << AFEC_ISR_EOC_Pos)               /**< (AFEC_ISR Mask) EOC */
+#define AFEC_ISR_EOC(value)                 (AFEC_ISR_EOC_Msk & ((value) << AFEC_ISR_EOC_Pos))  
+
+/* -------- AFEC_OVER : (AFEC Offset: 0x4c) (R/ 32) AFEC Overrun Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OVRE0:1;                   /**< bit:      0  Overrun Error 0                          */
+    uint32_t OVRE1:1;                   /**< bit:      1  Overrun Error 1                          */
+    uint32_t OVRE2:1;                   /**< bit:      2  Overrun Error 2                          */
+    uint32_t OVRE3:1;                   /**< bit:      3  Overrun Error 3                          */
+    uint32_t OVRE4:1;                   /**< bit:      4  Overrun Error 4                          */
+    uint32_t OVRE5:1;                   /**< bit:      5  Overrun Error 5                          */
+    uint32_t OVRE6:1;                   /**< bit:      6  Overrun Error 6                          */
+    uint32_t OVRE7:1;                   /**< bit:      7  Overrun Error 7                          */
+    uint32_t OVRE8:1;                   /**< bit:      8  Overrun Error 8                          */
+    uint32_t OVRE9:1;                   /**< bit:      9  Overrun Error 9                          */
+    uint32_t OVRE10:1;                  /**< bit:     10  Overrun Error 10                         */
+    uint32_t OVRE11:1;                  /**< bit:     11  Overrun Error 11                         */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OVRE:12;                   /**< bit:  0..11  Overrun Error xx                         */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_OVER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_OVER_OFFSET                    (0x4C)                                        /**<  (AFEC_OVER) AFEC Overrun Status Register  Offset */
+
+#define AFEC_OVER_OVRE0_Pos                 0                                              /**< (AFEC_OVER) Overrun Error 0 Position */
+#define AFEC_OVER_OVRE0_Msk                 (_U_(0x1) << AFEC_OVER_OVRE0_Pos)              /**< (AFEC_OVER) Overrun Error 0 Mask */
+#define AFEC_OVER_OVRE0                     AFEC_OVER_OVRE0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE0_Msk instead */
+#define AFEC_OVER_OVRE1_Pos                 1                                              /**< (AFEC_OVER) Overrun Error 1 Position */
+#define AFEC_OVER_OVRE1_Msk                 (_U_(0x1) << AFEC_OVER_OVRE1_Pos)              /**< (AFEC_OVER) Overrun Error 1 Mask */
+#define AFEC_OVER_OVRE1                     AFEC_OVER_OVRE1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE1_Msk instead */
+#define AFEC_OVER_OVRE2_Pos                 2                                              /**< (AFEC_OVER) Overrun Error 2 Position */
+#define AFEC_OVER_OVRE2_Msk                 (_U_(0x1) << AFEC_OVER_OVRE2_Pos)              /**< (AFEC_OVER) Overrun Error 2 Mask */
+#define AFEC_OVER_OVRE2                     AFEC_OVER_OVRE2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE2_Msk instead */
+#define AFEC_OVER_OVRE3_Pos                 3                                              /**< (AFEC_OVER) Overrun Error 3 Position */
+#define AFEC_OVER_OVRE3_Msk                 (_U_(0x1) << AFEC_OVER_OVRE3_Pos)              /**< (AFEC_OVER) Overrun Error 3 Mask */
+#define AFEC_OVER_OVRE3                     AFEC_OVER_OVRE3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE3_Msk instead */
+#define AFEC_OVER_OVRE4_Pos                 4                                              /**< (AFEC_OVER) Overrun Error 4 Position */
+#define AFEC_OVER_OVRE4_Msk                 (_U_(0x1) << AFEC_OVER_OVRE4_Pos)              /**< (AFEC_OVER) Overrun Error 4 Mask */
+#define AFEC_OVER_OVRE4                     AFEC_OVER_OVRE4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE4_Msk instead */
+#define AFEC_OVER_OVRE5_Pos                 5                                              /**< (AFEC_OVER) Overrun Error 5 Position */
+#define AFEC_OVER_OVRE5_Msk                 (_U_(0x1) << AFEC_OVER_OVRE5_Pos)              /**< (AFEC_OVER) Overrun Error 5 Mask */
+#define AFEC_OVER_OVRE5                     AFEC_OVER_OVRE5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE5_Msk instead */
+#define AFEC_OVER_OVRE6_Pos                 6                                              /**< (AFEC_OVER) Overrun Error 6 Position */
+#define AFEC_OVER_OVRE6_Msk                 (_U_(0x1) << AFEC_OVER_OVRE6_Pos)              /**< (AFEC_OVER) Overrun Error 6 Mask */
+#define AFEC_OVER_OVRE6                     AFEC_OVER_OVRE6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE6_Msk instead */
+#define AFEC_OVER_OVRE7_Pos                 7                                              /**< (AFEC_OVER) Overrun Error 7 Position */
+#define AFEC_OVER_OVRE7_Msk                 (_U_(0x1) << AFEC_OVER_OVRE7_Pos)              /**< (AFEC_OVER) Overrun Error 7 Mask */
+#define AFEC_OVER_OVRE7                     AFEC_OVER_OVRE7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE7_Msk instead */
+#define AFEC_OVER_OVRE8_Pos                 8                                              /**< (AFEC_OVER) Overrun Error 8 Position */
+#define AFEC_OVER_OVRE8_Msk                 (_U_(0x1) << AFEC_OVER_OVRE8_Pos)              /**< (AFEC_OVER) Overrun Error 8 Mask */
+#define AFEC_OVER_OVRE8                     AFEC_OVER_OVRE8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE8_Msk instead */
+#define AFEC_OVER_OVRE9_Pos                 9                                              /**< (AFEC_OVER) Overrun Error 9 Position */
+#define AFEC_OVER_OVRE9_Msk                 (_U_(0x1) << AFEC_OVER_OVRE9_Pos)              /**< (AFEC_OVER) Overrun Error 9 Mask */
+#define AFEC_OVER_OVRE9                     AFEC_OVER_OVRE9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE9_Msk instead */
+#define AFEC_OVER_OVRE10_Pos                10                                             /**< (AFEC_OVER) Overrun Error 10 Position */
+#define AFEC_OVER_OVRE10_Msk                (_U_(0x1) << AFEC_OVER_OVRE10_Pos)             /**< (AFEC_OVER) Overrun Error 10 Mask */
+#define AFEC_OVER_OVRE10                    AFEC_OVER_OVRE10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE10_Msk instead */
+#define AFEC_OVER_OVRE11_Pos                11                                             /**< (AFEC_OVER) Overrun Error 11 Position */
+#define AFEC_OVER_OVRE11_Msk                (_U_(0x1) << AFEC_OVER_OVRE11_Pos)             /**< (AFEC_OVER) Overrun Error 11 Mask */
+#define AFEC_OVER_OVRE11                    AFEC_OVER_OVRE11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE11_Msk instead */
+#define AFEC_OVER_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_OVER) Register MASK  (Use AFEC_OVER_Msk instead)  */
+#define AFEC_OVER_Msk                       _U_(0xFFF)                                     /**< (AFEC_OVER) Register Mask  */
+
+#define AFEC_OVER_OVRE_Pos                  0                                              /**< (AFEC_OVER Position) Overrun Error xx */
+#define AFEC_OVER_OVRE_Msk                  (_U_(0xFFF) << AFEC_OVER_OVRE_Pos)             /**< (AFEC_OVER Mask) OVRE */
+#define AFEC_OVER_OVRE(value)               (AFEC_OVER_OVRE_Msk & ((value) << AFEC_OVER_OVRE_Pos))  
+
+/* -------- AFEC_CWR : (AFEC Offset: 0x50) (R/W 32) AFEC Compare Window Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LOWTHRES:16;               /**< bit:  0..15  Low Threshold                            */
+    uint32_t HIGHTHRES:16;              /**< bit: 16..31  High Threshold                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CWR_OFFSET                     (0x50)                                        /**<  (AFEC_CWR) AFEC Compare Window Register  Offset */
+
+#define AFEC_CWR_LOWTHRES_Pos               0                                              /**< (AFEC_CWR) Low Threshold Position */
+#define AFEC_CWR_LOWTHRES_Msk               (_U_(0xFFFF) << AFEC_CWR_LOWTHRES_Pos)         /**< (AFEC_CWR) Low Threshold Mask */
+#define AFEC_CWR_LOWTHRES(value)            (AFEC_CWR_LOWTHRES_Msk & ((value) << AFEC_CWR_LOWTHRES_Pos))
+#define AFEC_CWR_HIGHTHRES_Pos              16                                             /**< (AFEC_CWR) High Threshold Position */
+#define AFEC_CWR_HIGHTHRES_Msk              (_U_(0xFFFF) << AFEC_CWR_HIGHTHRES_Pos)        /**< (AFEC_CWR) High Threshold Mask */
+#define AFEC_CWR_HIGHTHRES(value)           (AFEC_CWR_HIGHTHRES_Msk & ((value) << AFEC_CWR_HIGHTHRES_Pos))
+#define AFEC_CWR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_CWR) Register MASK  (Use AFEC_CWR_Msk instead)  */
+#define AFEC_CWR_Msk                        _U_(0xFFFFFFFF)                                /**< (AFEC_CWR) Register Mask  */
+
+
+/* -------- AFEC_CGR : (AFEC Offset: 0x54) (R/W 32) AFEC Channel Gain Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GAIN0:2;                   /**< bit:   0..1  Gain for Channel 0                       */
+    uint32_t GAIN1:2;                   /**< bit:   2..3  Gain for Channel 1                       */
+    uint32_t GAIN2:2;                   /**< bit:   4..5  Gain for Channel 2                       */
+    uint32_t GAIN3:2;                   /**< bit:   6..7  Gain for Channel 3                       */
+    uint32_t GAIN4:2;                   /**< bit:   8..9  Gain for Channel 4                       */
+    uint32_t GAIN5:2;                   /**< bit: 10..11  Gain for Channel 5                       */
+    uint32_t GAIN6:2;                   /**< bit: 12..13  Gain for Channel 6                       */
+    uint32_t GAIN7:2;                   /**< bit: 14..15  Gain for Channel 7                       */
+    uint32_t GAIN8:2;                   /**< bit: 16..17  Gain for Channel 8                       */
+    uint32_t GAIN9:2;                   /**< bit: 18..19  Gain for Channel 9                       */
+    uint32_t GAIN10:2;                  /**< bit: 20..21  Gain for Channel 10                      */
+    uint32_t GAIN11:2;                  /**< bit: 22..23  Gain for Channel 11                      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CGR_OFFSET                     (0x54)                                        /**<  (AFEC_CGR) AFEC Channel Gain Register  Offset */
+
+#define AFEC_CGR_GAIN0_Pos                  0                                              /**< (AFEC_CGR) Gain for Channel 0 Position */
+#define AFEC_CGR_GAIN0_Msk                  (_U_(0x3) << AFEC_CGR_GAIN0_Pos)               /**< (AFEC_CGR) Gain for Channel 0 Mask */
+#define AFEC_CGR_GAIN0(value)               (AFEC_CGR_GAIN0_Msk & ((value) << AFEC_CGR_GAIN0_Pos))
+#define AFEC_CGR_GAIN1_Pos                  2                                              /**< (AFEC_CGR) Gain for Channel 1 Position */
+#define AFEC_CGR_GAIN1_Msk                  (_U_(0x3) << AFEC_CGR_GAIN1_Pos)               /**< (AFEC_CGR) Gain for Channel 1 Mask */
+#define AFEC_CGR_GAIN1(value)               (AFEC_CGR_GAIN1_Msk & ((value) << AFEC_CGR_GAIN1_Pos))
+#define AFEC_CGR_GAIN2_Pos                  4                                              /**< (AFEC_CGR) Gain for Channel 2 Position */
+#define AFEC_CGR_GAIN2_Msk                  (_U_(0x3) << AFEC_CGR_GAIN2_Pos)               /**< (AFEC_CGR) Gain for Channel 2 Mask */
+#define AFEC_CGR_GAIN2(value)               (AFEC_CGR_GAIN2_Msk & ((value) << AFEC_CGR_GAIN2_Pos))
+#define AFEC_CGR_GAIN3_Pos                  6                                              /**< (AFEC_CGR) Gain for Channel 3 Position */
+#define AFEC_CGR_GAIN3_Msk                  (_U_(0x3) << AFEC_CGR_GAIN3_Pos)               /**< (AFEC_CGR) Gain for Channel 3 Mask */
+#define AFEC_CGR_GAIN3(value)               (AFEC_CGR_GAIN3_Msk & ((value) << AFEC_CGR_GAIN3_Pos))
+#define AFEC_CGR_GAIN4_Pos                  8                                              /**< (AFEC_CGR) Gain for Channel 4 Position */
+#define AFEC_CGR_GAIN4_Msk                  (_U_(0x3) << AFEC_CGR_GAIN4_Pos)               /**< (AFEC_CGR) Gain for Channel 4 Mask */
+#define AFEC_CGR_GAIN4(value)               (AFEC_CGR_GAIN4_Msk & ((value) << AFEC_CGR_GAIN4_Pos))
+#define AFEC_CGR_GAIN5_Pos                  10                                             /**< (AFEC_CGR) Gain for Channel 5 Position */
+#define AFEC_CGR_GAIN5_Msk                  (_U_(0x3) << AFEC_CGR_GAIN5_Pos)               /**< (AFEC_CGR) Gain for Channel 5 Mask */
+#define AFEC_CGR_GAIN5(value)               (AFEC_CGR_GAIN5_Msk & ((value) << AFEC_CGR_GAIN5_Pos))
+#define AFEC_CGR_GAIN6_Pos                  12                                             /**< (AFEC_CGR) Gain for Channel 6 Position */
+#define AFEC_CGR_GAIN6_Msk                  (_U_(0x3) << AFEC_CGR_GAIN6_Pos)               /**< (AFEC_CGR) Gain for Channel 6 Mask */
+#define AFEC_CGR_GAIN6(value)               (AFEC_CGR_GAIN6_Msk & ((value) << AFEC_CGR_GAIN6_Pos))
+#define AFEC_CGR_GAIN7_Pos                  14                                             /**< (AFEC_CGR) Gain for Channel 7 Position */
+#define AFEC_CGR_GAIN7_Msk                  (_U_(0x3) << AFEC_CGR_GAIN7_Pos)               /**< (AFEC_CGR) Gain for Channel 7 Mask */
+#define AFEC_CGR_GAIN7(value)               (AFEC_CGR_GAIN7_Msk & ((value) << AFEC_CGR_GAIN7_Pos))
+#define AFEC_CGR_GAIN8_Pos                  16                                             /**< (AFEC_CGR) Gain for Channel 8 Position */
+#define AFEC_CGR_GAIN8_Msk                  (_U_(0x3) << AFEC_CGR_GAIN8_Pos)               /**< (AFEC_CGR) Gain for Channel 8 Mask */
+#define AFEC_CGR_GAIN8(value)               (AFEC_CGR_GAIN8_Msk & ((value) << AFEC_CGR_GAIN8_Pos))
+#define AFEC_CGR_GAIN9_Pos                  18                                             /**< (AFEC_CGR) Gain for Channel 9 Position */
+#define AFEC_CGR_GAIN9_Msk                  (_U_(0x3) << AFEC_CGR_GAIN9_Pos)               /**< (AFEC_CGR) Gain for Channel 9 Mask */
+#define AFEC_CGR_GAIN9(value)               (AFEC_CGR_GAIN9_Msk & ((value) << AFEC_CGR_GAIN9_Pos))
+#define AFEC_CGR_GAIN10_Pos                 20                                             /**< (AFEC_CGR) Gain for Channel 10 Position */
+#define AFEC_CGR_GAIN10_Msk                 (_U_(0x3) << AFEC_CGR_GAIN10_Pos)              /**< (AFEC_CGR) Gain for Channel 10 Mask */
+#define AFEC_CGR_GAIN10(value)              (AFEC_CGR_GAIN10_Msk & ((value) << AFEC_CGR_GAIN10_Pos))
+#define AFEC_CGR_GAIN11_Pos                 22                                             /**< (AFEC_CGR) Gain for Channel 11 Position */
+#define AFEC_CGR_GAIN11_Msk                 (_U_(0x3) << AFEC_CGR_GAIN11_Pos)              /**< (AFEC_CGR) Gain for Channel 11 Mask */
+#define AFEC_CGR_GAIN11(value)              (AFEC_CGR_GAIN11_Msk & ((value) << AFEC_CGR_GAIN11_Pos))
+#define AFEC_CGR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (AFEC_CGR) Register MASK  (Use AFEC_CGR_Msk instead)  */
+#define AFEC_CGR_Msk                        _U_(0xFFFFFF)                                  /**< (AFEC_CGR) Register Mask  */
+
+
+/* -------- AFEC_DIFFR : (AFEC Offset: 0x60) (R/W 32) AFEC Channel Differential Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIFF0:1;                   /**< bit:      0  Differential inputs for channel 0        */
+    uint32_t DIFF1:1;                   /**< bit:      1  Differential inputs for channel 1        */
+    uint32_t DIFF2:1;                   /**< bit:      2  Differential inputs for channel 2        */
+    uint32_t DIFF3:1;                   /**< bit:      3  Differential inputs for channel 3        */
+    uint32_t DIFF4:1;                   /**< bit:      4  Differential inputs for channel 4        */
+    uint32_t DIFF5:1;                   /**< bit:      5  Differential inputs for channel 5        */
+    uint32_t DIFF6:1;                   /**< bit:      6  Differential inputs for channel 6        */
+    uint32_t DIFF7:1;                   /**< bit:      7  Differential inputs for channel 7        */
+    uint32_t DIFF8:1;                   /**< bit:      8  Differential inputs for channel 8        */
+    uint32_t DIFF9:1;                   /**< bit:      9  Differential inputs for channel 9        */
+    uint32_t DIFF10:1;                  /**< bit:     10  Differential inputs for channel 10       */
+    uint32_t DIFF11:1;                  /**< bit:     11  Differential inputs for channel 11       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DIFF:12;                   /**< bit:  0..11  Differential inputs for channel xx       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_DIFFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_DIFFR_OFFSET                   (0x60)                                        /**<  (AFEC_DIFFR) AFEC Channel Differential Register  Offset */
+
+#define AFEC_DIFFR_DIFF0_Pos                0                                              /**< (AFEC_DIFFR) Differential inputs for channel 0 Position */
+#define AFEC_DIFFR_DIFF0_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF0_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 0 Mask */
+#define AFEC_DIFFR_DIFF0                    AFEC_DIFFR_DIFF0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF0_Msk instead */
+#define AFEC_DIFFR_DIFF1_Pos                1                                              /**< (AFEC_DIFFR) Differential inputs for channel 1 Position */
+#define AFEC_DIFFR_DIFF1_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF1_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 1 Mask */
+#define AFEC_DIFFR_DIFF1                    AFEC_DIFFR_DIFF1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF1_Msk instead */
+#define AFEC_DIFFR_DIFF2_Pos                2                                              /**< (AFEC_DIFFR) Differential inputs for channel 2 Position */
+#define AFEC_DIFFR_DIFF2_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF2_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 2 Mask */
+#define AFEC_DIFFR_DIFF2                    AFEC_DIFFR_DIFF2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF2_Msk instead */
+#define AFEC_DIFFR_DIFF3_Pos                3                                              /**< (AFEC_DIFFR) Differential inputs for channel 3 Position */
+#define AFEC_DIFFR_DIFF3_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF3_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 3 Mask */
+#define AFEC_DIFFR_DIFF3                    AFEC_DIFFR_DIFF3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF3_Msk instead */
+#define AFEC_DIFFR_DIFF4_Pos                4                                              /**< (AFEC_DIFFR) Differential inputs for channel 4 Position */
+#define AFEC_DIFFR_DIFF4_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF4_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 4 Mask */
+#define AFEC_DIFFR_DIFF4                    AFEC_DIFFR_DIFF4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF4_Msk instead */
+#define AFEC_DIFFR_DIFF5_Pos                5                                              /**< (AFEC_DIFFR) Differential inputs for channel 5 Position */
+#define AFEC_DIFFR_DIFF5_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF5_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 5 Mask */
+#define AFEC_DIFFR_DIFF5                    AFEC_DIFFR_DIFF5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF5_Msk instead */
+#define AFEC_DIFFR_DIFF6_Pos                6                                              /**< (AFEC_DIFFR) Differential inputs for channel 6 Position */
+#define AFEC_DIFFR_DIFF6_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF6_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 6 Mask */
+#define AFEC_DIFFR_DIFF6                    AFEC_DIFFR_DIFF6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF6_Msk instead */
+#define AFEC_DIFFR_DIFF7_Pos                7                                              /**< (AFEC_DIFFR) Differential inputs for channel 7 Position */
+#define AFEC_DIFFR_DIFF7_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF7_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 7 Mask */
+#define AFEC_DIFFR_DIFF7                    AFEC_DIFFR_DIFF7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF7_Msk instead */
+#define AFEC_DIFFR_DIFF8_Pos                8                                              /**< (AFEC_DIFFR) Differential inputs for channel 8 Position */
+#define AFEC_DIFFR_DIFF8_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF8_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 8 Mask */
+#define AFEC_DIFFR_DIFF8                    AFEC_DIFFR_DIFF8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF8_Msk instead */
+#define AFEC_DIFFR_DIFF9_Pos                9                                              /**< (AFEC_DIFFR) Differential inputs for channel 9 Position */
+#define AFEC_DIFFR_DIFF9_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF9_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 9 Mask */
+#define AFEC_DIFFR_DIFF9                    AFEC_DIFFR_DIFF9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF9_Msk instead */
+#define AFEC_DIFFR_DIFF10_Pos               10                                             /**< (AFEC_DIFFR) Differential inputs for channel 10 Position */
+#define AFEC_DIFFR_DIFF10_Msk               (_U_(0x1) << AFEC_DIFFR_DIFF10_Pos)            /**< (AFEC_DIFFR) Differential inputs for channel 10 Mask */
+#define AFEC_DIFFR_DIFF10                   AFEC_DIFFR_DIFF10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF10_Msk instead */
+#define AFEC_DIFFR_DIFF11_Pos               11                                             /**< (AFEC_DIFFR) Differential inputs for channel 11 Position */
+#define AFEC_DIFFR_DIFF11_Msk               (_U_(0x1) << AFEC_DIFFR_DIFF11_Pos)            /**< (AFEC_DIFFR) Differential inputs for channel 11 Mask */
+#define AFEC_DIFFR_DIFF11                   AFEC_DIFFR_DIFF11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF11_Msk instead */
+#define AFEC_DIFFR_MASK                     _U_(0xFFF)                                     /**< \deprecated (AFEC_DIFFR) Register MASK  (Use AFEC_DIFFR_Msk instead)  */
+#define AFEC_DIFFR_Msk                      _U_(0xFFF)                                     /**< (AFEC_DIFFR) Register Mask  */
+
+#define AFEC_DIFFR_DIFF_Pos                 0                                              /**< (AFEC_DIFFR Position) Differential inputs for channel xx */
+#define AFEC_DIFFR_DIFF_Msk                 (_U_(0xFFF) << AFEC_DIFFR_DIFF_Pos)            /**< (AFEC_DIFFR Mask) DIFF */
+#define AFEC_DIFFR_DIFF(value)              (AFEC_DIFFR_DIFF_Msk & ((value) << AFEC_DIFFR_DIFF_Pos))  
+
+/* -------- AFEC_CSELR : (AFEC Offset: 0x64) (R/W 32) AFEC Channel Selection Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL:4;                    /**< bit:   0..3  Channel Selection                        */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CSELR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CSELR_OFFSET                   (0x64)                                        /**<  (AFEC_CSELR) AFEC Channel Selection Register  Offset */
+
+#define AFEC_CSELR_CSEL_Pos                 0                                              /**< (AFEC_CSELR) Channel Selection Position */
+#define AFEC_CSELR_CSEL_Msk                 (_U_(0xF) << AFEC_CSELR_CSEL_Pos)              /**< (AFEC_CSELR) Channel Selection Mask */
+#define AFEC_CSELR_CSEL(value)              (AFEC_CSELR_CSEL_Msk & ((value) << AFEC_CSELR_CSEL_Pos))
+#define AFEC_CSELR_MASK                     _U_(0x0F)                                      /**< \deprecated (AFEC_CSELR) Register MASK  (Use AFEC_CSELR_Msk instead)  */
+#define AFEC_CSELR_Msk                      _U_(0x0F)                                      /**< (AFEC_CSELR) Register Mask  */
+
+
+/* -------- AFEC_CDR : (AFEC Offset: 0x68) (R/ 32) AFEC Channel Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:16;                   /**< bit:  0..15  Converted Data                           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CDR_OFFSET                     (0x68)                                        /**<  (AFEC_CDR) AFEC Channel Data Register  Offset */
+
+#define AFEC_CDR_DATA_Pos                   0                                              /**< (AFEC_CDR) Converted Data Position */
+#define AFEC_CDR_DATA_Msk                   (_U_(0xFFFF) << AFEC_CDR_DATA_Pos)             /**< (AFEC_CDR) Converted Data Mask */
+#define AFEC_CDR_DATA(value)                (AFEC_CDR_DATA_Msk & ((value) << AFEC_CDR_DATA_Pos))
+#define AFEC_CDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (AFEC_CDR) Register MASK  (Use AFEC_CDR_Msk instead)  */
+#define AFEC_CDR_Msk                        _U_(0xFFFF)                                    /**< (AFEC_CDR) Register Mask  */
+
+
+/* -------- AFEC_COCR : (AFEC Offset: 0x6c) (R/W 32) AFEC Channel Offset Compensation Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AOFF:10;                   /**< bit:   0..9  Analog Offset                            */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_COCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_COCR_OFFSET                    (0x6C)                                        /**<  (AFEC_COCR) AFEC Channel Offset Compensation Register  Offset */
+
+#define AFEC_COCR_AOFF_Pos                  0                                              /**< (AFEC_COCR) Analog Offset Position */
+#define AFEC_COCR_AOFF_Msk                  (_U_(0x3FF) << AFEC_COCR_AOFF_Pos)             /**< (AFEC_COCR) Analog Offset Mask */
+#define AFEC_COCR_AOFF(value)               (AFEC_COCR_AOFF_Msk & ((value) << AFEC_COCR_AOFF_Pos))
+#define AFEC_COCR_MASK                      _U_(0x3FF)                                     /**< \deprecated (AFEC_COCR) Register MASK  (Use AFEC_COCR_Msk instead)  */
+#define AFEC_COCR_Msk                       _U_(0x3FF)                                     /**< (AFEC_COCR) Register Mask  */
+
+
+/* -------- AFEC_TEMPMR : (AFEC Offset: 0x70) (R/W 32) AFEC Temperature Sensor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RTCT:1;                    /**< bit:      0  Temperature Sensor RTC Trigger Mode      */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t TEMPCMPMOD:2;              /**< bit:   4..5  Temperature Comparison Mode              */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_TEMPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_TEMPMR_OFFSET                  (0x70)                                        /**<  (AFEC_TEMPMR) AFEC Temperature Sensor Mode Register  Offset */
+
+#define AFEC_TEMPMR_RTCT_Pos                0                                              /**< (AFEC_TEMPMR) Temperature Sensor RTC Trigger Mode Position */
+#define AFEC_TEMPMR_RTCT_Msk                (_U_(0x1) << AFEC_TEMPMR_RTCT_Pos)             /**< (AFEC_TEMPMR) Temperature Sensor RTC Trigger Mode Mask */
+#define AFEC_TEMPMR_RTCT                    AFEC_TEMPMR_RTCT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_TEMPMR_RTCT_Msk instead */
+#define AFEC_TEMPMR_TEMPCMPMOD_Pos          4                                              /**< (AFEC_TEMPMR) Temperature Comparison Mode Position */
+#define AFEC_TEMPMR_TEMPCMPMOD_Msk          (_U_(0x3) << AFEC_TEMPMR_TEMPCMPMOD_Pos)       /**< (AFEC_TEMPMR) Temperature Comparison Mode Mask */
+#define AFEC_TEMPMR_TEMPCMPMOD(value)       (AFEC_TEMPMR_TEMPCMPMOD_Msk & ((value) << AFEC_TEMPMR_TEMPCMPMOD_Pos))
+#define   AFEC_TEMPMR_TEMPCMPMOD_LOW_Val    _U_(0x0)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is lower than the low threshold of the window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_HIGH_Val   _U_(0x1)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is higher than the high threshold of the window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_IN_Val     _U_(0x2)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is in the comparison window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_OUT_Val    _U_(0x3)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is out of the comparison window.  */
+#define AFEC_TEMPMR_TEMPCMPMOD_LOW          (AFEC_TEMPMR_TEMPCMPMOD_LOW_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is lower than the low threshold of the window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_HIGH         (AFEC_TEMPMR_TEMPCMPMOD_HIGH_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is higher than the high threshold of the window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_IN           (AFEC_TEMPMR_TEMPCMPMOD_IN_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is in the comparison window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_OUT          (AFEC_TEMPMR_TEMPCMPMOD_OUT_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is out of the comparison window. Position  */
+#define AFEC_TEMPMR_MASK                    _U_(0x31)                                      /**< \deprecated (AFEC_TEMPMR) Register MASK  (Use AFEC_TEMPMR_Msk instead)  */
+#define AFEC_TEMPMR_Msk                     _U_(0x31)                                      /**< (AFEC_TEMPMR) Register Mask  */
+
+
+/* -------- AFEC_TEMPCWR : (AFEC Offset: 0x74) (R/W 32) AFEC Temperature Compare Window Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TLOWTHRES:16;              /**< bit:  0..15  Temperature Low Threshold                */
+    uint32_t THIGHTHRES:16;             /**< bit: 16..31  Temperature High Threshold               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_TEMPCWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_TEMPCWR_OFFSET                 (0x74)                                        /**<  (AFEC_TEMPCWR) AFEC Temperature Compare Window Register  Offset */
+
+#define AFEC_TEMPCWR_TLOWTHRES_Pos          0                                              /**< (AFEC_TEMPCWR) Temperature Low Threshold Position */
+#define AFEC_TEMPCWR_TLOWTHRES_Msk          (_U_(0xFFFF) << AFEC_TEMPCWR_TLOWTHRES_Pos)    /**< (AFEC_TEMPCWR) Temperature Low Threshold Mask */
+#define AFEC_TEMPCWR_TLOWTHRES(value)       (AFEC_TEMPCWR_TLOWTHRES_Msk & ((value) << AFEC_TEMPCWR_TLOWTHRES_Pos))
+#define AFEC_TEMPCWR_THIGHTHRES_Pos         16                                             /**< (AFEC_TEMPCWR) Temperature High Threshold Position */
+#define AFEC_TEMPCWR_THIGHTHRES_Msk         (_U_(0xFFFF) << AFEC_TEMPCWR_THIGHTHRES_Pos)   /**< (AFEC_TEMPCWR) Temperature High Threshold Mask */
+#define AFEC_TEMPCWR_THIGHTHRES(value)      (AFEC_TEMPCWR_THIGHTHRES_Msk & ((value) << AFEC_TEMPCWR_THIGHTHRES_Pos))
+#define AFEC_TEMPCWR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_TEMPCWR) Register MASK  (Use AFEC_TEMPCWR_Msk instead)  */
+#define AFEC_TEMPCWR_Msk                    _U_(0xFFFFFFFF)                                /**< (AFEC_TEMPCWR) Register Mask  */
+
+
+/* -------- AFEC_ACR : (AFEC Offset: 0x94) (R/W 32) AFEC Analog Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t PGA0EN:1;                  /**< bit:      2  PGA0 Enable                              */
+    uint32_t PGA1EN:1;                  /**< bit:      3  PGA1 Enable                              */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t IBCTL:2;                   /**< bit:   8..9  AFE Bias Current Control                 */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_ACR_OFFSET                     (0x94)                                        /**<  (AFEC_ACR) AFEC Analog Control Register  Offset */
+
+#define AFEC_ACR_PGA0EN_Pos                 2                                              /**< (AFEC_ACR) PGA0 Enable Position */
+#define AFEC_ACR_PGA0EN_Msk                 (_U_(0x1) << AFEC_ACR_PGA0EN_Pos)              /**< (AFEC_ACR) PGA0 Enable Mask */
+#define AFEC_ACR_PGA0EN                     AFEC_ACR_PGA0EN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ACR_PGA0EN_Msk instead */
+#define AFEC_ACR_PGA1EN_Pos                 3                                              /**< (AFEC_ACR) PGA1 Enable Position */
+#define AFEC_ACR_PGA1EN_Msk                 (_U_(0x1) << AFEC_ACR_PGA1EN_Pos)              /**< (AFEC_ACR) PGA1 Enable Mask */
+#define AFEC_ACR_PGA1EN                     AFEC_ACR_PGA1EN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ACR_PGA1EN_Msk instead */
+#define AFEC_ACR_IBCTL_Pos                  8                                              /**< (AFEC_ACR) AFE Bias Current Control Position */
+#define AFEC_ACR_IBCTL_Msk                  (_U_(0x3) << AFEC_ACR_IBCTL_Pos)               /**< (AFEC_ACR) AFE Bias Current Control Mask */
+#define AFEC_ACR_IBCTL(value)               (AFEC_ACR_IBCTL_Msk & ((value) << AFEC_ACR_IBCTL_Pos))
+#define AFEC_ACR_MASK                       _U_(0x30C)                                     /**< \deprecated (AFEC_ACR) Register MASK  (Use AFEC_ACR_Msk instead)  */
+#define AFEC_ACR_Msk                        _U_(0x30C)                                     /**< (AFEC_ACR) Register Mask  */
+
+
+/* -------- AFEC_SHMR : (AFEC Offset: 0xa0) (R/W 32) AFEC Sample & Hold Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DUAL0:1;                   /**< bit:      0  Dual Sample & Hold for channel 0         */
+    uint32_t DUAL1:1;                   /**< bit:      1  Dual Sample & Hold for channel 1         */
+    uint32_t DUAL2:1;                   /**< bit:      2  Dual Sample & Hold for channel 2         */
+    uint32_t DUAL3:1;                   /**< bit:      3  Dual Sample & Hold for channel 3         */
+    uint32_t DUAL4:1;                   /**< bit:      4  Dual Sample & Hold for channel 4         */
+    uint32_t DUAL5:1;                   /**< bit:      5  Dual Sample & Hold for channel 5         */
+    uint32_t DUAL6:1;                   /**< bit:      6  Dual Sample & Hold for channel 6         */
+    uint32_t DUAL7:1;                   /**< bit:      7  Dual Sample & Hold for channel 7         */
+    uint32_t DUAL8:1;                   /**< bit:      8  Dual Sample & Hold for channel 8         */
+    uint32_t DUAL9:1;                   /**< bit:      9  Dual Sample & Hold for channel 9         */
+    uint32_t DUAL10:1;                  /**< bit:     10  Dual Sample & Hold for channel 10        */
+    uint32_t DUAL11:1;                  /**< bit:     11  Dual Sample & Hold for channel 11        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DUAL:12;                   /**< bit:  0..11  Dual Sample & Hold for channel xx        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SHMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SHMR_OFFSET                    (0xA0)                                        /**<  (AFEC_SHMR) AFEC Sample & Hold Mode Register  Offset */
+
+#define AFEC_SHMR_DUAL0_Pos                 0                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 0 Position */
+#define AFEC_SHMR_DUAL0_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL0_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 0 Mask */
+#define AFEC_SHMR_DUAL0                     AFEC_SHMR_DUAL0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL0_Msk instead */
+#define AFEC_SHMR_DUAL1_Pos                 1                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 1 Position */
+#define AFEC_SHMR_DUAL1_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL1_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 1 Mask */
+#define AFEC_SHMR_DUAL1                     AFEC_SHMR_DUAL1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL1_Msk instead */
+#define AFEC_SHMR_DUAL2_Pos                 2                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 2 Position */
+#define AFEC_SHMR_DUAL2_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL2_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 2 Mask */
+#define AFEC_SHMR_DUAL2                     AFEC_SHMR_DUAL2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL2_Msk instead */
+#define AFEC_SHMR_DUAL3_Pos                 3                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 3 Position */
+#define AFEC_SHMR_DUAL3_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL3_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 3 Mask */
+#define AFEC_SHMR_DUAL3                     AFEC_SHMR_DUAL3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL3_Msk instead */
+#define AFEC_SHMR_DUAL4_Pos                 4                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 4 Position */
+#define AFEC_SHMR_DUAL4_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL4_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 4 Mask */
+#define AFEC_SHMR_DUAL4                     AFEC_SHMR_DUAL4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL4_Msk instead */
+#define AFEC_SHMR_DUAL5_Pos                 5                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 5 Position */
+#define AFEC_SHMR_DUAL5_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL5_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 5 Mask */
+#define AFEC_SHMR_DUAL5                     AFEC_SHMR_DUAL5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL5_Msk instead */
+#define AFEC_SHMR_DUAL6_Pos                 6                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 6 Position */
+#define AFEC_SHMR_DUAL6_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL6_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 6 Mask */
+#define AFEC_SHMR_DUAL6                     AFEC_SHMR_DUAL6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL6_Msk instead */
+#define AFEC_SHMR_DUAL7_Pos                 7                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 7 Position */
+#define AFEC_SHMR_DUAL7_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL7_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 7 Mask */
+#define AFEC_SHMR_DUAL7                     AFEC_SHMR_DUAL7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL7_Msk instead */
+#define AFEC_SHMR_DUAL8_Pos                 8                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 8 Position */
+#define AFEC_SHMR_DUAL8_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL8_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 8 Mask */
+#define AFEC_SHMR_DUAL8                     AFEC_SHMR_DUAL8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL8_Msk instead */
+#define AFEC_SHMR_DUAL9_Pos                 9                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 9 Position */
+#define AFEC_SHMR_DUAL9_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL9_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 9 Mask */
+#define AFEC_SHMR_DUAL9                     AFEC_SHMR_DUAL9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL9_Msk instead */
+#define AFEC_SHMR_DUAL10_Pos                10                                             /**< (AFEC_SHMR) Dual Sample & Hold for channel 10 Position */
+#define AFEC_SHMR_DUAL10_Msk                (_U_(0x1) << AFEC_SHMR_DUAL10_Pos)             /**< (AFEC_SHMR) Dual Sample & Hold for channel 10 Mask */
+#define AFEC_SHMR_DUAL10                    AFEC_SHMR_DUAL10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL10_Msk instead */
+#define AFEC_SHMR_DUAL11_Pos                11                                             /**< (AFEC_SHMR) Dual Sample & Hold for channel 11 Position */
+#define AFEC_SHMR_DUAL11_Msk                (_U_(0x1) << AFEC_SHMR_DUAL11_Pos)             /**< (AFEC_SHMR) Dual Sample & Hold for channel 11 Mask */
+#define AFEC_SHMR_DUAL11                    AFEC_SHMR_DUAL11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL11_Msk instead */
+#define AFEC_SHMR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_SHMR) Register MASK  (Use AFEC_SHMR_Msk instead)  */
+#define AFEC_SHMR_Msk                       _U_(0xFFF)                                     /**< (AFEC_SHMR) Register Mask  */
+
+#define AFEC_SHMR_DUAL_Pos                  0                                              /**< (AFEC_SHMR Position) Dual Sample & Hold for channel xx */
+#define AFEC_SHMR_DUAL_Msk                  (_U_(0xFFF) << AFEC_SHMR_DUAL_Pos)             /**< (AFEC_SHMR Mask) DUAL */
+#define AFEC_SHMR_DUAL(value)               (AFEC_SHMR_DUAL_Msk & ((value) << AFEC_SHMR_DUAL_Pos))  
+
+/* -------- AFEC_COSR : (AFEC Offset: 0xd0) (R/W 32) AFEC Correction Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL:1;                    /**< bit:      0  Sample & Hold unit Correction Select     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_COSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_COSR_OFFSET                    (0xD0)                                        /**<  (AFEC_COSR) AFEC Correction Select Register  Offset */
+
+#define AFEC_COSR_CSEL_Pos                  0                                              /**< (AFEC_COSR) Sample & Hold unit Correction Select Position */
+#define AFEC_COSR_CSEL_Msk                  (_U_(0x1) << AFEC_COSR_CSEL_Pos)               /**< (AFEC_COSR) Sample & Hold unit Correction Select Mask */
+#define AFEC_COSR_CSEL                      AFEC_COSR_CSEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_COSR_CSEL_Msk instead */
+#define AFEC_COSR_MASK                      _U_(0x01)                                      /**< \deprecated (AFEC_COSR) Register MASK  (Use AFEC_COSR_Msk instead)  */
+#define AFEC_COSR_Msk                       _U_(0x01)                                      /**< (AFEC_COSR) Register Mask  */
+
+
+/* -------- AFEC_CVR : (AFEC Offset: 0xd4) (R/W 32) AFEC Correction Values Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSETCORR:16;             /**< bit:  0..15  Offset Correction                        */
+    uint32_t GAINCORR:16;               /**< bit: 16..31  Gain Correction                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CVR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CVR_OFFSET                     (0xD4)                                        /**<  (AFEC_CVR) AFEC Correction Values Register  Offset */
+
+#define AFEC_CVR_OFFSETCORR_Pos             0                                              /**< (AFEC_CVR) Offset Correction Position */
+#define AFEC_CVR_OFFSETCORR_Msk             (_U_(0xFFFF) << AFEC_CVR_OFFSETCORR_Pos)       /**< (AFEC_CVR) Offset Correction Mask */
+#define AFEC_CVR_OFFSETCORR(value)          (AFEC_CVR_OFFSETCORR_Msk & ((value) << AFEC_CVR_OFFSETCORR_Pos))
+#define AFEC_CVR_GAINCORR_Pos               16                                             /**< (AFEC_CVR) Gain Correction Position */
+#define AFEC_CVR_GAINCORR_Msk               (_U_(0xFFFF) << AFEC_CVR_GAINCORR_Pos)         /**< (AFEC_CVR) Gain Correction Mask */
+#define AFEC_CVR_GAINCORR(value)            (AFEC_CVR_GAINCORR_Msk & ((value) << AFEC_CVR_GAINCORR_Pos))
+#define AFEC_CVR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_CVR) Register MASK  (Use AFEC_CVR_Msk instead)  */
+#define AFEC_CVR_Msk                        _U_(0xFFFFFFFF)                                /**< (AFEC_CVR) Register Mask  */
+
+
+/* -------- AFEC_CECR : (AFEC Offset: 0xd8) (R/W 32) AFEC Channel Error Correction Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ECORR0:1;                  /**< bit:      0  Error Correction Enable for channel 0    */
+    uint32_t ECORR1:1;                  /**< bit:      1  Error Correction Enable for channel 1    */
+    uint32_t ECORR2:1;                  /**< bit:      2  Error Correction Enable for channel 2    */
+    uint32_t ECORR3:1;                  /**< bit:      3  Error Correction Enable for channel 3    */
+    uint32_t ECORR4:1;                  /**< bit:      4  Error Correction Enable for channel 4    */
+    uint32_t ECORR5:1;                  /**< bit:      5  Error Correction Enable for channel 5    */
+    uint32_t ECORR6:1;                  /**< bit:      6  Error Correction Enable for channel 6    */
+    uint32_t ECORR7:1;                  /**< bit:      7  Error Correction Enable for channel 7    */
+    uint32_t ECORR8:1;                  /**< bit:      8  Error Correction Enable for channel 8    */
+    uint32_t ECORR9:1;                  /**< bit:      9  Error Correction Enable for channel 9    */
+    uint32_t ECORR10:1;                 /**< bit:     10  Error Correction Enable for channel 10   */
+    uint32_t ECORR11:1;                 /**< bit:     11  Error Correction Enable for channel 11   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ECORR:12;                  /**< bit:  0..11  Error Correction Enable for channel xx   */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CECR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CECR_OFFSET                    (0xD8)                                        /**<  (AFEC_CECR) AFEC Channel Error Correction Register  Offset */
+
+#define AFEC_CECR_ECORR0_Pos                0                                              /**< (AFEC_CECR) Error Correction Enable for channel 0 Position */
+#define AFEC_CECR_ECORR0_Msk                (_U_(0x1) << AFEC_CECR_ECORR0_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 0 Mask */
+#define AFEC_CECR_ECORR0                    AFEC_CECR_ECORR0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR0_Msk instead */
+#define AFEC_CECR_ECORR1_Pos                1                                              /**< (AFEC_CECR) Error Correction Enable for channel 1 Position */
+#define AFEC_CECR_ECORR1_Msk                (_U_(0x1) << AFEC_CECR_ECORR1_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 1 Mask */
+#define AFEC_CECR_ECORR1                    AFEC_CECR_ECORR1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR1_Msk instead */
+#define AFEC_CECR_ECORR2_Pos                2                                              /**< (AFEC_CECR) Error Correction Enable for channel 2 Position */
+#define AFEC_CECR_ECORR2_Msk                (_U_(0x1) << AFEC_CECR_ECORR2_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 2 Mask */
+#define AFEC_CECR_ECORR2                    AFEC_CECR_ECORR2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR2_Msk instead */
+#define AFEC_CECR_ECORR3_Pos                3                                              /**< (AFEC_CECR) Error Correction Enable for channel 3 Position */
+#define AFEC_CECR_ECORR3_Msk                (_U_(0x1) << AFEC_CECR_ECORR3_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 3 Mask */
+#define AFEC_CECR_ECORR3                    AFEC_CECR_ECORR3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR3_Msk instead */
+#define AFEC_CECR_ECORR4_Pos                4                                              /**< (AFEC_CECR) Error Correction Enable for channel 4 Position */
+#define AFEC_CECR_ECORR4_Msk                (_U_(0x1) << AFEC_CECR_ECORR4_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 4 Mask */
+#define AFEC_CECR_ECORR4                    AFEC_CECR_ECORR4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR4_Msk instead */
+#define AFEC_CECR_ECORR5_Pos                5                                              /**< (AFEC_CECR) Error Correction Enable for channel 5 Position */
+#define AFEC_CECR_ECORR5_Msk                (_U_(0x1) << AFEC_CECR_ECORR5_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 5 Mask */
+#define AFEC_CECR_ECORR5                    AFEC_CECR_ECORR5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR5_Msk instead */
+#define AFEC_CECR_ECORR6_Pos                6                                              /**< (AFEC_CECR) Error Correction Enable for channel 6 Position */
+#define AFEC_CECR_ECORR6_Msk                (_U_(0x1) << AFEC_CECR_ECORR6_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 6 Mask */
+#define AFEC_CECR_ECORR6                    AFEC_CECR_ECORR6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR6_Msk instead */
+#define AFEC_CECR_ECORR7_Pos                7                                              /**< (AFEC_CECR) Error Correction Enable for channel 7 Position */
+#define AFEC_CECR_ECORR7_Msk                (_U_(0x1) << AFEC_CECR_ECORR7_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 7 Mask */
+#define AFEC_CECR_ECORR7                    AFEC_CECR_ECORR7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR7_Msk instead */
+#define AFEC_CECR_ECORR8_Pos                8                                              /**< (AFEC_CECR) Error Correction Enable for channel 8 Position */
+#define AFEC_CECR_ECORR8_Msk                (_U_(0x1) << AFEC_CECR_ECORR8_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 8 Mask */
+#define AFEC_CECR_ECORR8                    AFEC_CECR_ECORR8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR8_Msk instead */
+#define AFEC_CECR_ECORR9_Pos                9                                              /**< (AFEC_CECR) Error Correction Enable for channel 9 Position */
+#define AFEC_CECR_ECORR9_Msk                (_U_(0x1) << AFEC_CECR_ECORR9_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 9 Mask */
+#define AFEC_CECR_ECORR9                    AFEC_CECR_ECORR9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR9_Msk instead */
+#define AFEC_CECR_ECORR10_Pos               10                                             /**< (AFEC_CECR) Error Correction Enable for channel 10 Position */
+#define AFEC_CECR_ECORR10_Msk               (_U_(0x1) << AFEC_CECR_ECORR10_Pos)            /**< (AFEC_CECR) Error Correction Enable for channel 10 Mask */
+#define AFEC_CECR_ECORR10                   AFEC_CECR_ECORR10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR10_Msk instead */
+#define AFEC_CECR_ECORR11_Pos               11                                             /**< (AFEC_CECR) Error Correction Enable for channel 11 Position */
+#define AFEC_CECR_ECORR11_Msk               (_U_(0x1) << AFEC_CECR_ECORR11_Pos)            /**< (AFEC_CECR) Error Correction Enable for channel 11 Mask */
+#define AFEC_CECR_ECORR11                   AFEC_CECR_ECORR11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR11_Msk instead */
+#define AFEC_CECR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CECR) Register MASK  (Use AFEC_CECR_Msk instead)  */
+#define AFEC_CECR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CECR) Register Mask  */
+
+#define AFEC_CECR_ECORR_Pos                 0                                              /**< (AFEC_CECR Position) Error Correction Enable for channel xx */
+#define AFEC_CECR_ECORR_Msk                 (_U_(0xFFF) << AFEC_CECR_ECORR_Pos)            /**< (AFEC_CECR Mask) ECORR */
+#define AFEC_CECR_ECORR(value)              (AFEC_CECR_ECORR_Msk & ((value) << AFEC_CECR_ECORR_Pos))  
+
+/* -------- AFEC_WPMR : (AFEC Offset: 0xe4) (R/W 32) AFEC Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect KEY                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_WPMR_OFFSET                    (0xE4)                                        /**<  (AFEC_WPMR) AFEC Write Protection Mode Register  Offset */
+
+#define AFEC_WPMR_WPEN_Pos                  0                                              /**< (AFEC_WPMR) Write Protection Enable Position */
+#define AFEC_WPMR_WPEN_Msk                  (_U_(0x1) << AFEC_WPMR_WPEN_Pos)               /**< (AFEC_WPMR) Write Protection Enable Mask */
+#define AFEC_WPMR_WPEN                      AFEC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_WPMR_WPEN_Msk instead */
+#define AFEC_WPMR_WPKEY_Pos                 8                                              /**< (AFEC_WPMR) Write Protect KEY Position */
+#define AFEC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << AFEC_WPMR_WPKEY_Pos)         /**< (AFEC_WPMR) Write Protect KEY Mask */
+#define AFEC_WPMR_WPKEY(value)              (AFEC_WPMR_WPKEY_Msk & ((value) << AFEC_WPMR_WPKEY_Pos))
+#define   AFEC_WPMR_WPKEY_PASSWD_Val        _U_(0x414443)                                  /**< (AFEC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define AFEC_WPMR_WPKEY_PASSWD              (AFEC_WPMR_WPKEY_PASSWD_Val << AFEC_WPMR_WPKEY_Pos)  /**< (AFEC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define AFEC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (AFEC_WPMR) Register MASK  (Use AFEC_WPMR_Msk instead)  */
+#define AFEC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (AFEC_WPMR) Register Mask  */
+
+
+/* -------- AFEC_WPSR : (AFEC Offset: 0xe8) (R/ 32) AFEC Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protect Violation Status           */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protect Violation Source           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_WPSR_OFFSET                    (0xE8)                                        /**<  (AFEC_WPSR) AFEC Write Protection Status Register  Offset */
+
+#define AFEC_WPSR_WPVS_Pos                  0                                              /**< (AFEC_WPSR) Write Protect Violation Status Position */
+#define AFEC_WPSR_WPVS_Msk                  (_U_(0x1) << AFEC_WPSR_WPVS_Pos)               /**< (AFEC_WPSR) Write Protect Violation Status Mask */
+#define AFEC_WPSR_WPVS                      AFEC_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_WPSR_WPVS_Msk instead */
+#define AFEC_WPSR_WPVSRC_Pos                8                                              /**< (AFEC_WPSR) Write Protect Violation Source Position */
+#define AFEC_WPSR_WPVSRC_Msk                (_U_(0xFFFF) << AFEC_WPSR_WPVSRC_Pos)          /**< (AFEC_WPSR) Write Protect Violation Source Mask */
+#define AFEC_WPSR_WPVSRC(value)             (AFEC_WPSR_WPVSRC_Msk & ((value) << AFEC_WPSR_WPVSRC_Pos))
+#define AFEC_WPSR_MASK                      _U_(0xFFFF01)                                  /**< \deprecated (AFEC_WPSR) Register MASK  (Use AFEC_WPSR_Msk instead)  */
+#define AFEC_WPSR_Msk                       _U_(0xFFFF01)                                  /**< (AFEC_WPSR) Register Mask  */
+
+
+/* -------- AFEC_VERSION : (AFEC Offset: 0xfc) (R/ 32) AFEC Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_VERSION_OFFSET                 (0xFC)                                        /**<  (AFEC_VERSION) AFEC Version Register  Offset */
+
+#define AFEC_VERSION_VERSION_Pos            0                                              /**< (AFEC_VERSION) Version of the Hardware Module Position */
+#define AFEC_VERSION_VERSION_Msk            (_U_(0xFFF) << AFEC_VERSION_VERSION_Pos)       /**< (AFEC_VERSION) Version of the Hardware Module Mask */
+#define AFEC_VERSION_VERSION(value)         (AFEC_VERSION_VERSION_Msk & ((value) << AFEC_VERSION_VERSION_Pos))
+#define AFEC_VERSION_MFN_Pos                16                                             /**< (AFEC_VERSION) Metal Fix Number Position */
+#define AFEC_VERSION_MFN_Msk                (_U_(0x7) << AFEC_VERSION_MFN_Pos)             /**< (AFEC_VERSION) Metal Fix Number Mask */
+#define AFEC_VERSION_MFN(value)             (AFEC_VERSION_MFN_Msk & ((value) << AFEC_VERSION_MFN_Pos))
+#define AFEC_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (AFEC_VERSION) Register MASK  (Use AFEC_VERSION_Msk instead)  */
+#define AFEC_VERSION_Msk                    _U_(0x70FFF)                                   /**< (AFEC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief AFEC hardware registers */
+typedef struct {  
+  __O  uint32_t AFEC_CR;        /**< (AFEC Offset: 0x00) AFEC Control Register */
+  __IO uint32_t AFEC_MR;        /**< (AFEC Offset: 0x04) AFEC Mode Register */
+  __IO uint32_t AFEC_EMR;       /**< (AFEC Offset: 0x08) AFEC Extended Mode Register */
+  __IO uint32_t AFEC_SEQ1R;     /**< (AFEC Offset: 0x0C) AFEC Channel Sequence 1 Register */
+  __IO uint32_t AFEC_SEQ2R;     /**< (AFEC Offset: 0x10) AFEC Channel Sequence 2 Register */
+  __O  uint32_t AFEC_CHER;      /**< (AFEC Offset: 0x14) AFEC Channel Enable Register */
+  __O  uint32_t AFEC_CHDR;      /**< (AFEC Offset: 0x18) AFEC Channel Disable Register */
+  __I  uint32_t AFEC_CHSR;      /**< (AFEC Offset: 0x1C) AFEC Channel Status Register */
+  __I  uint32_t AFEC_LCDR;      /**< (AFEC Offset: 0x20) AFEC Last Converted Data Register */
+  __O  uint32_t AFEC_IER;       /**< (AFEC Offset: 0x24) AFEC Interrupt Enable Register */
+  __O  uint32_t AFEC_IDR;       /**< (AFEC Offset: 0x28) AFEC Interrupt Disable Register */
+  __I  uint32_t AFEC_IMR;       /**< (AFEC Offset: 0x2C) AFEC Interrupt Mask Register */
+  __I  uint32_t AFEC_ISR;       /**< (AFEC Offset: 0x30) AFEC Interrupt Status Register */
+  __I  uint8_t                        Reserved1[24];
+  __I  uint32_t AFEC_OVER;      /**< (AFEC Offset: 0x4C) AFEC Overrun Status Register */
+  __IO uint32_t AFEC_CWR;       /**< (AFEC Offset: 0x50) AFEC Compare Window Register */
+  __IO uint32_t AFEC_CGR;       /**< (AFEC Offset: 0x54) AFEC Channel Gain Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO uint32_t AFEC_DIFFR;     /**< (AFEC Offset: 0x60) AFEC Channel Differential Register */
+  __IO uint32_t AFEC_CSELR;     /**< (AFEC Offset: 0x64) AFEC Channel Selection Register */
+  __I  uint32_t AFEC_CDR;       /**< (AFEC Offset: 0x68) AFEC Channel Data Register */
+  __IO uint32_t AFEC_COCR;      /**< (AFEC Offset: 0x6C) AFEC Channel Offset Compensation Register */
+  __IO uint32_t AFEC_TEMPMR;    /**< (AFEC Offset: 0x70) AFEC Temperature Sensor Mode Register */
+  __IO uint32_t AFEC_TEMPCWR;   /**< (AFEC Offset: 0x74) AFEC Temperature Compare Window Register */
+  __I  uint8_t                        Reserved3[28];
+  __IO uint32_t AFEC_ACR;       /**< (AFEC Offset: 0x94) AFEC Analog Control Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO uint32_t AFEC_SHMR;      /**< (AFEC Offset: 0xA0) AFEC Sample & Hold Mode Register */
+  __I  uint8_t                        Reserved5[44];
+  __IO uint32_t AFEC_COSR;      /**< (AFEC Offset: 0xD0) AFEC Correction Select Register */
+  __IO uint32_t AFEC_CVR;       /**< (AFEC Offset: 0xD4) AFEC Correction Values Register */
+  __IO uint32_t AFEC_CECR;      /**< (AFEC Offset: 0xD8) AFEC Channel Error Correction Register */
+  __I  uint8_t                        Reserved6[8];
+  __IO uint32_t AFEC_WPMR;      /**< (AFEC Offset: 0xE4) AFEC Write Protection Mode Register */
+  __I  uint32_t AFEC_WPSR;      /**< (AFEC Offset: 0xE8) AFEC Write Protection Status Register */
+  __I  uint8_t                        Reserved7[16];
+  __I  uint32_t AFEC_VERSION;   /**< (AFEC Offset: 0xFC) AFEC Version Register */
+} Afec;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief AFEC hardware registers */
+typedef struct {  
+  __O  AFEC_CR_Type                   AFEC_CR;        /**< Offset: 0x00 ( /W  32) AFEC Control Register */
+  __IO AFEC_MR_Type                   AFEC_MR;        /**< Offset: 0x04 (R/W  32) AFEC Mode Register */
+  __IO AFEC_EMR_Type                  AFEC_EMR;       /**< Offset: 0x08 (R/W  32) AFEC Extended Mode Register */
+  __IO AFEC_SEQ1R_Type                AFEC_SEQ1R;     /**< Offset: 0x0C (R/W  32) AFEC Channel Sequence 1 Register */
+  __IO AFEC_SEQ2R_Type                AFEC_SEQ2R;     /**< Offset: 0x10 (R/W  32) AFEC Channel Sequence 2 Register */
+  __O  AFEC_CHER_Type                 AFEC_CHER;      /**< Offset: 0x14 ( /W  32) AFEC Channel Enable Register */
+  __O  AFEC_CHDR_Type                 AFEC_CHDR;      /**< Offset: 0x18 ( /W  32) AFEC Channel Disable Register */
+  __I  AFEC_CHSR_Type                 AFEC_CHSR;      /**< Offset: 0x1C (R/   32) AFEC Channel Status Register */
+  __I  AFEC_LCDR_Type                 AFEC_LCDR;      /**< Offset: 0x20 (R/   32) AFEC Last Converted Data Register */
+  __O  AFEC_IER_Type                  AFEC_IER;       /**< Offset: 0x24 ( /W  32) AFEC Interrupt Enable Register */
+  __O  AFEC_IDR_Type                  AFEC_IDR;       /**< Offset: 0x28 ( /W  32) AFEC Interrupt Disable Register */
+  __I  AFEC_IMR_Type                  AFEC_IMR;       /**< Offset: 0x2C (R/   32) AFEC Interrupt Mask Register */
+  __I  AFEC_ISR_Type                  AFEC_ISR;       /**< Offset: 0x30 (R/   32) AFEC Interrupt Status Register */
+  __I  uint8_t                        Reserved1[24];
+  __I  AFEC_OVER_Type                 AFEC_OVER;      /**< Offset: 0x4C (R/   32) AFEC Overrun Status Register */
+  __IO AFEC_CWR_Type                  AFEC_CWR;       /**< Offset: 0x50 (R/W  32) AFEC Compare Window Register */
+  __IO AFEC_CGR_Type                  AFEC_CGR;       /**< Offset: 0x54 (R/W  32) AFEC Channel Gain Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO AFEC_DIFFR_Type                AFEC_DIFFR;     /**< Offset: 0x60 (R/W  32) AFEC Channel Differential Register */
+  __IO AFEC_CSELR_Type                AFEC_CSELR;     /**< Offset: 0x64 (R/W  32) AFEC Channel Selection Register */
+  __I  AFEC_CDR_Type                  AFEC_CDR;       /**< Offset: 0x68 (R/   32) AFEC Channel Data Register */
+  __IO AFEC_COCR_Type                 AFEC_COCR;      /**< Offset: 0x6C (R/W  32) AFEC Channel Offset Compensation Register */
+  __IO AFEC_TEMPMR_Type               AFEC_TEMPMR;    /**< Offset: 0x70 (R/W  32) AFEC Temperature Sensor Mode Register */
+  __IO AFEC_TEMPCWR_Type              AFEC_TEMPCWR;   /**< Offset: 0x74 (R/W  32) AFEC Temperature Compare Window Register */
+  __I  uint8_t                        Reserved3[28];
+  __IO AFEC_ACR_Type                  AFEC_ACR;       /**< Offset: 0x94 (R/W  32) AFEC Analog Control Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO AFEC_SHMR_Type                 AFEC_SHMR;      /**< Offset: 0xA0 (R/W  32) AFEC Sample & Hold Mode Register */
+  __I  uint8_t                        Reserved5[44];
+  __IO AFEC_COSR_Type                 AFEC_COSR;      /**< Offset: 0xD0 (R/W  32) AFEC Correction Select Register */
+  __IO AFEC_CVR_Type                  AFEC_CVR;       /**< Offset: 0xD4 (R/W  32) AFEC Correction Values Register */
+  __IO AFEC_CECR_Type                 AFEC_CECR;      /**< Offset: 0xD8 (R/W  32) AFEC Channel Error Correction Register */
+  __I  uint8_t                        Reserved6[8];
+  __IO AFEC_WPMR_Type                 AFEC_WPMR;      /**< Offset: 0xE4 (R/W  32) AFEC Write Protection Mode Register */
+  __I  AFEC_WPSR_Type                 AFEC_WPSR;      /**< Offset: 0xE8 (R/   32) AFEC Write Protection Status Register */
+  __I  uint8_t                        Reserved7[16];
+  __I  AFEC_VERSION_Type              AFEC_VERSION;   /**< Offset: 0xFC (R/   32) AFEC Version Register */
+} Afec;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Front-End Controller */
+
+#endif /* _SAMV71_AFEC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/chipid.h
+++ b/asf/sam/include/samv71/component/chipid.h
@@ -1,0 +1,242 @@
+/**
+ * \file
+ *
+ * \brief Component description for CHIPID
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_CHIPID_COMPONENT_H_
+#define _SAMV71_CHIPID_COMPONENT_H_
+#define _SAMV71_CHIPID_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Chip Identifier
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CHIPID */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define CHIPID_6417                       /**< (CHIPID) Module ID */
+#define REV_CHIPID ZC                     /**< (CHIPID) Module revision */
+
+/* -------- CHIPID_CIDR : (CHIPID Offset: 0x00) (R/ 32) Chip ID Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:5;                 /**< bit:   0..4  Version of the Device                    */
+    uint32_t EPROC:3;                   /**< bit:   5..7  Embedded Processor                       */
+    uint32_t NVPSIZ:4;                  /**< bit:  8..11  Nonvolatile Program Memory Size          */
+    uint32_t NVPSIZ2:4;                 /**< bit: 12..15  Second Nonvolatile Program Memory Size   */
+    uint32_t SRAMSIZ:4;                 /**< bit: 16..19  Internal SRAM Size                       */
+    uint32_t ARCH:8;                    /**< bit: 20..27  Architecture Identifier                  */
+    uint32_t NVPTYP:3;                  /**< bit: 28..30  Nonvolatile Program Memory Type          */
+    uint32_t EXT:1;                     /**< bit:     31  Extension Flag                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CHIPID_CIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_CIDR_OFFSET                  (0x00)                                        /**<  (CHIPID_CIDR) Chip ID Register  Offset */
+
+#define CHIPID_CIDR_VERSION_Pos             0                                              /**< (CHIPID_CIDR) Version of the Device Position */
+#define CHIPID_CIDR_VERSION_Msk             (_U_(0x1F) << CHIPID_CIDR_VERSION_Pos)         /**< (CHIPID_CIDR) Version of the Device Mask */
+#define CHIPID_CIDR_VERSION(value)          (CHIPID_CIDR_VERSION_Msk & ((value) << CHIPID_CIDR_VERSION_Pos))
+#define CHIPID_CIDR_EPROC_Pos               5                                              /**< (CHIPID_CIDR) Embedded Processor Position */
+#define CHIPID_CIDR_EPROC_Msk               (_U_(0x7) << CHIPID_CIDR_EPROC_Pos)            /**< (CHIPID_CIDR) Embedded Processor Mask */
+#define CHIPID_CIDR_EPROC(value)            (CHIPID_CIDR_EPROC_Msk & ((value) << CHIPID_CIDR_EPROC_Pos))
+#define   CHIPID_CIDR_EPROC_SAMx7_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) Cortex-M7  */
+#define   CHIPID_CIDR_EPROC_ARM946ES_Val    _U_(0x1)                                       /**< (CHIPID_CIDR) ARM946ES  */
+#define   CHIPID_CIDR_EPROC_ARM7TDMI_Val    _U_(0x2)                                       /**< (CHIPID_CIDR) ARM7TDMI  */
+#define   CHIPID_CIDR_EPROC_CM3_Val         _U_(0x3)                                       /**< (CHIPID_CIDR) Cortex-M3  */
+#define   CHIPID_CIDR_EPROC_ARM920T_Val     _U_(0x4)                                       /**< (CHIPID_CIDR) ARM920T  */
+#define   CHIPID_CIDR_EPROC_ARM926EJS_Val   _U_(0x5)                                       /**< (CHIPID_CIDR) ARM926EJS  */
+#define   CHIPID_CIDR_EPROC_CA5_Val         _U_(0x6)                                       /**< (CHIPID_CIDR) Cortex-A5  */
+#define   CHIPID_CIDR_EPROC_CM4_Val         _U_(0x7)                                       /**< (CHIPID_CIDR) Cortex-M4  */
+#define CHIPID_CIDR_EPROC_SAMx7             (CHIPID_CIDR_EPROC_SAMx7_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M7 Position  */
+#define CHIPID_CIDR_EPROC_ARM946ES          (CHIPID_CIDR_EPROC_ARM946ES_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM946ES Position  */
+#define CHIPID_CIDR_EPROC_ARM7TDMI          (CHIPID_CIDR_EPROC_ARM7TDMI_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM7TDMI Position  */
+#define CHIPID_CIDR_EPROC_CM3               (CHIPID_CIDR_EPROC_CM3_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M3 Position  */
+#define CHIPID_CIDR_EPROC_ARM920T           (CHIPID_CIDR_EPROC_ARM920T_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM920T Position  */
+#define CHIPID_CIDR_EPROC_ARM926EJS         (CHIPID_CIDR_EPROC_ARM926EJS_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM926EJS Position  */
+#define CHIPID_CIDR_EPROC_CA5               (CHIPID_CIDR_EPROC_CA5_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-A5 Position  */
+#define CHIPID_CIDR_EPROC_CM4               (CHIPID_CIDR_EPROC_CM4_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M4 Position  */
+#define CHIPID_CIDR_NVPSIZ_Pos              8                                              /**< (CHIPID_CIDR) Nonvolatile Program Memory Size Position */
+#define CHIPID_CIDR_NVPSIZ_Msk              (_U_(0xF) << CHIPID_CIDR_NVPSIZ_Pos)           /**< (CHIPID_CIDR) Nonvolatile Program Memory Size Mask */
+#define CHIPID_CIDR_NVPSIZ(value)           (CHIPID_CIDR_NVPSIZ_Msk & ((value) << CHIPID_CIDR_NVPSIZ_Pos))
+#define   CHIPID_CIDR_NVPSIZ_NONE_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) None  */
+#define   CHIPID_CIDR_NVPSIZ_8K_Val         _U_(0x1)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_16K_Val        _U_(0x2)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_32K_Val        _U_(0x3)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_64K_Val        _U_(0x5)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_128K_Val       _U_(0x7)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_160K_Val       _U_(0x8)                                       /**< (CHIPID_CIDR) 160 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_256K_Val       _U_(0x9)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_512K_Val       _U_(0xA)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_1024K_Val      _U_(0xC)                                       /**< (CHIPID_CIDR) 1024 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_2048K_Val      _U_(0xE)                                       /**< (CHIPID_CIDR) 2048 Kbytes  */
+#define CHIPID_CIDR_NVPSIZ_NONE             (CHIPID_CIDR_NVPSIZ_NONE_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) None Position  */
+#define CHIPID_CIDR_NVPSIZ_8K               (CHIPID_CIDR_NVPSIZ_8K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_16K              (CHIPID_CIDR_NVPSIZ_16K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_32K              (CHIPID_CIDR_NVPSIZ_32K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_64K              (CHIPID_CIDR_NVPSIZ_64K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_128K             (CHIPID_CIDR_NVPSIZ_128K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_160K             (CHIPID_CIDR_NVPSIZ_160K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 160 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_256K             (CHIPID_CIDR_NVPSIZ_256K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_512K             (CHIPID_CIDR_NVPSIZ_512K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_1024K            (CHIPID_CIDR_NVPSIZ_1024K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 1024 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_2048K            (CHIPID_CIDR_NVPSIZ_2048K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 2048 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_Pos             12                                             /**< (CHIPID_CIDR) Second Nonvolatile Program Memory Size Position */
+#define CHIPID_CIDR_NVPSIZ2_Msk             (_U_(0xF) << CHIPID_CIDR_NVPSIZ2_Pos)          /**< (CHIPID_CIDR) Second Nonvolatile Program Memory Size Mask */
+#define CHIPID_CIDR_NVPSIZ2(value)          (CHIPID_CIDR_NVPSIZ2_Msk & ((value) << CHIPID_CIDR_NVPSIZ2_Pos))
+#define   CHIPID_CIDR_NVPSIZ2_NONE_Val      _U_(0x0)                                       /**< (CHIPID_CIDR) None  */
+#define   CHIPID_CIDR_NVPSIZ2_8K_Val        _U_(0x1)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_16K_Val       _U_(0x2)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_32K_Val       _U_(0x3)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_64K_Val       _U_(0x5)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_128K_Val      _U_(0x7)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_256K_Val      _U_(0x9)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_512K_Val      _U_(0xA)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_1024K_Val     _U_(0xC)                                       /**< (CHIPID_CIDR) 1024 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_2048K_Val     _U_(0xE)                                       /**< (CHIPID_CIDR) 2048 Kbytes  */
+#define CHIPID_CIDR_NVPSIZ2_NONE            (CHIPID_CIDR_NVPSIZ2_NONE_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) None Position  */
+#define CHIPID_CIDR_NVPSIZ2_8K              (CHIPID_CIDR_NVPSIZ2_8K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_16K             (CHIPID_CIDR_NVPSIZ2_16K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_32K             (CHIPID_CIDR_NVPSIZ2_32K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_64K             (CHIPID_CIDR_NVPSIZ2_64K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_128K            (CHIPID_CIDR_NVPSIZ2_128K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_256K            (CHIPID_CIDR_NVPSIZ2_256K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_512K            (CHIPID_CIDR_NVPSIZ2_512K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_1024K           (CHIPID_CIDR_NVPSIZ2_1024K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 1024 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_2048K           (CHIPID_CIDR_NVPSIZ2_2048K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 2048 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_Pos             16                                             /**< (CHIPID_CIDR) Internal SRAM Size Position */
+#define CHIPID_CIDR_SRAMSIZ_Msk             (_U_(0xF) << CHIPID_CIDR_SRAMSIZ_Pos)          /**< (CHIPID_CIDR) Internal SRAM Size Mask */
+#define CHIPID_CIDR_SRAMSIZ(value)          (CHIPID_CIDR_SRAMSIZ_Msk & ((value) << CHIPID_CIDR_SRAMSIZ_Pos))
+#define   CHIPID_CIDR_SRAMSIZ_48K_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) 48 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_192K_Val      _U_(0x1)                                       /**< (CHIPID_CIDR) 192 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_384K_Val      _U_(0x2)                                       /**< (CHIPID_CIDR) 384 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_6K_Val        _U_(0x3)                                       /**< (CHIPID_CIDR) 6 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_24K_Val       _U_(0x4)                                       /**< (CHIPID_CIDR) 24 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_4K_Val        _U_(0x5)                                       /**< (CHIPID_CIDR) 4 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_80K_Val       _U_(0x6)                                       /**< (CHIPID_CIDR) 80 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_160K_Val      _U_(0x7)                                       /**< (CHIPID_CIDR) 160 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_8K_Val        _U_(0x8)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_16K_Val       _U_(0x9)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_32K_Val       _U_(0xA)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_64K_Val       _U_(0xB)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_128K_Val      _U_(0xC)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_256K_Val      _U_(0xD)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_96K_Val       _U_(0xE)                                       /**< (CHIPID_CIDR) 96 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_512K_Val      _U_(0xF)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define CHIPID_CIDR_SRAMSIZ_48K             (CHIPID_CIDR_SRAMSIZ_48K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 48 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_192K            (CHIPID_CIDR_SRAMSIZ_192K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 192 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_384K            (CHIPID_CIDR_SRAMSIZ_384K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 384 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_6K              (CHIPID_CIDR_SRAMSIZ_6K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 6 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_24K             (CHIPID_CIDR_SRAMSIZ_24K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 24 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_4K              (CHIPID_CIDR_SRAMSIZ_4K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 4 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_80K             (CHIPID_CIDR_SRAMSIZ_80K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 80 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_160K            (CHIPID_CIDR_SRAMSIZ_160K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 160 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_8K              (CHIPID_CIDR_SRAMSIZ_8K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_16K             (CHIPID_CIDR_SRAMSIZ_16K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_32K             (CHIPID_CIDR_SRAMSIZ_32K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_64K             (CHIPID_CIDR_SRAMSIZ_64K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_128K            (CHIPID_CIDR_SRAMSIZ_128K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_256K            (CHIPID_CIDR_SRAMSIZ_256K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_96K             (CHIPID_CIDR_SRAMSIZ_96K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 96 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_512K            (CHIPID_CIDR_SRAMSIZ_512K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_ARCH_Pos                20                                             /**< (CHIPID_CIDR) Architecture Identifier Position */
+#define CHIPID_CIDR_ARCH_Msk                (_U_(0xFF) << CHIPID_CIDR_ARCH_Pos)            /**< (CHIPID_CIDR) Architecture Identifier Mask */
+#define CHIPID_CIDR_ARCH(value)             (CHIPID_CIDR_ARCH_Msk & ((value) << CHIPID_CIDR_ARCH_Pos))
+#define   CHIPID_CIDR_ARCH_SAMV71_Val       _U_(0x12)                                      /**< (CHIPID_CIDR) SAM V71  */
+#define CHIPID_CIDR_ARCH_SAMV71             (CHIPID_CIDR_ARCH_SAMV71_Val << CHIPID_CIDR_ARCH_Pos)  /**< (CHIPID_CIDR) SAM V71 Position  */
+#define CHIPID_CIDR_NVPTYP_Pos              28                                             /**< (CHIPID_CIDR) Nonvolatile Program Memory Type Position */
+#define CHIPID_CIDR_NVPTYP_Msk              (_U_(0x7) << CHIPID_CIDR_NVPTYP_Pos)           /**< (CHIPID_CIDR) Nonvolatile Program Memory Type Mask */
+#define CHIPID_CIDR_NVPTYP(value)           (CHIPID_CIDR_NVPTYP_Msk & ((value) << CHIPID_CIDR_NVPTYP_Pos))
+#define   CHIPID_CIDR_NVPTYP_ROM_Val        _U_(0x0)                                       /**< (CHIPID_CIDR) ROM  */
+#define   CHIPID_CIDR_NVPTYP_ROMLESS_Val    _U_(0x1)                                       /**< (CHIPID_CIDR) ROMless or on-chip Flash  */
+#define   CHIPID_CIDR_NVPTYP_FLASH_Val      _U_(0x2)                                       /**< (CHIPID_CIDR) Embedded Flash Memory  */
+#define   CHIPID_CIDR_NVPTYP_ROM_FLASH_Val  _U_(0x3)                                       /**< (CHIPID_CIDR) ROM and Embedded Flash Memory- NVPSIZ is ROM size- NVPSIZ2 is Flash size  */
+#define   CHIPID_CIDR_NVPTYP_SRAM_Val       _U_(0x4)                                       /**< (CHIPID_CIDR) SRAM emulating ROM  */
+#define CHIPID_CIDR_NVPTYP_ROM              (CHIPID_CIDR_NVPTYP_ROM_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROM Position  */
+#define CHIPID_CIDR_NVPTYP_ROMLESS          (CHIPID_CIDR_NVPTYP_ROMLESS_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROMless or on-chip Flash Position  */
+#define CHIPID_CIDR_NVPTYP_FLASH            (CHIPID_CIDR_NVPTYP_FLASH_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) Embedded Flash Memory Position  */
+#define CHIPID_CIDR_NVPTYP_ROM_FLASH        (CHIPID_CIDR_NVPTYP_ROM_FLASH_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROM and Embedded Flash Memory- NVPSIZ is ROM size- NVPSIZ2 is Flash size Position  */
+#define CHIPID_CIDR_NVPTYP_SRAM             (CHIPID_CIDR_NVPTYP_SRAM_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) SRAM emulating ROM Position  */
+#define CHIPID_CIDR_EXT_Pos                 31                                             /**< (CHIPID_CIDR) Extension Flag Position */
+#define CHIPID_CIDR_EXT_Msk                 (_U_(0x1) << CHIPID_CIDR_EXT_Pos)              /**< (CHIPID_CIDR) Extension Flag Mask */
+#define CHIPID_CIDR_EXT                     CHIPID_CIDR_EXT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use CHIPID_CIDR_EXT_Msk instead */
+#define CHIPID_CIDR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (CHIPID_CIDR) Register MASK  (Use CHIPID_CIDR_Msk instead)  */
+#define CHIPID_CIDR_Msk                     _U_(0xFFFFFFFF)                                /**< (CHIPID_CIDR) Register Mask  */
+
+
+/* -------- CHIPID_EXID : (CHIPID Offset: 0x04) (R/ 32) Chip ID Extension Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EXID:32;                   /**< bit:  0..31  Chip ID Extension                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CHIPID_EXID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_EXID_OFFSET                  (0x04)                                        /**<  (CHIPID_EXID) Chip ID Extension Register  Offset */
+
+#define CHIPID_EXID_EXID_Pos                0                                              /**< (CHIPID_EXID) Chip ID Extension Position */
+#define CHIPID_EXID_EXID_Msk                (_U_(0xFFFFFFFF) << CHIPID_EXID_EXID_Pos)      /**< (CHIPID_EXID) Chip ID Extension Mask */
+#define CHIPID_EXID_EXID(value)             (CHIPID_EXID_EXID_Msk & ((value) << CHIPID_EXID_EXID_Pos))
+#define CHIPID_EXID_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (CHIPID_EXID) Register MASK  (Use CHIPID_EXID_Msk instead)  */
+#define CHIPID_EXID_Msk                     _U_(0xFFFFFFFF)                                /**< (CHIPID_EXID) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief CHIPID hardware registers */
+typedef struct {  
+  __I  uint32_t CHIPID_CIDR;    /**< (CHIPID Offset: 0x00) Chip ID Register */
+  __I  uint32_t CHIPID_EXID;    /**< (CHIPID Offset: 0x04) Chip ID Extension Register */
+} Chipid;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief CHIPID hardware registers */
+typedef struct {  
+  __I  CHIPID_CIDR_Type               CHIPID_CIDR;    /**< Offset: 0x00 (R/   32) Chip ID Register */
+  __I  CHIPID_EXID_Type               CHIPID_EXID;    /**< Offset: 0x04 (R/   32) Chip ID Extension Register */
+} Chipid;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Chip Identifier */
+
+#endif /* _SAMV71_CHIPID_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/dacc.h
+++ b/asf/sam/include/samv71/component/dacc.h
@@ -1,0 +1,744 @@
+/**
+ * \file
+ *
+ * \brief Component description for DACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_DACC_COMPONENT_H_
+#define _SAMV71_DACC_COMPONENT_H_
+#define _SAMV71_DACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Digital-to-Analog Converter Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DACC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define DACC_11246                      /**< (DACC) Module ID */
+#define REV_DACC E                      /**< (DACC) Module revision */
+
+/* -------- DACC_CR : (DACC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CR_OFFSET                      (0x00)                                        /**<  (DACC_CR) Control Register  Offset */
+
+#define DACC_CR_SWRST_Pos                   0                                              /**< (DACC_CR) Software Reset Position */
+#define DACC_CR_SWRST_Msk                   (_U_(0x1) << DACC_CR_SWRST_Pos)                /**< (DACC_CR) Software Reset Mask */
+#define DACC_CR_SWRST                       DACC_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CR_SWRST_Msk instead */
+#define DACC_CR_MASK                        _U_(0x01)                                      /**< \deprecated (DACC_CR) Register MASK  (Use DACC_CR_Msk instead)  */
+#define DACC_CR_Msk                         _U_(0x01)                                      /**< (DACC_CR) Register Mask  */
+
+
+/* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXS0:1;                   /**< bit:      0  Max Speed Mode for Channel 0             */
+    uint32_t MAXS1:1;                   /**< bit:      1  Max Speed Mode for Channel 1             */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t WORD:1;                    /**< bit:      4  Word Transfer Mode                       */
+    uint32_t ZERO:1;                    /**< bit:      5  Must always be written to 0.             */
+    uint32_t :17;                       /**< bit:  6..22  Reserved */
+    uint32_t DIFF:1;                    /**< bit:     23  Differential Mode                        */
+    uint32_t PRESCALER:4;               /**< bit: 24..27  Peripheral Clock to DAC Clock Ratio      */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t MAXS:2;                    /**< bit:   0..1  Max Speed Mode for Channel x             */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_MR_OFFSET                      (0x04)                                        /**<  (DACC_MR) Mode Register  Offset */
+
+#define DACC_MR_MAXS0_Pos                   0                                              /**< (DACC_MR) Max Speed Mode for Channel 0 Position */
+#define DACC_MR_MAXS0_Msk                   (_U_(0x1) << DACC_MR_MAXS0_Pos)                /**< (DACC_MR) Max Speed Mode for Channel 0 Mask */
+#define DACC_MR_MAXS0                       DACC_MR_MAXS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_MAXS0_Msk instead */
+#define   DACC_MR_MAXS0_TRIG_EVENT_Val      _U_(0x0)                                       /**< (DACC_MR) Trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.)  */
+#define   DACC_MR_MAXS0_MAXIMUM_Val         _U_(0x1)                                       /**< (DACC_MR) Max speed mode enabled.  */
+#define DACC_MR_MAXS0_TRIG_EVENT            (DACC_MR_MAXS0_TRIG_EVENT_Val << DACC_MR_MAXS0_Pos)  /**< (DACC_MR) Trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.) Position  */
+#define DACC_MR_MAXS0_MAXIMUM               (DACC_MR_MAXS0_MAXIMUM_Val << DACC_MR_MAXS0_Pos)  /**< (DACC_MR) Max speed mode enabled. Position  */
+#define DACC_MR_MAXS1_Pos                   1                                              /**< (DACC_MR) Max Speed Mode for Channel 1 Position */
+#define DACC_MR_MAXS1_Msk                   (_U_(0x1) << DACC_MR_MAXS1_Pos)                /**< (DACC_MR) Max Speed Mode for Channel 1 Mask */
+#define DACC_MR_MAXS1                       DACC_MR_MAXS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_MAXS1_Msk instead */
+#define   DACC_MR_MAXS1_TRIG_EVENT_Val      _U_(0x0)                                       /**< (DACC_MR) Trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.)  */
+#define   DACC_MR_MAXS1_MAXIMUM_Val         _U_(0x1)                                       /**< (DACC_MR) Max speed mode enabled.  */
+#define DACC_MR_MAXS1_TRIG_EVENT            (DACC_MR_MAXS1_TRIG_EVENT_Val << DACC_MR_MAXS1_Pos)  /**< (DACC_MR) Trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.) Position  */
+#define DACC_MR_MAXS1_MAXIMUM               (DACC_MR_MAXS1_MAXIMUM_Val << DACC_MR_MAXS1_Pos)  /**< (DACC_MR) Max speed mode enabled. Position  */
+#define DACC_MR_WORD_Pos                    4                                              /**< (DACC_MR) Word Transfer Mode Position */
+#define DACC_MR_WORD_Msk                    (_U_(0x1) << DACC_MR_WORD_Pos)                 /**< (DACC_MR) Word Transfer Mode Mask */
+#define DACC_MR_WORD                        DACC_MR_WORD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_WORD_Msk instead */
+#define   DACC_MR_WORD_DISABLED_Val         _U_(0x0)                                       /**< (DACC_MR) One data to convert is written to the FIFO per access to DACC.  */
+#define   DACC_MR_WORD_ENABLED_Val          _U_(0x1)                                       /**< (DACC_MR) Two data to convert are written to the FIFO per access to DACC (reduces the number of requests to DMA and the number of system bus accesses).  */
+#define DACC_MR_WORD_DISABLED               (DACC_MR_WORD_DISABLED_Val << DACC_MR_WORD_Pos)  /**< (DACC_MR) One data to convert is written to the FIFO per access to DACC. Position  */
+#define DACC_MR_WORD_ENABLED                (DACC_MR_WORD_ENABLED_Val << DACC_MR_WORD_Pos)  /**< (DACC_MR) Two data to convert are written to the FIFO per access to DACC (reduces the number of requests to DMA and the number of system bus accesses). Position  */
+#define DACC_MR_ZERO_Pos                    5                                              /**< (DACC_MR) Must always be written to 0. Position */
+#define DACC_MR_ZERO_Msk                    (_U_(0x1) << DACC_MR_ZERO_Pos)                 /**< (DACC_MR) Must always be written to 0. Mask */
+#define DACC_MR_ZERO                        DACC_MR_ZERO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_ZERO_Msk instead */
+#define DACC_MR_DIFF_Pos                    23                                             /**< (DACC_MR) Differential Mode Position */
+#define DACC_MR_DIFF_Msk                    (_U_(0x1) << DACC_MR_DIFF_Pos)                 /**< (DACC_MR) Differential Mode Mask */
+#define DACC_MR_DIFF                        DACC_MR_DIFF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_DIFF_Msk instead */
+#define   DACC_MR_DIFF_DISABLED_Val         _U_(0x0)                                       /**< (DACC_MR) DAC0 and DAC1 are single-ended outputs.  */
+#define   DACC_MR_DIFF_ENABLED_Val          _U_(0x1)                                       /**< (DACC_MR) DACP and DACN are differential outputs. The differential level is configured by the channel 0 value.  */
+#define DACC_MR_DIFF_DISABLED               (DACC_MR_DIFF_DISABLED_Val << DACC_MR_DIFF_Pos)  /**< (DACC_MR) DAC0 and DAC1 are single-ended outputs. Position  */
+#define DACC_MR_DIFF_ENABLED                (DACC_MR_DIFF_ENABLED_Val << DACC_MR_DIFF_Pos)  /**< (DACC_MR) DACP and DACN are differential outputs. The differential level is configured by the channel 0 value. Position  */
+#define DACC_MR_PRESCALER_Pos               24                                             /**< (DACC_MR) Peripheral Clock to DAC Clock Ratio Position */
+#define DACC_MR_PRESCALER_Msk               (_U_(0xF) << DACC_MR_PRESCALER_Pos)            /**< (DACC_MR) Peripheral Clock to DAC Clock Ratio Mask */
+#define DACC_MR_PRESCALER(value)            (DACC_MR_PRESCALER_Msk & ((value) << DACC_MR_PRESCALER_Pos))
+#define DACC_MR_MASK                        _U_(0xF800033)                                 /**< \deprecated (DACC_MR) Register MASK  (Use DACC_MR_Msk instead)  */
+#define DACC_MR_Msk                         _U_(0xF800033)                                 /**< (DACC_MR) Register Mask  */
+
+#define DACC_MR_MAXS_Pos                    0                                              /**< (DACC_MR Position) Max Speed Mode for Channel x */
+#define DACC_MR_MAXS_Msk                    (_U_(0x3) << DACC_MR_MAXS_Pos)                 /**< (DACC_MR Mask) MAXS */
+#define DACC_MR_MAXS(value)                 (DACC_MR_MAXS_Msk & ((value) << DACC_MR_MAXS_Pos))  
+
+/* -------- DACC_TRIGR : (DACC Offset: 0x08) (R/W 32) Trigger Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRGEN0:1;                  /**< bit:      0  Trigger Enable of Channel 0              */
+    uint32_t TRGEN1:1;                  /**< bit:      1  Trigger Enable of Channel 1              */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t TRGSEL0:3;                 /**< bit:   4..6  Trigger Selection of Channel 0           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TRGSEL1:3;                 /**< bit:  8..10  Trigger Selection of Channel 1           */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t OSR0:3;                    /**< bit: 16..18  Over Sampling Ratio of Channel 0         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t OSR1:3;                    /**< bit: 20..22  Over Sampling Ratio of Channel 1         */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TRGEN:2;                   /**< bit:   0..1  Trigger Enable of Channel x              */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_TRIGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_TRIGR_OFFSET                   (0x08)                                        /**<  (DACC_TRIGR) Trigger Register  Offset */
+
+#define DACC_TRIGR_TRGEN0_Pos               0                                              /**< (DACC_TRIGR) Trigger Enable of Channel 0 Position */
+#define DACC_TRIGR_TRGEN0_Msk               (_U_(0x1) << DACC_TRIGR_TRGEN0_Pos)            /**< (DACC_TRIGR) Trigger Enable of Channel 0 Mask */
+#define DACC_TRIGR_TRGEN0                   DACC_TRIGR_TRGEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_TRIGR_TRGEN0_Msk instead */
+#define   DACC_TRIGR_TRGEN0_DIS_Val         _U_(0x0)                                       /**< (DACC_TRIGR) Trigger mode disabled. DACC is in Free-running mode or Max speed mode.  */
+#define   DACC_TRIGR_TRGEN0_EN_Val          _U_(0x1)                                       /**< (DACC_TRIGR) Trigger mode enabled.  */
+#define DACC_TRIGR_TRGEN0_DIS               (DACC_TRIGR_TRGEN0_DIS_Val << DACC_TRIGR_TRGEN0_Pos)  /**< (DACC_TRIGR) Trigger mode disabled. DACC is in Free-running mode or Max speed mode. Position  */
+#define DACC_TRIGR_TRGEN0_EN                (DACC_TRIGR_TRGEN0_EN_Val << DACC_TRIGR_TRGEN0_Pos)  /**< (DACC_TRIGR) Trigger mode enabled. Position  */
+#define DACC_TRIGR_TRGEN1_Pos               1                                              /**< (DACC_TRIGR) Trigger Enable of Channel 1 Position */
+#define DACC_TRIGR_TRGEN1_Msk               (_U_(0x1) << DACC_TRIGR_TRGEN1_Pos)            /**< (DACC_TRIGR) Trigger Enable of Channel 1 Mask */
+#define DACC_TRIGR_TRGEN1                   DACC_TRIGR_TRGEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_TRIGR_TRGEN1_Msk instead */
+#define   DACC_TRIGR_TRGEN1_DIS_Val         _U_(0x0)                                       /**< (DACC_TRIGR) Trigger mode disabled. DACC is in Free-running mode or Max speed mode.  */
+#define   DACC_TRIGR_TRGEN1_EN_Val          _U_(0x1)                                       /**< (DACC_TRIGR) Trigger mode enabled.  */
+#define DACC_TRIGR_TRGEN1_DIS               (DACC_TRIGR_TRGEN1_DIS_Val << DACC_TRIGR_TRGEN1_Pos)  /**< (DACC_TRIGR) Trigger mode disabled. DACC is in Free-running mode or Max speed mode. Position  */
+#define DACC_TRIGR_TRGEN1_EN                (DACC_TRIGR_TRGEN1_EN_Val << DACC_TRIGR_TRGEN1_Pos)  /**< (DACC_TRIGR) Trigger mode enabled. Position  */
+#define DACC_TRIGR_TRGSEL0_Pos              4                                              /**< (DACC_TRIGR) Trigger Selection of Channel 0 Position */
+#define DACC_TRIGR_TRGSEL0_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL0_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 0 Mask */
+#define DACC_TRIGR_TRGSEL0(value)           (DACC_TRIGR_TRGSEL0_Msk & ((value) << DACC_TRIGR_TRGSEL0_Pos))
+#define   DACC_TRIGR_TRGSEL0_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DATRG  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 output  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC1 output  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC2 output  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 event 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 event 1  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 event 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 event 1  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL0          (DACC_TRIGR_TRGSEL0_TRGSEL0_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) DATRG Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL1          (DACC_TRIGR_TRGSEL0_TRGSEL1_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 output Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL2          (DACC_TRIGR_TRGSEL0_TRGSEL2_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC1 output Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL3          (DACC_TRIGR_TRGSEL0_TRGSEL3_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC2 output Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL4          (DACC_TRIGR_TRGSEL0_TRGSEL4_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 event 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL5          (DACC_TRIGR_TRGSEL0_TRGSEL5_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 event 1 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL6          (DACC_TRIGR_TRGSEL0_TRGSEL6_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 event 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL7          (DACC_TRIGR_TRGSEL0_TRGSEL7_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 event 1 Position  */
+#define DACC_TRIGR_TRGSEL1_Pos              8                                              /**< (DACC_TRIGR) Trigger Selection of Channel 1 Position */
+#define DACC_TRIGR_TRGSEL1_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL1_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 1 Mask */
+#define DACC_TRIGR_TRGSEL1(value)           (DACC_TRIGR_TRGSEL1_Msk & ((value) << DACC_TRIGR_TRGSEL1_Pos))
+#define   DACC_TRIGR_TRGSEL1_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DATRG  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 output  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC1 output  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC2 output  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 event 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 event 1  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 event 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 event 1  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL0          (DACC_TRIGR_TRGSEL1_TRGSEL0_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) DATRG Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL1          (DACC_TRIGR_TRGSEL1_TRGSEL1_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 output Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL2          (DACC_TRIGR_TRGSEL1_TRGSEL2_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC1 output Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL3          (DACC_TRIGR_TRGSEL1_TRGSEL3_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC2 output Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL4          (DACC_TRIGR_TRGSEL1_TRGSEL4_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 event 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL5          (DACC_TRIGR_TRGSEL1_TRGSEL5_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 event 1 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL6          (DACC_TRIGR_TRGSEL1_TRGSEL6_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 event 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL7          (DACC_TRIGR_TRGSEL1_TRGSEL7_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 event 1 Position  */
+#define DACC_TRIGR_OSR0_Pos                 16                                             /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Position */
+#define DACC_TRIGR_OSR0_Msk                 (_U_(0x7) << DACC_TRIGR_OSR0_Pos)              /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Mask */
+#define DACC_TRIGR_OSR0(value)              (DACC_TRIGR_OSR0_Msk & ((value) << DACC_TRIGR_OSR0_Pos))
+#define   DACC_TRIGR_OSR0_OSR_1_Val         _U_(0x0)                                       /**< (DACC_TRIGR) OSR = 1  */
+#define   DACC_TRIGR_OSR0_OSR_2_Val         _U_(0x1)                                       /**< (DACC_TRIGR) OSR = 2  */
+#define   DACC_TRIGR_OSR0_OSR_4_Val         _U_(0x2)                                       /**< (DACC_TRIGR) OSR = 4  */
+#define   DACC_TRIGR_OSR0_OSR_8_Val         _U_(0x3)                                       /**< (DACC_TRIGR) OSR = 8  */
+#define   DACC_TRIGR_OSR0_OSR_16_Val        _U_(0x4)                                       /**< (DACC_TRIGR) OSR = 16  */
+#define   DACC_TRIGR_OSR0_OSR_32_Val        _U_(0x5)                                       /**< (DACC_TRIGR) OSR = 32  */
+#define DACC_TRIGR_OSR0_OSR_1               (DACC_TRIGR_OSR0_OSR_1_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 1 Position  */
+#define DACC_TRIGR_OSR0_OSR_2               (DACC_TRIGR_OSR0_OSR_2_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 2 Position  */
+#define DACC_TRIGR_OSR0_OSR_4               (DACC_TRIGR_OSR0_OSR_4_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 4 Position  */
+#define DACC_TRIGR_OSR0_OSR_8               (DACC_TRIGR_OSR0_OSR_8_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 8 Position  */
+#define DACC_TRIGR_OSR0_OSR_16              (DACC_TRIGR_OSR0_OSR_16_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 16 Position  */
+#define DACC_TRIGR_OSR0_OSR_32              (DACC_TRIGR_OSR0_OSR_32_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 32 Position  */
+#define DACC_TRIGR_OSR1_Pos                 20                                             /**< (DACC_TRIGR) Over Sampling Ratio of Channel 1 Position */
+#define DACC_TRIGR_OSR1_Msk                 (_U_(0x7) << DACC_TRIGR_OSR1_Pos)              /**< (DACC_TRIGR) Over Sampling Ratio of Channel 1 Mask */
+#define DACC_TRIGR_OSR1(value)              (DACC_TRIGR_OSR1_Msk & ((value) << DACC_TRIGR_OSR1_Pos))
+#define   DACC_TRIGR_OSR1_OSR_1_Val         _U_(0x0)                                       /**< (DACC_TRIGR) OSR = 1  */
+#define   DACC_TRIGR_OSR1_OSR_2_Val         _U_(0x1)                                       /**< (DACC_TRIGR) OSR = 2  */
+#define   DACC_TRIGR_OSR1_OSR_4_Val         _U_(0x2)                                       /**< (DACC_TRIGR) OSR = 4  */
+#define   DACC_TRIGR_OSR1_OSR_8_Val         _U_(0x3)                                       /**< (DACC_TRIGR) OSR = 8  */
+#define   DACC_TRIGR_OSR1_OSR_16_Val        _U_(0x4)                                       /**< (DACC_TRIGR) OSR = 16  */
+#define   DACC_TRIGR_OSR1_OSR_32_Val        _U_(0x5)                                       /**< (DACC_TRIGR) OSR = 32  */
+#define DACC_TRIGR_OSR1_OSR_1               (DACC_TRIGR_OSR1_OSR_1_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 1 Position  */
+#define DACC_TRIGR_OSR1_OSR_2               (DACC_TRIGR_OSR1_OSR_2_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 2 Position  */
+#define DACC_TRIGR_OSR1_OSR_4               (DACC_TRIGR_OSR1_OSR_4_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 4 Position  */
+#define DACC_TRIGR_OSR1_OSR_8               (DACC_TRIGR_OSR1_OSR_8_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 8 Position  */
+#define DACC_TRIGR_OSR1_OSR_16              (DACC_TRIGR_OSR1_OSR_16_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 16 Position  */
+#define DACC_TRIGR_OSR1_OSR_32              (DACC_TRIGR_OSR1_OSR_32_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 32 Position  */
+#define DACC_TRIGR_MASK                     _U_(0x770773)                                  /**< \deprecated (DACC_TRIGR) Register MASK  (Use DACC_TRIGR_Msk instead)  */
+#define DACC_TRIGR_Msk                      _U_(0x770773)                                  /**< (DACC_TRIGR) Register Mask  */
+
+#define DACC_TRIGR_TRGEN_Pos                0                                              /**< (DACC_TRIGR Position) Trigger Enable of Channel x */
+#define DACC_TRIGR_TRGEN_Msk                (_U_(0x3) << DACC_TRIGR_TRGEN_Pos)             /**< (DACC_TRIGR Mask) TRGEN */
+#define DACC_TRIGR_TRGEN(value)             (DACC_TRIGR_TRGEN_Msk & ((value) << DACC_TRIGR_TRGEN_Pos))  
+
+/* -------- DACC_CHER : (DACC Offset: 0x10) (/W 32) Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Enable                         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Enable                         */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHER_OFFSET                    (0x10)                                        /**<  (DACC_CHER) Channel Enable Register  Offset */
+
+#define DACC_CHER_CH0_Pos                   0                                              /**< (DACC_CHER) Channel 0 Enable Position */
+#define DACC_CHER_CH0_Msk                   (_U_(0x1) << DACC_CHER_CH0_Pos)                /**< (DACC_CHER) Channel 0 Enable Mask */
+#define DACC_CHER_CH0                       DACC_CHER_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHER_CH0_Msk instead */
+#define DACC_CHER_CH1_Pos                   1                                              /**< (DACC_CHER) Channel 1 Enable Position */
+#define DACC_CHER_CH1_Msk                   (_U_(0x1) << DACC_CHER_CH1_Pos)                /**< (DACC_CHER) Channel 1 Enable Mask */
+#define DACC_CHER_CH1                       DACC_CHER_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHER_CH1_Msk instead */
+#define DACC_CHER_MASK                      _U_(0x03)                                      /**< \deprecated (DACC_CHER) Register MASK  (Use DACC_CHER_Msk instead)  */
+#define DACC_CHER_Msk                       _U_(0x03)                                      /**< (DACC_CHER) Register Mask  */
+
+#define DACC_CHER_CH_Pos                    0                                              /**< (DACC_CHER Position) Channel x Enable */
+#define DACC_CHER_CH_Msk                    (_U_(0x3) << DACC_CHER_CH_Pos)                 /**< (DACC_CHER Mask) CH */
+#define DACC_CHER_CH(value)                 (DACC_CHER_CH_Msk & ((value) << DACC_CHER_CH_Pos))  
+
+/* -------- DACC_CHDR : (DACC Offset: 0x14) (/W 32) Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Disable                        */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Disable                        */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHDR_OFFSET                    (0x14)                                        /**<  (DACC_CHDR) Channel Disable Register  Offset */
+
+#define DACC_CHDR_CH0_Pos                   0                                              /**< (DACC_CHDR) Channel 0 Disable Position */
+#define DACC_CHDR_CH0_Msk                   (_U_(0x1) << DACC_CHDR_CH0_Pos)                /**< (DACC_CHDR) Channel 0 Disable Mask */
+#define DACC_CHDR_CH0                       DACC_CHDR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHDR_CH0_Msk instead */
+#define DACC_CHDR_CH1_Pos                   1                                              /**< (DACC_CHDR) Channel 1 Disable Position */
+#define DACC_CHDR_CH1_Msk                   (_U_(0x1) << DACC_CHDR_CH1_Pos)                /**< (DACC_CHDR) Channel 1 Disable Mask */
+#define DACC_CHDR_CH1                       DACC_CHDR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHDR_CH1_Msk instead */
+#define DACC_CHDR_MASK                      _U_(0x03)                                      /**< \deprecated (DACC_CHDR) Register MASK  (Use DACC_CHDR_Msk instead)  */
+#define DACC_CHDR_Msk                       _U_(0x03)                                      /**< (DACC_CHDR) Register Mask  */
+
+#define DACC_CHDR_CH_Pos                    0                                              /**< (DACC_CHDR Position) Channel x Disable */
+#define DACC_CHDR_CH_Msk                    (_U_(0x3) << DACC_CHDR_CH_Pos)                 /**< (DACC_CHDR Mask) CH */
+#define DACC_CHDR_CH(value)                 (DACC_CHDR_CH_Msk & ((value) << DACC_CHDR_CH_Pos))  
+
+/* -------- DACC_CHSR : (DACC Offset: 0x18) (R/ 32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Status                         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t DACRDY0:1;                 /**< bit:      8  DAC Ready Flag                           */
+    uint32_t DACRDY1:1;                 /**< bit:      9  DAC Ready Flag                           */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Status                         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t DACRDY:2;                  /**< bit:   8..9  DAC Ready Flag                           */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHSR_OFFSET                    (0x18)                                        /**<  (DACC_CHSR) Channel Status Register  Offset */
+
+#define DACC_CHSR_CH0_Pos                   0                                              /**< (DACC_CHSR) Channel 0 Status Position */
+#define DACC_CHSR_CH0_Msk                   (_U_(0x1) << DACC_CHSR_CH0_Pos)                /**< (DACC_CHSR) Channel 0 Status Mask */
+#define DACC_CHSR_CH0                       DACC_CHSR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_CH0_Msk instead */
+#define DACC_CHSR_CH1_Pos                   1                                              /**< (DACC_CHSR) Channel 1 Status Position */
+#define DACC_CHSR_CH1_Msk                   (_U_(0x1) << DACC_CHSR_CH1_Pos)                /**< (DACC_CHSR) Channel 1 Status Mask */
+#define DACC_CHSR_CH1                       DACC_CHSR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_CH1_Msk instead */
+#define DACC_CHSR_DACRDY0_Pos               8                                              /**< (DACC_CHSR) DAC Ready Flag Position */
+#define DACC_CHSR_DACRDY0_Msk               (_U_(0x1) << DACC_CHSR_DACRDY0_Pos)            /**< (DACC_CHSR) DAC Ready Flag Mask */
+#define DACC_CHSR_DACRDY0                   DACC_CHSR_DACRDY0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_DACRDY0_Msk instead */
+#define DACC_CHSR_DACRDY1_Pos               9                                              /**< (DACC_CHSR) DAC Ready Flag Position */
+#define DACC_CHSR_DACRDY1_Msk               (_U_(0x1) << DACC_CHSR_DACRDY1_Pos)            /**< (DACC_CHSR) DAC Ready Flag Mask */
+#define DACC_CHSR_DACRDY1                   DACC_CHSR_DACRDY1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_DACRDY1_Msk instead */
+#define DACC_CHSR_MASK                      _U_(0x303)                                     /**< \deprecated (DACC_CHSR) Register MASK  (Use DACC_CHSR_Msk instead)  */
+#define DACC_CHSR_Msk                       _U_(0x303)                                     /**< (DACC_CHSR) Register Mask  */
+
+#define DACC_CHSR_CH_Pos                    0                                              /**< (DACC_CHSR Position) Channel x Status */
+#define DACC_CHSR_CH_Msk                    (_U_(0x3) << DACC_CHSR_CH_Pos)                 /**< (DACC_CHSR Mask) CH */
+#define DACC_CHSR_CH(value)                 (DACC_CHSR_CH_Msk & ((value) << DACC_CHSR_CH_Pos))  
+#define DACC_CHSR_DACRDY_Pos                8                                              /**< (DACC_CHSR Position) DAC Ready Flag */
+#define DACC_CHSR_DACRDY_Msk                (_U_(0x3) << DACC_CHSR_DACRDY_Pos)             /**< (DACC_CHSR Mask) DACRDY */
+#define DACC_CHSR_DACRDY(value)             (DACC_CHSR_DACRDY_Msk & ((value) << DACC_CHSR_DACRDY_Pos))  
+
+/* -------- DACC_CDR : (DACC Offset: 0x1c) (/W 32) Conversion Data Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA0:16;                  /**< bit:  0..15  Data to Convert for channel 0            */
+    uint32_t DATA1:16;                  /**< bit: 16..31  Data to Convert for channel 1            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CDR_OFFSET                     (0x1C)                                        /**<  (DACC_CDR) Conversion Data Register 0  Offset */
+
+#define DACC_CDR_DATA0_Pos                  0                                              /**< (DACC_CDR) Data to Convert for channel 0 Position */
+#define DACC_CDR_DATA0_Msk                  (_U_(0xFFFF) << DACC_CDR_DATA0_Pos)            /**< (DACC_CDR) Data to Convert for channel 0 Mask */
+#define DACC_CDR_DATA0(value)               (DACC_CDR_DATA0_Msk & ((value) << DACC_CDR_DATA0_Pos))
+#define DACC_CDR_DATA1_Pos                  16                                             /**< (DACC_CDR) Data to Convert for channel 1 Position */
+#define DACC_CDR_DATA1_Msk                  (_U_(0xFFFF) << DACC_CDR_DATA1_Pos)            /**< (DACC_CDR) Data to Convert for channel 1 Mask */
+#define DACC_CDR_DATA1(value)               (DACC_CDR_DATA1_Msk & ((value) << DACC_CDR_DATA1_Pos))
+#define DACC_CDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DACC_CDR) Register MASK  (Use DACC_CDR_Msk instead)  */
+#define DACC_CDR_Msk                        _U_(0xFFFFFFFF)                                /**< (DACC_CDR) Register Mask  */
+
+
+/* -------- DACC_IER : (DACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Enable of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Enable of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Enable of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Enable of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Enable of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Enable of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IER_OFFSET                     (0x24)                                        /**<  (DACC_IER) Interrupt Enable Register  Offset */
+
+#define DACC_IER_TXRDY0_Pos                 0                                              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 0 Position */
+#define DACC_IER_TXRDY0_Msk                 (_U_(0x1) << DACC_IER_TXRDY0_Pos)              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 0 Mask */
+#define DACC_IER_TXRDY0                     DACC_IER_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_TXRDY0_Msk instead */
+#define DACC_IER_TXRDY1_Pos                 1                                              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 1 Position */
+#define DACC_IER_TXRDY1_Msk                 (_U_(0x1) << DACC_IER_TXRDY1_Pos)              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 1 Mask */
+#define DACC_IER_TXRDY1                     DACC_IER_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_TXRDY1_Msk instead */
+#define DACC_IER_EOC0_Pos                   4                                              /**< (DACC_IER) End of Conversion Interrupt Enable of channel 0 Position */
+#define DACC_IER_EOC0_Msk                   (_U_(0x1) << DACC_IER_EOC0_Pos)                /**< (DACC_IER) End of Conversion Interrupt Enable of channel 0 Mask */
+#define DACC_IER_EOC0                       DACC_IER_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_EOC0_Msk instead */
+#define DACC_IER_EOC1_Pos                   5                                              /**< (DACC_IER) End of Conversion Interrupt Enable of channel 1 Position */
+#define DACC_IER_EOC1_Msk                   (_U_(0x1) << DACC_IER_EOC1_Pos)                /**< (DACC_IER) End of Conversion Interrupt Enable of channel 1 Mask */
+#define DACC_IER_EOC1                       DACC_IER_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_EOC1_Msk instead */
+#define DACC_IER_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IER) Register MASK  (Use DACC_IER_Msk instead)  */
+#define DACC_IER_Msk                        _U_(0x33)                                      /**< (DACC_IER) Register Mask  */
+
+#define DACC_IER_TXRDY_Pos                  0                                              /**< (DACC_IER Position) Transmit Ready Interrupt Enable of channel x */
+#define DACC_IER_TXRDY_Msk                  (_U_(0x3) << DACC_IER_TXRDY_Pos)               /**< (DACC_IER Mask) TXRDY */
+#define DACC_IER_TXRDY(value)               (DACC_IER_TXRDY_Msk & ((value) << DACC_IER_TXRDY_Pos))  
+#define DACC_IER_EOC_Pos                    4                                              /**< (DACC_IER Position) End of Conversion Interrupt Enable of channel x */
+#define DACC_IER_EOC_Msk                    (_U_(0x3) << DACC_IER_EOC_Pos)                 /**< (DACC_IER Mask) EOC */
+#define DACC_IER_EOC(value)                 (DACC_IER_EOC_Msk & ((value) << DACC_IER_EOC_Pos))  
+
+/* -------- DACC_IDR : (DACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Disable of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Disable of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Disable of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Disable of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Disable of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Disable of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IDR_OFFSET                     (0x28)                                        /**<  (DACC_IDR) Interrupt Disable Register  Offset */
+
+#define DACC_IDR_TXRDY0_Pos                 0                                              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 0 Position */
+#define DACC_IDR_TXRDY0_Msk                 (_U_(0x1) << DACC_IDR_TXRDY0_Pos)              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 0 Mask */
+#define DACC_IDR_TXRDY0                     DACC_IDR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_TXRDY0_Msk instead */
+#define DACC_IDR_TXRDY1_Pos                 1                                              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 1 Position */
+#define DACC_IDR_TXRDY1_Msk                 (_U_(0x1) << DACC_IDR_TXRDY1_Pos)              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 1 Mask */
+#define DACC_IDR_TXRDY1                     DACC_IDR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_TXRDY1_Msk instead */
+#define DACC_IDR_EOC0_Pos                   4                                              /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 0 Position */
+#define DACC_IDR_EOC0_Msk                   (_U_(0x1) << DACC_IDR_EOC0_Pos)                /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 0 Mask */
+#define DACC_IDR_EOC0                       DACC_IDR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_EOC0_Msk instead */
+#define DACC_IDR_EOC1_Pos                   5                                              /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 1 Position */
+#define DACC_IDR_EOC1_Msk                   (_U_(0x1) << DACC_IDR_EOC1_Pos)                /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 1 Mask */
+#define DACC_IDR_EOC1                       DACC_IDR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_EOC1_Msk instead */
+#define DACC_IDR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IDR) Register MASK  (Use DACC_IDR_Msk instead)  */
+#define DACC_IDR_Msk                        _U_(0x33)                                      /**< (DACC_IDR) Register Mask  */
+
+#define DACC_IDR_TXRDY_Pos                  0                                              /**< (DACC_IDR Position) Transmit Ready Interrupt Disable of channel x */
+#define DACC_IDR_TXRDY_Msk                  (_U_(0x3) << DACC_IDR_TXRDY_Pos)               /**< (DACC_IDR Mask) TXRDY */
+#define DACC_IDR_TXRDY(value)               (DACC_IDR_TXRDY_Msk & ((value) << DACC_IDR_TXRDY_Pos))  
+#define DACC_IDR_EOC_Pos                    4                                              /**< (DACC_IDR Position) End of Conversion Interrupt Disable of channel x */
+#define DACC_IDR_EOC_Msk                    (_U_(0x3) << DACC_IDR_EOC_Pos)                 /**< (DACC_IDR Mask) EOC */
+#define DACC_IDR_EOC(value)                 (DACC_IDR_EOC_Msk & ((value) << DACC_IDR_EOC_Pos))  
+
+/* -------- DACC_IMR : (DACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Mask of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Mask of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Mask of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Mask of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Mask of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Mask of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IMR_OFFSET                     (0x2C)                                        /**<  (DACC_IMR) Interrupt Mask Register  Offset */
+
+#define DACC_IMR_TXRDY0_Pos                 0                                              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 0 Position */
+#define DACC_IMR_TXRDY0_Msk                 (_U_(0x1) << DACC_IMR_TXRDY0_Pos)              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 0 Mask */
+#define DACC_IMR_TXRDY0                     DACC_IMR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_TXRDY0_Msk instead */
+#define DACC_IMR_TXRDY1_Pos                 1                                              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 1 Position */
+#define DACC_IMR_TXRDY1_Msk                 (_U_(0x1) << DACC_IMR_TXRDY1_Pos)              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 1 Mask */
+#define DACC_IMR_TXRDY1                     DACC_IMR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_TXRDY1_Msk instead */
+#define DACC_IMR_EOC0_Pos                   4                                              /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 0 Position */
+#define DACC_IMR_EOC0_Msk                   (_U_(0x1) << DACC_IMR_EOC0_Pos)                /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 0 Mask */
+#define DACC_IMR_EOC0                       DACC_IMR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_EOC0_Msk instead */
+#define DACC_IMR_EOC1_Pos                   5                                              /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 1 Position */
+#define DACC_IMR_EOC1_Msk                   (_U_(0x1) << DACC_IMR_EOC1_Pos)                /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 1 Mask */
+#define DACC_IMR_EOC1                       DACC_IMR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_EOC1_Msk instead */
+#define DACC_IMR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IMR) Register MASK  (Use DACC_IMR_Msk instead)  */
+#define DACC_IMR_Msk                        _U_(0x33)                                      /**< (DACC_IMR) Register Mask  */
+
+#define DACC_IMR_TXRDY_Pos                  0                                              /**< (DACC_IMR Position) Transmit Ready Interrupt Mask of channel x */
+#define DACC_IMR_TXRDY_Msk                  (_U_(0x3) << DACC_IMR_TXRDY_Pos)               /**< (DACC_IMR Mask) TXRDY */
+#define DACC_IMR_TXRDY(value)               (DACC_IMR_TXRDY_Msk & ((value) << DACC_IMR_TXRDY_Pos))  
+#define DACC_IMR_EOC_Pos                    4                                              /**< (DACC_IMR Position) End of Conversion Interrupt Mask of channel x */
+#define DACC_IMR_EOC_Msk                    (_U_(0x3) << DACC_IMR_EOC_Pos)                 /**< (DACC_IMR Mask) EOC */
+#define DACC_IMR_EOC(value)                 (DACC_IMR_EOC_Msk & ((value) << DACC_IMR_EOC_Pos))  
+
+/* -------- DACC_ISR : (DACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Flag of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Flag of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Flag of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Flag of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Flag of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Flag of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_ISR_OFFSET                     (0x30)                                        /**<  (DACC_ISR) Interrupt Status Register  Offset */
+
+#define DACC_ISR_TXRDY0_Pos                 0                                              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 0 Position */
+#define DACC_ISR_TXRDY0_Msk                 (_U_(0x1) << DACC_ISR_TXRDY0_Pos)              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 0 Mask */
+#define DACC_ISR_TXRDY0                     DACC_ISR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_TXRDY0_Msk instead */
+#define DACC_ISR_TXRDY1_Pos                 1                                              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 1 Position */
+#define DACC_ISR_TXRDY1_Msk                 (_U_(0x1) << DACC_ISR_TXRDY1_Pos)              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 1 Mask */
+#define DACC_ISR_TXRDY1                     DACC_ISR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_TXRDY1_Msk instead */
+#define DACC_ISR_EOC0_Pos                   4                                              /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 0 Position */
+#define DACC_ISR_EOC0_Msk                   (_U_(0x1) << DACC_ISR_EOC0_Pos)                /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 0 Mask */
+#define DACC_ISR_EOC0                       DACC_ISR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_EOC0_Msk instead */
+#define DACC_ISR_EOC1_Pos                   5                                              /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 1 Position */
+#define DACC_ISR_EOC1_Msk                   (_U_(0x1) << DACC_ISR_EOC1_Pos)                /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 1 Mask */
+#define DACC_ISR_EOC1                       DACC_ISR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_EOC1_Msk instead */
+#define DACC_ISR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_ISR) Register MASK  (Use DACC_ISR_Msk instead)  */
+#define DACC_ISR_Msk                        _U_(0x33)                                      /**< (DACC_ISR) Register Mask  */
+
+#define DACC_ISR_TXRDY_Pos                  0                                              /**< (DACC_ISR Position) Transmit Ready Interrupt Flag of channel x */
+#define DACC_ISR_TXRDY_Msk                  (_U_(0x3) << DACC_ISR_TXRDY_Pos)               /**< (DACC_ISR Mask) TXRDY */
+#define DACC_ISR_TXRDY(value)               (DACC_ISR_TXRDY_Msk & ((value) << DACC_ISR_TXRDY_Pos))  
+#define DACC_ISR_EOC_Pos                    4                                              /**< (DACC_ISR Position) End of Conversion Interrupt Flag of channel x */
+#define DACC_ISR_EOC_Msk                    (_U_(0x3) << DACC_ISR_EOC_Pos)                 /**< (DACC_ISR Mask) EOC */
+#define DACC_ISR_EOC(value)                 (DACC_ISR_EOC_Msk & ((value) << DACC_ISR_EOC_Pos))  
+
+/* -------- DACC_ACR : (DACC Offset: 0x94) (R/W 32) Analog Current Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IBCTLCH0:2;                /**< bit:   0..1  Analog Output Current Control            */
+    uint32_t IBCTLCH1:2;                /**< bit:   2..3  Analog Output Current Control            */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_ACR_OFFSET                     (0x94)                                        /**<  (DACC_ACR) Analog Current Register  Offset */
+
+#define DACC_ACR_IBCTLCH0_Pos               0                                              /**< (DACC_ACR) Analog Output Current Control Position */
+#define DACC_ACR_IBCTLCH0_Msk               (_U_(0x3) << DACC_ACR_IBCTLCH0_Pos)            /**< (DACC_ACR) Analog Output Current Control Mask */
+#define DACC_ACR_IBCTLCH0(value)            (DACC_ACR_IBCTLCH0_Msk & ((value) << DACC_ACR_IBCTLCH0_Pos))
+#define DACC_ACR_IBCTLCH1_Pos               2                                              /**< (DACC_ACR) Analog Output Current Control Position */
+#define DACC_ACR_IBCTLCH1_Msk               (_U_(0x3) << DACC_ACR_IBCTLCH1_Pos)            /**< (DACC_ACR) Analog Output Current Control Mask */
+#define DACC_ACR_IBCTLCH1(value)            (DACC_ACR_IBCTLCH1_Msk & ((value) << DACC_ACR_IBCTLCH1_Pos))
+#define DACC_ACR_MASK                       _U_(0x0F)                                      /**< \deprecated (DACC_ACR) Register MASK  (Use DACC_ACR_Msk instead)  */
+#define DACC_ACR_Msk                        _U_(0x0F)                                      /**< (DACC_ACR) Register Mask  */
+
+
+/* -------- DACC_WPMR : (DACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect Key                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPMR_OFFSET                    (0xE4)                                        /**<  (DACC_WPMR) Write Protection Mode Register  Offset */
+
+#define DACC_WPMR_WPEN_Pos                  0                                              /**< (DACC_WPMR) Write Protection Enable Position */
+#define DACC_WPMR_WPEN_Msk                  (_U_(0x1) << DACC_WPMR_WPEN_Pos)               /**< (DACC_WPMR) Write Protection Enable Mask */
+#define DACC_WPMR_WPEN                      DACC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_WPMR_WPEN_Msk instead */
+#define DACC_WPMR_WPKEY_Pos                 8                                              /**< (DACC_WPMR) Write Protect Key Position */
+#define DACC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << DACC_WPMR_WPKEY_Pos)         /**< (DACC_WPMR) Write Protect Key Mask */
+#define DACC_WPMR_WPKEY(value)              (DACC_WPMR_WPKEY_Msk & ((value) << DACC_WPMR_WPKEY_Pos))
+#define   DACC_WPMR_WPKEY_PASSWD_Val        _U_(0x444143)                                  /**< (DACC_WPMR) Writing any other value in this field aborts the write operation of bit WPEN.Always reads as 0.  */
+#define DACC_WPMR_WPKEY_PASSWD              (DACC_WPMR_WPKEY_PASSWD_Val << DACC_WPMR_WPKEY_Pos)  /**< (DACC_WPMR) Writing any other value in this field aborts the write operation of bit WPEN.Always reads as 0. Position  */
+#define DACC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (DACC_WPMR) Register MASK  (Use DACC_WPMR_Msk instead)  */
+#define DACC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (DACC_WPMR) Register Mask  */
+
+
+/* -------- DACC_WPSR : (DACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPSR_OFFSET                    (0xE8)                                        /**<  (DACC_WPSR) Write Protection Status Register  Offset */
+
+#define DACC_WPSR_WPVS_Pos                  0                                              /**< (DACC_WPSR) Write Protection Violation Status Position */
+#define DACC_WPSR_WPVS_Msk                  (_U_(0x1) << DACC_WPSR_WPVS_Pos)               /**< (DACC_WPSR) Write Protection Violation Status Mask */
+#define DACC_WPSR_WPVS                      DACC_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_WPSR_WPVS_Msk instead */
+#define DACC_WPSR_WPVSRC_Pos                8                                              /**< (DACC_WPSR) Write Protection Violation Source Position */
+#define DACC_WPSR_WPVSRC_Msk                (_U_(0xFF) << DACC_WPSR_WPVSRC_Pos)            /**< (DACC_WPSR) Write Protection Violation Source Mask */
+#define DACC_WPSR_WPVSRC(value)             (DACC_WPSR_WPVSRC_Msk & ((value) << DACC_WPSR_WPVSRC_Pos))
+#define DACC_WPSR_MASK                      _U_(0xFF01)                                    /**< \deprecated (DACC_WPSR) Register MASK  (Use DACC_WPSR_Msk instead)  */
+#define DACC_WPSR_Msk                       _U_(0xFF01)                                    /**< (DACC_WPSR) Register Mask  */
+
+
+/* -------- DACC_VERSION : (DACC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version                                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_VERSION_OFFSET                 (0xFC)                                        /**<  (DACC_VERSION) Version Register  Offset */
+
+#define DACC_VERSION_VERSION_Pos            0                                              /**< (DACC_VERSION) Version Position */
+#define DACC_VERSION_VERSION_Msk            (_U_(0xFFF) << DACC_VERSION_VERSION_Pos)       /**< (DACC_VERSION) Version Mask */
+#define DACC_VERSION_VERSION(value)         (DACC_VERSION_VERSION_Msk & ((value) << DACC_VERSION_VERSION_Pos))
+#define DACC_VERSION_MFN_Pos                16                                             /**< (DACC_VERSION) Metal Fix Number Position */
+#define DACC_VERSION_MFN_Msk                (_U_(0x7) << DACC_VERSION_MFN_Pos)             /**< (DACC_VERSION) Metal Fix Number Mask */
+#define DACC_VERSION_MFN(value)             (DACC_VERSION_MFN_Msk & ((value) << DACC_VERSION_MFN_Pos))
+#define DACC_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (DACC_VERSION) Register MASK  (Use DACC_VERSION_Msk instead)  */
+#define DACC_VERSION_Msk                    _U_(0x70FFF)                                   /**< (DACC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief DACC hardware registers */
+typedef struct {  
+  __O  uint32_t DACC_CR;        /**< (DACC Offset: 0x00) Control Register */
+  __IO uint32_t DACC_MR;        /**< (DACC Offset: 0x04) Mode Register */
+  __IO uint32_t DACC_TRIGR;     /**< (DACC Offset: 0x08) Trigger Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t DACC_CHER;      /**< (DACC Offset: 0x10) Channel Enable Register */
+  __O  uint32_t DACC_CHDR;      /**< (DACC Offset: 0x14) Channel Disable Register */
+  __I  uint32_t DACC_CHSR;      /**< (DACC Offset: 0x18) Channel Status Register */
+  __O  uint32_t DACC_CDR[2];    /**< (DACC Offset: 0x1C) Conversion Data Register 0 */
+  __O  uint32_t DACC_IER;       /**< (DACC Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t DACC_IDR;       /**< (DACC Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t DACC_IMR;       /**< (DACC Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t DACC_ISR;       /**< (DACC Offset: 0x30) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO uint32_t DACC_ACR;       /**< (DACC Offset: 0x94) Analog Current Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO uint32_t DACC_WPMR;      /**< (DACC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t DACC_WPSR;      /**< (DACC Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  uint32_t DACC_VERSION;   /**< (DACC Offset: 0xFC) Version Register */
+} Dacc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief DACC hardware registers */
+typedef struct {  
+  __O  DACC_CR_Type                   DACC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO DACC_MR_Type                   DACC_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO DACC_TRIGR_Type                DACC_TRIGR;     /**< Offset: 0x08 (R/W  32) Trigger Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  DACC_CHER_Type                 DACC_CHER;      /**< Offset: 0x10 ( /W  32) Channel Enable Register */
+  __O  DACC_CHDR_Type                 DACC_CHDR;      /**< Offset: 0x14 ( /W  32) Channel Disable Register */
+  __I  DACC_CHSR_Type                 DACC_CHSR;      /**< Offset: 0x18 (R/   32) Channel Status Register */
+  __O  DACC_CDR_Type                  DACC_CDR[2];    /**< Offset: 0x1C ( /W  32) Conversion Data Register 0 */
+  __O  DACC_IER_Type                  DACC_IER;       /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  DACC_IDR_Type                  DACC_IDR;       /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  DACC_IMR_Type                  DACC_IMR;       /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  DACC_ISR_Type                  DACC_ISR;       /**< Offset: 0x30 (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO DACC_ACR_Type                  DACC_ACR;       /**< Offset: 0x94 (R/W  32) Analog Current Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO DACC_WPMR_Type                 DACC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  DACC_WPSR_Type                 DACC_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  DACC_VERSION_Type              DACC_VERSION;   /**< Offset: 0xFC (R/   32) Version Register */
+} Dacc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Digital-to-Analog Converter Controller */
+
+#endif /* _SAMV71_DACC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/efc.h
+++ b/asf/sam/include/samv71/component/efc.h
@@ -1,0 +1,319 @@
+/**
+ * \file
+ *
+ * \brief Component description for EFC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_EFC_COMPONENT_H_
+#define _SAMV71_EFC_COMPONENT_H_
+#define _SAMV71_EFC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Embedded Flash Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EFC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define EFC_6450                       /**< (EFC) Module ID */
+#define REV_EFC Y                      /**< (EFC) Module revision */
+
+/* -------- EEFC_FMR : (EFC Offset: 0x00) (R/W 32) EEFC Flash Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Interrupt Enable             */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t FWS:4;                     /**< bit:  8..11  Flash Wait State                         */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t SCOD:1;                    /**< bit:     16  Sequential Code Optimization Disable     */
+    uint32_t :9;                        /**< bit: 17..25  Reserved */
+    uint32_t CLOE:1;                    /**< bit:     26  Code Loop Optimization Enable            */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FMR_OFFSET                     (0x00)                                        /**<  (EEFC_FMR) EEFC Flash Mode Register  Offset */
+
+#define EEFC_FMR_FRDY_Pos                   0                                              /**< (EEFC_FMR) Flash Ready Interrupt Enable Position */
+#define EEFC_FMR_FRDY_Msk                   (_U_(0x1) << EEFC_FMR_FRDY_Pos)                /**< (EEFC_FMR) Flash Ready Interrupt Enable Mask */
+#define EEFC_FMR_FRDY                       EEFC_FMR_FRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_FRDY_Msk instead */
+#define EEFC_FMR_FWS_Pos                    8                                              /**< (EEFC_FMR) Flash Wait State Position */
+#define EEFC_FMR_FWS_Msk                    (_U_(0xF) << EEFC_FMR_FWS_Pos)                 /**< (EEFC_FMR) Flash Wait State Mask */
+#define EEFC_FMR_FWS(value)                 (EEFC_FMR_FWS_Msk & ((value) << EEFC_FMR_FWS_Pos))
+#define EEFC_FMR_SCOD_Pos                   16                                             /**< (EEFC_FMR) Sequential Code Optimization Disable Position */
+#define EEFC_FMR_SCOD_Msk                   (_U_(0x1) << EEFC_FMR_SCOD_Pos)                /**< (EEFC_FMR) Sequential Code Optimization Disable Mask */
+#define EEFC_FMR_SCOD                       EEFC_FMR_SCOD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_SCOD_Msk instead */
+#define EEFC_FMR_CLOE_Pos                   26                                             /**< (EEFC_FMR) Code Loop Optimization Enable Position */
+#define EEFC_FMR_CLOE_Msk                   (_U_(0x1) << EEFC_FMR_CLOE_Pos)                /**< (EEFC_FMR) Code Loop Optimization Enable Mask */
+#define EEFC_FMR_CLOE                       EEFC_FMR_CLOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_CLOE_Msk instead */
+#define EEFC_FMR_MASK                       _U_(0x4010F01)                                 /**< \deprecated (EEFC_FMR) Register MASK  (Use EEFC_FMR_Msk instead)  */
+#define EEFC_FMR_Msk                        _U_(0x4010F01)                                 /**< (EEFC_FMR) Register Mask  */
+
+
+/* -------- EEFC_FCR : (EFC Offset: 0x04) (/W 32) EEFC Flash Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCMD:8;                    /**< bit:   0..7  Flash Command                            */
+    uint32_t FARG:16;                   /**< bit:  8..23  Flash Command Argument                   */
+    uint32_t FKEY:8;                    /**< bit: 24..31  Flash Writing Protection Key             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FCR_OFFSET                     (0x04)                                        /**<  (EEFC_FCR) EEFC Flash Command Register  Offset */
+
+#define EEFC_FCR_FCMD_Pos                   0                                              /**< (EEFC_FCR) Flash Command Position */
+#define EEFC_FCR_FCMD_Msk                   (_U_(0xFF) << EEFC_FCR_FCMD_Pos)               /**< (EEFC_FCR) Flash Command Mask */
+#define EEFC_FCR_FCMD(value)                (EEFC_FCR_FCMD_Msk & ((value) << EEFC_FCR_FCMD_Pos))
+#define   EEFC_FCR_FCMD_GETD_Val            _U_(0x0)                                       /**< (EEFC_FCR) Get Flash descriptor  */
+#define   EEFC_FCR_FCMD_WP_Val              _U_(0x1)                                       /**< (EEFC_FCR) Write page  */
+#define   EEFC_FCR_FCMD_WPL_Val             _U_(0x2)                                       /**< (EEFC_FCR) Write page and lock  */
+#define   EEFC_FCR_FCMD_EWP_Val             _U_(0x3)                                       /**< (EEFC_FCR) Erase page and write page  */
+#define   EEFC_FCR_FCMD_EWPL_Val            _U_(0x4)                                       /**< (EEFC_FCR) Erase page and write page then lock  */
+#define   EEFC_FCR_FCMD_EA_Val              _U_(0x5)                                       /**< (EEFC_FCR) Erase all  */
+#define   EEFC_FCR_FCMD_EPA_Val             _U_(0x7)                                       /**< (EEFC_FCR) Erase pages  */
+#define   EEFC_FCR_FCMD_SLB_Val             _U_(0x8)                                       /**< (EEFC_FCR) Set lock bit  */
+#define   EEFC_FCR_FCMD_CLB_Val             _U_(0x9)                                       /**< (EEFC_FCR) Clear lock bit  */
+#define   EEFC_FCR_FCMD_GLB_Val             _U_(0xA)                                       /**< (EEFC_FCR) Get lock bit  */
+#define   EEFC_FCR_FCMD_SGPB_Val            _U_(0xB)                                       /**< (EEFC_FCR) Set GPNVM bit  */
+#define   EEFC_FCR_FCMD_CGPB_Val            _U_(0xC)                                       /**< (EEFC_FCR) Clear GPNVM bit  */
+#define   EEFC_FCR_FCMD_GGPB_Val            _U_(0xD)                                       /**< (EEFC_FCR) Get GPNVM bit  */
+#define   EEFC_FCR_FCMD_STUI_Val            _U_(0xE)                                       /**< (EEFC_FCR) Start read unique identifier  */
+#define   EEFC_FCR_FCMD_SPUI_Val            _U_(0xF)                                       /**< (EEFC_FCR) Stop read unique identifier  */
+#define   EEFC_FCR_FCMD_GCALB_Val           _U_(0x10)                                      /**< (EEFC_FCR) Get CALIB bit  */
+#define   EEFC_FCR_FCMD_ES_Val              _U_(0x11)                                      /**< (EEFC_FCR) Erase sector  */
+#define   EEFC_FCR_FCMD_WUS_Val             _U_(0x12)                                      /**< (EEFC_FCR) Write user signature  */
+#define   EEFC_FCR_FCMD_EUS_Val             _U_(0x13)                                      /**< (EEFC_FCR) Erase user signature  */
+#define   EEFC_FCR_FCMD_STUS_Val            _U_(0x14)                                      /**< (EEFC_FCR) Start read user signature  */
+#define   EEFC_FCR_FCMD_SPUS_Val            _U_(0x15)                                      /**< (EEFC_FCR) Stop read user signature  */
+#define EEFC_FCR_FCMD_GETD                  (EEFC_FCR_FCMD_GETD_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get Flash descriptor Position  */
+#define EEFC_FCR_FCMD_WP                    (EEFC_FCR_FCMD_WP_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Write page Position  */
+#define EEFC_FCR_FCMD_WPL                   (EEFC_FCR_FCMD_WPL_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Write page and lock Position  */
+#define EEFC_FCR_FCMD_EWP                   (EEFC_FCR_FCMD_EWP_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase page and write page Position  */
+#define EEFC_FCR_FCMD_EWPL                  (EEFC_FCR_FCMD_EWPL_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Erase page and write page then lock Position  */
+#define EEFC_FCR_FCMD_EA                    (EEFC_FCR_FCMD_EA_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Erase all Position  */
+#define EEFC_FCR_FCMD_EPA                   (EEFC_FCR_FCMD_EPA_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase pages Position  */
+#define EEFC_FCR_FCMD_SLB                   (EEFC_FCR_FCMD_SLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Set lock bit Position  */
+#define EEFC_FCR_FCMD_CLB                   (EEFC_FCR_FCMD_CLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Clear lock bit Position  */
+#define EEFC_FCR_FCMD_GLB                   (EEFC_FCR_FCMD_GLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Get lock bit Position  */
+#define EEFC_FCR_FCMD_SGPB                  (EEFC_FCR_FCMD_SGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Set GPNVM bit Position  */
+#define EEFC_FCR_FCMD_CGPB                  (EEFC_FCR_FCMD_CGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Clear GPNVM bit Position  */
+#define EEFC_FCR_FCMD_GGPB                  (EEFC_FCR_FCMD_GGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get GPNVM bit Position  */
+#define EEFC_FCR_FCMD_STUI                  (EEFC_FCR_FCMD_STUI_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Start read unique identifier Position  */
+#define EEFC_FCR_FCMD_SPUI                  (EEFC_FCR_FCMD_SPUI_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Stop read unique identifier Position  */
+#define EEFC_FCR_FCMD_GCALB                 (EEFC_FCR_FCMD_GCALB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get CALIB bit Position  */
+#define EEFC_FCR_FCMD_ES                    (EEFC_FCR_FCMD_ES_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Erase sector Position  */
+#define EEFC_FCR_FCMD_WUS                   (EEFC_FCR_FCMD_WUS_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Write user signature Position  */
+#define EEFC_FCR_FCMD_EUS                   (EEFC_FCR_FCMD_EUS_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase user signature Position  */
+#define EEFC_FCR_FCMD_STUS                  (EEFC_FCR_FCMD_STUS_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Start read user signature Position  */
+#define EEFC_FCR_FCMD_SPUS                  (EEFC_FCR_FCMD_SPUS_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Stop read user signature Position  */
+#define EEFC_FCR_FARG_Pos                   8                                              /**< (EEFC_FCR) Flash Command Argument Position */
+#define EEFC_FCR_FARG_Msk                   (_U_(0xFFFF) << EEFC_FCR_FARG_Pos)             /**< (EEFC_FCR) Flash Command Argument Mask */
+#define EEFC_FCR_FARG(value)                (EEFC_FCR_FARG_Msk & ((value) << EEFC_FCR_FARG_Pos))
+#define EEFC_FCR_FKEY_Pos                   24                                             /**< (EEFC_FCR) Flash Writing Protection Key Position */
+#define EEFC_FCR_FKEY_Msk                   (_U_(0xFF) << EEFC_FCR_FKEY_Pos)               /**< (EEFC_FCR) Flash Writing Protection Key Mask */
+#define EEFC_FCR_FKEY(value)                (EEFC_FCR_FKEY_Msk & ((value) << EEFC_FCR_FKEY_Pos))
+#define   EEFC_FCR_FKEY_PASSWD_Val          _U_(0x5A)                                      /**< (EEFC_FCR) The 0x5A value enables the command defined by the bits of the register. If the field is written with a different value, the write is not performed and no action is started.  */
+#define EEFC_FCR_FKEY_PASSWD                (EEFC_FCR_FKEY_PASSWD_Val << EEFC_FCR_FKEY_Pos)  /**< (EEFC_FCR) The 0x5A value enables the command defined by the bits of the register. If the field is written with a different value, the write is not performed and no action is started. Position  */
+#define EEFC_FCR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (EEFC_FCR) Register MASK  (Use EEFC_FCR_Msk instead)  */
+#define EEFC_FCR_Msk                        _U_(0xFFFFFFFF)                                /**< (EEFC_FCR) Register Mask  */
+
+
+/* -------- EEFC_FSR : (EFC Offset: 0x08) (R/ 32) EEFC Flash Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Status (cleared when Flash is busy) */
+    uint32_t FCMDE:1;                   /**< bit:      1  Flash Command Error Status (cleared on read or by writing EEFC_FCR) */
+    uint32_t FLOCKE:1;                  /**< bit:      2  Flash Lock Error Status (cleared on read) */
+    uint32_t FLERR:1;                   /**< bit:      3  Flash Error Status (cleared when a programming operation starts) */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t UECCELSB:1;                /**< bit:     16  Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t MECCELSB:1;                /**< bit:     17  Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t UECCEMSB:1;                /**< bit:     18  Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t MECCEMSB:1;                /**< bit:     19  Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FSR_OFFSET                     (0x08)                                        /**<  (EEFC_FSR) EEFC Flash Status Register  Offset */
+
+#define EEFC_FSR_FRDY_Pos                   0                                              /**< (EEFC_FSR) Flash Ready Status (cleared when Flash is busy) Position */
+#define EEFC_FSR_FRDY_Msk                   (_U_(0x1) << EEFC_FSR_FRDY_Pos)                /**< (EEFC_FSR) Flash Ready Status (cleared when Flash is busy) Mask */
+#define EEFC_FSR_FRDY                       EEFC_FSR_FRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FRDY_Msk instead */
+#define EEFC_FSR_FCMDE_Pos                  1                                              /**< (EEFC_FSR) Flash Command Error Status (cleared on read or by writing EEFC_FCR) Position */
+#define EEFC_FSR_FCMDE_Msk                  (_U_(0x1) << EEFC_FSR_FCMDE_Pos)               /**< (EEFC_FSR) Flash Command Error Status (cleared on read or by writing EEFC_FCR) Mask */
+#define EEFC_FSR_FCMDE                      EEFC_FSR_FCMDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FCMDE_Msk instead */
+#define EEFC_FSR_FLOCKE_Pos                 2                                              /**< (EEFC_FSR) Flash Lock Error Status (cleared on read) Position */
+#define EEFC_FSR_FLOCKE_Msk                 (_U_(0x1) << EEFC_FSR_FLOCKE_Pos)              /**< (EEFC_FSR) Flash Lock Error Status (cleared on read) Mask */
+#define EEFC_FSR_FLOCKE                     EEFC_FSR_FLOCKE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FLOCKE_Msk instead */
+#define EEFC_FSR_FLERR_Pos                  3                                              /**< (EEFC_FSR) Flash Error Status (cleared when a programming operation starts) Position */
+#define EEFC_FSR_FLERR_Msk                  (_U_(0x1) << EEFC_FSR_FLERR_Pos)               /**< (EEFC_FSR) Flash Error Status (cleared when a programming operation starts) Mask */
+#define EEFC_FSR_FLERR                      EEFC_FSR_FLERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FLERR_Msk instead */
+#define EEFC_FSR_UECCELSB_Pos               16                                             /**< (EEFC_FSR) Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_UECCELSB_Msk               (_U_(0x1) << EEFC_FSR_UECCELSB_Pos)            /**< (EEFC_FSR) Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_UECCELSB                   EEFC_FSR_UECCELSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_UECCELSB_Msk instead */
+#define EEFC_FSR_MECCELSB_Pos               17                                             /**< (EEFC_FSR) Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_MECCELSB_Msk               (_U_(0x1) << EEFC_FSR_MECCELSB_Pos)            /**< (EEFC_FSR) Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_MECCELSB                   EEFC_FSR_MECCELSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_MECCELSB_Msk instead */
+#define EEFC_FSR_UECCEMSB_Pos               18                                             /**< (EEFC_FSR) Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_UECCEMSB_Msk               (_U_(0x1) << EEFC_FSR_UECCEMSB_Pos)            /**< (EEFC_FSR) Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_UECCEMSB                   EEFC_FSR_UECCEMSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_UECCEMSB_Msk instead */
+#define EEFC_FSR_MECCEMSB_Pos               19                                             /**< (EEFC_FSR) Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_MECCEMSB_Msk               (_U_(0x1) << EEFC_FSR_MECCEMSB_Pos)            /**< (EEFC_FSR) Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_MECCEMSB                   EEFC_FSR_MECCEMSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_MECCEMSB_Msk instead */
+#define EEFC_FSR_MASK                       _U_(0xF000F)                                   /**< \deprecated (EEFC_FSR) Register MASK  (Use EEFC_FSR_Msk instead)  */
+#define EEFC_FSR_Msk                        _U_(0xF000F)                                   /**< (EEFC_FSR) Register Mask  */
+
+
+/* -------- EEFC_FRR : (EFC Offset: 0x0c) (R/ 32) EEFC Flash Result Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FVALUE:32;                 /**< bit:  0..31  Flash Result Value                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FRR_OFFSET                     (0x0C)                                        /**<  (EEFC_FRR) EEFC Flash Result Register  Offset */
+
+#define EEFC_FRR_FVALUE_Pos                 0                                              /**< (EEFC_FRR) Flash Result Value Position */
+#define EEFC_FRR_FVALUE_Msk                 (_U_(0xFFFFFFFF) << EEFC_FRR_FVALUE_Pos)       /**< (EEFC_FRR) Flash Result Value Mask */
+#define EEFC_FRR_FVALUE(value)              (EEFC_FRR_FVALUE_Msk & ((value) << EEFC_FRR_FVALUE_Pos))
+#define EEFC_FRR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (EEFC_FRR) Register MASK  (Use EEFC_FRR_Msk instead)  */
+#define EEFC_FRR_Msk                        _U_(0xFFFFFFFF)                                /**< (EEFC_FRR) Register Mask  */
+
+
+/* -------- EEFC_VERSION : (EFC Offset: 0x14) (R/ 32) EEFC Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_VERSION_OFFSET                 (0x14)                                        /**<  (EEFC_VERSION) EEFC Version Register  Offset */
+
+#define EEFC_VERSION_VERSION_Pos            0                                              /**< (EEFC_VERSION) Version of the Hardware Module Position */
+#define EEFC_VERSION_VERSION_Msk            (_U_(0xFFF) << EEFC_VERSION_VERSION_Pos)       /**< (EEFC_VERSION) Version of the Hardware Module Mask */
+#define EEFC_VERSION_VERSION(value)         (EEFC_VERSION_VERSION_Msk & ((value) << EEFC_VERSION_VERSION_Pos))
+#define EEFC_VERSION_MFN_Pos                16                                             /**< (EEFC_VERSION) Metal Fix Number Position */
+#define EEFC_VERSION_MFN_Msk                (_U_(0x7) << EEFC_VERSION_MFN_Pos)             /**< (EEFC_VERSION) Metal Fix Number Mask */
+#define EEFC_VERSION_MFN(value)             (EEFC_VERSION_MFN_Msk & ((value) << EEFC_VERSION_MFN_Pos))
+#define EEFC_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (EEFC_VERSION) Register MASK  (Use EEFC_VERSION_Msk instead)  */
+#define EEFC_VERSION_Msk                    _U_(0x70FFF)                                   /**< (EEFC_VERSION) Register Mask  */
+
+
+/* -------- EEFC_WPMR : (EFC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_WPMR_OFFSET                    (0xE4)                                        /**<  (EEFC_WPMR) Write Protection Mode Register  Offset */
+
+#define EEFC_WPMR_WPEN_Pos                  0                                              /**< (EEFC_WPMR) Write Protection Enable Position */
+#define EEFC_WPMR_WPEN_Msk                  (_U_(0x1) << EEFC_WPMR_WPEN_Pos)               /**< (EEFC_WPMR) Write Protection Enable Mask */
+#define EEFC_WPMR_WPEN                      EEFC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_WPMR_WPEN_Msk instead */
+#define EEFC_WPMR_WPKEY_Pos                 8                                              /**< (EEFC_WPMR) Write Protection Key Position */
+#define EEFC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << EEFC_WPMR_WPKEY_Pos)         /**< (EEFC_WPMR) Write Protection Key Mask */
+#define EEFC_WPMR_WPKEY(value)              (EEFC_WPMR_WPKEY_Msk & ((value) << EEFC_WPMR_WPKEY_Pos))
+#define   EEFC_WPMR_WPKEY_PASSWD_Val        _U_(0x454643)                                  /**< (EEFC_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define EEFC_WPMR_WPKEY_PASSWD              (EEFC_WPMR_WPKEY_PASSWD_Val << EEFC_WPMR_WPKEY_Pos)  /**< (EEFC_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define EEFC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (EEFC_WPMR) Register MASK  (Use EEFC_WPMR_Msk instead)  */
+#define EEFC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (EEFC_WPMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief EFC hardware registers */
+typedef struct {  
+  __IO uint32_t EEFC_FMR;       /**< (EFC Offset: 0x00) EEFC Flash Mode Register */
+  __O  uint32_t EEFC_FCR;       /**< (EFC Offset: 0x04) EEFC Flash Command Register */
+  __I  uint32_t EEFC_FSR;       /**< (EFC Offset: 0x08) EEFC Flash Status Register */
+  __I  uint32_t EEFC_FRR;       /**< (EFC Offset: 0x0C) EEFC Flash Result Register */
+  __I  uint8_t                        Reserved1[4];
+  __I  uint32_t EEFC_VERSION;   /**< (EFC Offset: 0x14) EEFC Version Register */
+  __I  uint8_t                        Reserved2[204];
+  __IO uint32_t EEFC_WPMR;      /**< (EFC Offset: 0xE4) Write Protection Mode Register */
+} Efc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief EFC hardware registers */
+typedef struct {  
+  __IO EEFC_FMR_Type                  EEFC_FMR;       /**< Offset: 0x00 (R/W  32) EEFC Flash Mode Register */
+  __O  EEFC_FCR_Type                  EEFC_FCR;       /**< Offset: 0x04 ( /W  32) EEFC Flash Command Register */
+  __I  EEFC_FSR_Type                  EEFC_FSR;       /**< Offset: 0x08 (R/   32) EEFC Flash Status Register */
+  __I  EEFC_FRR_Type                  EEFC_FRR;       /**< Offset: 0x0C (R/   32) EEFC Flash Result Register */
+  __I  uint8_t                        Reserved1[4];
+  __I  EEFC_VERSION_Type              EEFC_VERSION;   /**< Offset: 0x14 (R/   32) EEFC Version Register */
+  __I  uint8_t                        Reserved2[204];
+  __IO EEFC_WPMR_Type                 EEFC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+} Efc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Embedded Flash Controller */
+
+#endif /* _SAMV71_EFC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/gmac.h
+++ b/asf/sam/include/samv71/component/gmac.h
@@ -1,0 +1,5219 @@
+/**
+ * \file
+ *
+ * \brief Component description for GMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_GMAC_COMPONENT_H_
+#define _SAMV71_GMAC_COMPONENT_H_
+#define _SAMV71_GMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Gigabit Ethernet MAC
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GMAC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define GMAC_11046                      /**< (GMAC) Module ID */
+#define REV_GMAC P                      /**< (GMAC) Module revision */
+
+/* -------- GMAC_SAB : (GMAC Offset: 0x00) (R/W 32) Specific Address 1 Bottom Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAB_OFFSET                     (0x00)                                        /**<  (GMAC_SAB) Specific Address 1 Bottom Register  Offset */
+
+#define GMAC_SAB_ADDR_Pos                   0                                              /**< (GMAC_SAB) Specific Address 1 Position */
+#define GMAC_SAB_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_SAB_ADDR_Pos)         /**< (GMAC_SAB) Specific Address 1 Mask */
+#define GMAC_SAB_ADDR(value)                (GMAC_SAB_ADDR_Msk & ((value) << GMAC_SAB_ADDR_Pos))
+#define GMAC_SAB_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SAB) Register MASK  (Use GMAC_SAB_Msk instead)  */
+#define GMAC_SAB_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_SAB) Register Mask  */
+
+
+/* -------- GMAC_SAT : (GMAC Offset: 0x04) (R/W 32) Specific Address 1 Top Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1                       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAT_OFFSET                     (0x04)                                        /**<  (GMAC_SAT) Specific Address 1 Top Register  Offset */
+
+#define GMAC_SAT_ADDR_Pos                   0                                              /**< (GMAC_SAT) Specific Address 1 Position */
+#define GMAC_SAT_ADDR_Msk                   (_U_(0xFFFF) << GMAC_SAT_ADDR_Pos)             /**< (GMAC_SAT) Specific Address 1 Mask */
+#define GMAC_SAT_ADDR(value)                (GMAC_SAT_ADDR_Msk & ((value) << GMAC_SAT_ADDR_Pos))
+#define GMAC_SAT_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_SAT) Register MASK  (Use GMAC_SAT_Msk instead)  */
+#define GMAC_SAT_Msk                        _U_(0xFFFF)                                    /**< (GMAC_SAT) Register Mask  */
+
+
+/* -------- GMAC_NCR : (GMAC Offset: 0x00) (R/W 32) Network Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t LBL:1;                     /**< bit:      1  Loop Back Local                          */
+    uint32_t RXEN:1;                    /**< bit:      2  Receive Enable                           */
+    uint32_t TXEN:1;                    /**< bit:      3  Transmit Enable                          */
+    uint32_t MPE:1;                     /**< bit:      4  Management Port Enable                   */
+    uint32_t CLRSTAT:1;                 /**< bit:      5  Clear Statistics Registers               */
+    uint32_t INCSTAT:1;                 /**< bit:      6  Increment Statistics Registers           */
+    uint32_t WESTAT:1;                  /**< bit:      7  Write Enable for Statistics Registers    */
+    uint32_t BP:1;                      /**< bit:      8  Back pressure                            */
+    uint32_t TSTART:1;                  /**< bit:      9  Start Transmission                       */
+    uint32_t THALT:1;                   /**< bit:     10  Transmit Halt                            */
+    uint32_t TXPF:1;                    /**< bit:     11  Transmit Pause Frame                     */
+    uint32_t TXZQPF:1;                  /**< bit:     12  Transmit Zero Quantum Pause Frame        */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t SRTSM:1;                   /**< bit:     15  Store Receive Time Stamp to Memory       */
+    uint32_t ENPBPR:1;                  /**< bit:     16  Enable PFC Priority-based Pause Reception */
+    uint32_t TXPBPF:1;                  /**< bit:     17  Transmit PFC Priority-based Pause Frame  */
+    uint32_t FNP:1;                     /**< bit:     18  Flush Next Packet                        */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NCR_OFFSET                     (0x00)                                        /**<  (GMAC_NCR) Network Control Register  Offset */
+
+#define GMAC_NCR_LBL_Pos                    1                                              /**< (GMAC_NCR) Loop Back Local Position */
+#define GMAC_NCR_LBL_Msk                    (_U_(0x1) << GMAC_NCR_LBL_Pos)                 /**< (GMAC_NCR) Loop Back Local Mask */
+#define GMAC_NCR_LBL                        GMAC_NCR_LBL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_LBL_Msk instead */
+#define GMAC_NCR_RXEN_Pos                   2                                              /**< (GMAC_NCR) Receive Enable Position */
+#define GMAC_NCR_RXEN_Msk                   (_U_(0x1) << GMAC_NCR_RXEN_Pos)                /**< (GMAC_NCR) Receive Enable Mask */
+#define GMAC_NCR_RXEN                       GMAC_NCR_RXEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_RXEN_Msk instead */
+#define GMAC_NCR_TXEN_Pos                   3                                              /**< (GMAC_NCR) Transmit Enable Position */
+#define GMAC_NCR_TXEN_Msk                   (_U_(0x1) << GMAC_NCR_TXEN_Pos)                /**< (GMAC_NCR) Transmit Enable Mask */
+#define GMAC_NCR_TXEN                       GMAC_NCR_TXEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXEN_Msk instead */
+#define GMAC_NCR_MPE_Pos                    4                                              /**< (GMAC_NCR) Management Port Enable Position */
+#define GMAC_NCR_MPE_Msk                    (_U_(0x1) << GMAC_NCR_MPE_Pos)                 /**< (GMAC_NCR) Management Port Enable Mask */
+#define GMAC_NCR_MPE                        GMAC_NCR_MPE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_MPE_Msk instead */
+#define GMAC_NCR_CLRSTAT_Pos                5                                              /**< (GMAC_NCR) Clear Statistics Registers Position */
+#define GMAC_NCR_CLRSTAT_Msk                (_U_(0x1) << GMAC_NCR_CLRSTAT_Pos)             /**< (GMAC_NCR) Clear Statistics Registers Mask */
+#define GMAC_NCR_CLRSTAT                    GMAC_NCR_CLRSTAT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_CLRSTAT_Msk instead */
+#define GMAC_NCR_INCSTAT_Pos                6                                              /**< (GMAC_NCR) Increment Statistics Registers Position */
+#define GMAC_NCR_INCSTAT_Msk                (_U_(0x1) << GMAC_NCR_INCSTAT_Pos)             /**< (GMAC_NCR) Increment Statistics Registers Mask */
+#define GMAC_NCR_INCSTAT                    GMAC_NCR_INCSTAT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_INCSTAT_Msk instead */
+#define GMAC_NCR_WESTAT_Pos                 7                                              /**< (GMAC_NCR) Write Enable for Statistics Registers Position */
+#define GMAC_NCR_WESTAT_Msk                 (_U_(0x1) << GMAC_NCR_WESTAT_Pos)              /**< (GMAC_NCR) Write Enable for Statistics Registers Mask */
+#define GMAC_NCR_WESTAT                     GMAC_NCR_WESTAT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_WESTAT_Msk instead */
+#define GMAC_NCR_BP_Pos                     8                                              /**< (GMAC_NCR) Back pressure Position */
+#define GMAC_NCR_BP_Msk                     (_U_(0x1) << GMAC_NCR_BP_Pos)                  /**< (GMAC_NCR) Back pressure Mask */
+#define GMAC_NCR_BP                         GMAC_NCR_BP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_BP_Msk instead */
+#define GMAC_NCR_TSTART_Pos                 9                                              /**< (GMAC_NCR) Start Transmission Position */
+#define GMAC_NCR_TSTART_Msk                 (_U_(0x1) << GMAC_NCR_TSTART_Pos)              /**< (GMAC_NCR) Start Transmission Mask */
+#define GMAC_NCR_TSTART                     GMAC_NCR_TSTART_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TSTART_Msk instead */
+#define GMAC_NCR_THALT_Pos                  10                                             /**< (GMAC_NCR) Transmit Halt Position */
+#define GMAC_NCR_THALT_Msk                  (_U_(0x1) << GMAC_NCR_THALT_Pos)               /**< (GMAC_NCR) Transmit Halt Mask */
+#define GMAC_NCR_THALT                      GMAC_NCR_THALT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_THALT_Msk instead */
+#define GMAC_NCR_TXPF_Pos                   11                                             /**< (GMAC_NCR) Transmit Pause Frame Position */
+#define GMAC_NCR_TXPF_Msk                   (_U_(0x1) << GMAC_NCR_TXPF_Pos)                /**< (GMAC_NCR) Transmit Pause Frame Mask */
+#define GMAC_NCR_TXPF                       GMAC_NCR_TXPF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXPF_Msk instead */
+#define GMAC_NCR_TXZQPF_Pos                 12                                             /**< (GMAC_NCR) Transmit Zero Quantum Pause Frame Position */
+#define GMAC_NCR_TXZQPF_Msk                 (_U_(0x1) << GMAC_NCR_TXZQPF_Pos)              /**< (GMAC_NCR) Transmit Zero Quantum Pause Frame Mask */
+#define GMAC_NCR_TXZQPF                     GMAC_NCR_TXZQPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXZQPF_Msk instead */
+#define GMAC_NCR_SRTSM_Pos                  15                                             /**< (GMAC_NCR) Store Receive Time Stamp to Memory Position */
+#define GMAC_NCR_SRTSM_Msk                  (_U_(0x1) << GMAC_NCR_SRTSM_Pos)               /**< (GMAC_NCR) Store Receive Time Stamp to Memory Mask */
+#define GMAC_NCR_SRTSM                      GMAC_NCR_SRTSM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_SRTSM_Msk instead */
+#define GMAC_NCR_ENPBPR_Pos                 16                                             /**< (GMAC_NCR) Enable PFC Priority-based Pause Reception Position */
+#define GMAC_NCR_ENPBPR_Msk                 (_U_(0x1) << GMAC_NCR_ENPBPR_Pos)              /**< (GMAC_NCR) Enable PFC Priority-based Pause Reception Mask */
+#define GMAC_NCR_ENPBPR                     GMAC_NCR_ENPBPR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_ENPBPR_Msk instead */
+#define GMAC_NCR_TXPBPF_Pos                 17                                             /**< (GMAC_NCR) Transmit PFC Priority-based Pause Frame Position */
+#define GMAC_NCR_TXPBPF_Msk                 (_U_(0x1) << GMAC_NCR_TXPBPF_Pos)              /**< (GMAC_NCR) Transmit PFC Priority-based Pause Frame Mask */
+#define GMAC_NCR_TXPBPF                     GMAC_NCR_TXPBPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXPBPF_Msk instead */
+#define GMAC_NCR_FNP_Pos                    18                                             /**< (GMAC_NCR) Flush Next Packet Position */
+#define GMAC_NCR_FNP_Msk                    (_U_(0x1) << GMAC_NCR_FNP_Pos)                 /**< (GMAC_NCR) Flush Next Packet Mask */
+#define GMAC_NCR_FNP                        GMAC_NCR_FNP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_FNP_Msk instead */
+#define GMAC_NCR_MASK                       _U_(0x79FFE)                                   /**< \deprecated (GMAC_NCR) Register MASK  (Use GMAC_NCR_Msk instead)  */
+#define GMAC_NCR_Msk                        _U_(0x79FFE)                                   /**< (GMAC_NCR) Register Mask  */
+
+
+/* -------- GMAC_NCFGR : (GMAC Offset: 0x04) (R/W 32) Network Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPD:1;                     /**< bit:      0  Speed                                    */
+    uint32_t FD:1;                      /**< bit:      1  Full Duplex                              */
+    uint32_t DNVLAN:1;                  /**< bit:      2  Discard Non-VLAN FRAMES                  */
+    uint32_t JFRAME:1;                  /**< bit:      3  Jumbo Frame Size                         */
+    uint32_t CAF:1;                     /**< bit:      4  Copy All Frames                          */
+    uint32_t NBC:1;                     /**< bit:      5  No Broadcast                             */
+    uint32_t MTIHEN:1;                  /**< bit:      6  Multicast Hash Enable                    */
+    uint32_t UNIHEN:1;                  /**< bit:      7  Unicast Hash Enable                      */
+    uint32_t MAXFS:1;                   /**< bit:      8  1536 Maximum Frame Size                  */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t RTY:1;                     /**< bit:     12  Retry Test                               */
+    uint32_t PEN:1;                     /**< bit:     13  Pause Enable                             */
+    uint32_t RXBUFO:2;                  /**< bit: 14..15  Receive Buffer Offset                    */
+    uint32_t LFERD:1;                   /**< bit:     16  Length Field Error Frame Discard         */
+    uint32_t RFCS:1;                    /**< bit:     17  Remove FCS                               */
+    uint32_t CLK:3;                     /**< bit: 18..20  MDC CLock Division                       */
+    uint32_t DBW:2;                     /**< bit: 21..22  Data Bus Width                           */
+    uint32_t DCPF:1;                    /**< bit:     23  Disable Copy of Pause Frames             */
+    uint32_t RXCOEN:1;                  /**< bit:     24  Receive Checksum Offload Enable          */
+    uint32_t EFRHD:1;                   /**< bit:     25  Enable Frames Received in Half Duplex    */
+    uint32_t IRXFCS:1;                  /**< bit:     26  Ignore RX FCS                            */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t IPGSEN:1;                  /**< bit:     28  IP Stretch Enable                        */
+    uint32_t RXBP:1;                    /**< bit:     29  Receive Bad Preamble                     */
+    uint32_t IRXER:1;                   /**< bit:     30  Ignore IPG GRXER                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NCFGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NCFGR_OFFSET                   (0x04)                                        /**<  (GMAC_NCFGR) Network Configuration Register  Offset */
+
+#define GMAC_NCFGR_SPD_Pos                  0                                              /**< (GMAC_NCFGR) Speed Position */
+#define GMAC_NCFGR_SPD_Msk                  (_U_(0x1) << GMAC_NCFGR_SPD_Pos)               /**< (GMAC_NCFGR) Speed Mask */
+#define GMAC_NCFGR_SPD                      GMAC_NCFGR_SPD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_SPD_Msk instead */
+#define GMAC_NCFGR_FD_Pos                   1                                              /**< (GMAC_NCFGR) Full Duplex Position */
+#define GMAC_NCFGR_FD_Msk                   (_U_(0x1) << GMAC_NCFGR_FD_Pos)                /**< (GMAC_NCFGR) Full Duplex Mask */
+#define GMAC_NCFGR_FD                       GMAC_NCFGR_FD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_FD_Msk instead */
+#define GMAC_NCFGR_DNVLAN_Pos               2                                              /**< (GMAC_NCFGR) Discard Non-VLAN FRAMES Position */
+#define GMAC_NCFGR_DNVLAN_Msk               (_U_(0x1) << GMAC_NCFGR_DNVLAN_Pos)            /**< (GMAC_NCFGR) Discard Non-VLAN FRAMES Mask */
+#define GMAC_NCFGR_DNVLAN                   GMAC_NCFGR_DNVLAN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_DNVLAN_Msk instead */
+#define GMAC_NCFGR_JFRAME_Pos               3                                              /**< (GMAC_NCFGR) Jumbo Frame Size Position */
+#define GMAC_NCFGR_JFRAME_Msk               (_U_(0x1) << GMAC_NCFGR_JFRAME_Pos)            /**< (GMAC_NCFGR) Jumbo Frame Size Mask */
+#define GMAC_NCFGR_JFRAME                   GMAC_NCFGR_JFRAME_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_JFRAME_Msk instead */
+#define GMAC_NCFGR_CAF_Pos                  4                                              /**< (GMAC_NCFGR) Copy All Frames Position */
+#define GMAC_NCFGR_CAF_Msk                  (_U_(0x1) << GMAC_NCFGR_CAF_Pos)               /**< (GMAC_NCFGR) Copy All Frames Mask */
+#define GMAC_NCFGR_CAF                      GMAC_NCFGR_CAF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_CAF_Msk instead */
+#define GMAC_NCFGR_NBC_Pos                  5                                              /**< (GMAC_NCFGR) No Broadcast Position */
+#define GMAC_NCFGR_NBC_Msk                  (_U_(0x1) << GMAC_NCFGR_NBC_Pos)               /**< (GMAC_NCFGR) No Broadcast Mask */
+#define GMAC_NCFGR_NBC                      GMAC_NCFGR_NBC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_NBC_Msk instead */
+#define GMAC_NCFGR_MTIHEN_Pos               6                                              /**< (GMAC_NCFGR) Multicast Hash Enable Position */
+#define GMAC_NCFGR_MTIHEN_Msk               (_U_(0x1) << GMAC_NCFGR_MTIHEN_Pos)            /**< (GMAC_NCFGR) Multicast Hash Enable Mask */
+#define GMAC_NCFGR_MTIHEN                   GMAC_NCFGR_MTIHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_MTIHEN_Msk instead */
+#define GMAC_NCFGR_UNIHEN_Pos               7                                              /**< (GMAC_NCFGR) Unicast Hash Enable Position */
+#define GMAC_NCFGR_UNIHEN_Msk               (_U_(0x1) << GMAC_NCFGR_UNIHEN_Pos)            /**< (GMAC_NCFGR) Unicast Hash Enable Mask */
+#define GMAC_NCFGR_UNIHEN                   GMAC_NCFGR_UNIHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_UNIHEN_Msk instead */
+#define GMAC_NCFGR_MAXFS_Pos                8                                              /**< (GMAC_NCFGR) 1536 Maximum Frame Size Position */
+#define GMAC_NCFGR_MAXFS_Msk                (_U_(0x1) << GMAC_NCFGR_MAXFS_Pos)             /**< (GMAC_NCFGR) 1536 Maximum Frame Size Mask */
+#define GMAC_NCFGR_MAXFS                    GMAC_NCFGR_MAXFS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_MAXFS_Msk instead */
+#define GMAC_NCFGR_RTY_Pos                  12                                             /**< (GMAC_NCFGR) Retry Test Position */
+#define GMAC_NCFGR_RTY_Msk                  (_U_(0x1) << GMAC_NCFGR_RTY_Pos)               /**< (GMAC_NCFGR) Retry Test Mask */
+#define GMAC_NCFGR_RTY                      GMAC_NCFGR_RTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RTY_Msk instead */
+#define GMAC_NCFGR_PEN_Pos                  13                                             /**< (GMAC_NCFGR) Pause Enable Position */
+#define GMAC_NCFGR_PEN_Msk                  (_U_(0x1) << GMAC_NCFGR_PEN_Pos)               /**< (GMAC_NCFGR) Pause Enable Mask */
+#define GMAC_NCFGR_PEN                      GMAC_NCFGR_PEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_PEN_Msk instead */
+#define GMAC_NCFGR_RXBUFO_Pos               14                                             /**< (GMAC_NCFGR) Receive Buffer Offset Position */
+#define GMAC_NCFGR_RXBUFO_Msk               (_U_(0x3) << GMAC_NCFGR_RXBUFO_Pos)            /**< (GMAC_NCFGR) Receive Buffer Offset Mask */
+#define GMAC_NCFGR_RXBUFO(value)            (GMAC_NCFGR_RXBUFO_Msk & ((value) << GMAC_NCFGR_RXBUFO_Pos))
+#define GMAC_NCFGR_LFERD_Pos                16                                             /**< (GMAC_NCFGR) Length Field Error Frame Discard Position */
+#define GMAC_NCFGR_LFERD_Msk                (_U_(0x1) << GMAC_NCFGR_LFERD_Pos)             /**< (GMAC_NCFGR) Length Field Error Frame Discard Mask */
+#define GMAC_NCFGR_LFERD                    GMAC_NCFGR_LFERD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_LFERD_Msk instead */
+#define GMAC_NCFGR_RFCS_Pos                 17                                             /**< (GMAC_NCFGR) Remove FCS Position */
+#define GMAC_NCFGR_RFCS_Msk                 (_U_(0x1) << GMAC_NCFGR_RFCS_Pos)              /**< (GMAC_NCFGR) Remove FCS Mask */
+#define GMAC_NCFGR_RFCS                     GMAC_NCFGR_RFCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RFCS_Msk instead */
+#define GMAC_NCFGR_CLK_Pos                  18                                             /**< (GMAC_NCFGR) MDC CLock Division Position */
+#define GMAC_NCFGR_CLK_Msk                  (_U_(0x7) << GMAC_NCFGR_CLK_Pos)               /**< (GMAC_NCFGR) MDC CLock Division Mask */
+#define GMAC_NCFGR_CLK(value)               (GMAC_NCFGR_CLK_Msk & ((value) << GMAC_NCFGR_CLK_Pos))
+#define   GMAC_NCFGR_CLK_MCK_8_Val          _U_(0x0)                                       /**< (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_16_Val         _U_(0x1)                                       /**< (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_32_Val         _U_(0x2)                                       /**< (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_48_Val         _U_(0x3)                                       /**< (GMAC_NCFGR) MCK divided by 48 (MCK up to 120 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_64_Val         _U_(0x4)                                       /**< (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_96_Val         _U_(0x5)                                       /**< (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz)  */
+#define GMAC_NCFGR_CLK_MCK_8                (GMAC_NCFGR_CLK_MCK_8_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_16               (GMAC_NCFGR_CLK_MCK_16_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_32               (GMAC_NCFGR_CLK_MCK_32_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_48               (GMAC_NCFGR_CLK_MCK_48_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 48 (MCK up to 120 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_64               (GMAC_NCFGR_CLK_MCK_64_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_96               (GMAC_NCFGR_CLK_MCK_96_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz) Position  */
+#define GMAC_NCFGR_DBW_Pos                  21                                             /**< (GMAC_NCFGR) Data Bus Width Position */
+#define GMAC_NCFGR_DBW_Msk                  (_U_(0x3) << GMAC_NCFGR_DBW_Pos)               /**< (GMAC_NCFGR) Data Bus Width Mask */
+#define GMAC_NCFGR_DBW(value)               (GMAC_NCFGR_DBW_Msk & ((value) << GMAC_NCFGR_DBW_Pos))
+#define GMAC_NCFGR_DCPF_Pos                 23                                             /**< (GMAC_NCFGR) Disable Copy of Pause Frames Position */
+#define GMAC_NCFGR_DCPF_Msk                 (_U_(0x1) << GMAC_NCFGR_DCPF_Pos)              /**< (GMAC_NCFGR) Disable Copy of Pause Frames Mask */
+#define GMAC_NCFGR_DCPF                     GMAC_NCFGR_DCPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_DCPF_Msk instead */
+#define GMAC_NCFGR_RXCOEN_Pos               24                                             /**< (GMAC_NCFGR) Receive Checksum Offload Enable Position */
+#define GMAC_NCFGR_RXCOEN_Msk               (_U_(0x1) << GMAC_NCFGR_RXCOEN_Pos)            /**< (GMAC_NCFGR) Receive Checksum Offload Enable Mask */
+#define GMAC_NCFGR_RXCOEN                   GMAC_NCFGR_RXCOEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RXCOEN_Msk instead */
+#define GMAC_NCFGR_EFRHD_Pos                25                                             /**< (GMAC_NCFGR) Enable Frames Received in Half Duplex Position */
+#define GMAC_NCFGR_EFRHD_Msk                (_U_(0x1) << GMAC_NCFGR_EFRHD_Pos)             /**< (GMAC_NCFGR) Enable Frames Received in Half Duplex Mask */
+#define GMAC_NCFGR_EFRHD                    GMAC_NCFGR_EFRHD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_EFRHD_Msk instead */
+#define GMAC_NCFGR_IRXFCS_Pos               26                                             /**< (GMAC_NCFGR) Ignore RX FCS Position */
+#define GMAC_NCFGR_IRXFCS_Msk               (_U_(0x1) << GMAC_NCFGR_IRXFCS_Pos)            /**< (GMAC_NCFGR) Ignore RX FCS Mask */
+#define GMAC_NCFGR_IRXFCS                   GMAC_NCFGR_IRXFCS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IRXFCS_Msk instead */
+#define GMAC_NCFGR_IPGSEN_Pos               28                                             /**< (GMAC_NCFGR) IP Stretch Enable Position */
+#define GMAC_NCFGR_IPGSEN_Msk               (_U_(0x1) << GMAC_NCFGR_IPGSEN_Pos)            /**< (GMAC_NCFGR) IP Stretch Enable Mask */
+#define GMAC_NCFGR_IPGSEN                   GMAC_NCFGR_IPGSEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IPGSEN_Msk instead */
+#define GMAC_NCFGR_RXBP_Pos                 29                                             /**< (GMAC_NCFGR) Receive Bad Preamble Position */
+#define GMAC_NCFGR_RXBP_Msk                 (_U_(0x1) << GMAC_NCFGR_RXBP_Pos)              /**< (GMAC_NCFGR) Receive Bad Preamble Mask */
+#define GMAC_NCFGR_RXBP                     GMAC_NCFGR_RXBP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RXBP_Msk instead */
+#define GMAC_NCFGR_IRXER_Pos                30                                             /**< (GMAC_NCFGR) Ignore IPG GRXER Position */
+#define GMAC_NCFGR_IRXER_Msk                (_U_(0x1) << GMAC_NCFGR_IRXER_Pos)             /**< (GMAC_NCFGR) Ignore IPG GRXER Mask */
+#define GMAC_NCFGR_IRXER                    GMAC_NCFGR_IRXER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IRXER_Msk instead */
+#define GMAC_NCFGR_MASK                     _U_(0x77FFF1FF)                                /**< \deprecated (GMAC_NCFGR) Register MASK  (Use GMAC_NCFGR_Msk instead)  */
+#define GMAC_NCFGR_Msk                      _U_(0x77FFF1FF)                                /**< (GMAC_NCFGR) Register Mask  */
+
+
+/* -------- GMAC_NSR : (GMAC Offset: 0x08) (R/ 32) Network Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t MDIO:1;                    /**< bit:      1  MDIO Input Status                        */
+    uint32_t IDLE:1;                    /**< bit:      2  PHY Management Logic Idle                */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NSR_OFFSET                     (0x08)                                        /**<  (GMAC_NSR) Network Status Register  Offset */
+
+#define GMAC_NSR_MDIO_Pos                   1                                              /**< (GMAC_NSR) MDIO Input Status Position */
+#define GMAC_NSR_MDIO_Msk                   (_U_(0x1) << GMAC_NSR_MDIO_Pos)                /**< (GMAC_NSR) MDIO Input Status Mask */
+#define GMAC_NSR_MDIO                       GMAC_NSR_MDIO_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_MDIO_Msk instead */
+#define GMAC_NSR_IDLE_Pos                   2                                              /**< (GMAC_NSR) PHY Management Logic Idle Position */
+#define GMAC_NSR_IDLE_Msk                   (_U_(0x1) << GMAC_NSR_IDLE_Pos)                /**< (GMAC_NSR) PHY Management Logic Idle Mask */
+#define GMAC_NSR_IDLE                       GMAC_NSR_IDLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_IDLE_Msk instead */
+#define GMAC_NSR_MASK                       _U_(0x06)                                      /**< \deprecated (GMAC_NSR) Register MASK  (Use GMAC_NSR_Msk instead)  */
+#define GMAC_NSR_Msk                        _U_(0x06)                                      /**< (GMAC_NSR) Register Mask  */
+
+
+/* -------- GMAC_UR : (GMAC Offset: 0x0c) (R/W 32) User Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RMII:1;                    /**< bit:      0  Reduced MII Mode                         */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UR_OFFSET                      (0x0C)                                        /**<  (GMAC_UR) User Register  Offset */
+
+#define GMAC_UR_RMII_Pos                    0                                              /**< (GMAC_UR) Reduced MII Mode Position */
+#define GMAC_UR_RMII_Msk                    (_U_(0x1) << GMAC_UR_RMII_Pos)                 /**< (GMAC_UR) Reduced MII Mode Mask */
+#define GMAC_UR_RMII                        GMAC_UR_RMII_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_UR_RMII_Msk instead */
+#define GMAC_UR_MASK                        _U_(0x01)                                      /**< \deprecated (GMAC_UR) Register MASK  (Use GMAC_UR_Msk instead)  */
+#define GMAC_UR_Msk                         _U_(0x01)                                      /**< (GMAC_UR) Register Mask  */
+
+
+/* -------- GMAC_DCFGR : (GMAC Offset: 0x10) (R/W 32) DMA Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FBLDO:5;                   /**< bit:   0..4  Fixed Burst Length for DMA Data Operations: */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t ESMA:1;                    /**< bit:      6  Endian Swap Mode Enable for Management Descriptor Accesses */
+    uint32_t ESPA:1;                    /**< bit:      7  Endian Swap Mode Enable for Packet Data Accesses */
+    uint32_t RXBMS:2;                   /**< bit:   8..9  Receiver Packet Buffer Memory Size Select */
+    uint32_t TXPBMS:1;                  /**< bit:     10  Transmitter Packet Buffer Memory Size Select */
+    uint32_t TXCOEN:1;                  /**< bit:     11  Transmitter Checksum Generation Offload Enable */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DRBS:8;                    /**< bit: 16..23  DMA Receive Buffer Size                  */
+    uint32_t DDRP:1;                    /**< bit:     24  DMA Discard Receive Packets              */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_DCFGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_DCFGR_OFFSET                   (0x10)                                        /**<  (GMAC_DCFGR) DMA Configuration Register  Offset */
+
+#define GMAC_DCFGR_FBLDO_Pos                0                                              /**< (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: Position */
+#define GMAC_DCFGR_FBLDO_Msk                (_U_(0x1F) << GMAC_DCFGR_FBLDO_Pos)            /**< (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: Mask */
+#define GMAC_DCFGR_FBLDO(value)             (GMAC_DCFGR_FBLDO_Msk & ((value) << GMAC_DCFGR_FBLDO_Pos))
+#define   GMAC_DCFGR_FBLDO_SINGLE_Val       _U_(0x1)                                       /**< (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts  */
+#define   GMAC_DCFGR_FBLDO_INCR4_Val        _U_(0x4)                                       /**< (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default)  */
+#define   GMAC_DCFGR_FBLDO_INCR8_Val        _U_(0x8)                                       /**< (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts  */
+#define   GMAC_DCFGR_FBLDO_INCR16_Val       _U_(0x10)                                      /**< (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts  */
+#define GMAC_DCFGR_FBLDO_SINGLE             (GMAC_DCFGR_FBLDO_SINGLE_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts Position  */
+#define GMAC_DCFGR_FBLDO_INCR4              (GMAC_DCFGR_FBLDO_INCR4_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default) Position  */
+#define GMAC_DCFGR_FBLDO_INCR8              (GMAC_DCFGR_FBLDO_INCR8_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts Position  */
+#define GMAC_DCFGR_FBLDO_INCR16             (GMAC_DCFGR_FBLDO_INCR16_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts Position  */
+#define GMAC_DCFGR_ESMA_Pos                 6                                              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses Position */
+#define GMAC_DCFGR_ESMA_Msk                 (_U_(0x1) << GMAC_DCFGR_ESMA_Pos)              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses Mask */
+#define GMAC_DCFGR_ESMA                     GMAC_DCFGR_ESMA_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_ESMA_Msk instead */
+#define GMAC_DCFGR_ESPA_Pos                 7                                              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses Position */
+#define GMAC_DCFGR_ESPA_Msk                 (_U_(0x1) << GMAC_DCFGR_ESPA_Pos)              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses Mask */
+#define GMAC_DCFGR_ESPA                     GMAC_DCFGR_ESPA_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_ESPA_Msk instead */
+#define GMAC_DCFGR_RXBMS_Pos                8                                              /**< (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select Position */
+#define GMAC_DCFGR_RXBMS_Msk                (_U_(0x3) << GMAC_DCFGR_RXBMS_Pos)             /**< (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select Mask */
+#define GMAC_DCFGR_RXBMS(value)             (GMAC_DCFGR_RXBMS_Msk & ((value) << GMAC_DCFGR_RXBMS_Pos))
+#define   GMAC_DCFGR_RXBMS_EIGHTH_Val       _U_(0x0)                                       /**< (GMAC_DCFGR) 4/8 Kbyte Memory Size  */
+#define   GMAC_DCFGR_RXBMS_QUARTER_Val      _U_(0x1)                                       /**< (GMAC_DCFGR) 4/4 Kbytes Memory Size  */
+#define   GMAC_DCFGR_RXBMS_HALF_Val         _U_(0x2)                                       /**< (GMAC_DCFGR) 4/2 Kbytes Memory Size  */
+#define   GMAC_DCFGR_RXBMS_FULL_Val         _U_(0x3)                                       /**< (GMAC_DCFGR) 4 Kbytes Memory Size  */
+#define GMAC_DCFGR_RXBMS_EIGHTH             (GMAC_DCFGR_RXBMS_EIGHTH_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/8 Kbyte Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_QUARTER            (GMAC_DCFGR_RXBMS_QUARTER_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/4 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_HALF               (GMAC_DCFGR_RXBMS_HALF_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/2 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_FULL               (GMAC_DCFGR_RXBMS_FULL_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_TXPBMS_Pos               10                                             /**< (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select Position */
+#define GMAC_DCFGR_TXPBMS_Msk               (_U_(0x1) << GMAC_DCFGR_TXPBMS_Pos)            /**< (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select Mask */
+#define GMAC_DCFGR_TXPBMS                   GMAC_DCFGR_TXPBMS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_TXPBMS_Msk instead */
+#define GMAC_DCFGR_TXCOEN_Pos               11                                             /**< (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable Position */
+#define GMAC_DCFGR_TXCOEN_Msk               (_U_(0x1) << GMAC_DCFGR_TXCOEN_Pos)            /**< (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable Mask */
+#define GMAC_DCFGR_TXCOEN                   GMAC_DCFGR_TXCOEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_TXCOEN_Msk instead */
+#define GMAC_DCFGR_DRBS_Pos                 16                                             /**< (GMAC_DCFGR) DMA Receive Buffer Size Position */
+#define GMAC_DCFGR_DRBS_Msk                 (_U_(0xFF) << GMAC_DCFGR_DRBS_Pos)             /**< (GMAC_DCFGR) DMA Receive Buffer Size Mask */
+#define GMAC_DCFGR_DRBS(value)              (GMAC_DCFGR_DRBS_Msk & ((value) << GMAC_DCFGR_DRBS_Pos))
+#define GMAC_DCFGR_DDRP_Pos                 24                                             /**< (GMAC_DCFGR) DMA Discard Receive Packets Position */
+#define GMAC_DCFGR_DDRP_Msk                 (_U_(0x1) << GMAC_DCFGR_DDRP_Pos)              /**< (GMAC_DCFGR) DMA Discard Receive Packets Mask */
+#define GMAC_DCFGR_DDRP                     GMAC_DCFGR_DDRP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_DDRP_Msk instead */
+#define GMAC_DCFGR_MASK                     _U_(0x1FF0FDF)                                 /**< \deprecated (GMAC_DCFGR) Register MASK  (Use GMAC_DCFGR_Msk instead)  */
+#define GMAC_DCFGR_Msk                      _U_(0x1FF0FDF)                                 /**< (GMAC_DCFGR) Register Mask  */
+
+
+/* -------- GMAC_TSR : (GMAC Offset: 0x14) (R/W 32) Transmit Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UBR:1;                     /**< bit:      0  Used Bit Read                            */
+    uint32_t COL:1;                     /**< bit:      1  Collision Occurred                       */
+    uint32_t RLE:1;                     /**< bit:      2  Retry Limit Exceeded                     */
+    uint32_t TXGO:1;                    /**< bit:      3  Transmit Go                              */
+    uint32_t TFC:1;                     /**< bit:      4  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TXCOMP:1;                  /**< bit:      5  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t HRESP:1;                   /**< bit:      8  HRESP Not OK                             */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSR_OFFSET                     (0x14)                                        /**<  (GMAC_TSR) Transmit Status Register  Offset */
+
+#define GMAC_TSR_UBR_Pos                    0                                              /**< (GMAC_TSR) Used Bit Read Position */
+#define GMAC_TSR_UBR_Msk                    (_U_(0x1) << GMAC_TSR_UBR_Pos)                 /**< (GMAC_TSR) Used Bit Read Mask */
+#define GMAC_TSR_UBR                        GMAC_TSR_UBR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_UBR_Msk instead */
+#define GMAC_TSR_COL_Pos                    1                                              /**< (GMAC_TSR) Collision Occurred Position */
+#define GMAC_TSR_COL_Msk                    (_U_(0x1) << GMAC_TSR_COL_Pos)                 /**< (GMAC_TSR) Collision Occurred Mask */
+#define GMAC_TSR_COL                        GMAC_TSR_COL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_COL_Msk instead */
+#define GMAC_TSR_RLE_Pos                    2                                              /**< (GMAC_TSR) Retry Limit Exceeded Position */
+#define GMAC_TSR_RLE_Msk                    (_U_(0x1) << GMAC_TSR_RLE_Pos)                 /**< (GMAC_TSR) Retry Limit Exceeded Mask */
+#define GMAC_TSR_RLE                        GMAC_TSR_RLE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_RLE_Msk instead */
+#define GMAC_TSR_TXGO_Pos                   3                                              /**< (GMAC_TSR) Transmit Go Position */
+#define GMAC_TSR_TXGO_Msk                   (_U_(0x1) << GMAC_TSR_TXGO_Pos)                /**< (GMAC_TSR) Transmit Go Mask */
+#define GMAC_TSR_TXGO                       GMAC_TSR_TXGO_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TXGO_Msk instead */
+#define GMAC_TSR_TFC_Pos                    4                                              /**< (GMAC_TSR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_TSR_TFC_Msk                    (_U_(0x1) << GMAC_TSR_TFC_Pos)                 /**< (GMAC_TSR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_TSR_TFC                        GMAC_TSR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TFC_Msk instead */
+#define GMAC_TSR_TXCOMP_Pos                 5                                              /**< (GMAC_TSR) Transmit Complete Position */
+#define GMAC_TSR_TXCOMP_Msk                 (_U_(0x1) << GMAC_TSR_TXCOMP_Pos)              /**< (GMAC_TSR) Transmit Complete Mask */
+#define GMAC_TSR_TXCOMP                     GMAC_TSR_TXCOMP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TXCOMP_Msk instead */
+#define GMAC_TSR_HRESP_Pos                  8                                              /**< (GMAC_TSR) HRESP Not OK Position */
+#define GMAC_TSR_HRESP_Msk                  (_U_(0x1) << GMAC_TSR_HRESP_Pos)               /**< (GMAC_TSR) HRESP Not OK Mask */
+#define GMAC_TSR_HRESP                      GMAC_TSR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_HRESP_Msk instead */
+#define GMAC_TSR_MASK                       _U_(0x13F)                                     /**< \deprecated (GMAC_TSR) Register MASK  (Use GMAC_TSR_Msk instead)  */
+#define GMAC_TSR_Msk                        _U_(0x13F)                                     /**< (GMAC_TSR) Register Mask  */
+
+
+/* -------- GMAC_RBQB : (GMAC Offset: 0x18) (R/W 32) Receive Buffer Queue Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Receive Buffer Queue Base Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBQB_OFFSET                    (0x18)                                        /**<  (GMAC_RBQB) Receive Buffer Queue Base Address Register  Offset */
+
+#define GMAC_RBQB_ADDR_Pos                  2                                              /**< (GMAC_RBQB) Receive Buffer Queue Base Address Position */
+#define GMAC_RBQB_ADDR_Msk                  (_U_(0x3FFFFFFF) << GMAC_RBQB_ADDR_Pos)        /**< (GMAC_RBQB) Receive Buffer Queue Base Address Mask */
+#define GMAC_RBQB_ADDR(value)               (GMAC_RBQB_ADDR_Msk & ((value) << GMAC_RBQB_ADDR_Pos))
+#define GMAC_RBQB_MASK                      _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_RBQB) Register MASK  (Use GMAC_RBQB_Msk instead)  */
+#define GMAC_RBQB_Msk                       _U_(0xFFFFFFFC)                                /**< (GMAC_RBQB) Register Mask  */
+
+
+/* -------- GMAC_TBQB : (GMAC Offset: 0x1c) (R/W 32) Transmit Buffer Queue Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Transmit Buffer Queue Base Address       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBQB_OFFSET                    (0x1C)                                        /**<  (GMAC_TBQB) Transmit Buffer Queue Base Address Register  Offset */
+
+#define GMAC_TBQB_ADDR_Pos                  2                                              /**< (GMAC_TBQB) Transmit Buffer Queue Base Address Position */
+#define GMAC_TBQB_ADDR_Msk                  (_U_(0x3FFFFFFF) << GMAC_TBQB_ADDR_Pos)        /**< (GMAC_TBQB) Transmit Buffer Queue Base Address Mask */
+#define GMAC_TBQB_ADDR(value)               (GMAC_TBQB_ADDR_Msk & ((value) << GMAC_TBQB_ADDR_Pos))
+#define GMAC_TBQB_MASK                      _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_TBQB) Register MASK  (Use GMAC_TBQB_Msk instead)  */
+#define GMAC_TBQB_Msk                       _U_(0xFFFFFFFC)                                /**< (GMAC_TBQB) Register Mask  */
+
+
+/* -------- GMAC_RSR : (GMAC Offset: 0x20) (R/W 32) Receive Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BNA:1;                     /**< bit:      0  Buffer Not Available                     */
+    uint32_t REC:1;                     /**< bit:      1  Frame Received                           */
+    uint32_t RXOVR:1;                   /**< bit:      2  Receive Overrun                          */
+    uint32_t HNO:1;                     /**< bit:      3  HRESP Not OK                             */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RSR_OFFSET                     (0x20)                                        /**<  (GMAC_RSR) Receive Status Register  Offset */
+
+#define GMAC_RSR_BNA_Pos                    0                                              /**< (GMAC_RSR) Buffer Not Available Position */
+#define GMAC_RSR_BNA_Msk                    (_U_(0x1) << GMAC_RSR_BNA_Pos)                 /**< (GMAC_RSR) Buffer Not Available Mask */
+#define GMAC_RSR_BNA                        GMAC_RSR_BNA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_BNA_Msk instead */
+#define GMAC_RSR_REC_Pos                    1                                              /**< (GMAC_RSR) Frame Received Position */
+#define GMAC_RSR_REC_Msk                    (_U_(0x1) << GMAC_RSR_REC_Pos)                 /**< (GMAC_RSR) Frame Received Mask */
+#define GMAC_RSR_REC                        GMAC_RSR_REC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_REC_Msk instead */
+#define GMAC_RSR_RXOVR_Pos                  2                                              /**< (GMAC_RSR) Receive Overrun Position */
+#define GMAC_RSR_RXOVR_Msk                  (_U_(0x1) << GMAC_RSR_RXOVR_Pos)               /**< (GMAC_RSR) Receive Overrun Mask */
+#define GMAC_RSR_RXOVR                      GMAC_RSR_RXOVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_RXOVR_Msk instead */
+#define GMAC_RSR_HNO_Pos                    3                                              /**< (GMAC_RSR) HRESP Not OK Position */
+#define GMAC_RSR_HNO_Msk                    (_U_(0x1) << GMAC_RSR_HNO_Pos)                 /**< (GMAC_RSR) HRESP Not OK Mask */
+#define GMAC_RSR_HNO                        GMAC_RSR_HNO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_HNO_Msk instead */
+#define GMAC_RSR_MASK                       _U_(0x0F)                                      /**< \deprecated (GMAC_RSR) Register MASK  (Use GMAC_RSR_Msk instead)  */
+#define GMAC_RSR_Msk                        _U_(0x0F)                                      /**< (GMAC_RSR) Register Mask  */
+
+
+/* -------- GMAC_ISR : (GMAC Offset: 0x24) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded                     */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t :3;                        /**< bit: 15..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ISR_OFFSET                     (0x24)                                        /**<  (GMAC_ISR) Interrupt Status Register  Offset */
+
+#define GMAC_ISR_MFS_Pos                    0                                              /**< (GMAC_ISR) Management Frame Sent Position */
+#define GMAC_ISR_MFS_Msk                    (_U_(0x1) << GMAC_ISR_MFS_Pos)                 /**< (GMAC_ISR) Management Frame Sent Mask */
+#define GMAC_ISR_MFS                        GMAC_ISR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_MFS_Msk instead */
+#define GMAC_ISR_RCOMP_Pos                  1                                              /**< (GMAC_ISR) Receive Complete Position */
+#define GMAC_ISR_RCOMP_Msk                  (_U_(0x1) << GMAC_ISR_RCOMP_Pos)               /**< (GMAC_ISR) Receive Complete Mask */
+#define GMAC_ISR_RCOMP                      GMAC_ISR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RCOMP_Msk instead */
+#define GMAC_ISR_RXUBR_Pos                  2                                              /**< (GMAC_ISR) RX Used Bit Read Position */
+#define GMAC_ISR_RXUBR_Msk                  (_U_(0x1) << GMAC_ISR_RXUBR_Pos)               /**< (GMAC_ISR) RX Used Bit Read Mask */
+#define GMAC_ISR_RXUBR                      GMAC_ISR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RXUBR_Msk instead */
+#define GMAC_ISR_TXUBR_Pos                  3                                              /**< (GMAC_ISR) TX Used Bit Read Position */
+#define GMAC_ISR_TXUBR_Msk                  (_U_(0x1) << GMAC_ISR_TXUBR_Pos)               /**< (GMAC_ISR) TX Used Bit Read Mask */
+#define GMAC_ISR_TXUBR                      GMAC_ISR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TXUBR_Msk instead */
+#define GMAC_ISR_TUR_Pos                    4                                              /**< (GMAC_ISR) Transmit Underrun Position */
+#define GMAC_ISR_TUR_Msk                    (_U_(0x1) << GMAC_ISR_TUR_Pos)                 /**< (GMAC_ISR) Transmit Underrun Mask */
+#define GMAC_ISR_TUR                        GMAC_ISR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TUR_Msk instead */
+#define GMAC_ISR_RLEX_Pos                   5                                              /**< (GMAC_ISR) Retry Limit Exceeded Position */
+#define GMAC_ISR_RLEX_Msk                   (_U_(0x1) << GMAC_ISR_RLEX_Pos)                /**< (GMAC_ISR) Retry Limit Exceeded Mask */
+#define GMAC_ISR_RLEX                       GMAC_ISR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RLEX_Msk instead */
+#define GMAC_ISR_TFC_Pos                    6                                              /**< (GMAC_ISR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_ISR_TFC_Msk                    (_U_(0x1) << GMAC_ISR_TFC_Pos)                 /**< (GMAC_ISR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_ISR_TFC                        GMAC_ISR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TFC_Msk instead */
+#define GMAC_ISR_TCOMP_Pos                  7                                              /**< (GMAC_ISR) Transmit Complete Position */
+#define GMAC_ISR_TCOMP_Msk                  (_U_(0x1) << GMAC_ISR_TCOMP_Pos)               /**< (GMAC_ISR) Transmit Complete Mask */
+#define GMAC_ISR_TCOMP                      GMAC_ISR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TCOMP_Msk instead */
+#define GMAC_ISR_ROVR_Pos                   10                                             /**< (GMAC_ISR) Receive Overrun Position */
+#define GMAC_ISR_ROVR_Msk                   (_U_(0x1) << GMAC_ISR_ROVR_Pos)                /**< (GMAC_ISR) Receive Overrun Mask */
+#define GMAC_ISR_ROVR                       GMAC_ISR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_ROVR_Msk instead */
+#define GMAC_ISR_HRESP_Pos                  11                                             /**< (GMAC_ISR) HRESP Not OK Position */
+#define GMAC_ISR_HRESP_Msk                  (_U_(0x1) << GMAC_ISR_HRESP_Pos)               /**< (GMAC_ISR) HRESP Not OK Mask */
+#define GMAC_ISR_HRESP                      GMAC_ISR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_HRESP_Msk instead */
+#define GMAC_ISR_PFNZ_Pos                   12                                             /**< (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_ISR_PFNZ_Msk                   (_U_(0x1) << GMAC_ISR_PFNZ_Pos)                /**< (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_ISR_PFNZ                       GMAC_ISR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PFNZ_Msk instead */
+#define GMAC_ISR_PTZ_Pos                    13                                             /**< (GMAC_ISR) Pause Time Zero Position */
+#define GMAC_ISR_PTZ_Msk                    (_U_(0x1) << GMAC_ISR_PTZ_Pos)                 /**< (GMAC_ISR) Pause Time Zero Mask */
+#define GMAC_ISR_PTZ                        GMAC_ISR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PTZ_Msk instead */
+#define GMAC_ISR_PFTR_Pos                   14                                             /**< (GMAC_ISR) Pause Frame Transmitted Position */
+#define GMAC_ISR_PFTR_Msk                   (_U_(0x1) << GMAC_ISR_PFTR_Pos)                /**< (GMAC_ISR) Pause Frame Transmitted Mask */
+#define GMAC_ISR_PFTR                       GMAC_ISR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PFTR_Msk instead */
+#define GMAC_ISR_DRQFR_Pos                  18                                             /**< (GMAC_ISR) PTP Delay Request Frame Received Position */
+#define GMAC_ISR_DRQFR_Msk                  (_U_(0x1) << GMAC_ISR_DRQFR_Pos)               /**< (GMAC_ISR) PTP Delay Request Frame Received Mask */
+#define GMAC_ISR_DRQFR                      GMAC_ISR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_DRQFR_Msk instead */
+#define GMAC_ISR_SFR_Pos                    19                                             /**< (GMAC_ISR) PTP Sync Frame Received Position */
+#define GMAC_ISR_SFR_Msk                    (_U_(0x1) << GMAC_ISR_SFR_Pos)                 /**< (GMAC_ISR) PTP Sync Frame Received Mask */
+#define GMAC_ISR_SFR                        GMAC_ISR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SFR_Msk instead */
+#define GMAC_ISR_DRQFT_Pos                  20                                             /**< (GMAC_ISR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_ISR_DRQFT_Msk                  (_U_(0x1) << GMAC_ISR_DRQFT_Pos)               /**< (GMAC_ISR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_ISR_DRQFT                      GMAC_ISR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_DRQFT_Msk instead */
+#define GMAC_ISR_SFT_Pos                    21                                             /**< (GMAC_ISR) PTP Sync Frame Transmitted Position */
+#define GMAC_ISR_SFT_Msk                    (_U_(0x1) << GMAC_ISR_SFT_Pos)                 /**< (GMAC_ISR) PTP Sync Frame Transmitted Mask */
+#define GMAC_ISR_SFT                        GMAC_ISR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SFT_Msk instead */
+#define GMAC_ISR_PDRQFR_Pos                 22                                             /**< (GMAC_ISR) PDelay Request Frame Received Position */
+#define GMAC_ISR_PDRQFR_Msk                 (_U_(0x1) << GMAC_ISR_PDRQFR_Pos)              /**< (GMAC_ISR) PDelay Request Frame Received Mask */
+#define GMAC_ISR_PDRQFR                     GMAC_ISR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRQFR_Msk instead */
+#define GMAC_ISR_PDRSFR_Pos                 23                                             /**< (GMAC_ISR) PDelay Response Frame Received Position */
+#define GMAC_ISR_PDRSFR_Msk                 (_U_(0x1) << GMAC_ISR_PDRSFR_Pos)              /**< (GMAC_ISR) PDelay Response Frame Received Mask */
+#define GMAC_ISR_PDRSFR                     GMAC_ISR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRSFR_Msk instead */
+#define GMAC_ISR_PDRQFT_Pos                 24                                             /**< (GMAC_ISR) PDelay Request Frame Transmitted Position */
+#define GMAC_ISR_PDRQFT_Msk                 (_U_(0x1) << GMAC_ISR_PDRQFT_Pos)              /**< (GMAC_ISR) PDelay Request Frame Transmitted Mask */
+#define GMAC_ISR_PDRQFT                     GMAC_ISR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRQFT_Msk instead */
+#define GMAC_ISR_PDRSFT_Pos                 25                                             /**< (GMAC_ISR) PDelay Response Frame Transmitted Position */
+#define GMAC_ISR_PDRSFT_Msk                 (_U_(0x1) << GMAC_ISR_PDRSFT_Pos)              /**< (GMAC_ISR) PDelay Response Frame Transmitted Mask */
+#define GMAC_ISR_PDRSFT                     GMAC_ISR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRSFT_Msk instead */
+#define GMAC_ISR_SRI_Pos                    26                                             /**< (GMAC_ISR) TSU Seconds Register Increment Position */
+#define GMAC_ISR_SRI_Msk                    (_U_(0x1) << GMAC_ISR_SRI_Pos)                 /**< (GMAC_ISR) TSU Seconds Register Increment Mask */
+#define GMAC_ISR_SRI                        GMAC_ISR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SRI_Msk instead */
+#define GMAC_ISR_WOL_Pos                    28                                             /**< (GMAC_ISR) Wake On LAN Position */
+#define GMAC_ISR_WOL_Msk                    (_U_(0x1) << GMAC_ISR_WOL_Pos)                 /**< (GMAC_ISR) Wake On LAN Mask */
+#define GMAC_ISR_WOL                        GMAC_ISR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_WOL_Msk instead */
+#define GMAC_ISR_MASK                       _U_(0x17FC7CFF)                                /**< \deprecated (GMAC_ISR) Register MASK  (Use GMAC_ISR_Msk instead)  */
+#define GMAC_ISR_Msk                        _U_(0x17FC7CFF)                                /**< (GMAC_ISR) Register Mask  */
+
+
+/* -------- GMAC_IER : (GMAC Offset: 0x28) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IER_OFFSET                     (0x28)                                        /**<  (GMAC_IER) Interrupt Enable Register  Offset */
+
+#define GMAC_IER_MFS_Pos                    0                                              /**< (GMAC_IER) Management Frame Sent Position */
+#define GMAC_IER_MFS_Msk                    (_U_(0x1) << GMAC_IER_MFS_Pos)                 /**< (GMAC_IER) Management Frame Sent Mask */
+#define GMAC_IER_MFS                        GMAC_IER_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_MFS_Msk instead */
+#define GMAC_IER_RCOMP_Pos                  1                                              /**< (GMAC_IER) Receive Complete Position */
+#define GMAC_IER_RCOMP_Msk                  (_U_(0x1) << GMAC_IER_RCOMP_Pos)               /**< (GMAC_IER) Receive Complete Mask */
+#define GMAC_IER_RCOMP                      GMAC_IER_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RCOMP_Msk instead */
+#define GMAC_IER_RXUBR_Pos                  2                                              /**< (GMAC_IER) RX Used Bit Read Position */
+#define GMAC_IER_RXUBR_Msk                  (_U_(0x1) << GMAC_IER_RXUBR_Pos)               /**< (GMAC_IER) RX Used Bit Read Mask */
+#define GMAC_IER_RXUBR                      GMAC_IER_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RXUBR_Msk instead */
+#define GMAC_IER_TXUBR_Pos                  3                                              /**< (GMAC_IER) TX Used Bit Read Position */
+#define GMAC_IER_TXUBR_Msk                  (_U_(0x1) << GMAC_IER_TXUBR_Pos)               /**< (GMAC_IER) TX Used Bit Read Mask */
+#define GMAC_IER_TXUBR                      GMAC_IER_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TXUBR_Msk instead */
+#define GMAC_IER_TUR_Pos                    4                                              /**< (GMAC_IER) Transmit Underrun Position */
+#define GMAC_IER_TUR_Msk                    (_U_(0x1) << GMAC_IER_TUR_Pos)                 /**< (GMAC_IER) Transmit Underrun Mask */
+#define GMAC_IER_TUR                        GMAC_IER_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TUR_Msk instead */
+#define GMAC_IER_RLEX_Pos                   5                                              /**< (GMAC_IER) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IER_RLEX_Msk                   (_U_(0x1) << GMAC_IER_RLEX_Pos)                /**< (GMAC_IER) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IER_RLEX                       GMAC_IER_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RLEX_Msk instead */
+#define GMAC_IER_TFC_Pos                    6                                              /**< (GMAC_IER) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IER_TFC_Msk                    (_U_(0x1) << GMAC_IER_TFC_Pos)                 /**< (GMAC_IER) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IER_TFC                        GMAC_IER_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TFC_Msk instead */
+#define GMAC_IER_TCOMP_Pos                  7                                              /**< (GMAC_IER) Transmit Complete Position */
+#define GMAC_IER_TCOMP_Msk                  (_U_(0x1) << GMAC_IER_TCOMP_Pos)               /**< (GMAC_IER) Transmit Complete Mask */
+#define GMAC_IER_TCOMP                      GMAC_IER_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TCOMP_Msk instead */
+#define GMAC_IER_ROVR_Pos                   10                                             /**< (GMAC_IER) Receive Overrun Position */
+#define GMAC_IER_ROVR_Msk                   (_U_(0x1) << GMAC_IER_ROVR_Pos)                /**< (GMAC_IER) Receive Overrun Mask */
+#define GMAC_IER_ROVR                       GMAC_IER_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_ROVR_Msk instead */
+#define GMAC_IER_HRESP_Pos                  11                                             /**< (GMAC_IER) HRESP Not OK Position */
+#define GMAC_IER_HRESP_Msk                  (_U_(0x1) << GMAC_IER_HRESP_Pos)               /**< (GMAC_IER) HRESP Not OK Mask */
+#define GMAC_IER_HRESP                      GMAC_IER_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_HRESP_Msk instead */
+#define GMAC_IER_PFNZ_Pos                   12                                             /**< (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IER_PFNZ_Msk                   (_U_(0x1) << GMAC_IER_PFNZ_Pos)                /**< (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IER_PFNZ                       GMAC_IER_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PFNZ_Msk instead */
+#define GMAC_IER_PTZ_Pos                    13                                             /**< (GMAC_IER) Pause Time Zero Position */
+#define GMAC_IER_PTZ_Msk                    (_U_(0x1) << GMAC_IER_PTZ_Pos)                 /**< (GMAC_IER) Pause Time Zero Mask */
+#define GMAC_IER_PTZ                        GMAC_IER_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PTZ_Msk instead */
+#define GMAC_IER_PFTR_Pos                   14                                             /**< (GMAC_IER) Pause Frame Transmitted Position */
+#define GMAC_IER_PFTR_Msk                   (_U_(0x1) << GMAC_IER_PFTR_Pos)                /**< (GMAC_IER) Pause Frame Transmitted Mask */
+#define GMAC_IER_PFTR                       GMAC_IER_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PFTR_Msk instead */
+#define GMAC_IER_EXINT_Pos                  15                                             /**< (GMAC_IER) External Interrupt Position */
+#define GMAC_IER_EXINT_Msk                  (_U_(0x1) << GMAC_IER_EXINT_Pos)               /**< (GMAC_IER) External Interrupt Mask */
+#define GMAC_IER_EXINT                      GMAC_IER_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_EXINT_Msk instead */
+#define GMAC_IER_DRQFR_Pos                  18                                             /**< (GMAC_IER) PTP Delay Request Frame Received Position */
+#define GMAC_IER_DRQFR_Msk                  (_U_(0x1) << GMAC_IER_DRQFR_Pos)               /**< (GMAC_IER) PTP Delay Request Frame Received Mask */
+#define GMAC_IER_DRQFR                      GMAC_IER_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_DRQFR_Msk instead */
+#define GMAC_IER_SFR_Pos                    19                                             /**< (GMAC_IER) PTP Sync Frame Received Position */
+#define GMAC_IER_SFR_Msk                    (_U_(0x1) << GMAC_IER_SFR_Pos)                 /**< (GMAC_IER) PTP Sync Frame Received Mask */
+#define GMAC_IER_SFR                        GMAC_IER_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SFR_Msk instead */
+#define GMAC_IER_DRQFT_Pos                  20                                             /**< (GMAC_IER) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IER_DRQFT_Msk                  (_U_(0x1) << GMAC_IER_DRQFT_Pos)               /**< (GMAC_IER) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IER_DRQFT                      GMAC_IER_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_DRQFT_Msk instead */
+#define GMAC_IER_SFT_Pos                    21                                             /**< (GMAC_IER) PTP Sync Frame Transmitted Position */
+#define GMAC_IER_SFT_Msk                    (_U_(0x1) << GMAC_IER_SFT_Pos)                 /**< (GMAC_IER) PTP Sync Frame Transmitted Mask */
+#define GMAC_IER_SFT                        GMAC_IER_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SFT_Msk instead */
+#define GMAC_IER_PDRQFR_Pos                 22                                             /**< (GMAC_IER) PDelay Request Frame Received Position */
+#define GMAC_IER_PDRQFR_Msk                 (_U_(0x1) << GMAC_IER_PDRQFR_Pos)              /**< (GMAC_IER) PDelay Request Frame Received Mask */
+#define GMAC_IER_PDRQFR                     GMAC_IER_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRQFR_Msk instead */
+#define GMAC_IER_PDRSFR_Pos                 23                                             /**< (GMAC_IER) PDelay Response Frame Received Position */
+#define GMAC_IER_PDRSFR_Msk                 (_U_(0x1) << GMAC_IER_PDRSFR_Pos)              /**< (GMAC_IER) PDelay Response Frame Received Mask */
+#define GMAC_IER_PDRSFR                     GMAC_IER_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRSFR_Msk instead */
+#define GMAC_IER_PDRQFT_Pos                 24                                             /**< (GMAC_IER) PDelay Request Frame Transmitted Position */
+#define GMAC_IER_PDRQFT_Msk                 (_U_(0x1) << GMAC_IER_PDRQFT_Pos)              /**< (GMAC_IER) PDelay Request Frame Transmitted Mask */
+#define GMAC_IER_PDRQFT                     GMAC_IER_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRQFT_Msk instead */
+#define GMAC_IER_PDRSFT_Pos                 25                                             /**< (GMAC_IER) PDelay Response Frame Transmitted Position */
+#define GMAC_IER_PDRSFT_Msk                 (_U_(0x1) << GMAC_IER_PDRSFT_Pos)              /**< (GMAC_IER) PDelay Response Frame Transmitted Mask */
+#define GMAC_IER_PDRSFT                     GMAC_IER_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRSFT_Msk instead */
+#define GMAC_IER_SRI_Pos                    26                                             /**< (GMAC_IER) TSU Seconds Register Increment Position */
+#define GMAC_IER_SRI_Msk                    (_U_(0x1) << GMAC_IER_SRI_Pos)                 /**< (GMAC_IER) TSU Seconds Register Increment Mask */
+#define GMAC_IER_SRI                        GMAC_IER_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SRI_Msk instead */
+#define GMAC_IER_RXLPISBC_Pos               27                                             /**< (GMAC_IER) Enable RX LPI Indication Position */
+#define GMAC_IER_RXLPISBC_Msk               (_U_(0x1) << GMAC_IER_RXLPISBC_Pos)            /**< (GMAC_IER) Enable RX LPI Indication Mask */
+#define GMAC_IER_RXLPISBC                   GMAC_IER_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RXLPISBC_Msk instead */
+#define GMAC_IER_WOL_Pos                    28                                             /**< (GMAC_IER) Wake On LAN Position */
+#define GMAC_IER_WOL_Msk                    (_U_(0x1) << GMAC_IER_WOL_Pos)                 /**< (GMAC_IER) Wake On LAN Mask */
+#define GMAC_IER_WOL                        GMAC_IER_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_WOL_Msk instead */
+#define GMAC_IER_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IER) TSU Timer Comparison Position */
+#define GMAC_IER_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IER_TSUTIMCOMP_Pos)          /**< (GMAC_IER) TSU Timer Comparison Mask */
+#define GMAC_IER_TSUTIMCOMP                 GMAC_IER_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TSUTIMCOMP_Msk instead */
+#define GMAC_IER_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IER) Register MASK  (Use GMAC_IER_Msk instead)  */
+#define GMAC_IER_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IER) Register Mask  */
+
+
+/* -------- GMAC_IDR : (GMAC Offset: 0x2c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IDR_OFFSET                     (0x2C)                                        /**<  (GMAC_IDR) Interrupt Disable Register  Offset */
+
+#define GMAC_IDR_MFS_Pos                    0                                              /**< (GMAC_IDR) Management Frame Sent Position */
+#define GMAC_IDR_MFS_Msk                    (_U_(0x1) << GMAC_IDR_MFS_Pos)                 /**< (GMAC_IDR) Management Frame Sent Mask */
+#define GMAC_IDR_MFS                        GMAC_IDR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_MFS_Msk instead */
+#define GMAC_IDR_RCOMP_Pos                  1                                              /**< (GMAC_IDR) Receive Complete Position */
+#define GMAC_IDR_RCOMP_Msk                  (_U_(0x1) << GMAC_IDR_RCOMP_Pos)               /**< (GMAC_IDR) Receive Complete Mask */
+#define GMAC_IDR_RCOMP                      GMAC_IDR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RCOMP_Msk instead */
+#define GMAC_IDR_RXUBR_Pos                  2                                              /**< (GMAC_IDR) RX Used Bit Read Position */
+#define GMAC_IDR_RXUBR_Msk                  (_U_(0x1) << GMAC_IDR_RXUBR_Pos)               /**< (GMAC_IDR) RX Used Bit Read Mask */
+#define GMAC_IDR_RXUBR                      GMAC_IDR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RXUBR_Msk instead */
+#define GMAC_IDR_TXUBR_Pos                  3                                              /**< (GMAC_IDR) TX Used Bit Read Position */
+#define GMAC_IDR_TXUBR_Msk                  (_U_(0x1) << GMAC_IDR_TXUBR_Pos)               /**< (GMAC_IDR) TX Used Bit Read Mask */
+#define GMAC_IDR_TXUBR                      GMAC_IDR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TXUBR_Msk instead */
+#define GMAC_IDR_TUR_Pos                    4                                              /**< (GMAC_IDR) Transmit Underrun Position */
+#define GMAC_IDR_TUR_Msk                    (_U_(0x1) << GMAC_IDR_TUR_Pos)                 /**< (GMAC_IDR) Transmit Underrun Mask */
+#define GMAC_IDR_TUR                        GMAC_IDR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TUR_Msk instead */
+#define GMAC_IDR_RLEX_Pos                   5                                              /**< (GMAC_IDR) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IDR_RLEX_Msk                   (_U_(0x1) << GMAC_IDR_RLEX_Pos)                /**< (GMAC_IDR) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IDR_RLEX                       GMAC_IDR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RLEX_Msk instead */
+#define GMAC_IDR_TFC_Pos                    6                                              /**< (GMAC_IDR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IDR_TFC_Msk                    (_U_(0x1) << GMAC_IDR_TFC_Pos)                 /**< (GMAC_IDR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IDR_TFC                        GMAC_IDR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TFC_Msk instead */
+#define GMAC_IDR_TCOMP_Pos                  7                                              /**< (GMAC_IDR) Transmit Complete Position */
+#define GMAC_IDR_TCOMP_Msk                  (_U_(0x1) << GMAC_IDR_TCOMP_Pos)               /**< (GMAC_IDR) Transmit Complete Mask */
+#define GMAC_IDR_TCOMP                      GMAC_IDR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TCOMP_Msk instead */
+#define GMAC_IDR_ROVR_Pos                   10                                             /**< (GMAC_IDR) Receive Overrun Position */
+#define GMAC_IDR_ROVR_Msk                   (_U_(0x1) << GMAC_IDR_ROVR_Pos)                /**< (GMAC_IDR) Receive Overrun Mask */
+#define GMAC_IDR_ROVR                       GMAC_IDR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_ROVR_Msk instead */
+#define GMAC_IDR_HRESP_Pos                  11                                             /**< (GMAC_IDR) HRESP Not OK Position */
+#define GMAC_IDR_HRESP_Msk                  (_U_(0x1) << GMAC_IDR_HRESP_Pos)               /**< (GMAC_IDR) HRESP Not OK Mask */
+#define GMAC_IDR_HRESP                      GMAC_IDR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_HRESP_Msk instead */
+#define GMAC_IDR_PFNZ_Pos                   12                                             /**< (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IDR_PFNZ_Msk                   (_U_(0x1) << GMAC_IDR_PFNZ_Pos)                /**< (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IDR_PFNZ                       GMAC_IDR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PFNZ_Msk instead */
+#define GMAC_IDR_PTZ_Pos                    13                                             /**< (GMAC_IDR) Pause Time Zero Position */
+#define GMAC_IDR_PTZ_Msk                    (_U_(0x1) << GMAC_IDR_PTZ_Pos)                 /**< (GMAC_IDR) Pause Time Zero Mask */
+#define GMAC_IDR_PTZ                        GMAC_IDR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PTZ_Msk instead */
+#define GMAC_IDR_PFTR_Pos                   14                                             /**< (GMAC_IDR) Pause Frame Transmitted Position */
+#define GMAC_IDR_PFTR_Msk                   (_U_(0x1) << GMAC_IDR_PFTR_Pos)                /**< (GMAC_IDR) Pause Frame Transmitted Mask */
+#define GMAC_IDR_PFTR                       GMAC_IDR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PFTR_Msk instead */
+#define GMAC_IDR_EXINT_Pos                  15                                             /**< (GMAC_IDR) External Interrupt Position */
+#define GMAC_IDR_EXINT_Msk                  (_U_(0x1) << GMAC_IDR_EXINT_Pos)               /**< (GMAC_IDR) External Interrupt Mask */
+#define GMAC_IDR_EXINT                      GMAC_IDR_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_EXINT_Msk instead */
+#define GMAC_IDR_DRQFR_Pos                  18                                             /**< (GMAC_IDR) PTP Delay Request Frame Received Position */
+#define GMAC_IDR_DRQFR_Msk                  (_U_(0x1) << GMAC_IDR_DRQFR_Pos)               /**< (GMAC_IDR) PTP Delay Request Frame Received Mask */
+#define GMAC_IDR_DRQFR                      GMAC_IDR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_DRQFR_Msk instead */
+#define GMAC_IDR_SFR_Pos                    19                                             /**< (GMAC_IDR) PTP Sync Frame Received Position */
+#define GMAC_IDR_SFR_Msk                    (_U_(0x1) << GMAC_IDR_SFR_Pos)                 /**< (GMAC_IDR) PTP Sync Frame Received Mask */
+#define GMAC_IDR_SFR                        GMAC_IDR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SFR_Msk instead */
+#define GMAC_IDR_DRQFT_Pos                  20                                             /**< (GMAC_IDR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IDR_DRQFT_Msk                  (_U_(0x1) << GMAC_IDR_DRQFT_Pos)               /**< (GMAC_IDR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IDR_DRQFT                      GMAC_IDR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_DRQFT_Msk instead */
+#define GMAC_IDR_SFT_Pos                    21                                             /**< (GMAC_IDR) PTP Sync Frame Transmitted Position */
+#define GMAC_IDR_SFT_Msk                    (_U_(0x1) << GMAC_IDR_SFT_Pos)                 /**< (GMAC_IDR) PTP Sync Frame Transmitted Mask */
+#define GMAC_IDR_SFT                        GMAC_IDR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SFT_Msk instead */
+#define GMAC_IDR_PDRQFR_Pos                 22                                             /**< (GMAC_IDR) PDelay Request Frame Received Position */
+#define GMAC_IDR_PDRQFR_Msk                 (_U_(0x1) << GMAC_IDR_PDRQFR_Pos)              /**< (GMAC_IDR) PDelay Request Frame Received Mask */
+#define GMAC_IDR_PDRQFR                     GMAC_IDR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRQFR_Msk instead */
+#define GMAC_IDR_PDRSFR_Pos                 23                                             /**< (GMAC_IDR) PDelay Response Frame Received Position */
+#define GMAC_IDR_PDRSFR_Msk                 (_U_(0x1) << GMAC_IDR_PDRSFR_Pos)              /**< (GMAC_IDR) PDelay Response Frame Received Mask */
+#define GMAC_IDR_PDRSFR                     GMAC_IDR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRSFR_Msk instead */
+#define GMAC_IDR_PDRQFT_Pos                 24                                             /**< (GMAC_IDR) PDelay Request Frame Transmitted Position */
+#define GMAC_IDR_PDRQFT_Msk                 (_U_(0x1) << GMAC_IDR_PDRQFT_Pos)              /**< (GMAC_IDR) PDelay Request Frame Transmitted Mask */
+#define GMAC_IDR_PDRQFT                     GMAC_IDR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRQFT_Msk instead */
+#define GMAC_IDR_PDRSFT_Pos                 25                                             /**< (GMAC_IDR) PDelay Response Frame Transmitted Position */
+#define GMAC_IDR_PDRSFT_Msk                 (_U_(0x1) << GMAC_IDR_PDRSFT_Pos)              /**< (GMAC_IDR) PDelay Response Frame Transmitted Mask */
+#define GMAC_IDR_PDRSFT                     GMAC_IDR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRSFT_Msk instead */
+#define GMAC_IDR_SRI_Pos                    26                                             /**< (GMAC_IDR) TSU Seconds Register Increment Position */
+#define GMAC_IDR_SRI_Msk                    (_U_(0x1) << GMAC_IDR_SRI_Pos)                 /**< (GMAC_IDR) TSU Seconds Register Increment Mask */
+#define GMAC_IDR_SRI                        GMAC_IDR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SRI_Msk instead */
+#define GMAC_IDR_RXLPISBC_Pos               27                                             /**< (GMAC_IDR) Enable RX LPI Indication Position */
+#define GMAC_IDR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IDR_RXLPISBC_Pos)            /**< (GMAC_IDR) Enable RX LPI Indication Mask */
+#define GMAC_IDR_RXLPISBC                   GMAC_IDR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RXLPISBC_Msk instead */
+#define GMAC_IDR_WOL_Pos                    28                                             /**< (GMAC_IDR) Wake On LAN Position */
+#define GMAC_IDR_WOL_Msk                    (_U_(0x1) << GMAC_IDR_WOL_Pos)                 /**< (GMAC_IDR) Wake On LAN Mask */
+#define GMAC_IDR_WOL                        GMAC_IDR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_WOL_Msk instead */
+#define GMAC_IDR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IDR) TSU Timer Comparison Position */
+#define GMAC_IDR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IDR_TSUTIMCOMP_Pos)          /**< (GMAC_IDR) TSU Timer Comparison Mask */
+#define GMAC_IDR_TSUTIMCOMP                 GMAC_IDR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TSUTIMCOMP_Msk instead */
+#define GMAC_IDR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IDR) Register MASK  (Use GMAC_IDR_Msk instead)  */
+#define GMAC_IDR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IDR) Register Mask  */
+
+
+/* -------- GMAC_IMR : (GMAC Offset: 0x30) (R/W 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded                     */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IMR_OFFSET                     (0x30)                                        /**<  (GMAC_IMR) Interrupt Mask Register  Offset */
+
+#define GMAC_IMR_MFS_Pos                    0                                              /**< (GMAC_IMR) Management Frame Sent Position */
+#define GMAC_IMR_MFS_Msk                    (_U_(0x1) << GMAC_IMR_MFS_Pos)                 /**< (GMAC_IMR) Management Frame Sent Mask */
+#define GMAC_IMR_MFS                        GMAC_IMR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_MFS_Msk instead */
+#define GMAC_IMR_RCOMP_Pos                  1                                              /**< (GMAC_IMR) Receive Complete Position */
+#define GMAC_IMR_RCOMP_Msk                  (_U_(0x1) << GMAC_IMR_RCOMP_Pos)               /**< (GMAC_IMR) Receive Complete Mask */
+#define GMAC_IMR_RCOMP                      GMAC_IMR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RCOMP_Msk instead */
+#define GMAC_IMR_RXUBR_Pos                  2                                              /**< (GMAC_IMR) RX Used Bit Read Position */
+#define GMAC_IMR_RXUBR_Msk                  (_U_(0x1) << GMAC_IMR_RXUBR_Pos)               /**< (GMAC_IMR) RX Used Bit Read Mask */
+#define GMAC_IMR_RXUBR                      GMAC_IMR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RXUBR_Msk instead */
+#define GMAC_IMR_TXUBR_Pos                  3                                              /**< (GMAC_IMR) TX Used Bit Read Position */
+#define GMAC_IMR_TXUBR_Msk                  (_U_(0x1) << GMAC_IMR_TXUBR_Pos)               /**< (GMAC_IMR) TX Used Bit Read Mask */
+#define GMAC_IMR_TXUBR                      GMAC_IMR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TXUBR_Msk instead */
+#define GMAC_IMR_TUR_Pos                    4                                              /**< (GMAC_IMR) Transmit Underrun Position */
+#define GMAC_IMR_TUR_Msk                    (_U_(0x1) << GMAC_IMR_TUR_Pos)                 /**< (GMAC_IMR) Transmit Underrun Mask */
+#define GMAC_IMR_TUR                        GMAC_IMR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TUR_Msk instead */
+#define GMAC_IMR_RLEX_Pos                   5                                              /**< (GMAC_IMR) Retry Limit Exceeded Position */
+#define GMAC_IMR_RLEX_Msk                   (_U_(0x1) << GMAC_IMR_RLEX_Pos)                /**< (GMAC_IMR) Retry Limit Exceeded Mask */
+#define GMAC_IMR_RLEX                       GMAC_IMR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RLEX_Msk instead */
+#define GMAC_IMR_TFC_Pos                    6                                              /**< (GMAC_IMR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IMR_TFC_Msk                    (_U_(0x1) << GMAC_IMR_TFC_Pos)                 /**< (GMAC_IMR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IMR_TFC                        GMAC_IMR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TFC_Msk instead */
+#define GMAC_IMR_TCOMP_Pos                  7                                              /**< (GMAC_IMR) Transmit Complete Position */
+#define GMAC_IMR_TCOMP_Msk                  (_U_(0x1) << GMAC_IMR_TCOMP_Pos)               /**< (GMAC_IMR) Transmit Complete Mask */
+#define GMAC_IMR_TCOMP                      GMAC_IMR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TCOMP_Msk instead */
+#define GMAC_IMR_ROVR_Pos                   10                                             /**< (GMAC_IMR) Receive Overrun Position */
+#define GMAC_IMR_ROVR_Msk                   (_U_(0x1) << GMAC_IMR_ROVR_Pos)                /**< (GMAC_IMR) Receive Overrun Mask */
+#define GMAC_IMR_ROVR                       GMAC_IMR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_ROVR_Msk instead */
+#define GMAC_IMR_HRESP_Pos                  11                                             /**< (GMAC_IMR) HRESP Not OK Position */
+#define GMAC_IMR_HRESP_Msk                  (_U_(0x1) << GMAC_IMR_HRESP_Pos)               /**< (GMAC_IMR) HRESP Not OK Mask */
+#define GMAC_IMR_HRESP                      GMAC_IMR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_HRESP_Msk instead */
+#define GMAC_IMR_PFNZ_Pos                   12                                             /**< (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IMR_PFNZ_Msk                   (_U_(0x1) << GMAC_IMR_PFNZ_Pos)                /**< (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IMR_PFNZ                       GMAC_IMR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PFNZ_Msk instead */
+#define GMAC_IMR_PTZ_Pos                    13                                             /**< (GMAC_IMR) Pause Time Zero Position */
+#define GMAC_IMR_PTZ_Msk                    (_U_(0x1) << GMAC_IMR_PTZ_Pos)                 /**< (GMAC_IMR) Pause Time Zero Mask */
+#define GMAC_IMR_PTZ                        GMAC_IMR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PTZ_Msk instead */
+#define GMAC_IMR_PFTR_Pos                   14                                             /**< (GMAC_IMR) Pause Frame Transmitted Position */
+#define GMAC_IMR_PFTR_Msk                   (_U_(0x1) << GMAC_IMR_PFTR_Pos)                /**< (GMAC_IMR) Pause Frame Transmitted Mask */
+#define GMAC_IMR_PFTR                       GMAC_IMR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PFTR_Msk instead */
+#define GMAC_IMR_EXINT_Pos                  15                                             /**< (GMAC_IMR) External Interrupt Position */
+#define GMAC_IMR_EXINT_Msk                  (_U_(0x1) << GMAC_IMR_EXINT_Pos)               /**< (GMAC_IMR) External Interrupt Mask */
+#define GMAC_IMR_EXINT                      GMAC_IMR_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_EXINT_Msk instead */
+#define GMAC_IMR_DRQFR_Pos                  18                                             /**< (GMAC_IMR) PTP Delay Request Frame Received Position */
+#define GMAC_IMR_DRQFR_Msk                  (_U_(0x1) << GMAC_IMR_DRQFR_Pos)               /**< (GMAC_IMR) PTP Delay Request Frame Received Mask */
+#define GMAC_IMR_DRQFR                      GMAC_IMR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_DRQFR_Msk instead */
+#define GMAC_IMR_SFR_Pos                    19                                             /**< (GMAC_IMR) PTP Sync Frame Received Position */
+#define GMAC_IMR_SFR_Msk                    (_U_(0x1) << GMAC_IMR_SFR_Pos)                 /**< (GMAC_IMR) PTP Sync Frame Received Mask */
+#define GMAC_IMR_SFR                        GMAC_IMR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SFR_Msk instead */
+#define GMAC_IMR_DRQFT_Pos                  20                                             /**< (GMAC_IMR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IMR_DRQFT_Msk                  (_U_(0x1) << GMAC_IMR_DRQFT_Pos)               /**< (GMAC_IMR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IMR_DRQFT                      GMAC_IMR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_DRQFT_Msk instead */
+#define GMAC_IMR_SFT_Pos                    21                                             /**< (GMAC_IMR) PTP Sync Frame Transmitted Position */
+#define GMAC_IMR_SFT_Msk                    (_U_(0x1) << GMAC_IMR_SFT_Pos)                 /**< (GMAC_IMR) PTP Sync Frame Transmitted Mask */
+#define GMAC_IMR_SFT                        GMAC_IMR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SFT_Msk instead */
+#define GMAC_IMR_PDRQFR_Pos                 22                                             /**< (GMAC_IMR) PDelay Request Frame Received Position */
+#define GMAC_IMR_PDRQFR_Msk                 (_U_(0x1) << GMAC_IMR_PDRQFR_Pos)              /**< (GMAC_IMR) PDelay Request Frame Received Mask */
+#define GMAC_IMR_PDRQFR                     GMAC_IMR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRQFR_Msk instead */
+#define GMAC_IMR_PDRSFR_Pos                 23                                             /**< (GMAC_IMR) PDelay Response Frame Received Position */
+#define GMAC_IMR_PDRSFR_Msk                 (_U_(0x1) << GMAC_IMR_PDRSFR_Pos)              /**< (GMAC_IMR) PDelay Response Frame Received Mask */
+#define GMAC_IMR_PDRSFR                     GMAC_IMR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRSFR_Msk instead */
+#define GMAC_IMR_PDRQFT_Pos                 24                                             /**< (GMAC_IMR) PDelay Request Frame Transmitted Position */
+#define GMAC_IMR_PDRQFT_Msk                 (_U_(0x1) << GMAC_IMR_PDRQFT_Pos)              /**< (GMAC_IMR) PDelay Request Frame Transmitted Mask */
+#define GMAC_IMR_PDRQFT                     GMAC_IMR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRQFT_Msk instead */
+#define GMAC_IMR_PDRSFT_Pos                 25                                             /**< (GMAC_IMR) PDelay Response Frame Transmitted Position */
+#define GMAC_IMR_PDRSFT_Msk                 (_U_(0x1) << GMAC_IMR_PDRSFT_Pos)              /**< (GMAC_IMR) PDelay Response Frame Transmitted Mask */
+#define GMAC_IMR_PDRSFT                     GMAC_IMR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRSFT_Msk instead */
+#define GMAC_IMR_SRI_Pos                    26                                             /**< (GMAC_IMR) TSU Seconds Register Increment Position */
+#define GMAC_IMR_SRI_Msk                    (_U_(0x1) << GMAC_IMR_SRI_Pos)                 /**< (GMAC_IMR) TSU Seconds Register Increment Mask */
+#define GMAC_IMR_SRI                        GMAC_IMR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SRI_Msk instead */
+#define GMAC_IMR_RXLPISBC_Pos               27                                             /**< (GMAC_IMR) Enable RX LPI Indication Position */
+#define GMAC_IMR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IMR_RXLPISBC_Pos)            /**< (GMAC_IMR) Enable RX LPI Indication Mask */
+#define GMAC_IMR_RXLPISBC                   GMAC_IMR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RXLPISBC_Msk instead */
+#define GMAC_IMR_WOL_Pos                    28                                             /**< (GMAC_IMR) Wake On LAN Position */
+#define GMAC_IMR_WOL_Msk                    (_U_(0x1) << GMAC_IMR_WOL_Pos)                 /**< (GMAC_IMR) Wake On LAN Mask */
+#define GMAC_IMR_WOL                        GMAC_IMR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_WOL_Msk instead */
+#define GMAC_IMR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IMR) TSU Timer Comparison Position */
+#define GMAC_IMR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IMR_TSUTIMCOMP_Pos)          /**< (GMAC_IMR) TSU Timer Comparison Mask */
+#define GMAC_IMR_TSUTIMCOMP                 GMAC_IMR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TSUTIMCOMP_Msk instead */
+#define GMAC_IMR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IMR) Register MASK  (Use GMAC_IMR_Msk instead)  */
+#define GMAC_IMR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IMR) Register Mask  */
+
+
+/* -------- GMAC_MAN : (GMAC Offset: 0x34) (R/W 32) PHY Maintenance Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:16;                   /**< bit:  0..15  PHY Data                                 */
+    uint32_t WTN:2;                     /**< bit: 16..17  Write Ten                                */
+    uint32_t REGA:5;                    /**< bit: 18..22  Register Address                         */
+    uint32_t PHYA:5;                    /**< bit: 23..27  PHY Address                              */
+    uint32_t OP:2;                      /**< bit: 28..29  Operation                                */
+    uint32_t CLTTO:1;                   /**< bit:     30  Clause 22 Operation                      */
+    uint32_t WZO:1;                     /**< bit:     31  Write ZERO                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MAN_OFFSET                     (0x34)                                        /**<  (GMAC_MAN) PHY Maintenance Register  Offset */
+
+#define GMAC_MAN_DATA_Pos                   0                                              /**< (GMAC_MAN) PHY Data Position */
+#define GMAC_MAN_DATA_Msk                   (_U_(0xFFFF) << GMAC_MAN_DATA_Pos)             /**< (GMAC_MAN) PHY Data Mask */
+#define GMAC_MAN_DATA(value)                (GMAC_MAN_DATA_Msk & ((value) << GMAC_MAN_DATA_Pos))
+#define GMAC_MAN_WTN_Pos                    16                                             /**< (GMAC_MAN) Write Ten Position */
+#define GMAC_MAN_WTN_Msk                    (_U_(0x3) << GMAC_MAN_WTN_Pos)                 /**< (GMAC_MAN) Write Ten Mask */
+#define GMAC_MAN_WTN(value)                 (GMAC_MAN_WTN_Msk & ((value) << GMAC_MAN_WTN_Pos))
+#define GMAC_MAN_REGA_Pos                   18                                             /**< (GMAC_MAN) Register Address Position */
+#define GMAC_MAN_REGA_Msk                   (_U_(0x1F) << GMAC_MAN_REGA_Pos)               /**< (GMAC_MAN) Register Address Mask */
+#define GMAC_MAN_REGA(value)                (GMAC_MAN_REGA_Msk & ((value) << GMAC_MAN_REGA_Pos))
+#define GMAC_MAN_PHYA_Pos                   23                                             /**< (GMAC_MAN) PHY Address Position */
+#define GMAC_MAN_PHYA_Msk                   (_U_(0x1F) << GMAC_MAN_PHYA_Pos)               /**< (GMAC_MAN) PHY Address Mask */
+#define GMAC_MAN_PHYA(value)                (GMAC_MAN_PHYA_Msk & ((value) << GMAC_MAN_PHYA_Pos))
+#define GMAC_MAN_OP_Pos                     28                                             /**< (GMAC_MAN) Operation Position */
+#define GMAC_MAN_OP_Msk                     (_U_(0x3) << GMAC_MAN_OP_Pos)                  /**< (GMAC_MAN) Operation Mask */
+#define GMAC_MAN_OP(value)                  (GMAC_MAN_OP_Msk & ((value) << GMAC_MAN_OP_Pos))
+#define GMAC_MAN_CLTTO_Pos                  30                                             /**< (GMAC_MAN) Clause 22 Operation Position */
+#define GMAC_MAN_CLTTO_Msk                  (_U_(0x1) << GMAC_MAN_CLTTO_Pos)               /**< (GMAC_MAN) Clause 22 Operation Mask */
+#define GMAC_MAN_CLTTO                      GMAC_MAN_CLTTO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_MAN_CLTTO_Msk instead */
+#define GMAC_MAN_WZO_Pos                    31                                             /**< (GMAC_MAN) Write ZERO Position */
+#define GMAC_MAN_WZO_Msk                    (_U_(0x1) << GMAC_MAN_WZO_Pos)                 /**< (GMAC_MAN) Write ZERO Mask */
+#define GMAC_MAN_WZO                        GMAC_MAN_WZO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_MAN_WZO_Msk instead */
+#define GMAC_MAN_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MAN) Register MASK  (Use GMAC_MAN_Msk instead)  */
+#define GMAC_MAN_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MAN) Register Mask  */
+
+
+/* -------- GMAC_RPQ : (GMAC Offset: 0x38) (R/ 32) Received Pause Quantum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RPQ:16;                    /**< bit:  0..15  Received Pause Quantum                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RPQ_OFFSET                     (0x38)                                        /**<  (GMAC_RPQ) Received Pause Quantum Register  Offset */
+
+#define GMAC_RPQ_RPQ_Pos                    0                                              /**< (GMAC_RPQ) Received Pause Quantum Position */
+#define GMAC_RPQ_RPQ_Msk                    (_U_(0xFFFF) << GMAC_RPQ_RPQ_Pos)              /**< (GMAC_RPQ) Received Pause Quantum Mask */
+#define GMAC_RPQ_RPQ(value)                 (GMAC_RPQ_RPQ_Msk & ((value) << GMAC_RPQ_RPQ_Pos))
+#define GMAC_RPQ_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_RPQ) Register MASK  (Use GMAC_RPQ_Msk instead)  */
+#define GMAC_RPQ_Msk                        _U_(0xFFFF)                                    /**< (GMAC_RPQ) Register Mask  */
+
+
+/* -------- GMAC_TPQ : (GMAC Offset: 0x3c) (R/W 32) Transmit Pause Quantum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TPQ:16;                    /**< bit:  0..15  Transmit Pause Quantum                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPQ_OFFSET                     (0x3C)                                        /**<  (GMAC_TPQ) Transmit Pause Quantum Register  Offset */
+
+#define GMAC_TPQ_TPQ_Pos                    0                                              /**< (GMAC_TPQ) Transmit Pause Quantum Position */
+#define GMAC_TPQ_TPQ_Msk                    (_U_(0xFFFF) << GMAC_TPQ_TPQ_Pos)              /**< (GMAC_TPQ) Transmit Pause Quantum Mask */
+#define GMAC_TPQ_TPQ(value)                 (GMAC_TPQ_TPQ_Msk & ((value) << GMAC_TPQ_TPQ_Pos))
+#define GMAC_TPQ_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_TPQ) Register MASK  (Use GMAC_TPQ_Msk instead)  */
+#define GMAC_TPQ_Msk                        _U_(0xFFFF)                                    /**< (GMAC_TPQ) Register Mask  */
+
+
+/* -------- GMAC_TPSF : (GMAC Offset: 0x40) (R/W 32) TX Partial Store and Forward Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TPB1ADR:12;                /**< bit:  0..11  Transmit Partial Store and Forward Address */
+    uint32_t :19;                       /**< bit: 12..30  Reserved */
+    uint32_t ENTXP:1;                   /**< bit:     31  Enable TX Partial Store and Forward Operation */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPSF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPSF_OFFSET                    (0x40)                                        /**<  (GMAC_TPSF) TX Partial Store and Forward Register  Offset */
+
+#define GMAC_TPSF_TPB1ADR_Pos               0                                              /**< (GMAC_TPSF) Transmit Partial Store and Forward Address Position */
+#define GMAC_TPSF_TPB1ADR_Msk               (_U_(0xFFF) << GMAC_TPSF_TPB1ADR_Pos)          /**< (GMAC_TPSF) Transmit Partial Store and Forward Address Mask */
+#define GMAC_TPSF_TPB1ADR(value)            (GMAC_TPSF_TPB1ADR_Msk & ((value) << GMAC_TPSF_TPB1ADR_Pos))
+#define GMAC_TPSF_ENTXP_Pos                 31                                             /**< (GMAC_TPSF) Enable TX Partial Store and Forward Operation Position */
+#define GMAC_TPSF_ENTXP_Msk                 (_U_(0x1) << GMAC_TPSF_ENTXP_Pos)              /**< (GMAC_TPSF) Enable TX Partial Store and Forward Operation Mask */
+#define GMAC_TPSF_ENTXP                     GMAC_TPSF_ENTXP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TPSF_ENTXP_Msk instead */
+#define GMAC_TPSF_MASK                      _U_(0x80000FFF)                                /**< \deprecated (GMAC_TPSF) Register MASK  (Use GMAC_TPSF_Msk instead)  */
+#define GMAC_TPSF_Msk                       _U_(0x80000FFF)                                /**< (GMAC_TPSF) Register Mask  */
+
+
+/* -------- GMAC_RPSF : (GMAC Offset: 0x44) (R/W 32) RX Partial Store and Forward Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RPB1ADR:12;                /**< bit:  0..11  Receive Partial Store and Forward Address */
+    uint32_t :19;                       /**< bit: 12..30  Reserved */
+    uint32_t ENRXP:1;                   /**< bit:     31  Enable RX Partial Store and Forward Operation */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RPSF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RPSF_OFFSET                    (0x44)                                        /**<  (GMAC_RPSF) RX Partial Store and Forward Register  Offset */
+
+#define GMAC_RPSF_RPB1ADR_Pos               0                                              /**< (GMAC_RPSF) Receive Partial Store and Forward Address Position */
+#define GMAC_RPSF_RPB1ADR_Msk               (_U_(0xFFF) << GMAC_RPSF_RPB1ADR_Pos)          /**< (GMAC_RPSF) Receive Partial Store and Forward Address Mask */
+#define GMAC_RPSF_RPB1ADR(value)            (GMAC_RPSF_RPB1ADR_Msk & ((value) << GMAC_RPSF_RPB1ADR_Pos))
+#define GMAC_RPSF_ENRXP_Pos                 31                                             /**< (GMAC_RPSF) Enable RX Partial Store and Forward Operation Position */
+#define GMAC_RPSF_ENRXP_Msk                 (_U_(0x1) << GMAC_RPSF_ENRXP_Pos)              /**< (GMAC_RPSF) Enable RX Partial Store and Forward Operation Mask */
+#define GMAC_RPSF_ENRXP                     GMAC_RPSF_ENRXP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RPSF_ENRXP_Msk instead */
+#define GMAC_RPSF_MASK                      _U_(0x80000FFF)                                /**< \deprecated (GMAC_RPSF) Register MASK  (Use GMAC_RPSF_Msk instead)  */
+#define GMAC_RPSF_Msk                       _U_(0x80000FFF)                                /**< (GMAC_RPSF) Register Mask  */
+
+
+/* -------- GMAC_RJFML : (GMAC Offset: 0x48) (R/W 32) RX Jumbo Frame Max Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FML:14;                    /**< bit:  0..13  Frame Max Length                         */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RJFML_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RJFML_OFFSET                   (0x48)                                        /**<  (GMAC_RJFML) RX Jumbo Frame Max Length Register  Offset */
+
+#define GMAC_RJFML_FML_Pos                  0                                              /**< (GMAC_RJFML) Frame Max Length Position */
+#define GMAC_RJFML_FML_Msk                  (_U_(0x3FFF) << GMAC_RJFML_FML_Pos)            /**< (GMAC_RJFML) Frame Max Length Mask */
+#define GMAC_RJFML_FML(value)               (GMAC_RJFML_FML_Msk & ((value) << GMAC_RJFML_FML_Pos))
+#define GMAC_RJFML_MASK                     _U_(0x3FFF)                                    /**< \deprecated (GMAC_RJFML) Register MASK  (Use GMAC_RJFML_Msk instead)  */
+#define GMAC_RJFML_Msk                      _U_(0x3FFF)                                    /**< (GMAC_RJFML) Register Mask  */
+
+
+/* -------- GMAC_HRB : (GMAC Offset: 0x80) (R/W 32) Hash Register Bottom -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_HRB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_HRB_OFFSET                     (0x80)                                        /**<  (GMAC_HRB) Hash Register Bottom  Offset */
+
+#define GMAC_HRB_ADDR_Pos                   0                                              /**< (GMAC_HRB) Hash Address Position */
+#define GMAC_HRB_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_HRB_ADDR_Pos)         /**< (GMAC_HRB) Hash Address Mask */
+#define GMAC_HRB_ADDR(value)                (GMAC_HRB_ADDR_Msk & ((value) << GMAC_HRB_ADDR_Pos))
+#define GMAC_HRB_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_HRB) Register MASK  (Use GMAC_HRB_Msk instead)  */
+#define GMAC_HRB_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_HRB) Register Mask  */
+
+
+/* -------- GMAC_HRT : (GMAC Offset: 0x84) (R/W 32) Hash Register Top -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_HRT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_HRT_OFFSET                     (0x84)                                        /**<  (GMAC_HRT) Hash Register Top  Offset */
+
+#define GMAC_HRT_ADDR_Pos                   0                                              /**< (GMAC_HRT) Hash Address Position */
+#define GMAC_HRT_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_HRT_ADDR_Pos)         /**< (GMAC_HRT) Hash Address Mask */
+#define GMAC_HRT_ADDR(value)                (GMAC_HRT_ADDR_Msk & ((value) << GMAC_HRT_ADDR_Pos))
+#define GMAC_HRT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_HRT) Register MASK  (Use GMAC_HRT_Msk instead)  */
+#define GMAC_HRT_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_HRT) Register Mask  */
+
+
+/* -------- GMAC_TIDM1 : (GMAC Offset: 0xa8) (R/W 32) Type ID Match 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 1                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID1:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM1_OFFSET                   (0xA8)                                        /**<  (GMAC_TIDM1) Type ID Match 1 Register  Offset */
+
+#define GMAC_TIDM1_TID_Pos                  0                                              /**< (GMAC_TIDM1) Type ID Match 1 Position */
+#define GMAC_TIDM1_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM1_TID_Pos)            /**< (GMAC_TIDM1) Type ID Match 1 Mask */
+#define GMAC_TIDM1_TID(value)               (GMAC_TIDM1_TID_Msk & ((value) << GMAC_TIDM1_TID_Pos))
+#define GMAC_TIDM1_ENID1_Pos                31                                             /**< (GMAC_TIDM1) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM1_ENID1_Msk                (_U_(0x1) << GMAC_TIDM1_ENID1_Pos)             /**< (GMAC_TIDM1) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM1_ENID1                    GMAC_TIDM1_ENID1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM1_ENID1_Msk instead */
+#define GMAC_TIDM1_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM1) Register MASK  (Use GMAC_TIDM1_Msk instead)  */
+#define GMAC_TIDM1_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM1) Register Mask  */
+
+#define GMAC_TIDM1_ENID_Pos                 31                                             /**< (GMAC_TIDM1 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM1_ENID_Msk                 (_U_(0x1) << GMAC_TIDM1_ENID_Pos)              /**< (GMAC_TIDM1 Mask) ENID */
+#define GMAC_TIDM1_ENID(value)              (GMAC_TIDM1_ENID_Msk & ((value) << GMAC_TIDM1_ENID_Pos))  
+
+/* -------- GMAC_TIDM2 : (GMAC Offset: 0xac) (R/W 32) Type ID Match 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 2                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID2:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM2_OFFSET                   (0xAC)                                        /**<  (GMAC_TIDM2) Type ID Match 2 Register  Offset */
+
+#define GMAC_TIDM2_TID_Pos                  0                                              /**< (GMAC_TIDM2) Type ID Match 2 Position */
+#define GMAC_TIDM2_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM2_TID_Pos)            /**< (GMAC_TIDM2) Type ID Match 2 Mask */
+#define GMAC_TIDM2_TID(value)               (GMAC_TIDM2_TID_Msk & ((value) << GMAC_TIDM2_TID_Pos))
+#define GMAC_TIDM2_ENID2_Pos                31                                             /**< (GMAC_TIDM2) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM2_ENID2_Msk                (_U_(0x1) << GMAC_TIDM2_ENID2_Pos)             /**< (GMAC_TIDM2) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM2_ENID2                    GMAC_TIDM2_ENID2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM2_ENID2_Msk instead */
+#define GMAC_TIDM2_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM2) Register MASK  (Use GMAC_TIDM2_Msk instead)  */
+#define GMAC_TIDM2_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM2) Register Mask  */
+
+#define GMAC_TIDM2_ENID_Pos                 31                                             /**< (GMAC_TIDM2 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM2_ENID_Msk                 (_U_(0x1) << GMAC_TIDM2_ENID_Pos)              /**< (GMAC_TIDM2 Mask) ENID */
+#define GMAC_TIDM2_ENID(value)              (GMAC_TIDM2_ENID_Msk & ((value) << GMAC_TIDM2_ENID_Pos))  
+
+/* -------- GMAC_TIDM3 : (GMAC Offset: 0xb0) (R/W 32) Type ID Match 3 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 3                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID3:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM3_OFFSET                   (0xB0)                                        /**<  (GMAC_TIDM3) Type ID Match 3 Register  Offset */
+
+#define GMAC_TIDM3_TID_Pos                  0                                              /**< (GMAC_TIDM3) Type ID Match 3 Position */
+#define GMAC_TIDM3_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM3_TID_Pos)            /**< (GMAC_TIDM3) Type ID Match 3 Mask */
+#define GMAC_TIDM3_TID(value)               (GMAC_TIDM3_TID_Msk & ((value) << GMAC_TIDM3_TID_Pos))
+#define GMAC_TIDM3_ENID3_Pos                31                                             /**< (GMAC_TIDM3) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM3_ENID3_Msk                (_U_(0x1) << GMAC_TIDM3_ENID3_Pos)             /**< (GMAC_TIDM3) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM3_ENID3                    GMAC_TIDM3_ENID3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM3_ENID3_Msk instead */
+#define GMAC_TIDM3_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM3) Register MASK  (Use GMAC_TIDM3_Msk instead)  */
+#define GMAC_TIDM3_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM3) Register Mask  */
+
+#define GMAC_TIDM3_ENID_Pos                 31                                             /**< (GMAC_TIDM3 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM3_ENID_Msk                 (_U_(0x1) << GMAC_TIDM3_ENID_Pos)              /**< (GMAC_TIDM3 Mask) ENID */
+#define GMAC_TIDM3_ENID(value)              (GMAC_TIDM3_ENID_Msk & ((value) << GMAC_TIDM3_ENID_Pos))  
+
+/* -------- GMAC_TIDM4 : (GMAC Offset: 0xb4) (R/W 32) Type ID Match 4 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 4                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID4:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM4_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM4_OFFSET                   (0xB4)                                        /**<  (GMAC_TIDM4) Type ID Match 4 Register  Offset */
+
+#define GMAC_TIDM4_TID_Pos                  0                                              /**< (GMAC_TIDM4) Type ID Match 4 Position */
+#define GMAC_TIDM4_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM4_TID_Pos)            /**< (GMAC_TIDM4) Type ID Match 4 Mask */
+#define GMAC_TIDM4_TID(value)               (GMAC_TIDM4_TID_Msk & ((value) << GMAC_TIDM4_TID_Pos))
+#define GMAC_TIDM4_ENID4_Pos                31                                             /**< (GMAC_TIDM4) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM4_ENID4_Msk                (_U_(0x1) << GMAC_TIDM4_ENID4_Pos)             /**< (GMAC_TIDM4) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM4_ENID4                    GMAC_TIDM4_ENID4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM4_ENID4_Msk instead */
+#define GMAC_TIDM4_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM4) Register MASK  (Use GMAC_TIDM4_Msk instead)  */
+#define GMAC_TIDM4_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM4) Register Mask  */
+
+#define GMAC_TIDM4_ENID_Pos                 31                                             /**< (GMAC_TIDM4 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM4_ENID_Msk                 (_U_(0x1) << GMAC_TIDM4_ENID_Pos)              /**< (GMAC_TIDM4 Mask) ENID */
+#define GMAC_TIDM4_ENID(value)              (GMAC_TIDM4_ENID_Msk & ((value) << GMAC_TIDM4_ENID_Pos))  
+
+/* -------- GMAC_WOL : (GMAC Offset: 0xb8) (R/W 32) Wake on LAN Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IP:16;                     /**< bit:  0..15  ARP Request IP Address                   */
+    uint32_t MAG:1;                     /**< bit:     16  Magic Packet Event Enable                */
+    uint32_t ARP:1;                     /**< bit:     17  ARP Request IP Address                   */
+    uint32_t SA1:1;                     /**< bit:     18  Specific Address Register 1 Event Enable */
+    uint32_t MTI:1;                     /**< bit:     19  Multicast Hash Event Enable              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t SA:1;                      /**< bit:     18  Specific Address Register x Event Enable */
+    uint32_t :13;                       /**< bit: 19..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_WOL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_WOL_OFFSET                     (0xB8)                                        /**<  (GMAC_WOL) Wake on LAN Register  Offset */
+
+#define GMAC_WOL_IP_Pos                     0                                              /**< (GMAC_WOL) ARP Request IP Address Position */
+#define GMAC_WOL_IP_Msk                     (_U_(0xFFFF) << GMAC_WOL_IP_Pos)               /**< (GMAC_WOL) ARP Request IP Address Mask */
+#define GMAC_WOL_IP(value)                  (GMAC_WOL_IP_Msk & ((value) << GMAC_WOL_IP_Pos))
+#define GMAC_WOL_MAG_Pos                    16                                             /**< (GMAC_WOL) Magic Packet Event Enable Position */
+#define GMAC_WOL_MAG_Msk                    (_U_(0x1) << GMAC_WOL_MAG_Pos)                 /**< (GMAC_WOL) Magic Packet Event Enable Mask */
+#define GMAC_WOL_MAG                        GMAC_WOL_MAG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_MAG_Msk instead */
+#define GMAC_WOL_ARP_Pos                    17                                             /**< (GMAC_WOL) ARP Request IP Address Position */
+#define GMAC_WOL_ARP_Msk                    (_U_(0x1) << GMAC_WOL_ARP_Pos)                 /**< (GMAC_WOL) ARP Request IP Address Mask */
+#define GMAC_WOL_ARP                        GMAC_WOL_ARP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_ARP_Msk instead */
+#define GMAC_WOL_SA1_Pos                    18                                             /**< (GMAC_WOL) Specific Address Register 1 Event Enable Position */
+#define GMAC_WOL_SA1_Msk                    (_U_(0x1) << GMAC_WOL_SA1_Pos)                 /**< (GMAC_WOL) Specific Address Register 1 Event Enable Mask */
+#define GMAC_WOL_SA1                        GMAC_WOL_SA1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_SA1_Msk instead */
+#define GMAC_WOL_MTI_Pos                    19                                             /**< (GMAC_WOL) Multicast Hash Event Enable Position */
+#define GMAC_WOL_MTI_Msk                    (_U_(0x1) << GMAC_WOL_MTI_Pos)                 /**< (GMAC_WOL) Multicast Hash Event Enable Mask */
+#define GMAC_WOL_MTI                        GMAC_WOL_MTI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_MTI_Msk instead */
+#define GMAC_WOL_MASK                       _U_(0xFFFFF)                                   /**< \deprecated (GMAC_WOL) Register MASK  (Use GMAC_WOL_Msk instead)  */
+#define GMAC_WOL_Msk                        _U_(0xFFFFF)                                   /**< (GMAC_WOL) Register Mask  */
+
+#define GMAC_WOL_SA_Pos                     18                                             /**< (GMAC_WOL Position) Specific Address Register x Event Enable */
+#define GMAC_WOL_SA_Msk                     (_U_(0x1) << GMAC_WOL_SA_Pos)                  /**< (GMAC_WOL Mask) SA */
+#define GMAC_WOL_SA(value)                  (GMAC_WOL_SA_Msk & ((value) << GMAC_WOL_SA_Pos))  
+
+/* -------- GMAC_IPGS : (GMAC Offset: 0xbc) (R/W 32) IPG Stretch Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FL:16;                     /**< bit:  0..15  Frame Length                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IPGS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IPGS_OFFSET                    (0xBC)                                        /**<  (GMAC_IPGS) IPG Stretch Register  Offset */
+
+#define GMAC_IPGS_FL_Pos                    0                                              /**< (GMAC_IPGS) Frame Length Position */
+#define GMAC_IPGS_FL_Msk                    (_U_(0xFFFF) << GMAC_IPGS_FL_Pos)              /**< (GMAC_IPGS) Frame Length Mask */
+#define GMAC_IPGS_FL(value)                 (GMAC_IPGS_FL_Msk & ((value) << GMAC_IPGS_FL_Pos))
+#define GMAC_IPGS_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_IPGS) Register MASK  (Use GMAC_IPGS_Msk instead)  */
+#define GMAC_IPGS_Msk                       _U_(0xFFFF)                                    /**< (GMAC_IPGS) Register Mask  */
+
+
+/* -------- GMAC_SVLAN : (GMAC Offset: 0xc0) (R/W 32) Stacked VLAN Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VLAN_TYPE:16;              /**< bit:  0..15  User Defined VLAN_TYPE Field             */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ESVLAN:1;                  /**< bit:     31  Enable Stacked VLAN Processing Mode      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SVLAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SVLAN_OFFSET                   (0xC0)                                        /**<  (GMAC_SVLAN) Stacked VLAN Register  Offset */
+
+#define GMAC_SVLAN_VLAN_TYPE_Pos            0                                              /**< (GMAC_SVLAN) User Defined VLAN_TYPE Field Position */
+#define GMAC_SVLAN_VLAN_TYPE_Msk            (_U_(0xFFFF) << GMAC_SVLAN_VLAN_TYPE_Pos)      /**< (GMAC_SVLAN) User Defined VLAN_TYPE Field Mask */
+#define GMAC_SVLAN_VLAN_TYPE(value)         (GMAC_SVLAN_VLAN_TYPE_Msk & ((value) << GMAC_SVLAN_VLAN_TYPE_Pos))
+#define GMAC_SVLAN_ESVLAN_Pos               31                                             /**< (GMAC_SVLAN) Enable Stacked VLAN Processing Mode Position */
+#define GMAC_SVLAN_ESVLAN_Msk               (_U_(0x1) << GMAC_SVLAN_ESVLAN_Pos)            /**< (GMAC_SVLAN) Enable Stacked VLAN Processing Mode Mask */
+#define GMAC_SVLAN_ESVLAN                   GMAC_SVLAN_ESVLAN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_SVLAN_ESVLAN_Msk instead */
+#define GMAC_SVLAN_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_SVLAN) Register MASK  (Use GMAC_SVLAN_Msk instead)  */
+#define GMAC_SVLAN_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_SVLAN) Register Mask  */
+
+
+/* -------- GMAC_TPFCP : (GMAC Offset: 0xc4) (R/W 32) Transmit PFC Pause Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PEV:8;                     /**< bit:   0..7  Priority Enable Vector                   */
+    uint32_t PQ:8;                      /**< bit:  8..15  Pause Quantum                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPFCP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPFCP_OFFSET                   (0xC4)                                        /**<  (GMAC_TPFCP) Transmit PFC Pause Register  Offset */
+
+#define GMAC_TPFCP_PEV_Pos                  0                                              /**< (GMAC_TPFCP) Priority Enable Vector Position */
+#define GMAC_TPFCP_PEV_Msk                  (_U_(0xFF) << GMAC_TPFCP_PEV_Pos)              /**< (GMAC_TPFCP) Priority Enable Vector Mask */
+#define GMAC_TPFCP_PEV(value)               (GMAC_TPFCP_PEV_Msk & ((value) << GMAC_TPFCP_PEV_Pos))
+#define GMAC_TPFCP_PQ_Pos                   8                                              /**< (GMAC_TPFCP) Pause Quantum Position */
+#define GMAC_TPFCP_PQ_Msk                   (_U_(0xFF) << GMAC_TPFCP_PQ_Pos)               /**< (GMAC_TPFCP) Pause Quantum Mask */
+#define GMAC_TPFCP_PQ(value)                (GMAC_TPFCP_PQ_Msk & ((value) << GMAC_TPFCP_PQ_Pos))
+#define GMAC_TPFCP_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_TPFCP) Register MASK  (Use GMAC_TPFCP_Msk instead)  */
+#define GMAC_TPFCP_Msk                      _U_(0xFFFF)                                    /**< (GMAC_TPFCP) Register Mask  */
+
+
+/* -------- GMAC_SAMB1 : (GMAC Offset: 0xc8) (R/W 32) Specific Address 1 Mask Bottom Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1 Mask                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAMB1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAMB1_OFFSET                   (0xC8)                                        /**<  (GMAC_SAMB1) Specific Address 1 Mask Bottom Register  Offset */
+
+#define GMAC_SAMB1_ADDR_Pos                 0                                              /**< (GMAC_SAMB1) Specific Address 1 Mask Position */
+#define GMAC_SAMB1_ADDR_Msk                 (_U_(0xFFFFFFFF) << GMAC_SAMB1_ADDR_Pos)       /**< (GMAC_SAMB1) Specific Address 1 Mask Mask */
+#define GMAC_SAMB1_ADDR(value)              (GMAC_SAMB1_ADDR_Msk & ((value) << GMAC_SAMB1_ADDR_Pos))
+#define GMAC_SAMB1_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SAMB1) Register MASK  (Use GMAC_SAMB1_Msk instead)  */
+#define GMAC_SAMB1_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_SAMB1) Register Mask  */
+
+
+/* -------- GMAC_SAMT1 : (GMAC Offset: 0xcc) (R/W 32) Specific Address 1 Mask Top Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1 Mask                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAMT1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAMT1_OFFSET                   (0xCC)                                        /**<  (GMAC_SAMT1) Specific Address 1 Mask Top Register  Offset */
+
+#define GMAC_SAMT1_ADDR_Pos                 0                                              /**< (GMAC_SAMT1) Specific Address 1 Mask Position */
+#define GMAC_SAMT1_ADDR_Msk                 (_U_(0xFFFF) << GMAC_SAMT1_ADDR_Pos)           /**< (GMAC_SAMT1) Specific Address 1 Mask Mask */
+#define GMAC_SAMT1_ADDR(value)              (GMAC_SAMT1_ADDR_Msk & ((value) << GMAC_SAMT1_ADDR_Pos))
+#define GMAC_SAMT1_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_SAMT1) Register MASK  (Use GMAC_SAMT1_Msk instead)  */
+#define GMAC_SAMT1_Msk                      _U_(0xFFFF)                                    /**< (GMAC_SAMT1) Register Mask  */
+
+
+/* -------- GMAC_NSC : (GMAC Offset: 0xdc) (R/W 32) 1588 Timer Nanosecond Comparison Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NANOSEC:22;                /**< bit:  0..21  1588 Timer Nanosecond Comparison Value   */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NSC_OFFSET                     (0xDC)                                        /**<  (GMAC_NSC) 1588 Timer Nanosecond Comparison Register  Offset */
+
+#define GMAC_NSC_NANOSEC_Pos                0                                              /**< (GMAC_NSC) 1588 Timer Nanosecond Comparison Value Position */
+#define GMAC_NSC_NANOSEC_Msk                (_U_(0x3FFFFF) << GMAC_NSC_NANOSEC_Pos)        /**< (GMAC_NSC) 1588 Timer Nanosecond Comparison Value Mask */
+#define GMAC_NSC_NANOSEC(value)             (GMAC_NSC_NANOSEC_Msk & ((value) << GMAC_NSC_NANOSEC_Pos))
+#define GMAC_NSC_MASK                       _U_(0x3FFFFF)                                  /**< \deprecated (GMAC_NSC) Register MASK  (Use GMAC_NSC_Msk instead)  */
+#define GMAC_NSC_Msk                        _U_(0x3FFFFF)                                  /**< (GMAC_NSC) Register Mask  */
+
+
+/* -------- GMAC_SCL : (GMAC Offset: 0xe0) (R/W 32) 1588 Timer Second Comparison Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:32;                    /**< bit:  0..31  1588 Timer Second Comparison Value       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCL_OFFSET                     (0xE0)                                        /**<  (GMAC_SCL) 1588 Timer Second Comparison Low Register  Offset */
+
+#define GMAC_SCL_SEC_Pos                    0                                              /**< (GMAC_SCL) 1588 Timer Second Comparison Value Position */
+#define GMAC_SCL_SEC_Msk                    (_U_(0xFFFFFFFF) << GMAC_SCL_SEC_Pos)          /**< (GMAC_SCL) 1588 Timer Second Comparison Value Mask */
+#define GMAC_SCL_SEC(value)                 (GMAC_SCL_SEC_Msk & ((value) << GMAC_SCL_SEC_Pos))
+#define GMAC_SCL_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SCL) Register MASK  (Use GMAC_SCL_Msk instead)  */
+#define GMAC_SCL_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_SCL) Register Mask  */
+
+
+/* -------- GMAC_SCH : (GMAC Offset: 0xe4) (R/W 32) 1588 Timer Second Comparison High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:16;                    /**< bit:  0..15  1588 Timer Second Comparison Value       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCH_OFFSET                     (0xE4)                                        /**<  (GMAC_SCH) 1588 Timer Second Comparison High Register  Offset */
+
+#define GMAC_SCH_SEC_Pos                    0                                              /**< (GMAC_SCH) 1588 Timer Second Comparison Value Position */
+#define GMAC_SCH_SEC_Msk                    (_U_(0xFFFF) << GMAC_SCH_SEC_Pos)              /**< (GMAC_SCH) 1588 Timer Second Comparison Value Mask */
+#define GMAC_SCH_SEC(value)                 (GMAC_SCH_SEC_Msk & ((value) << GMAC_SCH_SEC_Pos))
+#define GMAC_SCH_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_SCH) Register MASK  (Use GMAC_SCH_Msk instead)  */
+#define GMAC_SCH_Msk                        _U_(0xFFFF)                                    /**< (GMAC_SCH) Register Mask  */
+
+
+/* -------- GMAC_EFTSH : (GMAC Offset: 0xe8) (R/ 32) PTP Event Frame Transmitted Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTSH_OFFSET                   (0xE8)                                        /**<  (GMAC_EFTSH) PTP Event Frame Transmitted Seconds High Register  Offset */
+
+#define GMAC_EFTSH_RUD_Pos                  0                                              /**< (GMAC_EFTSH) Register Update Position */
+#define GMAC_EFTSH_RUD_Msk                  (_U_(0xFFFF) << GMAC_EFTSH_RUD_Pos)            /**< (GMAC_EFTSH) Register Update Mask */
+#define GMAC_EFTSH_RUD(value)               (GMAC_EFTSH_RUD_Msk & ((value) << GMAC_EFTSH_RUD_Pos))
+#define GMAC_EFTSH_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_EFTSH) Register MASK  (Use GMAC_EFTSH_Msk instead)  */
+#define GMAC_EFTSH_Msk                      _U_(0xFFFF)                                    /**< (GMAC_EFTSH) Register Mask  */
+
+
+/* -------- GMAC_EFRSH : (GMAC Offset: 0xec) (R/ 32) PTP Event Frame Received Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRSH_OFFSET                   (0xEC)                                        /**<  (GMAC_EFRSH) PTP Event Frame Received Seconds High Register  Offset */
+
+#define GMAC_EFRSH_RUD_Pos                  0                                              /**< (GMAC_EFRSH) Register Update Position */
+#define GMAC_EFRSH_RUD_Msk                  (_U_(0xFFFF) << GMAC_EFRSH_RUD_Pos)            /**< (GMAC_EFRSH) Register Update Mask */
+#define GMAC_EFRSH_RUD(value)               (GMAC_EFRSH_RUD_Msk & ((value) << GMAC_EFRSH_RUD_Pos))
+#define GMAC_EFRSH_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_EFRSH) Register MASK  (Use GMAC_EFRSH_Msk instead)  */
+#define GMAC_EFRSH_Msk                      _U_(0xFFFF)                                    /**< (GMAC_EFRSH) Register Mask  */
+
+
+/* -------- GMAC_PEFTSH : (GMAC Offset: 0xf0) (R/ 32) PTP Peer Event Frame Transmitted Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTSH_OFFSET                  (0xF0)                                        /**<  (GMAC_PEFTSH) PTP Peer Event Frame Transmitted Seconds High Register  Offset */
+
+#define GMAC_PEFTSH_RUD_Pos                 0                                              /**< (GMAC_PEFTSH) Register Update Position */
+#define GMAC_PEFTSH_RUD_Msk                 (_U_(0xFFFF) << GMAC_PEFTSH_RUD_Pos)           /**< (GMAC_PEFTSH) Register Update Mask */
+#define GMAC_PEFTSH_RUD(value)              (GMAC_PEFTSH_RUD_Msk & ((value) << GMAC_PEFTSH_RUD_Pos))
+#define GMAC_PEFTSH_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_PEFTSH) Register MASK  (Use GMAC_PEFTSH_Msk instead)  */
+#define GMAC_PEFTSH_Msk                     _U_(0xFFFF)                                    /**< (GMAC_PEFTSH) Register Mask  */
+
+
+/* -------- GMAC_PEFRSH : (GMAC Offset: 0xf4) (R/ 32) PTP Peer Event Frame Received Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRSH_OFFSET                  (0xF4)                                        /**<  (GMAC_PEFRSH) PTP Peer Event Frame Received Seconds High Register  Offset */
+
+#define GMAC_PEFRSH_RUD_Pos                 0                                              /**< (GMAC_PEFRSH) Register Update Position */
+#define GMAC_PEFRSH_RUD_Msk                 (_U_(0xFFFF) << GMAC_PEFRSH_RUD_Pos)           /**< (GMAC_PEFRSH) Register Update Mask */
+#define GMAC_PEFRSH_RUD(value)              (GMAC_PEFRSH_RUD_Msk & ((value) << GMAC_PEFRSH_RUD_Pos))
+#define GMAC_PEFRSH_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_PEFRSH) Register MASK  (Use GMAC_PEFRSH_Msk instead)  */
+#define GMAC_PEFRSH_Msk                     _U_(0xFFFF)                                    /**< (GMAC_PEFRSH) Register Mask  */
+
+
+/* -------- GMAC_MID : (GMAC Offset: 0xfc) (R/ 32) Module ID Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MREV:16;                   /**< bit:  0..15  Module Revision                          */
+    uint32_t MID:16;                    /**< bit: 16..31  Module Identification Number             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MID_OFFSET                     (0xFC)                                        /**<  (GMAC_MID) Module ID Register  Offset */
+
+#define GMAC_MID_MREV_Pos                   0                                              /**< (GMAC_MID) Module Revision Position */
+#define GMAC_MID_MREV_Msk                   (_U_(0xFFFF) << GMAC_MID_MREV_Pos)             /**< (GMAC_MID) Module Revision Mask */
+#define GMAC_MID_MREV(value)                (GMAC_MID_MREV_Msk & ((value) << GMAC_MID_MREV_Pos))
+#define GMAC_MID_MID_Pos                    16                                             /**< (GMAC_MID) Module Identification Number Position */
+#define GMAC_MID_MID_Msk                    (_U_(0xFFFF) << GMAC_MID_MID_Pos)              /**< (GMAC_MID) Module Identification Number Mask */
+#define GMAC_MID_MID(value)                 (GMAC_MID_MID_Msk & ((value) << GMAC_MID_MID_Pos))
+#define GMAC_MID_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MID) Register MASK  (Use GMAC_MID_Msk instead)  */
+#define GMAC_MID_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MID) Register Mask  */
+
+
+/* -------- GMAC_OTLO : (GMAC Offset: 0x100) (R/ 32) Octets Transmitted Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXO:32;                    /**< bit:  0..31  Transmitted Octets                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OTLO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OTLO_OFFSET                    (0x100)                                       /**<  (GMAC_OTLO) Octets Transmitted Low Register  Offset */
+
+#define GMAC_OTLO_TXO_Pos                   0                                              /**< (GMAC_OTLO) Transmitted Octets Position */
+#define GMAC_OTLO_TXO_Msk                   (_U_(0xFFFFFFFF) << GMAC_OTLO_TXO_Pos)         /**< (GMAC_OTLO) Transmitted Octets Mask */
+#define GMAC_OTLO_TXO(value)                (GMAC_OTLO_TXO_Msk & ((value) << GMAC_OTLO_TXO_Pos))
+#define GMAC_OTLO_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_OTLO) Register MASK  (Use GMAC_OTLO_Msk instead)  */
+#define GMAC_OTLO_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_OTLO) Register Mask  */
+
+
+/* -------- GMAC_OTHI : (GMAC Offset: 0x104) (R/ 32) Octets Transmitted High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXO:16;                    /**< bit:  0..15  Transmitted Octets                       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OTHI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OTHI_OFFSET                    (0x104)                                       /**<  (GMAC_OTHI) Octets Transmitted High Register  Offset */
+
+#define GMAC_OTHI_TXO_Pos                   0                                              /**< (GMAC_OTHI) Transmitted Octets Position */
+#define GMAC_OTHI_TXO_Msk                   (_U_(0xFFFF) << GMAC_OTHI_TXO_Pos)             /**< (GMAC_OTHI) Transmitted Octets Mask */
+#define GMAC_OTHI_TXO(value)                (GMAC_OTHI_TXO_Msk & ((value) << GMAC_OTHI_TXO_Pos))
+#define GMAC_OTHI_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_OTHI) Register MASK  (Use GMAC_OTHI_Msk instead)  */
+#define GMAC_OTHI_Msk                       _U_(0xFFFF)                                    /**< (GMAC_OTHI) Register Mask  */
+
+
+/* -------- GMAC_FT : (GMAC Offset: 0x108) (R/ 32) Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FTX:32;                    /**< bit:  0..31  Frames Transmitted without Error         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FT_OFFSET                      (0x108)                                       /**<  (GMAC_FT) Frames Transmitted Register  Offset */
+
+#define GMAC_FT_FTX_Pos                     0                                              /**< (GMAC_FT) Frames Transmitted without Error Position */
+#define GMAC_FT_FTX_Msk                     (_U_(0xFFFFFFFF) << GMAC_FT_FTX_Pos)           /**< (GMAC_FT) Frames Transmitted without Error Mask */
+#define GMAC_FT_FTX(value)                  (GMAC_FT_FTX_Msk & ((value) << GMAC_FT_FTX_Pos))
+#define GMAC_FT_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_FT) Register MASK  (Use GMAC_FT_Msk instead)  */
+#define GMAC_FT_Msk                         _U_(0xFFFFFFFF)                                /**< (GMAC_FT) Register Mask  */
+
+
+/* -------- GMAC_BCFT : (GMAC Offset: 0x10c) (R/ 32) Broadcast Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BFTX:32;                   /**< bit:  0..31  Broadcast Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BCFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BCFT_OFFSET                    (0x10C)                                       /**<  (GMAC_BCFT) Broadcast Frames Transmitted Register  Offset */
+
+#define GMAC_BCFT_BFTX_Pos                  0                                              /**< (GMAC_BCFT) Broadcast Frames Transmitted without Error Position */
+#define GMAC_BCFT_BFTX_Msk                  (_U_(0xFFFFFFFF) << GMAC_BCFT_BFTX_Pos)        /**< (GMAC_BCFT) Broadcast Frames Transmitted without Error Mask */
+#define GMAC_BCFT_BFTX(value)               (GMAC_BCFT_BFTX_Msk & ((value) << GMAC_BCFT_BFTX_Pos))
+#define GMAC_BCFT_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BCFT) Register MASK  (Use GMAC_BCFT_Msk instead)  */
+#define GMAC_BCFT_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_BCFT) Register Mask  */
+
+
+/* -------- GMAC_MFT : (GMAC Offset: 0x110) (R/ 32) Multicast Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFTX:32;                   /**< bit:  0..31  Multicast Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MFT_OFFSET                     (0x110)                                       /**<  (GMAC_MFT) Multicast Frames Transmitted Register  Offset */
+
+#define GMAC_MFT_MFTX_Pos                   0                                              /**< (GMAC_MFT) Multicast Frames Transmitted without Error Position */
+#define GMAC_MFT_MFTX_Msk                   (_U_(0xFFFFFFFF) << GMAC_MFT_MFTX_Pos)         /**< (GMAC_MFT) Multicast Frames Transmitted without Error Mask */
+#define GMAC_MFT_MFTX(value)                (GMAC_MFT_MFTX_Msk & ((value) << GMAC_MFT_MFTX_Pos))
+#define GMAC_MFT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MFT) Register MASK  (Use GMAC_MFT_Msk instead)  */
+#define GMAC_MFT_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MFT) Register Mask  */
+
+
+/* -------- GMAC_PFT : (GMAC Offset: 0x114) (R/ 32) Pause Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PFTX:16;                   /**< bit:  0..15  Pause Frames Transmitted Register        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PFT_OFFSET                     (0x114)                                       /**<  (GMAC_PFT) Pause Frames Transmitted Register  Offset */
+
+#define GMAC_PFT_PFTX_Pos                   0                                              /**< (GMAC_PFT) Pause Frames Transmitted Register Position */
+#define GMAC_PFT_PFTX_Msk                   (_U_(0xFFFF) << GMAC_PFT_PFTX_Pos)             /**< (GMAC_PFT) Pause Frames Transmitted Register Mask */
+#define GMAC_PFT_PFTX(value)                (GMAC_PFT_PFTX_Msk & ((value) << GMAC_PFT_PFTX_Pos))
+#define GMAC_PFT_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_PFT) Register MASK  (Use GMAC_PFT_Msk instead)  */
+#define GMAC_PFT_Msk                        _U_(0xFFFF)                                    /**< (GMAC_PFT) Register Mask  */
+
+
+/* -------- GMAC_BFT64 : (GMAC Offset: 0x118) (R/ 32) 64 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  64 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BFT64_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BFT64_OFFSET                   (0x118)                                       /**<  (GMAC_BFT64) 64 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_BFT64_NFTX_Pos                 0                                              /**< (GMAC_BFT64) 64 Byte Frames Transmitted without Error Position */
+#define GMAC_BFT64_NFTX_Msk                 (_U_(0xFFFFFFFF) << GMAC_BFT64_NFTX_Pos)       /**< (GMAC_BFT64) 64 Byte Frames Transmitted without Error Mask */
+#define GMAC_BFT64_NFTX(value)              (GMAC_BFT64_NFTX_Msk & ((value) << GMAC_BFT64_NFTX_Pos))
+#define GMAC_BFT64_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BFT64) Register MASK  (Use GMAC_BFT64_Msk instead)  */
+#define GMAC_BFT64_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_BFT64) Register Mask  */
+
+
+/* -------- GMAC_TBFT127 : (GMAC Offset: 0x11c) (R/ 32) 65 to 127 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT127_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT127_OFFSET                 (0x11C)                                       /**<  (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT127_NFTX_Pos               0                                              /**< (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT127_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT127_NFTX_Pos)     /**< (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT127_NFTX(value)            (GMAC_TBFT127_NFTX_Msk & ((value) << GMAC_TBFT127_NFTX_Pos))
+#define GMAC_TBFT127_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT127) Register MASK  (Use GMAC_TBFT127_Msk instead)  */
+#define GMAC_TBFT127_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT127) Register Mask  */
+
+
+/* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) (R/ 32) 128 to 255 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT255_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT255_OFFSET                 (0x120)                                       /**<  (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT255_NFTX_Pos               0                                              /**< (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT255_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT255_NFTX_Pos)     /**< (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT255_NFTX(value)            (GMAC_TBFT255_NFTX_Msk & ((value) << GMAC_TBFT255_NFTX_Pos))
+#define GMAC_TBFT255_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT255) Register MASK  (Use GMAC_TBFT255_Msk instead)  */
+#define GMAC_TBFT255_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT255) Register Mask  */
+
+
+/* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) (R/ 32) 256 to 511 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT511_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT511_OFFSET                 (0x124)                                       /**<  (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT511_NFTX_Pos               0                                              /**< (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT511_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT511_NFTX_Pos)     /**< (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT511_NFTX(value)            (GMAC_TBFT511_NFTX_Msk & ((value) << GMAC_TBFT511_NFTX_Pos))
+#define GMAC_TBFT511_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT511) Register MASK  (Use GMAC_TBFT511_Msk instead)  */
+#define GMAC_TBFT511_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT511) Register Mask  */
+
+
+/* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) (R/ 32) 512 to 1023 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT1023_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT1023_OFFSET                (0x128)                                       /**<  (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT1023_NFTX_Pos              0                                              /**< (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT1023_NFTX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFT1023_NFTX_Pos)    /**< (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT1023_NFTX(value)           (GMAC_TBFT1023_NFTX_Msk & ((value) << GMAC_TBFT1023_NFTX_Pos))
+#define GMAC_TBFT1023_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT1023) Register MASK  (Use GMAC_TBFT1023_Msk instead)  */
+#define GMAC_TBFT1023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT1023) Register Mask  */
+
+
+/* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12c) (R/ 32) 1024 to 1518 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT1518_OFFSET                (0x12C)                                       /**<  (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT1518_NFTX_Pos              0                                              /**< (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT1518_NFTX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFT1518_NFTX_Pos)    /**< (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT1518_NFTX(value)           (GMAC_TBFT1518_NFTX_Msk & ((value) << GMAC_TBFT1518_NFTX_Pos))
+#define GMAC_TBFT1518_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT1518) Register MASK  (Use GMAC_TBFT1518_Msk instead)  */
+#define GMAC_TBFT1518_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT1518) Register Mask  */
+
+
+/* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) (R/ 32) Greater Than 1518 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  Greater than 1518 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_GTBFT1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_GTBFT1518_OFFSET               (0x130)                                       /**<  (GMAC_GTBFT1518) Greater Than 1518 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_GTBFT1518_NFTX_Pos             0                                              /**< (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error Position */
+#define GMAC_GTBFT1518_NFTX_Msk             (_U_(0xFFFFFFFF) << GMAC_GTBFT1518_NFTX_Pos)   /**< (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error Mask */
+#define GMAC_GTBFT1518_NFTX(value)          (GMAC_GTBFT1518_NFTX_Msk & ((value) << GMAC_GTBFT1518_NFTX_Pos))
+#define GMAC_GTBFT1518_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_GTBFT1518) Register MASK  (Use GMAC_GTBFT1518_Msk instead)  */
+#define GMAC_GTBFT1518_Msk                  _U_(0xFFFFFFFF)                                /**< (GMAC_GTBFT1518) Register Mask  */
+
+
+/* -------- GMAC_TUR : (GMAC Offset: 0x134) (R/ 32) Transmit Underruns Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXUNR:10;                  /**< bit:   0..9  Transmit Underruns                       */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TUR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TUR_OFFSET                     (0x134)                                       /**<  (GMAC_TUR) Transmit Underruns Register  Offset */
+
+#define GMAC_TUR_TXUNR_Pos                  0                                              /**< (GMAC_TUR) Transmit Underruns Position */
+#define GMAC_TUR_TXUNR_Msk                  (_U_(0x3FF) << GMAC_TUR_TXUNR_Pos)             /**< (GMAC_TUR) Transmit Underruns Mask */
+#define GMAC_TUR_TXUNR(value)               (GMAC_TUR_TXUNR_Msk & ((value) << GMAC_TUR_TXUNR_Pos))
+#define GMAC_TUR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_TUR) Register MASK  (Use GMAC_TUR_Msk instead)  */
+#define GMAC_TUR_Msk                        _U_(0x3FF)                                     /**< (GMAC_TUR) Register Mask  */
+
+
+/* -------- GMAC_SCF : (GMAC Offset: 0x138) (R/ 32) Single Collision Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCOL:18;                   /**< bit:  0..17  Single Collision                         */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCF_OFFSET                     (0x138)                                       /**<  (GMAC_SCF) Single Collision Frames Register  Offset */
+
+#define GMAC_SCF_SCOL_Pos                   0                                              /**< (GMAC_SCF) Single Collision Position */
+#define GMAC_SCF_SCOL_Msk                   (_U_(0x3FFFF) << GMAC_SCF_SCOL_Pos)            /**< (GMAC_SCF) Single Collision Mask */
+#define GMAC_SCF_SCOL(value)                (GMAC_SCF_SCOL_Msk & ((value) << GMAC_SCF_SCOL_Pos))
+#define GMAC_SCF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_SCF) Register MASK  (Use GMAC_SCF_Msk instead)  */
+#define GMAC_SCF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_SCF) Register Mask  */
+
+
+/* -------- GMAC_MCF : (GMAC Offset: 0x13c) (R/ 32) Multiple Collision Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCOL:18;                   /**< bit:  0..17  Multiple Collision                       */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MCF_OFFSET                     (0x13C)                                       /**<  (GMAC_MCF) Multiple Collision Frames Register  Offset */
+
+#define GMAC_MCF_MCOL_Pos                   0                                              /**< (GMAC_MCF) Multiple Collision Position */
+#define GMAC_MCF_MCOL_Msk                   (_U_(0x3FFFF) << GMAC_MCF_MCOL_Pos)            /**< (GMAC_MCF) Multiple Collision Mask */
+#define GMAC_MCF_MCOL(value)                (GMAC_MCF_MCOL_Msk & ((value) << GMAC_MCF_MCOL_Pos))
+#define GMAC_MCF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_MCF) Register MASK  (Use GMAC_MCF_Msk instead)  */
+#define GMAC_MCF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_MCF) Register Mask  */
+
+
+/* -------- GMAC_EC : (GMAC Offset: 0x140) (R/ 32) Excessive Collisions Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t XCOL:10;                   /**< bit:   0..9  Excessive Collisions                     */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EC_OFFSET                      (0x140)                                       /**<  (GMAC_EC) Excessive Collisions Register  Offset */
+
+#define GMAC_EC_XCOL_Pos                    0                                              /**< (GMAC_EC) Excessive Collisions Position */
+#define GMAC_EC_XCOL_Msk                    (_U_(0x3FF) << GMAC_EC_XCOL_Pos)               /**< (GMAC_EC) Excessive Collisions Mask */
+#define GMAC_EC_XCOL(value)                 (GMAC_EC_XCOL_Msk & ((value) << GMAC_EC_XCOL_Pos))
+#define GMAC_EC_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_EC) Register MASK  (Use GMAC_EC_Msk instead)  */
+#define GMAC_EC_Msk                         _U_(0x3FF)                                     /**< (GMAC_EC) Register Mask  */
+
+
+/* -------- GMAC_LC : (GMAC Offset: 0x144) (R/ 32) Late Collisions Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LCOL:10;                   /**< bit:   0..9  Late Collisions                          */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_LC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_LC_OFFSET                      (0x144)                                       /**<  (GMAC_LC) Late Collisions Register  Offset */
+
+#define GMAC_LC_LCOL_Pos                    0                                              /**< (GMAC_LC) Late Collisions Position */
+#define GMAC_LC_LCOL_Msk                    (_U_(0x3FF) << GMAC_LC_LCOL_Pos)               /**< (GMAC_LC) Late Collisions Mask */
+#define GMAC_LC_LCOL(value)                 (GMAC_LC_LCOL_Msk & ((value) << GMAC_LC_LCOL_Pos))
+#define GMAC_LC_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_LC) Register MASK  (Use GMAC_LC_Msk instead)  */
+#define GMAC_LC_Msk                         _U_(0x3FF)                                     /**< (GMAC_LC) Register Mask  */
+
+
+/* -------- GMAC_DTF : (GMAC Offset: 0x148) (R/ 32) Deferred Transmission Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DEFT:18;                   /**< bit:  0..17  Deferred Transmission                    */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_DTF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_DTF_OFFSET                     (0x148)                                       /**<  (GMAC_DTF) Deferred Transmission Frames Register  Offset */
+
+#define GMAC_DTF_DEFT_Pos                   0                                              /**< (GMAC_DTF) Deferred Transmission Position */
+#define GMAC_DTF_DEFT_Msk                   (_U_(0x3FFFF) << GMAC_DTF_DEFT_Pos)            /**< (GMAC_DTF) Deferred Transmission Mask */
+#define GMAC_DTF_DEFT(value)                (GMAC_DTF_DEFT_Msk & ((value) << GMAC_DTF_DEFT_Pos))
+#define GMAC_DTF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_DTF) Register MASK  (Use GMAC_DTF_Msk instead)  */
+#define GMAC_DTF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_DTF) Register Mask  */
+
+
+/* -------- GMAC_CSE : (GMAC Offset: 0x14c) (R/ 32) Carrier Sense Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSR:10;                    /**< bit:   0..9  Carrier Sense Error                      */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CSE_OFFSET                     (0x14C)                                       /**<  (GMAC_CSE) Carrier Sense Errors Register  Offset */
+
+#define GMAC_CSE_CSR_Pos                    0                                              /**< (GMAC_CSE) Carrier Sense Error Position */
+#define GMAC_CSE_CSR_Msk                    (_U_(0x3FF) << GMAC_CSE_CSR_Pos)               /**< (GMAC_CSE) Carrier Sense Error Mask */
+#define GMAC_CSE_CSR(value)                 (GMAC_CSE_CSR_Msk & ((value) << GMAC_CSE_CSR_Pos))
+#define GMAC_CSE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_CSE) Register MASK  (Use GMAC_CSE_Msk instead)  */
+#define GMAC_CSE_Msk                        _U_(0x3FF)                                     /**< (GMAC_CSE) Register Mask  */
+
+
+/* -------- GMAC_ORLO : (GMAC Offset: 0x150) (R/ 32) Octets Received Low Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXO:32;                    /**< bit:  0..31  Received Octets                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ORLO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ORLO_OFFSET                    (0x150)                                       /**<  (GMAC_ORLO) Octets Received Low Received Register  Offset */
+
+#define GMAC_ORLO_RXO_Pos                   0                                              /**< (GMAC_ORLO) Received Octets Position */
+#define GMAC_ORLO_RXO_Msk                   (_U_(0xFFFFFFFF) << GMAC_ORLO_RXO_Pos)         /**< (GMAC_ORLO) Received Octets Mask */
+#define GMAC_ORLO_RXO(value)                (GMAC_ORLO_RXO_Msk & ((value) << GMAC_ORLO_RXO_Pos))
+#define GMAC_ORLO_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_ORLO) Register MASK  (Use GMAC_ORLO_Msk instead)  */
+#define GMAC_ORLO_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_ORLO) Register Mask  */
+
+
+/* -------- GMAC_ORHI : (GMAC Offset: 0x154) (R/ 32) Octets Received High Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXO:16;                    /**< bit:  0..15  Received Octets                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ORHI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ORHI_OFFSET                    (0x154)                                       /**<  (GMAC_ORHI) Octets Received High Received Register  Offset */
+
+#define GMAC_ORHI_RXO_Pos                   0                                              /**< (GMAC_ORHI) Received Octets Position */
+#define GMAC_ORHI_RXO_Msk                   (_U_(0xFFFF) << GMAC_ORHI_RXO_Pos)             /**< (GMAC_ORHI) Received Octets Mask */
+#define GMAC_ORHI_RXO(value)                (GMAC_ORHI_RXO_Msk & ((value) << GMAC_ORHI_RXO_Pos))
+#define GMAC_ORHI_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_ORHI) Register MASK  (Use GMAC_ORHI_Msk instead)  */
+#define GMAC_ORHI_Msk                       _U_(0xFFFF)                                    /**< (GMAC_ORHI) Register Mask  */
+
+
+/* -------- GMAC_FR : (GMAC Offset: 0x158) (R/ 32) Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRX:32;                    /**< bit:  0..31  Frames Received without Error            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FR_OFFSET                      (0x158)                                       /**<  (GMAC_FR) Frames Received Register  Offset */
+
+#define GMAC_FR_FRX_Pos                     0                                              /**< (GMAC_FR) Frames Received without Error Position */
+#define GMAC_FR_FRX_Msk                     (_U_(0xFFFFFFFF) << GMAC_FR_FRX_Pos)           /**< (GMAC_FR) Frames Received without Error Mask */
+#define GMAC_FR_FRX(value)                  (GMAC_FR_FRX_Msk & ((value) << GMAC_FR_FRX_Pos))
+#define GMAC_FR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_FR) Register MASK  (Use GMAC_FR_Msk instead)  */
+#define GMAC_FR_Msk                         _U_(0xFFFFFFFF)                                /**< (GMAC_FR) Register Mask  */
+
+
+/* -------- GMAC_BCFR : (GMAC Offset: 0x15c) (R/ 32) Broadcast Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BFRX:32;                   /**< bit:  0..31  Broadcast Frames Received without Error  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BCFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BCFR_OFFSET                    (0x15C)                                       /**<  (GMAC_BCFR) Broadcast Frames Received Register  Offset */
+
+#define GMAC_BCFR_BFRX_Pos                  0                                              /**< (GMAC_BCFR) Broadcast Frames Received without Error Position */
+#define GMAC_BCFR_BFRX_Msk                  (_U_(0xFFFFFFFF) << GMAC_BCFR_BFRX_Pos)        /**< (GMAC_BCFR) Broadcast Frames Received without Error Mask */
+#define GMAC_BCFR_BFRX(value)               (GMAC_BCFR_BFRX_Msk & ((value) << GMAC_BCFR_BFRX_Pos))
+#define GMAC_BCFR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BCFR) Register MASK  (Use GMAC_BCFR_Msk instead)  */
+#define GMAC_BCFR_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_BCFR) Register Mask  */
+
+
+/* -------- GMAC_MFR : (GMAC Offset: 0x160) (R/ 32) Multicast Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFRX:32;                   /**< bit:  0..31  Multicast Frames Received without Error  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MFR_OFFSET                     (0x160)                                       /**<  (GMAC_MFR) Multicast Frames Received Register  Offset */
+
+#define GMAC_MFR_MFRX_Pos                   0                                              /**< (GMAC_MFR) Multicast Frames Received without Error Position */
+#define GMAC_MFR_MFRX_Msk                   (_U_(0xFFFFFFFF) << GMAC_MFR_MFRX_Pos)         /**< (GMAC_MFR) Multicast Frames Received without Error Mask */
+#define GMAC_MFR_MFRX(value)                (GMAC_MFR_MFRX_Msk & ((value) << GMAC_MFR_MFRX_Pos))
+#define GMAC_MFR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MFR) Register MASK  (Use GMAC_MFR_Msk instead)  */
+#define GMAC_MFR_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MFR) Register Mask  */
+
+
+/* -------- GMAC_PFR : (GMAC Offset: 0x164) (R/ 32) Pause Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PFRX:16;                   /**< bit:  0..15  Pause Frames Received Register           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PFR_OFFSET                     (0x164)                                       /**<  (GMAC_PFR) Pause Frames Received Register  Offset */
+
+#define GMAC_PFR_PFRX_Pos                   0                                              /**< (GMAC_PFR) Pause Frames Received Register Position */
+#define GMAC_PFR_PFRX_Msk                   (_U_(0xFFFF) << GMAC_PFR_PFRX_Pos)             /**< (GMAC_PFR) Pause Frames Received Register Mask */
+#define GMAC_PFR_PFRX(value)                (GMAC_PFR_PFRX_Msk & ((value) << GMAC_PFR_PFRX_Pos))
+#define GMAC_PFR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_PFR) Register MASK  (Use GMAC_PFR_Msk instead)  */
+#define GMAC_PFR_Msk                        _U_(0xFFFF)                                    /**< (GMAC_PFR) Register Mask  */
+
+
+/* -------- GMAC_BFR64 : (GMAC Offset: 0x168) (R/ 32) 64 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  64 Byte Frames Received without Error    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BFR64_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BFR64_OFFSET                   (0x168)                                       /**<  (GMAC_BFR64) 64 Byte Frames Received Register  Offset */
+
+#define GMAC_BFR64_NFRX_Pos                 0                                              /**< (GMAC_BFR64) 64 Byte Frames Received without Error Position */
+#define GMAC_BFR64_NFRX_Msk                 (_U_(0xFFFFFFFF) << GMAC_BFR64_NFRX_Pos)       /**< (GMAC_BFR64) 64 Byte Frames Received without Error Mask */
+#define GMAC_BFR64_NFRX(value)              (GMAC_BFR64_NFRX_Msk & ((value) << GMAC_BFR64_NFRX_Pos))
+#define GMAC_BFR64_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BFR64) Register MASK  (Use GMAC_BFR64_Msk instead)  */
+#define GMAC_BFR64_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_BFR64) Register Mask  */
+
+
+/* -------- GMAC_TBFR127 : (GMAC Offset: 0x16c) (R/ 32) 65 to 127 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR127_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR127_OFFSET                 (0x16C)                                       /**<  (GMAC_TBFR127) 65 to 127 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR127_NFRX_Pos               0                                              /**< (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error Position */
+#define GMAC_TBFR127_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR127_NFRX_Pos)     /**< (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error Mask */
+#define GMAC_TBFR127_NFRX(value)            (GMAC_TBFR127_NFRX_Msk & ((value) << GMAC_TBFR127_NFRX_Pos))
+#define GMAC_TBFR127_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR127) Register MASK  (Use GMAC_TBFR127_Msk instead)  */
+#define GMAC_TBFR127_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR127) Register Mask  */
+
+
+/* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) (R/ 32) 128 to 255 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR255_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR255_OFFSET                 (0x170)                                       /**<  (GMAC_TBFR255) 128 to 255 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR255_NFRX_Pos               0                                              /**< (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error Position */
+#define GMAC_TBFR255_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR255_NFRX_Pos)     /**< (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error Mask */
+#define GMAC_TBFR255_NFRX(value)            (GMAC_TBFR255_NFRX_Msk & ((value) << GMAC_TBFR255_NFRX_Pos))
+#define GMAC_TBFR255_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR255) Register MASK  (Use GMAC_TBFR255_Msk instead)  */
+#define GMAC_TBFR255_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR255) Register Mask  */
+
+
+/* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) (R/ 32) 256 to 511 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR511_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR511_OFFSET                 (0x174)                                       /**<  (GMAC_TBFR511) 256 to 511 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR511_NFRX_Pos               0                                              /**< (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error Position */
+#define GMAC_TBFR511_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR511_NFRX_Pos)     /**< (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error Mask */
+#define GMAC_TBFR511_NFRX(value)            (GMAC_TBFR511_NFRX_Msk & ((value) << GMAC_TBFR511_NFRX_Pos))
+#define GMAC_TBFR511_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR511) Register MASK  (Use GMAC_TBFR511_Msk instead)  */
+#define GMAC_TBFR511_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR511) Register Mask  */
+
+
+/* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) (R/ 32) 512 to 1023 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR1023_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR1023_OFFSET                (0x178)                                       /**<  (GMAC_TBFR1023) 512 to 1023 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR1023_NFRX_Pos              0                                              /**< (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error Position */
+#define GMAC_TBFR1023_NFRX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFR1023_NFRX_Pos)    /**< (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error Mask */
+#define GMAC_TBFR1023_NFRX(value)           (GMAC_TBFR1023_NFRX_Msk & ((value) << GMAC_TBFR1023_NFRX_Pos))
+#define GMAC_TBFR1023_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR1023) Register MASK  (Use GMAC_TBFR1023_Msk instead)  */
+#define GMAC_TBFR1023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR1023) Register Mask  */
+
+
+/* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17c) (R/ 32) 1024 to 1518 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR1518_OFFSET                (0x17C)                                       /**<  (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR1518_NFRX_Pos              0                                              /**< (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error Position */
+#define GMAC_TBFR1518_NFRX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFR1518_NFRX_Pos)    /**< (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error Mask */
+#define GMAC_TBFR1518_NFRX(value)           (GMAC_TBFR1518_NFRX_Msk & ((value) << GMAC_TBFR1518_NFRX_Pos))
+#define GMAC_TBFR1518_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR1518) Register MASK  (Use GMAC_TBFR1518_Msk instead)  */
+#define GMAC_TBFR1518_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR1518) Register Mask  */
+
+
+/* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) (R/ 32) 1519 to Maximum Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  1519 to Maximum Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TMXBFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TMXBFR_OFFSET                  (0x180)                                       /**<  (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received Register  Offset */
+
+#define GMAC_TMXBFR_NFRX_Pos                0                                              /**< (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error Position */
+#define GMAC_TMXBFR_NFRX_Msk                (_U_(0xFFFFFFFF) << GMAC_TMXBFR_NFRX_Pos)      /**< (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error Mask */
+#define GMAC_TMXBFR_NFRX(value)             (GMAC_TMXBFR_NFRX_Msk & ((value) << GMAC_TMXBFR_NFRX_Pos))
+#define GMAC_TMXBFR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TMXBFR) Register MASK  (Use GMAC_TMXBFR_Msk instead)  */
+#define GMAC_TMXBFR_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_TMXBFR) Register Mask  */
+
+
+/* -------- GMAC_UFR : (GMAC Offset: 0x184) (R/ 32) Undersize Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UFRX:10;                   /**< bit:   0..9  Undersize Frames Received                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UFR_OFFSET                     (0x184)                                       /**<  (GMAC_UFR) Undersize Frames Received Register  Offset */
+
+#define GMAC_UFR_UFRX_Pos                   0                                              /**< (GMAC_UFR) Undersize Frames Received Position */
+#define GMAC_UFR_UFRX_Msk                   (_U_(0x3FF) << GMAC_UFR_UFRX_Pos)              /**< (GMAC_UFR) Undersize Frames Received Mask */
+#define GMAC_UFR_UFRX(value)                (GMAC_UFR_UFRX_Msk & ((value) << GMAC_UFR_UFRX_Pos))
+#define GMAC_UFR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_UFR) Register MASK  (Use GMAC_UFR_Msk instead)  */
+#define GMAC_UFR_Msk                        _U_(0x3FF)                                     /**< (GMAC_UFR) Register Mask  */
+
+
+/* -------- GMAC_OFR : (GMAC Offset: 0x188) (R/ 32) Oversize Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFRX:10;                   /**< bit:   0..9  Oversized Frames Received                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OFR_OFFSET                     (0x188)                                       /**<  (GMAC_OFR) Oversize Frames Received Register  Offset */
+
+#define GMAC_OFR_OFRX_Pos                   0                                              /**< (GMAC_OFR) Oversized Frames Received Position */
+#define GMAC_OFR_OFRX_Msk                   (_U_(0x3FF) << GMAC_OFR_OFRX_Pos)              /**< (GMAC_OFR) Oversized Frames Received Mask */
+#define GMAC_OFR_OFRX(value)                (GMAC_OFR_OFRX_Msk & ((value) << GMAC_OFR_OFRX_Pos))
+#define GMAC_OFR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_OFR) Register MASK  (Use GMAC_OFR_Msk instead)  */
+#define GMAC_OFR_Msk                        _U_(0x3FF)                                     /**< (GMAC_OFR) Register Mask  */
+
+
+/* -------- GMAC_JR : (GMAC Offset: 0x18c) (R/ 32) Jabbers Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t JRX:10;                    /**< bit:   0..9  Jabbers Received                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_JR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_JR_OFFSET                      (0x18C)                                       /**<  (GMAC_JR) Jabbers Received Register  Offset */
+
+#define GMAC_JR_JRX_Pos                     0                                              /**< (GMAC_JR) Jabbers Received Position */
+#define GMAC_JR_JRX_Msk                     (_U_(0x3FF) << GMAC_JR_JRX_Pos)                /**< (GMAC_JR) Jabbers Received Mask */
+#define GMAC_JR_JRX(value)                  (GMAC_JR_JRX_Msk & ((value) << GMAC_JR_JRX_Pos))
+#define GMAC_JR_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_JR) Register MASK  (Use GMAC_JR_Msk instead)  */
+#define GMAC_JR_Msk                         _U_(0x3FF)                                     /**< (GMAC_JR) Register Mask  */
+
+
+/* -------- GMAC_FCSE : (GMAC Offset: 0x190) (R/ 32) Frame Check Sequence Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCKR:10;                   /**< bit:   0..9  Frame Check Sequence Errors              */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FCSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FCSE_OFFSET                    (0x190)                                       /**<  (GMAC_FCSE) Frame Check Sequence Errors Register  Offset */
+
+#define GMAC_FCSE_FCKR_Pos                  0                                              /**< (GMAC_FCSE) Frame Check Sequence Errors Position */
+#define GMAC_FCSE_FCKR_Msk                  (_U_(0x3FF) << GMAC_FCSE_FCKR_Pos)             /**< (GMAC_FCSE) Frame Check Sequence Errors Mask */
+#define GMAC_FCSE_FCKR(value)               (GMAC_FCSE_FCKR_Msk & ((value) << GMAC_FCSE_FCKR_Pos))
+#define GMAC_FCSE_MASK                      _U_(0x3FF)                                     /**< \deprecated (GMAC_FCSE) Register MASK  (Use GMAC_FCSE_Msk instead)  */
+#define GMAC_FCSE_Msk                       _U_(0x3FF)                                     /**< (GMAC_FCSE) Register Mask  */
+
+
+/* -------- GMAC_LFFE : (GMAC Offset: 0x194) (R/ 32) Length Field Frame Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LFER:10;                   /**< bit:   0..9  Length Field Frame Errors                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_LFFE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_LFFE_OFFSET                    (0x194)                                       /**<  (GMAC_LFFE) Length Field Frame Errors Register  Offset */
+
+#define GMAC_LFFE_LFER_Pos                  0                                              /**< (GMAC_LFFE) Length Field Frame Errors Position */
+#define GMAC_LFFE_LFER_Msk                  (_U_(0x3FF) << GMAC_LFFE_LFER_Pos)             /**< (GMAC_LFFE) Length Field Frame Errors Mask */
+#define GMAC_LFFE_LFER(value)               (GMAC_LFFE_LFER_Msk & ((value) << GMAC_LFFE_LFER_Pos))
+#define GMAC_LFFE_MASK                      _U_(0x3FF)                                     /**< \deprecated (GMAC_LFFE) Register MASK  (Use GMAC_LFFE_Msk instead)  */
+#define GMAC_LFFE_Msk                       _U_(0x3FF)                                     /**< (GMAC_LFFE) Register Mask  */
+
+
+/* -------- GMAC_RSE : (GMAC Offset: 0x198) (R/ 32) Receive Symbol Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXSE:10;                   /**< bit:   0..9  Receive Symbol Errors                    */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RSE_OFFSET                     (0x198)                                       /**<  (GMAC_RSE) Receive Symbol Errors Register  Offset */
+
+#define GMAC_RSE_RXSE_Pos                   0                                              /**< (GMAC_RSE) Receive Symbol Errors Position */
+#define GMAC_RSE_RXSE_Msk                   (_U_(0x3FF) << GMAC_RSE_RXSE_Pos)              /**< (GMAC_RSE) Receive Symbol Errors Mask */
+#define GMAC_RSE_RXSE(value)                (GMAC_RSE_RXSE_Msk & ((value) << GMAC_RSE_RXSE_Pos))
+#define GMAC_RSE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_RSE) Register MASK  (Use GMAC_RSE_Msk instead)  */
+#define GMAC_RSE_Msk                        _U_(0x3FF)                                     /**< (GMAC_RSE) Register Mask  */
+
+
+/* -------- GMAC_AE : (GMAC Offset: 0x19c) (R/ 32) Alignment Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AER:10;                    /**< bit:   0..9  Alignment Errors                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_AE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_AE_OFFSET                      (0x19C)                                       /**<  (GMAC_AE) Alignment Errors Register  Offset */
+
+#define GMAC_AE_AER_Pos                     0                                              /**< (GMAC_AE) Alignment Errors Position */
+#define GMAC_AE_AER_Msk                     (_U_(0x3FF) << GMAC_AE_AER_Pos)                /**< (GMAC_AE) Alignment Errors Mask */
+#define GMAC_AE_AER(value)                  (GMAC_AE_AER_Msk & ((value) << GMAC_AE_AER_Pos))
+#define GMAC_AE_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_AE) Register MASK  (Use GMAC_AE_Msk instead)  */
+#define GMAC_AE_Msk                         _U_(0x3FF)                                     /**< (GMAC_AE) Register Mask  */
+
+
+/* -------- GMAC_RRE : (GMAC Offset: 0x1a0) (R/ 32) Receive Resource Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRER:18;                  /**< bit:  0..17  Receive Resource Errors                  */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RRE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RRE_OFFSET                     (0x1A0)                                       /**<  (GMAC_RRE) Receive Resource Errors Register  Offset */
+
+#define GMAC_RRE_RXRER_Pos                  0                                              /**< (GMAC_RRE) Receive Resource Errors Position */
+#define GMAC_RRE_RXRER_Msk                  (_U_(0x3FFFF) << GMAC_RRE_RXRER_Pos)           /**< (GMAC_RRE) Receive Resource Errors Mask */
+#define GMAC_RRE_RXRER(value)               (GMAC_RRE_RXRER_Msk & ((value) << GMAC_RRE_RXRER_Pos))
+#define GMAC_RRE_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_RRE) Register MASK  (Use GMAC_RRE_Msk instead)  */
+#define GMAC_RRE_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_RRE) Register Mask  */
+
+
+/* -------- GMAC_ROE : (GMAC Offset: 0x1a4) (R/ 32) Receive Overrun Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXOVR:10;                  /**< bit:   0..9  Receive Overruns                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ROE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ROE_OFFSET                     (0x1A4)                                       /**<  (GMAC_ROE) Receive Overrun Register  Offset */
+
+#define GMAC_ROE_RXOVR_Pos                  0                                              /**< (GMAC_ROE) Receive Overruns Position */
+#define GMAC_ROE_RXOVR_Msk                  (_U_(0x3FF) << GMAC_ROE_RXOVR_Pos)             /**< (GMAC_ROE) Receive Overruns Mask */
+#define GMAC_ROE_RXOVR(value)               (GMAC_ROE_RXOVR_Msk & ((value) << GMAC_ROE_RXOVR_Pos))
+#define GMAC_ROE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_ROE) Register MASK  (Use GMAC_ROE_Msk instead)  */
+#define GMAC_ROE_Msk                        _U_(0x3FF)                                     /**< (GMAC_ROE) Register Mask  */
+
+
+/* -------- GMAC_IHCE : (GMAC Offset: 0x1a8) (R/ 32) IP Header Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HCKER:8;                   /**< bit:   0..7  IP Header Checksum Errors                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IHCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IHCE_OFFSET                    (0x1A8)                                       /**<  (GMAC_IHCE) IP Header Checksum Errors Register  Offset */
+
+#define GMAC_IHCE_HCKER_Pos                 0                                              /**< (GMAC_IHCE) IP Header Checksum Errors Position */
+#define GMAC_IHCE_HCKER_Msk                 (_U_(0xFF) << GMAC_IHCE_HCKER_Pos)             /**< (GMAC_IHCE) IP Header Checksum Errors Mask */
+#define GMAC_IHCE_HCKER(value)              (GMAC_IHCE_HCKER_Msk & ((value) << GMAC_IHCE_HCKER_Pos))
+#define GMAC_IHCE_MASK                      _U_(0xFF)                                      /**< \deprecated (GMAC_IHCE) Register MASK  (Use GMAC_IHCE_Msk instead)  */
+#define GMAC_IHCE_Msk                       _U_(0xFF)                                      /**< (GMAC_IHCE) Register Mask  */
+
+
+/* -------- GMAC_TCE : (GMAC Offset: 0x1ac) (R/ 32) TCP Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCKER:8;                   /**< bit:   0..7  TCP Checksum Errors                      */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TCE_OFFSET                     (0x1AC)                                       /**<  (GMAC_TCE) TCP Checksum Errors Register  Offset */
+
+#define GMAC_TCE_TCKER_Pos                  0                                              /**< (GMAC_TCE) TCP Checksum Errors Position */
+#define GMAC_TCE_TCKER_Msk                  (_U_(0xFF) << GMAC_TCE_TCKER_Pos)              /**< (GMAC_TCE) TCP Checksum Errors Mask */
+#define GMAC_TCE_TCKER(value)               (GMAC_TCE_TCKER_Msk & ((value) << GMAC_TCE_TCKER_Pos))
+#define GMAC_TCE_MASK                       _U_(0xFF)                                      /**< \deprecated (GMAC_TCE) Register MASK  (Use GMAC_TCE_Msk instead)  */
+#define GMAC_TCE_Msk                        _U_(0xFF)                                      /**< (GMAC_TCE) Register Mask  */
+
+
+/* -------- GMAC_UCE : (GMAC Offset: 0x1b0) (R/ 32) UDP Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UCKER:8;                   /**< bit:   0..7  UDP Checksum Errors                      */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UCE_OFFSET                     (0x1B0)                                       /**<  (GMAC_UCE) UDP Checksum Errors Register  Offset */
+
+#define GMAC_UCE_UCKER_Pos                  0                                              /**< (GMAC_UCE) UDP Checksum Errors Position */
+#define GMAC_UCE_UCKER_Msk                  (_U_(0xFF) << GMAC_UCE_UCKER_Pos)              /**< (GMAC_UCE) UDP Checksum Errors Mask */
+#define GMAC_UCE_UCKER(value)               (GMAC_UCE_UCKER_Msk & ((value) << GMAC_UCE_UCKER_Pos))
+#define GMAC_UCE_MASK                       _U_(0xFF)                                      /**< \deprecated (GMAC_UCE) Register MASK  (Use GMAC_UCE_Msk instead)  */
+#define GMAC_UCE_Msk                        _U_(0xFF)                                      /**< (GMAC_UCE) Register Mask  */
+
+
+/* -------- GMAC_TISUBN : (GMAC Offset: 0x1bc) (R/W 32) 1588 Timer Increment Sub-nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LSBTIR:16;                 /**< bit:  0..15  Lower Significant Bits of Timer Increment Register */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TISUBN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TISUBN_OFFSET                  (0x1BC)                                       /**<  (GMAC_TISUBN) 1588 Timer Increment Sub-nanoseconds Register  Offset */
+
+#define GMAC_TISUBN_LSBTIR_Pos              0                                              /**< (GMAC_TISUBN) Lower Significant Bits of Timer Increment Register Position */
+#define GMAC_TISUBN_LSBTIR_Msk              (_U_(0xFFFF) << GMAC_TISUBN_LSBTIR_Pos)        /**< (GMAC_TISUBN) Lower Significant Bits of Timer Increment Register Mask */
+#define GMAC_TISUBN_LSBTIR(value)           (GMAC_TISUBN_LSBTIR_Msk & ((value) << GMAC_TISUBN_LSBTIR_Pos))
+#define GMAC_TISUBN_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_TISUBN) Register MASK  (Use GMAC_TISUBN_Msk instead)  */
+#define GMAC_TISUBN_Msk                     _U_(0xFFFF)                                    /**< (GMAC_TISUBN) Register Mask  */
+
+
+/* -------- GMAC_TSH : (GMAC Offset: 0x1c0) (R/W 32) 1588 Timer Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCS:16;                    /**< bit:  0..15  Timer Count in Seconds                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSH_OFFSET                     (0x1C0)                                       /**<  (GMAC_TSH) 1588 Timer Seconds High Register  Offset */
+
+#define GMAC_TSH_TCS_Pos                    0                                              /**< (GMAC_TSH) Timer Count in Seconds Position */
+#define GMAC_TSH_TCS_Msk                    (_U_(0xFFFF) << GMAC_TSH_TCS_Pos)              /**< (GMAC_TSH) Timer Count in Seconds Mask */
+#define GMAC_TSH_TCS(value)                 (GMAC_TSH_TCS_Msk & ((value) << GMAC_TSH_TCS_Pos))
+#define GMAC_TSH_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_TSH) Register MASK  (Use GMAC_TSH_Msk instead)  */
+#define GMAC_TSH_Msk                        _U_(0xFFFF)                                    /**< (GMAC_TSH) Register Mask  */
+
+
+/* -------- GMAC_TSL : (GMAC Offset: 0x1d0) (R/W 32) 1588 Timer Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCS:32;                    /**< bit:  0..31  Timer Count in Seconds                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSL_OFFSET                     (0x1D0)                                       /**<  (GMAC_TSL) 1588 Timer Seconds Low Register  Offset */
+
+#define GMAC_TSL_TCS_Pos                    0                                              /**< (GMAC_TSL) Timer Count in Seconds Position */
+#define GMAC_TSL_TCS_Msk                    (_U_(0xFFFFFFFF) << GMAC_TSL_TCS_Pos)          /**< (GMAC_TSL) Timer Count in Seconds Mask */
+#define GMAC_TSL_TCS(value)                 (GMAC_TSL_TCS_Msk & ((value) << GMAC_TSL_TCS_Pos))
+#define GMAC_TSL_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TSL) Register MASK  (Use GMAC_TSL_Msk instead)  */
+#define GMAC_TSL_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_TSL) Register Mask  */
+
+
+/* -------- GMAC_TN : (GMAC Offset: 0x1d4) (R/W 32) 1588 Timer Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TNS:30;                    /**< bit:  0..29  Timer Count in Nanoseconds               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TN_OFFSET                      (0x1D4)                                       /**<  (GMAC_TN) 1588 Timer Nanoseconds Register  Offset */
+
+#define GMAC_TN_TNS_Pos                     0                                              /**< (GMAC_TN) Timer Count in Nanoseconds Position */
+#define GMAC_TN_TNS_Msk                     (_U_(0x3FFFFFFF) << GMAC_TN_TNS_Pos)           /**< (GMAC_TN) Timer Count in Nanoseconds Mask */
+#define GMAC_TN_TNS(value)                  (GMAC_TN_TNS_Msk & ((value) << GMAC_TN_TNS_Pos))
+#define GMAC_TN_MASK                        _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_TN) Register MASK  (Use GMAC_TN_Msk instead)  */
+#define GMAC_TN_Msk                         _U_(0x3FFFFFFF)                                /**< (GMAC_TN) Register Mask  */
+
+
+/* -------- GMAC_TA : (GMAC Offset: 0x1d8) (/W 32) 1588 Timer Adjust Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ITDT:30;                   /**< bit:  0..29  Increment/Decrement                      */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t ADJ:1;                     /**< bit:     31  Adjust 1588 Timer                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TA_OFFSET                      (0x1D8)                                       /**<  (GMAC_TA) 1588 Timer Adjust Register  Offset */
+
+#define GMAC_TA_ITDT_Pos                    0                                              /**< (GMAC_TA) Increment/Decrement Position */
+#define GMAC_TA_ITDT_Msk                    (_U_(0x3FFFFFFF) << GMAC_TA_ITDT_Pos)          /**< (GMAC_TA) Increment/Decrement Mask */
+#define GMAC_TA_ITDT(value)                 (GMAC_TA_ITDT_Msk & ((value) << GMAC_TA_ITDT_Pos))
+#define GMAC_TA_ADJ_Pos                     31                                             /**< (GMAC_TA) Adjust 1588 Timer Position */
+#define GMAC_TA_ADJ_Msk                     (_U_(0x1) << GMAC_TA_ADJ_Pos)                  /**< (GMAC_TA) Adjust 1588 Timer Mask */
+#define GMAC_TA_ADJ                         GMAC_TA_ADJ_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TA_ADJ_Msk instead */
+#define GMAC_TA_MASK                        _U_(0xBFFFFFFF)                                /**< \deprecated (GMAC_TA) Register MASK  (Use GMAC_TA_Msk instead)  */
+#define GMAC_TA_Msk                         _U_(0xBFFFFFFF)                                /**< (GMAC_TA) Register Mask  */
+
+
+/* -------- GMAC_TI : (GMAC Offset: 0x1dc) (R/W 32) 1588 Timer Increment Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CNS:8;                     /**< bit:   0..7  Count Nanoseconds                        */
+    uint32_t ACNS:8;                    /**< bit:  8..15  Alternative Count Nanoseconds            */
+    uint32_t NIT:8;                     /**< bit: 16..23  Number of Increments                     */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TI_OFFSET                      (0x1DC)                                       /**<  (GMAC_TI) 1588 Timer Increment Register  Offset */
+
+#define GMAC_TI_CNS_Pos                     0                                              /**< (GMAC_TI) Count Nanoseconds Position */
+#define GMAC_TI_CNS_Msk                     (_U_(0xFF) << GMAC_TI_CNS_Pos)                 /**< (GMAC_TI) Count Nanoseconds Mask */
+#define GMAC_TI_CNS(value)                  (GMAC_TI_CNS_Msk & ((value) << GMAC_TI_CNS_Pos))
+#define GMAC_TI_ACNS_Pos                    8                                              /**< (GMAC_TI) Alternative Count Nanoseconds Position */
+#define GMAC_TI_ACNS_Msk                    (_U_(0xFF) << GMAC_TI_ACNS_Pos)                /**< (GMAC_TI) Alternative Count Nanoseconds Mask */
+#define GMAC_TI_ACNS(value)                 (GMAC_TI_ACNS_Msk & ((value) << GMAC_TI_ACNS_Pos))
+#define GMAC_TI_NIT_Pos                     16                                             /**< (GMAC_TI) Number of Increments Position */
+#define GMAC_TI_NIT_Msk                     (_U_(0xFF) << GMAC_TI_NIT_Pos)                 /**< (GMAC_TI) Number of Increments Mask */
+#define GMAC_TI_NIT(value)                  (GMAC_TI_NIT_Msk & ((value) << GMAC_TI_NIT_Pos))
+#define GMAC_TI_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (GMAC_TI) Register MASK  (Use GMAC_TI_Msk instead)  */
+#define GMAC_TI_Msk                         _U_(0xFFFFFF)                                  /**< (GMAC_TI) Register Mask  */
+
+
+/* -------- GMAC_EFTSL : (GMAC Offset: 0x1e0) (R/ 32) PTP Event Frame Transmitted Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTSL_OFFSET                   (0x1E0)                                       /**<  (GMAC_EFTSL) PTP Event Frame Transmitted Seconds Low Register  Offset */
+
+#define GMAC_EFTSL_RUD_Pos                  0                                              /**< (GMAC_EFTSL) Register Update Position */
+#define GMAC_EFTSL_RUD_Msk                  (_U_(0xFFFFFFFF) << GMAC_EFTSL_RUD_Pos)        /**< (GMAC_EFTSL) Register Update Mask */
+#define GMAC_EFTSL_RUD(value)               (GMAC_EFTSL_RUD_Msk & ((value) << GMAC_EFTSL_RUD_Pos))
+#define GMAC_EFTSL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_EFTSL) Register MASK  (Use GMAC_EFTSL_Msk instead)  */
+#define GMAC_EFTSL_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_EFTSL) Register Mask  */
+
+
+/* -------- GMAC_EFTN : (GMAC Offset: 0x1e4) (R/ 32) PTP Event Frame Transmitted Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTN_OFFSET                    (0x1E4)                                       /**<  (GMAC_EFTN) PTP Event Frame Transmitted Nanoseconds Register  Offset */
+
+#define GMAC_EFTN_RUD_Pos                   0                                              /**< (GMAC_EFTN) Register Update Position */
+#define GMAC_EFTN_RUD_Msk                   (_U_(0x3FFFFFFF) << GMAC_EFTN_RUD_Pos)         /**< (GMAC_EFTN) Register Update Mask */
+#define GMAC_EFTN_RUD(value)                (GMAC_EFTN_RUD_Msk & ((value) << GMAC_EFTN_RUD_Pos))
+#define GMAC_EFTN_MASK                      _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_EFTN) Register MASK  (Use GMAC_EFTN_Msk instead)  */
+#define GMAC_EFTN_Msk                       _U_(0x3FFFFFFF)                                /**< (GMAC_EFTN) Register Mask  */
+
+
+/* -------- GMAC_EFRSL : (GMAC Offset: 0x1e8) (R/ 32) PTP Event Frame Received Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRSL_OFFSET                   (0x1E8)                                       /**<  (GMAC_EFRSL) PTP Event Frame Received Seconds Low Register  Offset */
+
+#define GMAC_EFRSL_RUD_Pos                  0                                              /**< (GMAC_EFRSL) Register Update Position */
+#define GMAC_EFRSL_RUD_Msk                  (_U_(0xFFFFFFFF) << GMAC_EFRSL_RUD_Pos)        /**< (GMAC_EFRSL) Register Update Mask */
+#define GMAC_EFRSL_RUD(value)               (GMAC_EFRSL_RUD_Msk & ((value) << GMAC_EFRSL_RUD_Pos))
+#define GMAC_EFRSL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_EFRSL) Register MASK  (Use GMAC_EFRSL_Msk instead)  */
+#define GMAC_EFRSL_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_EFRSL) Register Mask  */
+
+
+/* -------- GMAC_EFRN : (GMAC Offset: 0x1ec) (R/ 32) PTP Event Frame Received Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRN_OFFSET                    (0x1EC)                                       /**<  (GMAC_EFRN) PTP Event Frame Received Nanoseconds Register  Offset */
+
+#define GMAC_EFRN_RUD_Pos                   0                                              /**< (GMAC_EFRN) Register Update Position */
+#define GMAC_EFRN_RUD_Msk                   (_U_(0x3FFFFFFF) << GMAC_EFRN_RUD_Pos)         /**< (GMAC_EFRN) Register Update Mask */
+#define GMAC_EFRN_RUD(value)                (GMAC_EFRN_RUD_Msk & ((value) << GMAC_EFRN_RUD_Pos))
+#define GMAC_EFRN_MASK                      _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_EFRN) Register MASK  (Use GMAC_EFRN_Msk instead)  */
+#define GMAC_EFRN_Msk                       _U_(0x3FFFFFFF)                                /**< (GMAC_EFRN) Register Mask  */
+
+
+/* -------- GMAC_PEFTSL : (GMAC Offset: 0x1f0) (R/ 32) PTP Peer Event Frame Transmitted Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTSL_OFFSET                  (0x1F0)                                       /**<  (GMAC_PEFTSL) PTP Peer Event Frame Transmitted Seconds Low Register  Offset */
+
+#define GMAC_PEFTSL_RUD_Pos                 0                                              /**< (GMAC_PEFTSL) Register Update Position */
+#define GMAC_PEFTSL_RUD_Msk                 (_U_(0xFFFFFFFF) << GMAC_PEFTSL_RUD_Pos)       /**< (GMAC_PEFTSL) Register Update Mask */
+#define GMAC_PEFTSL_RUD(value)              (GMAC_PEFTSL_RUD_Msk & ((value) << GMAC_PEFTSL_RUD_Pos))
+#define GMAC_PEFTSL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_PEFTSL) Register MASK  (Use GMAC_PEFTSL_Msk instead)  */
+#define GMAC_PEFTSL_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_PEFTSL) Register Mask  */
+
+
+/* -------- GMAC_PEFTN : (GMAC Offset: 0x1f4) (R/ 32) PTP Peer Event Frame Transmitted Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTN_OFFSET                   (0x1F4)                                       /**<  (GMAC_PEFTN) PTP Peer Event Frame Transmitted Nanoseconds Register  Offset */
+
+#define GMAC_PEFTN_RUD_Pos                  0                                              /**< (GMAC_PEFTN) Register Update Position */
+#define GMAC_PEFTN_RUD_Msk                  (_U_(0x3FFFFFFF) << GMAC_PEFTN_RUD_Pos)        /**< (GMAC_PEFTN) Register Update Mask */
+#define GMAC_PEFTN_RUD(value)               (GMAC_PEFTN_RUD_Msk & ((value) << GMAC_PEFTN_RUD_Pos))
+#define GMAC_PEFTN_MASK                     _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_PEFTN) Register MASK  (Use GMAC_PEFTN_Msk instead)  */
+#define GMAC_PEFTN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFTN) Register Mask  */
+
+
+/* -------- GMAC_PEFRSL : (GMAC Offset: 0x1f8) (R/ 32) PTP Peer Event Frame Received Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRSL_OFFSET                  (0x1F8)                                       /**<  (GMAC_PEFRSL) PTP Peer Event Frame Received Seconds Low Register  Offset */
+
+#define GMAC_PEFRSL_RUD_Pos                 0                                              /**< (GMAC_PEFRSL) Register Update Position */
+#define GMAC_PEFRSL_RUD_Msk                 (_U_(0xFFFFFFFF) << GMAC_PEFRSL_RUD_Pos)       /**< (GMAC_PEFRSL) Register Update Mask */
+#define GMAC_PEFRSL_RUD(value)              (GMAC_PEFRSL_RUD_Msk & ((value) << GMAC_PEFRSL_RUD_Pos))
+#define GMAC_PEFRSL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_PEFRSL) Register MASK  (Use GMAC_PEFRSL_Msk instead)  */
+#define GMAC_PEFRSL_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_PEFRSL) Register Mask  */
+
+
+/* -------- GMAC_PEFRN : (GMAC Offset: 0x1fc) (R/ 32) PTP Peer Event Frame Received Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRN_OFFSET                   (0x1FC)                                       /**<  (GMAC_PEFRN) PTP Peer Event Frame Received Nanoseconds Register  Offset */
+
+#define GMAC_PEFRN_RUD_Pos                  0                                              /**< (GMAC_PEFRN) Register Update Position */
+#define GMAC_PEFRN_RUD_Msk                  (_U_(0x3FFFFFFF) << GMAC_PEFRN_RUD_Pos)        /**< (GMAC_PEFRN) Register Update Mask */
+#define GMAC_PEFRN_RUD(value)               (GMAC_PEFRN_RUD_Msk & ((value) << GMAC_PEFRN_RUD_Pos))
+#define GMAC_PEFRN_MASK                     _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_PEFRN) Register MASK  (Use GMAC_PEFRN_Msk instead)  */
+#define GMAC_PEFRN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFRN) Register Mask  */
+
+
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x3fc) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ISRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ISRPQ_OFFSET                   (0x3FC)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
+#define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
+#define GMAC_ISRPQ_RCOMP                    GMAC_ISRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RCOMP_Msk instead */
+#define GMAC_ISRPQ_RXUBR_Pos                2                                              /**< (GMAC_ISRPQ) RX Used Bit Read Position */
+#define GMAC_ISRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_ISRPQ_RXUBR_Pos)             /**< (GMAC_ISRPQ) RX Used Bit Read Mask */
+#define GMAC_ISRPQ_RXUBR                    GMAC_ISRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RXUBR_Msk instead */
+#define GMAC_ISRPQ_RLEX_Pos                 5                                              /**< (GMAC_ISRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_ISRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_ISRPQ_RLEX_Pos)              /**< (GMAC_ISRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_ISRPQ_RLEX                     GMAC_ISRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RLEX_Msk instead */
+#define GMAC_ISRPQ_TFC_Pos                  6                                              /**< (GMAC_ISRPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_ISRPQ_TFC_Msk                  (_U_(0x1) << GMAC_ISRPQ_TFC_Pos)               /**< (GMAC_ISRPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_ISRPQ_TFC                      GMAC_ISRPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_TFC_Msk instead */
+#define GMAC_ISRPQ_TCOMP_Pos                7                                              /**< (GMAC_ISRPQ) Transmit Complete Position */
+#define GMAC_ISRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_TCOMP_Pos)             /**< (GMAC_ISRPQ) Transmit Complete Mask */
+#define GMAC_ISRPQ_TCOMP                    GMAC_ISRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_TCOMP_Msk instead */
+#define GMAC_ISRPQ_ROVR_Pos                 10                                             /**< (GMAC_ISRPQ) Receive Overrun Position */
+#define GMAC_ISRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_ISRPQ_ROVR_Pos)              /**< (GMAC_ISRPQ) Receive Overrun Mask */
+#define GMAC_ISRPQ_ROVR                     GMAC_ISRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_ROVR_Msk instead */
+#define GMAC_ISRPQ_HRESP_Pos                11                                             /**< (GMAC_ISRPQ) HRESP Not OK Position */
+#define GMAC_ISRPQ_HRESP_Msk                (_U_(0x1) << GMAC_ISRPQ_HRESP_Pos)             /**< (GMAC_ISRPQ) HRESP Not OK Mask */
+#define GMAC_ISRPQ_HRESP                    GMAC_ISRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_HRESP_Msk instead */
+#define GMAC_ISRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_ISRPQ) Register MASK  (Use GMAC_ISRPQ_Msk instead)  */
+#define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
+
+
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x43c) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXBQBA:30;                 /**< bit:  2..31  Transmit Buffer Queue Base Address       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBQBAPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBQBAPQ_OFFSET                 (0x43C)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
+#define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
+#define GMAC_TBQBAPQ_TXBQBA(value)          (GMAC_TBQBAPQ_TXBQBA_Msk & ((value) << GMAC_TBQBAPQ_TXBQBA_Pos))
+#define GMAC_TBQBAPQ_MASK                   _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_TBQBAPQ) Register MASK  (Use GMAC_TBQBAPQ_Msk instead)  */
+#define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
+
+
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x47c) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBQBA:30;                 /**< bit:  2..31  Receive Buffer Queue Base Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBQBAPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBQBAPQ_OFFSET                 (0x47C)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
+#define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
+#define GMAC_RBQBAPQ_RXBQBA(value)          (GMAC_RBQBAPQ_RXBQBA_Msk & ((value) << GMAC_RBQBAPQ_RXBQBA_Pos))
+#define GMAC_RBQBAPQ_MASK                   _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_RBQBAPQ) Register MASK  (Use GMAC_RBQBAPQ_Msk instead)  */
+#define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
+
+
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x49c) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RBS:16;                    /**< bit:  0..15  Receive Buffer Size                      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBSRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBSRPQ_OFFSET                  (0x49C)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
+#define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
+#define GMAC_RBSRPQ_RBS(value)              (GMAC_RBSRPQ_RBS_Msk & ((value) << GMAC_RBSRPQ_RBS_Pos))
+#define GMAC_RBSRPQ_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_RBSRPQ) Register MASK  (Use GMAC_RBSRPQ_Msk instead)  */
+#define GMAC_RBSRPQ_Msk                     _U_(0xFFFF)                                    /**< (GMAC_RBSRPQ) Register Mask  */
+
+
+/* -------- GMAC_CBSCR : (GMAC Offset: 0x4bc) (R/W 32) Credit-Based Shaping Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QBE:1;                     /**< bit:      0  Queue B CBS Enable                       */
+    uint32_t QAE:1;                     /**< bit:      1  Queue A CBS Enable                       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSCR_OFFSET                   (0x4BC)                                       /**<  (GMAC_CBSCR) Credit-Based Shaping Control Register  Offset */
+
+#define GMAC_CBSCR_QBE_Pos                  0                                              /**< (GMAC_CBSCR) Queue B CBS Enable Position */
+#define GMAC_CBSCR_QBE_Msk                  (_U_(0x1) << GMAC_CBSCR_QBE_Pos)               /**< (GMAC_CBSCR) Queue B CBS Enable Mask */
+#define GMAC_CBSCR_QBE                      GMAC_CBSCR_QBE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_CBSCR_QBE_Msk instead */
+#define GMAC_CBSCR_QAE_Pos                  1                                              /**< (GMAC_CBSCR) Queue A CBS Enable Position */
+#define GMAC_CBSCR_QAE_Msk                  (_U_(0x1) << GMAC_CBSCR_QAE_Pos)               /**< (GMAC_CBSCR) Queue A CBS Enable Mask */
+#define GMAC_CBSCR_QAE                      GMAC_CBSCR_QAE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_CBSCR_QAE_Msk instead */
+#define GMAC_CBSCR_MASK                     _U_(0x03)                                      /**< \deprecated (GMAC_CBSCR) Register MASK  (Use GMAC_CBSCR_Msk instead)  */
+#define GMAC_CBSCR_Msk                      _U_(0x03)                                      /**< (GMAC_CBSCR) Register Mask  */
+
+
+/* -------- GMAC_CBSISQA : (GMAC Offset: 0x4c0) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSISQA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSISQA_OFFSET                 (0x4C0)                                       /**<  (GMAC_CBSISQA) Credit-Based Shaping IdleSlope Register for Queue A  Offset */
+
+#define GMAC_CBSISQA_IS_Pos                 0                                              /**< (GMAC_CBSISQA) IdleSlope Position */
+#define GMAC_CBSISQA_IS_Msk                 (_U_(0xFFFFFFFF) << GMAC_CBSISQA_IS_Pos)       /**< (GMAC_CBSISQA) IdleSlope Mask */
+#define GMAC_CBSISQA_IS(value)              (GMAC_CBSISQA_IS_Msk & ((value) << GMAC_CBSISQA_IS_Pos))
+#define GMAC_CBSISQA_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_CBSISQA) Register MASK  (Use GMAC_CBSISQA_Msk instead)  */
+#define GMAC_CBSISQA_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_CBSISQA) Register Mask  */
+
+
+/* -------- GMAC_CBSISQB : (GMAC Offset: 0x4c4) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSISQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSISQB_OFFSET                 (0x4C4)                                       /**<  (GMAC_CBSISQB) Credit-Based Shaping IdleSlope Register for Queue B  Offset */
+
+#define GMAC_CBSISQB_IS_Pos                 0                                              /**< (GMAC_CBSISQB) IdleSlope Position */
+#define GMAC_CBSISQB_IS_Msk                 (_U_(0xFFFFFFFF) << GMAC_CBSISQB_IS_Pos)       /**< (GMAC_CBSISQB) IdleSlope Mask */
+#define GMAC_CBSISQB_IS(value)              (GMAC_CBSISQB_IS_Msk & ((value) << GMAC_CBSISQB_IS_Pos))
+#define GMAC_CBSISQB_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_CBSISQB) Register MASK  (Use GMAC_CBSISQB_Msk instead)  */
+#define GMAC_CBSISQB_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_CBSISQB) Register Mask  */
+
+
+/* -------- GMAC_ST1RPQ : (GMAC Offset: 0x500) (R/W 32) Screening Type 1 Register Priority Queue (index = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t DSTCM:8;                   /**< bit:  4..11  Differentiated Services or Traffic Class Match */
+    uint32_t UDPM:16;                   /**< bit: 12..27  UDP Port Match                           */
+    uint32_t DSTCE:1;                   /**< bit:     28  Differentiated Services or Traffic Class Match Enable */
+    uint32_t UDPE:1;                    /**< bit:     29  UDP Port Match Enable                    */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST1RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST1RPQ_OFFSET                  (0x500)                                       /**<  (GMAC_ST1RPQ) Screening Type 1 Register Priority Queue (index = 0) 0  Offset */
+
+#define GMAC_ST1RPQ_QNB_Pos                 0                                              /**< (GMAC_ST1RPQ) Queue Number (0-2) Position */
+#define GMAC_ST1RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST1RPQ_QNB_Pos)              /**< (GMAC_ST1RPQ) Queue Number (0-2) Mask */
+#define GMAC_ST1RPQ_QNB(value)              (GMAC_ST1RPQ_QNB_Msk & ((value) << GMAC_ST1RPQ_QNB_Pos))
+#define GMAC_ST1RPQ_DSTCM_Pos               4                                              /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Position */
+#define GMAC_ST1RPQ_DSTCM_Msk               (_U_(0xFF) << GMAC_ST1RPQ_DSTCM_Pos)           /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Mask */
+#define GMAC_ST1RPQ_DSTCM(value)            (GMAC_ST1RPQ_DSTCM_Msk & ((value) << GMAC_ST1RPQ_DSTCM_Pos))
+#define GMAC_ST1RPQ_UDPM_Pos                12                                             /**< (GMAC_ST1RPQ) UDP Port Match Position */
+#define GMAC_ST1RPQ_UDPM_Msk                (_U_(0xFFFF) << GMAC_ST1RPQ_UDPM_Pos)          /**< (GMAC_ST1RPQ) UDP Port Match Mask */
+#define GMAC_ST1RPQ_UDPM(value)             (GMAC_ST1RPQ_UDPM_Msk & ((value) << GMAC_ST1RPQ_UDPM_Pos))
+#define GMAC_ST1RPQ_DSTCE_Pos               28                                             /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Enable Position */
+#define GMAC_ST1RPQ_DSTCE_Msk               (_U_(0x1) << GMAC_ST1RPQ_DSTCE_Pos)            /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Enable Mask */
+#define GMAC_ST1RPQ_DSTCE                   GMAC_ST1RPQ_DSTCE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST1RPQ_DSTCE_Msk instead */
+#define GMAC_ST1RPQ_UDPE_Pos                29                                             /**< (GMAC_ST1RPQ) UDP Port Match Enable Position */
+#define GMAC_ST1RPQ_UDPE_Msk                (_U_(0x1) << GMAC_ST1RPQ_UDPE_Pos)             /**< (GMAC_ST1RPQ) UDP Port Match Enable Mask */
+#define GMAC_ST1RPQ_UDPE                    GMAC_ST1RPQ_UDPE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST1RPQ_UDPE_Msk instead */
+#define GMAC_ST1RPQ_MASK                    _U_(0x3FFFFFF7)                                /**< \deprecated (GMAC_ST1RPQ) Register MASK  (Use GMAC_ST1RPQ_Msk instead)  */
+#define GMAC_ST1RPQ_Msk                     _U_(0x3FFFFFF7)                                /**< (GMAC_ST1RPQ) Register Mask  */
+
+
+/* -------- GMAC_ST2RPQ : (GMAC Offset: 0x540) (R/W 32) Screening Type 2 Register Priority Queue (index = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t VLANP:3;                   /**< bit:   4..6  VLAN Priority                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t VLANE:1;                   /**< bit:      8  VLAN Enable                              */
+    uint32_t I2ETH:3;                   /**< bit:  9..11  Index of Screening Type 2 EtherType register x */
+    uint32_t ETHE:1;                    /**< bit:     12  EtherType Enable                         */
+    uint32_t COMPA:5;                   /**< bit: 13..17  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPAE:1;                  /**< bit:     18  Compare A Enable                         */
+    uint32_t COMPB:5;                   /**< bit: 19..23  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPBE:1;                  /**< bit:     24  Compare B Enable                         */
+    uint32_t COMPC:5;                   /**< bit: 25..29  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPCE:1;                  /**< bit:     30  Compare C Enable                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2RPQ_OFFSET                  (0x540)                                       /**<  (GMAC_ST2RPQ) Screening Type 2 Register Priority Queue (index = 0) 0  Offset */
+
+#define GMAC_ST2RPQ_QNB_Pos                 0                                              /**< (GMAC_ST2RPQ) Queue Number (0-2) Position */
+#define GMAC_ST2RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST2RPQ_QNB_Pos)              /**< (GMAC_ST2RPQ) Queue Number (0-2) Mask */
+#define GMAC_ST2RPQ_QNB(value)              (GMAC_ST2RPQ_QNB_Msk & ((value) << GMAC_ST2RPQ_QNB_Pos))
+#define GMAC_ST2RPQ_VLANP_Pos               4                                              /**< (GMAC_ST2RPQ) VLAN Priority Position */
+#define GMAC_ST2RPQ_VLANP_Msk               (_U_(0x7) << GMAC_ST2RPQ_VLANP_Pos)            /**< (GMAC_ST2RPQ) VLAN Priority Mask */
+#define GMAC_ST2RPQ_VLANP(value)            (GMAC_ST2RPQ_VLANP_Msk & ((value) << GMAC_ST2RPQ_VLANP_Pos))
+#define GMAC_ST2RPQ_VLANE_Pos               8                                              /**< (GMAC_ST2RPQ) VLAN Enable Position */
+#define GMAC_ST2RPQ_VLANE_Msk               (_U_(0x1) << GMAC_ST2RPQ_VLANE_Pos)            /**< (GMAC_ST2RPQ) VLAN Enable Mask */
+#define GMAC_ST2RPQ_VLANE                   GMAC_ST2RPQ_VLANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_VLANE_Msk instead */
+#define GMAC_ST2RPQ_I2ETH_Pos               9                                              /**< (GMAC_ST2RPQ) Index of Screening Type 2 EtherType register x Position */
+#define GMAC_ST2RPQ_I2ETH_Msk               (_U_(0x7) << GMAC_ST2RPQ_I2ETH_Pos)            /**< (GMAC_ST2RPQ) Index of Screening Type 2 EtherType register x Mask */
+#define GMAC_ST2RPQ_I2ETH(value)            (GMAC_ST2RPQ_I2ETH_Msk & ((value) << GMAC_ST2RPQ_I2ETH_Pos))
+#define GMAC_ST2RPQ_ETHE_Pos                12                                             /**< (GMAC_ST2RPQ) EtherType Enable Position */
+#define GMAC_ST2RPQ_ETHE_Msk                (_U_(0x1) << GMAC_ST2RPQ_ETHE_Pos)             /**< (GMAC_ST2RPQ) EtherType Enable Mask */
+#define GMAC_ST2RPQ_ETHE                    GMAC_ST2RPQ_ETHE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_ETHE_Msk instead */
+#define GMAC_ST2RPQ_COMPA_Pos               13                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPA_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPA_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPA(value)            (GMAC_ST2RPQ_COMPA_Msk & ((value) << GMAC_ST2RPQ_COMPA_Pos))
+#define GMAC_ST2RPQ_COMPAE_Pos              18                                             /**< (GMAC_ST2RPQ) Compare A Enable Position */
+#define GMAC_ST2RPQ_COMPAE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPAE_Pos)           /**< (GMAC_ST2RPQ) Compare A Enable Mask */
+#define GMAC_ST2RPQ_COMPAE                  GMAC_ST2RPQ_COMPAE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPAE_Msk instead */
+#define GMAC_ST2RPQ_COMPB_Pos               19                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPB_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPB_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPB(value)            (GMAC_ST2RPQ_COMPB_Msk & ((value) << GMAC_ST2RPQ_COMPB_Pos))
+#define GMAC_ST2RPQ_COMPBE_Pos              24                                             /**< (GMAC_ST2RPQ) Compare B Enable Position */
+#define GMAC_ST2RPQ_COMPBE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPBE_Pos)           /**< (GMAC_ST2RPQ) Compare B Enable Mask */
+#define GMAC_ST2RPQ_COMPBE                  GMAC_ST2RPQ_COMPBE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPBE_Msk instead */
+#define GMAC_ST2RPQ_COMPC_Pos               25                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPC_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPC_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPC(value)            (GMAC_ST2RPQ_COMPC_Msk & ((value) << GMAC_ST2RPQ_COMPC_Pos))
+#define GMAC_ST2RPQ_COMPCE_Pos              30                                             /**< (GMAC_ST2RPQ) Compare C Enable Position */
+#define GMAC_ST2RPQ_COMPCE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPCE_Pos)           /**< (GMAC_ST2RPQ) Compare C Enable Mask */
+#define GMAC_ST2RPQ_COMPCE                  GMAC_ST2RPQ_COMPCE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPCE_Msk instead */
+#define GMAC_ST2RPQ_MASK                    _U_(0x7FFFFF77)                                /**< \deprecated (GMAC_ST2RPQ) Register MASK  (Use GMAC_ST2RPQ_Msk instead)  */
+#define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
+
+
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x5fc) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IERPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IERPQ_OFFSET                   (0x5FC)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
+#define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
+#define GMAC_IERPQ_RCOMP                    GMAC_IERPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RCOMP_Msk instead */
+#define GMAC_IERPQ_RXUBR_Pos                2                                              /**< (GMAC_IERPQ) RX Used Bit Read Position */
+#define GMAC_IERPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IERPQ_RXUBR_Pos)             /**< (GMAC_IERPQ) RX Used Bit Read Mask */
+#define GMAC_IERPQ_RXUBR                    GMAC_IERPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RXUBR_Msk instead */
+#define GMAC_IERPQ_RLEX_Pos                 5                                              /**< (GMAC_IERPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IERPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IERPQ_RLEX_Pos)              /**< (GMAC_IERPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IERPQ_RLEX                     GMAC_IERPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RLEX_Msk instead */
+#define GMAC_IERPQ_TFC_Pos                  6                                              /**< (GMAC_IERPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IERPQ_TFC_Msk                  (_U_(0x1) << GMAC_IERPQ_TFC_Pos)               /**< (GMAC_IERPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IERPQ_TFC                      GMAC_IERPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_TFC_Msk instead */
+#define GMAC_IERPQ_TCOMP_Pos                7                                              /**< (GMAC_IERPQ) Transmit Complete Position */
+#define GMAC_IERPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_TCOMP_Pos)             /**< (GMAC_IERPQ) Transmit Complete Mask */
+#define GMAC_IERPQ_TCOMP                    GMAC_IERPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_TCOMP_Msk instead */
+#define GMAC_IERPQ_ROVR_Pos                 10                                             /**< (GMAC_IERPQ) Receive Overrun Position */
+#define GMAC_IERPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IERPQ_ROVR_Pos)              /**< (GMAC_IERPQ) Receive Overrun Mask */
+#define GMAC_IERPQ_ROVR                     GMAC_IERPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_ROVR_Msk instead */
+#define GMAC_IERPQ_HRESP_Pos                11                                             /**< (GMAC_IERPQ) HRESP Not OK Position */
+#define GMAC_IERPQ_HRESP_Msk                (_U_(0x1) << GMAC_IERPQ_HRESP_Pos)             /**< (GMAC_IERPQ) HRESP Not OK Mask */
+#define GMAC_IERPQ_HRESP                    GMAC_IERPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_HRESP_Msk instead */
+#define GMAC_IERPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IERPQ) Register MASK  (Use GMAC_IERPQ_Msk instead)  */
+#define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
+
+
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x61c) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IDRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IDRPQ_OFFSET                   (0x61C)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
+#define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
+#define GMAC_IDRPQ_RCOMP                    GMAC_IDRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RCOMP_Msk instead */
+#define GMAC_IDRPQ_RXUBR_Pos                2                                              /**< (GMAC_IDRPQ) RX Used Bit Read Position */
+#define GMAC_IDRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IDRPQ_RXUBR_Pos)             /**< (GMAC_IDRPQ) RX Used Bit Read Mask */
+#define GMAC_IDRPQ_RXUBR                    GMAC_IDRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RXUBR_Msk instead */
+#define GMAC_IDRPQ_RLEX_Pos                 5                                              /**< (GMAC_IDRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IDRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IDRPQ_RLEX_Pos)              /**< (GMAC_IDRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IDRPQ_RLEX                     GMAC_IDRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RLEX_Msk instead */
+#define GMAC_IDRPQ_TFC_Pos                  6                                              /**< (GMAC_IDRPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IDRPQ_TFC_Msk                  (_U_(0x1) << GMAC_IDRPQ_TFC_Pos)               /**< (GMAC_IDRPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IDRPQ_TFC                      GMAC_IDRPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_TFC_Msk instead */
+#define GMAC_IDRPQ_TCOMP_Pos                7                                              /**< (GMAC_IDRPQ) Transmit Complete Position */
+#define GMAC_IDRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_TCOMP_Pos)             /**< (GMAC_IDRPQ) Transmit Complete Mask */
+#define GMAC_IDRPQ_TCOMP                    GMAC_IDRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_TCOMP_Msk instead */
+#define GMAC_IDRPQ_ROVR_Pos                 10                                             /**< (GMAC_IDRPQ) Receive Overrun Position */
+#define GMAC_IDRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IDRPQ_ROVR_Pos)              /**< (GMAC_IDRPQ) Receive Overrun Mask */
+#define GMAC_IDRPQ_ROVR                     GMAC_IDRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_ROVR_Msk instead */
+#define GMAC_IDRPQ_HRESP_Pos                11                                             /**< (GMAC_IDRPQ) HRESP Not OK Position */
+#define GMAC_IDRPQ_HRESP_Msk                (_U_(0x1) << GMAC_IDRPQ_HRESP_Pos)             /**< (GMAC_IDRPQ) HRESP Not OK Mask */
+#define GMAC_IDRPQ_HRESP                    GMAC_IDRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_HRESP_Msk instead */
+#define GMAC_IDRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IDRPQ) Register MASK  (Use GMAC_IDRPQ_Msk instead)  */
+#define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
+
+
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x63c) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t AHB:1;                     /**< bit:      6  AHB Error                                */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IMRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IMRPQ_OFFSET                   (0x63C)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
+
+#define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
+#define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */
+#define GMAC_IMRPQ_RCOMP                    GMAC_IMRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RCOMP_Msk instead */
+#define GMAC_IMRPQ_RXUBR_Pos                2                                              /**< (GMAC_IMRPQ) RX Used Bit Read Position */
+#define GMAC_IMRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IMRPQ_RXUBR_Pos)             /**< (GMAC_IMRPQ) RX Used Bit Read Mask */
+#define GMAC_IMRPQ_RXUBR                    GMAC_IMRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RXUBR_Msk instead */
+#define GMAC_IMRPQ_RLEX_Pos                 5                                              /**< (GMAC_IMRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IMRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IMRPQ_RLEX_Pos)              /**< (GMAC_IMRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IMRPQ_RLEX                     GMAC_IMRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RLEX_Msk instead */
+#define GMAC_IMRPQ_AHB_Pos                  6                                              /**< (GMAC_IMRPQ) AHB Error Position */
+#define GMAC_IMRPQ_AHB_Msk                  (_U_(0x1) << GMAC_IMRPQ_AHB_Pos)               /**< (GMAC_IMRPQ) AHB Error Mask */
+#define GMAC_IMRPQ_AHB                      GMAC_IMRPQ_AHB_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_AHB_Msk instead */
+#define GMAC_IMRPQ_TCOMP_Pos                7                                              /**< (GMAC_IMRPQ) Transmit Complete Position */
+#define GMAC_IMRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_TCOMP_Pos)             /**< (GMAC_IMRPQ) Transmit Complete Mask */
+#define GMAC_IMRPQ_TCOMP                    GMAC_IMRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_TCOMP_Msk instead */
+#define GMAC_IMRPQ_ROVR_Pos                 10                                             /**< (GMAC_IMRPQ) Receive Overrun Position */
+#define GMAC_IMRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IMRPQ_ROVR_Pos)              /**< (GMAC_IMRPQ) Receive Overrun Mask */
+#define GMAC_IMRPQ_ROVR                     GMAC_IMRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_ROVR_Msk instead */
+#define GMAC_IMRPQ_HRESP_Pos                11                                             /**< (GMAC_IMRPQ) HRESP Not OK Position */
+#define GMAC_IMRPQ_HRESP_Msk                (_U_(0x1) << GMAC_IMRPQ_HRESP_Pos)             /**< (GMAC_IMRPQ) HRESP Not OK Mask */
+#define GMAC_IMRPQ_HRESP                    GMAC_IMRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_HRESP_Msk instead */
+#define GMAC_IMRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IMRPQ) Register MASK  (Use GMAC_IMRPQ_Msk instead)  */
+#define GMAC_IMRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IMRPQ) Register Mask  */
+
+
+/* -------- GMAC_ST2ER : (GMAC Offset: 0x6e0) (R/W 32) Screening Type 2 Ethertype Register (index = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COMPVAL:16;                /**< bit:  0..15  Ethertype Compare Value                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2ER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2ER_OFFSET                   (0x6E0)                                       /**<  (GMAC_ST2ER) Screening Type 2 Ethertype Register (index = 0) 0  Offset */
+
+#define GMAC_ST2ER_COMPVAL_Pos              0                                              /**< (GMAC_ST2ER) Ethertype Compare Value Position */
+#define GMAC_ST2ER_COMPVAL_Msk              (_U_(0xFFFF) << GMAC_ST2ER_COMPVAL_Pos)        /**< (GMAC_ST2ER) Ethertype Compare Value Mask */
+#define GMAC_ST2ER_COMPVAL(value)           (GMAC_ST2ER_COMPVAL_Msk & ((value) << GMAC_ST2ER_COMPVAL_Pos))
+#define GMAC_ST2ER_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_ST2ER) Register MASK  (Use GMAC_ST2ER_Msk instead)  */
+#define GMAC_ST2ER_Msk                      _U_(0xFFFF)                                    /**< (GMAC_ST2ER) Register Mask  */
+
+
+/* -------- GMAC_ST2CW00 : (GMAC Offset: 0x700) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW00_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW00_OFFSET                 (0x700)                                       /**<  (GMAC_ST2CW00) Screening Type 2 Compare Word 0 Register (index = 0)  Offset */
+
+#define GMAC_ST2CW00_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW00) Mask Value Position */
+#define GMAC_ST2CW00_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW00_MASKVAL_Pos)      /**< (GMAC_ST2CW00) Mask Value Mask */
+#define GMAC_ST2CW00_MASKVAL(value)         (GMAC_ST2CW00_MASKVAL_Msk & ((value) << GMAC_ST2CW00_MASKVAL_Pos))
+#define GMAC_ST2CW00_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW00) Compare Value Position */
+#define GMAC_ST2CW00_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW00_COMPVAL_Pos)      /**< (GMAC_ST2CW00) Compare Value Mask */
+#define GMAC_ST2CW00_COMPVAL(value)         (GMAC_ST2CW00_COMPVAL_Msk & ((value) << GMAC_ST2CW00_COMPVAL_Pos))
+#define GMAC_ST2CW00_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW00) Register Mask  */
+
+
+/* -------- GMAC_ST2CW10 : (GMAC Offset: 0x704) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW10_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW10_OFFSET                 (0x704)                                       /**<  (GMAC_ST2CW10) Screening Type 2 Compare Word 1 Register (index = 0)  Offset */
+
+#define GMAC_ST2CW10_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW10) Offset Value in Bytes Position */
+#define GMAC_ST2CW10_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW10_OFFSVAL_Pos)        /**< (GMAC_ST2CW10) Offset Value in Bytes Mask */
+#define GMAC_ST2CW10_OFFSVAL(value)         (GMAC_ST2CW10_OFFSVAL_Msk & ((value) << GMAC_ST2CW10_OFFSVAL_Pos))
+#define GMAC_ST2CW10_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW10) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW10_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW10_OFFSSTRT_Pos)        /**< (GMAC_ST2CW10) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW10_OFFSSTRT(value)        (GMAC_ST2CW10_OFFSSTRT_Msk & ((value) << GMAC_ST2CW10_OFFSSTRT_Pos))
+#define   GMAC_ST2CW10_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW10) Offset from the start of the frame  */
+#define   GMAC_ST2CW10_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW10) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW10_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW10) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW10_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW10) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW10_OFFSSTRT_FRAMESTART    (GMAC_ST2CW10_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the start of the frame Position  */
+#define GMAC_ST2CW10_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW10_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW10_OFFSSTRT_IP            (GMAC_ST2CW10_OFFSSTRT_IP_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW10_OFFSSTRT_TCP_UDP       (GMAC_ST2CW10_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW10_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW10) Register MASK  (Use GMAC_ST2CW10_Msk instead)  */
+#define GMAC_ST2CW10_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW10) Register Mask  */
+
+
+/* -------- GMAC_ST2CW01 : (GMAC Offset: 0x708) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW01_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW01_OFFSET                 (0x708)                                       /**<  (GMAC_ST2CW01) Screening Type 2 Compare Word 0 Register (index = 1)  Offset */
+
+#define GMAC_ST2CW01_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW01) Mask Value Position */
+#define GMAC_ST2CW01_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW01_MASKVAL_Pos)      /**< (GMAC_ST2CW01) Mask Value Mask */
+#define GMAC_ST2CW01_MASKVAL(value)         (GMAC_ST2CW01_MASKVAL_Msk & ((value) << GMAC_ST2CW01_MASKVAL_Pos))
+#define GMAC_ST2CW01_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW01) Compare Value Position */
+#define GMAC_ST2CW01_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW01_COMPVAL_Pos)      /**< (GMAC_ST2CW01) Compare Value Mask */
+#define GMAC_ST2CW01_COMPVAL(value)         (GMAC_ST2CW01_COMPVAL_Msk & ((value) << GMAC_ST2CW01_COMPVAL_Pos))
+#define GMAC_ST2CW01_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW01) Register Mask  */
+
+
+/* -------- GMAC_ST2CW11 : (GMAC Offset: 0x70c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW11_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW11_OFFSET                 (0x70C)                                       /**<  (GMAC_ST2CW11) Screening Type 2 Compare Word 1 Register (index = 1)  Offset */
+
+#define GMAC_ST2CW11_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW11) Offset Value in Bytes Position */
+#define GMAC_ST2CW11_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW11_OFFSVAL_Pos)        /**< (GMAC_ST2CW11) Offset Value in Bytes Mask */
+#define GMAC_ST2CW11_OFFSVAL(value)         (GMAC_ST2CW11_OFFSVAL_Msk & ((value) << GMAC_ST2CW11_OFFSVAL_Pos))
+#define GMAC_ST2CW11_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW11) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW11_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW11_OFFSSTRT_Pos)        /**< (GMAC_ST2CW11) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW11_OFFSSTRT(value)        (GMAC_ST2CW11_OFFSSTRT_Msk & ((value) << GMAC_ST2CW11_OFFSSTRT_Pos))
+#define   GMAC_ST2CW11_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW11) Offset from the start of the frame  */
+#define   GMAC_ST2CW11_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW11) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW11_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW11) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW11_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW11) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW11_OFFSSTRT_FRAMESTART    (GMAC_ST2CW11_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the start of the frame Position  */
+#define GMAC_ST2CW11_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW11_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW11_OFFSSTRT_IP            (GMAC_ST2CW11_OFFSSTRT_IP_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW11_OFFSSTRT_TCP_UDP       (GMAC_ST2CW11_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW11_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW11) Register MASK  (Use GMAC_ST2CW11_Msk instead)  */
+#define GMAC_ST2CW11_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW11) Register Mask  */
+
+
+/* -------- GMAC_ST2CW02 : (GMAC Offset: 0x710) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW02_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW02_OFFSET                 (0x710)                                       /**<  (GMAC_ST2CW02) Screening Type 2 Compare Word 0 Register (index = 2)  Offset */
+
+#define GMAC_ST2CW02_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW02) Mask Value Position */
+#define GMAC_ST2CW02_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW02_MASKVAL_Pos)      /**< (GMAC_ST2CW02) Mask Value Mask */
+#define GMAC_ST2CW02_MASKVAL(value)         (GMAC_ST2CW02_MASKVAL_Msk & ((value) << GMAC_ST2CW02_MASKVAL_Pos))
+#define GMAC_ST2CW02_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW02) Compare Value Position */
+#define GMAC_ST2CW02_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW02_COMPVAL_Pos)      /**< (GMAC_ST2CW02) Compare Value Mask */
+#define GMAC_ST2CW02_COMPVAL(value)         (GMAC_ST2CW02_COMPVAL_Msk & ((value) << GMAC_ST2CW02_COMPVAL_Pos))
+#define GMAC_ST2CW02_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW02) Register Mask  */
+
+
+/* -------- GMAC_ST2CW12 : (GMAC Offset: 0x714) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW12_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW12_OFFSET                 (0x714)                                       /**<  (GMAC_ST2CW12) Screening Type 2 Compare Word 1 Register (index = 2)  Offset */
+
+#define GMAC_ST2CW12_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW12) Offset Value in Bytes Position */
+#define GMAC_ST2CW12_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW12_OFFSVAL_Pos)        /**< (GMAC_ST2CW12) Offset Value in Bytes Mask */
+#define GMAC_ST2CW12_OFFSVAL(value)         (GMAC_ST2CW12_OFFSVAL_Msk & ((value) << GMAC_ST2CW12_OFFSVAL_Pos))
+#define GMAC_ST2CW12_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW12) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW12_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW12_OFFSSTRT_Pos)        /**< (GMAC_ST2CW12) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW12_OFFSSTRT(value)        (GMAC_ST2CW12_OFFSSTRT_Msk & ((value) << GMAC_ST2CW12_OFFSSTRT_Pos))
+#define   GMAC_ST2CW12_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW12) Offset from the start of the frame  */
+#define   GMAC_ST2CW12_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW12) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW12_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW12) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW12_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW12) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW12_OFFSSTRT_FRAMESTART    (GMAC_ST2CW12_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the start of the frame Position  */
+#define GMAC_ST2CW12_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW12_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW12_OFFSSTRT_IP            (GMAC_ST2CW12_OFFSSTRT_IP_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW12_OFFSSTRT_TCP_UDP       (GMAC_ST2CW12_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW12_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW12) Register MASK  (Use GMAC_ST2CW12_Msk instead)  */
+#define GMAC_ST2CW12_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW12) Register Mask  */
+
+
+/* -------- GMAC_ST2CW03 : (GMAC Offset: 0x718) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 3) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW03_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW03_OFFSET                 (0x718)                                       /**<  (GMAC_ST2CW03) Screening Type 2 Compare Word 0 Register (index = 3)  Offset */
+
+#define GMAC_ST2CW03_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW03) Mask Value Position */
+#define GMAC_ST2CW03_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW03_MASKVAL_Pos)      /**< (GMAC_ST2CW03) Mask Value Mask */
+#define GMAC_ST2CW03_MASKVAL(value)         (GMAC_ST2CW03_MASKVAL_Msk & ((value) << GMAC_ST2CW03_MASKVAL_Pos))
+#define GMAC_ST2CW03_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW03) Compare Value Position */
+#define GMAC_ST2CW03_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW03_COMPVAL_Pos)      /**< (GMAC_ST2CW03) Compare Value Mask */
+#define GMAC_ST2CW03_COMPVAL(value)         (GMAC_ST2CW03_COMPVAL_Msk & ((value) << GMAC_ST2CW03_COMPVAL_Pos))
+#define GMAC_ST2CW03_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW03) Register Mask  */
+
+
+/* -------- GMAC_ST2CW13 : (GMAC Offset: 0x71c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 3) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW13_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW13_OFFSET                 (0x71C)                                       /**<  (GMAC_ST2CW13) Screening Type 2 Compare Word 1 Register (index = 3)  Offset */
+
+#define GMAC_ST2CW13_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW13) Offset Value in Bytes Position */
+#define GMAC_ST2CW13_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW13_OFFSVAL_Pos)        /**< (GMAC_ST2CW13) Offset Value in Bytes Mask */
+#define GMAC_ST2CW13_OFFSVAL(value)         (GMAC_ST2CW13_OFFSVAL_Msk & ((value) << GMAC_ST2CW13_OFFSVAL_Pos))
+#define GMAC_ST2CW13_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW13) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW13_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW13_OFFSSTRT_Pos)        /**< (GMAC_ST2CW13) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW13_OFFSSTRT(value)        (GMAC_ST2CW13_OFFSSTRT_Msk & ((value) << GMAC_ST2CW13_OFFSSTRT_Pos))
+#define   GMAC_ST2CW13_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW13) Offset from the start of the frame  */
+#define   GMAC_ST2CW13_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW13) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW13_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW13) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW13_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW13) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW13_OFFSSTRT_FRAMESTART    (GMAC_ST2CW13_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the start of the frame Position  */
+#define GMAC_ST2CW13_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW13_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW13_OFFSSTRT_IP            (GMAC_ST2CW13_OFFSSTRT_IP_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW13_OFFSSTRT_TCP_UDP       (GMAC_ST2CW13_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW13_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW13) Register MASK  (Use GMAC_ST2CW13_Msk instead)  */
+#define GMAC_ST2CW13_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW13) Register Mask  */
+
+
+/* -------- GMAC_ST2CW04 : (GMAC Offset: 0x720) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 4) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW04_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW04_OFFSET                 (0x720)                                       /**<  (GMAC_ST2CW04) Screening Type 2 Compare Word 0 Register (index = 4)  Offset */
+
+#define GMAC_ST2CW04_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW04) Mask Value Position */
+#define GMAC_ST2CW04_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW04_MASKVAL_Pos)      /**< (GMAC_ST2CW04) Mask Value Mask */
+#define GMAC_ST2CW04_MASKVAL(value)         (GMAC_ST2CW04_MASKVAL_Msk & ((value) << GMAC_ST2CW04_MASKVAL_Pos))
+#define GMAC_ST2CW04_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW04) Compare Value Position */
+#define GMAC_ST2CW04_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW04_COMPVAL_Pos)      /**< (GMAC_ST2CW04) Compare Value Mask */
+#define GMAC_ST2CW04_COMPVAL(value)         (GMAC_ST2CW04_COMPVAL_Msk & ((value) << GMAC_ST2CW04_COMPVAL_Pos))
+#define GMAC_ST2CW04_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW04) Register Mask  */
+
+
+/* -------- GMAC_ST2CW14 : (GMAC Offset: 0x724) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 4) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW14_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW14_OFFSET                 (0x724)                                       /**<  (GMAC_ST2CW14) Screening Type 2 Compare Word 1 Register (index = 4)  Offset */
+
+#define GMAC_ST2CW14_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW14) Offset Value in Bytes Position */
+#define GMAC_ST2CW14_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW14_OFFSVAL_Pos)        /**< (GMAC_ST2CW14) Offset Value in Bytes Mask */
+#define GMAC_ST2CW14_OFFSVAL(value)         (GMAC_ST2CW14_OFFSVAL_Msk & ((value) << GMAC_ST2CW14_OFFSVAL_Pos))
+#define GMAC_ST2CW14_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW14) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW14_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW14_OFFSSTRT_Pos)        /**< (GMAC_ST2CW14) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW14_OFFSSTRT(value)        (GMAC_ST2CW14_OFFSSTRT_Msk & ((value) << GMAC_ST2CW14_OFFSSTRT_Pos))
+#define   GMAC_ST2CW14_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW14) Offset from the start of the frame  */
+#define   GMAC_ST2CW14_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW14) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW14_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW14) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW14_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW14) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW14_OFFSSTRT_FRAMESTART    (GMAC_ST2CW14_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the start of the frame Position  */
+#define GMAC_ST2CW14_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW14_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW14_OFFSSTRT_IP            (GMAC_ST2CW14_OFFSSTRT_IP_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW14_OFFSSTRT_TCP_UDP       (GMAC_ST2CW14_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW14_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW14) Register MASK  (Use GMAC_ST2CW14_Msk instead)  */
+#define GMAC_ST2CW14_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW14) Register Mask  */
+
+
+/* -------- GMAC_ST2CW05 : (GMAC Offset: 0x728) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW05_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW05_OFFSET                 (0x728)                                       /**<  (GMAC_ST2CW05) Screening Type 2 Compare Word 0 Register (index = 5)  Offset */
+
+#define GMAC_ST2CW05_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW05) Mask Value Position */
+#define GMAC_ST2CW05_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW05_MASKVAL_Pos)      /**< (GMAC_ST2CW05) Mask Value Mask */
+#define GMAC_ST2CW05_MASKVAL(value)         (GMAC_ST2CW05_MASKVAL_Msk & ((value) << GMAC_ST2CW05_MASKVAL_Pos))
+#define GMAC_ST2CW05_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW05) Compare Value Position */
+#define GMAC_ST2CW05_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW05_COMPVAL_Pos)      /**< (GMAC_ST2CW05) Compare Value Mask */
+#define GMAC_ST2CW05_COMPVAL(value)         (GMAC_ST2CW05_COMPVAL_Msk & ((value) << GMAC_ST2CW05_COMPVAL_Pos))
+#define GMAC_ST2CW05_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW05) Register Mask  */
+
+
+/* -------- GMAC_ST2CW15 : (GMAC Offset: 0x72c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW15_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW15_OFFSET                 (0x72C)                                       /**<  (GMAC_ST2CW15) Screening Type 2 Compare Word 1 Register (index = 5)  Offset */
+
+#define GMAC_ST2CW15_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW15) Offset Value in Bytes Position */
+#define GMAC_ST2CW15_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW15_OFFSVAL_Pos)        /**< (GMAC_ST2CW15) Offset Value in Bytes Mask */
+#define GMAC_ST2CW15_OFFSVAL(value)         (GMAC_ST2CW15_OFFSVAL_Msk & ((value) << GMAC_ST2CW15_OFFSVAL_Pos))
+#define GMAC_ST2CW15_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW15) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW15_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW15_OFFSSTRT_Pos)        /**< (GMAC_ST2CW15) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW15_OFFSSTRT(value)        (GMAC_ST2CW15_OFFSSTRT_Msk & ((value) << GMAC_ST2CW15_OFFSSTRT_Pos))
+#define   GMAC_ST2CW15_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW15) Offset from the start of the frame  */
+#define   GMAC_ST2CW15_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW15) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW15_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW15) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW15_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW15) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW15_OFFSSTRT_FRAMESTART    (GMAC_ST2CW15_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the start of the frame Position  */
+#define GMAC_ST2CW15_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW15_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW15_OFFSSTRT_IP            (GMAC_ST2CW15_OFFSSTRT_IP_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW15_OFFSSTRT_TCP_UDP       (GMAC_ST2CW15_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW15_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW15) Register MASK  (Use GMAC_ST2CW15_Msk instead)  */
+#define GMAC_ST2CW15_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW15) Register Mask  */
+
+
+/* -------- GMAC_ST2CW06 : (GMAC Offset: 0x730) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 6) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW06_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW06_OFFSET                 (0x730)                                       /**<  (GMAC_ST2CW06) Screening Type 2 Compare Word 0 Register (index = 6)  Offset */
+
+#define GMAC_ST2CW06_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW06) Mask Value Position */
+#define GMAC_ST2CW06_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW06_MASKVAL_Pos)      /**< (GMAC_ST2CW06) Mask Value Mask */
+#define GMAC_ST2CW06_MASKVAL(value)         (GMAC_ST2CW06_MASKVAL_Msk & ((value) << GMAC_ST2CW06_MASKVAL_Pos))
+#define GMAC_ST2CW06_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW06) Compare Value Position */
+#define GMAC_ST2CW06_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW06_COMPVAL_Pos)      /**< (GMAC_ST2CW06) Compare Value Mask */
+#define GMAC_ST2CW06_COMPVAL(value)         (GMAC_ST2CW06_COMPVAL_Msk & ((value) << GMAC_ST2CW06_COMPVAL_Pos))
+#define GMAC_ST2CW06_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW06) Register Mask  */
+
+
+/* -------- GMAC_ST2CW16 : (GMAC Offset: 0x734) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 6) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW16_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW16_OFFSET                 (0x734)                                       /**<  (GMAC_ST2CW16) Screening Type 2 Compare Word 1 Register (index = 6)  Offset */
+
+#define GMAC_ST2CW16_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW16) Offset Value in Bytes Position */
+#define GMAC_ST2CW16_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW16_OFFSVAL_Pos)        /**< (GMAC_ST2CW16) Offset Value in Bytes Mask */
+#define GMAC_ST2CW16_OFFSVAL(value)         (GMAC_ST2CW16_OFFSVAL_Msk & ((value) << GMAC_ST2CW16_OFFSVAL_Pos))
+#define GMAC_ST2CW16_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW16) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW16_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW16_OFFSSTRT_Pos)        /**< (GMAC_ST2CW16) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW16_OFFSSTRT(value)        (GMAC_ST2CW16_OFFSSTRT_Msk & ((value) << GMAC_ST2CW16_OFFSSTRT_Pos))
+#define   GMAC_ST2CW16_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW16) Offset from the start of the frame  */
+#define   GMAC_ST2CW16_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW16) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW16_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW16) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW16_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW16) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW16_OFFSSTRT_FRAMESTART    (GMAC_ST2CW16_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the start of the frame Position  */
+#define GMAC_ST2CW16_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW16_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW16_OFFSSTRT_IP            (GMAC_ST2CW16_OFFSSTRT_IP_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW16_OFFSSTRT_TCP_UDP       (GMAC_ST2CW16_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW16_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW16) Register MASK  (Use GMAC_ST2CW16_Msk instead)  */
+#define GMAC_ST2CW16_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW16) Register Mask  */
+
+
+/* -------- GMAC_ST2CW07 : (GMAC Offset: 0x738) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 7) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW07_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW07_OFFSET                 (0x738)                                       /**<  (GMAC_ST2CW07) Screening Type 2 Compare Word 0 Register (index = 7)  Offset */
+
+#define GMAC_ST2CW07_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW07) Mask Value Position */
+#define GMAC_ST2CW07_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW07_MASKVAL_Pos)      /**< (GMAC_ST2CW07) Mask Value Mask */
+#define GMAC_ST2CW07_MASKVAL(value)         (GMAC_ST2CW07_MASKVAL_Msk & ((value) << GMAC_ST2CW07_MASKVAL_Pos))
+#define GMAC_ST2CW07_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW07) Compare Value Position */
+#define GMAC_ST2CW07_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW07_COMPVAL_Pos)      /**< (GMAC_ST2CW07) Compare Value Mask */
+#define GMAC_ST2CW07_COMPVAL(value)         (GMAC_ST2CW07_COMPVAL_Msk & ((value) << GMAC_ST2CW07_COMPVAL_Pos))
+#define GMAC_ST2CW07_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW07) Register Mask  */
+
+
+/* -------- GMAC_ST2CW17 : (GMAC Offset: 0x73c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 7) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW17_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW17_OFFSET                 (0x73C)                                       /**<  (GMAC_ST2CW17) Screening Type 2 Compare Word 1 Register (index = 7)  Offset */
+
+#define GMAC_ST2CW17_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW17) Offset Value in Bytes Position */
+#define GMAC_ST2CW17_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW17_OFFSVAL_Pos)        /**< (GMAC_ST2CW17) Offset Value in Bytes Mask */
+#define GMAC_ST2CW17_OFFSVAL(value)         (GMAC_ST2CW17_OFFSVAL_Msk & ((value) << GMAC_ST2CW17_OFFSVAL_Pos))
+#define GMAC_ST2CW17_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW17) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW17_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW17_OFFSSTRT_Pos)        /**< (GMAC_ST2CW17) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW17_OFFSSTRT(value)        (GMAC_ST2CW17_OFFSSTRT_Msk & ((value) << GMAC_ST2CW17_OFFSSTRT_Pos))
+#define   GMAC_ST2CW17_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW17) Offset from the start of the frame  */
+#define   GMAC_ST2CW17_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW17) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW17_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW17) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW17_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW17) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW17_OFFSSTRT_FRAMESTART    (GMAC_ST2CW17_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the start of the frame Position  */
+#define GMAC_ST2CW17_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW17_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW17_OFFSSTRT_IP            (GMAC_ST2CW17_OFFSSTRT_IP_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW17_OFFSSTRT_TCP_UDP       (GMAC_ST2CW17_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW17_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW17) Register MASK  (Use GMAC_ST2CW17_Msk instead)  */
+#define GMAC_ST2CW17_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW17) Register Mask  */
+
+
+/* -------- GMAC_ST2CW08 : (GMAC Offset: 0x740) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 8) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW08_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW08_OFFSET                 (0x740)                                       /**<  (GMAC_ST2CW08) Screening Type 2 Compare Word 0 Register (index = 8)  Offset */
+
+#define GMAC_ST2CW08_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW08) Mask Value Position */
+#define GMAC_ST2CW08_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW08_MASKVAL_Pos)      /**< (GMAC_ST2CW08) Mask Value Mask */
+#define GMAC_ST2CW08_MASKVAL(value)         (GMAC_ST2CW08_MASKVAL_Msk & ((value) << GMAC_ST2CW08_MASKVAL_Pos))
+#define GMAC_ST2CW08_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW08) Compare Value Position */
+#define GMAC_ST2CW08_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW08_COMPVAL_Pos)      /**< (GMAC_ST2CW08) Compare Value Mask */
+#define GMAC_ST2CW08_COMPVAL(value)         (GMAC_ST2CW08_COMPVAL_Msk & ((value) << GMAC_ST2CW08_COMPVAL_Pos))
+#define GMAC_ST2CW08_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW08) Register Mask  */
+
+
+/* -------- GMAC_ST2CW18 : (GMAC Offset: 0x744) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 8) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW18_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW18_OFFSET                 (0x744)                                       /**<  (GMAC_ST2CW18) Screening Type 2 Compare Word 1 Register (index = 8)  Offset */
+
+#define GMAC_ST2CW18_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW18) Offset Value in Bytes Position */
+#define GMAC_ST2CW18_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW18_OFFSVAL_Pos)        /**< (GMAC_ST2CW18) Offset Value in Bytes Mask */
+#define GMAC_ST2CW18_OFFSVAL(value)         (GMAC_ST2CW18_OFFSVAL_Msk & ((value) << GMAC_ST2CW18_OFFSVAL_Pos))
+#define GMAC_ST2CW18_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW18) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW18_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW18_OFFSSTRT_Pos)        /**< (GMAC_ST2CW18) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW18_OFFSSTRT(value)        (GMAC_ST2CW18_OFFSSTRT_Msk & ((value) << GMAC_ST2CW18_OFFSSTRT_Pos))
+#define   GMAC_ST2CW18_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW18) Offset from the start of the frame  */
+#define   GMAC_ST2CW18_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW18) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW18_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW18) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW18_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW18) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW18_OFFSSTRT_FRAMESTART    (GMAC_ST2CW18_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the start of the frame Position  */
+#define GMAC_ST2CW18_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW18_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW18_OFFSSTRT_IP            (GMAC_ST2CW18_OFFSSTRT_IP_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW18_OFFSSTRT_TCP_UDP       (GMAC_ST2CW18_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW18_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW18) Register MASK  (Use GMAC_ST2CW18_Msk instead)  */
+#define GMAC_ST2CW18_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW18) Register Mask  */
+
+
+/* -------- GMAC_ST2CW09 : (GMAC Offset: 0x748) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 9) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW09_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW09_OFFSET                 (0x748)                                       /**<  (GMAC_ST2CW09) Screening Type 2 Compare Word 0 Register (index = 9)  Offset */
+
+#define GMAC_ST2CW09_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW09) Mask Value Position */
+#define GMAC_ST2CW09_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW09_MASKVAL_Pos)      /**< (GMAC_ST2CW09) Mask Value Mask */
+#define GMAC_ST2CW09_MASKVAL(value)         (GMAC_ST2CW09_MASKVAL_Msk & ((value) << GMAC_ST2CW09_MASKVAL_Pos))
+#define GMAC_ST2CW09_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW09) Compare Value Position */
+#define GMAC_ST2CW09_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW09_COMPVAL_Pos)      /**< (GMAC_ST2CW09) Compare Value Mask */
+#define GMAC_ST2CW09_COMPVAL(value)         (GMAC_ST2CW09_COMPVAL_Msk & ((value) << GMAC_ST2CW09_COMPVAL_Pos))
+#define GMAC_ST2CW09_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW09) Register Mask  */
+
+
+/* -------- GMAC_ST2CW19 : (GMAC Offset: 0x74c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 9) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW19_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW19_OFFSET                 (0x74C)                                       /**<  (GMAC_ST2CW19) Screening Type 2 Compare Word 1 Register (index = 9)  Offset */
+
+#define GMAC_ST2CW19_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW19) Offset Value in Bytes Position */
+#define GMAC_ST2CW19_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW19_OFFSVAL_Pos)        /**< (GMAC_ST2CW19) Offset Value in Bytes Mask */
+#define GMAC_ST2CW19_OFFSVAL(value)         (GMAC_ST2CW19_OFFSVAL_Msk & ((value) << GMAC_ST2CW19_OFFSVAL_Pos))
+#define GMAC_ST2CW19_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW19) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW19_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW19_OFFSSTRT_Pos)        /**< (GMAC_ST2CW19) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW19_OFFSSTRT(value)        (GMAC_ST2CW19_OFFSSTRT_Msk & ((value) << GMAC_ST2CW19_OFFSSTRT_Pos))
+#define   GMAC_ST2CW19_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW19) Offset from the start of the frame  */
+#define   GMAC_ST2CW19_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW19) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW19_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW19) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW19_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW19) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW19_OFFSSTRT_FRAMESTART    (GMAC_ST2CW19_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the start of the frame Position  */
+#define GMAC_ST2CW19_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW19_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW19_OFFSSTRT_IP            (GMAC_ST2CW19_OFFSSTRT_IP_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW19_OFFSSTRT_TCP_UDP       (GMAC_ST2CW19_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW19_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW19) Register MASK  (Use GMAC_ST2CW19_Msk instead)  */
+#define GMAC_ST2CW19_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW19) Register Mask  */
+
+
+/* -------- GMAC_ST2CW010 : (GMAC Offset: 0x750) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 10) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW010_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW010_OFFSET                (0x750)                                       /**<  (GMAC_ST2CW010) Screening Type 2 Compare Word 0 Register (index = 10)  Offset */
+
+#define GMAC_ST2CW010_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW010) Mask Value Position */
+#define GMAC_ST2CW010_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW010_MASKVAL_Pos)     /**< (GMAC_ST2CW010) Mask Value Mask */
+#define GMAC_ST2CW010_MASKVAL(value)        (GMAC_ST2CW010_MASKVAL_Msk & ((value) << GMAC_ST2CW010_MASKVAL_Pos))
+#define GMAC_ST2CW010_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW010) Compare Value Position */
+#define GMAC_ST2CW010_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW010_COMPVAL_Pos)     /**< (GMAC_ST2CW010) Compare Value Mask */
+#define GMAC_ST2CW010_COMPVAL(value)        (GMAC_ST2CW010_COMPVAL_Msk & ((value) << GMAC_ST2CW010_COMPVAL_Pos))
+#define GMAC_ST2CW010_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW010) Register Mask  */
+
+
+/* -------- GMAC_ST2CW110 : (GMAC Offset: 0x754) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 10) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW110_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW110_OFFSET                (0x754)                                       /**<  (GMAC_ST2CW110) Screening Type 2 Compare Word 1 Register (index = 10)  Offset */
+
+#define GMAC_ST2CW110_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW110) Offset Value in Bytes Position */
+#define GMAC_ST2CW110_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW110_OFFSVAL_Pos)       /**< (GMAC_ST2CW110) Offset Value in Bytes Mask */
+#define GMAC_ST2CW110_OFFSVAL(value)        (GMAC_ST2CW110_OFFSVAL_Msk & ((value) << GMAC_ST2CW110_OFFSVAL_Pos))
+#define GMAC_ST2CW110_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW110) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW110_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW110_OFFSSTRT_Pos)       /**< (GMAC_ST2CW110) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW110_OFFSSTRT(value)       (GMAC_ST2CW110_OFFSSTRT_Msk & ((value) << GMAC_ST2CW110_OFFSSTRT_Pos))
+#define   GMAC_ST2CW110_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW110) Offset from the start of the frame  */
+#define   GMAC_ST2CW110_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW110) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW110_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW110) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW110_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW110) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW110_OFFSSTRT_FRAMESTART   (GMAC_ST2CW110_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the start of the frame Position  */
+#define GMAC_ST2CW110_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW110_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW110_OFFSSTRT_IP           (GMAC_ST2CW110_OFFSSTRT_IP_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW110_OFFSSTRT_TCP_UDP      (GMAC_ST2CW110_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW110_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW110) Register MASK  (Use GMAC_ST2CW110_Msk instead)  */
+#define GMAC_ST2CW110_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW110) Register Mask  */
+
+
+/* -------- GMAC_ST2CW011 : (GMAC Offset: 0x758) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 11) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW011_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW011_OFFSET                (0x758)                                       /**<  (GMAC_ST2CW011) Screening Type 2 Compare Word 0 Register (index = 11)  Offset */
+
+#define GMAC_ST2CW011_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW011) Mask Value Position */
+#define GMAC_ST2CW011_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW011_MASKVAL_Pos)     /**< (GMAC_ST2CW011) Mask Value Mask */
+#define GMAC_ST2CW011_MASKVAL(value)        (GMAC_ST2CW011_MASKVAL_Msk & ((value) << GMAC_ST2CW011_MASKVAL_Pos))
+#define GMAC_ST2CW011_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW011) Compare Value Position */
+#define GMAC_ST2CW011_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW011_COMPVAL_Pos)     /**< (GMAC_ST2CW011) Compare Value Mask */
+#define GMAC_ST2CW011_COMPVAL(value)        (GMAC_ST2CW011_COMPVAL_Msk & ((value) << GMAC_ST2CW011_COMPVAL_Pos))
+#define GMAC_ST2CW011_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW011) Register Mask  */
+
+
+/* -------- GMAC_ST2CW111 : (GMAC Offset: 0x75c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 11) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW111_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW111_OFFSET                (0x75C)                                       /**<  (GMAC_ST2CW111) Screening Type 2 Compare Word 1 Register (index = 11)  Offset */
+
+#define GMAC_ST2CW111_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW111) Offset Value in Bytes Position */
+#define GMAC_ST2CW111_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW111_OFFSVAL_Pos)       /**< (GMAC_ST2CW111) Offset Value in Bytes Mask */
+#define GMAC_ST2CW111_OFFSVAL(value)        (GMAC_ST2CW111_OFFSVAL_Msk & ((value) << GMAC_ST2CW111_OFFSVAL_Pos))
+#define GMAC_ST2CW111_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW111) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW111_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW111_OFFSSTRT_Pos)       /**< (GMAC_ST2CW111) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW111_OFFSSTRT(value)       (GMAC_ST2CW111_OFFSSTRT_Msk & ((value) << GMAC_ST2CW111_OFFSSTRT_Pos))
+#define   GMAC_ST2CW111_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW111) Offset from the start of the frame  */
+#define   GMAC_ST2CW111_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW111) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW111_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW111) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW111_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW111) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW111_OFFSSTRT_FRAMESTART   (GMAC_ST2CW111_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the start of the frame Position  */
+#define GMAC_ST2CW111_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW111_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW111_OFFSSTRT_IP           (GMAC_ST2CW111_OFFSSTRT_IP_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW111_OFFSSTRT_TCP_UDP      (GMAC_ST2CW111_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW111_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW111) Register MASK  (Use GMAC_ST2CW111_Msk instead)  */
+#define GMAC_ST2CW111_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW111) Register Mask  */
+
+
+/* -------- GMAC_ST2CW012 : (GMAC Offset: 0x760) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 12) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW012_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW012_OFFSET                (0x760)                                       /**<  (GMAC_ST2CW012) Screening Type 2 Compare Word 0 Register (index = 12)  Offset */
+
+#define GMAC_ST2CW012_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW012) Mask Value Position */
+#define GMAC_ST2CW012_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW012_MASKVAL_Pos)     /**< (GMAC_ST2CW012) Mask Value Mask */
+#define GMAC_ST2CW012_MASKVAL(value)        (GMAC_ST2CW012_MASKVAL_Msk & ((value) << GMAC_ST2CW012_MASKVAL_Pos))
+#define GMAC_ST2CW012_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW012) Compare Value Position */
+#define GMAC_ST2CW012_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW012_COMPVAL_Pos)     /**< (GMAC_ST2CW012) Compare Value Mask */
+#define GMAC_ST2CW012_COMPVAL(value)        (GMAC_ST2CW012_COMPVAL_Msk & ((value) << GMAC_ST2CW012_COMPVAL_Pos))
+#define GMAC_ST2CW012_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW012) Register Mask  */
+
+
+/* -------- GMAC_ST2CW112 : (GMAC Offset: 0x764) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 12) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW112_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW112_OFFSET                (0x764)                                       /**<  (GMAC_ST2CW112) Screening Type 2 Compare Word 1 Register (index = 12)  Offset */
+
+#define GMAC_ST2CW112_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW112) Offset Value in Bytes Position */
+#define GMAC_ST2CW112_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW112_OFFSVAL_Pos)       /**< (GMAC_ST2CW112) Offset Value in Bytes Mask */
+#define GMAC_ST2CW112_OFFSVAL(value)        (GMAC_ST2CW112_OFFSVAL_Msk & ((value) << GMAC_ST2CW112_OFFSVAL_Pos))
+#define GMAC_ST2CW112_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW112) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW112_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW112_OFFSSTRT_Pos)       /**< (GMAC_ST2CW112) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW112_OFFSSTRT(value)       (GMAC_ST2CW112_OFFSSTRT_Msk & ((value) << GMAC_ST2CW112_OFFSSTRT_Pos))
+#define   GMAC_ST2CW112_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW112) Offset from the start of the frame  */
+#define   GMAC_ST2CW112_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW112) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW112_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW112) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW112_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW112) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW112_OFFSSTRT_FRAMESTART   (GMAC_ST2CW112_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the start of the frame Position  */
+#define GMAC_ST2CW112_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW112_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW112_OFFSSTRT_IP           (GMAC_ST2CW112_OFFSSTRT_IP_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW112_OFFSSTRT_TCP_UDP      (GMAC_ST2CW112_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW112_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW112) Register MASK  (Use GMAC_ST2CW112_Msk instead)  */
+#define GMAC_ST2CW112_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW112) Register Mask  */
+
+
+/* -------- GMAC_ST2CW013 : (GMAC Offset: 0x768) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 13) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW013_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW013_OFFSET                (0x768)                                       /**<  (GMAC_ST2CW013) Screening Type 2 Compare Word 0 Register (index = 13)  Offset */
+
+#define GMAC_ST2CW013_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW013) Mask Value Position */
+#define GMAC_ST2CW013_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW013_MASKVAL_Pos)     /**< (GMAC_ST2CW013) Mask Value Mask */
+#define GMAC_ST2CW013_MASKVAL(value)        (GMAC_ST2CW013_MASKVAL_Msk & ((value) << GMAC_ST2CW013_MASKVAL_Pos))
+#define GMAC_ST2CW013_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW013) Compare Value Position */
+#define GMAC_ST2CW013_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW013_COMPVAL_Pos)     /**< (GMAC_ST2CW013) Compare Value Mask */
+#define GMAC_ST2CW013_COMPVAL(value)        (GMAC_ST2CW013_COMPVAL_Msk & ((value) << GMAC_ST2CW013_COMPVAL_Pos))
+#define GMAC_ST2CW013_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW013) Register Mask  */
+
+
+/* -------- GMAC_ST2CW113 : (GMAC Offset: 0x76c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 13) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW113_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW113_OFFSET                (0x76C)                                       /**<  (GMAC_ST2CW113) Screening Type 2 Compare Word 1 Register (index = 13)  Offset */
+
+#define GMAC_ST2CW113_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW113) Offset Value in Bytes Position */
+#define GMAC_ST2CW113_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW113_OFFSVAL_Pos)       /**< (GMAC_ST2CW113) Offset Value in Bytes Mask */
+#define GMAC_ST2CW113_OFFSVAL(value)        (GMAC_ST2CW113_OFFSVAL_Msk & ((value) << GMAC_ST2CW113_OFFSVAL_Pos))
+#define GMAC_ST2CW113_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW113) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW113_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW113_OFFSSTRT_Pos)       /**< (GMAC_ST2CW113) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW113_OFFSSTRT(value)       (GMAC_ST2CW113_OFFSSTRT_Msk & ((value) << GMAC_ST2CW113_OFFSSTRT_Pos))
+#define   GMAC_ST2CW113_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW113) Offset from the start of the frame  */
+#define   GMAC_ST2CW113_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW113) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW113_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW113) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW113_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW113) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW113_OFFSSTRT_FRAMESTART   (GMAC_ST2CW113_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the start of the frame Position  */
+#define GMAC_ST2CW113_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW113_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW113_OFFSSTRT_IP           (GMAC_ST2CW113_OFFSSTRT_IP_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW113_OFFSSTRT_TCP_UDP      (GMAC_ST2CW113_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW113_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW113) Register MASK  (Use GMAC_ST2CW113_Msk instead)  */
+#define GMAC_ST2CW113_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW113) Register Mask  */
+
+
+/* -------- GMAC_ST2CW014 : (GMAC Offset: 0x770) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 14) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW014_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW014_OFFSET                (0x770)                                       /**<  (GMAC_ST2CW014) Screening Type 2 Compare Word 0 Register (index = 14)  Offset */
+
+#define GMAC_ST2CW014_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW014) Mask Value Position */
+#define GMAC_ST2CW014_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW014_MASKVAL_Pos)     /**< (GMAC_ST2CW014) Mask Value Mask */
+#define GMAC_ST2CW014_MASKVAL(value)        (GMAC_ST2CW014_MASKVAL_Msk & ((value) << GMAC_ST2CW014_MASKVAL_Pos))
+#define GMAC_ST2CW014_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW014) Compare Value Position */
+#define GMAC_ST2CW014_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW014_COMPVAL_Pos)     /**< (GMAC_ST2CW014) Compare Value Mask */
+#define GMAC_ST2CW014_COMPVAL(value)        (GMAC_ST2CW014_COMPVAL_Msk & ((value) << GMAC_ST2CW014_COMPVAL_Pos))
+#define GMAC_ST2CW014_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW014) Register Mask  */
+
+
+/* -------- GMAC_ST2CW114 : (GMAC Offset: 0x774) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 14) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW114_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW114_OFFSET                (0x774)                                       /**<  (GMAC_ST2CW114) Screening Type 2 Compare Word 1 Register (index = 14)  Offset */
+
+#define GMAC_ST2CW114_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW114) Offset Value in Bytes Position */
+#define GMAC_ST2CW114_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW114_OFFSVAL_Pos)       /**< (GMAC_ST2CW114) Offset Value in Bytes Mask */
+#define GMAC_ST2CW114_OFFSVAL(value)        (GMAC_ST2CW114_OFFSVAL_Msk & ((value) << GMAC_ST2CW114_OFFSVAL_Pos))
+#define GMAC_ST2CW114_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW114) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW114_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW114_OFFSSTRT_Pos)       /**< (GMAC_ST2CW114) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW114_OFFSSTRT(value)       (GMAC_ST2CW114_OFFSSTRT_Msk & ((value) << GMAC_ST2CW114_OFFSSTRT_Pos))
+#define   GMAC_ST2CW114_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW114) Offset from the start of the frame  */
+#define   GMAC_ST2CW114_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW114) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW114_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW114) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW114_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW114) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW114_OFFSSTRT_FRAMESTART   (GMAC_ST2CW114_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the start of the frame Position  */
+#define GMAC_ST2CW114_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW114_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW114_OFFSSTRT_IP           (GMAC_ST2CW114_OFFSSTRT_IP_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW114_OFFSSTRT_TCP_UDP      (GMAC_ST2CW114_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW114_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW114) Register MASK  (Use GMAC_ST2CW114_Msk instead)  */
+#define GMAC_ST2CW114_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW114) Register Mask  */
+
+
+/* -------- GMAC_ST2CW015 : (GMAC Offset: 0x778) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 15) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW015_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW015_OFFSET                (0x778)                                       /**<  (GMAC_ST2CW015) Screening Type 2 Compare Word 0 Register (index = 15)  Offset */
+
+#define GMAC_ST2CW015_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW015) Mask Value Position */
+#define GMAC_ST2CW015_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW015_MASKVAL_Pos)     /**< (GMAC_ST2CW015) Mask Value Mask */
+#define GMAC_ST2CW015_MASKVAL(value)        (GMAC_ST2CW015_MASKVAL_Msk & ((value) << GMAC_ST2CW015_MASKVAL_Pos))
+#define GMAC_ST2CW015_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW015) Compare Value Position */
+#define GMAC_ST2CW015_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW015_COMPVAL_Pos)     /**< (GMAC_ST2CW015) Compare Value Mask */
+#define GMAC_ST2CW015_COMPVAL(value)        (GMAC_ST2CW015_COMPVAL_Msk & ((value) << GMAC_ST2CW015_COMPVAL_Pos))
+#define GMAC_ST2CW015_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW015) Register Mask  */
+
+
+/* -------- GMAC_ST2CW115 : (GMAC Offset: 0x77c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 15) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW115_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW115_OFFSET                (0x77C)                                       /**<  (GMAC_ST2CW115) Screening Type 2 Compare Word 1 Register (index = 15)  Offset */
+
+#define GMAC_ST2CW115_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW115) Offset Value in Bytes Position */
+#define GMAC_ST2CW115_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW115_OFFSVAL_Pos)       /**< (GMAC_ST2CW115) Offset Value in Bytes Mask */
+#define GMAC_ST2CW115_OFFSVAL(value)        (GMAC_ST2CW115_OFFSVAL_Msk & ((value) << GMAC_ST2CW115_OFFSVAL_Pos))
+#define GMAC_ST2CW115_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW115) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW115_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW115_OFFSSTRT_Pos)       /**< (GMAC_ST2CW115) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW115_OFFSSTRT(value)       (GMAC_ST2CW115_OFFSSTRT_Msk & ((value) << GMAC_ST2CW115_OFFSSTRT_Pos))
+#define   GMAC_ST2CW115_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW115) Offset from the start of the frame  */
+#define   GMAC_ST2CW115_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW115) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW115_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW115) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW115_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW115) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW115_OFFSSTRT_FRAMESTART   (GMAC_ST2CW115_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the start of the frame Position  */
+#define GMAC_ST2CW115_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW115_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW115_OFFSSTRT_IP           (GMAC_ST2CW115_OFFSSTRT_IP_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW115_OFFSSTRT_TCP_UDP      (GMAC_ST2CW115_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW115_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW115) Register MASK  (Use GMAC_ST2CW115_Msk instead)  */
+#define GMAC_ST2CW115_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW115) Register Mask  */
+
+
+/* -------- GMAC_ST2CW016 : (GMAC Offset: 0x780) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 16) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW016_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW016_OFFSET                (0x780)                                       /**<  (GMAC_ST2CW016) Screening Type 2 Compare Word 0 Register (index = 16)  Offset */
+
+#define GMAC_ST2CW016_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW016) Mask Value Position */
+#define GMAC_ST2CW016_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW016_MASKVAL_Pos)     /**< (GMAC_ST2CW016) Mask Value Mask */
+#define GMAC_ST2CW016_MASKVAL(value)        (GMAC_ST2CW016_MASKVAL_Msk & ((value) << GMAC_ST2CW016_MASKVAL_Pos))
+#define GMAC_ST2CW016_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW016) Compare Value Position */
+#define GMAC_ST2CW016_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW016_COMPVAL_Pos)     /**< (GMAC_ST2CW016) Compare Value Mask */
+#define GMAC_ST2CW016_COMPVAL(value)        (GMAC_ST2CW016_COMPVAL_Msk & ((value) << GMAC_ST2CW016_COMPVAL_Pos))
+#define GMAC_ST2CW016_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW016) Register Mask  */
+
+
+/* -------- GMAC_ST2CW116 : (GMAC Offset: 0x784) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 16) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW116_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW116_OFFSET                (0x784)                                       /**<  (GMAC_ST2CW116) Screening Type 2 Compare Word 1 Register (index = 16)  Offset */
+
+#define GMAC_ST2CW116_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW116) Offset Value in Bytes Position */
+#define GMAC_ST2CW116_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW116_OFFSVAL_Pos)       /**< (GMAC_ST2CW116) Offset Value in Bytes Mask */
+#define GMAC_ST2CW116_OFFSVAL(value)        (GMAC_ST2CW116_OFFSVAL_Msk & ((value) << GMAC_ST2CW116_OFFSVAL_Pos))
+#define GMAC_ST2CW116_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW116) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW116_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW116_OFFSSTRT_Pos)       /**< (GMAC_ST2CW116) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW116_OFFSSTRT(value)       (GMAC_ST2CW116_OFFSSTRT_Msk & ((value) << GMAC_ST2CW116_OFFSSTRT_Pos))
+#define   GMAC_ST2CW116_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW116) Offset from the start of the frame  */
+#define   GMAC_ST2CW116_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW116) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW116_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW116) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW116_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW116) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW116_OFFSSTRT_FRAMESTART   (GMAC_ST2CW116_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the start of the frame Position  */
+#define GMAC_ST2CW116_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW116_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW116_OFFSSTRT_IP           (GMAC_ST2CW116_OFFSSTRT_IP_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW116_OFFSSTRT_TCP_UDP      (GMAC_ST2CW116_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW116_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW116) Register MASK  (Use GMAC_ST2CW116_Msk instead)  */
+#define GMAC_ST2CW116_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW116) Register Mask  */
+
+
+/* -------- GMAC_ST2CW017 : (GMAC Offset: 0x788) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 17) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW017_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW017_OFFSET                (0x788)                                       /**<  (GMAC_ST2CW017) Screening Type 2 Compare Word 0 Register (index = 17)  Offset */
+
+#define GMAC_ST2CW017_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW017) Mask Value Position */
+#define GMAC_ST2CW017_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW017_MASKVAL_Pos)     /**< (GMAC_ST2CW017) Mask Value Mask */
+#define GMAC_ST2CW017_MASKVAL(value)        (GMAC_ST2CW017_MASKVAL_Msk & ((value) << GMAC_ST2CW017_MASKVAL_Pos))
+#define GMAC_ST2CW017_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW017) Compare Value Position */
+#define GMAC_ST2CW017_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW017_COMPVAL_Pos)     /**< (GMAC_ST2CW017) Compare Value Mask */
+#define GMAC_ST2CW017_COMPVAL(value)        (GMAC_ST2CW017_COMPVAL_Msk & ((value) << GMAC_ST2CW017_COMPVAL_Pos))
+#define GMAC_ST2CW017_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW017) Register Mask  */
+
+
+/* -------- GMAC_ST2CW117 : (GMAC Offset: 0x78c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 17) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW117_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW117_OFFSET                (0x78C)                                       /**<  (GMAC_ST2CW117) Screening Type 2 Compare Word 1 Register (index = 17)  Offset */
+
+#define GMAC_ST2CW117_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW117) Offset Value in Bytes Position */
+#define GMAC_ST2CW117_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW117_OFFSVAL_Pos)       /**< (GMAC_ST2CW117) Offset Value in Bytes Mask */
+#define GMAC_ST2CW117_OFFSVAL(value)        (GMAC_ST2CW117_OFFSVAL_Msk & ((value) << GMAC_ST2CW117_OFFSVAL_Pos))
+#define GMAC_ST2CW117_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW117) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW117_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW117_OFFSSTRT_Pos)       /**< (GMAC_ST2CW117) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW117_OFFSSTRT(value)       (GMAC_ST2CW117_OFFSSTRT_Msk & ((value) << GMAC_ST2CW117_OFFSSTRT_Pos))
+#define   GMAC_ST2CW117_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW117) Offset from the start of the frame  */
+#define   GMAC_ST2CW117_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW117) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW117_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW117) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW117_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW117) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW117_OFFSSTRT_FRAMESTART   (GMAC_ST2CW117_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the start of the frame Position  */
+#define GMAC_ST2CW117_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW117_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW117_OFFSSTRT_IP           (GMAC_ST2CW117_OFFSSTRT_IP_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW117_OFFSSTRT_TCP_UDP      (GMAC_ST2CW117_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW117_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW117) Register MASK  (Use GMAC_ST2CW117_Msk instead)  */
+#define GMAC_ST2CW117_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW117) Register Mask  */
+
+
+/* -------- GMAC_ST2CW018 : (GMAC Offset: 0x790) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 18) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW018_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW018_OFFSET                (0x790)                                       /**<  (GMAC_ST2CW018) Screening Type 2 Compare Word 0 Register (index = 18)  Offset */
+
+#define GMAC_ST2CW018_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW018) Mask Value Position */
+#define GMAC_ST2CW018_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW018_MASKVAL_Pos)     /**< (GMAC_ST2CW018) Mask Value Mask */
+#define GMAC_ST2CW018_MASKVAL(value)        (GMAC_ST2CW018_MASKVAL_Msk & ((value) << GMAC_ST2CW018_MASKVAL_Pos))
+#define GMAC_ST2CW018_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW018) Compare Value Position */
+#define GMAC_ST2CW018_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW018_COMPVAL_Pos)     /**< (GMAC_ST2CW018) Compare Value Mask */
+#define GMAC_ST2CW018_COMPVAL(value)        (GMAC_ST2CW018_COMPVAL_Msk & ((value) << GMAC_ST2CW018_COMPVAL_Pos))
+#define GMAC_ST2CW018_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW018) Register Mask  */
+
+
+/* -------- GMAC_ST2CW118 : (GMAC Offset: 0x794) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 18) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW118_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW118_OFFSET                (0x794)                                       /**<  (GMAC_ST2CW118) Screening Type 2 Compare Word 1 Register (index = 18)  Offset */
+
+#define GMAC_ST2CW118_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW118) Offset Value in Bytes Position */
+#define GMAC_ST2CW118_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW118_OFFSVAL_Pos)       /**< (GMAC_ST2CW118) Offset Value in Bytes Mask */
+#define GMAC_ST2CW118_OFFSVAL(value)        (GMAC_ST2CW118_OFFSVAL_Msk & ((value) << GMAC_ST2CW118_OFFSVAL_Pos))
+#define GMAC_ST2CW118_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW118) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW118_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW118_OFFSSTRT_Pos)       /**< (GMAC_ST2CW118) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW118_OFFSSTRT(value)       (GMAC_ST2CW118_OFFSSTRT_Msk & ((value) << GMAC_ST2CW118_OFFSSTRT_Pos))
+#define   GMAC_ST2CW118_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW118) Offset from the start of the frame  */
+#define   GMAC_ST2CW118_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW118) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW118_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW118) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW118_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW118) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW118_OFFSSTRT_FRAMESTART   (GMAC_ST2CW118_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the start of the frame Position  */
+#define GMAC_ST2CW118_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW118_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW118_OFFSSTRT_IP           (GMAC_ST2CW118_OFFSSTRT_IP_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW118_OFFSSTRT_TCP_UDP      (GMAC_ST2CW118_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW118_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW118) Register MASK  (Use GMAC_ST2CW118_Msk instead)  */
+#define GMAC_ST2CW118_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW118) Register Mask  */
+
+
+/* -------- GMAC_ST2CW019 : (GMAC Offset: 0x798) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 19) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW019_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW019_OFFSET                (0x798)                                       /**<  (GMAC_ST2CW019) Screening Type 2 Compare Word 0 Register (index = 19)  Offset */
+
+#define GMAC_ST2CW019_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW019) Mask Value Position */
+#define GMAC_ST2CW019_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW019_MASKVAL_Pos)     /**< (GMAC_ST2CW019) Mask Value Mask */
+#define GMAC_ST2CW019_MASKVAL(value)        (GMAC_ST2CW019_MASKVAL_Msk & ((value) << GMAC_ST2CW019_MASKVAL_Pos))
+#define GMAC_ST2CW019_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW019) Compare Value Position */
+#define GMAC_ST2CW019_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW019_COMPVAL_Pos)     /**< (GMAC_ST2CW019) Compare Value Mask */
+#define GMAC_ST2CW019_COMPVAL(value)        (GMAC_ST2CW019_COMPVAL_Msk & ((value) << GMAC_ST2CW019_COMPVAL_Pos))
+#define GMAC_ST2CW019_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW019) Register Mask  */
+
+
+/* -------- GMAC_ST2CW119 : (GMAC Offset: 0x79c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 19) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW119_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW119_OFFSET                (0x79C)                                       /**<  (GMAC_ST2CW119) Screening Type 2 Compare Word 1 Register (index = 19)  Offset */
+
+#define GMAC_ST2CW119_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW119) Offset Value in Bytes Position */
+#define GMAC_ST2CW119_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW119_OFFSVAL_Pos)       /**< (GMAC_ST2CW119) Offset Value in Bytes Mask */
+#define GMAC_ST2CW119_OFFSVAL(value)        (GMAC_ST2CW119_OFFSVAL_Msk & ((value) << GMAC_ST2CW119_OFFSVAL_Pos))
+#define GMAC_ST2CW119_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW119) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW119_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW119_OFFSSTRT_Pos)       /**< (GMAC_ST2CW119) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW119_OFFSSTRT(value)       (GMAC_ST2CW119_OFFSSTRT_Msk & ((value) << GMAC_ST2CW119_OFFSSTRT_Pos))
+#define   GMAC_ST2CW119_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW119) Offset from the start of the frame  */
+#define   GMAC_ST2CW119_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW119) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW119_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW119) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW119_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW119) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW119_OFFSSTRT_FRAMESTART   (GMAC_ST2CW119_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the start of the frame Position  */
+#define GMAC_ST2CW119_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW119_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW119_OFFSSTRT_IP           (GMAC_ST2CW119_OFFSSTRT_IP_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW119_OFFSSTRT_TCP_UDP      (GMAC_ST2CW119_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW119_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW119) Register MASK  (Use GMAC_ST2CW119_Msk instead)  */
+#define GMAC_ST2CW119_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW119) Register Mask  */
+
+
+/* -------- GMAC_ST2CW020 : (GMAC Offset: 0x7a0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 20) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW020_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW020_OFFSET                (0x7A0)                                       /**<  (GMAC_ST2CW020) Screening Type 2 Compare Word 0 Register (index = 20)  Offset */
+
+#define GMAC_ST2CW020_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW020) Mask Value Position */
+#define GMAC_ST2CW020_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW020_MASKVAL_Pos)     /**< (GMAC_ST2CW020) Mask Value Mask */
+#define GMAC_ST2CW020_MASKVAL(value)        (GMAC_ST2CW020_MASKVAL_Msk & ((value) << GMAC_ST2CW020_MASKVAL_Pos))
+#define GMAC_ST2CW020_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW020) Compare Value Position */
+#define GMAC_ST2CW020_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW020_COMPVAL_Pos)     /**< (GMAC_ST2CW020) Compare Value Mask */
+#define GMAC_ST2CW020_COMPVAL(value)        (GMAC_ST2CW020_COMPVAL_Msk & ((value) << GMAC_ST2CW020_COMPVAL_Pos))
+#define GMAC_ST2CW020_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW020) Register Mask  */
+
+
+/* -------- GMAC_ST2CW120 : (GMAC Offset: 0x7a4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 20) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW120_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW120_OFFSET                (0x7A4)                                       /**<  (GMAC_ST2CW120) Screening Type 2 Compare Word 1 Register (index = 20)  Offset */
+
+#define GMAC_ST2CW120_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW120) Offset Value in Bytes Position */
+#define GMAC_ST2CW120_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW120_OFFSVAL_Pos)       /**< (GMAC_ST2CW120) Offset Value in Bytes Mask */
+#define GMAC_ST2CW120_OFFSVAL(value)        (GMAC_ST2CW120_OFFSVAL_Msk & ((value) << GMAC_ST2CW120_OFFSVAL_Pos))
+#define GMAC_ST2CW120_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW120) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW120_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW120_OFFSSTRT_Pos)       /**< (GMAC_ST2CW120) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW120_OFFSSTRT(value)       (GMAC_ST2CW120_OFFSSTRT_Msk & ((value) << GMAC_ST2CW120_OFFSSTRT_Pos))
+#define   GMAC_ST2CW120_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW120) Offset from the start of the frame  */
+#define   GMAC_ST2CW120_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW120) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW120_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW120) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW120_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW120) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW120_OFFSSTRT_FRAMESTART   (GMAC_ST2CW120_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the start of the frame Position  */
+#define GMAC_ST2CW120_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW120_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW120_OFFSSTRT_IP           (GMAC_ST2CW120_OFFSSTRT_IP_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW120_OFFSSTRT_TCP_UDP      (GMAC_ST2CW120_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW120_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW120) Register MASK  (Use GMAC_ST2CW120_Msk instead)  */
+#define GMAC_ST2CW120_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW120) Register Mask  */
+
+
+/* -------- GMAC_ST2CW021 : (GMAC Offset: 0x7a8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 21) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW021_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW021_OFFSET                (0x7A8)                                       /**<  (GMAC_ST2CW021) Screening Type 2 Compare Word 0 Register (index = 21)  Offset */
+
+#define GMAC_ST2CW021_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW021) Mask Value Position */
+#define GMAC_ST2CW021_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW021_MASKVAL_Pos)     /**< (GMAC_ST2CW021) Mask Value Mask */
+#define GMAC_ST2CW021_MASKVAL(value)        (GMAC_ST2CW021_MASKVAL_Msk & ((value) << GMAC_ST2CW021_MASKVAL_Pos))
+#define GMAC_ST2CW021_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW021) Compare Value Position */
+#define GMAC_ST2CW021_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW021_COMPVAL_Pos)     /**< (GMAC_ST2CW021) Compare Value Mask */
+#define GMAC_ST2CW021_COMPVAL(value)        (GMAC_ST2CW021_COMPVAL_Msk & ((value) << GMAC_ST2CW021_COMPVAL_Pos))
+#define GMAC_ST2CW021_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW021) Register Mask  */
+
+
+/* -------- GMAC_ST2CW121 : (GMAC Offset: 0x7ac) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 21) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW121_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW121_OFFSET                (0x7AC)                                       /**<  (GMAC_ST2CW121) Screening Type 2 Compare Word 1 Register (index = 21)  Offset */
+
+#define GMAC_ST2CW121_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW121) Offset Value in Bytes Position */
+#define GMAC_ST2CW121_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW121_OFFSVAL_Pos)       /**< (GMAC_ST2CW121) Offset Value in Bytes Mask */
+#define GMAC_ST2CW121_OFFSVAL(value)        (GMAC_ST2CW121_OFFSVAL_Msk & ((value) << GMAC_ST2CW121_OFFSVAL_Pos))
+#define GMAC_ST2CW121_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW121) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW121_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW121_OFFSSTRT_Pos)       /**< (GMAC_ST2CW121) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW121_OFFSSTRT(value)       (GMAC_ST2CW121_OFFSSTRT_Msk & ((value) << GMAC_ST2CW121_OFFSSTRT_Pos))
+#define   GMAC_ST2CW121_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW121) Offset from the start of the frame  */
+#define   GMAC_ST2CW121_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW121) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW121_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW121) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW121_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW121) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW121_OFFSSTRT_FRAMESTART   (GMAC_ST2CW121_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the start of the frame Position  */
+#define GMAC_ST2CW121_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW121_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW121_OFFSSTRT_IP           (GMAC_ST2CW121_OFFSSTRT_IP_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW121_OFFSSTRT_TCP_UDP      (GMAC_ST2CW121_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW121_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW121) Register MASK  (Use GMAC_ST2CW121_Msk instead)  */
+#define GMAC_ST2CW121_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW121) Register Mask  */
+
+
+/* -------- GMAC_ST2CW022 : (GMAC Offset: 0x7b0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 22) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW022_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW022_OFFSET                (0x7B0)                                       /**<  (GMAC_ST2CW022) Screening Type 2 Compare Word 0 Register (index = 22)  Offset */
+
+#define GMAC_ST2CW022_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW022) Mask Value Position */
+#define GMAC_ST2CW022_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW022_MASKVAL_Pos)     /**< (GMAC_ST2CW022) Mask Value Mask */
+#define GMAC_ST2CW022_MASKVAL(value)        (GMAC_ST2CW022_MASKVAL_Msk & ((value) << GMAC_ST2CW022_MASKVAL_Pos))
+#define GMAC_ST2CW022_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW022) Compare Value Position */
+#define GMAC_ST2CW022_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW022_COMPVAL_Pos)     /**< (GMAC_ST2CW022) Compare Value Mask */
+#define GMAC_ST2CW022_COMPVAL(value)        (GMAC_ST2CW022_COMPVAL_Msk & ((value) << GMAC_ST2CW022_COMPVAL_Pos))
+#define GMAC_ST2CW022_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW022) Register Mask  */
+
+
+/* -------- GMAC_ST2CW122 : (GMAC Offset: 0x7b4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 22) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW122_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW122_OFFSET                (0x7B4)                                       /**<  (GMAC_ST2CW122) Screening Type 2 Compare Word 1 Register (index = 22)  Offset */
+
+#define GMAC_ST2CW122_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW122) Offset Value in Bytes Position */
+#define GMAC_ST2CW122_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW122_OFFSVAL_Pos)       /**< (GMAC_ST2CW122) Offset Value in Bytes Mask */
+#define GMAC_ST2CW122_OFFSVAL(value)        (GMAC_ST2CW122_OFFSVAL_Msk & ((value) << GMAC_ST2CW122_OFFSVAL_Pos))
+#define GMAC_ST2CW122_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW122) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW122_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW122_OFFSSTRT_Pos)       /**< (GMAC_ST2CW122) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW122_OFFSSTRT(value)       (GMAC_ST2CW122_OFFSSTRT_Msk & ((value) << GMAC_ST2CW122_OFFSSTRT_Pos))
+#define   GMAC_ST2CW122_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW122) Offset from the start of the frame  */
+#define   GMAC_ST2CW122_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW122) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW122_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW122) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW122_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW122) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW122_OFFSSTRT_FRAMESTART   (GMAC_ST2CW122_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the start of the frame Position  */
+#define GMAC_ST2CW122_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW122_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW122_OFFSSTRT_IP           (GMAC_ST2CW122_OFFSSTRT_IP_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW122_OFFSSTRT_TCP_UDP      (GMAC_ST2CW122_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW122_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW122) Register MASK  (Use GMAC_ST2CW122_Msk instead)  */
+#define GMAC_ST2CW122_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW122) Register Mask  */
+
+
+/* -------- GMAC_ST2CW023 : (GMAC Offset: 0x7b8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 23) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW023_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW023_OFFSET                (0x7B8)                                       /**<  (GMAC_ST2CW023) Screening Type 2 Compare Word 0 Register (index = 23)  Offset */
+
+#define GMAC_ST2CW023_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW023) Mask Value Position */
+#define GMAC_ST2CW023_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW023_MASKVAL_Pos)     /**< (GMAC_ST2CW023) Mask Value Mask */
+#define GMAC_ST2CW023_MASKVAL(value)        (GMAC_ST2CW023_MASKVAL_Msk & ((value) << GMAC_ST2CW023_MASKVAL_Pos))
+#define GMAC_ST2CW023_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW023) Compare Value Position */
+#define GMAC_ST2CW023_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW023_COMPVAL_Pos)     /**< (GMAC_ST2CW023) Compare Value Mask */
+#define GMAC_ST2CW023_COMPVAL(value)        (GMAC_ST2CW023_COMPVAL_Msk & ((value) << GMAC_ST2CW023_COMPVAL_Pos))
+#define GMAC_ST2CW023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW023) Register Mask  */
+
+
+/* -------- GMAC_ST2CW123 : (GMAC Offset: 0x7bc) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 23) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW123_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW123_OFFSET                (0x7BC)                                       /**<  (GMAC_ST2CW123) Screening Type 2 Compare Word 1 Register (index = 23)  Offset */
+
+#define GMAC_ST2CW123_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW123) Offset Value in Bytes Position */
+#define GMAC_ST2CW123_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW123_OFFSVAL_Pos)       /**< (GMAC_ST2CW123) Offset Value in Bytes Mask */
+#define GMAC_ST2CW123_OFFSVAL(value)        (GMAC_ST2CW123_OFFSVAL_Msk & ((value) << GMAC_ST2CW123_OFFSVAL_Pos))
+#define GMAC_ST2CW123_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW123) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW123_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW123_OFFSSTRT_Pos)       /**< (GMAC_ST2CW123) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW123_OFFSSTRT(value)       (GMAC_ST2CW123_OFFSSTRT_Msk & ((value) << GMAC_ST2CW123_OFFSSTRT_Pos))
+#define   GMAC_ST2CW123_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW123) Offset from the start of the frame  */
+#define   GMAC_ST2CW123_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW123) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW123_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW123) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW123_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW123) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW123_OFFSSTRT_FRAMESTART   (GMAC_ST2CW123_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the start of the frame Position  */
+#define GMAC_ST2CW123_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW123_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW123_OFFSSTRT_IP           (GMAC_ST2CW123_OFFSSTRT_IP_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW123_OFFSSTRT_TCP_UDP      (GMAC_ST2CW123_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW123_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW123) Register MASK  (Use GMAC_ST2CW123_Msk instead)  */
+#define GMAC_ST2CW123_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW123) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief GMAC_SA hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_SAB;       /**< (GMAC_SA Offset: 0x00) Specific Address 1 Bottom Register */
+  __IO uint32_t GMAC_SAT;       /**< (GMAC_SA Offset: 0x04) Specific Address 1 Top Register */
+} GmacSa;
+
+#define GMACSA_NUMBER 4
+/** \brief GMAC hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_NCR;       /**< (GMAC Offset: 0x00) Network Control Register */
+  __IO uint32_t GMAC_NCFGR;     /**< (GMAC Offset: 0x04) Network Configuration Register */
+  __I  uint32_t GMAC_NSR;       /**< (GMAC Offset: 0x08) Network Status Register */
+  __IO uint32_t GMAC_UR;        /**< (GMAC Offset: 0x0C) User Register */
+  __IO uint32_t GMAC_DCFGR;     /**< (GMAC Offset: 0x10) DMA Configuration Register */
+  __IO uint32_t GMAC_TSR;       /**< (GMAC Offset: 0x14) Transmit Status Register */
+  __IO uint32_t GMAC_RBQB;      /**< (GMAC Offset: 0x18) Receive Buffer Queue Base Address Register */
+  __IO uint32_t GMAC_TBQB;      /**< (GMAC Offset: 0x1C) Transmit Buffer Queue Base Address Register */
+  __IO uint32_t GMAC_RSR;       /**< (GMAC Offset: 0x20) Receive Status Register */
+  __I  uint32_t GMAC_ISR;       /**< (GMAC Offset: 0x24) Interrupt Status Register */
+  __O  uint32_t GMAC_IER;       /**< (GMAC Offset: 0x28) Interrupt Enable Register */
+  __O  uint32_t GMAC_IDR;       /**< (GMAC Offset: 0x2C) Interrupt Disable Register */
+  __IO uint32_t GMAC_IMR;       /**< (GMAC Offset: 0x30) Interrupt Mask Register */
+  __IO uint32_t GMAC_MAN;       /**< (GMAC Offset: 0x34) PHY Maintenance Register */
+  __I  uint32_t GMAC_RPQ;       /**< (GMAC Offset: 0x38) Received Pause Quantum Register */
+  __IO uint32_t GMAC_TPQ;       /**< (GMAC Offset: 0x3C) Transmit Pause Quantum Register */
+  __IO uint32_t GMAC_TPSF;      /**< (GMAC Offset: 0x40) TX Partial Store and Forward Register */
+  __IO uint32_t GMAC_RPSF;      /**< (GMAC Offset: 0x44) RX Partial Store and Forward Register */
+  __IO uint32_t GMAC_RJFML;     /**< (GMAC Offset: 0x48) RX Jumbo Frame Max Length Register */
+  __I  uint8_t                        Reserved1[52];
+  __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
+  __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
+       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+  __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
+  __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
+  __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
+  __IO uint32_t GMAC_TIDM4;     /**< (GMAC Offset: 0xB4) Type ID Match 4 Register */
+  __IO uint32_t GMAC_WOL;       /**< (GMAC Offset: 0xB8) Wake on LAN Register */
+  __IO uint32_t GMAC_IPGS;      /**< (GMAC Offset: 0xBC) IPG Stretch Register */
+  __IO uint32_t GMAC_SVLAN;     /**< (GMAC Offset: 0xC0) Stacked VLAN Register */
+  __IO uint32_t GMAC_TPFCP;     /**< (GMAC Offset: 0xC4) Transmit PFC Pause Register */
+  __IO uint32_t GMAC_SAMB1;     /**< (GMAC Offset: 0xC8) Specific Address 1 Mask Bottom Register */
+  __IO uint32_t GMAC_SAMT1;     /**< (GMAC Offset: 0xCC) Specific Address 1 Mask Top Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO uint32_t GMAC_NSC;       /**< (GMAC Offset: 0xDC) 1588 Timer Nanosecond Comparison Register */
+  __IO uint32_t GMAC_SCL;       /**< (GMAC Offset: 0xE0) 1588 Timer Second Comparison Low Register */
+  __IO uint32_t GMAC_SCH;       /**< (GMAC Offset: 0xE4) 1588 Timer Second Comparison High Register */
+  __I  uint32_t GMAC_EFTSH;     /**< (GMAC Offset: 0xE8) PTP Event Frame Transmitted Seconds High Register */
+  __I  uint32_t GMAC_EFRSH;     /**< (GMAC Offset: 0xEC) PTP Event Frame Received Seconds High Register */
+  __I  uint32_t GMAC_PEFTSH;    /**< (GMAC Offset: 0xF0) PTP Peer Event Frame Transmitted Seconds High Register */
+  __I  uint32_t GMAC_PEFRSH;    /**< (GMAC Offset: 0xF4) PTP Peer Event Frame Received Seconds High Register */
+  __I  uint8_t                        Reserved3[4];
+  __I  uint32_t GMAC_MID;       /**< (GMAC Offset: 0xFC) Module ID Register */
+  __I  uint32_t GMAC_OTLO;      /**< (GMAC Offset: 0x100) Octets Transmitted Low Register */
+  __I  uint32_t GMAC_OTHI;      /**< (GMAC Offset: 0x104) Octets Transmitted High Register */
+  __I  uint32_t GMAC_FT;        /**< (GMAC Offset: 0x108) Frames Transmitted Register */
+  __I  uint32_t GMAC_BCFT;      /**< (GMAC Offset: 0x10C) Broadcast Frames Transmitted Register */
+  __I  uint32_t GMAC_MFT;       /**< (GMAC Offset: 0x110) Multicast Frames Transmitted Register */
+  __I  uint32_t GMAC_PFT;       /**< (GMAC Offset: 0x114) Pause Frames Transmitted Register */
+  __I  uint32_t GMAC_BFT64;     /**< (GMAC Offset: 0x118) 64 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT127;   /**< (GMAC Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT255;   /**< (GMAC Offset: 0x120) 128 to 255 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT511;   /**< (GMAC Offset: 0x124) 256 to 511 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT1023;  /**< (GMAC Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT1518;  /**< (GMAC Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_GTBFT1518; /**< (GMAC Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TUR;       /**< (GMAC Offset: 0x134) Transmit Underruns Register */
+  __I  uint32_t GMAC_SCF;       /**< (GMAC Offset: 0x138) Single Collision Frames Register */
+  __I  uint32_t GMAC_MCF;       /**< (GMAC Offset: 0x13C) Multiple Collision Frames Register */
+  __I  uint32_t GMAC_EC;        /**< (GMAC Offset: 0x140) Excessive Collisions Register */
+  __I  uint32_t GMAC_LC;        /**< (GMAC Offset: 0x144) Late Collisions Register */
+  __I  uint32_t GMAC_DTF;       /**< (GMAC Offset: 0x148) Deferred Transmission Frames Register */
+  __I  uint32_t GMAC_CSE;       /**< (GMAC Offset: 0x14C) Carrier Sense Errors Register */
+  __I  uint32_t GMAC_ORLO;      /**< (GMAC Offset: 0x150) Octets Received Low Received Register */
+  __I  uint32_t GMAC_ORHI;      /**< (GMAC Offset: 0x154) Octets Received High Received Register */
+  __I  uint32_t GMAC_FR;        /**< (GMAC Offset: 0x158) Frames Received Register */
+  __I  uint32_t GMAC_BCFR;      /**< (GMAC Offset: 0x15C) Broadcast Frames Received Register */
+  __I  uint32_t GMAC_MFR;       /**< (GMAC Offset: 0x160) Multicast Frames Received Register */
+  __I  uint32_t GMAC_PFR;       /**< (GMAC Offset: 0x164) Pause Frames Received Register */
+  __I  uint32_t GMAC_BFR64;     /**< (GMAC Offset: 0x168) 64 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR127;   /**< (GMAC Offset: 0x16C) 65 to 127 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR255;   /**< (GMAC Offset: 0x170) 128 to 255 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR511;   /**< (GMAC Offset: 0x174) 256 to 511 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR1023;  /**< (GMAC Offset: 0x178) 512 to 1023 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR1518;  /**< (GMAC Offset: 0x17C) 1024 to 1518 Byte Frames Received Register */
+  __I  uint32_t GMAC_TMXBFR;    /**< (GMAC Offset: 0x180) 1519 to Maximum Byte Frames Received Register */
+  __I  uint32_t GMAC_UFR;       /**< (GMAC Offset: 0x184) Undersize Frames Received Register */
+  __I  uint32_t GMAC_OFR;       /**< (GMAC Offset: 0x188) Oversize Frames Received Register */
+  __I  uint32_t GMAC_JR;        /**< (GMAC Offset: 0x18C) Jabbers Received Register */
+  __I  uint32_t GMAC_FCSE;      /**< (GMAC Offset: 0x190) Frame Check Sequence Errors Register */
+  __I  uint32_t GMAC_LFFE;      /**< (GMAC Offset: 0x194) Length Field Frame Errors Register */
+  __I  uint32_t GMAC_RSE;       /**< (GMAC Offset: 0x198) Receive Symbol Errors Register */
+  __I  uint32_t GMAC_AE;        /**< (GMAC Offset: 0x19C) Alignment Errors Register */
+  __I  uint32_t GMAC_RRE;       /**< (GMAC Offset: 0x1A0) Receive Resource Errors Register */
+  __I  uint32_t GMAC_ROE;       /**< (GMAC Offset: 0x1A4) Receive Overrun Register */
+  __I  uint32_t GMAC_IHCE;      /**< (GMAC Offset: 0x1A8) IP Header Checksum Errors Register */
+  __I  uint32_t GMAC_TCE;       /**< (GMAC Offset: 0x1AC) TCP Checksum Errors Register */
+  __I  uint32_t GMAC_UCE;       /**< (GMAC Offset: 0x1B0) UDP Checksum Errors Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO uint32_t GMAC_TISUBN;    /**< (GMAC Offset: 0x1BC) 1588 Timer Increment Sub-nanoseconds Register */
+  __IO uint32_t GMAC_TSH;       /**< (GMAC Offset: 0x1C0) 1588 Timer Seconds High Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO uint32_t GMAC_TSL;       /**< (GMAC Offset: 0x1D0) 1588 Timer Seconds Low Register */
+  __IO uint32_t GMAC_TN;        /**< (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register */
+  __O  uint32_t GMAC_TA;        /**< (GMAC Offset: 0x1D8) 1588 Timer Adjust Register */
+  __IO uint32_t GMAC_TI;        /**< (GMAC Offset: 0x1DC) 1588 Timer Increment Register */
+  __I  uint32_t GMAC_EFTSL;     /**< (GMAC Offset: 0x1E0) PTP Event Frame Transmitted Seconds Low Register */
+  __I  uint32_t GMAC_EFTN;      /**< (GMAC Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds Register */
+  __I  uint32_t GMAC_EFRSL;     /**< (GMAC Offset: 0x1E8) PTP Event Frame Received Seconds Low Register */
+  __I  uint32_t GMAC_EFRN;      /**< (GMAC Offset: 0x1EC) PTP Event Frame Received Nanoseconds Register */
+  __I  uint32_t GMAC_PEFTSL;    /**< (GMAC Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds Low Register */
+  __I  uint32_t GMAC_PEFTN;     /**< (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds Register */
+  __I  uint32_t GMAC_PEFRSL;    /**< (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds Low Register */
+  __I  uint32_t GMAC_PEFRN;     /**< (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds Register */
+  __I  uint8_t                        Reserved6[508];
+  __I  uint32_t GMAC_ISRPQ[2];  /**< (GMAC Offset: 0x3FC) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved7[56];
+  __IO uint32_t GMAC_TBQBAPQ[2]; /**< (GMAC Offset: 0x43C) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved8[56];
+  __IO uint32_t GMAC_RBQBAPQ[2]; /**< (GMAC Offset: 0x47C) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved9[24];
+  __IO uint32_t GMAC_RBSRPQ[2]; /**< (GMAC Offset: 0x49C) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[24];
+  __IO uint32_t GMAC_CBSCR;     /**< (GMAC Offset: 0x4BC) Credit-Based Shaping Control Register */
+  __IO uint32_t GMAC_CBSISQA;   /**< (GMAC Offset: 0x4C0) Credit-Based Shaping IdleSlope Register for Queue A */
+  __IO uint32_t GMAC_CBSISQB;   /**< (GMAC Offset: 0x4C4) Credit-Based Shaping IdleSlope Register for Queue B */
+  __I  uint8_t                        Reserved11[56];
+  __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue (index = 0) 0 */
+  __I  uint8_t                        Reserved12[48];
+  __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue (index = 0) 0 */
+  __I  uint8_t                        Reserved13[156];
+  __O  uint32_t GMAC_IERPQ[2];  /**< (GMAC Offset: 0x5FC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved14[24];
+  __O  uint32_t GMAC_IDRPQ[2];  /**< (GMAC Offset: 0x61C) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved15[24];
+  __IO uint32_t GMAC_IMRPQ[2];  /**< (GMAC Offset: 0x63C) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[156];
+  __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register (index = 0) 0 */
+  __I  uint8_t                        Reserved17[16];
+  __IO uint32_t GMAC_ST2CW00;   /**< (GMAC Offset: 0x700) Screening Type 2 Compare Word 0 Register (index = 0) */
+  __IO uint32_t GMAC_ST2CW10;   /**< (GMAC Offset: 0x704) Screening Type 2 Compare Word 1 Register (index = 0) */
+  __IO uint32_t GMAC_ST2CW01;   /**< (GMAC Offset: 0x708) Screening Type 2 Compare Word 0 Register (index = 1) */
+  __IO uint32_t GMAC_ST2CW11;   /**< (GMAC Offset: 0x70C) Screening Type 2 Compare Word 1 Register (index = 1) */
+  __IO uint32_t GMAC_ST2CW02;   /**< (GMAC Offset: 0x710) Screening Type 2 Compare Word 0 Register (index = 2) */
+  __IO uint32_t GMAC_ST2CW12;   /**< (GMAC Offset: 0x714) Screening Type 2 Compare Word 1 Register (index = 2) */
+  __IO uint32_t GMAC_ST2CW03;   /**< (GMAC Offset: 0x718) Screening Type 2 Compare Word 0 Register (index = 3) */
+  __IO uint32_t GMAC_ST2CW13;   /**< (GMAC Offset: 0x71C) Screening Type 2 Compare Word 1 Register (index = 3) */
+  __IO uint32_t GMAC_ST2CW04;   /**< (GMAC Offset: 0x720) Screening Type 2 Compare Word 0 Register (index = 4) */
+  __IO uint32_t GMAC_ST2CW14;   /**< (GMAC Offset: 0x724) Screening Type 2 Compare Word 1 Register (index = 4) */
+  __IO uint32_t GMAC_ST2CW05;   /**< (GMAC Offset: 0x728) Screening Type 2 Compare Word 0 Register (index = 5) */
+  __IO uint32_t GMAC_ST2CW15;   /**< (GMAC Offset: 0x72C) Screening Type 2 Compare Word 1 Register (index = 5) */
+  __IO uint32_t GMAC_ST2CW06;   /**< (GMAC Offset: 0x730) Screening Type 2 Compare Word 0 Register (index = 6) */
+  __IO uint32_t GMAC_ST2CW16;   /**< (GMAC Offset: 0x734) Screening Type 2 Compare Word 1 Register (index = 6) */
+  __IO uint32_t GMAC_ST2CW07;   /**< (GMAC Offset: 0x738) Screening Type 2 Compare Word 0 Register (index = 7) */
+  __IO uint32_t GMAC_ST2CW17;   /**< (GMAC Offset: 0x73C) Screening Type 2 Compare Word 1 Register (index = 7) */
+  __IO uint32_t GMAC_ST2CW08;   /**< (GMAC Offset: 0x740) Screening Type 2 Compare Word 0 Register (index = 8) */
+  __IO uint32_t GMAC_ST2CW18;   /**< (GMAC Offset: 0x744) Screening Type 2 Compare Word 1 Register (index = 8) */
+  __IO uint32_t GMAC_ST2CW09;   /**< (GMAC Offset: 0x748) Screening Type 2 Compare Word 0 Register (index = 9) */
+  __IO uint32_t GMAC_ST2CW19;   /**< (GMAC Offset: 0x74C) Screening Type 2 Compare Word 1 Register (index = 9) */
+  __IO uint32_t GMAC_ST2CW010;  /**< (GMAC Offset: 0x750) Screening Type 2 Compare Word 0 Register (index = 10) */
+  __IO uint32_t GMAC_ST2CW110;  /**< (GMAC Offset: 0x754) Screening Type 2 Compare Word 1 Register (index = 10) */
+  __IO uint32_t GMAC_ST2CW011;  /**< (GMAC Offset: 0x758) Screening Type 2 Compare Word 0 Register (index = 11) */
+  __IO uint32_t GMAC_ST2CW111;  /**< (GMAC Offset: 0x75C) Screening Type 2 Compare Word 1 Register (index = 11) */
+  __IO uint32_t GMAC_ST2CW012;  /**< (GMAC Offset: 0x760) Screening Type 2 Compare Word 0 Register (index = 12) */
+  __IO uint32_t GMAC_ST2CW112;  /**< (GMAC Offset: 0x764) Screening Type 2 Compare Word 1 Register (index = 12) */
+  __IO uint32_t GMAC_ST2CW013;  /**< (GMAC Offset: 0x768) Screening Type 2 Compare Word 0 Register (index = 13) */
+  __IO uint32_t GMAC_ST2CW113;  /**< (GMAC Offset: 0x76C) Screening Type 2 Compare Word 1 Register (index = 13) */
+  __IO uint32_t GMAC_ST2CW014;  /**< (GMAC Offset: 0x770) Screening Type 2 Compare Word 0 Register (index = 14) */
+  __IO uint32_t GMAC_ST2CW114;  /**< (GMAC Offset: 0x774) Screening Type 2 Compare Word 1 Register (index = 14) */
+  __IO uint32_t GMAC_ST2CW015;  /**< (GMAC Offset: 0x778) Screening Type 2 Compare Word 0 Register (index = 15) */
+  __IO uint32_t GMAC_ST2CW115;  /**< (GMAC Offset: 0x77C) Screening Type 2 Compare Word 1 Register (index = 15) */
+  __IO uint32_t GMAC_ST2CW016;  /**< (GMAC Offset: 0x780) Screening Type 2 Compare Word 0 Register (index = 16) */
+  __IO uint32_t GMAC_ST2CW116;  /**< (GMAC Offset: 0x784) Screening Type 2 Compare Word 1 Register (index = 16) */
+  __IO uint32_t GMAC_ST2CW017;  /**< (GMAC Offset: 0x788) Screening Type 2 Compare Word 0 Register (index = 17) */
+  __IO uint32_t GMAC_ST2CW117;  /**< (GMAC Offset: 0x78C) Screening Type 2 Compare Word 1 Register (index = 17) */
+  __IO uint32_t GMAC_ST2CW018;  /**< (GMAC Offset: 0x790) Screening Type 2 Compare Word 0 Register (index = 18) */
+  __IO uint32_t GMAC_ST2CW118;  /**< (GMAC Offset: 0x794) Screening Type 2 Compare Word 1 Register (index = 18) */
+  __IO uint32_t GMAC_ST2CW019;  /**< (GMAC Offset: 0x798) Screening Type 2 Compare Word 0 Register (index = 19) */
+  __IO uint32_t GMAC_ST2CW119;  /**< (GMAC Offset: 0x79C) Screening Type 2 Compare Word 1 Register (index = 19) */
+  __IO uint32_t GMAC_ST2CW020;  /**< (GMAC Offset: 0x7A0) Screening Type 2 Compare Word 0 Register (index = 20) */
+  __IO uint32_t GMAC_ST2CW120;  /**< (GMAC Offset: 0x7A4) Screening Type 2 Compare Word 1 Register (index = 20) */
+  __IO uint32_t GMAC_ST2CW021;  /**< (GMAC Offset: 0x7A8) Screening Type 2 Compare Word 0 Register (index = 21) */
+  __IO uint32_t GMAC_ST2CW121;  /**< (GMAC Offset: 0x7AC) Screening Type 2 Compare Word 1 Register (index = 21) */
+  __IO uint32_t GMAC_ST2CW022;  /**< (GMAC Offset: 0x7B0) Screening Type 2 Compare Word 0 Register (index = 22) */
+  __IO uint32_t GMAC_ST2CW122;  /**< (GMAC Offset: 0x7B4) Screening Type 2 Compare Word 1 Register (index = 22) */
+  __IO uint32_t GMAC_ST2CW023;  /**< (GMAC Offset: 0x7B8) Screening Type 2 Compare Word 0 Register (index = 23) */
+  __IO uint32_t GMAC_ST2CW123;  /**< (GMAC Offset: 0x7BC) Screening Type 2 Compare Word 1 Register (index = 23) */
+} Gmac;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief GMAC_SA hardware registers */
+typedef struct {  
+  __IO GMAC_SAB_Type                  GMAC_SAB;       /**< Offset: 0x00 (R/W  32) Specific Address 1 Bottom Register */
+  __IO GMAC_SAT_Type                  GMAC_SAT;       /**< Offset: 0x04 (R/W  32) Specific Address 1 Top Register */
+} GmacSa;
+
+/** \brief GMAC hardware registers */
+typedef struct {  
+  __IO GMAC_NCR_Type                  GMAC_NCR;       /**< Offset: 0x00 (R/W  32) Network Control Register */
+  __IO GMAC_NCFGR_Type                GMAC_NCFGR;     /**< Offset: 0x04 (R/W  32) Network Configuration Register */
+  __I  GMAC_NSR_Type                  GMAC_NSR;       /**< Offset: 0x08 (R/   32) Network Status Register */
+  __IO GMAC_UR_Type                   GMAC_UR;        /**< Offset: 0x0C (R/W  32) User Register */
+  __IO GMAC_DCFGR_Type                GMAC_DCFGR;     /**< Offset: 0x10 (R/W  32) DMA Configuration Register */
+  __IO GMAC_TSR_Type                  GMAC_TSR;       /**< Offset: 0x14 (R/W  32) Transmit Status Register */
+  __IO GMAC_RBQB_Type                 GMAC_RBQB;      /**< Offset: 0x18 (R/W  32) Receive Buffer Queue Base Address Register */
+  __IO GMAC_TBQB_Type                 GMAC_TBQB;      /**< Offset: 0x1C (R/W  32) Transmit Buffer Queue Base Address Register */
+  __IO GMAC_RSR_Type                  GMAC_RSR;       /**< Offset: 0x20 (R/W  32) Receive Status Register */
+  __I  GMAC_ISR_Type                  GMAC_ISR;       /**< Offset: 0x24 (R/   32) Interrupt Status Register */
+  __O  GMAC_IER_Type                  GMAC_IER;       /**< Offset: 0x28 ( /W  32) Interrupt Enable Register */
+  __O  GMAC_IDR_Type                  GMAC_IDR;       /**< Offset: 0x2C ( /W  32) Interrupt Disable Register */
+  __IO GMAC_IMR_Type                  GMAC_IMR;       /**< Offset: 0x30 (R/W  32) Interrupt Mask Register */
+  __IO GMAC_MAN_Type                  GMAC_MAN;       /**< Offset: 0x34 (R/W  32) PHY Maintenance Register */
+  __I  GMAC_RPQ_Type                  GMAC_RPQ;       /**< Offset: 0x38 (R/   32) Received Pause Quantum Register */
+  __IO GMAC_TPQ_Type                  GMAC_TPQ;       /**< Offset: 0x3C (R/W  32) Transmit Pause Quantum Register */
+  __IO GMAC_TPSF_Type                 GMAC_TPSF;      /**< Offset: 0x40 (R/W  32) TX Partial Store and Forward Register */
+  __IO GMAC_RPSF_Type                 GMAC_RPSF;      /**< Offset: 0x44 (R/W  32) RX Partial Store and Forward Register */
+  __IO GMAC_RJFML_Type                GMAC_RJFML;     /**< Offset: 0x48 (R/W  32) RX Jumbo Frame Max Length Register */
+  __I  uint8_t                        Reserved1[52];
+  __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
+  __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
+       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+  __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
+  __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
+  __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */
+  __IO GMAC_TIDM4_Type                GMAC_TIDM4;     /**< Offset: 0xB4 (R/W  32) Type ID Match 4 Register */
+  __IO GMAC_WOL_Type                  GMAC_WOL;       /**< Offset: 0xB8 (R/W  32) Wake on LAN Register */
+  __IO GMAC_IPGS_Type                 GMAC_IPGS;      /**< Offset: 0xBC (R/W  32) IPG Stretch Register */
+  __IO GMAC_SVLAN_Type                GMAC_SVLAN;     /**< Offset: 0xC0 (R/W  32) Stacked VLAN Register */
+  __IO GMAC_TPFCP_Type                GMAC_TPFCP;     /**< Offset: 0xC4 (R/W  32) Transmit PFC Pause Register */
+  __IO GMAC_SAMB1_Type                GMAC_SAMB1;     /**< Offset: 0xC8 (R/W  32) Specific Address 1 Mask Bottom Register */
+  __IO GMAC_SAMT1_Type                GMAC_SAMT1;     /**< Offset: 0xCC (R/W  32) Specific Address 1 Mask Top Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO GMAC_NSC_Type                  GMAC_NSC;       /**< Offset: 0xDC (R/W  32) 1588 Timer Nanosecond Comparison Register */
+  __IO GMAC_SCL_Type                  GMAC_SCL;       /**< Offset: 0xE0 (R/W  32) 1588 Timer Second Comparison Low Register */
+  __IO GMAC_SCH_Type                  GMAC_SCH;       /**< Offset: 0xE4 (R/W  32) 1588 Timer Second Comparison High Register */
+  __I  GMAC_EFTSH_Type                GMAC_EFTSH;     /**< Offset: 0xE8 (R/   32) PTP Event Frame Transmitted Seconds High Register */
+  __I  GMAC_EFRSH_Type                GMAC_EFRSH;     /**< Offset: 0xEC (R/   32) PTP Event Frame Received Seconds High Register */
+  __I  GMAC_PEFTSH_Type               GMAC_PEFTSH;    /**< Offset: 0xF0 (R/   32) PTP Peer Event Frame Transmitted Seconds High Register */
+  __I  GMAC_PEFRSH_Type               GMAC_PEFRSH;    /**< Offset: 0xF4 (R/   32) PTP Peer Event Frame Received Seconds High Register */
+  __I  uint8_t                        Reserved3[4];
+  __I  GMAC_MID_Type                  GMAC_MID;       /**< Offset: 0xFC (R/   32) Module ID Register */
+  __I  GMAC_OTLO_Type                 GMAC_OTLO;      /**< Offset: 0x100 (R/   32) Octets Transmitted Low Register */
+  __I  GMAC_OTHI_Type                 GMAC_OTHI;      /**< Offset: 0x104 (R/   32) Octets Transmitted High Register */
+  __I  GMAC_FT_Type                   GMAC_FT;        /**< Offset: 0x108 (R/   32) Frames Transmitted Register */
+  __I  GMAC_BCFT_Type                 GMAC_BCFT;      /**< Offset: 0x10C (R/   32) Broadcast Frames Transmitted Register */
+  __I  GMAC_MFT_Type                  GMAC_MFT;       /**< Offset: 0x110 (R/   32) Multicast Frames Transmitted Register */
+  __I  GMAC_PFT_Type                  GMAC_PFT;       /**< Offset: 0x114 (R/   32) Pause Frames Transmitted Register */
+  __I  GMAC_BFT64_Type                GMAC_BFT64;     /**< Offset: 0x118 (R/   32) 64 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT127_Type              GMAC_TBFT127;   /**< Offset: 0x11C (R/   32) 65 to 127 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT255_Type              GMAC_TBFT255;   /**< Offset: 0x120 (R/   32) 128 to 255 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT511_Type              GMAC_TBFT511;   /**< Offset: 0x124 (R/   32) 256 to 511 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT1023_Type             GMAC_TBFT1023;  /**< Offset: 0x128 (R/   32) 512 to 1023 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT1518_Type             GMAC_TBFT1518;  /**< Offset: 0x12C (R/   32) 1024 to 1518 Byte Frames Transmitted Register */
+  __I  GMAC_GTBFT1518_Type            GMAC_GTBFT1518; /**< Offset: 0x130 (R/   32) Greater Than 1518 Byte Frames Transmitted Register */
+  __I  GMAC_TUR_Type                  GMAC_TUR;       /**< Offset: 0x134 (R/   32) Transmit Underruns Register */
+  __I  GMAC_SCF_Type                  GMAC_SCF;       /**< Offset: 0x138 (R/   32) Single Collision Frames Register */
+  __I  GMAC_MCF_Type                  GMAC_MCF;       /**< Offset: 0x13C (R/   32) Multiple Collision Frames Register */
+  __I  GMAC_EC_Type                   GMAC_EC;        /**< Offset: 0x140 (R/   32) Excessive Collisions Register */
+  __I  GMAC_LC_Type                   GMAC_LC;        /**< Offset: 0x144 (R/   32) Late Collisions Register */
+  __I  GMAC_DTF_Type                  GMAC_DTF;       /**< Offset: 0x148 (R/   32) Deferred Transmission Frames Register */
+  __I  GMAC_CSE_Type                  GMAC_CSE;       /**< Offset: 0x14C (R/   32) Carrier Sense Errors Register */
+  __I  GMAC_ORLO_Type                 GMAC_ORLO;      /**< Offset: 0x150 (R/   32) Octets Received Low Received Register */
+  __I  GMAC_ORHI_Type                 GMAC_ORHI;      /**< Offset: 0x154 (R/   32) Octets Received High Received Register */
+  __I  GMAC_FR_Type                   GMAC_FR;        /**< Offset: 0x158 (R/   32) Frames Received Register */
+  __I  GMAC_BCFR_Type                 GMAC_BCFR;      /**< Offset: 0x15C (R/   32) Broadcast Frames Received Register */
+  __I  GMAC_MFR_Type                  GMAC_MFR;       /**< Offset: 0x160 (R/   32) Multicast Frames Received Register */
+  __I  GMAC_PFR_Type                  GMAC_PFR;       /**< Offset: 0x164 (R/   32) Pause Frames Received Register */
+  __I  GMAC_BFR64_Type                GMAC_BFR64;     /**< Offset: 0x168 (R/   32) 64 Byte Frames Received Register */
+  __I  GMAC_TBFR127_Type              GMAC_TBFR127;   /**< Offset: 0x16C (R/   32) 65 to 127 Byte Frames Received Register */
+  __I  GMAC_TBFR255_Type              GMAC_TBFR255;   /**< Offset: 0x170 (R/   32) 128 to 255 Byte Frames Received Register */
+  __I  GMAC_TBFR511_Type              GMAC_TBFR511;   /**< Offset: 0x174 (R/   32) 256 to 511 Byte Frames Received Register */
+  __I  GMAC_TBFR1023_Type             GMAC_TBFR1023;  /**< Offset: 0x178 (R/   32) 512 to 1023 Byte Frames Received Register */
+  __I  GMAC_TBFR1518_Type             GMAC_TBFR1518;  /**< Offset: 0x17C (R/   32) 1024 to 1518 Byte Frames Received Register */
+  __I  GMAC_TMXBFR_Type               GMAC_TMXBFR;    /**< Offset: 0x180 (R/   32) 1519 to Maximum Byte Frames Received Register */
+  __I  GMAC_UFR_Type                  GMAC_UFR;       /**< Offset: 0x184 (R/   32) Undersize Frames Received Register */
+  __I  GMAC_OFR_Type                  GMAC_OFR;       /**< Offset: 0x188 (R/   32) Oversize Frames Received Register */
+  __I  GMAC_JR_Type                   GMAC_JR;        /**< Offset: 0x18C (R/   32) Jabbers Received Register */
+  __I  GMAC_FCSE_Type                 GMAC_FCSE;      /**< Offset: 0x190 (R/   32) Frame Check Sequence Errors Register */
+  __I  GMAC_LFFE_Type                 GMAC_LFFE;      /**< Offset: 0x194 (R/   32) Length Field Frame Errors Register */
+  __I  GMAC_RSE_Type                  GMAC_RSE;       /**< Offset: 0x198 (R/   32) Receive Symbol Errors Register */
+  __I  GMAC_AE_Type                   GMAC_AE;        /**< Offset: 0x19C (R/   32) Alignment Errors Register */
+  __I  GMAC_RRE_Type                  GMAC_RRE;       /**< Offset: 0x1A0 (R/   32) Receive Resource Errors Register */
+  __I  GMAC_ROE_Type                  GMAC_ROE;       /**< Offset: 0x1A4 (R/   32) Receive Overrun Register */
+  __I  GMAC_IHCE_Type                 GMAC_IHCE;      /**< Offset: 0x1A8 (R/   32) IP Header Checksum Errors Register */
+  __I  GMAC_TCE_Type                  GMAC_TCE;       /**< Offset: 0x1AC (R/   32) TCP Checksum Errors Register */
+  __I  GMAC_UCE_Type                  GMAC_UCE;       /**< Offset: 0x1B0 (R/   32) UDP Checksum Errors Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO GMAC_TISUBN_Type               GMAC_TISUBN;    /**< Offset: 0x1BC (R/W  32) 1588 Timer Increment Sub-nanoseconds Register */
+  __IO GMAC_TSH_Type                  GMAC_TSH;       /**< Offset: 0x1C0 (R/W  32) 1588 Timer Seconds High Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO GMAC_TSL_Type                  GMAC_TSL;       /**< Offset: 0x1D0 (R/W  32) 1588 Timer Seconds Low Register */
+  __IO GMAC_TN_Type                   GMAC_TN;        /**< Offset: 0x1D4 (R/W  32) 1588 Timer Nanoseconds Register */
+  __O  GMAC_TA_Type                   GMAC_TA;        /**< Offset: 0x1D8 ( /W  32) 1588 Timer Adjust Register */
+  __IO GMAC_TI_Type                   GMAC_TI;        /**< Offset: 0x1DC (R/W  32) 1588 Timer Increment Register */
+  __I  GMAC_EFTSL_Type                GMAC_EFTSL;     /**< Offset: 0x1E0 (R/   32) PTP Event Frame Transmitted Seconds Low Register */
+  __I  GMAC_EFTN_Type                 GMAC_EFTN;      /**< Offset: 0x1E4 (R/   32) PTP Event Frame Transmitted Nanoseconds Register */
+  __I  GMAC_EFRSL_Type                GMAC_EFRSL;     /**< Offset: 0x1E8 (R/   32) PTP Event Frame Received Seconds Low Register */
+  __I  GMAC_EFRN_Type                 GMAC_EFRN;      /**< Offset: 0x1EC (R/   32) PTP Event Frame Received Nanoseconds Register */
+  __I  GMAC_PEFTSL_Type               GMAC_PEFTSL;    /**< Offset: 0x1F0 (R/   32) PTP Peer Event Frame Transmitted Seconds Low Register */
+  __I  GMAC_PEFTN_Type                GMAC_PEFTN;     /**< Offset: 0x1F4 (R/   32) PTP Peer Event Frame Transmitted Nanoseconds Register */
+  __I  GMAC_PEFRSL_Type               GMAC_PEFRSL;    /**< Offset: 0x1F8 (R/   32) PTP Peer Event Frame Received Seconds Low Register */
+  __I  GMAC_PEFRN_Type                GMAC_PEFRN;     /**< Offset: 0x1FC (R/   32) PTP Peer Event Frame Received Nanoseconds Register */
+  __I  uint8_t                        Reserved6[508];
+  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[2];  /**< Offset: 0x3FC (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved7[56];
+  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[2]; /**< Offset: 0x43C (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved8[56];
+  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[2]; /**< Offset: 0x47C (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved9[24];
+  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[2]; /**< Offset: 0x49C (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[24];
+  __IO GMAC_CBSCR_Type                GMAC_CBSCR;     /**< Offset: 0x4BC (R/W  32) Credit-Based Shaping Control Register */
+  __IO GMAC_CBSISQA_Type              GMAC_CBSISQA;   /**< Offset: 0x4C0 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue A */
+  __IO GMAC_CBSISQB_Type              GMAC_CBSISQB;   /**< Offset: 0x4C4 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue B */
+  __I  uint8_t                        Reserved11[56];
+  __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue (index = 0) 0 */
+  __I  uint8_t                        Reserved12[48];
+  __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue (index = 0) 0 */
+  __I  uint8_t                        Reserved13[156];
+  __O  GMAC_IERPQ_Type                GMAC_IERPQ[2];  /**< Offset: 0x5FC ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved14[24];
+  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[2];  /**< Offset: 0x61C ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved15[24];
+  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[2];  /**< Offset: 0x63C (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[156];
+  __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register (index = 0) 0 */
+  __I  uint8_t                        Reserved17[16];
+  __IO GMAC_ST2CW00_Type              GMAC_ST2CW00;   /**< Offset: 0x700 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 0) */
+  __IO GMAC_ST2CW10_Type              GMAC_ST2CW10;   /**< Offset: 0x704 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 0) */
+  __IO GMAC_ST2CW01_Type              GMAC_ST2CW01;   /**< Offset: 0x708 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 1) */
+  __IO GMAC_ST2CW11_Type              GMAC_ST2CW11;   /**< Offset: 0x70C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 1) */
+  __IO GMAC_ST2CW02_Type              GMAC_ST2CW02;   /**< Offset: 0x710 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 2) */
+  __IO GMAC_ST2CW12_Type              GMAC_ST2CW12;   /**< Offset: 0x714 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 2) */
+  __IO GMAC_ST2CW03_Type              GMAC_ST2CW03;   /**< Offset: 0x718 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 3) */
+  __IO GMAC_ST2CW13_Type              GMAC_ST2CW13;   /**< Offset: 0x71C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 3) */
+  __IO GMAC_ST2CW04_Type              GMAC_ST2CW04;   /**< Offset: 0x720 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 4) */
+  __IO GMAC_ST2CW14_Type              GMAC_ST2CW14;   /**< Offset: 0x724 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 4) */
+  __IO GMAC_ST2CW05_Type              GMAC_ST2CW05;   /**< Offset: 0x728 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 5) */
+  __IO GMAC_ST2CW15_Type              GMAC_ST2CW15;   /**< Offset: 0x72C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 5) */
+  __IO GMAC_ST2CW06_Type              GMAC_ST2CW06;   /**< Offset: 0x730 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 6) */
+  __IO GMAC_ST2CW16_Type              GMAC_ST2CW16;   /**< Offset: 0x734 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 6) */
+  __IO GMAC_ST2CW07_Type              GMAC_ST2CW07;   /**< Offset: 0x738 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 7) */
+  __IO GMAC_ST2CW17_Type              GMAC_ST2CW17;   /**< Offset: 0x73C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 7) */
+  __IO GMAC_ST2CW08_Type              GMAC_ST2CW08;   /**< Offset: 0x740 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 8) */
+  __IO GMAC_ST2CW18_Type              GMAC_ST2CW18;   /**< Offset: 0x744 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 8) */
+  __IO GMAC_ST2CW09_Type              GMAC_ST2CW09;   /**< Offset: 0x748 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 9) */
+  __IO GMAC_ST2CW19_Type              GMAC_ST2CW19;   /**< Offset: 0x74C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 9) */
+  __IO GMAC_ST2CW010_Type             GMAC_ST2CW010;  /**< Offset: 0x750 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 10) */
+  __IO GMAC_ST2CW110_Type             GMAC_ST2CW110;  /**< Offset: 0x754 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 10) */
+  __IO GMAC_ST2CW011_Type             GMAC_ST2CW011;  /**< Offset: 0x758 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 11) */
+  __IO GMAC_ST2CW111_Type             GMAC_ST2CW111;  /**< Offset: 0x75C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 11) */
+  __IO GMAC_ST2CW012_Type             GMAC_ST2CW012;  /**< Offset: 0x760 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 12) */
+  __IO GMAC_ST2CW112_Type             GMAC_ST2CW112;  /**< Offset: 0x764 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 12) */
+  __IO GMAC_ST2CW013_Type             GMAC_ST2CW013;  /**< Offset: 0x768 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 13) */
+  __IO GMAC_ST2CW113_Type             GMAC_ST2CW113;  /**< Offset: 0x76C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 13) */
+  __IO GMAC_ST2CW014_Type             GMAC_ST2CW014;  /**< Offset: 0x770 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 14) */
+  __IO GMAC_ST2CW114_Type             GMAC_ST2CW114;  /**< Offset: 0x774 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 14) */
+  __IO GMAC_ST2CW015_Type             GMAC_ST2CW015;  /**< Offset: 0x778 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 15) */
+  __IO GMAC_ST2CW115_Type             GMAC_ST2CW115;  /**< Offset: 0x77C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 15) */
+  __IO GMAC_ST2CW016_Type             GMAC_ST2CW016;  /**< Offset: 0x780 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 16) */
+  __IO GMAC_ST2CW116_Type             GMAC_ST2CW116;  /**< Offset: 0x784 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 16) */
+  __IO GMAC_ST2CW017_Type             GMAC_ST2CW017;  /**< Offset: 0x788 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 17) */
+  __IO GMAC_ST2CW117_Type             GMAC_ST2CW117;  /**< Offset: 0x78C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 17) */
+  __IO GMAC_ST2CW018_Type             GMAC_ST2CW018;  /**< Offset: 0x790 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 18) */
+  __IO GMAC_ST2CW118_Type             GMAC_ST2CW118;  /**< Offset: 0x794 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 18) */
+  __IO GMAC_ST2CW019_Type             GMAC_ST2CW019;  /**< Offset: 0x798 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 19) */
+  __IO GMAC_ST2CW119_Type             GMAC_ST2CW119;  /**< Offset: 0x79C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 19) */
+  __IO GMAC_ST2CW020_Type             GMAC_ST2CW020;  /**< Offset: 0x7A0 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 20) */
+  __IO GMAC_ST2CW120_Type             GMAC_ST2CW120;  /**< Offset: 0x7A4 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 20) */
+  __IO GMAC_ST2CW021_Type             GMAC_ST2CW021;  /**< Offset: 0x7A8 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 21) */
+  __IO GMAC_ST2CW121_Type             GMAC_ST2CW121;  /**< Offset: 0x7AC (R/W  32) Screening Type 2 Compare Word 1 Register (index = 21) */
+  __IO GMAC_ST2CW022_Type             GMAC_ST2CW022;  /**< Offset: 0x7B0 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 22) */
+  __IO GMAC_ST2CW122_Type             GMAC_ST2CW122;  /**< Offset: 0x7B4 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 22) */
+  __IO GMAC_ST2CW023_Type             GMAC_ST2CW023;  /**< Offset: 0x7B8 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 23) */
+  __IO GMAC_ST2CW123_Type             GMAC_ST2CW123;  /**< Offset: 0x7BC (R/W  32) Screening Type 2 Compare Word 1 Register (index = 23) */
+} Gmac;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Gigabit Ethernet MAC */
+
+#endif /* _SAMV71_GMAC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/gmac.h
+++ b/asf/sam/include/samv71/component/gmac.h
@@ -4864,7 +4864,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -5052,7 +5052,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GMAC_SA[4];     /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */

--- a/asf/sam/include/samv71/component/gpbr.h
+++ b/asf/sam/include/samv71/component/gpbr.h
@@ -1,0 +1,89 @@
+/**
+ * \file
+ *
+ * \brief Component description for GPBR
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_GPBR_COMPONENT_H_
+#define _SAMV71_GPBR_COMPONENT_H_
+#define _SAMV71_GPBR_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 General Purpose Backup Registers
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GPBR */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define GPBR_6378                       /**< (GPBR) Module ID */
+#define REV_GPBR H                      /**< (GPBR) Module revision */
+
+/* -------- GPBR_SYS_GPBR : (GPBR Offset: 0x00) (R/W 32) General Purpose Backup Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GPBR_VALUE:32;             /**< bit:  0..31  Value of GPBR x                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GPBR_SYS_GPBR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPBR_SYS_GPBR_OFFSET                (0x00)                                        /**<  (GPBR_SYS_GPBR) General Purpose Backup Register 0  Offset */
+
+#define GPBR_SYS_GPBR_GPBR_VALUE_Pos        0                                              /**< (GPBR_SYS_GPBR) Value of GPBR x Position */
+#define GPBR_SYS_GPBR_GPBR_VALUE_Msk        (_U_(0xFFFFFFFF) << GPBR_SYS_GPBR_GPBR_VALUE_Pos)  /**< (GPBR_SYS_GPBR) Value of GPBR x Mask */
+#define GPBR_SYS_GPBR_GPBR_VALUE(value)     (GPBR_SYS_GPBR_GPBR_VALUE_Msk & ((value) << GPBR_SYS_GPBR_GPBR_VALUE_Pos))
+#define GPBR_SYS_GPBR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GPBR_SYS_GPBR) Register MASK  (Use GPBR_SYS_GPBR_Msk instead)  */
+#define GPBR_SYS_GPBR_Msk                   _U_(0xFFFFFFFF)                                /**< (GPBR_SYS_GPBR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief GPBR hardware registers */
+typedef struct {  
+  __IO uint32_t SYS_GPBR[8];    /**< (GPBR Offset: 0x00) General Purpose Backup Register 0 */
+} Gpbr;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief GPBR hardware registers */
+typedef struct {  
+  __IO GPBR_SYS_GPBR_Type             SYS_GPBR[8];    /**< Offset: 0x00 (R/W  32) General Purpose Backup Register 0 */
+} Gpbr;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of General Purpose Backup Registers */
+
+#endif /* _SAMV71_GPBR_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/hsmci.h
+++ b/asf/sam/include/samv71/component/hsmci.h
@@ -1,0 +1,1202 @@
+/**
+ * \file
+ *
+ * \brief Component description for HSMCI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_HSMCI_COMPONENT_H_
+#define _SAMV71_HSMCI_COMPONENT_H_
+#define _SAMV71_HSMCI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 High Speed MultiMedia Card Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR HSMCI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define HSMCI_6449                       /**< (HSMCI) Module ID */
+#define REV_HSMCI Q                      /**< (HSMCI) Module revision */
+
+/* -------- HSMCI_CR : (HSMCI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCIEN:1;                   /**< bit:      0  Multi-Media Interface Enable             */
+    uint32_t MCIDIS:1;                  /**< bit:      1  Multi-Media Interface Disable            */
+    uint32_t PWSEN:1;                   /**< bit:      2  Power Save Mode Enable                   */
+    uint32_t PWSDIS:1;                  /**< bit:      3  Power Save Mode Disable                  */
+    uint32_t :3;                        /**< bit:   4..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  Software Reset                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CR_OFFSET                     (0x00)                                        /**<  (HSMCI_CR) Control Register  Offset */
+
+#define HSMCI_CR_MCIEN_Pos                  0                                              /**< (HSMCI_CR) Multi-Media Interface Enable Position */
+#define HSMCI_CR_MCIEN_Msk                  (_U_(0x1) << HSMCI_CR_MCIEN_Pos)               /**< (HSMCI_CR) Multi-Media Interface Enable Mask */
+#define HSMCI_CR_MCIEN                      HSMCI_CR_MCIEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_MCIEN_Msk instead */
+#define HSMCI_CR_MCIDIS_Pos                 1                                              /**< (HSMCI_CR) Multi-Media Interface Disable Position */
+#define HSMCI_CR_MCIDIS_Msk                 (_U_(0x1) << HSMCI_CR_MCIDIS_Pos)              /**< (HSMCI_CR) Multi-Media Interface Disable Mask */
+#define HSMCI_CR_MCIDIS                     HSMCI_CR_MCIDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_MCIDIS_Msk instead */
+#define HSMCI_CR_PWSEN_Pos                  2                                              /**< (HSMCI_CR) Power Save Mode Enable Position */
+#define HSMCI_CR_PWSEN_Msk                  (_U_(0x1) << HSMCI_CR_PWSEN_Pos)               /**< (HSMCI_CR) Power Save Mode Enable Mask */
+#define HSMCI_CR_PWSEN                      HSMCI_CR_PWSEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_PWSEN_Msk instead */
+#define HSMCI_CR_PWSDIS_Pos                 3                                              /**< (HSMCI_CR) Power Save Mode Disable Position */
+#define HSMCI_CR_PWSDIS_Msk                 (_U_(0x1) << HSMCI_CR_PWSDIS_Pos)              /**< (HSMCI_CR) Power Save Mode Disable Mask */
+#define HSMCI_CR_PWSDIS                     HSMCI_CR_PWSDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_PWSDIS_Msk instead */
+#define HSMCI_CR_SWRST_Pos                  7                                              /**< (HSMCI_CR) Software Reset Position */
+#define HSMCI_CR_SWRST_Msk                  (_U_(0x1) << HSMCI_CR_SWRST_Pos)               /**< (HSMCI_CR) Software Reset Mask */
+#define HSMCI_CR_SWRST                      HSMCI_CR_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_SWRST_Msk instead */
+#define HSMCI_CR_MASK                       _U_(0x8F)                                      /**< \deprecated (HSMCI_CR) Register MASK  (Use HSMCI_CR_Msk instead)  */
+#define HSMCI_CR_Msk                        _U_(0x8F)                                      /**< (HSMCI_CR) Register Mask  */
+
+
+/* -------- HSMCI_MR : (HSMCI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLKDIV:8;                  /**< bit:   0..7  Clock Divider                            */
+    uint32_t PWSDIV:3;                  /**< bit:  8..10  Power Saving Divider                     */
+    uint32_t RDPROOF:1;                 /**< bit:     11  Read Proof Enable                        */
+    uint32_t WRPROOF:1;                 /**< bit:     12  Write Proof Enable                       */
+    uint32_t FBYTE:1;                   /**< bit:     13  Force Byte Transfer                      */
+    uint32_t PADV:1;                    /**< bit:     14  Padding Value                            */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t CLKODD:1;                  /**< bit:     16  Clock divider is odd                     */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_MR_OFFSET                     (0x04)                                        /**<  (HSMCI_MR) Mode Register  Offset */
+
+#define HSMCI_MR_CLKDIV_Pos                 0                                              /**< (HSMCI_MR) Clock Divider Position */
+#define HSMCI_MR_CLKDIV_Msk                 (_U_(0xFF) << HSMCI_MR_CLKDIV_Pos)             /**< (HSMCI_MR) Clock Divider Mask */
+#define HSMCI_MR_CLKDIV(value)              (HSMCI_MR_CLKDIV_Msk & ((value) << HSMCI_MR_CLKDIV_Pos))
+#define HSMCI_MR_PWSDIV_Pos                 8                                              /**< (HSMCI_MR) Power Saving Divider Position */
+#define HSMCI_MR_PWSDIV_Msk                 (_U_(0x7) << HSMCI_MR_PWSDIV_Pos)              /**< (HSMCI_MR) Power Saving Divider Mask */
+#define HSMCI_MR_PWSDIV(value)              (HSMCI_MR_PWSDIV_Msk & ((value) << HSMCI_MR_PWSDIV_Pos))
+#define HSMCI_MR_RDPROOF_Pos                11                                             /**< (HSMCI_MR) Read Proof Enable Position */
+#define HSMCI_MR_RDPROOF_Msk                (_U_(0x1) << HSMCI_MR_RDPROOF_Pos)             /**< (HSMCI_MR) Read Proof Enable Mask */
+#define HSMCI_MR_RDPROOF                    HSMCI_MR_RDPROOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_RDPROOF_Msk instead */
+#define HSMCI_MR_WRPROOF_Pos                12                                             /**< (HSMCI_MR) Write Proof Enable Position */
+#define HSMCI_MR_WRPROOF_Msk                (_U_(0x1) << HSMCI_MR_WRPROOF_Pos)             /**< (HSMCI_MR) Write Proof Enable Mask */
+#define HSMCI_MR_WRPROOF                    HSMCI_MR_WRPROOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_WRPROOF_Msk instead */
+#define HSMCI_MR_FBYTE_Pos                  13                                             /**< (HSMCI_MR) Force Byte Transfer Position */
+#define HSMCI_MR_FBYTE_Msk                  (_U_(0x1) << HSMCI_MR_FBYTE_Pos)               /**< (HSMCI_MR) Force Byte Transfer Mask */
+#define HSMCI_MR_FBYTE                      HSMCI_MR_FBYTE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_FBYTE_Msk instead */
+#define HSMCI_MR_PADV_Pos                   14                                             /**< (HSMCI_MR) Padding Value Position */
+#define HSMCI_MR_PADV_Msk                   (_U_(0x1) << HSMCI_MR_PADV_Pos)                /**< (HSMCI_MR) Padding Value Mask */
+#define HSMCI_MR_PADV                       HSMCI_MR_PADV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_PADV_Msk instead */
+#define HSMCI_MR_CLKODD_Pos                 16                                             /**< (HSMCI_MR) Clock divider is odd Position */
+#define HSMCI_MR_CLKODD_Msk                 (_U_(0x1) << HSMCI_MR_CLKODD_Pos)              /**< (HSMCI_MR) Clock divider is odd Mask */
+#define HSMCI_MR_CLKODD                     HSMCI_MR_CLKODD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_CLKODD_Msk instead */
+#define HSMCI_MR_MASK                       _U_(0x17FFF)                                   /**< \deprecated (HSMCI_MR) Register MASK  (Use HSMCI_MR_Msk instead)  */
+#define HSMCI_MR_Msk                        _U_(0x17FFF)                                   /**< (HSMCI_MR) Register Mask  */
+
+
+/* -------- HSMCI_DTOR : (HSMCI Offset: 0x08) (R/W 32) Data Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTOCYC:4;                  /**< bit:   0..3  Data Timeout Cycle Number                */
+    uint32_t DTOMUL:3;                  /**< bit:   4..6  Data Timeout Multiplier                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_DTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_DTOR_OFFSET                   (0x08)                                        /**<  (HSMCI_DTOR) Data Timeout Register  Offset */
+
+#define HSMCI_DTOR_DTOCYC_Pos               0                                              /**< (HSMCI_DTOR) Data Timeout Cycle Number Position */
+#define HSMCI_DTOR_DTOCYC_Msk               (_U_(0xF) << HSMCI_DTOR_DTOCYC_Pos)            /**< (HSMCI_DTOR) Data Timeout Cycle Number Mask */
+#define HSMCI_DTOR_DTOCYC(value)            (HSMCI_DTOR_DTOCYC_Msk & ((value) << HSMCI_DTOR_DTOCYC_Pos))
+#define HSMCI_DTOR_DTOMUL_Pos               4                                              /**< (HSMCI_DTOR) Data Timeout Multiplier Position */
+#define HSMCI_DTOR_DTOMUL_Msk               (_U_(0x7) << HSMCI_DTOR_DTOMUL_Pos)            /**< (HSMCI_DTOR) Data Timeout Multiplier Mask */
+#define HSMCI_DTOR_DTOMUL(value)            (HSMCI_DTOR_DTOMUL_Msk & ((value) << HSMCI_DTOR_DTOMUL_Pos))
+#define   HSMCI_DTOR_DTOMUL_1_Val           _U_(0x0)                                       /**< (HSMCI_DTOR) DTOCYC  */
+#define   HSMCI_DTOR_DTOMUL_16_Val          _U_(0x1)                                       /**< (HSMCI_DTOR) DTOCYC x 16  */
+#define   HSMCI_DTOR_DTOMUL_128_Val         _U_(0x2)                                       /**< (HSMCI_DTOR) DTOCYC x 128  */
+#define   HSMCI_DTOR_DTOMUL_256_Val         _U_(0x3)                                       /**< (HSMCI_DTOR) DTOCYC x 256  */
+#define   HSMCI_DTOR_DTOMUL_1024_Val        _U_(0x4)                                       /**< (HSMCI_DTOR) DTOCYC x 1024  */
+#define   HSMCI_DTOR_DTOMUL_4096_Val        _U_(0x5)                                       /**< (HSMCI_DTOR) DTOCYC x 4096  */
+#define   HSMCI_DTOR_DTOMUL_65536_Val       _U_(0x6)                                       /**< (HSMCI_DTOR) DTOCYC x 65536  */
+#define   HSMCI_DTOR_DTOMUL_1048576_Val     _U_(0x7)                                       /**< (HSMCI_DTOR) DTOCYC x 1048576  */
+#define HSMCI_DTOR_DTOMUL_1                 (HSMCI_DTOR_DTOMUL_1_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC Position  */
+#define HSMCI_DTOR_DTOMUL_16                (HSMCI_DTOR_DTOMUL_16_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 16 Position  */
+#define HSMCI_DTOR_DTOMUL_128               (HSMCI_DTOR_DTOMUL_128_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 128 Position  */
+#define HSMCI_DTOR_DTOMUL_256               (HSMCI_DTOR_DTOMUL_256_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 256 Position  */
+#define HSMCI_DTOR_DTOMUL_1024              (HSMCI_DTOR_DTOMUL_1024_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 1024 Position  */
+#define HSMCI_DTOR_DTOMUL_4096              (HSMCI_DTOR_DTOMUL_4096_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 4096 Position  */
+#define HSMCI_DTOR_DTOMUL_65536             (HSMCI_DTOR_DTOMUL_65536_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 65536 Position  */
+#define HSMCI_DTOR_DTOMUL_1048576           (HSMCI_DTOR_DTOMUL_1048576_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 1048576 Position  */
+#define HSMCI_DTOR_MASK                     _U_(0x7F)                                      /**< \deprecated (HSMCI_DTOR) Register MASK  (Use HSMCI_DTOR_Msk instead)  */
+#define HSMCI_DTOR_Msk                      _U_(0x7F)                                      /**< (HSMCI_DTOR) Register Mask  */
+
+
+/* -------- HSMCI_SDCR : (HSMCI Offset: 0x0c) (R/W 32) SD/SDIO Card Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDCSEL:2;                  /**< bit:   0..1  SDCard/SDIO Slot                         */
+    uint32_t :4;                        /**< bit:   2..5  Reserved */
+    uint32_t SDCBUS:2;                  /**< bit:   6..7  SDCard/SDIO Bus Width                    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_SDCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_SDCR_OFFSET                   (0x0C)                                        /**<  (HSMCI_SDCR) SD/SDIO Card Register  Offset */
+
+#define HSMCI_SDCR_SDCSEL_Pos               0                                              /**< (HSMCI_SDCR) SDCard/SDIO Slot Position */
+#define HSMCI_SDCR_SDCSEL_Msk               (_U_(0x3) << HSMCI_SDCR_SDCSEL_Pos)            /**< (HSMCI_SDCR) SDCard/SDIO Slot Mask */
+#define HSMCI_SDCR_SDCSEL(value)            (HSMCI_SDCR_SDCSEL_Msk & ((value) << HSMCI_SDCR_SDCSEL_Pos))
+#define   HSMCI_SDCR_SDCSEL_SLOTA_Val       _U_(0x0)                                       /**< (HSMCI_SDCR) Slot A is selected.  */
+#define HSMCI_SDCR_SDCSEL_SLOTA             (HSMCI_SDCR_SDCSEL_SLOTA_Val << HSMCI_SDCR_SDCSEL_Pos)  /**< (HSMCI_SDCR) Slot A is selected. Position  */
+#define HSMCI_SDCR_SDCBUS_Pos               6                                              /**< (HSMCI_SDCR) SDCard/SDIO Bus Width Position */
+#define HSMCI_SDCR_SDCBUS_Msk               (_U_(0x3) << HSMCI_SDCR_SDCBUS_Pos)            /**< (HSMCI_SDCR) SDCard/SDIO Bus Width Mask */
+#define HSMCI_SDCR_SDCBUS(value)            (HSMCI_SDCR_SDCBUS_Msk & ((value) << HSMCI_SDCR_SDCBUS_Pos))
+#define   HSMCI_SDCR_SDCBUS_1_Val           _U_(0x0)                                       /**< (HSMCI_SDCR) 1 bit  */
+#define   HSMCI_SDCR_SDCBUS_4_Val           _U_(0x2)                                       /**< (HSMCI_SDCR) 4 bits  */
+#define   HSMCI_SDCR_SDCBUS_8_Val           _U_(0x3)                                       /**< (HSMCI_SDCR) 8 bits  */
+#define HSMCI_SDCR_SDCBUS_1                 (HSMCI_SDCR_SDCBUS_1_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 1 bit Position  */
+#define HSMCI_SDCR_SDCBUS_4                 (HSMCI_SDCR_SDCBUS_4_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 4 bits Position  */
+#define HSMCI_SDCR_SDCBUS_8                 (HSMCI_SDCR_SDCBUS_8_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 8 bits Position  */
+#define HSMCI_SDCR_MASK                     _U_(0xC3)                                      /**< \deprecated (HSMCI_SDCR) Register MASK  (Use HSMCI_SDCR_Msk instead)  */
+#define HSMCI_SDCR_Msk                      _U_(0xC3)                                      /**< (HSMCI_SDCR) Register Mask  */
+
+
+/* -------- HSMCI_ARGR : (HSMCI Offset: 0x10) (R/W 32) Argument Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ARG:32;                    /**< bit:  0..31  Command Argument                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_ARGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_ARGR_OFFSET                   (0x10)                                        /**<  (HSMCI_ARGR) Argument Register  Offset */
+
+#define HSMCI_ARGR_ARG_Pos                  0                                              /**< (HSMCI_ARGR) Command Argument Position */
+#define HSMCI_ARGR_ARG_Msk                  (_U_(0xFFFFFFFF) << HSMCI_ARGR_ARG_Pos)        /**< (HSMCI_ARGR) Command Argument Mask */
+#define HSMCI_ARGR_ARG(value)               (HSMCI_ARGR_ARG_Msk & ((value) << HSMCI_ARGR_ARG_Pos))
+#define HSMCI_ARGR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_ARGR) Register MASK  (Use HSMCI_ARGR_Msk instead)  */
+#define HSMCI_ARGR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_ARGR) Register Mask  */
+
+
+/* -------- HSMCI_CMDR : (HSMCI Offset: 0x14) (/W 32) Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDNB:6;                   /**< bit:   0..5  Command Number                           */
+    uint32_t RSPTYP:2;                  /**< bit:   6..7  Response Type                            */
+    uint32_t SPCMD:3;                   /**< bit:  8..10  Special Command                          */
+    uint32_t OPDCMD:1;                  /**< bit:     11  Open Drain Command                       */
+    uint32_t MAXLAT:1;                  /**< bit:     12  Max Latency for Command to Response      */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TRCMD:2;                   /**< bit: 16..17  Transfer Command                         */
+    uint32_t TRDIR:1;                   /**< bit:     18  Transfer Direction                       */
+    uint32_t TRTYP:3;                   /**< bit: 19..21  Transfer Type                            */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t IOSPCMD:2;                 /**< bit: 24..25  SDIO Special Command                     */
+    uint32_t ATACS:1;                   /**< bit:     26  ATA with Command Completion Signal       */
+    uint32_t BOOT_ACK:1;                /**< bit:     27  Boot Operation Acknowledge               */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CMDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CMDR_OFFSET                   (0x14)                                        /**<  (HSMCI_CMDR) Command Register  Offset */
+
+#define HSMCI_CMDR_CMDNB_Pos                0                                              /**< (HSMCI_CMDR) Command Number Position */
+#define HSMCI_CMDR_CMDNB_Msk                (_U_(0x3F) << HSMCI_CMDR_CMDNB_Pos)            /**< (HSMCI_CMDR) Command Number Mask */
+#define HSMCI_CMDR_CMDNB(value)             (HSMCI_CMDR_CMDNB_Msk & ((value) << HSMCI_CMDR_CMDNB_Pos))
+#define HSMCI_CMDR_RSPTYP_Pos               6                                              /**< (HSMCI_CMDR) Response Type Position */
+#define HSMCI_CMDR_RSPTYP_Msk               (_U_(0x3) << HSMCI_CMDR_RSPTYP_Pos)            /**< (HSMCI_CMDR) Response Type Mask */
+#define HSMCI_CMDR_RSPTYP(value)            (HSMCI_CMDR_RSPTYP_Msk & ((value) << HSMCI_CMDR_RSPTYP_Pos))
+#define   HSMCI_CMDR_RSPTYP_NORESP_Val      _U_(0x0)                                       /**< (HSMCI_CMDR) No response  */
+#define   HSMCI_CMDR_RSPTYP_48_BIT_Val      _U_(0x1)                                       /**< (HSMCI_CMDR) 48-bit response  */
+#define   HSMCI_CMDR_RSPTYP_136_BIT_Val     _U_(0x2)                                       /**< (HSMCI_CMDR) 136-bit response  */
+#define   HSMCI_CMDR_RSPTYP_R1B_Val         _U_(0x3)                                       /**< (HSMCI_CMDR) R1b response type  */
+#define HSMCI_CMDR_RSPTYP_NORESP            (HSMCI_CMDR_RSPTYP_NORESP_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) No response Position  */
+#define HSMCI_CMDR_RSPTYP_48_BIT            (HSMCI_CMDR_RSPTYP_48_BIT_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) 48-bit response Position  */
+#define HSMCI_CMDR_RSPTYP_136_BIT           (HSMCI_CMDR_RSPTYP_136_BIT_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) 136-bit response Position  */
+#define HSMCI_CMDR_RSPTYP_R1B               (HSMCI_CMDR_RSPTYP_R1B_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) R1b response type Position  */
+#define HSMCI_CMDR_SPCMD_Pos                8                                              /**< (HSMCI_CMDR) Special Command Position */
+#define HSMCI_CMDR_SPCMD_Msk                (_U_(0x7) << HSMCI_CMDR_SPCMD_Pos)             /**< (HSMCI_CMDR) Special Command Mask */
+#define HSMCI_CMDR_SPCMD(value)             (HSMCI_CMDR_SPCMD_Msk & ((value) << HSMCI_CMDR_SPCMD_Pos))
+#define   HSMCI_CMDR_SPCMD_STD_Val          _U_(0x0)                                       /**< (HSMCI_CMDR) Not a special CMD.  */
+#define   HSMCI_CMDR_SPCMD_INIT_Val         _U_(0x1)                                       /**< (HSMCI_CMDR) Initialization CMD: 74 clock cycles for initialization sequence.  */
+#define   HSMCI_CMDR_SPCMD_SYNC_Val         _U_(0x2)                                       /**< (HSMCI_CMDR) Synchronized CMD: Wait for the end of the current data block transfer before sending the pending command.  */
+#define   HSMCI_CMDR_SPCMD_CE_ATA_Val       _U_(0x3)                                       /**< (HSMCI_CMDR) CE-ATA Completion Signal disable Command. The host cancels the ability for the device to return a command completion signal on the command line.  */
+#define   HSMCI_CMDR_SPCMD_IT_CMD_Val       _U_(0x4)                                       /**< (HSMCI_CMDR) Interrupt command: Corresponds to the Interrupt Mode (CMD40).  */
+#define   HSMCI_CMDR_SPCMD_IT_RESP_Val      _U_(0x5)                                       /**< (HSMCI_CMDR) Interrupt response: Corresponds to the Interrupt Mode (CMD40).  */
+#define   HSMCI_CMDR_SPCMD_BOR_Val          _U_(0x6)                                       /**< (HSMCI_CMDR) Boot Operation Request. Start a boot operation mode, the host processor can read boot data from the MMC device directly.  */
+#define   HSMCI_CMDR_SPCMD_EBO_Val          _U_(0x7)                                       /**< (HSMCI_CMDR) End Boot Operation. This command allows the host processor to terminate the boot operation mode.  */
+#define HSMCI_CMDR_SPCMD_STD                (HSMCI_CMDR_SPCMD_STD_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Not a special CMD. Position  */
+#define HSMCI_CMDR_SPCMD_INIT               (HSMCI_CMDR_SPCMD_INIT_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Initialization CMD: 74 clock cycles for initialization sequence. Position  */
+#define HSMCI_CMDR_SPCMD_SYNC               (HSMCI_CMDR_SPCMD_SYNC_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Synchronized CMD: Wait for the end of the current data block transfer before sending the pending command. Position  */
+#define HSMCI_CMDR_SPCMD_CE_ATA             (HSMCI_CMDR_SPCMD_CE_ATA_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) CE-ATA Completion Signal disable Command. The host cancels the ability for the device to return a command completion signal on the command line. Position  */
+#define HSMCI_CMDR_SPCMD_IT_CMD             (HSMCI_CMDR_SPCMD_IT_CMD_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Interrupt command: Corresponds to the Interrupt Mode (CMD40). Position  */
+#define HSMCI_CMDR_SPCMD_IT_RESP            (HSMCI_CMDR_SPCMD_IT_RESP_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Interrupt response: Corresponds to the Interrupt Mode (CMD40). Position  */
+#define HSMCI_CMDR_SPCMD_BOR                (HSMCI_CMDR_SPCMD_BOR_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Boot Operation Request. Start a boot operation mode, the host processor can read boot data from the MMC device directly. Position  */
+#define HSMCI_CMDR_SPCMD_EBO                (HSMCI_CMDR_SPCMD_EBO_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) End Boot Operation. This command allows the host processor to terminate the boot operation mode. Position  */
+#define HSMCI_CMDR_OPDCMD_Pos               11                                             /**< (HSMCI_CMDR) Open Drain Command Position */
+#define HSMCI_CMDR_OPDCMD_Msk               (_U_(0x1) << HSMCI_CMDR_OPDCMD_Pos)            /**< (HSMCI_CMDR) Open Drain Command Mask */
+#define HSMCI_CMDR_OPDCMD                   HSMCI_CMDR_OPDCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_OPDCMD_Msk instead */
+#define   HSMCI_CMDR_OPDCMD_PUSHPULL_Val    _U_(0x0)                                       /**< (HSMCI_CMDR) Push pull command.  */
+#define   HSMCI_CMDR_OPDCMD_OPENDRAIN_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) Open drain command.  */
+#define HSMCI_CMDR_OPDCMD_PUSHPULL          (HSMCI_CMDR_OPDCMD_PUSHPULL_Val << HSMCI_CMDR_OPDCMD_Pos)  /**< (HSMCI_CMDR) Push pull command. Position  */
+#define HSMCI_CMDR_OPDCMD_OPENDRAIN         (HSMCI_CMDR_OPDCMD_OPENDRAIN_Val << HSMCI_CMDR_OPDCMD_Pos)  /**< (HSMCI_CMDR) Open drain command. Position  */
+#define HSMCI_CMDR_MAXLAT_Pos               12                                             /**< (HSMCI_CMDR) Max Latency for Command to Response Position */
+#define HSMCI_CMDR_MAXLAT_Msk               (_U_(0x1) << HSMCI_CMDR_MAXLAT_Pos)            /**< (HSMCI_CMDR) Max Latency for Command to Response Mask */
+#define HSMCI_CMDR_MAXLAT                   HSMCI_CMDR_MAXLAT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_MAXLAT_Msk instead */
+#define   HSMCI_CMDR_MAXLAT_5_Val           _U_(0x0)                                       /**< (HSMCI_CMDR) 5-cycle max latency.  */
+#define   HSMCI_CMDR_MAXLAT_64_Val          _U_(0x1)                                       /**< (HSMCI_CMDR) 64-cycle max latency.  */
+#define HSMCI_CMDR_MAXLAT_5                 (HSMCI_CMDR_MAXLAT_5_Val << HSMCI_CMDR_MAXLAT_Pos)  /**< (HSMCI_CMDR) 5-cycle max latency. Position  */
+#define HSMCI_CMDR_MAXLAT_64                (HSMCI_CMDR_MAXLAT_64_Val << HSMCI_CMDR_MAXLAT_Pos)  /**< (HSMCI_CMDR) 64-cycle max latency. Position  */
+#define HSMCI_CMDR_TRCMD_Pos                16                                             /**< (HSMCI_CMDR) Transfer Command Position */
+#define HSMCI_CMDR_TRCMD_Msk                (_U_(0x3) << HSMCI_CMDR_TRCMD_Pos)             /**< (HSMCI_CMDR) Transfer Command Mask */
+#define HSMCI_CMDR_TRCMD(value)             (HSMCI_CMDR_TRCMD_Msk & ((value) << HSMCI_CMDR_TRCMD_Pos))
+#define   HSMCI_CMDR_TRCMD_NO_DATA_Val      _U_(0x0)                                       /**< (HSMCI_CMDR) No data transfer  */
+#define   HSMCI_CMDR_TRCMD_START_DATA_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) Start data transfer  */
+#define   HSMCI_CMDR_TRCMD_STOP_DATA_Val    _U_(0x2)                                       /**< (HSMCI_CMDR) Stop data transfer  */
+#define HSMCI_CMDR_TRCMD_NO_DATA            (HSMCI_CMDR_TRCMD_NO_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) No data transfer Position  */
+#define HSMCI_CMDR_TRCMD_START_DATA         (HSMCI_CMDR_TRCMD_START_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) Start data transfer Position  */
+#define HSMCI_CMDR_TRCMD_STOP_DATA          (HSMCI_CMDR_TRCMD_STOP_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) Stop data transfer Position  */
+#define HSMCI_CMDR_TRDIR_Pos                18                                             /**< (HSMCI_CMDR) Transfer Direction Position */
+#define HSMCI_CMDR_TRDIR_Msk                (_U_(0x1) << HSMCI_CMDR_TRDIR_Pos)             /**< (HSMCI_CMDR) Transfer Direction Mask */
+#define HSMCI_CMDR_TRDIR                    HSMCI_CMDR_TRDIR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_TRDIR_Msk instead */
+#define   HSMCI_CMDR_TRDIR_WRITE_Val        _U_(0x0)                                       /**< (HSMCI_CMDR) Write.  */
+#define   HSMCI_CMDR_TRDIR_READ_Val         _U_(0x1)                                       /**< (HSMCI_CMDR) Read.  */
+#define HSMCI_CMDR_TRDIR_WRITE              (HSMCI_CMDR_TRDIR_WRITE_Val << HSMCI_CMDR_TRDIR_Pos)  /**< (HSMCI_CMDR) Write. Position  */
+#define HSMCI_CMDR_TRDIR_READ               (HSMCI_CMDR_TRDIR_READ_Val << HSMCI_CMDR_TRDIR_Pos)  /**< (HSMCI_CMDR) Read. Position  */
+#define HSMCI_CMDR_TRTYP_Pos                19                                             /**< (HSMCI_CMDR) Transfer Type Position */
+#define HSMCI_CMDR_TRTYP_Msk                (_U_(0x7) << HSMCI_CMDR_TRTYP_Pos)             /**< (HSMCI_CMDR) Transfer Type Mask */
+#define HSMCI_CMDR_TRTYP(value)             (HSMCI_CMDR_TRTYP_Msk & ((value) << HSMCI_CMDR_TRTYP_Pos))
+#define   HSMCI_CMDR_TRTYP_SINGLE_Val       _U_(0x0)                                       /**< (HSMCI_CMDR) MMC/SD Card Single Block  */
+#define   HSMCI_CMDR_TRTYP_MULTIPLE_Val     _U_(0x1)                                       /**< (HSMCI_CMDR) MMC/SD Card Multiple Block  */
+#define   HSMCI_CMDR_TRTYP_STREAM_Val       _U_(0x2)                                       /**< (HSMCI_CMDR) MMC Stream  */
+#define   HSMCI_CMDR_TRTYP_BYTE_Val         _U_(0x4)                                       /**< (HSMCI_CMDR) SDIO Byte  */
+#define   HSMCI_CMDR_TRTYP_BLOCK_Val        _U_(0x5)                                       /**< (HSMCI_CMDR) SDIO Block  */
+#define HSMCI_CMDR_TRTYP_SINGLE             (HSMCI_CMDR_TRTYP_SINGLE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC/SD Card Single Block Position  */
+#define HSMCI_CMDR_TRTYP_MULTIPLE           (HSMCI_CMDR_TRTYP_MULTIPLE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC/SD Card Multiple Block Position  */
+#define HSMCI_CMDR_TRTYP_STREAM             (HSMCI_CMDR_TRTYP_STREAM_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC Stream Position  */
+#define HSMCI_CMDR_TRTYP_BYTE               (HSMCI_CMDR_TRTYP_BYTE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) SDIO Byte Position  */
+#define HSMCI_CMDR_TRTYP_BLOCK              (HSMCI_CMDR_TRTYP_BLOCK_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) SDIO Block Position  */
+#define HSMCI_CMDR_IOSPCMD_Pos              24                                             /**< (HSMCI_CMDR) SDIO Special Command Position */
+#define HSMCI_CMDR_IOSPCMD_Msk              (_U_(0x3) << HSMCI_CMDR_IOSPCMD_Pos)           /**< (HSMCI_CMDR) SDIO Special Command Mask */
+#define HSMCI_CMDR_IOSPCMD(value)           (HSMCI_CMDR_IOSPCMD_Msk & ((value) << HSMCI_CMDR_IOSPCMD_Pos))
+#define   HSMCI_CMDR_IOSPCMD_STD_Val        _U_(0x0)                                       /**< (HSMCI_CMDR) Not an SDIO Special Command  */
+#define   HSMCI_CMDR_IOSPCMD_SUSPEND_Val    _U_(0x1)                                       /**< (HSMCI_CMDR) SDIO Suspend Command  */
+#define   HSMCI_CMDR_IOSPCMD_RESUME_Val     _U_(0x2)                                       /**< (HSMCI_CMDR) SDIO Resume Command  */
+#define HSMCI_CMDR_IOSPCMD_STD              (HSMCI_CMDR_IOSPCMD_STD_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) Not an SDIO Special Command Position  */
+#define HSMCI_CMDR_IOSPCMD_SUSPEND          (HSMCI_CMDR_IOSPCMD_SUSPEND_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) SDIO Suspend Command Position  */
+#define HSMCI_CMDR_IOSPCMD_RESUME           (HSMCI_CMDR_IOSPCMD_RESUME_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) SDIO Resume Command Position  */
+#define HSMCI_CMDR_ATACS_Pos                26                                             /**< (HSMCI_CMDR) ATA with Command Completion Signal Position */
+#define HSMCI_CMDR_ATACS_Msk                (_U_(0x1) << HSMCI_CMDR_ATACS_Pos)             /**< (HSMCI_CMDR) ATA with Command Completion Signal Mask */
+#define HSMCI_CMDR_ATACS                    HSMCI_CMDR_ATACS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_ATACS_Msk instead */
+#define   HSMCI_CMDR_ATACS_NORMAL_Val       _U_(0x0)                                       /**< (HSMCI_CMDR) Normal operation mode.  */
+#define   HSMCI_CMDR_ATACS_COMPLETION_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) This bit indicates that a completion signal is expected within a programmed amount of time (HSMCI_CSTOR).  */
+#define HSMCI_CMDR_ATACS_NORMAL             (HSMCI_CMDR_ATACS_NORMAL_Val << HSMCI_CMDR_ATACS_Pos)  /**< (HSMCI_CMDR) Normal operation mode. Position  */
+#define HSMCI_CMDR_ATACS_COMPLETION         (HSMCI_CMDR_ATACS_COMPLETION_Val << HSMCI_CMDR_ATACS_Pos)  /**< (HSMCI_CMDR) This bit indicates that a completion signal is expected within a programmed amount of time (HSMCI_CSTOR). Position  */
+#define HSMCI_CMDR_BOOT_ACK_Pos             27                                             /**< (HSMCI_CMDR) Boot Operation Acknowledge Position */
+#define HSMCI_CMDR_BOOT_ACK_Msk             (_U_(0x1) << HSMCI_CMDR_BOOT_ACK_Pos)          /**< (HSMCI_CMDR) Boot Operation Acknowledge Mask */
+#define HSMCI_CMDR_BOOT_ACK                 HSMCI_CMDR_BOOT_ACK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_BOOT_ACK_Msk instead */
+#define HSMCI_CMDR_MASK                     _U_(0xF3F1FFF)                                 /**< \deprecated (HSMCI_CMDR) Register MASK  (Use HSMCI_CMDR_Msk instead)  */
+#define HSMCI_CMDR_Msk                      _U_(0xF3F1FFF)                                 /**< (HSMCI_CMDR) Register Mask  */
+
+
+/* -------- HSMCI_BLKR : (HSMCI Offset: 0x18) (R/W 32) Block Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BCNT:16;                   /**< bit:  0..15  MMC/SDIO Block Count - SDIO Byte Count   */
+    uint32_t BLKLEN:16;                 /**< bit: 16..31  Data Block Length                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_BLKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_BLKR_OFFSET                   (0x18)                                        /**<  (HSMCI_BLKR) Block Register  Offset */
+
+#define HSMCI_BLKR_BCNT_Pos                 0                                              /**< (HSMCI_BLKR) MMC/SDIO Block Count - SDIO Byte Count Position */
+#define HSMCI_BLKR_BCNT_Msk                 (_U_(0xFFFF) << HSMCI_BLKR_BCNT_Pos)           /**< (HSMCI_BLKR) MMC/SDIO Block Count - SDIO Byte Count Mask */
+#define HSMCI_BLKR_BCNT(value)              (HSMCI_BLKR_BCNT_Msk & ((value) << HSMCI_BLKR_BCNT_Pos))
+#define HSMCI_BLKR_BLKLEN_Pos               16                                             /**< (HSMCI_BLKR) Data Block Length Position */
+#define HSMCI_BLKR_BLKLEN_Msk               (_U_(0xFFFF) << HSMCI_BLKR_BLKLEN_Pos)         /**< (HSMCI_BLKR) Data Block Length Mask */
+#define HSMCI_BLKR_BLKLEN(value)            (HSMCI_BLKR_BLKLEN_Msk & ((value) << HSMCI_BLKR_BLKLEN_Pos))
+#define HSMCI_BLKR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_BLKR) Register MASK  (Use HSMCI_BLKR_Msk instead)  */
+#define HSMCI_BLKR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_BLKR) Register Mask  */
+
+
+/* -------- HSMCI_CSTOR : (HSMCI Offset: 0x1c) (R/W 32) Completion Signal Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSTOCYC:4;                 /**< bit:   0..3  Completion Signal Timeout Cycle Number   */
+    uint32_t CSTOMUL:3;                 /**< bit:   4..6  Completion Signal Timeout Multiplier     */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CSTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CSTOR_OFFSET                  (0x1C)                                        /**<  (HSMCI_CSTOR) Completion Signal Timeout Register  Offset */
+
+#define HSMCI_CSTOR_CSTOCYC_Pos             0                                              /**< (HSMCI_CSTOR) Completion Signal Timeout Cycle Number Position */
+#define HSMCI_CSTOR_CSTOCYC_Msk             (_U_(0xF) << HSMCI_CSTOR_CSTOCYC_Pos)          /**< (HSMCI_CSTOR) Completion Signal Timeout Cycle Number Mask */
+#define HSMCI_CSTOR_CSTOCYC(value)          (HSMCI_CSTOR_CSTOCYC_Msk & ((value) << HSMCI_CSTOR_CSTOCYC_Pos))
+#define HSMCI_CSTOR_CSTOMUL_Pos             4                                              /**< (HSMCI_CSTOR) Completion Signal Timeout Multiplier Position */
+#define HSMCI_CSTOR_CSTOMUL_Msk             (_U_(0x7) << HSMCI_CSTOR_CSTOMUL_Pos)          /**< (HSMCI_CSTOR) Completion Signal Timeout Multiplier Mask */
+#define HSMCI_CSTOR_CSTOMUL(value)          (HSMCI_CSTOR_CSTOMUL_Msk & ((value) << HSMCI_CSTOR_CSTOMUL_Pos))
+#define   HSMCI_CSTOR_CSTOMUL_1_Val         _U_(0x0)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1  */
+#define   HSMCI_CSTOR_CSTOMUL_16_Val        _U_(0x1)                                       /**< (HSMCI_CSTOR) CSTOCYC x 16  */
+#define   HSMCI_CSTOR_CSTOMUL_128_Val       _U_(0x2)                                       /**< (HSMCI_CSTOR) CSTOCYC x 128  */
+#define   HSMCI_CSTOR_CSTOMUL_256_Val       _U_(0x3)                                       /**< (HSMCI_CSTOR) CSTOCYC x 256  */
+#define   HSMCI_CSTOR_CSTOMUL_1024_Val      _U_(0x4)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1024  */
+#define   HSMCI_CSTOR_CSTOMUL_4096_Val      _U_(0x5)                                       /**< (HSMCI_CSTOR) CSTOCYC x 4096  */
+#define   HSMCI_CSTOR_CSTOMUL_65536_Val     _U_(0x6)                                       /**< (HSMCI_CSTOR) CSTOCYC x 65536  */
+#define   HSMCI_CSTOR_CSTOMUL_1048576_Val   _U_(0x7)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1048576  */
+#define HSMCI_CSTOR_CSTOMUL_1               (HSMCI_CSTOR_CSTOMUL_1_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1 Position  */
+#define HSMCI_CSTOR_CSTOMUL_16              (HSMCI_CSTOR_CSTOMUL_16_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 16 Position  */
+#define HSMCI_CSTOR_CSTOMUL_128             (HSMCI_CSTOR_CSTOMUL_128_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 128 Position  */
+#define HSMCI_CSTOR_CSTOMUL_256             (HSMCI_CSTOR_CSTOMUL_256_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 256 Position  */
+#define HSMCI_CSTOR_CSTOMUL_1024            (HSMCI_CSTOR_CSTOMUL_1024_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1024 Position  */
+#define HSMCI_CSTOR_CSTOMUL_4096            (HSMCI_CSTOR_CSTOMUL_4096_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 4096 Position  */
+#define HSMCI_CSTOR_CSTOMUL_65536           (HSMCI_CSTOR_CSTOMUL_65536_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 65536 Position  */
+#define HSMCI_CSTOR_CSTOMUL_1048576         (HSMCI_CSTOR_CSTOMUL_1048576_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1048576 Position  */
+#define HSMCI_CSTOR_MASK                    _U_(0x7F)                                      /**< \deprecated (HSMCI_CSTOR) Register MASK  (Use HSMCI_CSTOR_Msk instead)  */
+#define HSMCI_CSTOR_Msk                     _U_(0x7F)                                      /**< (HSMCI_CSTOR) Register Mask  */
+
+
+/* -------- HSMCI_RSPR : (HSMCI Offset: 0x20) (R/ 32) Response Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSP:32;                    /**< bit:  0..31  Response                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_RSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_RSPR_OFFSET                   (0x20)                                        /**<  (HSMCI_RSPR) Response Register 0  Offset */
+
+#define HSMCI_RSPR_RSP_Pos                  0                                              /**< (HSMCI_RSPR) Response Position */
+#define HSMCI_RSPR_RSP_Msk                  (_U_(0xFFFFFFFF) << HSMCI_RSPR_RSP_Pos)        /**< (HSMCI_RSPR) Response Mask */
+#define HSMCI_RSPR_RSP(value)               (HSMCI_RSPR_RSP_Msk & ((value) << HSMCI_RSPR_RSP_Pos))
+#define HSMCI_RSPR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_RSPR) Register MASK  (Use HSMCI_RSPR_Msk instead)  */
+#define HSMCI_RSPR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_RSPR) Register Mask  */
+
+
+/* -------- HSMCI_RDR : (HSMCI Offset: 0x30) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Read                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_RDR_OFFSET                    (0x30)                                        /**<  (HSMCI_RDR) Receive Data Register  Offset */
+
+#define HSMCI_RDR_DATA_Pos                  0                                              /**< (HSMCI_RDR) Data to Read Position */
+#define HSMCI_RDR_DATA_Msk                  (_U_(0xFFFFFFFF) << HSMCI_RDR_DATA_Pos)        /**< (HSMCI_RDR) Data to Read Mask */
+#define HSMCI_RDR_DATA(value)               (HSMCI_RDR_DATA_Msk & ((value) << HSMCI_RDR_DATA_Pos))
+#define HSMCI_RDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_RDR) Register MASK  (Use HSMCI_RDR_Msk instead)  */
+#define HSMCI_RDR_Msk                       _U_(0xFFFFFFFF)                                /**< (HSMCI_RDR) Register Mask  */
+
+
+/* -------- HSMCI_TDR : (HSMCI Offset: 0x34) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Write                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_TDR_OFFSET                    (0x34)                                        /**<  (HSMCI_TDR) Transmit Data Register  Offset */
+
+#define HSMCI_TDR_DATA_Pos                  0                                              /**< (HSMCI_TDR) Data to Write Position */
+#define HSMCI_TDR_DATA_Msk                  (_U_(0xFFFFFFFF) << HSMCI_TDR_DATA_Pos)        /**< (HSMCI_TDR) Data to Write Mask */
+#define HSMCI_TDR_DATA(value)               (HSMCI_TDR_DATA_Msk & ((value) << HSMCI_TDR_DATA_Pos))
+#define HSMCI_TDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_TDR) Register MASK  (Use HSMCI_TDR_Msk instead)  */
+#define HSMCI_TDR_Msk                       _U_(0xFFFFFFFF)                                /**< (HSMCI_TDR) Register Mask  */
+
+
+/* -------- HSMCI_SR : (HSMCI Offset: 0x40) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready (cleared by writing in HSMCI_CMDR) */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready (cleared by reading HSMCI_RDR) */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready (cleared by writing in HSMCI_TDR) */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended (cleared on read)       */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress (cleared at the end of CRC16 calculation) */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  HSMCI Not Busy                           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A (cleared on read) */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status          */
+    uint32_t CSRCV:1;                   /**< bit:     13  CE-ATA Completion Signal Received (cleared on read) */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error (cleared on read)         */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error (cleared on read)    */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time-out Error (cleared on read) */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error (cleared on read) */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty flag                          */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done flag                       */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Operation Acknowledge Received (cleared on read) */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Operation Acknowledge Error (cleared on read) */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_SR_OFFSET                     (0x40)                                        /**<  (HSMCI_SR) Status Register  Offset */
+
+#define HSMCI_SR_CMDRDY_Pos                 0                                              /**< (HSMCI_SR) Command Ready (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_CMDRDY_Msk                 (_U_(0x1) << HSMCI_SR_CMDRDY_Pos)              /**< (HSMCI_SR) Command Ready (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_CMDRDY                     HSMCI_SR_CMDRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CMDRDY_Msk instead */
+#define HSMCI_SR_RXRDY_Pos                  1                                              /**< (HSMCI_SR) Receiver Ready (cleared by reading HSMCI_RDR) Position */
+#define HSMCI_SR_RXRDY_Msk                  (_U_(0x1) << HSMCI_SR_RXRDY_Pos)               /**< (HSMCI_SR) Receiver Ready (cleared by reading HSMCI_RDR) Mask */
+#define HSMCI_SR_RXRDY                      HSMCI_SR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RXRDY_Msk instead */
+#define HSMCI_SR_TXRDY_Pos                  2                                              /**< (HSMCI_SR) Transmit Ready (cleared by writing in HSMCI_TDR) Position */
+#define HSMCI_SR_TXRDY_Msk                  (_U_(0x1) << HSMCI_SR_TXRDY_Pos)               /**< (HSMCI_SR) Transmit Ready (cleared by writing in HSMCI_TDR) Mask */
+#define HSMCI_SR_TXRDY                      HSMCI_SR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_TXRDY_Msk instead */
+#define HSMCI_SR_BLKE_Pos                   3                                              /**< (HSMCI_SR) Data Block Ended (cleared on read) Position */
+#define HSMCI_SR_BLKE_Msk                   (_U_(0x1) << HSMCI_SR_BLKE_Pos)                /**< (HSMCI_SR) Data Block Ended (cleared on read) Mask */
+#define HSMCI_SR_BLKE                       HSMCI_SR_BLKE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_BLKE_Msk instead */
+#define HSMCI_SR_DTIP_Pos                   4                                              /**< (HSMCI_SR) Data Transfer in Progress (cleared at the end of CRC16 calculation) Position */
+#define HSMCI_SR_DTIP_Msk                   (_U_(0x1) << HSMCI_SR_DTIP_Pos)                /**< (HSMCI_SR) Data Transfer in Progress (cleared at the end of CRC16 calculation) Mask */
+#define HSMCI_SR_DTIP                       HSMCI_SR_DTIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DTIP_Msk instead */
+#define HSMCI_SR_NOTBUSY_Pos                5                                              /**< (HSMCI_SR) HSMCI Not Busy Position */
+#define HSMCI_SR_NOTBUSY_Msk                (_U_(0x1) << HSMCI_SR_NOTBUSY_Pos)             /**< (HSMCI_SR) HSMCI Not Busy Mask */
+#define HSMCI_SR_NOTBUSY                    HSMCI_SR_NOTBUSY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_NOTBUSY_Msk instead */
+#define HSMCI_SR_SDIOIRQA_Pos               8                                              /**< (HSMCI_SR) SDIO Interrupt for Slot A (cleared on read) Position */
+#define HSMCI_SR_SDIOIRQA_Msk               (_U_(0x1) << HSMCI_SR_SDIOIRQA_Pos)            /**< (HSMCI_SR) SDIO Interrupt for Slot A (cleared on read) Mask */
+#define HSMCI_SR_SDIOIRQA                   HSMCI_SR_SDIOIRQA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_SDIOIRQA_Msk instead */
+#define HSMCI_SR_SDIOWAIT_Pos               12                                             /**< (HSMCI_SR) SDIO Read Wait Operation Status Position */
+#define HSMCI_SR_SDIOWAIT_Msk               (_U_(0x1) << HSMCI_SR_SDIOWAIT_Pos)            /**< (HSMCI_SR) SDIO Read Wait Operation Status Mask */
+#define HSMCI_SR_SDIOWAIT                   HSMCI_SR_SDIOWAIT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_SDIOWAIT_Msk instead */
+#define HSMCI_SR_CSRCV_Pos                  13                                             /**< (HSMCI_SR) CE-ATA Completion Signal Received (cleared on read) Position */
+#define HSMCI_SR_CSRCV_Msk                  (_U_(0x1) << HSMCI_SR_CSRCV_Pos)               /**< (HSMCI_SR) CE-ATA Completion Signal Received (cleared on read) Mask */
+#define HSMCI_SR_CSRCV                      HSMCI_SR_CSRCV_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CSRCV_Msk instead */
+#define HSMCI_SR_RINDE_Pos                  16                                             /**< (HSMCI_SR) Response Index Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RINDE_Msk                  (_U_(0x1) << HSMCI_SR_RINDE_Pos)               /**< (HSMCI_SR) Response Index Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RINDE                      HSMCI_SR_RINDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RINDE_Msk instead */
+#define HSMCI_SR_RDIRE_Pos                  17                                             /**< (HSMCI_SR) Response Direction Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RDIRE_Msk                  (_U_(0x1) << HSMCI_SR_RDIRE_Pos)               /**< (HSMCI_SR) Response Direction Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RDIRE                      HSMCI_SR_RDIRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RDIRE_Msk instead */
+#define HSMCI_SR_RCRCE_Pos                  18                                             /**< (HSMCI_SR) Response CRC Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RCRCE_Msk                  (_U_(0x1) << HSMCI_SR_RCRCE_Pos)               /**< (HSMCI_SR) Response CRC Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RCRCE                      HSMCI_SR_RCRCE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RCRCE_Msk instead */
+#define HSMCI_SR_RENDE_Pos                  19                                             /**< (HSMCI_SR) Response End Bit Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RENDE_Msk                  (_U_(0x1) << HSMCI_SR_RENDE_Pos)               /**< (HSMCI_SR) Response End Bit Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RENDE                      HSMCI_SR_RENDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RENDE_Msk instead */
+#define HSMCI_SR_RTOE_Pos                   20                                             /**< (HSMCI_SR) Response Time-out Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RTOE_Msk                   (_U_(0x1) << HSMCI_SR_RTOE_Pos)                /**< (HSMCI_SR) Response Time-out Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RTOE                       HSMCI_SR_RTOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RTOE_Msk instead */
+#define HSMCI_SR_DCRCE_Pos                  21                                             /**< (HSMCI_SR) Data CRC Error (cleared on read) Position */
+#define HSMCI_SR_DCRCE_Msk                  (_U_(0x1) << HSMCI_SR_DCRCE_Pos)               /**< (HSMCI_SR) Data CRC Error (cleared on read) Mask */
+#define HSMCI_SR_DCRCE                      HSMCI_SR_DCRCE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DCRCE_Msk instead */
+#define HSMCI_SR_DTOE_Pos                   22                                             /**< (HSMCI_SR) Data Time-out Error (cleared on read) Position */
+#define HSMCI_SR_DTOE_Msk                   (_U_(0x1) << HSMCI_SR_DTOE_Pos)                /**< (HSMCI_SR) Data Time-out Error (cleared on read) Mask */
+#define HSMCI_SR_DTOE                       HSMCI_SR_DTOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DTOE_Msk instead */
+#define HSMCI_SR_CSTOE_Pos                  23                                             /**< (HSMCI_SR) Completion Signal Time-out Error (cleared on read) Position */
+#define HSMCI_SR_CSTOE_Msk                  (_U_(0x1) << HSMCI_SR_CSTOE_Pos)               /**< (HSMCI_SR) Completion Signal Time-out Error (cleared on read) Mask */
+#define HSMCI_SR_CSTOE                      HSMCI_SR_CSTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CSTOE_Msk instead */
+#define HSMCI_SR_BLKOVRE_Pos                24                                             /**< (HSMCI_SR) DMA Block Overrun Error (cleared on read) Position */
+#define HSMCI_SR_BLKOVRE_Msk                (_U_(0x1) << HSMCI_SR_BLKOVRE_Pos)             /**< (HSMCI_SR) DMA Block Overrun Error (cleared on read) Mask */
+#define HSMCI_SR_BLKOVRE                    HSMCI_SR_BLKOVRE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_BLKOVRE_Msk instead */
+#define HSMCI_SR_FIFOEMPTY_Pos              26                                             /**< (HSMCI_SR) FIFO empty flag Position */
+#define HSMCI_SR_FIFOEMPTY_Msk              (_U_(0x1) << HSMCI_SR_FIFOEMPTY_Pos)           /**< (HSMCI_SR) FIFO empty flag Mask */
+#define HSMCI_SR_FIFOEMPTY                  HSMCI_SR_FIFOEMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_FIFOEMPTY_Msk instead */
+#define HSMCI_SR_XFRDONE_Pos                27                                             /**< (HSMCI_SR) Transfer Done flag Position */
+#define HSMCI_SR_XFRDONE_Msk                (_U_(0x1) << HSMCI_SR_XFRDONE_Pos)             /**< (HSMCI_SR) Transfer Done flag Mask */
+#define HSMCI_SR_XFRDONE                    HSMCI_SR_XFRDONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_XFRDONE_Msk instead */
+#define HSMCI_SR_ACKRCV_Pos                 28                                             /**< (HSMCI_SR) Boot Operation Acknowledge Received (cleared on read) Position */
+#define HSMCI_SR_ACKRCV_Msk                 (_U_(0x1) << HSMCI_SR_ACKRCV_Pos)              /**< (HSMCI_SR) Boot Operation Acknowledge Received (cleared on read) Mask */
+#define HSMCI_SR_ACKRCV                     HSMCI_SR_ACKRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_ACKRCV_Msk instead */
+#define HSMCI_SR_ACKRCVE_Pos                29                                             /**< (HSMCI_SR) Boot Operation Acknowledge Error (cleared on read) Position */
+#define HSMCI_SR_ACKRCVE_Msk                (_U_(0x1) << HSMCI_SR_ACKRCVE_Pos)             /**< (HSMCI_SR) Boot Operation Acknowledge Error (cleared on read) Mask */
+#define HSMCI_SR_ACKRCVE                    HSMCI_SR_ACKRCVE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_ACKRCVE_Msk instead */
+#define HSMCI_SR_OVRE_Pos                   30                                             /**< (HSMCI_SR) Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Position */
+#define HSMCI_SR_OVRE_Msk                   (_U_(0x1) << HSMCI_SR_OVRE_Pos)                /**< (HSMCI_SR) Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Mask */
+#define HSMCI_SR_OVRE                       HSMCI_SR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_OVRE_Msk instead */
+#define HSMCI_SR_UNRE_Pos                   31                                             /**< (HSMCI_SR) Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Position */
+#define HSMCI_SR_UNRE_Msk                   (_U_(0x1) << HSMCI_SR_UNRE_Pos)                /**< (HSMCI_SR) Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Mask */
+#define HSMCI_SR_UNRE                       HSMCI_SR_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_UNRE_Msk instead */
+#define HSMCI_SR_MASK                       _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_SR) Register MASK  (Use HSMCI_SR_Msk instead)  */
+#define HSMCI_SR_Msk                        _U_(0xFDFF313F)                                /**< (HSMCI_SR) Register Mask  */
+
+
+/* -------- HSMCI_IER : (HSMCI Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Enable           */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Enable          */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Enable          */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Enable        */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Enable */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Enable           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Enable */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Enable */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal Received Interrupt Enable */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Enable    */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Enable */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Enable      */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Enable  */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Enable */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Enable          */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Enable     */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Timeout Error Interrupt Enable */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Enable */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty Interrupt enable              */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt enable           */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Acknowledge Interrupt Enable        */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Acknowledge Error Interrupt Enable  */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Enable                 */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IER_OFFSET                    (0x44)                                        /**<  (HSMCI_IER) Interrupt Enable Register  Offset */
+
+#define HSMCI_IER_CMDRDY_Pos                0                                              /**< (HSMCI_IER) Command Ready Interrupt Enable Position */
+#define HSMCI_IER_CMDRDY_Msk                (_U_(0x1) << HSMCI_IER_CMDRDY_Pos)             /**< (HSMCI_IER) Command Ready Interrupt Enable Mask */
+#define HSMCI_IER_CMDRDY                    HSMCI_IER_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CMDRDY_Msk instead */
+#define HSMCI_IER_RXRDY_Pos                 1                                              /**< (HSMCI_IER) Receiver Ready Interrupt Enable Position */
+#define HSMCI_IER_RXRDY_Msk                 (_U_(0x1) << HSMCI_IER_RXRDY_Pos)              /**< (HSMCI_IER) Receiver Ready Interrupt Enable Mask */
+#define HSMCI_IER_RXRDY                     HSMCI_IER_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RXRDY_Msk instead */
+#define HSMCI_IER_TXRDY_Pos                 2                                              /**< (HSMCI_IER) Transmit Ready Interrupt Enable Position */
+#define HSMCI_IER_TXRDY_Msk                 (_U_(0x1) << HSMCI_IER_TXRDY_Pos)              /**< (HSMCI_IER) Transmit Ready Interrupt Enable Mask */
+#define HSMCI_IER_TXRDY                     HSMCI_IER_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_TXRDY_Msk instead */
+#define HSMCI_IER_BLKE_Pos                  3                                              /**< (HSMCI_IER) Data Block Ended Interrupt Enable Position */
+#define HSMCI_IER_BLKE_Msk                  (_U_(0x1) << HSMCI_IER_BLKE_Pos)               /**< (HSMCI_IER) Data Block Ended Interrupt Enable Mask */
+#define HSMCI_IER_BLKE                      HSMCI_IER_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_BLKE_Msk instead */
+#define HSMCI_IER_DTIP_Pos                  4                                              /**< (HSMCI_IER) Data Transfer in Progress Interrupt Enable Position */
+#define HSMCI_IER_DTIP_Msk                  (_U_(0x1) << HSMCI_IER_DTIP_Pos)               /**< (HSMCI_IER) Data Transfer in Progress Interrupt Enable Mask */
+#define HSMCI_IER_DTIP                      HSMCI_IER_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DTIP_Msk instead */
+#define HSMCI_IER_NOTBUSY_Pos               5                                              /**< (HSMCI_IER) Data Not Busy Interrupt Enable Position */
+#define HSMCI_IER_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IER_NOTBUSY_Pos)            /**< (HSMCI_IER) Data Not Busy Interrupt Enable Mask */
+#define HSMCI_IER_NOTBUSY                   HSMCI_IER_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_NOTBUSY_Msk instead */
+#define HSMCI_IER_SDIOIRQA_Pos              8                                              /**< (HSMCI_IER) SDIO Interrupt for Slot A Interrupt Enable Position */
+#define HSMCI_IER_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IER_SDIOIRQA_Pos)           /**< (HSMCI_IER) SDIO Interrupt for Slot A Interrupt Enable Mask */
+#define HSMCI_IER_SDIOIRQA                  HSMCI_IER_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_SDIOIRQA_Msk instead */
+#define HSMCI_IER_SDIOWAIT_Pos              12                                             /**< (HSMCI_IER) SDIO Read Wait Operation Status Interrupt Enable Position */
+#define HSMCI_IER_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IER_SDIOWAIT_Pos)           /**< (HSMCI_IER) SDIO Read Wait Operation Status Interrupt Enable Mask */
+#define HSMCI_IER_SDIOWAIT                  HSMCI_IER_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_SDIOWAIT_Msk instead */
+#define HSMCI_IER_CSRCV_Pos                 13                                             /**< (HSMCI_IER) Completion Signal Received Interrupt Enable Position */
+#define HSMCI_IER_CSRCV_Msk                 (_U_(0x1) << HSMCI_IER_CSRCV_Pos)              /**< (HSMCI_IER) Completion Signal Received Interrupt Enable Mask */
+#define HSMCI_IER_CSRCV                     HSMCI_IER_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CSRCV_Msk instead */
+#define HSMCI_IER_RINDE_Pos                 16                                             /**< (HSMCI_IER) Response Index Error Interrupt Enable Position */
+#define HSMCI_IER_RINDE_Msk                 (_U_(0x1) << HSMCI_IER_RINDE_Pos)              /**< (HSMCI_IER) Response Index Error Interrupt Enable Mask */
+#define HSMCI_IER_RINDE                     HSMCI_IER_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RINDE_Msk instead */
+#define HSMCI_IER_RDIRE_Pos                 17                                             /**< (HSMCI_IER) Response Direction Error Interrupt Enable Position */
+#define HSMCI_IER_RDIRE_Msk                 (_U_(0x1) << HSMCI_IER_RDIRE_Pos)              /**< (HSMCI_IER) Response Direction Error Interrupt Enable Mask */
+#define HSMCI_IER_RDIRE                     HSMCI_IER_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RDIRE_Msk instead */
+#define HSMCI_IER_RCRCE_Pos                 18                                             /**< (HSMCI_IER) Response CRC Error Interrupt Enable Position */
+#define HSMCI_IER_RCRCE_Msk                 (_U_(0x1) << HSMCI_IER_RCRCE_Pos)              /**< (HSMCI_IER) Response CRC Error Interrupt Enable Mask */
+#define HSMCI_IER_RCRCE                     HSMCI_IER_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RCRCE_Msk instead */
+#define HSMCI_IER_RENDE_Pos                 19                                             /**< (HSMCI_IER) Response End Bit Error Interrupt Enable Position */
+#define HSMCI_IER_RENDE_Msk                 (_U_(0x1) << HSMCI_IER_RENDE_Pos)              /**< (HSMCI_IER) Response End Bit Error Interrupt Enable Mask */
+#define HSMCI_IER_RENDE                     HSMCI_IER_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RENDE_Msk instead */
+#define HSMCI_IER_RTOE_Pos                  20                                             /**< (HSMCI_IER) Response Time-out Error Interrupt Enable Position */
+#define HSMCI_IER_RTOE_Msk                  (_U_(0x1) << HSMCI_IER_RTOE_Pos)               /**< (HSMCI_IER) Response Time-out Error Interrupt Enable Mask */
+#define HSMCI_IER_RTOE                      HSMCI_IER_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RTOE_Msk instead */
+#define HSMCI_IER_DCRCE_Pos                 21                                             /**< (HSMCI_IER) Data CRC Error Interrupt Enable Position */
+#define HSMCI_IER_DCRCE_Msk                 (_U_(0x1) << HSMCI_IER_DCRCE_Pos)              /**< (HSMCI_IER) Data CRC Error Interrupt Enable Mask */
+#define HSMCI_IER_DCRCE                     HSMCI_IER_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DCRCE_Msk instead */
+#define HSMCI_IER_DTOE_Pos                  22                                             /**< (HSMCI_IER) Data Time-out Error Interrupt Enable Position */
+#define HSMCI_IER_DTOE_Msk                  (_U_(0x1) << HSMCI_IER_DTOE_Pos)               /**< (HSMCI_IER) Data Time-out Error Interrupt Enable Mask */
+#define HSMCI_IER_DTOE                      HSMCI_IER_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DTOE_Msk instead */
+#define HSMCI_IER_CSTOE_Pos                 23                                             /**< (HSMCI_IER) Completion Signal Timeout Error Interrupt Enable Position */
+#define HSMCI_IER_CSTOE_Msk                 (_U_(0x1) << HSMCI_IER_CSTOE_Pos)              /**< (HSMCI_IER) Completion Signal Timeout Error Interrupt Enable Mask */
+#define HSMCI_IER_CSTOE                     HSMCI_IER_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CSTOE_Msk instead */
+#define HSMCI_IER_BLKOVRE_Pos               24                                             /**< (HSMCI_IER) DMA Block Overrun Error Interrupt Enable Position */
+#define HSMCI_IER_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IER_BLKOVRE_Pos)            /**< (HSMCI_IER) DMA Block Overrun Error Interrupt Enable Mask */
+#define HSMCI_IER_BLKOVRE                   HSMCI_IER_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_BLKOVRE_Msk instead */
+#define HSMCI_IER_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IER) FIFO empty Interrupt enable Position */
+#define HSMCI_IER_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IER_FIFOEMPTY_Pos)          /**< (HSMCI_IER) FIFO empty Interrupt enable Mask */
+#define HSMCI_IER_FIFOEMPTY                 HSMCI_IER_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_FIFOEMPTY_Msk instead */
+#define HSMCI_IER_XFRDONE_Pos               27                                             /**< (HSMCI_IER) Transfer Done Interrupt enable Position */
+#define HSMCI_IER_XFRDONE_Msk               (_U_(0x1) << HSMCI_IER_XFRDONE_Pos)            /**< (HSMCI_IER) Transfer Done Interrupt enable Mask */
+#define HSMCI_IER_XFRDONE                   HSMCI_IER_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_XFRDONE_Msk instead */
+#define HSMCI_IER_ACKRCV_Pos                28                                             /**< (HSMCI_IER) Boot Acknowledge Interrupt Enable Position */
+#define HSMCI_IER_ACKRCV_Msk                (_U_(0x1) << HSMCI_IER_ACKRCV_Pos)             /**< (HSMCI_IER) Boot Acknowledge Interrupt Enable Mask */
+#define HSMCI_IER_ACKRCV                    HSMCI_IER_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_ACKRCV_Msk instead */
+#define HSMCI_IER_ACKRCVE_Pos               29                                             /**< (HSMCI_IER) Boot Acknowledge Error Interrupt Enable Position */
+#define HSMCI_IER_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IER_ACKRCVE_Pos)            /**< (HSMCI_IER) Boot Acknowledge Error Interrupt Enable Mask */
+#define HSMCI_IER_ACKRCVE                   HSMCI_IER_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_ACKRCVE_Msk instead */
+#define HSMCI_IER_OVRE_Pos                  30                                             /**< (HSMCI_IER) Overrun Interrupt Enable Position */
+#define HSMCI_IER_OVRE_Msk                  (_U_(0x1) << HSMCI_IER_OVRE_Pos)               /**< (HSMCI_IER) Overrun Interrupt Enable Mask */
+#define HSMCI_IER_OVRE                      HSMCI_IER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_OVRE_Msk instead */
+#define HSMCI_IER_UNRE_Pos                  31                                             /**< (HSMCI_IER) Underrun Interrupt Enable Position */
+#define HSMCI_IER_UNRE_Msk                  (_U_(0x1) << HSMCI_IER_UNRE_Pos)               /**< (HSMCI_IER) Underrun Interrupt Enable Mask */
+#define HSMCI_IER_UNRE                      HSMCI_IER_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_UNRE_Msk instead */
+#define HSMCI_IER_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IER) Register MASK  (Use HSMCI_IER_Msk instead)  */
+#define HSMCI_IER_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IER) Register Mask  */
+
+
+/* -------- HSMCI_IDR : (HSMCI Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Disable          */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Disable         */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Disable         */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Disable       */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Disable */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Disable          */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Disable */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Disable */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal received interrupt Disable */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Disable   */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Disable */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Disable     */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Disable */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Disable */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Disable         */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Disable    */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time out Error Interrupt Disable */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Disable */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty Interrupt Disable             */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt Disable          */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Acknowledge Interrupt Disable       */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Acknowledge Error Interrupt Disable */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Disable                */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Disable               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IDR_OFFSET                    (0x48)                                        /**<  (HSMCI_IDR) Interrupt Disable Register  Offset */
+
+#define HSMCI_IDR_CMDRDY_Pos                0                                              /**< (HSMCI_IDR) Command Ready Interrupt Disable Position */
+#define HSMCI_IDR_CMDRDY_Msk                (_U_(0x1) << HSMCI_IDR_CMDRDY_Pos)             /**< (HSMCI_IDR) Command Ready Interrupt Disable Mask */
+#define HSMCI_IDR_CMDRDY                    HSMCI_IDR_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CMDRDY_Msk instead */
+#define HSMCI_IDR_RXRDY_Pos                 1                                              /**< (HSMCI_IDR) Receiver Ready Interrupt Disable Position */
+#define HSMCI_IDR_RXRDY_Msk                 (_U_(0x1) << HSMCI_IDR_RXRDY_Pos)              /**< (HSMCI_IDR) Receiver Ready Interrupt Disable Mask */
+#define HSMCI_IDR_RXRDY                     HSMCI_IDR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RXRDY_Msk instead */
+#define HSMCI_IDR_TXRDY_Pos                 2                                              /**< (HSMCI_IDR) Transmit Ready Interrupt Disable Position */
+#define HSMCI_IDR_TXRDY_Msk                 (_U_(0x1) << HSMCI_IDR_TXRDY_Pos)              /**< (HSMCI_IDR) Transmit Ready Interrupt Disable Mask */
+#define HSMCI_IDR_TXRDY                     HSMCI_IDR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_TXRDY_Msk instead */
+#define HSMCI_IDR_BLKE_Pos                  3                                              /**< (HSMCI_IDR) Data Block Ended Interrupt Disable Position */
+#define HSMCI_IDR_BLKE_Msk                  (_U_(0x1) << HSMCI_IDR_BLKE_Pos)               /**< (HSMCI_IDR) Data Block Ended Interrupt Disable Mask */
+#define HSMCI_IDR_BLKE                      HSMCI_IDR_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_BLKE_Msk instead */
+#define HSMCI_IDR_DTIP_Pos                  4                                              /**< (HSMCI_IDR) Data Transfer in Progress Interrupt Disable Position */
+#define HSMCI_IDR_DTIP_Msk                  (_U_(0x1) << HSMCI_IDR_DTIP_Pos)               /**< (HSMCI_IDR) Data Transfer in Progress Interrupt Disable Mask */
+#define HSMCI_IDR_DTIP                      HSMCI_IDR_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DTIP_Msk instead */
+#define HSMCI_IDR_NOTBUSY_Pos               5                                              /**< (HSMCI_IDR) Data Not Busy Interrupt Disable Position */
+#define HSMCI_IDR_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IDR_NOTBUSY_Pos)            /**< (HSMCI_IDR) Data Not Busy Interrupt Disable Mask */
+#define HSMCI_IDR_NOTBUSY                   HSMCI_IDR_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_NOTBUSY_Msk instead */
+#define HSMCI_IDR_SDIOIRQA_Pos              8                                              /**< (HSMCI_IDR) SDIO Interrupt for Slot A Interrupt Disable Position */
+#define HSMCI_IDR_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IDR_SDIOIRQA_Pos)           /**< (HSMCI_IDR) SDIO Interrupt for Slot A Interrupt Disable Mask */
+#define HSMCI_IDR_SDIOIRQA                  HSMCI_IDR_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_SDIOIRQA_Msk instead */
+#define HSMCI_IDR_SDIOWAIT_Pos              12                                             /**< (HSMCI_IDR) SDIO Read Wait Operation Status Interrupt Disable Position */
+#define HSMCI_IDR_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IDR_SDIOWAIT_Pos)           /**< (HSMCI_IDR) SDIO Read Wait Operation Status Interrupt Disable Mask */
+#define HSMCI_IDR_SDIOWAIT                  HSMCI_IDR_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_SDIOWAIT_Msk instead */
+#define HSMCI_IDR_CSRCV_Pos                 13                                             /**< (HSMCI_IDR) Completion Signal received interrupt Disable Position */
+#define HSMCI_IDR_CSRCV_Msk                 (_U_(0x1) << HSMCI_IDR_CSRCV_Pos)              /**< (HSMCI_IDR) Completion Signal received interrupt Disable Mask */
+#define HSMCI_IDR_CSRCV                     HSMCI_IDR_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CSRCV_Msk instead */
+#define HSMCI_IDR_RINDE_Pos                 16                                             /**< (HSMCI_IDR) Response Index Error Interrupt Disable Position */
+#define HSMCI_IDR_RINDE_Msk                 (_U_(0x1) << HSMCI_IDR_RINDE_Pos)              /**< (HSMCI_IDR) Response Index Error Interrupt Disable Mask */
+#define HSMCI_IDR_RINDE                     HSMCI_IDR_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RINDE_Msk instead */
+#define HSMCI_IDR_RDIRE_Pos                 17                                             /**< (HSMCI_IDR) Response Direction Error Interrupt Disable Position */
+#define HSMCI_IDR_RDIRE_Msk                 (_U_(0x1) << HSMCI_IDR_RDIRE_Pos)              /**< (HSMCI_IDR) Response Direction Error Interrupt Disable Mask */
+#define HSMCI_IDR_RDIRE                     HSMCI_IDR_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RDIRE_Msk instead */
+#define HSMCI_IDR_RCRCE_Pos                 18                                             /**< (HSMCI_IDR) Response CRC Error Interrupt Disable Position */
+#define HSMCI_IDR_RCRCE_Msk                 (_U_(0x1) << HSMCI_IDR_RCRCE_Pos)              /**< (HSMCI_IDR) Response CRC Error Interrupt Disable Mask */
+#define HSMCI_IDR_RCRCE                     HSMCI_IDR_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RCRCE_Msk instead */
+#define HSMCI_IDR_RENDE_Pos                 19                                             /**< (HSMCI_IDR) Response End Bit Error Interrupt Disable Position */
+#define HSMCI_IDR_RENDE_Msk                 (_U_(0x1) << HSMCI_IDR_RENDE_Pos)              /**< (HSMCI_IDR) Response End Bit Error Interrupt Disable Mask */
+#define HSMCI_IDR_RENDE                     HSMCI_IDR_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RENDE_Msk instead */
+#define HSMCI_IDR_RTOE_Pos                  20                                             /**< (HSMCI_IDR) Response Time-out Error Interrupt Disable Position */
+#define HSMCI_IDR_RTOE_Msk                  (_U_(0x1) << HSMCI_IDR_RTOE_Pos)               /**< (HSMCI_IDR) Response Time-out Error Interrupt Disable Mask */
+#define HSMCI_IDR_RTOE                      HSMCI_IDR_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RTOE_Msk instead */
+#define HSMCI_IDR_DCRCE_Pos                 21                                             /**< (HSMCI_IDR) Data CRC Error Interrupt Disable Position */
+#define HSMCI_IDR_DCRCE_Msk                 (_U_(0x1) << HSMCI_IDR_DCRCE_Pos)              /**< (HSMCI_IDR) Data CRC Error Interrupt Disable Mask */
+#define HSMCI_IDR_DCRCE                     HSMCI_IDR_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DCRCE_Msk instead */
+#define HSMCI_IDR_DTOE_Pos                  22                                             /**< (HSMCI_IDR) Data Time-out Error Interrupt Disable Position */
+#define HSMCI_IDR_DTOE_Msk                  (_U_(0x1) << HSMCI_IDR_DTOE_Pos)               /**< (HSMCI_IDR) Data Time-out Error Interrupt Disable Mask */
+#define HSMCI_IDR_DTOE                      HSMCI_IDR_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DTOE_Msk instead */
+#define HSMCI_IDR_CSTOE_Pos                 23                                             /**< (HSMCI_IDR) Completion Signal Time out Error Interrupt Disable Position */
+#define HSMCI_IDR_CSTOE_Msk                 (_U_(0x1) << HSMCI_IDR_CSTOE_Pos)              /**< (HSMCI_IDR) Completion Signal Time out Error Interrupt Disable Mask */
+#define HSMCI_IDR_CSTOE                     HSMCI_IDR_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CSTOE_Msk instead */
+#define HSMCI_IDR_BLKOVRE_Pos               24                                             /**< (HSMCI_IDR) DMA Block Overrun Error Interrupt Disable Position */
+#define HSMCI_IDR_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IDR_BLKOVRE_Pos)            /**< (HSMCI_IDR) DMA Block Overrun Error Interrupt Disable Mask */
+#define HSMCI_IDR_BLKOVRE                   HSMCI_IDR_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_BLKOVRE_Msk instead */
+#define HSMCI_IDR_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IDR) FIFO empty Interrupt Disable Position */
+#define HSMCI_IDR_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IDR_FIFOEMPTY_Pos)          /**< (HSMCI_IDR) FIFO empty Interrupt Disable Mask */
+#define HSMCI_IDR_FIFOEMPTY                 HSMCI_IDR_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_FIFOEMPTY_Msk instead */
+#define HSMCI_IDR_XFRDONE_Pos               27                                             /**< (HSMCI_IDR) Transfer Done Interrupt Disable Position */
+#define HSMCI_IDR_XFRDONE_Msk               (_U_(0x1) << HSMCI_IDR_XFRDONE_Pos)            /**< (HSMCI_IDR) Transfer Done Interrupt Disable Mask */
+#define HSMCI_IDR_XFRDONE                   HSMCI_IDR_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_XFRDONE_Msk instead */
+#define HSMCI_IDR_ACKRCV_Pos                28                                             /**< (HSMCI_IDR) Boot Acknowledge Interrupt Disable Position */
+#define HSMCI_IDR_ACKRCV_Msk                (_U_(0x1) << HSMCI_IDR_ACKRCV_Pos)             /**< (HSMCI_IDR) Boot Acknowledge Interrupt Disable Mask */
+#define HSMCI_IDR_ACKRCV                    HSMCI_IDR_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_ACKRCV_Msk instead */
+#define HSMCI_IDR_ACKRCVE_Pos               29                                             /**< (HSMCI_IDR) Boot Acknowledge Error Interrupt Disable Position */
+#define HSMCI_IDR_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IDR_ACKRCVE_Pos)            /**< (HSMCI_IDR) Boot Acknowledge Error Interrupt Disable Mask */
+#define HSMCI_IDR_ACKRCVE                   HSMCI_IDR_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_ACKRCVE_Msk instead */
+#define HSMCI_IDR_OVRE_Pos                  30                                             /**< (HSMCI_IDR) Overrun Interrupt Disable Position */
+#define HSMCI_IDR_OVRE_Msk                  (_U_(0x1) << HSMCI_IDR_OVRE_Pos)               /**< (HSMCI_IDR) Overrun Interrupt Disable Mask */
+#define HSMCI_IDR_OVRE                      HSMCI_IDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_OVRE_Msk instead */
+#define HSMCI_IDR_UNRE_Pos                  31                                             /**< (HSMCI_IDR) Underrun Interrupt Disable Position */
+#define HSMCI_IDR_UNRE_Msk                  (_U_(0x1) << HSMCI_IDR_UNRE_Pos)               /**< (HSMCI_IDR) Underrun Interrupt Disable Mask */
+#define HSMCI_IDR_UNRE                      HSMCI_IDR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_UNRE_Msk instead */
+#define HSMCI_IDR_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IDR) Register MASK  (Use HSMCI_IDR_Msk instead)  */
+#define HSMCI_IDR_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IDR) Register Mask  */
+
+
+/* -------- HSMCI_IMR : (HSMCI Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Mask             */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Mask            */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Mask            */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Mask          */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Mask */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Mask             */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Mask */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Mask */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal Received Interrupt Mask */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Mask      */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Mask  */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Mask        */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Mask    */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Mask   */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Mask            */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Mask       */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time-out Error Interrupt Mask */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Mask   */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO Empty Interrupt Mask                */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt Mask             */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Operation Acknowledge Received Interrupt Mask */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Operation Acknowledge Error Interrupt Mask */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Mask                   */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Mask                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IMR_OFFSET                    (0x4C)                                        /**<  (HSMCI_IMR) Interrupt Mask Register  Offset */
+
+#define HSMCI_IMR_CMDRDY_Pos                0                                              /**< (HSMCI_IMR) Command Ready Interrupt Mask Position */
+#define HSMCI_IMR_CMDRDY_Msk                (_U_(0x1) << HSMCI_IMR_CMDRDY_Pos)             /**< (HSMCI_IMR) Command Ready Interrupt Mask Mask */
+#define HSMCI_IMR_CMDRDY                    HSMCI_IMR_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CMDRDY_Msk instead */
+#define HSMCI_IMR_RXRDY_Pos                 1                                              /**< (HSMCI_IMR) Receiver Ready Interrupt Mask Position */
+#define HSMCI_IMR_RXRDY_Msk                 (_U_(0x1) << HSMCI_IMR_RXRDY_Pos)              /**< (HSMCI_IMR) Receiver Ready Interrupt Mask Mask */
+#define HSMCI_IMR_RXRDY                     HSMCI_IMR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RXRDY_Msk instead */
+#define HSMCI_IMR_TXRDY_Pos                 2                                              /**< (HSMCI_IMR) Transmit Ready Interrupt Mask Position */
+#define HSMCI_IMR_TXRDY_Msk                 (_U_(0x1) << HSMCI_IMR_TXRDY_Pos)              /**< (HSMCI_IMR) Transmit Ready Interrupt Mask Mask */
+#define HSMCI_IMR_TXRDY                     HSMCI_IMR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_TXRDY_Msk instead */
+#define HSMCI_IMR_BLKE_Pos                  3                                              /**< (HSMCI_IMR) Data Block Ended Interrupt Mask Position */
+#define HSMCI_IMR_BLKE_Msk                  (_U_(0x1) << HSMCI_IMR_BLKE_Pos)               /**< (HSMCI_IMR) Data Block Ended Interrupt Mask Mask */
+#define HSMCI_IMR_BLKE                      HSMCI_IMR_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_BLKE_Msk instead */
+#define HSMCI_IMR_DTIP_Pos                  4                                              /**< (HSMCI_IMR) Data Transfer in Progress Interrupt Mask Position */
+#define HSMCI_IMR_DTIP_Msk                  (_U_(0x1) << HSMCI_IMR_DTIP_Pos)               /**< (HSMCI_IMR) Data Transfer in Progress Interrupt Mask Mask */
+#define HSMCI_IMR_DTIP                      HSMCI_IMR_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DTIP_Msk instead */
+#define HSMCI_IMR_NOTBUSY_Pos               5                                              /**< (HSMCI_IMR) Data Not Busy Interrupt Mask Position */
+#define HSMCI_IMR_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IMR_NOTBUSY_Pos)            /**< (HSMCI_IMR) Data Not Busy Interrupt Mask Mask */
+#define HSMCI_IMR_NOTBUSY                   HSMCI_IMR_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_NOTBUSY_Msk instead */
+#define HSMCI_IMR_SDIOIRQA_Pos              8                                              /**< (HSMCI_IMR) SDIO Interrupt for Slot A Interrupt Mask Position */
+#define HSMCI_IMR_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IMR_SDIOIRQA_Pos)           /**< (HSMCI_IMR) SDIO Interrupt for Slot A Interrupt Mask Mask */
+#define HSMCI_IMR_SDIOIRQA                  HSMCI_IMR_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_SDIOIRQA_Msk instead */
+#define HSMCI_IMR_SDIOWAIT_Pos              12                                             /**< (HSMCI_IMR) SDIO Read Wait Operation Status Interrupt Mask Position */
+#define HSMCI_IMR_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IMR_SDIOWAIT_Pos)           /**< (HSMCI_IMR) SDIO Read Wait Operation Status Interrupt Mask Mask */
+#define HSMCI_IMR_SDIOWAIT                  HSMCI_IMR_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_SDIOWAIT_Msk instead */
+#define HSMCI_IMR_CSRCV_Pos                 13                                             /**< (HSMCI_IMR) Completion Signal Received Interrupt Mask Position */
+#define HSMCI_IMR_CSRCV_Msk                 (_U_(0x1) << HSMCI_IMR_CSRCV_Pos)              /**< (HSMCI_IMR) Completion Signal Received Interrupt Mask Mask */
+#define HSMCI_IMR_CSRCV                     HSMCI_IMR_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CSRCV_Msk instead */
+#define HSMCI_IMR_RINDE_Pos                 16                                             /**< (HSMCI_IMR) Response Index Error Interrupt Mask Position */
+#define HSMCI_IMR_RINDE_Msk                 (_U_(0x1) << HSMCI_IMR_RINDE_Pos)              /**< (HSMCI_IMR) Response Index Error Interrupt Mask Mask */
+#define HSMCI_IMR_RINDE                     HSMCI_IMR_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RINDE_Msk instead */
+#define HSMCI_IMR_RDIRE_Pos                 17                                             /**< (HSMCI_IMR) Response Direction Error Interrupt Mask Position */
+#define HSMCI_IMR_RDIRE_Msk                 (_U_(0x1) << HSMCI_IMR_RDIRE_Pos)              /**< (HSMCI_IMR) Response Direction Error Interrupt Mask Mask */
+#define HSMCI_IMR_RDIRE                     HSMCI_IMR_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RDIRE_Msk instead */
+#define HSMCI_IMR_RCRCE_Pos                 18                                             /**< (HSMCI_IMR) Response CRC Error Interrupt Mask Position */
+#define HSMCI_IMR_RCRCE_Msk                 (_U_(0x1) << HSMCI_IMR_RCRCE_Pos)              /**< (HSMCI_IMR) Response CRC Error Interrupt Mask Mask */
+#define HSMCI_IMR_RCRCE                     HSMCI_IMR_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RCRCE_Msk instead */
+#define HSMCI_IMR_RENDE_Pos                 19                                             /**< (HSMCI_IMR) Response End Bit Error Interrupt Mask Position */
+#define HSMCI_IMR_RENDE_Msk                 (_U_(0x1) << HSMCI_IMR_RENDE_Pos)              /**< (HSMCI_IMR) Response End Bit Error Interrupt Mask Mask */
+#define HSMCI_IMR_RENDE                     HSMCI_IMR_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RENDE_Msk instead */
+#define HSMCI_IMR_RTOE_Pos                  20                                             /**< (HSMCI_IMR) Response Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_RTOE_Msk                  (_U_(0x1) << HSMCI_IMR_RTOE_Pos)               /**< (HSMCI_IMR) Response Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_RTOE                      HSMCI_IMR_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RTOE_Msk instead */
+#define HSMCI_IMR_DCRCE_Pos                 21                                             /**< (HSMCI_IMR) Data CRC Error Interrupt Mask Position */
+#define HSMCI_IMR_DCRCE_Msk                 (_U_(0x1) << HSMCI_IMR_DCRCE_Pos)              /**< (HSMCI_IMR) Data CRC Error Interrupt Mask Mask */
+#define HSMCI_IMR_DCRCE                     HSMCI_IMR_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DCRCE_Msk instead */
+#define HSMCI_IMR_DTOE_Pos                  22                                             /**< (HSMCI_IMR) Data Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_DTOE_Msk                  (_U_(0x1) << HSMCI_IMR_DTOE_Pos)               /**< (HSMCI_IMR) Data Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_DTOE                      HSMCI_IMR_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DTOE_Msk instead */
+#define HSMCI_IMR_CSTOE_Pos                 23                                             /**< (HSMCI_IMR) Completion Signal Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_CSTOE_Msk                 (_U_(0x1) << HSMCI_IMR_CSTOE_Pos)              /**< (HSMCI_IMR) Completion Signal Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_CSTOE                     HSMCI_IMR_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CSTOE_Msk instead */
+#define HSMCI_IMR_BLKOVRE_Pos               24                                             /**< (HSMCI_IMR) DMA Block Overrun Error Interrupt Mask Position */
+#define HSMCI_IMR_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IMR_BLKOVRE_Pos)            /**< (HSMCI_IMR) DMA Block Overrun Error Interrupt Mask Mask */
+#define HSMCI_IMR_BLKOVRE                   HSMCI_IMR_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_BLKOVRE_Msk instead */
+#define HSMCI_IMR_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IMR) FIFO Empty Interrupt Mask Position */
+#define HSMCI_IMR_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IMR_FIFOEMPTY_Pos)          /**< (HSMCI_IMR) FIFO Empty Interrupt Mask Mask */
+#define HSMCI_IMR_FIFOEMPTY                 HSMCI_IMR_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_FIFOEMPTY_Msk instead */
+#define HSMCI_IMR_XFRDONE_Pos               27                                             /**< (HSMCI_IMR) Transfer Done Interrupt Mask Position */
+#define HSMCI_IMR_XFRDONE_Msk               (_U_(0x1) << HSMCI_IMR_XFRDONE_Pos)            /**< (HSMCI_IMR) Transfer Done Interrupt Mask Mask */
+#define HSMCI_IMR_XFRDONE                   HSMCI_IMR_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_XFRDONE_Msk instead */
+#define HSMCI_IMR_ACKRCV_Pos                28                                             /**< (HSMCI_IMR) Boot Operation Acknowledge Received Interrupt Mask Position */
+#define HSMCI_IMR_ACKRCV_Msk                (_U_(0x1) << HSMCI_IMR_ACKRCV_Pos)             /**< (HSMCI_IMR) Boot Operation Acknowledge Received Interrupt Mask Mask */
+#define HSMCI_IMR_ACKRCV                    HSMCI_IMR_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_ACKRCV_Msk instead */
+#define HSMCI_IMR_ACKRCVE_Pos               29                                             /**< (HSMCI_IMR) Boot Operation Acknowledge Error Interrupt Mask Position */
+#define HSMCI_IMR_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IMR_ACKRCVE_Pos)            /**< (HSMCI_IMR) Boot Operation Acknowledge Error Interrupt Mask Mask */
+#define HSMCI_IMR_ACKRCVE                   HSMCI_IMR_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_ACKRCVE_Msk instead */
+#define HSMCI_IMR_OVRE_Pos                  30                                             /**< (HSMCI_IMR) Overrun Interrupt Mask Position */
+#define HSMCI_IMR_OVRE_Msk                  (_U_(0x1) << HSMCI_IMR_OVRE_Pos)               /**< (HSMCI_IMR) Overrun Interrupt Mask Mask */
+#define HSMCI_IMR_OVRE                      HSMCI_IMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_OVRE_Msk instead */
+#define HSMCI_IMR_UNRE_Pos                  31                                             /**< (HSMCI_IMR) Underrun Interrupt Mask Position */
+#define HSMCI_IMR_UNRE_Msk                  (_U_(0x1) << HSMCI_IMR_UNRE_Pos)               /**< (HSMCI_IMR) Underrun Interrupt Mask Mask */
+#define HSMCI_IMR_UNRE                      HSMCI_IMR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_UNRE_Msk instead */
+#define HSMCI_IMR_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IMR) Register MASK  (Use HSMCI_IMR_Msk instead)  */
+#define HSMCI_IMR_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IMR) Register Mask  */
+
+
+/* -------- HSMCI_DMA : (HSMCI Offset: 0x50) (R/W 32) DMA Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CHKSIZE:3;                 /**< bit:   4..6  DMA Channel Read and Write Chunk Size    */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t DMAEN:1;                   /**< bit:      8  DMA Hardware Handshaking Enable          */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_DMA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_DMA_OFFSET                    (0x50)                                        /**<  (HSMCI_DMA) DMA Configuration Register  Offset */
+
+#define HSMCI_DMA_CHKSIZE_Pos               4                                              /**< (HSMCI_DMA) DMA Channel Read and Write Chunk Size Position */
+#define HSMCI_DMA_CHKSIZE_Msk               (_U_(0x7) << HSMCI_DMA_CHKSIZE_Pos)            /**< (HSMCI_DMA) DMA Channel Read and Write Chunk Size Mask */
+#define HSMCI_DMA_CHKSIZE(value)            (HSMCI_DMA_CHKSIZE_Msk & ((value) << HSMCI_DMA_CHKSIZE_Pos))
+#define   HSMCI_DMA_CHKSIZE_1_Val           _U_(0x0)                                       /**< (HSMCI_DMA) 1 data available  */
+#define   HSMCI_DMA_CHKSIZE_2_Val           _U_(0x1)                                       /**< (HSMCI_DMA) 2 data available  */
+#define   HSMCI_DMA_CHKSIZE_4_Val           _U_(0x2)                                       /**< (HSMCI_DMA) 4 data available  */
+#define   HSMCI_DMA_CHKSIZE_8_Val           _U_(0x3)                                       /**< (HSMCI_DMA) 8 data available  */
+#define   HSMCI_DMA_CHKSIZE_16_Val          _U_(0x4)                                       /**< (HSMCI_DMA) 16 data available  */
+#define HSMCI_DMA_CHKSIZE_1                 (HSMCI_DMA_CHKSIZE_1_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 1 data available Position  */
+#define HSMCI_DMA_CHKSIZE_2                 (HSMCI_DMA_CHKSIZE_2_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 2 data available Position  */
+#define HSMCI_DMA_CHKSIZE_4                 (HSMCI_DMA_CHKSIZE_4_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 4 data available Position  */
+#define HSMCI_DMA_CHKSIZE_8                 (HSMCI_DMA_CHKSIZE_8_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 8 data available Position  */
+#define HSMCI_DMA_CHKSIZE_16                (HSMCI_DMA_CHKSIZE_16_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 16 data available Position  */
+#define HSMCI_DMA_DMAEN_Pos                 8                                              /**< (HSMCI_DMA) DMA Hardware Handshaking Enable Position */
+#define HSMCI_DMA_DMAEN_Msk                 (_U_(0x1) << HSMCI_DMA_DMAEN_Pos)              /**< (HSMCI_DMA) DMA Hardware Handshaking Enable Mask */
+#define HSMCI_DMA_DMAEN                     HSMCI_DMA_DMAEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_DMA_DMAEN_Msk instead */
+#define HSMCI_DMA_MASK                      _U_(0x170)                                     /**< \deprecated (HSMCI_DMA) Register MASK  (Use HSMCI_DMA_Msk instead)  */
+#define HSMCI_DMA_Msk                       _U_(0x170)                                     /**< (HSMCI_DMA) Register Mask  */
+
+
+/* -------- HSMCI_CFG : (HSMCI Offset: 0x54) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FIFOMODE:1;                /**< bit:      0  HSMCI Internal FIFO control mode         */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t FERRCTRL:1;                /**< bit:      4  Flow Error flag reset control mode       */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t HSMODE:1;                  /**< bit:      8  High Speed Mode                          */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t LSYNC:1;                   /**< bit:     12  Synchronize on the last block            */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CFG_OFFSET                    (0x54)                                        /**<  (HSMCI_CFG) Configuration Register  Offset */
+
+#define HSMCI_CFG_FIFOMODE_Pos              0                                              /**< (HSMCI_CFG) HSMCI Internal FIFO control mode Position */
+#define HSMCI_CFG_FIFOMODE_Msk              (_U_(0x1) << HSMCI_CFG_FIFOMODE_Pos)           /**< (HSMCI_CFG) HSMCI Internal FIFO control mode Mask */
+#define HSMCI_CFG_FIFOMODE                  HSMCI_CFG_FIFOMODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_FIFOMODE_Msk instead */
+#define HSMCI_CFG_FERRCTRL_Pos              4                                              /**< (HSMCI_CFG) Flow Error flag reset control mode Position */
+#define HSMCI_CFG_FERRCTRL_Msk              (_U_(0x1) << HSMCI_CFG_FERRCTRL_Pos)           /**< (HSMCI_CFG) Flow Error flag reset control mode Mask */
+#define HSMCI_CFG_FERRCTRL                  HSMCI_CFG_FERRCTRL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_FERRCTRL_Msk instead */
+#define HSMCI_CFG_HSMODE_Pos                8                                              /**< (HSMCI_CFG) High Speed Mode Position */
+#define HSMCI_CFG_HSMODE_Msk                (_U_(0x1) << HSMCI_CFG_HSMODE_Pos)             /**< (HSMCI_CFG) High Speed Mode Mask */
+#define HSMCI_CFG_HSMODE                    HSMCI_CFG_HSMODE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_HSMODE_Msk instead */
+#define HSMCI_CFG_LSYNC_Pos                 12                                             /**< (HSMCI_CFG) Synchronize on the last block Position */
+#define HSMCI_CFG_LSYNC_Msk                 (_U_(0x1) << HSMCI_CFG_LSYNC_Pos)              /**< (HSMCI_CFG) Synchronize on the last block Mask */
+#define HSMCI_CFG_LSYNC                     HSMCI_CFG_LSYNC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_LSYNC_Msk instead */
+#define HSMCI_CFG_MASK                      _U_(0x1111)                                    /**< \deprecated (HSMCI_CFG) Register MASK  (Use HSMCI_CFG_Msk instead)  */
+#define HSMCI_CFG_Msk                       _U_(0x1111)                                    /**< (HSMCI_CFG) Register Mask  */
+
+
+/* -------- HSMCI_WPMR : (HSMCI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect Key                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_WPMR_OFFSET                   (0xE4)                                        /**<  (HSMCI_WPMR) Write Protection Mode Register  Offset */
+
+#define HSMCI_WPMR_WPEN_Pos                 0                                              /**< (HSMCI_WPMR) Write Protect Enable Position */
+#define HSMCI_WPMR_WPEN_Msk                 (_U_(0x1) << HSMCI_WPMR_WPEN_Pos)              /**< (HSMCI_WPMR) Write Protect Enable Mask */
+#define HSMCI_WPMR_WPEN                     HSMCI_WPMR_WPEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_WPMR_WPEN_Msk instead */
+#define HSMCI_WPMR_WPKEY_Pos                8                                              /**< (HSMCI_WPMR) Write Protect Key Position */
+#define HSMCI_WPMR_WPKEY_Msk                (_U_(0xFFFFFF) << HSMCI_WPMR_WPKEY_Pos)        /**< (HSMCI_WPMR) Write Protect Key Mask */
+#define HSMCI_WPMR_WPKEY(value)             (HSMCI_WPMR_WPKEY_Msk & ((value) << HSMCI_WPMR_WPKEY_Pos))
+#define   HSMCI_WPMR_WPKEY_PASSWD_Val       _U_(0x4D4349)                                  /**< (HSMCI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define HSMCI_WPMR_WPKEY_PASSWD             (HSMCI_WPMR_WPKEY_PASSWD_Val << HSMCI_WPMR_WPKEY_Pos)  /**< (HSMCI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define HSMCI_WPMR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (HSMCI_WPMR) Register MASK  (Use HSMCI_WPMR_Msk instead)  */
+#define HSMCI_WPMR_Msk                      _U_(0xFFFFFF01)                                /**< (HSMCI_WPMR) Register Mask  */
+
+
+/* -------- HSMCI_WPSR : (HSMCI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_WPSR_OFFSET                   (0xE8)                                        /**<  (HSMCI_WPSR) Write Protection Status Register  Offset */
+
+#define HSMCI_WPSR_WPVS_Pos                 0                                              /**< (HSMCI_WPSR) Write Protection Violation Status Position */
+#define HSMCI_WPSR_WPVS_Msk                 (_U_(0x1) << HSMCI_WPSR_WPVS_Pos)              /**< (HSMCI_WPSR) Write Protection Violation Status Mask */
+#define HSMCI_WPSR_WPVS                     HSMCI_WPSR_WPVS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_WPSR_WPVS_Msk instead */
+#define HSMCI_WPSR_WPVSRC_Pos               8                                              /**< (HSMCI_WPSR) Write Protection Violation Source Position */
+#define HSMCI_WPSR_WPVSRC_Msk               (_U_(0xFFFF) << HSMCI_WPSR_WPVSRC_Pos)         /**< (HSMCI_WPSR) Write Protection Violation Source Mask */
+#define HSMCI_WPSR_WPVSRC(value)            (HSMCI_WPSR_WPVSRC_Msk & ((value) << HSMCI_WPSR_WPVSRC_Pos))
+#define HSMCI_WPSR_MASK                     _U_(0xFFFF01)                                  /**< \deprecated (HSMCI_WPSR) Register MASK  (Use HSMCI_WPSR_Msk instead)  */
+#define HSMCI_WPSR_Msk                      _U_(0xFFFF01)                                  /**< (HSMCI_WPSR) Register Mask  */
+
+
+/* -------- HSMCI_VERSION : (HSMCI Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_VERSION_OFFSET                (0xFC)                                        /**<  (HSMCI_VERSION) Version Register  Offset */
+
+#define HSMCI_VERSION_VERSION_Pos           0                                              /**< (HSMCI_VERSION) Hardware Module Version Position */
+#define HSMCI_VERSION_VERSION_Msk           (_U_(0xFFF) << HSMCI_VERSION_VERSION_Pos)      /**< (HSMCI_VERSION) Hardware Module Version Mask */
+#define HSMCI_VERSION_VERSION(value)        (HSMCI_VERSION_VERSION_Msk & ((value) << HSMCI_VERSION_VERSION_Pos))
+#define HSMCI_VERSION_MFN_Pos               16                                             /**< (HSMCI_VERSION) Metal Fix Number Position */
+#define HSMCI_VERSION_MFN_Msk               (_U_(0x7) << HSMCI_VERSION_MFN_Pos)            /**< (HSMCI_VERSION) Metal Fix Number Mask */
+#define HSMCI_VERSION_MFN(value)            (HSMCI_VERSION_MFN_Msk & ((value) << HSMCI_VERSION_MFN_Pos))
+#define HSMCI_VERSION_MASK                  _U_(0x70FFF)                                   /**< \deprecated (HSMCI_VERSION) Register MASK  (Use HSMCI_VERSION_Msk instead)  */
+#define HSMCI_VERSION_Msk                   _U_(0x70FFF)                                   /**< (HSMCI_VERSION) Register Mask  */
+
+
+/* -------- HSMCI_FIFO : (HSMCI Offset: 0x200) (R/W 32) FIFO Memory Aperture0 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Read or Data to Write            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_FIFO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_FIFO_OFFSET                   (0x200)                                       /**<  (HSMCI_FIFO) FIFO Memory Aperture0 0  Offset */
+
+#define HSMCI_FIFO_DATA_Pos                 0                                              /**< (HSMCI_FIFO) Data to Read or Data to Write Position */
+#define HSMCI_FIFO_DATA_Msk                 (_U_(0xFFFFFFFF) << HSMCI_FIFO_DATA_Pos)       /**< (HSMCI_FIFO) Data to Read or Data to Write Mask */
+#define HSMCI_FIFO_DATA(value)              (HSMCI_FIFO_DATA_Msk & ((value) << HSMCI_FIFO_DATA_Pos))
+#define HSMCI_FIFO_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_FIFO) Register MASK  (Use HSMCI_FIFO_Msk instead)  */
+#define HSMCI_FIFO_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_FIFO) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief HSMCI hardware registers */
+typedef struct {  
+  __O  uint32_t HSMCI_CR;       /**< (HSMCI Offset: 0x00) Control Register */
+  __IO uint32_t HSMCI_MR;       /**< (HSMCI Offset: 0x04) Mode Register */
+  __IO uint32_t HSMCI_DTOR;     /**< (HSMCI Offset: 0x08) Data Timeout Register */
+  __IO uint32_t HSMCI_SDCR;     /**< (HSMCI Offset: 0x0C) SD/SDIO Card Register */
+  __IO uint32_t HSMCI_ARGR;     /**< (HSMCI Offset: 0x10) Argument Register */
+  __O  uint32_t HSMCI_CMDR;     /**< (HSMCI Offset: 0x14) Command Register */
+  __IO uint32_t HSMCI_BLKR;     /**< (HSMCI Offset: 0x18) Block Register */
+  __IO uint32_t HSMCI_CSTOR;    /**< (HSMCI Offset: 0x1C) Completion Signal Timeout Register */
+  __I  uint32_t HSMCI_RSPR[4];  /**< (HSMCI Offset: 0x20) Response Register 0 */
+  __I  uint32_t HSMCI_RDR;      /**< (HSMCI Offset: 0x30) Receive Data Register */
+  __O  uint32_t HSMCI_TDR;      /**< (HSMCI Offset: 0x34) Transmit Data Register */
+  __I  uint8_t                        Reserved1[8];
+  __I  uint32_t HSMCI_SR;       /**< (HSMCI Offset: 0x40) Status Register */
+  __O  uint32_t HSMCI_IER;      /**< (HSMCI Offset: 0x44) Interrupt Enable Register */
+  __O  uint32_t HSMCI_IDR;      /**< (HSMCI Offset: 0x48) Interrupt Disable Register */
+  __I  uint32_t HSMCI_IMR;      /**< (HSMCI Offset: 0x4C) Interrupt Mask Register */
+  __IO uint32_t HSMCI_DMA;      /**< (HSMCI Offset: 0x50) DMA Configuration Register */
+  __IO uint32_t HSMCI_CFG;      /**< (HSMCI Offset: 0x54) Configuration Register */
+  __I  uint8_t                        Reserved2[140];
+  __IO uint32_t HSMCI_WPMR;     /**< (HSMCI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t HSMCI_WPSR;     /**< (HSMCI Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  uint32_t HSMCI_VERSION;  /**< (HSMCI Offset: 0xFC) Version Register */
+  __I  uint8_t                        Reserved4[256];
+  __IO uint32_t HSMCI_FIFO[256]; /**< (HSMCI Offset: 0x200) FIFO Memory Aperture0 0 */
+} Hsmci;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief HSMCI hardware registers */
+typedef struct {  
+  __O  HSMCI_CR_Type                  HSMCI_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO HSMCI_MR_Type                  HSMCI_MR;       /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO HSMCI_DTOR_Type                HSMCI_DTOR;     /**< Offset: 0x08 (R/W  32) Data Timeout Register */
+  __IO HSMCI_SDCR_Type                HSMCI_SDCR;     /**< Offset: 0x0C (R/W  32) SD/SDIO Card Register */
+  __IO HSMCI_ARGR_Type                HSMCI_ARGR;     /**< Offset: 0x10 (R/W  32) Argument Register */
+  __O  HSMCI_CMDR_Type                HSMCI_CMDR;     /**< Offset: 0x14 ( /W  32) Command Register */
+  __IO HSMCI_BLKR_Type                HSMCI_BLKR;     /**< Offset: 0x18 (R/W  32) Block Register */
+  __IO HSMCI_CSTOR_Type               HSMCI_CSTOR;    /**< Offset: 0x1C (R/W  32) Completion Signal Timeout Register */
+  __I  HSMCI_RSPR_Type                HSMCI_RSPR[4];  /**< Offset: 0x20 (R/   32) Response Register 0 */
+  __I  HSMCI_RDR_Type                 HSMCI_RDR;      /**< Offset: 0x30 (R/   32) Receive Data Register */
+  __O  HSMCI_TDR_Type                 HSMCI_TDR;      /**< Offset: 0x34 ( /W  32) Transmit Data Register */
+  __I  uint8_t                        Reserved1[8];
+  __I  HSMCI_SR_Type                  HSMCI_SR;       /**< Offset: 0x40 (R/   32) Status Register */
+  __O  HSMCI_IER_Type                 HSMCI_IER;      /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
+  __O  HSMCI_IDR_Type                 HSMCI_IDR;      /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
+  __I  HSMCI_IMR_Type                 HSMCI_IMR;      /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
+  __IO HSMCI_DMA_Type                 HSMCI_DMA;      /**< Offset: 0x50 (R/W  32) DMA Configuration Register */
+  __IO HSMCI_CFG_Type                 HSMCI_CFG;      /**< Offset: 0x54 (R/W  32) Configuration Register */
+  __I  uint8_t                        Reserved2[140];
+  __IO HSMCI_WPMR_Type                HSMCI_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  HSMCI_WPSR_Type                HSMCI_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  HSMCI_VERSION_Type             HSMCI_VERSION;  /**< Offset: 0xFC (R/   32) Version Register */
+  __I  uint8_t                        Reserved4[256];
+  __IO HSMCI_FIFO_Type                HSMCI_FIFO[256]; /**< Offset: 0x200 (R/W  32) FIFO Memory Aperture0 0 */
+} Hsmci;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of High Speed MultiMedia Card Interface */
+
+#endif /* _SAMV71_HSMCI_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/icm.h
+++ b/asf/sam/include/samv71/component/icm.h
@@ -1,0 +1,514 @@
+/**
+ * \file
+ *
+ * \brief Component description for ICM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ICM_COMPONENT_H_
+#define _SAMV71_ICM_COMPONENT_H_
+#define _SAMV71_ICM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Integrity Check Monitor
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ICM */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ICM_11105                      /**< (ICM) Module ID */
+#define REV_ICM G                      /**< (ICM) Module revision */
+
+/* -------- ICM_CFG : (ICM Offset: 0x00) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WBDIS:1;                   /**< bit:      0  Write Back Disable                       */
+    uint32_t EOMDIS:1;                  /**< bit:      1  End of Monitoring Disable                */
+    uint32_t SLBDIS:1;                  /**< bit:      2  Secondary List Branching Disable         */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t BBC:4;                     /**< bit:   4..7  Bus Burden Control                       */
+    uint32_t ASCD:1;                    /**< bit:      8  Automatic Switch To Compare Digest       */
+    uint32_t DUALBUFF:1;                /**< bit:      9  Dual Input Buffer                        */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t UIHASH:1;                  /**< bit:     12  User Initial Hash Value                  */
+    uint32_t UALGO:3;                   /**< bit: 13..15  User SHA Algorithm                       */
+    uint32_t HAPROT:6;                  /**< bit: 16..21  Region Hash Area Protection              */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t DAPROT:6;                  /**< bit: 24..29  Region Descriptor Area Protection        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_CFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_CFG_OFFSET                      (0x00)                                        /**<  (ICM_CFG) Configuration Register  Offset */
+
+#define ICM_CFG_WBDIS_Pos                   0                                              /**< (ICM_CFG) Write Back Disable Position */
+#define ICM_CFG_WBDIS_Msk                   (_U_(0x1) << ICM_CFG_WBDIS_Pos)                /**< (ICM_CFG) Write Back Disable Mask */
+#define ICM_CFG_WBDIS                       ICM_CFG_WBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_WBDIS_Msk instead */
+#define ICM_CFG_EOMDIS_Pos                  1                                              /**< (ICM_CFG) End of Monitoring Disable Position */
+#define ICM_CFG_EOMDIS_Msk                  (_U_(0x1) << ICM_CFG_EOMDIS_Pos)               /**< (ICM_CFG) End of Monitoring Disable Mask */
+#define ICM_CFG_EOMDIS                      ICM_CFG_EOMDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_EOMDIS_Msk instead */
+#define ICM_CFG_SLBDIS_Pos                  2                                              /**< (ICM_CFG) Secondary List Branching Disable Position */
+#define ICM_CFG_SLBDIS_Msk                  (_U_(0x1) << ICM_CFG_SLBDIS_Pos)               /**< (ICM_CFG) Secondary List Branching Disable Mask */
+#define ICM_CFG_SLBDIS                      ICM_CFG_SLBDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_SLBDIS_Msk instead */
+#define ICM_CFG_BBC_Pos                     4                                              /**< (ICM_CFG) Bus Burden Control Position */
+#define ICM_CFG_BBC_Msk                     (_U_(0xF) << ICM_CFG_BBC_Pos)                  /**< (ICM_CFG) Bus Burden Control Mask */
+#define ICM_CFG_BBC(value)                  (ICM_CFG_BBC_Msk & ((value) << ICM_CFG_BBC_Pos))
+#define ICM_CFG_ASCD_Pos                    8                                              /**< (ICM_CFG) Automatic Switch To Compare Digest Position */
+#define ICM_CFG_ASCD_Msk                    (_U_(0x1) << ICM_CFG_ASCD_Pos)                 /**< (ICM_CFG) Automatic Switch To Compare Digest Mask */
+#define ICM_CFG_ASCD                        ICM_CFG_ASCD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_ASCD_Msk instead */
+#define ICM_CFG_DUALBUFF_Pos                9                                              /**< (ICM_CFG) Dual Input Buffer Position */
+#define ICM_CFG_DUALBUFF_Msk                (_U_(0x1) << ICM_CFG_DUALBUFF_Pos)             /**< (ICM_CFG) Dual Input Buffer Mask */
+#define ICM_CFG_DUALBUFF                    ICM_CFG_DUALBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_DUALBUFF_Msk instead */
+#define ICM_CFG_UIHASH_Pos                  12                                             /**< (ICM_CFG) User Initial Hash Value Position */
+#define ICM_CFG_UIHASH_Msk                  (_U_(0x1) << ICM_CFG_UIHASH_Pos)               /**< (ICM_CFG) User Initial Hash Value Mask */
+#define ICM_CFG_UIHASH                      ICM_CFG_UIHASH_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_UIHASH_Msk instead */
+#define ICM_CFG_UALGO_Pos                   13                                             /**< (ICM_CFG) User SHA Algorithm Position */
+#define ICM_CFG_UALGO_Msk                   (_U_(0x7) << ICM_CFG_UALGO_Pos)                /**< (ICM_CFG) User SHA Algorithm Mask */
+#define ICM_CFG_UALGO(value)                (ICM_CFG_UALGO_Msk & ((value) << ICM_CFG_UALGO_Pos))
+#define   ICM_CFG_UALGO_SHA1_Val            _U_(0x0)                                       /**< (ICM_CFG) SHA1 algorithm processed  */
+#define   ICM_CFG_UALGO_SHA256_Val          _U_(0x1)                                       /**< (ICM_CFG) SHA256 algorithm processed  */
+#define   ICM_CFG_UALGO_SHA224_Val          _U_(0x4)                                       /**< (ICM_CFG) SHA224 algorithm processed  */
+#define ICM_CFG_UALGO_SHA1                  (ICM_CFG_UALGO_SHA1_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA1 algorithm processed Position  */
+#define ICM_CFG_UALGO_SHA256                (ICM_CFG_UALGO_SHA256_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA256 algorithm processed Position  */
+#define ICM_CFG_UALGO_SHA224                (ICM_CFG_UALGO_SHA224_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA224 algorithm processed Position  */
+#define ICM_CFG_HAPROT_Pos                  16                                             /**< (ICM_CFG) Region Hash Area Protection Position */
+#define ICM_CFG_HAPROT_Msk                  (_U_(0x3F) << ICM_CFG_HAPROT_Pos)              /**< (ICM_CFG) Region Hash Area Protection Mask */
+#define ICM_CFG_HAPROT(value)               (ICM_CFG_HAPROT_Msk & ((value) << ICM_CFG_HAPROT_Pos))
+#define ICM_CFG_DAPROT_Pos                  24                                             /**< (ICM_CFG) Region Descriptor Area Protection Position */
+#define ICM_CFG_DAPROT_Msk                  (_U_(0x3F) << ICM_CFG_DAPROT_Pos)              /**< (ICM_CFG) Region Descriptor Area Protection Mask */
+#define ICM_CFG_DAPROT(value)               (ICM_CFG_DAPROT_Msk & ((value) << ICM_CFG_DAPROT_Pos))
+#define ICM_CFG_MASK                        _U_(0x3F3FF3F7)                                /**< \deprecated (ICM_CFG) Register MASK  (Use ICM_CFG_Msk instead)  */
+#define ICM_CFG_Msk                         _U_(0x3F3FF3F7)                                /**< (ICM_CFG) Register Mask  */
+
+
+/* -------- ICM_CTRL : (ICM Offset: 0x04) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  ICM Enable                               */
+    uint32_t DISABLE:1;                 /**< bit:      1  ICM Disable Register                     */
+    uint32_t SWRST:1;                   /**< bit:      2  Software Reset                           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t REHASH:4;                  /**< bit:   4..7  Recompute Internal Hash                  */
+    uint32_t RMDIS:4;                   /**< bit:  8..11  Region Monitoring Disable                */
+    uint32_t RMEN:4;                    /**< bit: 12..15  Region Monitoring Enable                 */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_CTRL_OFFSET                     (0x04)                                        /**<  (ICM_CTRL) Control Register  Offset */
+
+#define ICM_CTRL_ENABLE_Pos                 0                                              /**< (ICM_CTRL) ICM Enable Position */
+#define ICM_CTRL_ENABLE_Msk                 (_U_(0x1) << ICM_CTRL_ENABLE_Pos)              /**< (ICM_CTRL) ICM Enable Mask */
+#define ICM_CTRL_ENABLE                     ICM_CTRL_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_ENABLE_Msk instead */
+#define ICM_CTRL_DISABLE_Pos                1                                              /**< (ICM_CTRL) ICM Disable Register Position */
+#define ICM_CTRL_DISABLE_Msk                (_U_(0x1) << ICM_CTRL_DISABLE_Pos)             /**< (ICM_CTRL) ICM Disable Register Mask */
+#define ICM_CTRL_DISABLE                    ICM_CTRL_DISABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_DISABLE_Msk instead */
+#define ICM_CTRL_SWRST_Pos                  2                                              /**< (ICM_CTRL) Software Reset Position */
+#define ICM_CTRL_SWRST_Msk                  (_U_(0x1) << ICM_CTRL_SWRST_Pos)               /**< (ICM_CTRL) Software Reset Mask */
+#define ICM_CTRL_SWRST                      ICM_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_SWRST_Msk instead */
+#define ICM_CTRL_REHASH_Pos                 4                                              /**< (ICM_CTRL) Recompute Internal Hash Position */
+#define ICM_CTRL_REHASH_Msk                 (_U_(0xF) << ICM_CTRL_REHASH_Pos)              /**< (ICM_CTRL) Recompute Internal Hash Mask */
+#define ICM_CTRL_REHASH(value)              (ICM_CTRL_REHASH_Msk & ((value) << ICM_CTRL_REHASH_Pos))
+#define ICM_CTRL_RMDIS_Pos                  8                                              /**< (ICM_CTRL) Region Monitoring Disable Position */
+#define ICM_CTRL_RMDIS_Msk                  (_U_(0xF) << ICM_CTRL_RMDIS_Pos)               /**< (ICM_CTRL) Region Monitoring Disable Mask */
+#define ICM_CTRL_RMDIS(value)               (ICM_CTRL_RMDIS_Msk & ((value) << ICM_CTRL_RMDIS_Pos))
+#define ICM_CTRL_RMEN_Pos                   12                                             /**< (ICM_CTRL) Region Monitoring Enable Position */
+#define ICM_CTRL_RMEN_Msk                   (_U_(0xF) << ICM_CTRL_RMEN_Pos)                /**< (ICM_CTRL) Region Monitoring Enable Mask */
+#define ICM_CTRL_RMEN(value)                (ICM_CTRL_RMEN_Msk & ((value) << ICM_CTRL_RMEN_Pos))
+#define ICM_CTRL_MASK                       _U_(0xFFF7)                                    /**< \deprecated (ICM_CTRL) Register MASK  (Use ICM_CTRL_Msk instead)  */
+#define ICM_CTRL_Msk                        _U_(0xFFF7)                                    /**< (ICM_CTRL) Register Mask  */
+
+
+/* -------- ICM_SR : (ICM Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  ICM Controller Enable Register           */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t RAWRMDIS:4;                /**< bit:  8..11  Region Monitoring Disabled Raw Status    */
+    uint32_t RMDIS:4;                   /**< bit: 12..15  Region Monitoring Disabled Status        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_SR_OFFSET                       (0x08)                                        /**<  (ICM_SR) Status Register  Offset */
+
+#define ICM_SR_ENABLE_Pos                   0                                              /**< (ICM_SR) ICM Controller Enable Register Position */
+#define ICM_SR_ENABLE_Msk                   (_U_(0x1) << ICM_SR_ENABLE_Pos)                /**< (ICM_SR) ICM Controller Enable Register Mask */
+#define ICM_SR_ENABLE                       ICM_SR_ENABLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_SR_ENABLE_Msk instead */
+#define ICM_SR_RAWRMDIS_Pos                 8                                              /**< (ICM_SR) Region Monitoring Disabled Raw Status Position */
+#define ICM_SR_RAWRMDIS_Msk                 (_U_(0xF) << ICM_SR_RAWRMDIS_Pos)              /**< (ICM_SR) Region Monitoring Disabled Raw Status Mask */
+#define ICM_SR_RAWRMDIS(value)              (ICM_SR_RAWRMDIS_Msk & ((value) << ICM_SR_RAWRMDIS_Pos))
+#define ICM_SR_RMDIS_Pos                    12                                             /**< (ICM_SR) Region Monitoring Disabled Status Position */
+#define ICM_SR_RMDIS_Msk                    (_U_(0xF) << ICM_SR_RMDIS_Pos)                 /**< (ICM_SR) Region Monitoring Disabled Status Mask */
+#define ICM_SR_RMDIS(value)                 (ICM_SR_RMDIS_Msk & ((value) << ICM_SR_RMDIS_Pos))
+#define ICM_SR_MASK                         _U_(0xFF01)                                    /**< \deprecated (ICM_SR) Register MASK  (Use ICM_SR_Msk instead)  */
+#define ICM_SR_Msk                          _U_(0xFF01)                                    /**< (ICM_SR) Register Mask  */
+
+
+/* -------- ICM_IER : (ICM Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Enable   */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Enable  */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Enable        */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition detected Interrupt Enable */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected Interrupt Enable */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Disable  */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IER_OFFSET                      (0x10)                                        /**<  (ICM_IER) Interrupt Enable Register  Offset */
+
+#define ICM_IER_RHC_Pos                     0                                              /**< (ICM_IER) Region Hash Completed Interrupt Enable Position */
+#define ICM_IER_RHC_Msk                     (_U_(0xF) << ICM_IER_RHC_Pos)                  /**< (ICM_IER) Region Hash Completed Interrupt Enable Mask */
+#define ICM_IER_RHC(value)                  (ICM_IER_RHC_Msk & ((value) << ICM_IER_RHC_Pos))
+#define ICM_IER_RDM_Pos                     4                                              /**< (ICM_IER) Region Digest Mismatch Interrupt Enable Position */
+#define ICM_IER_RDM_Msk                     (_U_(0xF) << ICM_IER_RDM_Pos)                  /**< (ICM_IER) Region Digest Mismatch Interrupt Enable Mask */
+#define ICM_IER_RDM(value)                  (ICM_IER_RDM_Msk & ((value) << ICM_IER_RDM_Pos))
+#define ICM_IER_RBE_Pos                     8                                              /**< (ICM_IER) Region Bus Error Interrupt Enable Position */
+#define ICM_IER_RBE_Msk                     (_U_(0xF) << ICM_IER_RBE_Pos)                  /**< (ICM_IER) Region Bus Error Interrupt Enable Mask */
+#define ICM_IER_RBE(value)                  (ICM_IER_RBE_Msk & ((value) << ICM_IER_RBE_Pos))
+#define ICM_IER_RWC_Pos                     12                                             /**< (ICM_IER) Region Wrap Condition detected Interrupt Enable Position */
+#define ICM_IER_RWC_Msk                     (_U_(0xF) << ICM_IER_RWC_Pos)                  /**< (ICM_IER) Region Wrap Condition detected Interrupt Enable Mask */
+#define ICM_IER_RWC(value)                  (ICM_IER_RWC_Msk & ((value) << ICM_IER_RWC_Pos))
+#define ICM_IER_REC_Pos                     16                                             /**< (ICM_IER) Region End bit Condition Detected Interrupt Enable Position */
+#define ICM_IER_REC_Msk                     (_U_(0xF) << ICM_IER_REC_Pos)                  /**< (ICM_IER) Region End bit Condition Detected Interrupt Enable Mask */
+#define ICM_IER_REC(value)                  (ICM_IER_REC_Msk & ((value) << ICM_IER_REC_Pos))
+#define ICM_IER_RSU_Pos                     20                                             /**< (ICM_IER) Region Status Updated Interrupt Disable Position */
+#define ICM_IER_RSU_Msk                     (_U_(0xF) << ICM_IER_RSU_Pos)                  /**< (ICM_IER) Region Status Updated Interrupt Disable Mask */
+#define ICM_IER_RSU(value)                  (ICM_IER_RSU_Msk & ((value) << ICM_IER_RSU_Pos))
+#define ICM_IER_URAD_Pos                    24                                             /**< (ICM_IER) Undefined Register Access Detection Interrupt Enable Position */
+#define ICM_IER_URAD_Msk                    (_U_(0x1) << ICM_IER_URAD_Pos)                 /**< (ICM_IER) Undefined Register Access Detection Interrupt Enable Mask */
+#define ICM_IER_URAD                        ICM_IER_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IER_URAD_Msk instead */
+#define ICM_IER_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IER) Register MASK  (Use ICM_IER_Msk instead)  */
+#define ICM_IER_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IER) Register Mask  */
+
+
+/* -------- ICM_IDR : (ICM Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Disable  */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Disable */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Disable       */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected Interrupt Disable */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition detected Interrupt Disable */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Disable  */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Disable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IDR_OFFSET                      (0x14)                                        /**<  (ICM_IDR) Interrupt Disable Register  Offset */
+
+#define ICM_IDR_RHC_Pos                     0                                              /**< (ICM_IDR) Region Hash Completed Interrupt Disable Position */
+#define ICM_IDR_RHC_Msk                     (_U_(0xF) << ICM_IDR_RHC_Pos)                  /**< (ICM_IDR) Region Hash Completed Interrupt Disable Mask */
+#define ICM_IDR_RHC(value)                  (ICM_IDR_RHC_Msk & ((value) << ICM_IDR_RHC_Pos))
+#define ICM_IDR_RDM_Pos                     4                                              /**< (ICM_IDR) Region Digest Mismatch Interrupt Disable Position */
+#define ICM_IDR_RDM_Msk                     (_U_(0xF) << ICM_IDR_RDM_Pos)                  /**< (ICM_IDR) Region Digest Mismatch Interrupt Disable Mask */
+#define ICM_IDR_RDM(value)                  (ICM_IDR_RDM_Msk & ((value) << ICM_IDR_RDM_Pos))
+#define ICM_IDR_RBE_Pos                     8                                              /**< (ICM_IDR) Region Bus Error Interrupt Disable Position */
+#define ICM_IDR_RBE_Msk                     (_U_(0xF) << ICM_IDR_RBE_Pos)                  /**< (ICM_IDR) Region Bus Error Interrupt Disable Mask */
+#define ICM_IDR_RBE(value)                  (ICM_IDR_RBE_Msk & ((value) << ICM_IDR_RBE_Pos))
+#define ICM_IDR_RWC_Pos                     12                                             /**< (ICM_IDR) Region Wrap Condition Detected Interrupt Disable Position */
+#define ICM_IDR_RWC_Msk                     (_U_(0xF) << ICM_IDR_RWC_Pos)                  /**< (ICM_IDR) Region Wrap Condition Detected Interrupt Disable Mask */
+#define ICM_IDR_RWC(value)                  (ICM_IDR_RWC_Msk & ((value) << ICM_IDR_RWC_Pos))
+#define ICM_IDR_REC_Pos                     16                                             /**< (ICM_IDR) Region End bit Condition detected Interrupt Disable Position */
+#define ICM_IDR_REC_Msk                     (_U_(0xF) << ICM_IDR_REC_Pos)                  /**< (ICM_IDR) Region End bit Condition detected Interrupt Disable Mask */
+#define ICM_IDR_REC(value)                  (ICM_IDR_REC_Msk & ((value) << ICM_IDR_REC_Pos))
+#define ICM_IDR_RSU_Pos                     20                                             /**< (ICM_IDR) Region Status Updated Interrupt Disable Position */
+#define ICM_IDR_RSU_Msk                     (_U_(0xF) << ICM_IDR_RSU_Pos)                  /**< (ICM_IDR) Region Status Updated Interrupt Disable Mask */
+#define ICM_IDR_RSU(value)                  (ICM_IDR_RSU_Msk & ((value) << ICM_IDR_RSU_Pos))
+#define ICM_IDR_URAD_Pos                    24                                             /**< (ICM_IDR) Undefined Register Access Detection Interrupt Disable Position */
+#define ICM_IDR_URAD_Msk                    (_U_(0x1) << ICM_IDR_URAD_Pos)                 /**< (ICM_IDR) Undefined Register Access Detection Interrupt Disable Mask */
+#define ICM_IDR_URAD                        ICM_IDR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IDR_URAD_Msk instead */
+#define ICM_IDR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IDR) Register MASK  (Use ICM_IDR_Msk instead)  */
+#define ICM_IDR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IDR) Register Mask  */
+
+
+/* -------- ICM_IMR : (ICM Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Mask     */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Mask    */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Mask          */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected Interrupt Mask */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected Interrupt Mask */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Mask     */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Mask */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IMR_OFFSET                      (0x18)                                        /**<  (ICM_IMR) Interrupt Mask Register  Offset */
+
+#define ICM_IMR_RHC_Pos                     0                                              /**< (ICM_IMR) Region Hash Completed Interrupt Mask Position */
+#define ICM_IMR_RHC_Msk                     (_U_(0xF) << ICM_IMR_RHC_Pos)                  /**< (ICM_IMR) Region Hash Completed Interrupt Mask Mask */
+#define ICM_IMR_RHC(value)                  (ICM_IMR_RHC_Msk & ((value) << ICM_IMR_RHC_Pos))
+#define ICM_IMR_RDM_Pos                     4                                              /**< (ICM_IMR) Region Digest Mismatch Interrupt Mask Position */
+#define ICM_IMR_RDM_Msk                     (_U_(0xF) << ICM_IMR_RDM_Pos)                  /**< (ICM_IMR) Region Digest Mismatch Interrupt Mask Mask */
+#define ICM_IMR_RDM(value)                  (ICM_IMR_RDM_Msk & ((value) << ICM_IMR_RDM_Pos))
+#define ICM_IMR_RBE_Pos                     8                                              /**< (ICM_IMR) Region Bus Error Interrupt Mask Position */
+#define ICM_IMR_RBE_Msk                     (_U_(0xF) << ICM_IMR_RBE_Pos)                  /**< (ICM_IMR) Region Bus Error Interrupt Mask Mask */
+#define ICM_IMR_RBE(value)                  (ICM_IMR_RBE_Msk & ((value) << ICM_IMR_RBE_Pos))
+#define ICM_IMR_RWC_Pos                     12                                             /**< (ICM_IMR) Region Wrap Condition Detected Interrupt Mask Position */
+#define ICM_IMR_RWC_Msk                     (_U_(0xF) << ICM_IMR_RWC_Pos)                  /**< (ICM_IMR) Region Wrap Condition Detected Interrupt Mask Mask */
+#define ICM_IMR_RWC(value)                  (ICM_IMR_RWC_Msk & ((value) << ICM_IMR_RWC_Pos))
+#define ICM_IMR_REC_Pos                     16                                             /**< (ICM_IMR) Region End bit Condition Detected Interrupt Mask Position */
+#define ICM_IMR_REC_Msk                     (_U_(0xF) << ICM_IMR_REC_Pos)                  /**< (ICM_IMR) Region End bit Condition Detected Interrupt Mask Mask */
+#define ICM_IMR_REC(value)                  (ICM_IMR_REC_Msk & ((value) << ICM_IMR_REC_Pos))
+#define ICM_IMR_RSU_Pos                     20                                             /**< (ICM_IMR) Region Status Updated Interrupt Mask Position */
+#define ICM_IMR_RSU_Msk                     (_U_(0xF) << ICM_IMR_RSU_Pos)                  /**< (ICM_IMR) Region Status Updated Interrupt Mask Mask */
+#define ICM_IMR_RSU(value)                  (ICM_IMR_RSU_Msk & ((value) << ICM_IMR_RSU_Pos))
+#define ICM_IMR_URAD_Pos                    24                                             /**< (ICM_IMR) Undefined Register Access Detection Interrupt Mask Position */
+#define ICM_IMR_URAD_Msk                    (_U_(0x1) << ICM_IMR_URAD_Pos)                 /**< (ICM_IMR) Undefined Register Access Detection Interrupt Mask Mask */
+#define ICM_IMR_URAD                        ICM_IMR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IMR_URAD_Msk instead */
+#define ICM_IMR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IMR) Register MASK  (Use ICM_IMR_Msk instead)  */
+#define ICM_IMR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IMR) Register Mask  */
+
+
+/* -------- ICM_ISR : (ICM Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed                    */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch                   */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error                         */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected           */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected        */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Detected           */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Status */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_ISR_OFFSET                      (0x1C)                                        /**<  (ICM_ISR) Interrupt Status Register  Offset */
+
+#define ICM_ISR_RHC_Pos                     0                                              /**< (ICM_ISR) Region Hash Completed Position */
+#define ICM_ISR_RHC_Msk                     (_U_(0xF) << ICM_ISR_RHC_Pos)                  /**< (ICM_ISR) Region Hash Completed Mask */
+#define ICM_ISR_RHC(value)                  (ICM_ISR_RHC_Msk & ((value) << ICM_ISR_RHC_Pos))
+#define ICM_ISR_RDM_Pos                     4                                              /**< (ICM_ISR) Region Digest Mismatch Position */
+#define ICM_ISR_RDM_Msk                     (_U_(0xF) << ICM_ISR_RDM_Pos)                  /**< (ICM_ISR) Region Digest Mismatch Mask */
+#define ICM_ISR_RDM(value)                  (ICM_ISR_RDM_Msk & ((value) << ICM_ISR_RDM_Pos))
+#define ICM_ISR_RBE_Pos                     8                                              /**< (ICM_ISR) Region Bus Error Position */
+#define ICM_ISR_RBE_Msk                     (_U_(0xF) << ICM_ISR_RBE_Pos)                  /**< (ICM_ISR) Region Bus Error Mask */
+#define ICM_ISR_RBE(value)                  (ICM_ISR_RBE_Msk & ((value) << ICM_ISR_RBE_Pos))
+#define ICM_ISR_RWC_Pos                     12                                             /**< (ICM_ISR) Region Wrap Condition Detected Position */
+#define ICM_ISR_RWC_Msk                     (_U_(0xF) << ICM_ISR_RWC_Pos)                  /**< (ICM_ISR) Region Wrap Condition Detected Mask */
+#define ICM_ISR_RWC(value)                  (ICM_ISR_RWC_Msk & ((value) << ICM_ISR_RWC_Pos))
+#define ICM_ISR_REC_Pos                     16                                             /**< (ICM_ISR) Region End bit Condition Detected Position */
+#define ICM_ISR_REC_Msk                     (_U_(0xF) << ICM_ISR_REC_Pos)                  /**< (ICM_ISR) Region End bit Condition Detected Mask */
+#define ICM_ISR_REC(value)                  (ICM_ISR_REC_Msk & ((value) << ICM_ISR_REC_Pos))
+#define ICM_ISR_RSU_Pos                     20                                             /**< (ICM_ISR) Region Status Updated Detected Position */
+#define ICM_ISR_RSU_Msk                     (_U_(0xF) << ICM_ISR_RSU_Pos)                  /**< (ICM_ISR) Region Status Updated Detected Mask */
+#define ICM_ISR_RSU(value)                  (ICM_ISR_RSU_Msk & ((value) << ICM_ISR_RSU_Pos))
+#define ICM_ISR_URAD_Pos                    24                                             /**< (ICM_ISR) Undefined Register Access Detection Status Position */
+#define ICM_ISR_URAD_Msk                    (_U_(0x1) << ICM_ISR_URAD_Pos)                 /**< (ICM_ISR) Undefined Register Access Detection Status Mask */
+#define ICM_ISR_URAD                        ICM_ISR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_ISR_URAD_Msk instead */
+#define ICM_ISR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_ISR) Register MASK  (Use ICM_ISR_Msk instead)  */
+#define ICM_ISR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_ISR) Register Mask  */
+
+
+/* -------- ICM_UASR : (ICM Offset: 0x20) (R/ 32) Undefined Access Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URAT:3;                    /**< bit:   0..2  Undefined Register Access Trace          */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_UASR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_UASR_OFFSET                     (0x20)                                        /**<  (ICM_UASR) Undefined Access Status Register  Offset */
+
+#define ICM_UASR_URAT_Pos                   0                                              /**< (ICM_UASR) Undefined Register Access Trace Position */
+#define ICM_UASR_URAT_Msk                   (_U_(0x7) << ICM_UASR_URAT_Pos)                /**< (ICM_UASR) Undefined Register Access Trace Mask */
+#define ICM_UASR_URAT(value)                (ICM_UASR_URAT_Msk & ((value) << ICM_UASR_URAT_Pos))
+#define   ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER_Val _U_(0x0)                                       /**< (ICM_UASR) Unspecified structure member set to one detected when the descriptor is loaded.  */
+#define   ICM_UASR_URAT_ICM_CFG_MODIFIED_Val _U_(0x1)                                       /**< (ICM_UASR) ICM_CFG modified during active monitoring.  */
+#define   ICM_UASR_URAT_ICM_DSCR_MODIFIED_Val _U_(0x2)                                       /**< (ICM_UASR) ICM_DSCR modified during active monitoring.  */
+#define   ICM_UASR_URAT_ICM_HASH_MODIFIED_Val _U_(0x3)                                       /**< (ICM_UASR) ICM_HASH modified during active monitoring  */
+#define   ICM_UASR_URAT_READ_ACCESS_Val     _U_(0x4)                                       /**< (ICM_UASR) Write-only register read access  */
+#define ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER  (ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) Unspecified structure member set to one detected when the descriptor is loaded. Position  */
+#define ICM_UASR_URAT_ICM_CFG_MODIFIED      (ICM_UASR_URAT_ICM_CFG_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_CFG modified during active monitoring. Position  */
+#define ICM_UASR_URAT_ICM_DSCR_MODIFIED     (ICM_UASR_URAT_ICM_DSCR_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_DSCR modified during active monitoring. Position  */
+#define ICM_UASR_URAT_ICM_HASH_MODIFIED     (ICM_UASR_URAT_ICM_HASH_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_HASH modified during active monitoring Position  */
+#define ICM_UASR_URAT_READ_ACCESS           (ICM_UASR_URAT_READ_ACCESS_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) Write-only register read access Position  */
+#define ICM_UASR_MASK                       _U_(0x07)                                      /**< \deprecated (ICM_UASR) Register MASK  (Use ICM_UASR_Msk instead)  */
+#define ICM_UASR_Msk                        _U_(0x07)                                      /**< (ICM_UASR) Register Mask  */
+
+
+/* -------- ICM_DSCR : (ICM Offset: 0x30) (R/W 32) Region Descriptor Area Start Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t DASA:26;                   /**< bit:  6..31  Descriptor Area Start Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_DSCR_OFFSET                     (0x30)                                        /**<  (ICM_DSCR) Region Descriptor Area Start Address Register  Offset */
+
+#define ICM_DSCR_DASA_Pos                   6                                              /**< (ICM_DSCR) Descriptor Area Start Address Position */
+#define ICM_DSCR_DASA_Msk                   (_U_(0x3FFFFFF) << ICM_DSCR_DASA_Pos)          /**< (ICM_DSCR) Descriptor Area Start Address Mask */
+#define ICM_DSCR_DASA(value)                (ICM_DSCR_DASA_Msk & ((value) << ICM_DSCR_DASA_Pos))
+#define ICM_DSCR_MASK                       _U_(0xFFFFFFC0)                                /**< \deprecated (ICM_DSCR) Register MASK  (Use ICM_DSCR_Msk instead)  */
+#define ICM_DSCR_Msk                        _U_(0xFFFFFFC0)                                /**< (ICM_DSCR) Register Mask  */
+
+
+/* -------- ICM_HASH : (ICM Offset: 0x34) (R/W 32) Region Hash Area Start Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t HASA:25;                   /**< bit:  7..31  Hash Area Start Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_HASH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_HASH_OFFSET                     (0x34)                                        /**<  (ICM_HASH) Region Hash Area Start Address Register  Offset */
+
+#define ICM_HASH_HASA_Pos                   7                                              /**< (ICM_HASH) Hash Area Start Address Position */
+#define ICM_HASH_HASA_Msk                   (_U_(0x1FFFFFF) << ICM_HASH_HASA_Pos)          /**< (ICM_HASH) Hash Area Start Address Mask */
+#define ICM_HASH_HASA(value)                (ICM_HASH_HASA_Msk & ((value) << ICM_HASH_HASA_Pos))
+#define ICM_HASH_MASK                       _U_(0xFFFFFF80)                                /**< \deprecated (ICM_HASH) Register MASK  (Use ICM_HASH_Msk instead)  */
+#define ICM_HASH_Msk                        _U_(0xFFFFFF80)                                /**< (ICM_HASH) Register Mask  */
+
+
+/* -------- ICM_UIHVAL : (ICM Offset: 0x38) (/W 32) User Initial Hash Value 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VAL:32;                    /**< bit:  0..31  Initial Hash Value                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_UIHVAL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_UIHVAL_OFFSET                   (0x38)                                        /**<  (ICM_UIHVAL) User Initial Hash Value 0 Register 0  Offset */
+
+#define ICM_UIHVAL_VAL_Pos                  0                                              /**< (ICM_UIHVAL) Initial Hash Value Position */
+#define ICM_UIHVAL_VAL_Msk                  (_U_(0xFFFFFFFF) << ICM_UIHVAL_VAL_Pos)        /**< (ICM_UIHVAL) Initial Hash Value Mask */
+#define ICM_UIHVAL_VAL(value)               (ICM_UIHVAL_VAL_Msk & ((value) << ICM_UIHVAL_VAL_Pos))
+#define ICM_UIHVAL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (ICM_UIHVAL) Register MASK  (Use ICM_UIHVAL_Msk instead)  */
+#define ICM_UIHVAL_Msk                      _U_(0xFFFFFFFF)                                /**< (ICM_UIHVAL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ICM hardware registers */
+typedef struct {  
+  __IO uint32_t ICM_CFG;        /**< (ICM Offset: 0x00) Configuration Register */
+  __O  uint32_t ICM_CTRL;       /**< (ICM Offset: 0x04) Control Register */
+  __I  uint32_t ICM_SR;         /**< (ICM Offset: 0x08) Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t ICM_IER;        /**< (ICM Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t ICM_IDR;        /**< (ICM Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t ICM_IMR;        /**< (ICM Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t ICM_ISR;        /**< (ICM Offset: 0x1C) Interrupt Status Register */
+  __I  uint32_t ICM_UASR;       /**< (ICM Offset: 0x20) Undefined Access Status Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO uint32_t ICM_DSCR;       /**< (ICM Offset: 0x30) Region Descriptor Area Start Address Register */
+  __IO uint32_t ICM_HASH;       /**< (ICM Offset: 0x34) Region Hash Area Start Address Register */
+  __O  uint32_t ICM_UIHVAL[8];  /**< (ICM Offset: 0x38) User Initial Hash Value 0 Register 0 */
+} Icm;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ICM hardware registers */
+typedef struct {  
+  __IO ICM_CFG_Type                   ICM_CFG;        /**< Offset: 0x00 (R/W  32) Configuration Register */
+  __O  ICM_CTRL_Type                  ICM_CTRL;       /**< Offset: 0x04 ( /W  32) Control Register */
+  __I  ICM_SR_Type                    ICM_SR;         /**< Offset: 0x08 (R/   32) Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  ICM_IER_Type                   ICM_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  ICM_IDR_Type                   ICM_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  ICM_IMR_Type                   ICM_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  ICM_ISR_Type                   ICM_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __I  ICM_UASR_Type                  ICM_UASR;       /**< Offset: 0x20 (R/   32) Undefined Access Status Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO ICM_DSCR_Type                  ICM_DSCR;       /**< Offset: 0x30 (R/W  32) Region Descriptor Area Start Address Register */
+  __IO ICM_HASH_Type                  ICM_HASH;       /**< Offset: 0x34 (R/W  32) Region Hash Area Start Address Register */
+  __O  ICM_UIHVAL_Type                ICM_UIHVAL[8];  /**< Offset: 0x38 ( /W  32) User Initial Hash Value 0 Register 0 */
+} Icm;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Integrity Check Monitor */
+
+#endif /* _SAMV71_ICM_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/isi.h
+++ b/asf/sam/include/samv71/component/isi.h
@@ -1,0 +1,1088 @@
+/**
+ * \file
+ *
+ * \brief Component description for ISI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ISI_COMPONENT_H_
+#define _SAMV71_ISI_COMPONENT_H_
+#define _SAMV71_ISI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Image Sensor Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ISI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ISI_6350                       /**< (ISI) Module ID */
+#define REV_ISI I                      /**< (ISI) Module revision */
+
+/* -------- ISI_CFG1 : (ISI Offset: 0x00) (R/W 32) ISI Configuration 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t HSYNC_POL:1;               /**< bit:      2  Horizontal Synchronization Polarity      */
+    uint32_t VSYNC_POL:1;               /**< bit:      3  Vertical Synchronization Polarity        */
+    uint32_t PIXCLK_POL:1;              /**< bit:      4  Pixel Clock Polarity                     */
+    uint32_t GRAYLE:1;                  /**< bit:      5  Grayscale Little Endian                  */
+    uint32_t EMB_SYNC:1;                /**< bit:      6  Embedded Synchronization                 */
+    uint32_t CRC_SYNC:1;                /**< bit:      7  Embedded Synchronization Correction      */
+    uint32_t FRATE:3;                   /**< bit:  8..10  Frame Rate [0..7]                        */
+    uint32_t DISCR:1;                   /**< bit:     11  Disable Codec Request                    */
+    uint32_t FULL:1;                    /**< bit:     12  Full Mode is Allowed                     */
+    uint32_t THMASK:2;                  /**< bit: 13..14  Threshold Mask                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SLD:8;                     /**< bit: 16..23  Start of Line Delay                      */
+    uint32_t SFD:8;                     /**< bit: 24..31  Start of Frame Delay                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CFG1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CFG1_OFFSET                     (0x00)                                        /**<  (ISI_CFG1) ISI Configuration 1 Register  Offset */
+
+#define ISI_CFG1_HSYNC_POL_Pos              2                                              /**< (ISI_CFG1) Horizontal Synchronization Polarity Position */
+#define ISI_CFG1_HSYNC_POL_Msk              (_U_(0x1) << ISI_CFG1_HSYNC_POL_Pos)           /**< (ISI_CFG1) Horizontal Synchronization Polarity Mask */
+#define ISI_CFG1_HSYNC_POL                  ISI_CFG1_HSYNC_POL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_HSYNC_POL_Msk instead */
+#define ISI_CFG1_VSYNC_POL_Pos              3                                              /**< (ISI_CFG1) Vertical Synchronization Polarity Position */
+#define ISI_CFG1_VSYNC_POL_Msk              (_U_(0x1) << ISI_CFG1_VSYNC_POL_Pos)           /**< (ISI_CFG1) Vertical Synchronization Polarity Mask */
+#define ISI_CFG1_VSYNC_POL                  ISI_CFG1_VSYNC_POL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_VSYNC_POL_Msk instead */
+#define ISI_CFG1_PIXCLK_POL_Pos             4                                              /**< (ISI_CFG1) Pixel Clock Polarity Position */
+#define ISI_CFG1_PIXCLK_POL_Msk             (_U_(0x1) << ISI_CFG1_PIXCLK_POL_Pos)          /**< (ISI_CFG1) Pixel Clock Polarity Mask */
+#define ISI_CFG1_PIXCLK_POL                 ISI_CFG1_PIXCLK_POL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_PIXCLK_POL_Msk instead */
+#define ISI_CFG1_GRAYLE_Pos                 5                                              /**< (ISI_CFG1) Grayscale Little Endian Position */
+#define ISI_CFG1_GRAYLE_Msk                 (_U_(0x1) << ISI_CFG1_GRAYLE_Pos)              /**< (ISI_CFG1) Grayscale Little Endian Mask */
+#define ISI_CFG1_GRAYLE                     ISI_CFG1_GRAYLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_GRAYLE_Msk instead */
+#define ISI_CFG1_EMB_SYNC_Pos               6                                              /**< (ISI_CFG1) Embedded Synchronization Position */
+#define ISI_CFG1_EMB_SYNC_Msk               (_U_(0x1) << ISI_CFG1_EMB_SYNC_Pos)            /**< (ISI_CFG1) Embedded Synchronization Mask */
+#define ISI_CFG1_EMB_SYNC                   ISI_CFG1_EMB_SYNC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_EMB_SYNC_Msk instead */
+#define ISI_CFG1_CRC_SYNC_Pos               7                                              /**< (ISI_CFG1) Embedded Synchronization Correction Position */
+#define ISI_CFG1_CRC_SYNC_Msk               (_U_(0x1) << ISI_CFG1_CRC_SYNC_Pos)            /**< (ISI_CFG1) Embedded Synchronization Correction Mask */
+#define ISI_CFG1_CRC_SYNC                   ISI_CFG1_CRC_SYNC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_CRC_SYNC_Msk instead */
+#define ISI_CFG1_FRATE_Pos                  8                                              /**< (ISI_CFG1) Frame Rate [0..7] Position */
+#define ISI_CFG1_FRATE_Msk                  (_U_(0x7) << ISI_CFG1_FRATE_Pos)               /**< (ISI_CFG1) Frame Rate [0..7] Mask */
+#define ISI_CFG1_FRATE(value)               (ISI_CFG1_FRATE_Msk & ((value) << ISI_CFG1_FRATE_Pos))
+#define ISI_CFG1_DISCR_Pos                  11                                             /**< (ISI_CFG1) Disable Codec Request Position */
+#define ISI_CFG1_DISCR_Msk                  (_U_(0x1) << ISI_CFG1_DISCR_Pos)               /**< (ISI_CFG1) Disable Codec Request Mask */
+#define ISI_CFG1_DISCR                      ISI_CFG1_DISCR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_DISCR_Msk instead */
+#define ISI_CFG1_FULL_Pos                   12                                             /**< (ISI_CFG1) Full Mode is Allowed Position */
+#define ISI_CFG1_FULL_Msk                   (_U_(0x1) << ISI_CFG1_FULL_Pos)                /**< (ISI_CFG1) Full Mode is Allowed Mask */
+#define ISI_CFG1_FULL                       ISI_CFG1_FULL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_FULL_Msk instead */
+#define ISI_CFG1_THMASK_Pos                 13                                             /**< (ISI_CFG1) Threshold Mask Position */
+#define ISI_CFG1_THMASK_Msk                 (_U_(0x3) << ISI_CFG1_THMASK_Pos)              /**< (ISI_CFG1) Threshold Mask Mask */
+#define ISI_CFG1_THMASK(value)              (ISI_CFG1_THMASK_Msk & ((value) << ISI_CFG1_THMASK_Pos))
+#define   ISI_CFG1_THMASK_BEATS_4_Val       _U_(0x0)                                       /**< (ISI_CFG1) Only 4 beats AHB burst allowed  */
+#define   ISI_CFG1_THMASK_BEATS_8_Val       _U_(0x1)                                       /**< (ISI_CFG1) Only 4 and 8 beats AHB burst allowed  */
+#define   ISI_CFG1_THMASK_BEATS_16_Val      _U_(0x2)                                       /**< (ISI_CFG1) 4, 8 and 16 beats AHB burst allowed  */
+#define ISI_CFG1_THMASK_BEATS_4             (ISI_CFG1_THMASK_BEATS_4_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) Only 4 beats AHB burst allowed Position  */
+#define ISI_CFG1_THMASK_BEATS_8             (ISI_CFG1_THMASK_BEATS_8_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) Only 4 and 8 beats AHB burst allowed Position  */
+#define ISI_CFG1_THMASK_BEATS_16            (ISI_CFG1_THMASK_BEATS_16_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) 4, 8 and 16 beats AHB burst allowed Position  */
+#define ISI_CFG1_SLD_Pos                    16                                             /**< (ISI_CFG1) Start of Line Delay Position */
+#define ISI_CFG1_SLD_Msk                    (_U_(0xFF) << ISI_CFG1_SLD_Pos)                /**< (ISI_CFG1) Start of Line Delay Mask */
+#define ISI_CFG1_SLD(value)                 (ISI_CFG1_SLD_Msk & ((value) << ISI_CFG1_SLD_Pos))
+#define ISI_CFG1_SFD_Pos                    24                                             /**< (ISI_CFG1) Start of Frame Delay Position */
+#define ISI_CFG1_SFD_Msk                    (_U_(0xFF) << ISI_CFG1_SFD_Pos)                /**< (ISI_CFG1) Start of Frame Delay Mask */
+#define ISI_CFG1_SFD(value)                 (ISI_CFG1_SFD_Msk & ((value) << ISI_CFG1_SFD_Pos))
+#define ISI_CFG1_Msk                        _U_(0xFFFF7FFC)                                /**< (ISI_CFG1) Register Mask  */
+
+
+/* -------- ISI_CFG2 : (ISI Offset: 0x04) (R/W 32) ISI Configuration 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IM_VSIZE:11;               /**< bit:  0..10  Vertical Size of the Image Sensor [0..2047] */
+    uint32_t GS_MODE:1;                 /**< bit:     11  Grayscale Pixel Format Mode              */
+    uint32_t RGB_MODE:1;                /**< bit:     12  RGB Input Mode                           */
+    uint32_t GRAYSCALE:1;               /**< bit:     13  Grayscale Mode Format Enable             */
+    uint32_t RGB_SWAP:1;                /**< bit:     14  RGB Format Swap Mode                     */
+    uint32_t COL_SPACE:1;               /**< bit:     15  Color Space for the Image Data           */
+    uint32_t IM_HSIZE:11;               /**< bit: 16..26  Horizontal Size of the Image Sensor [0..2047] */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t YCC_SWAP:2;                /**< bit: 28..29  YCrCb Format Swap Mode                   */
+    uint32_t RGB_CFG:2;                 /**< bit: 30..31  RGB Pixel Mapping Configuration          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CFG2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CFG2_OFFSET                     (0x04)                                        /**<  (ISI_CFG2) ISI Configuration 2 Register  Offset */
+
+#define ISI_CFG2_IM_VSIZE_Pos               0                                              /**< (ISI_CFG2) Vertical Size of the Image Sensor [0..2047] Position */
+#define ISI_CFG2_IM_VSIZE_Msk               (_U_(0x7FF) << ISI_CFG2_IM_VSIZE_Pos)          /**< (ISI_CFG2) Vertical Size of the Image Sensor [0..2047] Mask */
+#define ISI_CFG2_IM_VSIZE(value)            (ISI_CFG2_IM_VSIZE_Msk & ((value) << ISI_CFG2_IM_VSIZE_Pos))
+#define ISI_CFG2_GS_MODE_Pos                11                                             /**< (ISI_CFG2) Grayscale Pixel Format Mode Position */
+#define ISI_CFG2_GS_MODE_Msk                (_U_(0x1) << ISI_CFG2_GS_MODE_Pos)             /**< (ISI_CFG2) Grayscale Pixel Format Mode Mask */
+#define ISI_CFG2_GS_MODE                    ISI_CFG2_GS_MODE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_GS_MODE_Msk instead */
+#define ISI_CFG2_RGB_MODE_Pos               12                                             /**< (ISI_CFG2) RGB Input Mode Position */
+#define ISI_CFG2_RGB_MODE_Msk               (_U_(0x1) << ISI_CFG2_RGB_MODE_Pos)            /**< (ISI_CFG2) RGB Input Mode Mask */
+#define ISI_CFG2_RGB_MODE                   ISI_CFG2_RGB_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_RGB_MODE_Msk instead */
+#define ISI_CFG2_GRAYSCALE_Pos              13                                             /**< (ISI_CFG2) Grayscale Mode Format Enable Position */
+#define ISI_CFG2_GRAYSCALE_Msk              (_U_(0x1) << ISI_CFG2_GRAYSCALE_Pos)           /**< (ISI_CFG2) Grayscale Mode Format Enable Mask */
+#define ISI_CFG2_GRAYSCALE                  ISI_CFG2_GRAYSCALE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_GRAYSCALE_Msk instead */
+#define ISI_CFG2_RGB_SWAP_Pos               14                                             /**< (ISI_CFG2) RGB Format Swap Mode Position */
+#define ISI_CFG2_RGB_SWAP_Msk               (_U_(0x1) << ISI_CFG2_RGB_SWAP_Pos)            /**< (ISI_CFG2) RGB Format Swap Mode Mask */
+#define ISI_CFG2_RGB_SWAP                   ISI_CFG2_RGB_SWAP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_RGB_SWAP_Msk instead */
+#define ISI_CFG2_COL_SPACE_Pos              15                                             /**< (ISI_CFG2) Color Space for the Image Data Position */
+#define ISI_CFG2_COL_SPACE_Msk              (_U_(0x1) << ISI_CFG2_COL_SPACE_Pos)           /**< (ISI_CFG2) Color Space for the Image Data Mask */
+#define ISI_CFG2_COL_SPACE                  ISI_CFG2_COL_SPACE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_COL_SPACE_Msk instead */
+#define ISI_CFG2_IM_HSIZE_Pos               16                                             /**< (ISI_CFG2) Horizontal Size of the Image Sensor [0..2047] Position */
+#define ISI_CFG2_IM_HSIZE_Msk               (_U_(0x7FF) << ISI_CFG2_IM_HSIZE_Pos)          /**< (ISI_CFG2) Horizontal Size of the Image Sensor [0..2047] Mask */
+#define ISI_CFG2_IM_HSIZE(value)            (ISI_CFG2_IM_HSIZE_Msk & ((value) << ISI_CFG2_IM_HSIZE_Pos))
+#define ISI_CFG2_YCC_SWAP_Pos               28                                             /**< (ISI_CFG2) YCrCb Format Swap Mode Position */
+#define ISI_CFG2_YCC_SWAP_Msk               (_U_(0x3) << ISI_CFG2_YCC_SWAP_Pos)            /**< (ISI_CFG2) YCrCb Format Swap Mode Mask */
+#define ISI_CFG2_YCC_SWAP(value)            (ISI_CFG2_YCC_SWAP_Msk & ((value) << ISI_CFG2_YCC_SWAP_Pos))
+#define   ISI_CFG2_YCC_SWAP_DEFAULT_Val     _U_(0x0)                                       /**< (ISI_CFG2) Byte 0 Cb(i)Byte 1 Y(i)Byte 2 Cr(i)Byte 3 Y(i+1)  */
+#define   ISI_CFG2_YCC_SWAP_MODE1_Val       _U_(0x1)                                       /**< (ISI_CFG2) Byte 0 Cr(i)Byte 1 Y(i)Byte 2 Cb(i)Byte 3 Y(i+1)  */
+#define   ISI_CFG2_YCC_SWAP_MODE2_Val       _U_(0x2)                                       /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cb(i)Byte 2 Y(i+1)Byte 3 Cr(i)  */
+#define   ISI_CFG2_YCC_SWAP_MODE3_Val       _U_(0x3)                                       /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cr(i)Byte 2 Y(i+1)Byte 3 Cb(i)  */
+#define ISI_CFG2_YCC_SWAP_DEFAULT           (ISI_CFG2_YCC_SWAP_DEFAULT_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Cb(i)Byte 1 Y(i)Byte 2 Cr(i)Byte 3 Y(i+1) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE1             (ISI_CFG2_YCC_SWAP_MODE1_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Cr(i)Byte 1 Y(i)Byte 2 Cb(i)Byte 3 Y(i+1) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE2             (ISI_CFG2_YCC_SWAP_MODE2_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cb(i)Byte 2 Y(i+1)Byte 3 Cr(i) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE3             (ISI_CFG2_YCC_SWAP_MODE3_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cr(i)Byte 2 Y(i+1)Byte 3 Cb(i) Position  */
+#define ISI_CFG2_RGB_CFG_Pos                30                                             /**< (ISI_CFG2) RGB Pixel Mapping Configuration Position */
+#define ISI_CFG2_RGB_CFG_Msk                (_U_(0x3) << ISI_CFG2_RGB_CFG_Pos)             /**< (ISI_CFG2) RGB Pixel Mapping Configuration Mask */
+#define ISI_CFG2_RGB_CFG(value)             (ISI_CFG2_RGB_CFG_Msk & ((value) << ISI_CFG2_RGB_CFG_Pos))
+#define   ISI_CFG2_RGB_CFG_DEFAULT_Val      _U_(0x0)                                       /**< (ISI_CFG2) Byte 0 R/G(MSB)Byte 1 G(LSB)/BByte 2 R/G(MSB)Byte 3 G(LSB)/B  */
+#define   ISI_CFG2_RGB_CFG_MODE1_Val        _U_(0x1)                                       /**< (ISI_CFG2) Byte 0 B/G(MSB)Byte 1 G(LSB)/RByte 2 B/G(MSB)Byte 3 G(LSB)/R  */
+#define   ISI_CFG2_RGB_CFG_MODE2_Val        _U_(0x2)                                       /**< (ISI_CFG2) Byte 0 G(LSB)/RByte 1 B/G(MSB)Byte 2 G(LSB)/RByte 3 B/G(MSB)  */
+#define   ISI_CFG2_RGB_CFG_MODE3_Val        _U_(0x3)                                       /**< (ISI_CFG2) Byte 0 G(LSB)/BByte 1 R/G(MSB)Byte 2 G(LSB)/BByte 3 R/G(MSB)  */
+#define ISI_CFG2_RGB_CFG_DEFAULT            (ISI_CFG2_RGB_CFG_DEFAULT_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 R/G(MSB)Byte 1 G(LSB)/BByte 2 R/G(MSB)Byte 3 G(LSB)/B Position  */
+#define ISI_CFG2_RGB_CFG_MODE1              (ISI_CFG2_RGB_CFG_MODE1_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 B/G(MSB)Byte 1 G(LSB)/RByte 2 B/G(MSB)Byte 3 G(LSB)/R Position  */
+#define ISI_CFG2_RGB_CFG_MODE2              (ISI_CFG2_RGB_CFG_MODE2_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 G(LSB)/RByte 1 B/G(MSB)Byte 2 G(LSB)/RByte 3 B/G(MSB) Position  */
+#define ISI_CFG2_RGB_CFG_MODE3              (ISI_CFG2_RGB_CFG_MODE3_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 G(LSB)/BByte 1 R/G(MSB)Byte 2 G(LSB)/BByte 3 R/G(MSB) Position  */
+#define ISI_CFG2_MASK                       _U_(0xF7FFFFFF)                                /**< \deprecated (ISI_CFG2) Register MASK  (Use ISI_CFG2_Msk instead)  */
+#define ISI_CFG2_Msk                        _U_(0xF7FFFFFF)                                /**< (ISI_CFG2) Register Mask  */
+
+
+/* -------- ISI_PSIZE : (ISI Offset: 0x08) (R/W 32) ISI Preview Size Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PREV_VSIZE:10;             /**< bit:   0..9  Vertical Size for the Preview Path       */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t PREV_HSIZE:10;             /**< bit: 16..25  Horizontal Size for the Preview Path     */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_PSIZE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_PSIZE_OFFSET                    (0x08)                                        /**<  (ISI_PSIZE) ISI Preview Size Register  Offset */
+
+#define ISI_PSIZE_PREV_VSIZE_Pos            0                                              /**< (ISI_PSIZE) Vertical Size for the Preview Path Position */
+#define ISI_PSIZE_PREV_VSIZE_Msk            (_U_(0x3FF) << ISI_PSIZE_PREV_VSIZE_Pos)       /**< (ISI_PSIZE) Vertical Size for the Preview Path Mask */
+#define ISI_PSIZE_PREV_VSIZE(value)         (ISI_PSIZE_PREV_VSIZE_Msk & ((value) << ISI_PSIZE_PREV_VSIZE_Pos))
+#define ISI_PSIZE_PREV_HSIZE_Pos            16                                             /**< (ISI_PSIZE) Horizontal Size for the Preview Path Position */
+#define ISI_PSIZE_PREV_HSIZE_Msk            (_U_(0x3FF) << ISI_PSIZE_PREV_HSIZE_Pos)       /**< (ISI_PSIZE) Horizontal Size for the Preview Path Mask */
+#define ISI_PSIZE_PREV_HSIZE(value)         (ISI_PSIZE_PREV_HSIZE_Msk & ((value) << ISI_PSIZE_PREV_HSIZE_Pos))
+#define ISI_PSIZE_MASK                      _U_(0x3FF03FF)                                 /**< \deprecated (ISI_PSIZE) Register MASK  (Use ISI_PSIZE_Msk instead)  */
+#define ISI_PSIZE_Msk                       _U_(0x3FF03FF)                                 /**< (ISI_PSIZE) Register Mask  */
+
+
+/* -------- ISI_PDECF : (ISI Offset: 0x0c) (R/W 32) ISI Preview Decimation Factor Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DEC_FACTOR:8;              /**< bit:   0..7  Decimation Factor                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_PDECF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_PDECF_OFFSET                    (0x0C)                                        /**<  (ISI_PDECF) ISI Preview Decimation Factor Register  Offset */
+
+#define ISI_PDECF_DEC_FACTOR_Pos            0                                              /**< (ISI_PDECF) Decimation Factor Position */
+#define ISI_PDECF_DEC_FACTOR_Msk            (_U_(0xFF) << ISI_PDECF_DEC_FACTOR_Pos)        /**< (ISI_PDECF) Decimation Factor Mask */
+#define ISI_PDECF_DEC_FACTOR(value)         (ISI_PDECF_DEC_FACTOR_Msk & ((value) << ISI_PDECF_DEC_FACTOR_Pos))
+#define ISI_PDECF_MASK                      _U_(0xFF)                                      /**< \deprecated (ISI_PDECF) Register MASK  (Use ISI_PDECF_Msk instead)  */
+#define ISI_PDECF_Msk                       _U_(0xFF)                                      /**< (ISI_PDECF) Register Mask  */
+
+
+/* -------- ISI_Y2R_SET0 : (ISI Offset: 0x10) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C0:8;                      /**< bit:   0..7  Color Space Conversion Matrix Coefficient C0 */
+    uint32_t C1:8;                      /**< bit:  8..15  Color Space Conversion Matrix Coefficient C1 */
+    uint32_t C2:8;                      /**< bit: 16..23  Color Space Conversion Matrix Coefficient C2 */
+    uint32_t C3:8;                      /**< bit: 24..31  Color Space Conversion Matrix Coefficient C3 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_Y2R_SET0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_Y2R_SET0_OFFSET                 (0x10)                                        /**<  (ISI_Y2R_SET0) ISI Color Space Conversion YCrCb To RGB Set 0 Register  Offset */
+
+#define ISI_Y2R_SET0_C0_Pos                 0                                              /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C0 Position */
+#define ISI_Y2R_SET0_C0_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C0_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C0 Mask */
+#define ISI_Y2R_SET0_C0(value)              (ISI_Y2R_SET0_C0_Msk & ((value) << ISI_Y2R_SET0_C0_Pos))
+#define ISI_Y2R_SET0_C1_Pos                 8                                              /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C1 Position */
+#define ISI_Y2R_SET0_C1_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C1_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C1 Mask */
+#define ISI_Y2R_SET0_C1(value)              (ISI_Y2R_SET0_C1_Msk & ((value) << ISI_Y2R_SET0_C1_Pos))
+#define ISI_Y2R_SET0_C2_Pos                 16                                             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C2 Position */
+#define ISI_Y2R_SET0_C2_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C2_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C2 Mask */
+#define ISI_Y2R_SET0_C2(value)              (ISI_Y2R_SET0_C2_Msk & ((value) << ISI_Y2R_SET0_C2_Pos))
+#define ISI_Y2R_SET0_C3_Pos                 24                                             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C3 Position */
+#define ISI_Y2R_SET0_C3_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C3_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C3 Mask */
+#define ISI_Y2R_SET0_C3(value)              (ISI_Y2R_SET0_C3_Msk & ((value) << ISI_Y2R_SET0_C3_Pos))
+#define ISI_Y2R_SET0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (ISI_Y2R_SET0) Register MASK  (Use ISI_Y2R_SET0_Msk instead)  */
+#define ISI_Y2R_SET0_Msk                    _U_(0xFFFFFFFF)                                /**< (ISI_Y2R_SET0) Register Mask  */
+
+
+/* -------- ISI_Y2R_SET1 : (ISI Offset: 0x14) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C4:9;                      /**< bit:   0..8  Color Space Conversion Matrix Coefficient C4 */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t Yoff:1;                    /**< bit:     12  Color Space Conversion Luminance Default Offset */
+    uint32_t Croff:1;                   /**< bit:     13  Color Space Conversion Red Chrominance Default Offset */
+    uint32_t Cboff:1;                   /**< bit:     14  Color Space Conversion Blue Chrominance Default Offset */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_Y2R_SET1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_Y2R_SET1_OFFSET                 (0x14)                                        /**<  (ISI_Y2R_SET1) ISI Color Space Conversion YCrCb To RGB Set 1 Register  Offset */
+
+#define ISI_Y2R_SET1_C4_Pos                 0                                              /**< (ISI_Y2R_SET1) Color Space Conversion Matrix Coefficient C4 Position */
+#define ISI_Y2R_SET1_C4_Msk                 (_U_(0x1FF) << ISI_Y2R_SET1_C4_Pos)            /**< (ISI_Y2R_SET1) Color Space Conversion Matrix Coefficient C4 Mask */
+#define ISI_Y2R_SET1_C4(value)              (ISI_Y2R_SET1_C4_Msk & ((value) << ISI_Y2R_SET1_C4_Pos))
+#define ISI_Y2R_SET1_Yoff_Pos               12                                             /**< (ISI_Y2R_SET1) Color Space Conversion Luminance Default Offset Position */
+#define ISI_Y2R_SET1_Yoff_Msk               (_U_(0x1) << ISI_Y2R_SET1_Yoff_Pos)            /**< (ISI_Y2R_SET1) Color Space Conversion Luminance Default Offset Mask */
+#define ISI_Y2R_SET1_Yoff                   ISI_Y2R_SET1_Yoff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Yoff_Msk instead */
+#define ISI_Y2R_SET1_Croff_Pos              13                                             /**< (ISI_Y2R_SET1) Color Space Conversion Red Chrominance Default Offset Position */
+#define ISI_Y2R_SET1_Croff_Msk              (_U_(0x1) << ISI_Y2R_SET1_Croff_Pos)           /**< (ISI_Y2R_SET1) Color Space Conversion Red Chrominance Default Offset Mask */
+#define ISI_Y2R_SET1_Croff                  ISI_Y2R_SET1_Croff_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Croff_Msk instead */
+#define ISI_Y2R_SET1_Cboff_Pos              14                                             /**< (ISI_Y2R_SET1) Color Space Conversion Blue Chrominance Default Offset Position */
+#define ISI_Y2R_SET1_Cboff_Msk              (_U_(0x1) << ISI_Y2R_SET1_Cboff_Pos)           /**< (ISI_Y2R_SET1) Color Space Conversion Blue Chrominance Default Offset Mask */
+#define ISI_Y2R_SET1_Cboff                  ISI_Y2R_SET1_Cboff_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Cboff_Msk instead */
+#define ISI_Y2R_SET1_MASK                   _U_(0x71FF)                                    /**< \deprecated (ISI_Y2R_SET1) Register MASK  (Use ISI_Y2R_SET1_Msk instead)  */
+#define ISI_Y2R_SET1_Msk                    _U_(0x71FF)                                    /**< (ISI_Y2R_SET1) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET0 : (ISI Offset: 0x18) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C0:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C0 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C1:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C1 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C2:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C2 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Roff:1;                    /**< bit:     24  Color Space Conversion Red Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET0_OFFSET                 (0x18)                                        /**<  (ISI_R2Y_SET0) ISI Color Space Conversion RGB To YCrCb Set 0 Register  Offset */
+
+#define ISI_R2Y_SET0_C0_Pos                 0                                              /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C0 Position */
+#define ISI_R2Y_SET0_C0_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C0_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C0 Mask */
+#define ISI_R2Y_SET0_C0(value)              (ISI_R2Y_SET0_C0_Msk & ((value) << ISI_R2Y_SET0_C0_Pos))
+#define ISI_R2Y_SET0_C1_Pos                 8                                              /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C1 Position */
+#define ISI_R2Y_SET0_C1_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C1_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C1 Mask */
+#define ISI_R2Y_SET0_C1(value)              (ISI_R2Y_SET0_C1_Msk & ((value) << ISI_R2Y_SET0_C1_Pos))
+#define ISI_R2Y_SET0_C2_Pos                 16                                             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C2 Position */
+#define ISI_R2Y_SET0_C2_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C2_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C2 Mask */
+#define ISI_R2Y_SET0_C2(value)              (ISI_R2Y_SET0_C2_Msk & ((value) << ISI_R2Y_SET0_C2_Pos))
+#define ISI_R2Y_SET0_Roff_Pos               24                                             /**< (ISI_R2Y_SET0) Color Space Conversion Red Component Offset Position */
+#define ISI_R2Y_SET0_Roff_Msk               (_U_(0x1) << ISI_R2Y_SET0_Roff_Pos)            /**< (ISI_R2Y_SET0) Color Space Conversion Red Component Offset Mask */
+#define ISI_R2Y_SET0_Roff                   ISI_R2Y_SET0_Roff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET0_Roff_Msk instead */
+#define ISI_R2Y_SET0_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET0) Register MASK  (Use ISI_R2Y_SET0_Msk instead)  */
+#define ISI_R2Y_SET0_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET0) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET1 : (ISI Offset: 0x1c) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C3:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C3 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C4:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C4 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C5:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C5 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Goff:1;                    /**< bit:     24  Color Space Conversion Green Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET1_OFFSET                 (0x1C)                                        /**<  (ISI_R2Y_SET1) ISI Color Space Conversion RGB To YCrCb Set 1 Register  Offset */
+
+#define ISI_R2Y_SET1_C3_Pos                 0                                              /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C3 Position */
+#define ISI_R2Y_SET1_C3_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C3_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C3 Mask */
+#define ISI_R2Y_SET1_C3(value)              (ISI_R2Y_SET1_C3_Msk & ((value) << ISI_R2Y_SET1_C3_Pos))
+#define ISI_R2Y_SET1_C4_Pos                 8                                              /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C4 Position */
+#define ISI_R2Y_SET1_C4_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C4_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C4 Mask */
+#define ISI_R2Y_SET1_C4(value)              (ISI_R2Y_SET1_C4_Msk & ((value) << ISI_R2Y_SET1_C4_Pos))
+#define ISI_R2Y_SET1_C5_Pos                 16                                             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C5 Position */
+#define ISI_R2Y_SET1_C5_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C5_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C5 Mask */
+#define ISI_R2Y_SET1_C5(value)              (ISI_R2Y_SET1_C5_Msk & ((value) << ISI_R2Y_SET1_C5_Pos))
+#define ISI_R2Y_SET1_Goff_Pos               24                                             /**< (ISI_R2Y_SET1) Color Space Conversion Green Component Offset Position */
+#define ISI_R2Y_SET1_Goff_Msk               (_U_(0x1) << ISI_R2Y_SET1_Goff_Pos)            /**< (ISI_R2Y_SET1) Color Space Conversion Green Component Offset Mask */
+#define ISI_R2Y_SET1_Goff                   ISI_R2Y_SET1_Goff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET1_Goff_Msk instead */
+#define ISI_R2Y_SET1_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET1) Register MASK  (Use ISI_R2Y_SET1_Msk instead)  */
+#define ISI_R2Y_SET1_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET1) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET2 : (ISI Offset: 0x20) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C6:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C6 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C7:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C7 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C8:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C8 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Boff:1;                    /**< bit:     24  Color Space Conversion Blue Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET2_OFFSET                 (0x20)                                        /**<  (ISI_R2Y_SET2) ISI Color Space Conversion RGB To YCrCb Set 2 Register  Offset */
+
+#define ISI_R2Y_SET2_C6_Pos                 0                                              /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C6 Position */
+#define ISI_R2Y_SET2_C6_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C6_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C6 Mask */
+#define ISI_R2Y_SET2_C6(value)              (ISI_R2Y_SET2_C6_Msk & ((value) << ISI_R2Y_SET2_C6_Pos))
+#define ISI_R2Y_SET2_C7_Pos                 8                                              /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C7 Position */
+#define ISI_R2Y_SET2_C7_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C7_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C7 Mask */
+#define ISI_R2Y_SET2_C7(value)              (ISI_R2Y_SET2_C7_Msk & ((value) << ISI_R2Y_SET2_C7_Pos))
+#define ISI_R2Y_SET2_C8_Pos                 16                                             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C8 Position */
+#define ISI_R2Y_SET2_C8_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C8_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C8 Mask */
+#define ISI_R2Y_SET2_C8(value)              (ISI_R2Y_SET2_C8_Msk & ((value) << ISI_R2Y_SET2_C8_Pos))
+#define ISI_R2Y_SET2_Boff_Pos               24                                             /**< (ISI_R2Y_SET2) Color Space Conversion Blue Component Offset Position */
+#define ISI_R2Y_SET2_Boff_Msk               (_U_(0x1) << ISI_R2Y_SET2_Boff_Pos)            /**< (ISI_R2Y_SET2) Color Space Conversion Blue Component Offset Mask */
+#define ISI_R2Y_SET2_Boff                   ISI_R2Y_SET2_Boff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET2_Boff_Msk instead */
+#define ISI_R2Y_SET2_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET2) Register MASK  (Use ISI_R2Y_SET2_Msk instead)  */
+#define ISI_R2Y_SET2_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET2) Register Mask  */
+
+
+/* -------- ISI_CR : (ISI Offset: 0x24) (/W 32) ISI Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISI_EN:1;                  /**< bit:      0  ISI Module Enable Request                */
+    uint32_t ISI_DIS:1;                 /**< bit:      1  ISI Module Disable Request               */
+    uint32_t ISI_SRST:1;                /**< bit:      2  ISI Software Reset Request               */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t ISI_CDC:1;                 /**< bit:      8  ISI Codec Request                        */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CR_OFFSET                       (0x24)                                        /**<  (ISI_CR) ISI Control Register  Offset */
+
+#define ISI_CR_ISI_EN_Pos                   0                                              /**< (ISI_CR) ISI Module Enable Request Position */
+#define ISI_CR_ISI_EN_Msk                   (_U_(0x1) << ISI_CR_ISI_EN_Pos)                /**< (ISI_CR) ISI Module Enable Request Mask */
+#define ISI_CR_ISI_EN                       ISI_CR_ISI_EN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_EN_Msk instead */
+#define ISI_CR_ISI_DIS_Pos                  1                                              /**< (ISI_CR) ISI Module Disable Request Position */
+#define ISI_CR_ISI_DIS_Msk                  (_U_(0x1) << ISI_CR_ISI_DIS_Pos)               /**< (ISI_CR) ISI Module Disable Request Mask */
+#define ISI_CR_ISI_DIS                      ISI_CR_ISI_DIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_DIS_Msk instead */
+#define ISI_CR_ISI_SRST_Pos                 2                                              /**< (ISI_CR) ISI Software Reset Request Position */
+#define ISI_CR_ISI_SRST_Msk                 (_U_(0x1) << ISI_CR_ISI_SRST_Pos)              /**< (ISI_CR) ISI Software Reset Request Mask */
+#define ISI_CR_ISI_SRST                     ISI_CR_ISI_SRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_SRST_Msk instead */
+#define ISI_CR_ISI_CDC_Pos                  8                                              /**< (ISI_CR) ISI Codec Request Position */
+#define ISI_CR_ISI_CDC_Msk                  (_U_(0x1) << ISI_CR_ISI_CDC_Pos)               /**< (ISI_CR) ISI Codec Request Mask */
+#define ISI_CR_ISI_CDC                      ISI_CR_ISI_CDC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_CDC_Msk instead */
+#define ISI_CR_MASK                         _U_(0x107)                                     /**< \deprecated (ISI_CR) Register MASK  (Use ISI_CR_Msk instead)  */
+#define ISI_CR_Msk                          _U_(0x107)                                     /**< (ISI_CR) Register Mask  */
+
+
+/* -------- ISI_SR : (ISI Offset: 0x28) (R/ 32) ISI Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  Module Enable                            */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Module Disable Request has Terminated (cleared on read) */
+    uint32_t SRST:1;                    /**< bit:      2  Module Software Reset Request has Terminated (cleared on read) */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t CDC_PND:1;                 /**< bit:      8  Pending Codec Request                    */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization (cleared on read) */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer has Terminated (cleared on read) */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer has Terminated (cleared on read) */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t SIP:1;                     /**< bit:     19  Synchronization in Progress              */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow (cleared on read) */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow (cleared on read) */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  CRC Synchronization Error (cleared on read) */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overrun (cleared on read)     */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_SR_OFFSET                       (0x28)                                        /**<  (ISI_SR) ISI Status Register  Offset */
+
+#define ISI_SR_ENABLE_Pos                   0                                              /**< (ISI_SR) Module Enable Position */
+#define ISI_SR_ENABLE_Msk                   (_U_(0x1) << ISI_SR_ENABLE_Pos)                /**< (ISI_SR) Module Enable Mask */
+#define ISI_SR_ENABLE                       ISI_SR_ENABLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_ENABLE_Msk instead */
+#define ISI_SR_DIS_DONE_Pos                 1                                              /**< (ISI_SR) Module Disable Request has Terminated (cleared on read) Position */
+#define ISI_SR_DIS_DONE_Msk                 (_U_(0x1) << ISI_SR_DIS_DONE_Pos)              /**< (ISI_SR) Module Disable Request has Terminated (cleared on read) Mask */
+#define ISI_SR_DIS_DONE                     ISI_SR_DIS_DONE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_DIS_DONE_Msk instead */
+#define ISI_SR_SRST_Pos                     2                                              /**< (ISI_SR) Module Software Reset Request has Terminated (cleared on read) Position */
+#define ISI_SR_SRST_Msk                     (_U_(0x1) << ISI_SR_SRST_Pos)                  /**< (ISI_SR) Module Software Reset Request has Terminated (cleared on read) Mask */
+#define ISI_SR_SRST                         ISI_SR_SRST_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_SRST_Msk instead */
+#define ISI_SR_CDC_PND_Pos                  8                                              /**< (ISI_SR) Pending Codec Request Position */
+#define ISI_SR_CDC_PND_Msk                  (_U_(0x1) << ISI_SR_CDC_PND_Pos)               /**< (ISI_SR) Pending Codec Request Mask */
+#define ISI_SR_CDC_PND                      ISI_SR_CDC_PND_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CDC_PND_Msk instead */
+#define ISI_SR_VSYNC_Pos                    10                                             /**< (ISI_SR) Vertical Synchronization (cleared on read) Position */
+#define ISI_SR_VSYNC_Msk                    (_U_(0x1) << ISI_SR_VSYNC_Pos)                 /**< (ISI_SR) Vertical Synchronization (cleared on read) Mask */
+#define ISI_SR_VSYNC                        ISI_SR_VSYNC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_VSYNC_Msk instead */
+#define ISI_SR_PXFR_DONE_Pos                16                                             /**< (ISI_SR) Preview DMA Transfer has Terminated (cleared on read) Position */
+#define ISI_SR_PXFR_DONE_Msk                (_U_(0x1) << ISI_SR_PXFR_DONE_Pos)             /**< (ISI_SR) Preview DMA Transfer has Terminated (cleared on read) Mask */
+#define ISI_SR_PXFR_DONE                    ISI_SR_PXFR_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_PXFR_DONE_Msk instead */
+#define ISI_SR_CXFR_DONE_Pos                17                                             /**< (ISI_SR) Codec DMA Transfer has Terminated (cleared on read) Position */
+#define ISI_SR_CXFR_DONE_Msk                (_U_(0x1) << ISI_SR_CXFR_DONE_Pos)             /**< (ISI_SR) Codec DMA Transfer has Terminated (cleared on read) Mask */
+#define ISI_SR_CXFR_DONE                    ISI_SR_CXFR_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CXFR_DONE_Msk instead */
+#define ISI_SR_SIP_Pos                      19                                             /**< (ISI_SR) Synchronization in Progress Position */
+#define ISI_SR_SIP_Msk                      (_U_(0x1) << ISI_SR_SIP_Pos)                   /**< (ISI_SR) Synchronization in Progress Mask */
+#define ISI_SR_SIP                          ISI_SR_SIP_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_SIP_Msk instead */
+#define ISI_SR_P_OVR_Pos                    24                                             /**< (ISI_SR) Preview Datapath Overflow (cleared on read) Position */
+#define ISI_SR_P_OVR_Msk                    (_U_(0x1) << ISI_SR_P_OVR_Pos)                 /**< (ISI_SR) Preview Datapath Overflow (cleared on read) Mask */
+#define ISI_SR_P_OVR                        ISI_SR_P_OVR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_P_OVR_Msk instead */
+#define ISI_SR_C_OVR_Pos                    25                                             /**< (ISI_SR) Codec Datapath Overflow (cleared on read) Position */
+#define ISI_SR_C_OVR_Msk                    (_U_(0x1) << ISI_SR_C_OVR_Pos)                 /**< (ISI_SR) Codec Datapath Overflow (cleared on read) Mask */
+#define ISI_SR_C_OVR                        ISI_SR_C_OVR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_C_OVR_Msk instead */
+#define ISI_SR_CRC_ERR_Pos                  26                                             /**< (ISI_SR) CRC Synchronization Error (cleared on read) Position */
+#define ISI_SR_CRC_ERR_Msk                  (_U_(0x1) << ISI_SR_CRC_ERR_Pos)               /**< (ISI_SR) CRC Synchronization Error (cleared on read) Mask */
+#define ISI_SR_CRC_ERR                      ISI_SR_CRC_ERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CRC_ERR_Msk instead */
+#define ISI_SR_FR_OVR_Pos                   27                                             /**< (ISI_SR) Frame Rate Overrun (cleared on read) Position */
+#define ISI_SR_FR_OVR_Msk                   (_U_(0x1) << ISI_SR_FR_OVR_Pos)                /**< (ISI_SR) Frame Rate Overrun (cleared on read) Mask */
+#define ISI_SR_FR_OVR                       ISI_SR_FR_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_FR_OVR_Msk instead */
+#define ISI_SR_MASK                         _U_(0xF0B0507)                                 /**< \deprecated (ISI_SR) Register MASK  (Use ISI_SR_Msk instead)  */
+#define ISI_SR_Msk                          _U_(0xF0B0507)                                 /**< (ISI_SR) Register Mask  */
+
+
+/* -------- ISI_IER : (ISI Offset: 0x2c) (/W 32) ISI Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Disable Done Interrupt Enable            */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Interrupt Enable          */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization Interrupt Enable */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Done Interrupt Enable */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Done Interrupt Enable */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow Interrupt Enable */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow Interrupt Enable */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  Embedded Synchronization CRC Error Interrupt Enable */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overflow Interrupt Enable     */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IER_OFFSET                      (0x2C)                                        /**<  (ISI_IER) ISI Interrupt Enable Register  Offset */
+
+#define ISI_IER_DIS_DONE_Pos                1                                              /**< (ISI_IER) Disable Done Interrupt Enable Position */
+#define ISI_IER_DIS_DONE_Msk                (_U_(0x1) << ISI_IER_DIS_DONE_Pos)             /**< (ISI_IER) Disable Done Interrupt Enable Mask */
+#define ISI_IER_DIS_DONE                    ISI_IER_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_DIS_DONE_Msk instead */
+#define ISI_IER_SRST_Pos                    2                                              /**< (ISI_IER) Software Reset Interrupt Enable Position */
+#define ISI_IER_SRST_Msk                    (_U_(0x1) << ISI_IER_SRST_Pos)                 /**< (ISI_IER) Software Reset Interrupt Enable Mask */
+#define ISI_IER_SRST                        ISI_IER_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_SRST_Msk instead */
+#define ISI_IER_VSYNC_Pos                   10                                             /**< (ISI_IER) Vertical Synchronization Interrupt Enable Position */
+#define ISI_IER_VSYNC_Msk                   (_U_(0x1) << ISI_IER_VSYNC_Pos)                /**< (ISI_IER) Vertical Synchronization Interrupt Enable Mask */
+#define ISI_IER_VSYNC                       ISI_IER_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_VSYNC_Msk instead */
+#define ISI_IER_PXFR_DONE_Pos               16                                             /**< (ISI_IER) Preview DMA Transfer Done Interrupt Enable Position */
+#define ISI_IER_PXFR_DONE_Msk               (_U_(0x1) << ISI_IER_PXFR_DONE_Pos)            /**< (ISI_IER) Preview DMA Transfer Done Interrupt Enable Mask */
+#define ISI_IER_PXFR_DONE                   ISI_IER_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_PXFR_DONE_Msk instead */
+#define ISI_IER_CXFR_DONE_Pos               17                                             /**< (ISI_IER) Codec DMA Transfer Done Interrupt Enable Position */
+#define ISI_IER_CXFR_DONE_Msk               (_U_(0x1) << ISI_IER_CXFR_DONE_Pos)            /**< (ISI_IER) Codec DMA Transfer Done Interrupt Enable Mask */
+#define ISI_IER_CXFR_DONE                   ISI_IER_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_CXFR_DONE_Msk instead */
+#define ISI_IER_P_OVR_Pos                   24                                             /**< (ISI_IER) Preview Datapath Overflow Interrupt Enable Position */
+#define ISI_IER_P_OVR_Msk                   (_U_(0x1) << ISI_IER_P_OVR_Pos)                /**< (ISI_IER) Preview Datapath Overflow Interrupt Enable Mask */
+#define ISI_IER_P_OVR                       ISI_IER_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_P_OVR_Msk instead */
+#define ISI_IER_C_OVR_Pos                   25                                             /**< (ISI_IER) Codec Datapath Overflow Interrupt Enable Position */
+#define ISI_IER_C_OVR_Msk                   (_U_(0x1) << ISI_IER_C_OVR_Pos)                /**< (ISI_IER) Codec Datapath Overflow Interrupt Enable Mask */
+#define ISI_IER_C_OVR                       ISI_IER_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_C_OVR_Msk instead */
+#define ISI_IER_CRC_ERR_Pos                 26                                             /**< (ISI_IER) Embedded Synchronization CRC Error Interrupt Enable Position */
+#define ISI_IER_CRC_ERR_Msk                 (_U_(0x1) << ISI_IER_CRC_ERR_Pos)              /**< (ISI_IER) Embedded Synchronization CRC Error Interrupt Enable Mask */
+#define ISI_IER_CRC_ERR                     ISI_IER_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_CRC_ERR_Msk instead */
+#define ISI_IER_FR_OVR_Pos                  27                                             /**< (ISI_IER) Frame Rate Overflow Interrupt Enable Position */
+#define ISI_IER_FR_OVR_Msk                  (_U_(0x1) << ISI_IER_FR_OVR_Pos)               /**< (ISI_IER) Frame Rate Overflow Interrupt Enable Mask */
+#define ISI_IER_FR_OVR                      ISI_IER_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_FR_OVR_Msk instead */
+#define ISI_IER_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IER) Register MASK  (Use ISI_IER_Msk instead)  */
+#define ISI_IER_Msk                         _U_(0xF030406)                                 /**< (ISI_IER) Register Mask  */
+
+
+/* -------- ISI_IDR : (ISI Offset: 0x30) (/W 32) ISI Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Disable Done Interrupt Disable           */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Interrupt Disable         */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization Interrupt Disable */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Done Interrupt Disable */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Done Interrupt Disable */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow Interrupt Disable */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow Interrupt Disable */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  Embedded Synchronization CRC Error Interrupt Disable */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overflow Interrupt Disable    */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IDR_OFFSET                      (0x30)                                        /**<  (ISI_IDR) ISI Interrupt Disable Register  Offset */
+
+#define ISI_IDR_DIS_DONE_Pos                1                                              /**< (ISI_IDR) Disable Done Interrupt Disable Position */
+#define ISI_IDR_DIS_DONE_Msk                (_U_(0x1) << ISI_IDR_DIS_DONE_Pos)             /**< (ISI_IDR) Disable Done Interrupt Disable Mask */
+#define ISI_IDR_DIS_DONE                    ISI_IDR_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_DIS_DONE_Msk instead */
+#define ISI_IDR_SRST_Pos                    2                                              /**< (ISI_IDR) Software Reset Interrupt Disable Position */
+#define ISI_IDR_SRST_Msk                    (_U_(0x1) << ISI_IDR_SRST_Pos)                 /**< (ISI_IDR) Software Reset Interrupt Disable Mask */
+#define ISI_IDR_SRST                        ISI_IDR_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_SRST_Msk instead */
+#define ISI_IDR_VSYNC_Pos                   10                                             /**< (ISI_IDR) Vertical Synchronization Interrupt Disable Position */
+#define ISI_IDR_VSYNC_Msk                   (_U_(0x1) << ISI_IDR_VSYNC_Pos)                /**< (ISI_IDR) Vertical Synchronization Interrupt Disable Mask */
+#define ISI_IDR_VSYNC                       ISI_IDR_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_VSYNC_Msk instead */
+#define ISI_IDR_PXFR_DONE_Pos               16                                             /**< (ISI_IDR) Preview DMA Transfer Done Interrupt Disable Position */
+#define ISI_IDR_PXFR_DONE_Msk               (_U_(0x1) << ISI_IDR_PXFR_DONE_Pos)            /**< (ISI_IDR) Preview DMA Transfer Done Interrupt Disable Mask */
+#define ISI_IDR_PXFR_DONE                   ISI_IDR_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_PXFR_DONE_Msk instead */
+#define ISI_IDR_CXFR_DONE_Pos               17                                             /**< (ISI_IDR) Codec DMA Transfer Done Interrupt Disable Position */
+#define ISI_IDR_CXFR_DONE_Msk               (_U_(0x1) << ISI_IDR_CXFR_DONE_Pos)            /**< (ISI_IDR) Codec DMA Transfer Done Interrupt Disable Mask */
+#define ISI_IDR_CXFR_DONE                   ISI_IDR_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_CXFR_DONE_Msk instead */
+#define ISI_IDR_P_OVR_Pos                   24                                             /**< (ISI_IDR) Preview Datapath Overflow Interrupt Disable Position */
+#define ISI_IDR_P_OVR_Msk                   (_U_(0x1) << ISI_IDR_P_OVR_Pos)                /**< (ISI_IDR) Preview Datapath Overflow Interrupt Disable Mask */
+#define ISI_IDR_P_OVR                       ISI_IDR_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_P_OVR_Msk instead */
+#define ISI_IDR_C_OVR_Pos                   25                                             /**< (ISI_IDR) Codec Datapath Overflow Interrupt Disable Position */
+#define ISI_IDR_C_OVR_Msk                   (_U_(0x1) << ISI_IDR_C_OVR_Pos)                /**< (ISI_IDR) Codec Datapath Overflow Interrupt Disable Mask */
+#define ISI_IDR_C_OVR                       ISI_IDR_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_C_OVR_Msk instead */
+#define ISI_IDR_CRC_ERR_Pos                 26                                             /**< (ISI_IDR) Embedded Synchronization CRC Error Interrupt Disable Position */
+#define ISI_IDR_CRC_ERR_Msk                 (_U_(0x1) << ISI_IDR_CRC_ERR_Pos)              /**< (ISI_IDR) Embedded Synchronization CRC Error Interrupt Disable Mask */
+#define ISI_IDR_CRC_ERR                     ISI_IDR_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_CRC_ERR_Msk instead */
+#define ISI_IDR_FR_OVR_Pos                  27                                             /**< (ISI_IDR) Frame Rate Overflow Interrupt Disable Position */
+#define ISI_IDR_FR_OVR_Msk                  (_U_(0x1) << ISI_IDR_FR_OVR_Pos)               /**< (ISI_IDR) Frame Rate Overflow Interrupt Disable Mask */
+#define ISI_IDR_FR_OVR                      ISI_IDR_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_FR_OVR_Msk instead */
+#define ISI_IDR_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IDR) Register MASK  (Use ISI_IDR_Msk instead)  */
+#define ISI_IDR_Msk                         _U_(0xF030406)                                 /**< (ISI_IDR) Register Mask  */
+
+
+/* -------- ISI_IMR : (ISI Offset: 0x34) (R/ 32) ISI Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Module Disable Operation Completed       */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Completed                 */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization                 */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Completed           */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Completed             */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview FIFO Overflow                    */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec FIFO Overflow                      */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  CRC Synchronization Error                */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overrun                       */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IMR_OFFSET                      (0x34)                                        /**<  (ISI_IMR) ISI Interrupt Mask Register  Offset */
+
+#define ISI_IMR_DIS_DONE_Pos                1                                              /**< (ISI_IMR) Module Disable Operation Completed Position */
+#define ISI_IMR_DIS_DONE_Msk                (_U_(0x1) << ISI_IMR_DIS_DONE_Pos)             /**< (ISI_IMR) Module Disable Operation Completed Mask */
+#define ISI_IMR_DIS_DONE                    ISI_IMR_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_DIS_DONE_Msk instead */
+#define ISI_IMR_SRST_Pos                    2                                              /**< (ISI_IMR) Software Reset Completed Position */
+#define ISI_IMR_SRST_Msk                    (_U_(0x1) << ISI_IMR_SRST_Pos)                 /**< (ISI_IMR) Software Reset Completed Mask */
+#define ISI_IMR_SRST                        ISI_IMR_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_SRST_Msk instead */
+#define ISI_IMR_VSYNC_Pos                   10                                             /**< (ISI_IMR) Vertical Synchronization Position */
+#define ISI_IMR_VSYNC_Msk                   (_U_(0x1) << ISI_IMR_VSYNC_Pos)                /**< (ISI_IMR) Vertical Synchronization Mask */
+#define ISI_IMR_VSYNC                       ISI_IMR_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_VSYNC_Msk instead */
+#define ISI_IMR_PXFR_DONE_Pos               16                                             /**< (ISI_IMR) Preview DMA Transfer Completed Position */
+#define ISI_IMR_PXFR_DONE_Msk               (_U_(0x1) << ISI_IMR_PXFR_DONE_Pos)            /**< (ISI_IMR) Preview DMA Transfer Completed Mask */
+#define ISI_IMR_PXFR_DONE                   ISI_IMR_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_PXFR_DONE_Msk instead */
+#define ISI_IMR_CXFR_DONE_Pos               17                                             /**< (ISI_IMR) Codec DMA Transfer Completed Position */
+#define ISI_IMR_CXFR_DONE_Msk               (_U_(0x1) << ISI_IMR_CXFR_DONE_Pos)            /**< (ISI_IMR) Codec DMA Transfer Completed Mask */
+#define ISI_IMR_CXFR_DONE                   ISI_IMR_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_CXFR_DONE_Msk instead */
+#define ISI_IMR_P_OVR_Pos                   24                                             /**< (ISI_IMR) Preview FIFO Overflow Position */
+#define ISI_IMR_P_OVR_Msk                   (_U_(0x1) << ISI_IMR_P_OVR_Pos)                /**< (ISI_IMR) Preview FIFO Overflow Mask */
+#define ISI_IMR_P_OVR                       ISI_IMR_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_P_OVR_Msk instead */
+#define ISI_IMR_C_OVR_Pos                   25                                             /**< (ISI_IMR) Codec FIFO Overflow Position */
+#define ISI_IMR_C_OVR_Msk                   (_U_(0x1) << ISI_IMR_C_OVR_Pos)                /**< (ISI_IMR) Codec FIFO Overflow Mask */
+#define ISI_IMR_C_OVR                       ISI_IMR_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_C_OVR_Msk instead */
+#define ISI_IMR_CRC_ERR_Pos                 26                                             /**< (ISI_IMR) CRC Synchronization Error Position */
+#define ISI_IMR_CRC_ERR_Msk                 (_U_(0x1) << ISI_IMR_CRC_ERR_Pos)              /**< (ISI_IMR) CRC Synchronization Error Mask */
+#define ISI_IMR_CRC_ERR                     ISI_IMR_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_CRC_ERR_Msk instead */
+#define ISI_IMR_FR_OVR_Pos                  27                                             /**< (ISI_IMR) Frame Rate Overrun Position */
+#define ISI_IMR_FR_OVR_Msk                  (_U_(0x1) << ISI_IMR_FR_OVR_Pos)               /**< (ISI_IMR) Frame Rate Overrun Mask */
+#define ISI_IMR_FR_OVR                      ISI_IMR_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_FR_OVR_Msk instead */
+#define ISI_IMR_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IMR) Register MASK  (Use ISI_IMR_Msk instead)  */
+#define ISI_IMR_Msk                         _U_(0xF030406)                                 /**< (ISI_IMR) Register Mask  */
+
+
+/* -------- ISI_DMA_CHER : (ISI Offset: 0x38) (/W 32) DMA Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_EN:1;                 /**< bit:      0  Preview Channel Enable                   */
+    uint32_t C_CH_EN:1;                 /**< bit:      1  Codec Channel Enable                     */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHER_OFFSET                 (0x38)                                        /**<  (ISI_DMA_CHER) DMA Channel Enable Register  Offset */
+
+#define ISI_DMA_CHER_P_CH_EN_Pos            0                                              /**< (ISI_DMA_CHER) Preview Channel Enable Position */
+#define ISI_DMA_CHER_P_CH_EN_Msk            (_U_(0x1) << ISI_DMA_CHER_P_CH_EN_Pos)         /**< (ISI_DMA_CHER) Preview Channel Enable Mask */
+#define ISI_DMA_CHER_P_CH_EN                ISI_DMA_CHER_P_CH_EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHER_P_CH_EN_Msk instead */
+#define ISI_DMA_CHER_C_CH_EN_Pos            1                                              /**< (ISI_DMA_CHER) Codec Channel Enable Position */
+#define ISI_DMA_CHER_C_CH_EN_Msk            (_U_(0x1) << ISI_DMA_CHER_C_CH_EN_Pos)         /**< (ISI_DMA_CHER) Codec Channel Enable Mask */
+#define ISI_DMA_CHER_C_CH_EN                ISI_DMA_CHER_C_CH_EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHER_C_CH_EN_Msk instead */
+#define ISI_DMA_CHER_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHER) Register MASK  (Use ISI_DMA_CHER_Msk instead)  */
+#define ISI_DMA_CHER_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHER) Register Mask  */
+
+
+/* -------- ISI_DMA_CHDR : (ISI Offset: 0x3c) (/W 32) DMA Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_DIS:1;                /**< bit:      0  Preview Channel Disable Request          */
+    uint32_t C_CH_DIS:1;                /**< bit:      1  Codec Channel Disable Request            */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHDR_OFFSET                 (0x3C)                                        /**<  (ISI_DMA_CHDR) DMA Channel Disable Register  Offset */
+
+#define ISI_DMA_CHDR_P_CH_DIS_Pos           0                                              /**< (ISI_DMA_CHDR) Preview Channel Disable Request Position */
+#define ISI_DMA_CHDR_P_CH_DIS_Msk           (_U_(0x1) << ISI_DMA_CHDR_P_CH_DIS_Pos)        /**< (ISI_DMA_CHDR) Preview Channel Disable Request Mask */
+#define ISI_DMA_CHDR_P_CH_DIS               ISI_DMA_CHDR_P_CH_DIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHDR_P_CH_DIS_Msk instead */
+#define ISI_DMA_CHDR_C_CH_DIS_Pos           1                                              /**< (ISI_DMA_CHDR) Codec Channel Disable Request Position */
+#define ISI_DMA_CHDR_C_CH_DIS_Msk           (_U_(0x1) << ISI_DMA_CHDR_C_CH_DIS_Pos)        /**< (ISI_DMA_CHDR) Codec Channel Disable Request Mask */
+#define ISI_DMA_CHDR_C_CH_DIS               ISI_DMA_CHDR_C_CH_DIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHDR_C_CH_DIS_Msk instead */
+#define ISI_DMA_CHDR_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHDR) Register MASK  (Use ISI_DMA_CHDR_Msk instead)  */
+#define ISI_DMA_CHDR_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHDR) Register Mask  */
+
+
+/* -------- ISI_DMA_CHSR : (ISI Offset: 0x40) (R/ 32) DMA Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_S:1;                  /**< bit:      0  Preview DMA Channel Status               */
+    uint32_t C_CH_S:1;                  /**< bit:      1  Code DMA Channel Status                  */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHSR_OFFSET                 (0x40)                                        /**<  (ISI_DMA_CHSR) DMA Channel Status Register  Offset */
+
+#define ISI_DMA_CHSR_P_CH_S_Pos             0                                              /**< (ISI_DMA_CHSR) Preview DMA Channel Status Position */
+#define ISI_DMA_CHSR_P_CH_S_Msk             (_U_(0x1) << ISI_DMA_CHSR_P_CH_S_Pos)          /**< (ISI_DMA_CHSR) Preview DMA Channel Status Mask */
+#define ISI_DMA_CHSR_P_CH_S                 ISI_DMA_CHSR_P_CH_S_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHSR_P_CH_S_Msk instead */
+#define ISI_DMA_CHSR_C_CH_S_Pos             1                                              /**< (ISI_DMA_CHSR) Code DMA Channel Status Position */
+#define ISI_DMA_CHSR_C_CH_S_Msk             (_U_(0x1) << ISI_DMA_CHSR_C_CH_S_Pos)          /**< (ISI_DMA_CHSR) Code DMA Channel Status Mask */
+#define ISI_DMA_CHSR_C_CH_S                 ISI_DMA_CHSR_C_CH_S_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHSR_C_CH_S_Msk instead */
+#define ISI_DMA_CHSR_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHSR) Register MASK  (Use ISI_DMA_CHSR_Msk instead)  */
+#define ISI_DMA_CHSR_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHSR) Register Mask  */
+
+
+/* -------- ISI_DMA_P_ADDR : (ISI Offset: 0x44) (R/W 32) DMA Preview Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t P_ADDR:30;                 /**< bit:  2..31  Preview Image Base Address               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_ADDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_ADDR_OFFSET               (0x44)                                        /**<  (ISI_DMA_P_ADDR) DMA Preview Base Address Register  Offset */
+
+#define ISI_DMA_P_ADDR_P_ADDR_Pos           2                                              /**< (ISI_DMA_P_ADDR) Preview Image Base Address Position */
+#define ISI_DMA_P_ADDR_P_ADDR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_P_ADDR_P_ADDR_Pos)  /**< (ISI_DMA_P_ADDR) Preview Image Base Address Mask */
+#define ISI_DMA_P_ADDR_P_ADDR(value)        (ISI_DMA_P_ADDR_P_ADDR_Msk & ((value) << ISI_DMA_P_ADDR_P_ADDR_Pos))
+#define ISI_DMA_P_ADDR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_P_ADDR) Register MASK  (Use ISI_DMA_P_ADDR_Msk instead)  */
+#define ISI_DMA_P_ADDR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_P_ADDR) Register Mask  */
+
+
+/* -------- ISI_DMA_P_CTRL : (ISI Offset: 0x48) (R/W 32) DMA Preview Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
+    uint32_t P_WB:1;                    /**< bit:      1  Descriptor Writeback Control Bit         */
+    uint32_t P_IEN:1;                   /**< bit:      2  Transfer Done Flag Control               */
+    uint32_t P_DONE:1;                  /**< bit:      3  Preview Transfer Done                    */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_CTRL_OFFSET               (0x48)                                        /**<  (ISI_DMA_P_CTRL) DMA Preview Control Register  Offset */
+
+#define ISI_DMA_P_CTRL_P_FETCH_Pos          0                                              /**< (ISI_DMA_P_CTRL) Descriptor Fetch Control Bit Position */
+#define ISI_DMA_P_CTRL_P_FETCH_Msk          (_U_(0x1) << ISI_DMA_P_CTRL_P_FETCH_Pos)       /**< (ISI_DMA_P_CTRL) Descriptor Fetch Control Bit Mask */
+#define ISI_DMA_P_CTRL_P_FETCH              ISI_DMA_P_CTRL_P_FETCH_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_FETCH_Msk instead */
+#define ISI_DMA_P_CTRL_P_WB_Pos             1                                              /**< (ISI_DMA_P_CTRL) Descriptor Writeback Control Bit Position */
+#define ISI_DMA_P_CTRL_P_WB_Msk             (_U_(0x1) << ISI_DMA_P_CTRL_P_WB_Pos)          /**< (ISI_DMA_P_CTRL) Descriptor Writeback Control Bit Mask */
+#define ISI_DMA_P_CTRL_P_WB                 ISI_DMA_P_CTRL_P_WB_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_WB_Msk instead */
+#define ISI_DMA_P_CTRL_P_IEN_Pos            2                                              /**< (ISI_DMA_P_CTRL) Transfer Done Flag Control Position */
+#define ISI_DMA_P_CTRL_P_IEN_Msk            (_U_(0x1) << ISI_DMA_P_CTRL_P_IEN_Pos)         /**< (ISI_DMA_P_CTRL) Transfer Done Flag Control Mask */
+#define ISI_DMA_P_CTRL_P_IEN                ISI_DMA_P_CTRL_P_IEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_IEN_Msk instead */
+#define ISI_DMA_P_CTRL_P_DONE_Pos           3                                              /**< (ISI_DMA_P_CTRL) Preview Transfer Done Position */
+#define ISI_DMA_P_CTRL_P_DONE_Msk           (_U_(0x1) << ISI_DMA_P_CTRL_P_DONE_Pos)        /**< (ISI_DMA_P_CTRL) Preview Transfer Done Mask */
+#define ISI_DMA_P_CTRL_P_DONE               ISI_DMA_P_CTRL_P_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_DONE_Msk instead */
+#define ISI_DMA_P_CTRL_MASK                 _U_(0x0F)                                      /**< \deprecated (ISI_DMA_P_CTRL) Register MASK  (Use ISI_DMA_P_CTRL_Msk instead)  */
+#define ISI_DMA_P_CTRL_Msk                  _U_(0x0F)                                      /**< (ISI_DMA_P_CTRL) Register Mask  */
+
+
+/* -------- ISI_DMA_P_DSCR : (ISI Offset: 0x4c) (R/W 32) DMA Preview Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t P_DSCR:30;                 /**< bit:  2..31  Preview Descriptor Base Address          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_DSCR_OFFSET               (0x4C)                                        /**<  (ISI_DMA_P_DSCR) DMA Preview Descriptor Address Register  Offset */
+
+#define ISI_DMA_P_DSCR_P_DSCR_Pos           2                                              /**< (ISI_DMA_P_DSCR) Preview Descriptor Base Address Position */
+#define ISI_DMA_P_DSCR_P_DSCR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_P_DSCR_P_DSCR_Pos)  /**< (ISI_DMA_P_DSCR) Preview Descriptor Base Address Mask */
+#define ISI_DMA_P_DSCR_P_DSCR(value)        (ISI_DMA_P_DSCR_P_DSCR_Msk & ((value) << ISI_DMA_P_DSCR_P_DSCR_Pos))
+#define ISI_DMA_P_DSCR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_P_DSCR) Register MASK  (Use ISI_DMA_P_DSCR_Msk instead)  */
+#define ISI_DMA_P_DSCR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_P_DSCR) Register Mask  */
+
+
+/* -------- ISI_DMA_C_ADDR : (ISI Offset: 0x50) (R/W 32) DMA Codec Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t C_ADDR:30;                 /**< bit:  2..31  Codec Image Base Address                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_ADDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_ADDR_OFFSET               (0x50)                                        /**<  (ISI_DMA_C_ADDR) DMA Codec Base Address Register  Offset */
+
+#define ISI_DMA_C_ADDR_C_ADDR_Pos           2                                              /**< (ISI_DMA_C_ADDR) Codec Image Base Address Position */
+#define ISI_DMA_C_ADDR_C_ADDR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_C_ADDR_C_ADDR_Pos)  /**< (ISI_DMA_C_ADDR) Codec Image Base Address Mask */
+#define ISI_DMA_C_ADDR_C_ADDR(value)        (ISI_DMA_C_ADDR_C_ADDR_Msk & ((value) << ISI_DMA_C_ADDR_C_ADDR_Pos))
+#define ISI_DMA_C_ADDR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_C_ADDR) Register MASK  (Use ISI_DMA_C_ADDR_Msk instead)  */
+#define ISI_DMA_C_ADDR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_C_ADDR) Register Mask  */
+
+
+/* -------- ISI_DMA_C_CTRL : (ISI Offset: 0x54) (R/W 32) DMA Codec Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
+    uint32_t C_WB:1;                    /**< bit:      1  Descriptor Writeback Control Bit         */
+    uint32_t C_IEN:1;                   /**< bit:      2  Transfer Done Flag Control               */
+    uint32_t C_DONE:1;                  /**< bit:      3  Codec Transfer Done                      */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_CTRL_OFFSET               (0x54)                                        /**<  (ISI_DMA_C_CTRL) DMA Codec Control Register  Offset */
+
+#define ISI_DMA_C_CTRL_C_FETCH_Pos          0                                              /**< (ISI_DMA_C_CTRL) Descriptor Fetch Control Bit Position */
+#define ISI_DMA_C_CTRL_C_FETCH_Msk          (_U_(0x1) << ISI_DMA_C_CTRL_C_FETCH_Pos)       /**< (ISI_DMA_C_CTRL) Descriptor Fetch Control Bit Mask */
+#define ISI_DMA_C_CTRL_C_FETCH              ISI_DMA_C_CTRL_C_FETCH_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_FETCH_Msk instead */
+#define ISI_DMA_C_CTRL_C_WB_Pos             1                                              /**< (ISI_DMA_C_CTRL) Descriptor Writeback Control Bit Position */
+#define ISI_DMA_C_CTRL_C_WB_Msk             (_U_(0x1) << ISI_DMA_C_CTRL_C_WB_Pos)          /**< (ISI_DMA_C_CTRL) Descriptor Writeback Control Bit Mask */
+#define ISI_DMA_C_CTRL_C_WB                 ISI_DMA_C_CTRL_C_WB_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_WB_Msk instead */
+#define ISI_DMA_C_CTRL_C_IEN_Pos            2                                              /**< (ISI_DMA_C_CTRL) Transfer Done Flag Control Position */
+#define ISI_DMA_C_CTRL_C_IEN_Msk            (_U_(0x1) << ISI_DMA_C_CTRL_C_IEN_Pos)         /**< (ISI_DMA_C_CTRL) Transfer Done Flag Control Mask */
+#define ISI_DMA_C_CTRL_C_IEN                ISI_DMA_C_CTRL_C_IEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_IEN_Msk instead */
+#define ISI_DMA_C_CTRL_C_DONE_Pos           3                                              /**< (ISI_DMA_C_CTRL) Codec Transfer Done Position */
+#define ISI_DMA_C_CTRL_C_DONE_Msk           (_U_(0x1) << ISI_DMA_C_CTRL_C_DONE_Pos)        /**< (ISI_DMA_C_CTRL) Codec Transfer Done Mask */
+#define ISI_DMA_C_CTRL_C_DONE               ISI_DMA_C_CTRL_C_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_DONE_Msk instead */
+#define ISI_DMA_C_CTRL_MASK                 _U_(0x0F)                                      /**< \deprecated (ISI_DMA_C_CTRL) Register MASK  (Use ISI_DMA_C_CTRL_Msk instead)  */
+#define ISI_DMA_C_CTRL_Msk                  _U_(0x0F)                                      /**< (ISI_DMA_C_CTRL) Register Mask  */
+
+
+/* -------- ISI_DMA_C_DSCR : (ISI Offset: 0x58) (R/W 32) DMA Codec Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t C_DSCR:30;                 /**< bit:  2..31  Codec Descriptor Base Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_DSCR_OFFSET               (0x58)                                        /**<  (ISI_DMA_C_DSCR) DMA Codec Descriptor Address Register  Offset */
+
+#define ISI_DMA_C_DSCR_C_DSCR_Pos           2                                              /**< (ISI_DMA_C_DSCR) Codec Descriptor Base Address Position */
+#define ISI_DMA_C_DSCR_C_DSCR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_C_DSCR_C_DSCR_Pos)  /**< (ISI_DMA_C_DSCR) Codec Descriptor Base Address Mask */
+#define ISI_DMA_C_DSCR_C_DSCR(value)        (ISI_DMA_C_DSCR_C_DSCR_Msk & ((value) << ISI_DMA_C_DSCR_C_DSCR_Pos))
+#define ISI_DMA_C_DSCR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_C_DSCR) Register MASK  (Use ISI_DMA_C_DSCR_Msk instead)  */
+#define ISI_DMA_C_DSCR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_C_DSCR) Register Mask  */
+
+
+/* -------- ISI_WPMR : (ISI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key Password            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_WPMR_OFFSET                     (0xE4)                                        /**<  (ISI_WPMR) Write Protection Mode Register  Offset */
+
+#define ISI_WPMR_WPEN_Pos                   0                                              /**< (ISI_WPMR) Write Protection Enable Position */
+#define ISI_WPMR_WPEN_Msk                   (_U_(0x1) << ISI_WPMR_WPEN_Pos)                /**< (ISI_WPMR) Write Protection Enable Mask */
+#define ISI_WPMR_WPEN                       ISI_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_WPMR_WPEN_Msk instead */
+#define ISI_WPMR_WPKEY_Pos                  8                                              /**< (ISI_WPMR) Write Protection Key Password Position */
+#define ISI_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << ISI_WPMR_WPKEY_Pos)          /**< (ISI_WPMR) Write Protection Key Password Mask */
+#define ISI_WPMR_WPKEY(value)               (ISI_WPMR_WPKEY_Msk & ((value) << ISI_WPMR_WPKEY_Pos))
+#define   ISI_WPMR_WPKEY_PASSWD_Val         _U_(0x495349)                                  /**< (ISI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define ISI_WPMR_WPKEY_PASSWD               (ISI_WPMR_WPKEY_PASSWD_Val << ISI_WPMR_WPKEY_Pos)  /**< (ISI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define ISI_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (ISI_WPMR) Register MASK  (Use ISI_WPMR_Msk instead)  */
+#define ISI_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (ISI_WPMR) Register Mask  */
+
+
+/* -------- ISI_WPSR : (ISI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_WPSR_OFFSET                     (0xE8)                                        /**<  (ISI_WPSR) Write Protection Status Register  Offset */
+
+#define ISI_WPSR_WPVS_Pos                   0                                              /**< (ISI_WPSR) Write Protection Violation Status Position */
+#define ISI_WPSR_WPVS_Msk                   (_U_(0x1) << ISI_WPSR_WPVS_Pos)                /**< (ISI_WPSR) Write Protection Violation Status Mask */
+#define ISI_WPSR_WPVS                       ISI_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_WPSR_WPVS_Msk instead */
+#define ISI_WPSR_WPVSRC_Pos                 8                                              /**< (ISI_WPSR) Write Protection Violation Source Position */
+#define ISI_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << ISI_WPSR_WPVSRC_Pos)           /**< (ISI_WPSR) Write Protection Violation Source Mask */
+#define ISI_WPSR_WPVSRC(value)              (ISI_WPSR_WPVSRC_Msk & ((value) << ISI_WPSR_WPVSRC_Pos))
+#define ISI_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (ISI_WPSR) Register MASK  (Use ISI_WPSR_Msk instead)  */
+#define ISI_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (ISI_WPSR) Register Mask  */
+
+
+/* -------- ISI_VERSION : (ISI Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_VERSION_OFFSET                  (0xFC)                                        /**<  (ISI_VERSION) Version Register  Offset */
+
+#define ISI_VERSION_VERSION_Pos             0                                              /**< (ISI_VERSION) Version of the Hardware Module Position */
+#define ISI_VERSION_VERSION_Msk             (_U_(0xFFF) << ISI_VERSION_VERSION_Pos)        /**< (ISI_VERSION) Version of the Hardware Module Mask */
+#define ISI_VERSION_VERSION(value)          (ISI_VERSION_VERSION_Msk & ((value) << ISI_VERSION_VERSION_Pos))
+#define ISI_VERSION_MFN_Pos                 16                                             /**< (ISI_VERSION) Metal Fix Number Position */
+#define ISI_VERSION_MFN_Msk                 (_U_(0x7) << ISI_VERSION_MFN_Pos)              /**< (ISI_VERSION) Metal Fix Number Mask */
+#define ISI_VERSION_MFN(value)              (ISI_VERSION_MFN_Msk & ((value) << ISI_VERSION_MFN_Pos))
+#define ISI_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (ISI_VERSION) Register MASK  (Use ISI_VERSION_Msk instead)  */
+#define ISI_VERSION_Msk                     _U_(0x70FFF)                                   /**< (ISI_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ISI hardware registers */
+typedef struct {  
+  __IO uint32_t ISI_CFG1;       /**< (ISI Offset: 0x00) ISI Configuration 1 Register */
+  __IO uint32_t ISI_CFG2;       /**< (ISI Offset: 0x04) ISI Configuration 2 Register */
+  __IO uint32_t ISI_PSIZE;      /**< (ISI Offset: 0x08) ISI Preview Size Register */
+  __IO uint32_t ISI_PDECF;      /**< (ISI Offset: 0x0C) ISI Preview Decimation Factor Register */
+  __IO uint32_t ISI_Y2R_SET0;   /**< (ISI Offset: 0x10) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+  __IO uint32_t ISI_Y2R_SET1;   /**< (ISI Offset: 0x14) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+  __IO uint32_t ISI_R2Y_SET0;   /**< (ISI Offset: 0x18) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+  __IO uint32_t ISI_R2Y_SET1;   /**< (ISI Offset: 0x1C) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+  __IO uint32_t ISI_R2Y_SET2;   /**< (ISI Offset: 0x20) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+  __O  uint32_t ISI_CR;         /**< (ISI Offset: 0x24) ISI Control Register */
+  __I  uint32_t ISI_SR;         /**< (ISI Offset: 0x28) ISI Status Register */
+  __O  uint32_t ISI_IER;        /**< (ISI Offset: 0x2C) ISI Interrupt Enable Register */
+  __O  uint32_t ISI_IDR;        /**< (ISI Offset: 0x30) ISI Interrupt Disable Register */
+  __I  uint32_t ISI_IMR;        /**< (ISI Offset: 0x34) ISI Interrupt Mask Register */
+  __O  uint32_t ISI_DMA_CHER;   /**< (ISI Offset: 0x38) DMA Channel Enable Register */
+  __O  uint32_t ISI_DMA_CHDR;   /**< (ISI Offset: 0x3C) DMA Channel Disable Register */
+  __I  uint32_t ISI_DMA_CHSR;   /**< (ISI Offset: 0x40) DMA Channel Status Register */
+  __IO uint32_t ISI_DMA_P_ADDR; /**< (ISI Offset: 0x44) DMA Preview Base Address Register */
+  __IO uint32_t ISI_DMA_P_CTRL; /**< (ISI Offset: 0x48) DMA Preview Control Register */
+  __IO uint32_t ISI_DMA_P_DSCR; /**< (ISI Offset: 0x4C) DMA Preview Descriptor Address Register */
+  __IO uint32_t ISI_DMA_C_ADDR; /**< (ISI Offset: 0x50) DMA Codec Base Address Register */
+  __IO uint32_t ISI_DMA_C_CTRL; /**< (ISI Offset: 0x54) DMA Codec Control Register */
+  __IO uint32_t ISI_DMA_C_DSCR; /**< (ISI Offset: 0x58) DMA Codec Descriptor Address Register */
+  __I  uint8_t                        Reserved1[136];
+  __IO uint32_t ISI_WPMR;       /**< (ISI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t ISI_WPSR;       /**< (ISI Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved2[16];
+  __I  uint32_t ISI_VERSION;    /**< (ISI Offset: 0xFC) Version Register */
+} Isi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ISI hardware registers */
+typedef struct {  
+  __IO ISI_CFG1_Type                  ISI_CFG1;       /**< Offset: 0x00 (R/W  32) ISI Configuration 1 Register */
+  __IO ISI_CFG2_Type                  ISI_CFG2;       /**< Offset: 0x04 (R/W  32) ISI Configuration 2 Register */
+  __IO ISI_PSIZE_Type                 ISI_PSIZE;      /**< Offset: 0x08 (R/W  32) ISI Preview Size Register */
+  __IO ISI_PDECF_Type                 ISI_PDECF;      /**< Offset: 0x0C (R/W  32) ISI Preview Decimation Factor Register */
+  __IO ISI_Y2R_SET0_Type              ISI_Y2R_SET0;   /**< Offset: 0x10 (R/W  32) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+  __IO ISI_Y2R_SET1_Type              ISI_Y2R_SET1;   /**< Offset: 0x14 (R/W  32) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+  __IO ISI_R2Y_SET0_Type              ISI_R2Y_SET0;   /**< Offset: 0x18 (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+  __IO ISI_R2Y_SET1_Type              ISI_R2Y_SET1;   /**< Offset: 0x1C (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+  __IO ISI_R2Y_SET2_Type              ISI_R2Y_SET2;   /**< Offset: 0x20 (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+  __O  ISI_CR_Type                    ISI_CR;         /**< Offset: 0x24 ( /W  32) ISI Control Register */
+  __I  ISI_SR_Type                    ISI_SR;         /**< Offset: 0x28 (R/   32) ISI Status Register */
+  __O  ISI_IER_Type                   ISI_IER;        /**< Offset: 0x2C ( /W  32) ISI Interrupt Enable Register */
+  __O  ISI_IDR_Type                   ISI_IDR;        /**< Offset: 0x30 ( /W  32) ISI Interrupt Disable Register */
+  __I  ISI_IMR_Type                   ISI_IMR;        /**< Offset: 0x34 (R/   32) ISI Interrupt Mask Register */
+  __O  ISI_DMA_CHER_Type              ISI_DMA_CHER;   /**< Offset: 0x38 ( /W  32) DMA Channel Enable Register */
+  __O  ISI_DMA_CHDR_Type              ISI_DMA_CHDR;   /**< Offset: 0x3C ( /W  32) DMA Channel Disable Register */
+  __I  ISI_DMA_CHSR_Type              ISI_DMA_CHSR;   /**< Offset: 0x40 (R/   32) DMA Channel Status Register */
+  __IO ISI_DMA_P_ADDR_Type            ISI_DMA_P_ADDR; /**< Offset: 0x44 (R/W  32) DMA Preview Base Address Register */
+  __IO ISI_DMA_P_CTRL_Type            ISI_DMA_P_CTRL; /**< Offset: 0x48 (R/W  32) DMA Preview Control Register */
+  __IO ISI_DMA_P_DSCR_Type            ISI_DMA_P_DSCR; /**< Offset: 0x4C (R/W  32) DMA Preview Descriptor Address Register */
+  __IO ISI_DMA_C_ADDR_Type            ISI_DMA_C_ADDR; /**< Offset: 0x50 (R/W  32) DMA Codec Base Address Register */
+  __IO ISI_DMA_C_CTRL_Type            ISI_DMA_C_CTRL; /**< Offset: 0x54 (R/W  32) DMA Codec Control Register */
+  __IO ISI_DMA_C_DSCR_Type            ISI_DMA_C_DSCR; /**< Offset: 0x58 (R/W  32) DMA Codec Descriptor Address Register */
+  __I  uint8_t                        Reserved1[136];
+  __IO ISI_WPMR_Type                  ISI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  ISI_WPSR_Type                  ISI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved2[16];
+  __I  ISI_VERSION_Type               ISI_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+} Isi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Image Sensor Interface */
+
+#endif /* _SAMV71_ISI_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/matrix.h
+++ b/asf/sam/include/samv71/component/matrix.h
@@ -1,0 +1,556 @@
+/**
+ * \file
+ *
+ * \brief Component description for MATRIX
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MATRIX_COMPONENT_H_
+#define _SAMV71_MATRIX_COMPONENT_H_
+#define _SAMV71_MATRIX_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 AHB Bus Matrix
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MATRIX */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MATRIX_11282                      /**< (MATRIX) Module ID */
+#define REV_MATRIX H                      /**< (MATRIX) Module revision */
+
+/* -------- MATRIX_PRAS : (MATRIX Offset: 0x00) (R/W 32) Priority Register A for Slave 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t M0PR:2;                    /**< bit:   0..1  Master 0 Priority                        */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t M1PR:2;                    /**< bit:   4..5  Master 1 Priority                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t M2PR:2;                    /**< bit:   8..9  Master 2 Priority                        */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t M3PR:2;                    /**< bit: 12..13  Master 3 Priority                        */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t M4PR:2;                    /**< bit: 16..17  Master 4 Priority                        */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t M5PR:2;                    /**< bit: 20..21  Master 5 Priority                        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t M6PR:2;                    /**< bit: 24..25  Master 6 Priority                        */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t M7PR:2;                    /**< bit: 28..29  Master 7 Priority                        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_PRAS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_PRAS_OFFSET                  (0x00)                                        /**<  (MATRIX_PRAS) Priority Register A for Slave 0  Offset */
+
+#define MATRIX_PRAS_M0PR_Pos                0                                              /**< (MATRIX_PRAS) Master 0 Priority Position */
+#define MATRIX_PRAS_M0PR_Msk                (_U_(0x3) << MATRIX_PRAS_M0PR_Pos)             /**< (MATRIX_PRAS) Master 0 Priority Mask */
+#define MATRIX_PRAS_M0PR(value)             (MATRIX_PRAS_M0PR_Msk & ((value) << MATRIX_PRAS_M0PR_Pos))
+#define MATRIX_PRAS_M1PR_Pos                4                                              /**< (MATRIX_PRAS) Master 1 Priority Position */
+#define MATRIX_PRAS_M1PR_Msk                (_U_(0x3) << MATRIX_PRAS_M1PR_Pos)             /**< (MATRIX_PRAS) Master 1 Priority Mask */
+#define MATRIX_PRAS_M1PR(value)             (MATRIX_PRAS_M1PR_Msk & ((value) << MATRIX_PRAS_M1PR_Pos))
+#define MATRIX_PRAS_M2PR_Pos                8                                              /**< (MATRIX_PRAS) Master 2 Priority Position */
+#define MATRIX_PRAS_M2PR_Msk                (_U_(0x3) << MATRIX_PRAS_M2PR_Pos)             /**< (MATRIX_PRAS) Master 2 Priority Mask */
+#define MATRIX_PRAS_M2PR(value)             (MATRIX_PRAS_M2PR_Msk & ((value) << MATRIX_PRAS_M2PR_Pos))
+#define MATRIX_PRAS_M3PR_Pos                12                                             /**< (MATRIX_PRAS) Master 3 Priority Position */
+#define MATRIX_PRAS_M3PR_Msk                (_U_(0x3) << MATRIX_PRAS_M3PR_Pos)             /**< (MATRIX_PRAS) Master 3 Priority Mask */
+#define MATRIX_PRAS_M3PR(value)             (MATRIX_PRAS_M3PR_Msk & ((value) << MATRIX_PRAS_M3PR_Pos))
+#define MATRIX_PRAS_M4PR_Pos                16                                             /**< (MATRIX_PRAS) Master 4 Priority Position */
+#define MATRIX_PRAS_M4PR_Msk                (_U_(0x3) << MATRIX_PRAS_M4PR_Pos)             /**< (MATRIX_PRAS) Master 4 Priority Mask */
+#define MATRIX_PRAS_M4PR(value)             (MATRIX_PRAS_M4PR_Msk & ((value) << MATRIX_PRAS_M4PR_Pos))
+#define MATRIX_PRAS_M5PR_Pos                20                                             /**< (MATRIX_PRAS) Master 5 Priority Position */
+#define MATRIX_PRAS_M5PR_Msk                (_U_(0x3) << MATRIX_PRAS_M5PR_Pos)             /**< (MATRIX_PRAS) Master 5 Priority Mask */
+#define MATRIX_PRAS_M5PR(value)             (MATRIX_PRAS_M5PR_Msk & ((value) << MATRIX_PRAS_M5PR_Pos))
+#define MATRIX_PRAS_M6PR_Pos                24                                             /**< (MATRIX_PRAS) Master 6 Priority Position */
+#define MATRIX_PRAS_M6PR_Msk                (_U_(0x3) << MATRIX_PRAS_M6PR_Pos)             /**< (MATRIX_PRAS) Master 6 Priority Mask */
+#define MATRIX_PRAS_M6PR(value)             (MATRIX_PRAS_M6PR_Msk & ((value) << MATRIX_PRAS_M6PR_Pos))
+#define MATRIX_PRAS_M7PR_Pos                28                                             /**< (MATRIX_PRAS) Master 7 Priority Position */
+#define MATRIX_PRAS_M7PR_Msk                (_U_(0x3) << MATRIX_PRAS_M7PR_Pos)             /**< (MATRIX_PRAS) Master 7 Priority Mask */
+#define MATRIX_PRAS_M7PR(value)             (MATRIX_PRAS_M7PR_Msk & ((value) << MATRIX_PRAS_M7PR_Pos))
+#define MATRIX_PRAS_MASK                    _U_(0x33333333)                                /**< \deprecated (MATRIX_PRAS) Register MASK  (Use MATRIX_PRAS_Msk instead)  */
+#define MATRIX_PRAS_Msk                     _U_(0x33333333)                                /**< (MATRIX_PRAS) Register Mask  */
+
+
+/* -------- MATRIX_PRBS : (MATRIX Offset: 0x04) (R/W 32) Priority Register B for Slave 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t M8PR:2;                    /**< bit:   0..1  Master 8 Priority                        */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t M9PR:2;                    /**< bit:   4..5  Master 9 Priority                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t M10PR:2;                   /**< bit:   8..9  Master 10 Priority                       */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t M11PR:2;                   /**< bit: 12..13  Master 11 Priority                       */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_PRBS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_PRBS_OFFSET                  (0x04)                                        /**<  (MATRIX_PRBS) Priority Register B for Slave 0  Offset */
+
+#define MATRIX_PRBS_M8PR_Pos                0                                              /**< (MATRIX_PRBS) Master 8 Priority Position */
+#define MATRIX_PRBS_M8PR_Msk                (_U_(0x3) << MATRIX_PRBS_M8PR_Pos)             /**< (MATRIX_PRBS) Master 8 Priority Mask */
+#define MATRIX_PRBS_M8PR(value)             (MATRIX_PRBS_M8PR_Msk & ((value) << MATRIX_PRBS_M8PR_Pos))
+#define MATRIX_PRBS_M9PR_Pos                4                                              /**< (MATRIX_PRBS) Master 9 Priority Position */
+#define MATRIX_PRBS_M9PR_Msk                (_U_(0x3) << MATRIX_PRBS_M9PR_Pos)             /**< (MATRIX_PRBS) Master 9 Priority Mask */
+#define MATRIX_PRBS_M9PR(value)             (MATRIX_PRBS_M9PR_Msk & ((value) << MATRIX_PRBS_M9PR_Pos))
+#define MATRIX_PRBS_M10PR_Pos               8                                              /**< (MATRIX_PRBS) Master 10 Priority Position */
+#define MATRIX_PRBS_M10PR_Msk               (_U_(0x3) << MATRIX_PRBS_M10PR_Pos)            /**< (MATRIX_PRBS) Master 10 Priority Mask */
+#define MATRIX_PRBS_M10PR(value)            (MATRIX_PRBS_M10PR_Msk & ((value) << MATRIX_PRBS_M10PR_Pos))
+#define MATRIX_PRBS_M11PR_Pos               12                                             /**< (MATRIX_PRBS) Master 11 Priority Position */
+#define MATRIX_PRBS_M11PR_Msk               (_U_(0x3) << MATRIX_PRBS_M11PR_Pos)            /**< (MATRIX_PRBS) Master 11 Priority Mask */
+#define MATRIX_PRBS_M11PR(value)            (MATRIX_PRBS_M11PR_Msk & ((value) << MATRIX_PRBS_M11PR_Pos))
+#define MATRIX_PRBS_MASK                    _U_(0x3333)                                    /**< \deprecated (MATRIX_PRBS) Register MASK  (Use MATRIX_PRBS_Msk instead)  */
+#define MATRIX_PRBS_Msk                     _U_(0x3333)                                    /**< (MATRIX_PRBS) Register Mask  */
+
+
+/* -------- MATRIX_MCFG : (MATRIX Offset: 0x00) (R/W 32) Master Configuration Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ULBT:3;                    /**< bit:   0..2  Undefined Length Burst Type              */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_MCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_MCFG_OFFSET                  (0x00)                                        /**<  (MATRIX_MCFG) Master Configuration Register 0  Offset */
+
+#define MATRIX_MCFG_ULBT_Pos                0                                              /**< (MATRIX_MCFG) Undefined Length Burst Type Position */
+#define MATRIX_MCFG_ULBT_Msk                (_U_(0x7) << MATRIX_MCFG_ULBT_Pos)             /**< (MATRIX_MCFG) Undefined Length Burst Type Mask */
+#define MATRIX_MCFG_ULBT(value)             (MATRIX_MCFG_ULBT_Msk & ((value) << MATRIX_MCFG_ULBT_Pos))
+#define   MATRIX_MCFG_ULBT_UNLTD_LENGTH_Val _U_(0x0)                                       /**< (MATRIX_MCFG) Unlimited Length Burst-No predicted end of burst is generated, therefore INCR bursts coming from this master can only be broken if the Slave Slot Cycle Limit is reached. If the Slot Cycle Limit is not reached, the burst is normally completed by the master, at the latest, on the next AHB 1-Kbyte address boundary, allowing up to 256-beat word bursts or 128-beat double-word bursts.This value should not be used in the very particular case of a master capable of performing back-to-back undefined length bursts on a single slave, since this could indefinitely freeze the slave arbitration and thus prevent another master from accessing this slave.  */
+#define   MATRIX_MCFG_ULBT_SINGLE_ACCESS_Val _U_(0x1)                                       /**< (MATRIX_MCFG) Single Access-The undefined length burst is treated as a succession of single accesses, allowing re-arbitration at each beat of the INCR burst or bursts sequence.  */
+#define   MATRIX_MCFG_ULBT_4BEAT_BURST_Val  _U_(0x2)                                       /**< (MATRIX_MCFG) 4-beat Burst-The undefined length burst or bursts sequence is split into 4-beat bursts or less, allowing re-arbitration every 4 beats.  */
+#define   MATRIX_MCFG_ULBT_8BEAT_BURST_Val  _U_(0x3)                                       /**< (MATRIX_MCFG) 8-beat Burst-The undefined length burst or bursts sequence is split into 8-beat bursts or less, allowing re-arbitration every 8 beats.  */
+#define   MATRIX_MCFG_ULBT_16BEAT_BURST_Val _U_(0x4)                                       /**< (MATRIX_MCFG) 16-beat Burst-The undefined length burst or bursts sequence is split into 16-beat bursts or less, allowing re-arbitration every 16 beats.  */
+#define   MATRIX_MCFG_ULBT_32BEAT_BURST_Val _U_(0x5)                                       /**< (MATRIX_MCFG) 32-beat Burst -The undefined length burst or bursts sequence is split into 32-beat bursts or less, allowing re-arbitration every 32 beats.  */
+#define   MATRIX_MCFG_ULBT_64BEAT_BURST_Val _U_(0x6)                                       /**< (MATRIX_MCFG) 64-beat Burst-The undefined length burst or bursts sequence is split into 64-beat bursts or less, allowing re-arbitration every 64 beats.  */
+#define   MATRIX_MCFG_ULBT_128BEAT_BURST_Val _U_(0x7)                                       /**< (MATRIX_MCFG) 128-beat Burst-The undefined length burst or bursts sequence is split into 128-beat bursts or less, allowing re-arbitration every 128 beats.  */
+#define MATRIX_MCFG_ULBT_UNLTD_LENGTH       (MATRIX_MCFG_ULBT_UNLTD_LENGTH_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) Unlimited Length Burst-No predicted end of burst is generated, therefore INCR bursts coming from this master can only be broken if the Slave Slot Cycle Limit is reached. If the Slot Cycle Limit is not reached, the burst is normally completed by the master, at the latest, on the next AHB 1-Kbyte address boundary, allowing up to 256-beat word bursts or 128-beat double-word bursts.This value should not be used in the very particular case of a master capable of performing back-to-back undefined length bursts on a single slave, since this could indefinitely freeze the slave arbitration and thus prevent another master from accessing this slave. Position  */
+#define MATRIX_MCFG_ULBT_SINGLE_ACCESS      (MATRIX_MCFG_ULBT_SINGLE_ACCESS_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) Single Access-The undefined length burst is treated as a succession of single accesses, allowing re-arbitration at each beat of the INCR burst or bursts sequence. Position  */
+#define MATRIX_MCFG_ULBT_4BEAT_BURST        (MATRIX_MCFG_ULBT_4BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 4-beat Burst-The undefined length burst or bursts sequence is split into 4-beat bursts or less, allowing re-arbitration every 4 beats. Position  */
+#define MATRIX_MCFG_ULBT_8BEAT_BURST        (MATRIX_MCFG_ULBT_8BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 8-beat Burst-The undefined length burst or bursts sequence is split into 8-beat bursts or less, allowing re-arbitration every 8 beats. Position  */
+#define MATRIX_MCFG_ULBT_16BEAT_BURST       (MATRIX_MCFG_ULBT_16BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 16-beat Burst-The undefined length burst or bursts sequence is split into 16-beat bursts or less, allowing re-arbitration every 16 beats. Position  */
+#define MATRIX_MCFG_ULBT_32BEAT_BURST       (MATRIX_MCFG_ULBT_32BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 32-beat Burst -The undefined length burst or bursts sequence is split into 32-beat bursts or less, allowing re-arbitration every 32 beats. Position  */
+#define MATRIX_MCFG_ULBT_64BEAT_BURST       (MATRIX_MCFG_ULBT_64BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 64-beat Burst-The undefined length burst or bursts sequence is split into 64-beat bursts or less, allowing re-arbitration every 64 beats. Position  */
+#define MATRIX_MCFG_ULBT_128BEAT_BURST      (MATRIX_MCFG_ULBT_128BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 128-beat Burst-The undefined length burst or bursts sequence is split into 128-beat bursts or less, allowing re-arbitration every 128 beats. Position  */
+#define MATRIX_MCFG_MASK                    _U_(0x07)                                      /**< \deprecated (MATRIX_MCFG) Register MASK  (Use MATRIX_MCFG_Msk instead)  */
+#define MATRIX_MCFG_Msk                     _U_(0x07)                                      /**< (MATRIX_MCFG) Register Mask  */
+
+
+/* -------- MATRIX_SCFG : (MATRIX Offset: 0x40) (R/W 32) Slave Configuration Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SLOT_CYCLE:9;              /**< bit:   0..8  Maximum Bus Grant Duration for Masters   */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t DEFMSTR_TYPE:2;            /**< bit: 16..17  Default Master Type                      */
+    uint32_t FIXED_DEFMSTR:4;           /**< bit: 18..21  Fixed Default Master                     */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_SCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_SCFG_OFFSET                  (0x40)                                        /**<  (MATRIX_SCFG) Slave Configuration Register 0  Offset */
+
+#define MATRIX_SCFG_SLOT_CYCLE_Pos          0                                              /**< (MATRIX_SCFG) Maximum Bus Grant Duration for Masters Position */
+#define MATRIX_SCFG_SLOT_CYCLE_Msk          (_U_(0x1FF) << MATRIX_SCFG_SLOT_CYCLE_Pos)     /**< (MATRIX_SCFG) Maximum Bus Grant Duration for Masters Mask */
+#define MATRIX_SCFG_SLOT_CYCLE(value)       (MATRIX_SCFG_SLOT_CYCLE_Msk & ((value) << MATRIX_SCFG_SLOT_CYCLE_Pos))
+#define MATRIX_SCFG_DEFMSTR_TYPE_Pos        16                                             /**< (MATRIX_SCFG) Default Master Type Position */
+#define MATRIX_SCFG_DEFMSTR_TYPE_Msk        (_U_(0x3) << MATRIX_SCFG_DEFMSTR_TYPE_Pos)     /**< (MATRIX_SCFG) Default Master Type Mask */
+#define MATRIX_SCFG_DEFMSTR_TYPE(value)     (MATRIX_SCFG_DEFMSTR_TYPE_Msk & ((value) << MATRIX_SCFG_DEFMSTR_TYPE_Pos))
+#define   MATRIX_SCFG_DEFMSTR_TYPE_NONE_Val _U_(0x0)                                       /**< (MATRIX_SCFG) No Default Master-At the end of the current slave access, if no other master request is pending, the slave is disconnected from all masters.This results in a one clock cycle latency for the first access of a burst transfer or for a single access.  */
+#define   MATRIX_SCFG_DEFMSTR_TYPE_LAST_Val _U_(0x1)                                       /**< (MATRIX_SCFG) Last Default Master-At the end of the current slave access, if no other master request is pending, the slave stays connected to the last master having accessed it.This results in not having one clock cycle latency when the last master tries to access the slave again.  */
+#define   MATRIX_SCFG_DEFMSTR_TYPE_FIXED_Val _U_(0x2)                                       /**< (MATRIX_SCFG) Fixed Default Master-At the end of the current slave access, if no other master request is pending, the slave connects to the fixed master the number that has been written in the FIXED_DEFMSTR field.This results in not having one clock cycle latency when the fixed master tries to access the slave again.  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_NONE       (MATRIX_SCFG_DEFMSTR_TYPE_NONE_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) No Default Master-At the end of the current slave access, if no other master request is pending, the slave is disconnected from all masters.This results in a one clock cycle latency for the first access of a burst transfer or for a single access. Position  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_LAST       (MATRIX_SCFG_DEFMSTR_TYPE_LAST_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) Last Default Master-At the end of the current slave access, if no other master request is pending, the slave stays connected to the last master having accessed it.This results in not having one clock cycle latency when the last master tries to access the slave again. Position  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_FIXED      (MATRIX_SCFG_DEFMSTR_TYPE_FIXED_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) Fixed Default Master-At the end of the current slave access, if no other master request is pending, the slave connects to the fixed master the number that has been written in the FIXED_DEFMSTR field.This results in not having one clock cycle latency when the fixed master tries to access the slave again. Position  */
+#define MATRIX_SCFG_FIXED_DEFMSTR_Pos       18                                             /**< (MATRIX_SCFG) Fixed Default Master Position */
+#define MATRIX_SCFG_FIXED_DEFMSTR_Msk       (_U_(0xF) << MATRIX_SCFG_FIXED_DEFMSTR_Pos)    /**< (MATRIX_SCFG) Fixed Default Master Mask */
+#define MATRIX_SCFG_FIXED_DEFMSTR(value)    (MATRIX_SCFG_FIXED_DEFMSTR_Msk & ((value) << MATRIX_SCFG_FIXED_DEFMSTR_Pos))
+#define MATRIX_SCFG_MASK                    _U_(0x3F01FF)                                  /**< \deprecated (MATRIX_SCFG) Register MASK  (Use MATRIX_SCFG_Msk instead)  */
+#define MATRIX_SCFG_Msk                     _U_(0x3F01FF)                                  /**< (MATRIX_SCFG) Register Mask  */
+
+
+/* -------- MATRIX_MRCR : (MATRIX Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RCB0:1;                    /**< bit:      0  Remap Command Bit for Master 0           */
+    uint32_t RCB1:1;                    /**< bit:      1  Remap Command Bit for Master 1           */
+    uint32_t RCB2:1;                    /**< bit:      2  Remap Command Bit for Master 2           */
+    uint32_t RCB3:1;                    /**< bit:      3  Remap Command Bit for Master 3           */
+    uint32_t RCB4:1;                    /**< bit:      4  Remap Command Bit for Master 4           */
+    uint32_t RCB5:1;                    /**< bit:      5  Remap Command Bit for Master 5           */
+    uint32_t RCB6:1;                    /**< bit:      6  Remap Command Bit for Master 6           */
+    uint32_t RCB7:1;                    /**< bit:      7  Remap Command Bit for Master 7           */
+    uint32_t RCB8:1;                    /**< bit:      8  Remap Command Bit for Master 8           */
+    uint32_t RCB9:1;                    /**< bit:      9  Remap Command Bit for Master 9           */
+    uint32_t RCB10:1;                   /**< bit:     10  Remap Command Bit for Master 10          */
+    uint32_t RCB11:1;                   /**< bit:     11  Remap Command Bit for Master 11          */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RCB:12;                    /**< bit:  0..11  Remap Command Bit for Master xx          */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_MRCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_MRCR_OFFSET                  (0x100)                                       /**<  (MATRIX_MRCR) Master Remap Control Register  Offset */
+
+#define MATRIX_MRCR_RCB0_Pos                0                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 0 Position */
+#define MATRIX_MRCR_RCB0_Msk                (_U_(0x1) << MATRIX_MRCR_RCB0_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 0 Mask */
+#define MATRIX_MRCR_RCB0                    MATRIX_MRCR_RCB0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB0_Msk instead */
+#define MATRIX_MRCR_RCB1_Pos                1                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 1 Position */
+#define MATRIX_MRCR_RCB1_Msk                (_U_(0x1) << MATRIX_MRCR_RCB1_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 1 Mask */
+#define MATRIX_MRCR_RCB1                    MATRIX_MRCR_RCB1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB1_Msk instead */
+#define MATRIX_MRCR_RCB2_Pos                2                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 2 Position */
+#define MATRIX_MRCR_RCB2_Msk                (_U_(0x1) << MATRIX_MRCR_RCB2_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 2 Mask */
+#define MATRIX_MRCR_RCB2                    MATRIX_MRCR_RCB2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB2_Msk instead */
+#define MATRIX_MRCR_RCB3_Pos                3                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 3 Position */
+#define MATRIX_MRCR_RCB3_Msk                (_U_(0x1) << MATRIX_MRCR_RCB3_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 3 Mask */
+#define MATRIX_MRCR_RCB3                    MATRIX_MRCR_RCB3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB3_Msk instead */
+#define MATRIX_MRCR_RCB4_Pos                4                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 4 Position */
+#define MATRIX_MRCR_RCB4_Msk                (_U_(0x1) << MATRIX_MRCR_RCB4_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 4 Mask */
+#define MATRIX_MRCR_RCB4                    MATRIX_MRCR_RCB4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB4_Msk instead */
+#define MATRIX_MRCR_RCB5_Pos                5                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 5 Position */
+#define MATRIX_MRCR_RCB5_Msk                (_U_(0x1) << MATRIX_MRCR_RCB5_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 5 Mask */
+#define MATRIX_MRCR_RCB5                    MATRIX_MRCR_RCB5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB5_Msk instead */
+#define MATRIX_MRCR_RCB6_Pos                6                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 6 Position */
+#define MATRIX_MRCR_RCB6_Msk                (_U_(0x1) << MATRIX_MRCR_RCB6_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 6 Mask */
+#define MATRIX_MRCR_RCB6                    MATRIX_MRCR_RCB6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB6_Msk instead */
+#define MATRIX_MRCR_RCB7_Pos                7                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 7 Position */
+#define MATRIX_MRCR_RCB7_Msk                (_U_(0x1) << MATRIX_MRCR_RCB7_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 7 Mask */
+#define MATRIX_MRCR_RCB7                    MATRIX_MRCR_RCB7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB7_Msk instead */
+#define MATRIX_MRCR_RCB8_Pos                8                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 8 Position */
+#define MATRIX_MRCR_RCB8_Msk                (_U_(0x1) << MATRIX_MRCR_RCB8_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 8 Mask */
+#define MATRIX_MRCR_RCB8                    MATRIX_MRCR_RCB8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB8_Msk instead */
+#define MATRIX_MRCR_RCB9_Pos                9                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 9 Position */
+#define MATRIX_MRCR_RCB9_Msk                (_U_(0x1) << MATRIX_MRCR_RCB9_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 9 Mask */
+#define MATRIX_MRCR_RCB9                    MATRIX_MRCR_RCB9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB9_Msk instead */
+#define MATRIX_MRCR_RCB10_Pos               10                                             /**< (MATRIX_MRCR) Remap Command Bit for Master 10 Position */
+#define MATRIX_MRCR_RCB10_Msk               (_U_(0x1) << MATRIX_MRCR_RCB10_Pos)            /**< (MATRIX_MRCR) Remap Command Bit for Master 10 Mask */
+#define MATRIX_MRCR_RCB10                   MATRIX_MRCR_RCB10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB10_Msk instead */
+#define MATRIX_MRCR_RCB11_Pos               11                                             /**< (MATRIX_MRCR) Remap Command Bit for Master 11 Position */
+#define MATRIX_MRCR_RCB11_Msk               (_U_(0x1) << MATRIX_MRCR_RCB11_Pos)            /**< (MATRIX_MRCR) Remap Command Bit for Master 11 Mask */
+#define MATRIX_MRCR_RCB11                   MATRIX_MRCR_RCB11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB11_Msk instead */
+#define MATRIX_MRCR_MASK                    _U_(0xFFF)                                     /**< \deprecated (MATRIX_MRCR) Register MASK  (Use MATRIX_MRCR_Msk instead)  */
+#define MATRIX_MRCR_Msk                     _U_(0xFFF)                                     /**< (MATRIX_MRCR) Register Mask  */
+
+#define MATRIX_MRCR_RCB_Pos                 0                                              /**< (MATRIX_MRCR Position) Remap Command Bit for Master xx */
+#define MATRIX_MRCR_RCB_Msk                 (_U_(0xFFF) << MATRIX_MRCR_RCB_Pos)            /**< (MATRIX_MRCR Mask) RCB */
+#define MATRIX_MRCR_RCB(value)              (MATRIX_MRCR_RCB_Msk & ((value) << MATRIX_MRCR_RCB_Pos))  
+
+/* -------- CCFG_CAN0 : (MATRIX Offset: 0x110) (R/W 32) CAN0 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t CAN0DMABA:16;              /**< bit: 16..31  CAN0 DMA Base Address                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_CAN0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_CAN0_OFFSET                    (0x110)                                       /**<  (CCFG_CAN0) CAN0 Configuration Register  Offset */
+
+#define CCFG_CAN0_CAN0DMABA_Pos             16                                             /**< (CCFG_CAN0) CAN0 DMA Base Address Position */
+#define CCFG_CAN0_CAN0DMABA_Msk             (_U_(0xFFFF) << CCFG_CAN0_CAN0DMABA_Pos)       /**< (CCFG_CAN0) CAN0 DMA Base Address Mask */
+#define CCFG_CAN0_CAN0DMABA(value)          (CCFG_CAN0_CAN0DMABA_Msk & ((value) << CCFG_CAN0_CAN0DMABA_Pos))
+#define CCFG_CAN0_MASK                      _U_(0xFFFF0000)                                /**< \deprecated (CCFG_CAN0) Register MASK  (Use CCFG_CAN0_Msk instead)  */
+#define CCFG_CAN0_Msk                       _U_(0xFFFF0000)                                /**< (CCFG_CAN0) Register Mask  */
+
+
+/* -------- CCFG_SYSIO : (MATRIX Offset: 0x114) (R/W 32) System I/O and CAN1 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t SYSIO4:1;                  /**< bit:      4  PB4 or TDI Assignment                    */
+    uint32_t SYSIO5:1;                  /**< bit:      5  PB5 or TDO/TRACESWO Assignment           */
+    uint32_t SYSIO6:1;                  /**< bit:      6  PB6 or TMS/SWDIO Assignment              */
+    uint32_t SYSIO7:1;                  /**< bit:      7  PB7 or TCK/SWCLK Assignment              */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t SYSIO12:1;                 /**< bit:     12  PB12 or ERASE Assignment                 */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t CAN1DMABA:16;              /**< bit: 16..31  CAN1 DMA Base Address                    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t SYSIO:5;                   /**< bit:   4..8  PB4 or TDI Assignment                    */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_SYSIO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_SYSIO_OFFSET                   (0x114)                                       /**<  (CCFG_SYSIO) System I/O and CAN1 Configuration Register  Offset */
+
+#define CCFG_SYSIO_SYSIO4_Pos               4                                              /**< (CCFG_SYSIO) PB4 or TDI Assignment Position */
+#define CCFG_SYSIO_SYSIO4_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO4_Pos)            /**< (CCFG_SYSIO) PB4 or TDI Assignment Mask */
+#define CCFG_SYSIO_SYSIO4                   CCFG_SYSIO_SYSIO4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO4_Msk instead */
+#define CCFG_SYSIO_SYSIO5_Pos               5                                              /**< (CCFG_SYSIO) PB5 or TDO/TRACESWO Assignment Position */
+#define CCFG_SYSIO_SYSIO5_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO5_Pos)            /**< (CCFG_SYSIO) PB5 or TDO/TRACESWO Assignment Mask */
+#define CCFG_SYSIO_SYSIO5                   CCFG_SYSIO_SYSIO5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO5_Msk instead */
+#define CCFG_SYSIO_SYSIO6_Pos               6                                              /**< (CCFG_SYSIO) PB6 or TMS/SWDIO Assignment Position */
+#define CCFG_SYSIO_SYSIO6_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO6_Pos)            /**< (CCFG_SYSIO) PB6 or TMS/SWDIO Assignment Mask */
+#define CCFG_SYSIO_SYSIO6                   CCFG_SYSIO_SYSIO6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO6_Msk instead */
+#define CCFG_SYSIO_SYSIO7_Pos               7                                              /**< (CCFG_SYSIO) PB7 or TCK/SWCLK Assignment Position */
+#define CCFG_SYSIO_SYSIO7_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO7_Pos)            /**< (CCFG_SYSIO) PB7 or TCK/SWCLK Assignment Mask */
+#define CCFG_SYSIO_SYSIO7                   CCFG_SYSIO_SYSIO7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO7_Msk instead */
+#define CCFG_SYSIO_SYSIO12_Pos              12                                             /**< (CCFG_SYSIO) PB12 or ERASE Assignment Position */
+#define CCFG_SYSIO_SYSIO12_Msk              (_U_(0x1) << CCFG_SYSIO_SYSIO12_Pos)           /**< (CCFG_SYSIO) PB12 or ERASE Assignment Mask */
+#define CCFG_SYSIO_SYSIO12                  CCFG_SYSIO_SYSIO12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO12_Msk instead */
+#define CCFG_SYSIO_CAN1DMABA_Pos            16                                             /**< (CCFG_SYSIO) CAN1 DMA Base Address Position */
+#define CCFG_SYSIO_CAN1DMABA_Msk            (_U_(0xFFFF) << CCFG_SYSIO_CAN1DMABA_Pos)      /**< (CCFG_SYSIO) CAN1 DMA Base Address Mask */
+#define CCFG_SYSIO_CAN1DMABA(value)         (CCFG_SYSIO_CAN1DMABA_Msk & ((value) << CCFG_SYSIO_CAN1DMABA_Pos))
+#define CCFG_SYSIO_MASK                     _U_(0xFFFF10F0)                                /**< \deprecated (CCFG_SYSIO) Register MASK  (Use CCFG_SYSIO_Msk instead)  */
+#define CCFG_SYSIO_Msk                      _U_(0xFFFF10F0)                                /**< (CCFG_SYSIO) Register Mask  */
+
+#define CCFG_SYSIO_SYSIO_Pos                4                                              /**< (CCFG_SYSIO Position) PB4 or TDI Assignment */
+#define CCFG_SYSIO_SYSIO_Msk                (_U_(0x1F) << CCFG_SYSIO_SYSIO_Pos)            /**< (CCFG_SYSIO Mask) SYSIO */
+#define CCFG_SYSIO_SYSIO(value)             (CCFG_SYSIO_SYSIO_Msk & ((value) << CCFG_SYSIO_SYSIO_Pos))  
+
+/* -------- CCFG_SMCNFCS : (MATRIX Offset: 0x124) (R/W 32) SMC NAND Flash Chip Select Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMC_NFCS0:1;               /**< bit:      0  SMC NAND Flash Chip Select 0 Assignment  */
+    uint32_t SMC_NFCS1:1;               /**< bit:      1  SMC NAND Flash Chip Select 1 Assignment  */
+    uint32_t SMC_NFCS2:1;               /**< bit:      2  SMC NAND Flash Chip Select 2 Assignment  */
+    uint32_t SMC_NFCS3:1;               /**< bit:      3  SMC NAND Flash Chip Select 3 Assignment  */
+    uint32_t SDRAMEN:1;                 /**< bit:      4  SDRAM Enable                             */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SMC_NFCS:4;                /**< bit:   0..3  SMC NAND Flash Chip Select x Assignment  */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_SMCNFCS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_SMCNFCS_OFFSET                 (0x124)                                       /**<  (CCFG_SMCNFCS) SMC NAND Flash Chip Select Configuration Register  Offset */
+
+#define CCFG_SMCNFCS_SMC_NFCS0_Pos          0                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 0 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS0_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS0_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 0 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS0              CCFG_SMCNFCS_SMC_NFCS0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS0_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS1_Pos          1                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 1 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS1_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS1_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 1 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS1              CCFG_SMCNFCS_SMC_NFCS1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS1_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS2_Pos          2                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 2 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS2_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS2_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 2 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS2              CCFG_SMCNFCS_SMC_NFCS2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS2_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS3_Pos          3                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 3 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS3_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS3_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 3 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS3              CCFG_SMCNFCS_SMC_NFCS3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS3_Msk instead */
+#define CCFG_SMCNFCS_SDRAMEN_Pos            4                                              /**< (CCFG_SMCNFCS) SDRAM Enable Position */
+#define CCFG_SMCNFCS_SDRAMEN_Msk            (_U_(0x1) << CCFG_SMCNFCS_SDRAMEN_Pos)         /**< (CCFG_SMCNFCS) SDRAM Enable Mask */
+#define CCFG_SMCNFCS_SDRAMEN                CCFG_SMCNFCS_SDRAMEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SDRAMEN_Msk instead */
+#define CCFG_SMCNFCS_MASK                   _U_(0x1F)                                      /**< \deprecated (CCFG_SMCNFCS) Register MASK  (Use CCFG_SMCNFCS_Msk instead)  */
+#define CCFG_SMCNFCS_Msk                    _U_(0x1F)                                      /**< (CCFG_SMCNFCS) Register Mask  */
+
+#define CCFG_SMCNFCS_SMC_NFCS_Pos           0                                              /**< (CCFG_SMCNFCS Position) SMC NAND Flash Chip Select x Assignment */
+#define CCFG_SMCNFCS_SMC_NFCS_Msk           (_U_(0xF) << CCFG_SMCNFCS_SMC_NFCS_Pos)        /**< (CCFG_SMCNFCS Mask) SMC_NFCS */
+#define CCFG_SMCNFCS_SMC_NFCS(value)        (CCFG_SMCNFCS_SMC_NFCS_Msk & ((value) << CCFG_SMCNFCS_SMC_NFCS_Pos))  
+
+/* -------- MATRIX_WPMR : (MATRIX Offset: 0x1e4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_WPMR_OFFSET                  (0x1E4)                                       /**<  (MATRIX_WPMR) Write Protection Mode Register  Offset */
+
+#define MATRIX_WPMR_WPEN_Pos                0                                              /**< (MATRIX_WPMR) Write Protection Enable Position */
+#define MATRIX_WPMR_WPEN_Msk                (_U_(0x1) << MATRIX_WPMR_WPEN_Pos)             /**< (MATRIX_WPMR) Write Protection Enable Mask */
+#define MATRIX_WPMR_WPEN                    MATRIX_WPMR_WPEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_WPMR_WPEN_Msk instead */
+#define MATRIX_WPMR_WPKEY_Pos               8                                              /**< (MATRIX_WPMR) Write Protection Key Position */
+#define MATRIX_WPMR_WPKEY_Msk               (_U_(0xFFFFFF) << MATRIX_WPMR_WPKEY_Pos)       /**< (MATRIX_WPMR) Write Protection Key Mask */
+#define MATRIX_WPMR_WPKEY(value)            (MATRIX_WPMR_WPKEY_Msk & ((value) << MATRIX_WPMR_WPKEY_Pos))
+#define   MATRIX_WPMR_WPKEY_PASSWD_Val      _U_(0x4D4154)                                  /**< (MATRIX_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define MATRIX_WPMR_WPKEY_PASSWD            (MATRIX_WPMR_WPKEY_PASSWD_Val << MATRIX_WPMR_WPKEY_Pos)  /**< (MATRIX_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define MATRIX_WPMR_MASK                    _U_(0xFFFFFF01)                                /**< \deprecated (MATRIX_WPMR) Register MASK  (Use MATRIX_WPMR_Msk instead)  */
+#define MATRIX_WPMR_Msk                     _U_(0xFFFFFF01)                                /**< (MATRIX_WPMR) Register Mask  */
+
+
+/* -------- MATRIX_WPSR : (MATRIX Offset: 0x1e8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_WPSR_OFFSET                  (0x1E8)                                       /**<  (MATRIX_WPSR) Write Protection Status Register  Offset */
+
+#define MATRIX_WPSR_WPVS_Pos                0                                              /**< (MATRIX_WPSR) Write Protection Violation Status Position */
+#define MATRIX_WPSR_WPVS_Msk                (_U_(0x1) << MATRIX_WPSR_WPVS_Pos)             /**< (MATRIX_WPSR) Write Protection Violation Status Mask */
+#define MATRIX_WPSR_WPVS                    MATRIX_WPSR_WPVS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_WPSR_WPVS_Msk instead */
+#define MATRIX_WPSR_WPVSRC_Pos              8                                              /**< (MATRIX_WPSR) Write Protection Violation Source Position */
+#define MATRIX_WPSR_WPVSRC_Msk              (_U_(0xFFFF) << MATRIX_WPSR_WPVSRC_Pos)        /**< (MATRIX_WPSR) Write Protection Violation Source Mask */
+#define MATRIX_WPSR_WPVSRC(value)           (MATRIX_WPSR_WPVSRC_Msk & ((value) << MATRIX_WPSR_WPVSRC_Pos))
+#define MATRIX_WPSR_MASK                    _U_(0xFFFF01)                                  /**< \deprecated (MATRIX_WPSR) Register MASK  (Use MATRIX_WPSR_Msk instead)  */
+#define MATRIX_WPSR_Msk                     _U_(0xFFFF01)                                  /**< (MATRIX_WPSR) Register Mask  */
+
+
+/* -------- MATRIX_VERSION : (MATRIX Offset: 0x1fc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_VERSION_OFFSET               (0x1FC)                                       /**<  (MATRIX_VERSION) Version Register  Offset */
+
+#define MATRIX_VERSION_VERSION_Pos          0                                              /**< (MATRIX_VERSION) Version of the Hardware Module Position */
+#define MATRIX_VERSION_VERSION_Msk          (_U_(0xFFF) << MATRIX_VERSION_VERSION_Pos)     /**< (MATRIX_VERSION) Version of the Hardware Module Mask */
+#define MATRIX_VERSION_VERSION(value)       (MATRIX_VERSION_VERSION_Msk & ((value) << MATRIX_VERSION_VERSION_Pos))
+#define MATRIX_VERSION_MFN_Pos              16                                             /**< (MATRIX_VERSION) Metal Fix Number Position */
+#define MATRIX_VERSION_MFN_Msk              (_U_(0x7) << MATRIX_VERSION_MFN_Pos)           /**< (MATRIX_VERSION) Metal Fix Number Mask */
+#define MATRIX_VERSION_MFN(value)           (MATRIX_VERSION_MFN_Msk & ((value) << MATRIX_VERSION_MFN_Pos))
+#define MATRIX_VERSION_MASK                 _U_(0x70FFF)                                   /**< \deprecated (MATRIX_VERSION) Register MASK  (Use MATRIX_VERSION_Msk instead)  */
+#define MATRIX_VERSION_Msk                  _U_(0x70FFF)                                   /**< (MATRIX_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MATRIX_PR hardware registers */
+typedef struct {  
+  __IO uint32_t MATRIX_PRAS;    /**< (MATRIX_PR Offset: 0x00) Priority Register A for Slave 0 */
+  __IO uint32_t MATRIX_PRBS;    /**< (MATRIX_PR Offset: 0x04) Priority Register B for Slave 0 */
+} MatrixPr;
+
+#define MATRIXPR_NUMBER 9
+/** \brief MATRIX hardware registers */
+typedef struct {  
+  __IO uint32_t MATRIX_MCFG[12]; /**< (MATRIX Offset: 0x00) Master Configuration Register 0 */
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
+  __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO uint32_t CCFG_CAN0;      /**< (MATRIX Offset: 0x110) CAN0 Configuration Register */
+  __IO uint32_t CCFG_SYSIO;     /**< (MATRIX Offset: 0x114) System I/O and CAN1 Configuration Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO uint32_t CCFG_SMCNFCS;   /**< (MATRIX Offset: 0x124) SMC NAND Flash Chip Select Configuration Register */
+  __I  uint8_t                        Reserved6[188];
+  __IO uint32_t MATRIX_WPMR;    /**< (MATRIX Offset: 0x1E4) Write Protection Mode Register */
+  __I  uint32_t MATRIX_WPSR;    /**< (MATRIX Offset: 0x1E8) Write Protection Status Register */
+  __I  uint8_t                        Reserved7[16];
+  __I  uint32_t MATRIX_VERSION; /**< (MATRIX Offset: 0x1FC) Version Register */
+} Matrix;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MATRIX_PR hardware registers */
+typedef struct {  
+  __IO MATRIX_PRAS_Type               MATRIX_PRAS;    /**< Offset: 0x00 (R/W  32) Priority Register A for Slave 0 */
+  __IO MATRIX_PRBS_Type               MATRIX_PRBS;    /**< Offset: 0x04 (R/W  32) Priority Register B for Slave 0 */
+} MatrixPr;
+
+/** \brief MATRIX hardware registers */
+typedef struct {  
+  __IO MATRIX_MCFG_Type               MATRIX_MCFG[12]; /**< Offset: 0x00 (R/W  32) Master Configuration Register 0 */
+  __I  uint8_t                        Reserved1[16];
+  __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
+  __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO CCFG_CAN0_Type                 CCFG_CAN0;      /**< Offset: 0x110 (R/W  32) CAN0 Configuration Register */
+  __IO CCFG_SYSIO_Type                CCFG_SYSIO;     /**< Offset: 0x114 (R/W  32) System I/O and CAN1 Configuration Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO CCFG_SMCNFCS_Type              CCFG_SMCNFCS;   /**< Offset: 0x124 (R/W  32) SMC NAND Flash Chip Select Configuration Register */
+  __I  uint8_t                        Reserved6[188];
+  __IO MATRIX_WPMR_Type               MATRIX_WPMR;    /**< Offset: 0x1E4 (R/W  32) Write Protection Mode Register */
+  __I  MATRIX_WPSR_Type               MATRIX_WPSR;    /**< Offset: 0x1E8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved7[16];
+  __I  MATRIX_VERSION_Type            MATRIX_VERSION; /**< Offset: 0x1FC (R/   32) Version Register */
+} Matrix;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of AHB Bus Matrix */
+
+#endif /* _SAMV71_MATRIX_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/mcan.h
+++ b/asf/sam/include/samv71/component/mcan.h
@@ -1,0 +1,3261 @@
+/**
+ * \file
+ *
+ * \brief Component description for MCAN
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MCAN_COMPONENT_H_
+#define _SAMV71_MCAN_COMPONENT_H_
+#define _SAMV71_MCAN_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Controller Area Network
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MCAN */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MCAN_11273                      /**< (MCAN) Module ID */
+#define REV_MCAN J                      /**< (MCAN) Module revision */
+
+/* -------- MCAN_CREL : (MCAN Offset: 0x00) (R/ 32) Core Release Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DAY:8;                     /**< bit:   0..7  Timestamp Day                            */
+    uint32_t MON:8;                     /**< bit:  8..15  Timestamp Month                          */
+    uint32_t YEAR:4;                    /**< bit: 16..19  Timestamp Year                           */
+    uint32_t SUBSTEP:4;                 /**< bit: 20..23  Sub-step of Core Release                 */
+    uint32_t STEP:4;                    /**< bit: 24..27  Step of Core Release                     */
+    uint32_t REL:4;                     /**< bit: 28..31  Core Release                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CREL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CREL_OFFSET                    (0x00)                                        /**<  (MCAN_CREL) Core Release Register  Offset */
+
+#define MCAN_CREL_DAY_Pos                   0                                              /**< (MCAN_CREL) Timestamp Day Position */
+#define MCAN_CREL_DAY_Msk                   (_U_(0xFF) << MCAN_CREL_DAY_Pos)               /**< (MCAN_CREL) Timestamp Day Mask */
+#define MCAN_CREL_DAY(value)                (MCAN_CREL_DAY_Msk & ((value) << MCAN_CREL_DAY_Pos))
+#define MCAN_CREL_MON_Pos                   8                                              /**< (MCAN_CREL) Timestamp Month Position */
+#define MCAN_CREL_MON_Msk                   (_U_(0xFF) << MCAN_CREL_MON_Pos)               /**< (MCAN_CREL) Timestamp Month Mask */
+#define MCAN_CREL_MON(value)                (MCAN_CREL_MON_Msk & ((value) << MCAN_CREL_MON_Pos))
+#define MCAN_CREL_YEAR_Pos                  16                                             /**< (MCAN_CREL) Timestamp Year Position */
+#define MCAN_CREL_YEAR_Msk                  (_U_(0xF) << MCAN_CREL_YEAR_Pos)               /**< (MCAN_CREL) Timestamp Year Mask */
+#define MCAN_CREL_YEAR(value)               (MCAN_CREL_YEAR_Msk & ((value) << MCAN_CREL_YEAR_Pos))
+#define MCAN_CREL_SUBSTEP_Pos               20                                             /**< (MCAN_CREL) Sub-step of Core Release Position */
+#define MCAN_CREL_SUBSTEP_Msk               (_U_(0xF) << MCAN_CREL_SUBSTEP_Pos)            /**< (MCAN_CREL) Sub-step of Core Release Mask */
+#define MCAN_CREL_SUBSTEP(value)            (MCAN_CREL_SUBSTEP_Msk & ((value) << MCAN_CREL_SUBSTEP_Pos))
+#define MCAN_CREL_STEP_Pos                  24                                             /**< (MCAN_CREL) Step of Core Release Position */
+#define MCAN_CREL_STEP_Msk                  (_U_(0xF) << MCAN_CREL_STEP_Pos)               /**< (MCAN_CREL) Step of Core Release Mask */
+#define MCAN_CREL_STEP(value)               (MCAN_CREL_STEP_Msk & ((value) << MCAN_CREL_STEP_Pos))
+#define MCAN_CREL_REL_Pos                   28                                             /**< (MCAN_CREL) Core Release Position */
+#define MCAN_CREL_REL_Msk                   (_U_(0xF) << MCAN_CREL_REL_Pos)                /**< (MCAN_CREL) Core Release Mask */
+#define MCAN_CREL_REL(value)                (MCAN_CREL_REL_Msk & ((value) << MCAN_CREL_REL_Pos))
+#define MCAN_CREL_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_CREL) Register MASK  (Use MCAN_CREL_Msk instead)  */
+#define MCAN_CREL_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_CREL) Register Mask  */
+
+
+/* -------- MCAN_ENDN : (MCAN Offset: 0x04) (R/ 32) Endian Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ETV:32;                    /**< bit:  0..31  Endianness Test Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ENDN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ENDN_OFFSET                    (0x04)                                        /**<  (MCAN_ENDN) Endian Register  Offset */
+
+#define MCAN_ENDN_ETV_Pos                   0                                              /**< (MCAN_ENDN) Endianness Test Value Position */
+#define MCAN_ENDN_ETV_Msk                   (_U_(0xFFFFFFFF) << MCAN_ENDN_ETV_Pos)         /**< (MCAN_ENDN) Endianness Test Value Mask */
+#define MCAN_ENDN_ETV(value)                (MCAN_ENDN_ETV_Msk & ((value) << MCAN_ENDN_ETV_Pos))
+#define MCAN_ENDN_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_ENDN) Register MASK  (Use MCAN_ENDN_Msk instead)  */
+#define MCAN_ENDN_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_ENDN) Register Mask  */
+
+
+/* -------- MCAN_CUST : (MCAN Offset: 0x08) (R/W 32) Customer Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSV:32;                    /**< bit:  0..31  Customer-specific Value                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CUST_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CUST_OFFSET                    (0x08)                                        /**<  (MCAN_CUST) Customer Register  Offset */
+
+#define MCAN_CUST_CSV_Pos                   0                                              /**< (MCAN_CUST) Customer-specific Value Position */
+#define MCAN_CUST_CSV_Msk                   (_U_(0xFFFFFFFF) << MCAN_CUST_CSV_Pos)         /**< (MCAN_CUST) Customer-specific Value Mask */
+#define MCAN_CUST_CSV(value)                (MCAN_CUST_CSV_Msk & ((value) << MCAN_CUST_CSV_Pos))
+#define MCAN_CUST_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_CUST) Register MASK  (Use MCAN_CUST_Msk instead)  */
+#define MCAN_CUST_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_CUST) Register Mask  */
+
+
+/* -------- MCAN_FBTP : (MCAN Offset: 0x0c) (R/W 32) Fast Bit Timing and Prescaler Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FSJW:2;                    /**< bit:   0..1  Fast (Re) Synchronization Jump Width     */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t FTSEG2:3;                  /**< bit:   4..6  Fast Time Segment After Sample Point     */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t FTSEG1:4;                  /**< bit:  8..11  Fast Time Segment Before Sample Point    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t FBRP:5;                    /**< bit: 16..20  Fast Baud Rate Prescaler                 */
+    uint32_t :2;                        /**< bit: 21..22  Reserved */
+    uint32_t TDC:1;                     /**< bit:     23  Transceiver Delay Compensation           */
+    uint32_t TDCO:5;                    /**< bit: 24..28  Transceiver Delay Compensation Offset    */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_FBTP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_FBTP_OFFSET                    (0x0C)                                        /**<  (MCAN_FBTP) Fast Bit Timing and Prescaler Register  Offset */
+
+#define MCAN_FBTP_FSJW_Pos                  0                                              /**< (MCAN_FBTP) Fast (Re) Synchronization Jump Width Position */
+#define MCAN_FBTP_FSJW_Msk                  (_U_(0x3) << MCAN_FBTP_FSJW_Pos)               /**< (MCAN_FBTP) Fast (Re) Synchronization Jump Width Mask */
+#define MCAN_FBTP_FSJW(value)               (MCAN_FBTP_FSJW_Msk & ((value) << MCAN_FBTP_FSJW_Pos))
+#define MCAN_FBTP_FTSEG2_Pos                4                                              /**< (MCAN_FBTP) Fast Time Segment After Sample Point Position */
+#define MCAN_FBTP_FTSEG2_Msk                (_U_(0x7) << MCAN_FBTP_FTSEG2_Pos)             /**< (MCAN_FBTP) Fast Time Segment After Sample Point Mask */
+#define MCAN_FBTP_FTSEG2(value)             (MCAN_FBTP_FTSEG2_Msk & ((value) << MCAN_FBTP_FTSEG2_Pos))
+#define MCAN_FBTP_FTSEG1_Pos                8                                              /**< (MCAN_FBTP) Fast Time Segment Before Sample Point Position */
+#define MCAN_FBTP_FTSEG1_Msk                (_U_(0xF) << MCAN_FBTP_FTSEG1_Pos)             /**< (MCAN_FBTP) Fast Time Segment Before Sample Point Mask */
+#define MCAN_FBTP_FTSEG1(value)             (MCAN_FBTP_FTSEG1_Msk & ((value) << MCAN_FBTP_FTSEG1_Pos))
+#define MCAN_FBTP_FBRP_Pos                  16                                             /**< (MCAN_FBTP) Fast Baud Rate Prescaler Position */
+#define MCAN_FBTP_FBRP_Msk                  (_U_(0x1F) << MCAN_FBTP_FBRP_Pos)              /**< (MCAN_FBTP) Fast Baud Rate Prescaler Mask */
+#define MCAN_FBTP_FBRP(value)               (MCAN_FBTP_FBRP_Msk & ((value) << MCAN_FBTP_FBRP_Pos))
+#define MCAN_FBTP_TDC_Pos                   23                                             /**< (MCAN_FBTP) Transceiver Delay Compensation Position */
+#define MCAN_FBTP_TDC_Msk                   (_U_(0x1) << MCAN_FBTP_TDC_Pos)                /**< (MCAN_FBTP) Transceiver Delay Compensation Mask */
+#define MCAN_FBTP_TDC                       MCAN_FBTP_TDC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_FBTP_TDC_Msk instead */
+#define   MCAN_FBTP_TDC_DISABLED_Val        _U_(0x0)                                       /**< (MCAN_FBTP) Transceiver Delay Compensation disabled.  */
+#define   MCAN_FBTP_TDC_ENABLED_Val         _U_(0x1)                                       /**< (MCAN_FBTP) Transceiver Delay Compensation enabled.  */
+#define MCAN_FBTP_TDC_DISABLED              (MCAN_FBTP_TDC_DISABLED_Val << MCAN_FBTP_TDC_Pos)  /**< (MCAN_FBTP) Transceiver Delay Compensation disabled. Position  */
+#define MCAN_FBTP_TDC_ENABLED               (MCAN_FBTP_TDC_ENABLED_Val << MCAN_FBTP_TDC_Pos)  /**< (MCAN_FBTP) Transceiver Delay Compensation enabled. Position  */
+#define MCAN_FBTP_TDCO_Pos                  24                                             /**< (MCAN_FBTP) Transceiver Delay Compensation Offset Position */
+#define MCAN_FBTP_TDCO_Msk                  (_U_(0x1F) << MCAN_FBTP_TDCO_Pos)              /**< (MCAN_FBTP) Transceiver Delay Compensation Offset Mask */
+#define MCAN_FBTP_TDCO(value)               (MCAN_FBTP_TDCO_Msk & ((value) << MCAN_FBTP_TDCO_Pos))
+#define MCAN_FBTP_MASK                      _U_(0x1F9F0F73)                                /**< \deprecated (MCAN_FBTP) Register MASK  (Use MCAN_FBTP_Msk instead)  */
+#define MCAN_FBTP_Msk                       _U_(0x1F9F0F73)                                /**< (MCAN_FBTP) Register Mask  */
+
+
+/* -------- MCAN_TEST : (MCAN Offset: 0x10) (R/W 32) Test Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t LBCK:1;                    /**< bit:      4  Loop Back Mode (read/write)              */
+    uint32_t TX:2;                      /**< bit:   5..6  Control of Transmit Pin (read/write)     */
+    uint32_t RX:1;                      /**< bit:      7  Receive Pin (read-only)                  */
+    uint32_t TDCV:6;                    /**< bit:  8..13  Transceiver Delay Compensation Value (read-only) */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TEST_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TEST_OFFSET                    (0x10)                                        /**<  (MCAN_TEST) Test Register  Offset */
+
+#define MCAN_TEST_LBCK_Pos                  4                                              /**< (MCAN_TEST) Loop Back Mode (read/write) Position */
+#define MCAN_TEST_LBCK_Msk                  (_U_(0x1) << MCAN_TEST_LBCK_Pos)               /**< (MCAN_TEST) Loop Back Mode (read/write) Mask */
+#define MCAN_TEST_LBCK                      MCAN_TEST_LBCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TEST_LBCK_Msk instead */
+#define   MCAN_TEST_LBCK_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_TEST) Reset value. Loop Back mode is disabled.  */
+#define   MCAN_TEST_LBCK_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_TEST) Loop Back mode is enabled (see Section 6.1.9).  */
+#define MCAN_TEST_LBCK_DISABLED             (MCAN_TEST_LBCK_DISABLED_Val << MCAN_TEST_LBCK_Pos)  /**< (MCAN_TEST) Reset value. Loop Back mode is disabled. Position  */
+#define MCAN_TEST_LBCK_ENABLED              (MCAN_TEST_LBCK_ENABLED_Val << MCAN_TEST_LBCK_Pos)  /**< (MCAN_TEST) Loop Back mode is enabled (see Section 6.1.9). Position  */
+#define MCAN_TEST_TX_Pos                    5                                              /**< (MCAN_TEST) Control of Transmit Pin (read/write) Position */
+#define MCAN_TEST_TX_Msk                    (_U_(0x3) << MCAN_TEST_TX_Pos)                 /**< (MCAN_TEST) Control of Transmit Pin (read/write) Mask */
+#define MCAN_TEST_TX(value)                 (MCAN_TEST_TX_Msk & ((value) << MCAN_TEST_TX_Pos))
+#define   MCAN_TEST_TX_RESET_Val            _U_(0x0)                                       /**< (MCAN_TEST) Reset value, CANTX controlled by the CAN Core, updated at the end of the CAN bit time.  */
+#define   MCAN_TEST_TX_SAMPLE_POINT_MONITORING_Val _U_(0x1)                                       /**< (MCAN_TEST) Sample Point can be monitored at pin CANTX.  */
+#define   MCAN_TEST_TX_DOMINANT_Val         _U_(0x2)                                       /**< (MCAN_TEST) Dominant ('0') level at pin CANTX.  */
+#define   MCAN_TEST_TX_RECESSIVE_Val        _U_(0x3)                                       /**< (MCAN_TEST) Recessive ('1') at pin CANTX.  */
+#define MCAN_TEST_TX_RESET                  (MCAN_TEST_TX_RESET_Val << MCAN_TEST_TX_Pos)   /**< (MCAN_TEST) Reset value, CANTX controlled by the CAN Core, updated at the end of the CAN bit time. Position  */
+#define MCAN_TEST_TX_SAMPLE_POINT_MONITORING (MCAN_TEST_TX_SAMPLE_POINT_MONITORING_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Sample Point can be monitored at pin CANTX. Position  */
+#define MCAN_TEST_TX_DOMINANT               (MCAN_TEST_TX_DOMINANT_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Dominant ('0') level at pin CANTX. Position  */
+#define MCAN_TEST_TX_RECESSIVE              (MCAN_TEST_TX_RECESSIVE_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Recessive ('1') at pin CANTX. Position  */
+#define MCAN_TEST_RX_Pos                    7                                              /**< (MCAN_TEST) Receive Pin (read-only) Position */
+#define MCAN_TEST_RX_Msk                    (_U_(0x1) << MCAN_TEST_RX_Pos)                 /**< (MCAN_TEST) Receive Pin (read-only) Mask */
+#define MCAN_TEST_RX                        MCAN_TEST_RX_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TEST_RX_Msk instead */
+#define MCAN_TEST_TDCV_Pos                  8                                              /**< (MCAN_TEST) Transceiver Delay Compensation Value (read-only) Position */
+#define MCAN_TEST_TDCV_Msk                  (_U_(0x3F) << MCAN_TEST_TDCV_Pos)              /**< (MCAN_TEST) Transceiver Delay Compensation Value (read-only) Mask */
+#define MCAN_TEST_TDCV(value)               (MCAN_TEST_TDCV_Msk & ((value) << MCAN_TEST_TDCV_Pos))
+#define MCAN_TEST_MASK                      _U_(0x3FF0)                                    /**< \deprecated (MCAN_TEST) Register MASK  (Use MCAN_TEST_Msk instead)  */
+#define MCAN_TEST_Msk                       _U_(0x3FF0)                                    /**< (MCAN_TEST) Register Mask  */
+
+
+/* -------- MCAN_RWD : (MCAN Offset: 0x14) (R/W 32) RAM Watchdog Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDC:8;                     /**< bit:   0..7  Watchdog Configuration (read/write)      */
+    uint32_t WDV:8;                     /**< bit:  8..15  Watchdog Value (read-only)               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RWD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RWD_OFFSET                     (0x14)                                        /**<  (MCAN_RWD) RAM Watchdog Register  Offset */
+
+#define MCAN_RWD_WDC_Pos                    0                                              /**< (MCAN_RWD) Watchdog Configuration (read/write) Position */
+#define MCAN_RWD_WDC_Msk                    (_U_(0xFF) << MCAN_RWD_WDC_Pos)                /**< (MCAN_RWD) Watchdog Configuration (read/write) Mask */
+#define MCAN_RWD_WDC(value)                 (MCAN_RWD_WDC_Msk & ((value) << MCAN_RWD_WDC_Pos))
+#define MCAN_RWD_WDV_Pos                    8                                              /**< (MCAN_RWD) Watchdog Value (read-only) Position */
+#define MCAN_RWD_WDV_Msk                    (_U_(0xFF) << MCAN_RWD_WDV_Pos)                /**< (MCAN_RWD) Watchdog Value (read-only) Mask */
+#define MCAN_RWD_WDV(value)                 (MCAN_RWD_WDV_Msk & ((value) << MCAN_RWD_WDV_Pos))
+#define MCAN_RWD_MASK                       _U_(0xFFFF)                                    /**< \deprecated (MCAN_RWD) Register MASK  (Use MCAN_RWD_Msk instead)  */
+#define MCAN_RWD_Msk                        _U_(0xFFFF)                                    /**< (MCAN_RWD) Register Mask  */
+
+
+/* -------- MCAN_CCCR : (MCAN Offset: 0x18) (R/W 32) CC Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INIT:1;                    /**< bit:      0  Initialization (read/write)              */
+    uint32_t CCE:1;                     /**< bit:      1  Configuration Change Enable (read/write, write protection) */
+    uint32_t ASM:1;                     /**< bit:      2  Restricted Operation Mode (read/write, write protection against '1') */
+    uint32_t CSA:1;                     /**< bit:      3  Clock Stop Acknowledge (read-only)       */
+    uint32_t CSR:1;                     /**< bit:      4  Clock Stop Request (read/write)          */
+    uint32_t MON:1;                     /**< bit:      5  Bus Monitoring Mode (read/write, write protection against '1') */
+    uint32_t DAR:1;                     /**< bit:      6  Disable Automatic Retransmission (read/write, write protection) */
+    uint32_t TEST:1;                    /**< bit:      7  Test Mode Enable (read/write, write protection against '1') */
+    uint32_t CME:2;                     /**< bit:   8..9  CAN Mode Enable (read/write, write protection) */
+    uint32_t CMR:2;                     /**< bit: 10..11  CAN Mode Request (read/write)            */
+    uint32_t FDO:1;                     /**< bit:     12  CAN FD Operation (read-only)             */
+    uint32_t FDBS:1;                    /**< bit:     13  CAN FD Bit Rate Switching (read-only)    */
+    uint32_t TXP:1;                     /**< bit:     14  Transmit Pause (read/write, write protection) */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CCCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CCCR_OFFSET                    (0x18)                                        /**<  (MCAN_CCCR) CC Control Register  Offset */
+
+#define MCAN_CCCR_INIT_Pos                  0                                              /**< (MCAN_CCCR) Initialization (read/write) Position */
+#define MCAN_CCCR_INIT_Msk                  (_U_(0x1) << MCAN_CCCR_INIT_Pos)               /**< (MCAN_CCCR) Initialization (read/write) Mask */
+#define MCAN_CCCR_INIT                      MCAN_CCCR_INIT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_INIT_Msk instead */
+#define   MCAN_CCCR_INIT_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Normal operation.  */
+#define   MCAN_CCCR_INIT_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) Initialization is started.  */
+#define MCAN_CCCR_INIT_DISABLED             (MCAN_CCCR_INIT_DISABLED_Val << MCAN_CCCR_INIT_Pos)  /**< (MCAN_CCCR) Normal operation. Position  */
+#define MCAN_CCCR_INIT_ENABLED              (MCAN_CCCR_INIT_ENABLED_Val << MCAN_CCCR_INIT_Pos)  /**< (MCAN_CCCR) Initialization is started. Position  */
+#define MCAN_CCCR_CCE_Pos                   1                                              /**< (MCAN_CCCR) Configuration Change Enable (read/write, write protection) Position */
+#define MCAN_CCCR_CCE_Msk                   (_U_(0x1) << MCAN_CCCR_CCE_Pos)                /**< (MCAN_CCCR) Configuration Change Enable (read/write, write protection) Mask */
+#define MCAN_CCCR_CCE                       MCAN_CCCR_CCE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CCE_Msk instead */
+#define   MCAN_CCCR_CCE_PROTECTED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) The processor has no write access to the protected configuration registers.  */
+#define   MCAN_CCCR_CCE_CONFIGURABLE_Val    _U_(0x1)                                       /**< (MCAN_CCCR) The processor has write access to the protected configuration registers (while MCAN_CCCR.INIT = '1').  */
+#define MCAN_CCCR_CCE_PROTECTED             (MCAN_CCCR_CCE_PROTECTED_Val << MCAN_CCCR_CCE_Pos)  /**< (MCAN_CCCR) The processor has no write access to the protected configuration registers. Position  */
+#define MCAN_CCCR_CCE_CONFIGURABLE          (MCAN_CCCR_CCE_CONFIGURABLE_Val << MCAN_CCCR_CCE_Pos)  /**< (MCAN_CCCR) The processor has write access to the protected configuration registers (while MCAN_CCCR.INIT = '1'). Position  */
+#define MCAN_CCCR_ASM_Pos                   2                                              /**< (MCAN_CCCR) Restricted Operation Mode (read/write, write protection against '1') Position */
+#define MCAN_CCCR_ASM_Msk                   (_U_(0x1) << MCAN_CCCR_ASM_Pos)                /**< (MCAN_CCCR) Restricted Operation Mode (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_ASM                       MCAN_CCCR_ASM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_ASM_Msk instead */
+#define   MCAN_CCCR_ASM_NORMAL_Val          _U_(0x0)                                       /**< (MCAN_CCCR) Normal CAN operation.  */
+#define   MCAN_CCCR_ASM_RESTRICTED_Val      _U_(0x1)                                       /**< (MCAN_CCCR) Restricted operation mode active.  */
+#define MCAN_CCCR_ASM_NORMAL                (MCAN_CCCR_ASM_NORMAL_Val << MCAN_CCCR_ASM_Pos)  /**< (MCAN_CCCR) Normal CAN operation. Position  */
+#define MCAN_CCCR_ASM_RESTRICTED            (MCAN_CCCR_ASM_RESTRICTED_Val << MCAN_CCCR_ASM_Pos)  /**< (MCAN_CCCR) Restricted operation mode active. Position  */
+#define MCAN_CCCR_CSA_Pos                   3                                              /**< (MCAN_CCCR) Clock Stop Acknowledge (read-only) Position */
+#define MCAN_CCCR_CSA_Msk                   (_U_(0x1) << MCAN_CCCR_CSA_Pos)                /**< (MCAN_CCCR) Clock Stop Acknowledge (read-only) Mask */
+#define MCAN_CCCR_CSA                       MCAN_CCCR_CSA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CSA_Msk instead */
+#define MCAN_CCCR_CSR_Pos                   4                                              /**< (MCAN_CCCR) Clock Stop Request (read/write) Position */
+#define MCAN_CCCR_CSR_Msk                   (_U_(0x1) << MCAN_CCCR_CSR_Pos)                /**< (MCAN_CCCR) Clock Stop Request (read/write) Mask */
+#define MCAN_CCCR_CSR                       MCAN_CCCR_CSR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CSR_Msk instead */
+#define   MCAN_CCCR_CSR_NO_CLOCK_STOP_Val   _U_(0x0)                                       /**< (MCAN_CCCR) No clock stop is requested.  */
+#define   MCAN_CCCR_CSR_CLOCK_STOP_Val      _U_(0x1)                                       /**< (MCAN_CCCR) Clock stop requested. When clock stop is requested, first INIT and then CSA will be set after all pend-ing transfer requests have been completed and the CAN bus reached idle.  */
+#define MCAN_CCCR_CSR_NO_CLOCK_STOP         (MCAN_CCCR_CSR_NO_CLOCK_STOP_Val << MCAN_CCCR_CSR_Pos)  /**< (MCAN_CCCR) No clock stop is requested. Position  */
+#define MCAN_CCCR_CSR_CLOCK_STOP            (MCAN_CCCR_CSR_CLOCK_STOP_Val << MCAN_CCCR_CSR_Pos)  /**< (MCAN_CCCR) Clock stop requested. When clock stop is requested, first INIT and then CSA will be set after all pend-ing transfer requests have been completed and the CAN bus reached idle. Position  */
+#define MCAN_CCCR_MON_Pos                   5                                              /**< (MCAN_CCCR) Bus Monitoring Mode (read/write, write protection against '1') Position */
+#define MCAN_CCCR_MON_Msk                   (_U_(0x1) << MCAN_CCCR_MON_Pos)                /**< (MCAN_CCCR) Bus Monitoring Mode (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_MON                       MCAN_CCCR_MON_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_MON_Msk instead */
+#define   MCAN_CCCR_MON_DISABLED_Val        _U_(0x0)                                       /**< (MCAN_CCCR) Bus Monitoring mode is disabled.  */
+#define   MCAN_CCCR_MON_ENABLED_Val         _U_(0x1)                                       /**< (MCAN_CCCR) Bus Monitoring mode is enabled.  */
+#define MCAN_CCCR_MON_DISABLED              (MCAN_CCCR_MON_DISABLED_Val << MCAN_CCCR_MON_Pos)  /**< (MCAN_CCCR) Bus Monitoring mode is disabled. Position  */
+#define MCAN_CCCR_MON_ENABLED               (MCAN_CCCR_MON_ENABLED_Val << MCAN_CCCR_MON_Pos)  /**< (MCAN_CCCR) Bus Monitoring mode is enabled. Position  */
+#define MCAN_CCCR_DAR_Pos                   6                                              /**< (MCAN_CCCR) Disable Automatic Retransmission (read/write, write protection) Position */
+#define MCAN_CCCR_DAR_Msk                   (_U_(0x1) << MCAN_CCCR_DAR_Pos)                /**< (MCAN_CCCR) Disable Automatic Retransmission (read/write, write protection) Mask */
+#define MCAN_CCCR_DAR                       MCAN_CCCR_DAR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_DAR_Msk instead */
+#define   MCAN_CCCR_DAR_AUTO_RETX_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Automatic retransmission of messages not transmitted successfully enabled.  */
+#define   MCAN_CCCR_DAR_NO_AUTO_RETX_Val    _U_(0x1)                                       /**< (MCAN_CCCR) Automatic retransmission disabled.  */
+#define MCAN_CCCR_DAR_AUTO_RETX             (MCAN_CCCR_DAR_AUTO_RETX_Val << MCAN_CCCR_DAR_Pos)  /**< (MCAN_CCCR) Automatic retransmission of messages not transmitted successfully enabled. Position  */
+#define MCAN_CCCR_DAR_NO_AUTO_RETX          (MCAN_CCCR_DAR_NO_AUTO_RETX_Val << MCAN_CCCR_DAR_Pos)  /**< (MCAN_CCCR) Automatic retransmission disabled. Position  */
+#define MCAN_CCCR_TEST_Pos                  7                                              /**< (MCAN_CCCR) Test Mode Enable (read/write, write protection against '1') Position */
+#define MCAN_CCCR_TEST_Msk                  (_U_(0x1) << MCAN_CCCR_TEST_Pos)               /**< (MCAN_CCCR) Test Mode Enable (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_TEST                      MCAN_CCCR_TEST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_TEST_Msk instead */
+#define   MCAN_CCCR_TEST_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Normal operation, MCAN_TEST register holds reset values.  */
+#define   MCAN_CCCR_TEST_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) Test mode, write access to MCAN_TEST register enabled.  */
+#define MCAN_CCCR_TEST_DISABLED             (MCAN_CCCR_TEST_DISABLED_Val << MCAN_CCCR_TEST_Pos)  /**< (MCAN_CCCR) Normal operation, MCAN_TEST register holds reset values. Position  */
+#define MCAN_CCCR_TEST_ENABLED              (MCAN_CCCR_TEST_ENABLED_Val << MCAN_CCCR_TEST_Pos)  /**< (MCAN_CCCR) Test mode, write access to MCAN_TEST register enabled. Position  */
+#define MCAN_CCCR_CME_Pos                   8                                              /**< (MCAN_CCCR) CAN Mode Enable (read/write, write protection) Position */
+#define MCAN_CCCR_CME_Msk                   (_U_(0x3) << MCAN_CCCR_CME_Pos)                /**< (MCAN_CCCR) CAN Mode Enable (read/write, write protection) Mask */
+#define MCAN_CCCR_CME(value)                (MCAN_CCCR_CME_Msk & ((value) << MCAN_CCCR_CME_Pos))
+#define   MCAN_CCCR_CME_ISO11898_1_Val      _U_(0x0)                                       /**< (MCAN_CCCR) CAN operation according to ISO11898-1 enabled  */
+#define   MCAN_CCCR_CME_FD_Val              _U_(0x1)                                       /**< (MCAN_CCCR) CAN FD operation enabled  */
+#define MCAN_CCCR_CME_ISO11898_1            (MCAN_CCCR_CME_ISO11898_1_Val << MCAN_CCCR_CME_Pos)  /**< (MCAN_CCCR) CAN operation according to ISO11898-1 enabled Position  */
+#define MCAN_CCCR_CME_FD                    (MCAN_CCCR_CME_FD_Val << MCAN_CCCR_CME_Pos)    /**< (MCAN_CCCR) CAN FD operation enabled Position  */
+#define MCAN_CCCR_CMR_Pos                   10                                             /**< (MCAN_CCCR) CAN Mode Request (read/write) Position */
+#define MCAN_CCCR_CMR_Msk                   (_U_(0x3) << MCAN_CCCR_CMR_Pos)                /**< (MCAN_CCCR) CAN Mode Request (read/write) Mask */
+#define MCAN_CCCR_CMR(value)                (MCAN_CCCR_CMR_Msk & ((value) << MCAN_CCCR_CMR_Pos))
+#define   MCAN_CCCR_CMR_NO_CHANGE_Val       _U_(0x0)                                       /**< (MCAN_CCCR) No mode change  */
+#define   MCAN_CCCR_CMR_FD_Val              _U_(0x1)                                       /**< (MCAN_CCCR) Request CAN FD operation  */
+#define   MCAN_CCCR_CMR_FD_BITRATE_SWITCH_Val _U_(0x2)                                       /**< (MCAN_CCCR) Request CAN FD operation with bit rate switching  */
+#define   MCAN_CCCR_CMR_ISO11898_1_Val      _U_(0x3)                                       /**< (MCAN_CCCR) Request CAN operation according ISO11898-1  */
+#define MCAN_CCCR_CMR_NO_CHANGE             (MCAN_CCCR_CMR_NO_CHANGE_Val << MCAN_CCCR_CMR_Pos)  /**< (MCAN_CCCR) No mode change Position  */
+#define MCAN_CCCR_CMR_FD                    (MCAN_CCCR_CMR_FD_Val << MCAN_CCCR_CMR_Pos)    /**< (MCAN_CCCR) Request CAN FD operation Position  */
+#define MCAN_CCCR_CMR_FD_BITRATE_SWITCH     (MCAN_CCCR_CMR_FD_BITRATE_SWITCH_Val << MCAN_CCCR_CMR_Pos)  /**< (MCAN_CCCR) Request CAN FD operation with bit rate switching Position  */
+#define MCAN_CCCR_CMR_ISO11898_1            (MCAN_CCCR_CMR_ISO11898_1_Val << MCAN_CCCR_CMR_Pos)  /**< (MCAN_CCCR) Request CAN operation according ISO11898-1 Position  */
+#define MCAN_CCCR_FDO_Pos                   12                                             /**< (MCAN_CCCR) CAN FD Operation (read-only) Position */
+#define MCAN_CCCR_FDO_Msk                   (_U_(0x1) << MCAN_CCCR_FDO_Pos)                /**< (MCAN_CCCR) CAN FD Operation (read-only) Mask */
+#define MCAN_CCCR_FDO                       MCAN_CCCR_FDO_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_FDO_Msk instead */
+#define MCAN_CCCR_FDBS_Pos                  13                                             /**< (MCAN_CCCR) CAN FD Bit Rate Switching (read-only) Position */
+#define MCAN_CCCR_FDBS_Msk                  (_U_(0x1) << MCAN_CCCR_FDBS_Pos)               /**< (MCAN_CCCR) CAN FD Bit Rate Switching (read-only) Mask */
+#define MCAN_CCCR_FDBS                      MCAN_CCCR_FDBS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_FDBS_Msk instead */
+#define MCAN_CCCR_TXP_Pos                   14                                             /**< (MCAN_CCCR) Transmit Pause (read/write, write protection) Position */
+#define MCAN_CCCR_TXP_Msk                   (_U_(0x1) << MCAN_CCCR_TXP_Pos)                /**< (MCAN_CCCR) Transmit Pause (read/write, write protection) Mask */
+#define MCAN_CCCR_TXP                       MCAN_CCCR_TXP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_TXP_Msk instead */
+#define MCAN_CCCR_MASK                      _U_(0x7FFF)                                    /**< \deprecated (MCAN_CCCR) Register MASK  (Use MCAN_CCCR_Msk instead)  */
+#define MCAN_CCCR_Msk                       _U_(0x7FFF)                                    /**< (MCAN_CCCR) Register Mask  */
+
+
+/* -------- MCAN_BTP : (MCAN Offset: 0x1c) (R/W 32) Bit Timing and Prescaler Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SJW:4;                     /**< bit:   0..3  (Re) Synchronization Jump Width          */
+    uint32_t TSEG2:4;                   /**< bit:   4..7  Time Segment After Sample Point          */
+    uint32_t TSEG1:6;                   /**< bit:  8..13  Time Segment Before Sample Point         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t BRP:10;                    /**< bit: 16..25  Baud Rate Prescaler                      */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_BTP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_BTP_OFFSET                     (0x1C)                                        /**<  (MCAN_BTP) Bit Timing and Prescaler Register  Offset */
+
+#define MCAN_BTP_SJW_Pos                    0                                              /**< (MCAN_BTP) (Re) Synchronization Jump Width Position */
+#define MCAN_BTP_SJW_Msk                    (_U_(0xF) << MCAN_BTP_SJW_Pos)                 /**< (MCAN_BTP) (Re) Synchronization Jump Width Mask */
+#define MCAN_BTP_SJW(value)                 (MCAN_BTP_SJW_Msk & ((value) << MCAN_BTP_SJW_Pos))
+#define MCAN_BTP_TSEG2_Pos                  4                                              /**< (MCAN_BTP) Time Segment After Sample Point Position */
+#define MCAN_BTP_TSEG2_Msk                  (_U_(0xF) << MCAN_BTP_TSEG2_Pos)               /**< (MCAN_BTP) Time Segment After Sample Point Mask */
+#define MCAN_BTP_TSEG2(value)               (MCAN_BTP_TSEG2_Msk & ((value) << MCAN_BTP_TSEG2_Pos))
+#define MCAN_BTP_TSEG1_Pos                  8                                              /**< (MCAN_BTP) Time Segment Before Sample Point Position */
+#define MCAN_BTP_TSEG1_Msk                  (_U_(0x3F) << MCAN_BTP_TSEG1_Pos)              /**< (MCAN_BTP) Time Segment Before Sample Point Mask */
+#define MCAN_BTP_TSEG1(value)               (MCAN_BTP_TSEG1_Msk & ((value) << MCAN_BTP_TSEG1_Pos))
+#define MCAN_BTP_BRP_Pos                    16                                             /**< (MCAN_BTP) Baud Rate Prescaler Position */
+#define MCAN_BTP_BRP_Msk                    (_U_(0x3FF) << MCAN_BTP_BRP_Pos)               /**< (MCAN_BTP) Baud Rate Prescaler Mask */
+#define MCAN_BTP_BRP(value)                 (MCAN_BTP_BRP_Msk & ((value) << MCAN_BTP_BRP_Pos))
+#define MCAN_BTP_MASK                       _U_(0x3FF3FFF)                                 /**< \deprecated (MCAN_BTP) Register MASK  (Use MCAN_BTP_Msk instead)  */
+#define MCAN_BTP_Msk                        _U_(0x3FF3FFF)                                 /**< (MCAN_BTP) Register Mask  */
+
+
+/* -------- MCAN_TSCC : (MCAN Offset: 0x20) (R/W 32) Timestamp Counter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSS:2;                     /**< bit:   0..1  Timestamp Select                         */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t TCP:4;                     /**< bit: 16..19  Timestamp Counter Prescaler              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TSCC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TSCC_OFFSET                    (0x20)                                        /**<  (MCAN_TSCC) Timestamp Counter Configuration Register  Offset */
+
+#define MCAN_TSCC_TSS_Pos                   0                                              /**< (MCAN_TSCC) Timestamp Select Position */
+#define MCAN_TSCC_TSS_Msk                   (_U_(0x3) << MCAN_TSCC_TSS_Pos)                /**< (MCAN_TSCC) Timestamp Select Mask */
+#define MCAN_TSCC_TSS(value)                (MCAN_TSCC_TSS_Msk & ((value) << MCAN_TSCC_TSS_Pos))
+#define   MCAN_TSCC_TSS_ALWAYS_0_Val        _U_(0x0)                                       /**< (MCAN_TSCC) Timestamp counter value always 0x0000  */
+#define   MCAN_TSCC_TSS_TCP_INC_Val         _U_(0x1)                                       /**< (MCAN_TSCC) Timestamp counter value incremented according to TCP  */
+#define   MCAN_TSCC_TSS_EXT_TIMESTAMP_Val   _U_(0x2)                                       /**< (MCAN_TSCC) External timestamp counter value used  */
+#define MCAN_TSCC_TSS_ALWAYS_0              (MCAN_TSCC_TSS_ALWAYS_0_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) Timestamp counter value always 0x0000 Position  */
+#define MCAN_TSCC_TSS_TCP_INC               (MCAN_TSCC_TSS_TCP_INC_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) Timestamp counter value incremented according to TCP Position  */
+#define MCAN_TSCC_TSS_EXT_TIMESTAMP         (MCAN_TSCC_TSS_EXT_TIMESTAMP_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) External timestamp counter value used Position  */
+#define MCAN_TSCC_TCP_Pos                   16                                             /**< (MCAN_TSCC) Timestamp Counter Prescaler Position */
+#define MCAN_TSCC_TCP_Msk                   (_U_(0xF) << MCAN_TSCC_TCP_Pos)                /**< (MCAN_TSCC) Timestamp Counter Prescaler Mask */
+#define MCAN_TSCC_TCP(value)                (MCAN_TSCC_TCP_Msk & ((value) << MCAN_TSCC_TCP_Pos))
+#define MCAN_TSCC_MASK                      _U_(0xF0003)                                   /**< \deprecated (MCAN_TSCC) Register MASK  (Use MCAN_TSCC_Msk instead)  */
+#define MCAN_TSCC_Msk                       _U_(0xF0003)                                   /**< (MCAN_TSCC) Register Mask  */
+
+
+/* -------- MCAN_TSCV : (MCAN Offset: 0x24) (R/W 32) Timestamp Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSC:16;                    /**< bit:  0..15  Timestamp Counter (cleared on write)     */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TSCV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TSCV_OFFSET                    (0x24)                                        /**<  (MCAN_TSCV) Timestamp Counter Value Register  Offset */
+
+#define MCAN_TSCV_TSC_Pos                   0                                              /**< (MCAN_TSCV) Timestamp Counter (cleared on write) Position */
+#define MCAN_TSCV_TSC_Msk                   (_U_(0xFFFF) << MCAN_TSCV_TSC_Pos)             /**< (MCAN_TSCV) Timestamp Counter (cleared on write) Mask */
+#define MCAN_TSCV_TSC(value)                (MCAN_TSCV_TSC_Msk & ((value) << MCAN_TSCV_TSC_Pos))
+#define MCAN_TSCV_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_TSCV) Register MASK  (Use MCAN_TSCV_Msk instead)  */
+#define MCAN_TSCV_Msk                       _U_(0xFFFF)                                    /**< (MCAN_TSCV) Register Mask  */
+
+
+/* -------- MCAN_TOCC : (MCAN Offset: 0x28) (R/W 32) Timeout Counter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ETOC:1;                    /**< bit:      0  Enable Timeout Counter                   */
+    uint32_t TOS:2;                     /**< bit:   1..2  Timeout Select                           */
+    uint32_t :13;                       /**< bit:  3..15  Reserved */
+    uint32_t TOP:16;                    /**< bit: 16..31  Timeout Period                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TOCC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TOCC_OFFSET                    (0x28)                                        /**<  (MCAN_TOCC) Timeout Counter Configuration Register  Offset */
+
+#define MCAN_TOCC_ETOC_Pos                  0                                              /**< (MCAN_TOCC) Enable Timeout Counter Position */
+#define MCAN_TOCC_ETOC_Msk                  (_U_(0x1) << MCAN_TOCC_ETOC_Pos)               /**< (MCAN_TOCC) Enable Timeout Counter Mask */
+#define MCAN_TOCC_ETOC                      MCAN_TOCC_ETOC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TOCC_ETOC_Msk instead */
+#define   MCAN_TOCC_ETOC_NO_TIMEOUT_Val     _U_(0x0)                                       /**< (MCAN_TOCC) Timeout Counter disabled.  */
+#define   MCAN_TOCC_ETOC_TOS_CONTROLLED_Val _U_(0x1)                                       /**< (MCAN_TOCC) Timeout Counter enabled.  */
+#define MCAN_TOCC_ETOC_NO_TIMEOUT           (MCAN_TOCC_ETOC_NO_TIMEOUT_Val << MCAN_TOCC_ETOC_Pos)  /**< (MCAN_TOCC) Timeout Counter disabled. Position  */
+#define MCAN_TOCC_ETOC_TOS_CONTROLLED       (MCAN_TOCC_ETOC_TOS_CONTROLLED_Val << MCAN_TOCC_ETOC_Pos)  /**< (MCAN_TOCC) Timeout Counter enabled. Position  */
+#define MCAN_TOCC_TOS_Pos                   1                                              /**< (MCAN_TOCC) Timeout Select Position */
+#define MCAN_TOCC_TOS_Msk                   (_U_(0x3) << MCAN_TOCC_TOS_Pos)                /**< (MCAN_TOCC) Timeout Select Mask */
+#define MCAN_TOCC_TOS(value)                (MCAN_TOCC_TOS_Msk & ((value) << MCAN_TOCC_TOS_Pos))
+#define   MCAN_TOCC_TOS_CONTINUOUS_Val      _U_(0x0)                                       /**< (MCAN_TOCC) Continuous operation  */
+#define   MCAN_TOCC_TOS_TX_EV_TIMEOUT_Val   _U_(0x1)                                       /**< (MCAN_TOCC) Timeout controlled by Tx Event FIFO  */
+#define   MCAN_TOCC_TOS_RX0_EV_TIMEOUT_Val  _U_(0x2)                                       /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 0  */
+#define   MCAN_TOCC_TOS_RX1_EV_TIMEOUT_Val  _U_(0x3)                                       /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 1  */
+#define MCAN_TOCC_TOS_CONTINUOUS            (MCAN_TOCC_TOS_CONTINUOUS_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Continuous operation Position  */
+#define MCAN_TOCC_TOS_TX_EV_TIMEOUT         (MCAN_TOCC_TOS_TX_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Tx Event FIFO Position  */
+#define MCAN_TOCC_TOS_RX0_EV_TIMEOUT        (MCAN_TOCC_TOS_RX0_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 0 Position  */
+#define MCAN_TOCC_TOS_RX1_EV_TIMEOUT        (MCAN_TOCC_TOS_RX1_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 1 Position  */
+#define MCAN_TOCC_TOP_Pos                   16                                             /**< (MCAN_TOCC) Timeout Period Position */
+#define MCAN_TOCC_TOP_Msk                   (_U_(0xFFFF) << MCAN_TOCC_TOP_Pos)             /**< (MCAN_TOCC) Timeout Period Mask */
+#define MCAN_TOCC_TOP(value)                (MCAN_TOCC_TOP_Msk & ((value) << MCAN_TOCC_TOP_Pos))
+#define MCAN_TOCC_MASK                      _U_(0xFFFF0007)                                /**< \deprecated (MCAN_TOCC) Register MASK  (Use MCAN_TOCC_Msk instead)  */
+#define MCAN_TOCC_Msk                       _U_(0xFFFF0007)                                /**< (MCAN_TOCC) Register Mask  */
+
+
+/* -------- MCAN_TOCV : (MCAN Offset: 0x2c) (R/W 32) Timeout Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TOC:16;                    /**< bit:  0..15  Timeout Counter (cleared on write)       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TOCV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TOCV_OFFSET                    (0x2C)                                        /**<  (MCAN_TOCV) Timeout Counter Value Register  Offset */
+
+#define MCAN_TOCV_TOC_Pos                   0                                              /**< (MCAN_TOCV) Timeout Counter (cleared on write) Position */
+#define MCAN_TOCV_TOC_Msk                   (_U_(0xFFFF) << MCAN_TOCV_TOC_Pos)             /**< (MCAN_TOCV) Timeout Counter (cleared on write) Mask */
+#define MCAN_TOCV_TOC(value)                (MCAN_TOCV_TOC_Msk & ((value) << MCAN_TOCV_TOC_Pos))
+#define MCAN_TOCV_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_TOCV) Register MASK  (Use MCAN_TOCV_Msk instead)  */
+#define MCAN_TOCV_Msk                       _U_(0xFFFF)                                    /**< (MCAN_TOCV) Register Mask  */
+
+
+/* -------- MCAN_ECR : (MCAN Offset: 0x40) (R/ 32) Error Counter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TEC:8;                     /**< bit:   0..7  Transmit Error Counter                   */
+    uint32_t REC:7;                     /**< bit:  8..14  Receive Error Counter                    */
+    uint32_t RP:1;                      /**< bit:     15  Receive Error Passive                    */
+    uint32_t CEL:8;                     /**< bit: 16..23  CAN Error Logging (cleared on read)      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ECR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ECR_OFFSET                     (0x40)                                        /**<  (MCAN_ECR) Error Counter Register  Offset */
+
+#define MCAN_ECR_TEC_Pos                    0                                              /**< (MCAN_ECR) Transmit Error Counter Position */
+#define MCAN_ECR_TEC_Msk                    (_U_(0xFF) << MCAN_ECR_TEC_Pos)                /**< (MCAN_ECR) Transmit Error Counter Mask */
+#define MCAN_ECR_TEC(value)                 (MCAN_ECR_TEC_Msk & ((value) << MCAN_ECR_TEC_Pos))
+#define MCAN_ECR_REC_Pos                    8                                              /**< (MCAN_ECR) Receive Error Counter Position */
+#define MCAN_ECR_REC_Msk                    (_U_(0x7F) << MCAN_ECR_REC_Pos)                /**< (MCAN_ECR) Receive Error Counter Mask */
+#define MCAN_ECR_REC(value)                 (MCAN_ECR_REC_Msk & ((value) << MCAN_ECR_REC_Pos))
+#define MCAN_ECR_RP_Pos                     15                                             /**< (MCAN_ECR) Receive Error Passive Position */
+#define MCAN_ECR_RP_Msk                     (_U_(0x1) << MCAN_ECR_RP_Pos)                  /**< (MCAN_ECR) Receive Error Passive Mask */
+#define MCAN_ECR_RP                         MCAN_ECR_RP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ECR_RP_Msk instead */
+#define MCAN_ECR_CEL_Pos                    16                                             /**< (MCAN_ECR) CAN Error Logging (cleared on read) Position */
+#define MCAN_ECR_CEL_Msk                    (_U_(0xFF) << MCAN_ECR_CEL_Pos)                /**< (MCAN_ECR) CAN Error Logging (cleared on read) Mask */
+#define MCAN_ECR_CEL(value)                 (MCAN_ECR_CEL_Msk & ((value) << MCAN_ECR_CEL_Pos))
+#define MCAN_ECR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (MCAN_ECR) Register MASK  (Use MCAN_ECR_Msk instead)  */
+#define MCAN_ECR_Msk                        _U_(0xFFFFFF)                                  /**< (MCAN_ECR) Register Mask  */
+
+
+/* -------- MCAN_PSR : (MCAN Offset: 0x44) (R/ 32) Protocol Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEC:3;                     /**< bit:   0..2  Last Error Code (set to 111 on read)     */
+    uint32_t ACT:2;                     /**< bit:   3..4  Activity                                 */
+    uint32_t EP:1;                      /**< bit:      5  Error Passive                            */
+    uint32_t EW:1;                      /**< bit:      6  Warning Status                           */
+    uint32_t BO:1;                      /**< bit:      7  Bus_Off Status                           */
+    uint32_t FLEC:3;                    /**< bit:  8..10  Fast Last Error Code (set to 111 on read) */
+    uint32_t RESI:1;                    /**< bit:     11  ESI Flag of Last Received CAN FD Message (cleared on read) */
+    uint32_t RBRS:1;                    /**< bit:     12  BRS Flag of Last Received CAN FD Message (cleared on read) */
+    uint32_t REDL:1;                    /**< bit:     13  Received a CAN FD Message (cleared on read) */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_PSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_PSR_OFFSET                     (0x44)                                        /**<  (MCAN_PSR) Protocol Status Register  Offset */
+
+#define MCAN_PSR_LEC_Pos                    0                                              /**< (MCAN_PSR) Last Error Code (set to 111 on read) Position */
+#define MCAN_PSR_LEC_Msk                    (_U_(0x7) << MCAN_PSR_LEC_Pos)                 /**< (MCAN_PSR) Last Error Code (set to 111 on read) Mask */
+#define MCAN_PSR_LEC(value)                 (MCAN_PSR_LEC_Msk & ((value) << MCAN_PSR_LEC_Pos))
+#define   MCAN_PSR_LEC_NO_ERROR_Val         _U_(0x0)                                       /**< (MCAN_PSR) No error occurred since LEC has been reset by successful reception or transmission.  */
+#define   MCAN_PSR_LEC_STUFF_ERROR_Val      _U_(0x1)                                       /**< (MCAN_PSR) More than 5 equal bits in a sequence have occurred in a part of a received message where this is not allowed.  */
+#define   MCAN_PSR_LEC_FORM_ERROR_Val       _U_(0x2)                                       /**< (MCAN_PSR) A fixed format part of a received frame has the wrong format.  */
+#define   MCAN_PSR_LEC_ACK_ERROR_Val        _U_(0x3)                                       /**< (MCAN_PSR) The message transmitted by the MCAN was not acknowledged by another node.  */
+#define   MCAN_PSR_LEC_BIT1_ERROR_Val       _U_(0x4)                                       /**< (MCAN_PSR) During the transmission of a message (with the exception of the arbitration field), the device wanted to send a recessive level (bit of logical value '1'), but the monitored bus value was dominant.  */
+#define   MCAN_PSR_LEC_BIT0_ERROR_Val       _U_(0x5)                                       /**< (MCAN_PSR) During the transmission of a message (or acknowledge bit, or active error flag, or overload flag), the device wanted to send a dominant level (data or identifier bit logical value '0'), but the monitored bus value was recessive. During Bus_Off recovery this status is set each time a sequence of 11 recessive bits has been monitored. This enables the processor to monitor the proceeding of the Bus_Off recovery sequence (indicating the bus is not stuck at dominant or continuously disturbed).  */
+#define   MCAN_PSR_LEC_CRC_ERROR_Val        _U_(0x6)                                       /**< (MCAN_PSR) The CRC check sum of a received message was incorrect. The CRC of an incoming message does not match with the CRC calculated from the received data.  */
+#define   MCAN_PSR_LEC_NO_CHANGE_Val        _U_(0x7)                                       /**< (MCAN_PSR) Any read access to the Protocol Status Register re-initializes the LEC to '7'. When the LEC shows the value '7', no CAN bus event was detected since the last processor read access to the Protocol Status Register.  */
+#define MCAN_PSR_LEC_NO_ERROR               (MCAN_PSR_LEC_NO_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) No error occurred since LEC has been reset by successful reception or transmission. Position  */
+#define MCAN_PSR_LEC_STUFF_ERROR            (MCAN_PSR_LEC_STUFF_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) More than 5 equal bits in a sequence have occurred in a part of a received message where this is not allowed. Position  */
+#define MCAN_PSR_LEC_FORM_ERROR             (MCAN_PSR_LEC_FORM_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) A fixed format part of a received frame has the wrong format. Position  */
+#define MCAN_PSR_LEC_ACK_ERROR              (MCAN_PSR_LEC_ACK_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) The message transmitted by the MCAN was not acknowledged by another node. Position  */
+#define MCAN_PSR_LEC_BIT1_ERROR             (MCAN_PSR_LEC_BIT1_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) During the transmission of a message (with the exception of the arbitration field), the device wanted to send a recessive level (bit of logical value '1'), but the monitored bus value was dominant. Position  */
+#define MCAN_PSR_LEC_BIT0_ERROR             (MCAN_PSR_LEC_BIT0_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) During the transmission of a message (or acknowledge bit, or active error flag, or overload flag), the device wanted to send a dominant level (data or identifier bit logical value '0'), but the monitored bus value was recessive. During Bus_Off recovery this status is set each time a sequence of 11 recessive bits has been monitored. This enables the processor to monitor the proceeding of the Bus_Off recovery sequence (indicating the bus is not stuck at dominant or continuously disturbed). Position  */
+#define MCAN_PSR_LEC_CRC_ERROR              (MCAN_PSR_LEC_CRC_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) The CRC check sum of a received message was incorrect. The CRC of an incoming message does not match with the CRC calculated from the received data. Position  */
+#define MCAN_PSR_LEC_NO_CHANGE              (MCAN_PSR_LEC_NO_CHANGE_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) Any read access to the Protocol Status Register re-initializes the LEC to '7'. When the LEC shows the value '7', no CAN bus event was detected since the last processor read access to the Protocol Status Register. Position  */
+#define MCAN_PSR_ACT_Pos                    3                                              /**< (MCAN_PSR) Activity Position */
+#define MCAN_PSR_ACT_Msk                    (_U_(0x3) << MCAN_PSR_ACT_Pos)                 /**< (MCAN_PSR) Activity Mask */
+#define MCAN_PSR_ACT(value)                 (MCAN_PSR_ACT_Msk & ((value) << MCAN_PSR_ACT_Pos))
+#define   MCAN_PSR_ACT_SYNCHRONIZING_Val    _U_(0x0)                                       /**< (MCAN_PSR) Node is synchronizing on CAN communication  */
+#define   MCAN_PSR_ACT_IDLE_Val             _U_(0x1)                                       /**< (MCAN_PSR) Node is neither receiver nor transmitter  */
+#define   MCAN_PSR_ACT_RECEIVER_Val         _U_(0x2)                                       /**< (MCAN_PSR) Node is operating as receiver  */
+#define   MCAN_PSR_ACT_TRANSMITTER_Val      _U_(0x3)                                       /**< (MCAN_PSR) Node is operating as transmitter  */
+#define MCAN_PSR_ACT_SYNCHRONIZING          (MCAN_PSR_ACT_SYNCHRONIZING_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is synchronizing on CAN communication Position  */
+#define MCAN_PSR_ACT_IDLE                   (MCAN_PSR_ACT_IDLE_Val << MCAN_PSR_ACT_Pos)    /**< (MCAN_PSR) Node is neither receiver nor transmitter Position  */
+#define MCAN_PSR_ACT_RECEIVER               (MCAN_PSR_ACT_RECEIVER_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is operating as receiver Position  */
+#define MCAN_PSR_ACT_TRANSMITTER            (MCAN_PSR_ACT_TRANSMITTER_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is operating as transmitter Position  */
+#define MCAN_PSR_EP_Pos                     5                                              /**< (MCAN_PSR) Error Passive Position */
+#define MCAN_PSR_EP_Msk                     (_U_(0x1) << MCAN_PSR_EP_Pos)                  /**< (MCAN_PSR) Error Passive Mask */
+#define MCAN_PSR_EP                         MCAN_PSR_EP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_EP_Msk instead */
+#define MCAN_PSR_EW_Pos                     6                                              /**< (MCAN_PSR) Warning Status Position */
+#define MCAN_PSR_EW_Msk                     (_U_(0x1) << MCAN_PSR_EW_Pos)                  /**< (MCAN_PSR) Warning Status Mask */
+#define MCAN_PSR_EW                         MCAN_PSR_EW_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_EW_Msk instead */
+#define MCAN_PSR_BO_Pos                     7                                              /**< (MCAN_PSR) Bus_Off Status Position */
+#define MCAN_PSR_BO_Msk                     (_U_(0x1) << MCAN_PSR_BO_Pos)                  /**< (MCAN_PSR) Bus_Off Status Mask */
+#define MCAN_PSR_BO                         MCAN_PSR_BO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_BO_Msk instead */
+#define MCAN_PSR_FLEC_Pos                   8                                              /**< (MCAN_PSR) Fast Last Error Code (set to 111 on read) Position */
+#define MCAN_PSR_FLEC_Msk                   (_U_(0x7) << MCAN_PSR_FLEC_Pos)                /**< (MCAN_PSR) Fast Last Error Code (set to 111 on read) Mask */
+#define MCAN_PSR_FLEC(value)                (MCAN_PSR_FLEC_Msk & ((value) << MCAN_PSR_FLEC_Pos))
+#define MCAN_PSR_RESI_Pos                   11                                             /**< (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_RESI_Msk                   (_U_(0x1) << MCAN_PSR_RESI_Pos)                /**< (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_RESI                       MCAN_PSR_RESI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_RESI_Msk instead */
+#define MCAN_PSR_RBRS_Pos                   12                                             /**< (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_RBRS_Msk                   (_U_(0x1) << MCAN_PSR_RBRS_Pos)                /**< (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_RBRS                       MCAN_PSR_RBRS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_RBRS_Msk instead */
+#define MCAN_PSR_REDL_Pos                   13                                             /**< (MCAN_PSR) Received a CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_REDL_Msk                   (_U_(0x1) << MCAN_PSR_REDL_Pos)                /**< (MCAN_PSR) Received a CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_REDL                       MCAN_PSR_REDL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_REDL_Msk instead */
+#define MCAN_PSR_MASK                       _U_(0x3FFF)                                    /**< \deprecated (MCAN_PSR) Register MASK  (Use MCAN_PSR_Msk instead)  */
+#define MCAN_PSR_Msk                        _U_(0x3FFF)                                    /**< (MCAN_PSR) Register Mask  */
+
+
+/* -------- MCAN_IR : (MCAN Offset: 0x50) (R/W 32) Interrupt Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0N:1;                    /**< bit:      0  Receive FIFO 0 New Message               */
+    uint32_t RF0W:1;                    /**< bit:      1  Receive FIFO 0 Watermark Reached         */
+    uint32_t RF0F:1;                    /**< bit:      2  Receive FIFO 0 Full                      */
+    uint32_t RF0L:1;                    /**< bit:      3  Receive FIFO 0 Message Lost              */
+    uint32_t RF1N:1;                    /**< bit:      4  Receive FIFO 1 New Message               */
+    uint32_t RF1W:1;                    /**< bit:      5  Receive FIFO 1 Watermark Reached         */
+    uint32_t RF1F:1;                    /**< bit:      6  Receive FIFO 1 Full                      */
+    uint32_t RF1L:1;                    /**< bit:      7  Receive FIFO 1 Message Lost              */
+    uint32_t HPM:1;                     /**< bit:      8  High Priority Message                    */
+    uint32_t TC:1;                      /**< bit:      9  Transmission Completed                   */
+    uint32_t TCF:1;                     /**< bit:     10  Transmission Cancellation Finished       */
+    uint32_t TFE:1;                     /**< bit:     11  Tx FIFO Empty                            */
+    uint32_t TEFN:1;                    /**< bit:     12  Tx Event FIFO New Entry                  */
+    uint32_t TEFW:1;                    /**< bit:     13  Tx Event FIFO Watermark Reached          */
+    uint32_t TEFF:1;                    /**< bit:     14  Tx Event FIFO Full                       */
+    uint32_t TEFL:1;                    /**< bit:     15  Tx Event FIFO Element Lost               */
+    uint32_t TSW:1;                     /**< bit:     16  Timestamp Wraparound                     */
+    uint32_t MRAF:1;                    /**< bit:     17  Message RAM Access Failure               */
+    uint32_t TOO:1;                     /**< bit:     18  Timeout Occurred                         */
+    uint32_t DRX:1;                     /**< bit:     19  Message stored to Dedicated Receive Buffer */
+    uint32_t BEC:1;                     /**< bit:     20  Bit Error Corrected                      */
+    uint32_t BEU:1;                     /**< bit:     21  Bit Error Uncorrected                    */
+    uint32_t ELO:1;                     /**< bit:     22  Error Logging Overflow                   */
+    uint32_t EP:1;                      /**< bit:     23  Error Passive                            */
+    uint32_t EW:1;                      /**< bit:     24  Warning Status                           */
+    uint32_t BO:1;                      /**< bit:     25  Bus_Off Status                           */
+    uint32_t WDI:1;                     /**< bit:     26  Watchdog Interrupt                       */
+    uint32_t CRCE:1;                    /**< bit:     27  CRC Error                                */
+    uint32_t BE:1;                      /**< bit:     28  Bit Error                                */
+    uint32_t ACKE:1;                    /**< bit:     29  Acknowledge Error                        */
+    uint32_t FOE:1;                     /**< bit:     30  Format Error                             */
+    uint32_t STE:1;                     /**< bit:     31  Stuff Error                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_IR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_IR_OFFSET                      (0x50)                                        /**<  (MCAN_IR) Interrupt Register  Offset */
+
+#define MCAN_IR_RF0N_Pos                    0                                              /**< (MCAN_IR) Receive FIFO 0 New Message Position */
+#define MCAN_IR_RF0N_Msk                    (_U_(0x1) << MCAN_IR_RF0N_Pos)                 /**< (MCAN_IR) Receive FIFO 0 New Message Mask */
+#define MCAN_IR_RF0N                        MCAN_IR_RF0N_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0N_Msk instead */
+#define MCAN_IR_RF0W_Pos                    1                                              /**< (MCAN_IR) Receive FIFO 0 Watermark Reached Position */
+#define MCAN_IR_RF0W_Msk                    (_U_(0x1) << MCAN_IR_RF0W_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Watermark Reached Mask */
+#define MCAN_IR_RF0W                        MCAN_IR_RF0W_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0W_Msk instead */
+#define MCAN_IR_RF0F_Pos                    2                                              /**< (MCAN_IR) Receive FIFO 0 Full Position */
+#define MCAN_IR_RF0F_Msk                    (_U_(0x1) << MCAN_IR_RF0F_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Full Mask */
+#define MCAN_IR_RF0F                        MCAN_IR_RF0F_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0F_Msk instead */
+#define MCAN_IR_RF0L_Pos                    3                                              /**< (MCAN_IR) Receive FIFO 0 Message Lost Position */
+#define MCAN_IR_RF0L_Msk                    (_U_(0x1) << MCAN_IR_RF0L_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Message Lost Mask */
+#define MCAN_IR_RF0L                        MCAN_IR_RF0L_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0L_Msk instead */
+#define MCAN_IR_RF1N_Pos                    4                                              /**< (MCAN_IR) Receive FIFO 1 New Message Position */
+#define MCAN_IR_RF1N_Msk                    (_U_(0x1) << MCAN_IR_RF1N_Pos)                 /**< (MCAN_IR) Receive FIFO 1 New Message Mask */
+#define MCAN_IR_RF1N                        MCAN_IR_RF1N_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1N_Msk instead */
+#define MCAN_IR_RF1W_Pos                    5                                              /**< (MCAN_IR) Receive FIFO 1 Watermark Reached Position */
+#define MCAN_IR_RF1W_Msk                    (_U_(0x1) << MCAN_IR_RF1W_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Watermark Reached Mask */
+#define MCAN_IR_RF1W                        MCAN_IR_RF1W_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1W_Msk instead */
+#define MCAN_IR_RF1F_Pos                    6                                              /**< (MCAN_IR) Receive FIFO 1 Full Position */
+#define MCAN_IR_RF1F_Msk                    (_U_(0x1) << MCAN_IR_RF1F_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Full Mask */
+#define MCAN_IR_RF1F                        MCAN_IR_RF1F_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1F_Msk instead */
+#define MCAN_IR_RF1L_Pos                    7                                              /**< (MCAN_IR) Receive FIFO 1 Message Lost Position */
+#define MCAN_IR_RF1L_Msk                    (_U_(0x1) << MCAN_IR_RF1L_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Message Lost Mask */
+#define MCAN_IR_RF1L                        MCAN_IR_RF1L_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1L_Msk instead */
+#define MCAN_IR_HPM_Pos                     8                                              /**< (MCAN_IR) High Priority Message Position */
+#define MCAN_IR_HPM_Msk                     (_U_(0x1) << MCAN_IR_HPM_Pos)                  /**< (MCAN_IR) High Priority Message Mask */
+#define MCAN_IR_HPM                         MCAN_IR_HPM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_HPM_Msk instead */
+#define MCAN_IR_TC_Pos                      9                                              /**< (MCAN_IR) Transmission Completed Position */
+#define MCAN_IR_TC_Msk                      (_U_(0x1) << MCAN_IR_TC_Pos)                   /**< (MCAN_IR) Transmission Completed Mask */
+#define MCAN_IR_TC                          MCAN_IR_TC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TC_Msk instead */
+#define MCAN_IR_TCF_Pos                     10                                             /**< (MCAN_IR) Transmission Cancellation Finished Position */
+#define MCAN_IR_TCF_Msk                     (_U_(0x1) << MCAN_IR_TCF_Pos)                  /**< (MCAN_IR) Transmission Cancellation Finished Mask */
+#define MCAN_IR_TCF                         MCAN_IR_TCF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TCF_Msk instead */
+#define MCAN_IR_TFE_Pos                     11                                             /**< (MCAN_IR) Tx FIFO Empty Position */
+#define MCAN_IR_TFE_Msk                     (_U_(0x1) << MCAN_IR_TFE_Pos)                  /**< (MCAN_IR) Tx FIFO Empty Mask */
+#define MCAN_IR_TFE                         MCAN_IR_TFE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TFE_Msk instead */
+#define MCAN_IR_TEFN_Pos                    12                                             /**< (MCAN_IR) Tx Event FIFO New Entry Position */
+#define MCAN_IR_TEFN_Msk                    (_U_(0x1) << MCAN_IR_TEFN_Pos)                 /**< (MCAN_IR) Tx Event FIFO New Entry Mask */
+#define MCAN_IR_TEFN                        MCAN_IR_TEFN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFN_Msk instead */
+#define MCAN_IR_TEFW_Pos                    13                                             /**< (MCAN_IR) Tx Event FIFO Watermark Reached Position */
+#define MCAN_IR_TEFW_Msk                    (_U_(0x1) << MCAN_IR_TEFW_Pos)                 /**< (MCAN_IR) Tx Event FIFO Watermark Reached Mask */
+#define MCAN_IR_TEFW                        MCAN_IR_TEFW_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFW_Msk instead */
+#define MCAN_IR_TEFF_Pos                    14                                             /**< (MCAN_IR) Tx Event FIFO Full Position */
+#define MCAN_IR_TEFF_Msk                    (_U_(0x1) << MCAN_IR_TEFF_Pos)                 /**< (MCAN_IR) Tx Event FIFO Full Mask */
+#define MCAN_IR_TEFF                        MCAN_IR_TEFF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFF_Msk instead */
+#define MCAN_IR_TEFL_Pos                    15                                             /**< (MCAN_IR) Tx Event FIFO Element Lost Position */
+#define MCAN_IR_TEFL_Msk                    (_U_(0x1) << MCAN_IR_TEFL_Pos)                 /**< (MCAN_IR) Tx Event FIFO Element Lost Mask */
+#define MCAN_IR_TEFL                        MCAN_IR_TEFL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFL_Msk instead */
+#define MCAN_IR_TSW_Pos                     16                                             /**< (MCAN_IR) Timestamp Wraparound Position */
+#define MCAN_IR_TSW_Msk                     (_U_(0x1) << MCAN_IR_TSW_Pos)                  /**< (MCAN_IR) Timestamp Wraparound Mask */
+#define MCAN_IR_TSW                         MCAN_IR_TSW_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TSW_Msk instead */
+#define MCAN_IR_MRAF_Pos                    17                                             /**< (MCAN_IR) Message RAM Access Failure Position */
+#define MCAN_IR_MRAF_Msk                    (_U_(0x1) << MCAN_IR_MRAF_Pos)                 /**< (MCAN_IR) Message RAM Access Failure Mask */
+#define MCAN_IR_MRAF                        MCAN_IR_MRAF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_MRAF_Msk instead */
+#define MCAN_IR_TOO_Pos                     18                                             /**< (MCAN_IR) Timeout Occurred Position */
+#define MCAN_IR_TOO_Msk                     (_U_(0x1) << MCAN_IR_TOO_Pos)                  /**< (MCAN_IR) Timeout Occurred Mask */
+#define MCAN_IR_TOO                         MCAN_IR_TOO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TOO_Msk instead */
+#define MCAN_IR_DRX_Pos                     19                                             /**< (MCAN_IR) Message stored to Dedicated Receive Buffer Position */
+#define MCAN_IR_DRX_Msk                     (_U_(0x1) << MCAN_IR_DRX_Pos)                  /**< (MCAN_IR) Message stored to Dedicated Receive Buffer Mask */
+#define MCAN_IR_DRX                         MCAN_IR_DRX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_DRX_Msk instead */
+#define MCAN_IR_BEC_Pos                     20                                             /**< (MCAN_IR) Bit Error Corrected Position */
+#define MCAN_IR_BEC_Msk                     (_U_(0x1) << MCAN_IR_BEC_Pos)                  /**< (MCAN_IR) Bit Error Corrected Mask */
+#define MCAN_IR_BEC                         MCAN_IR_BEC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_BEC_Msk instead */
+#define MCAN_IR_BEU_Pos                     21                                             /**< (MCAN_IR) Bit Error Uncorrected Position */
+#define MCAN_IR_BEU_Msk                     (_U_(0x1) << MCAN_IR_BEU_Pos)                  /**< (MCAN_IR) Bit Error Uncorrected Mask */
+#define MCAN_IR_BEU                         MCAN_IR_BEU_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_BEU_Msk instead */
+#define MCAN_IR_ELO_Pos                     22                                             /**< (MCAN_IR) Error Logging Overflow Position */
+#define MCAN_IR_ELO_Msk                     (_U_(0x1) << MCAN_IR_ELO_Pos)                  /**< (MCAN_IR) Error Logging Overflow Mask */
+#define MCAN_IR_ELO                         MCAN_IR_ELO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_ELO_Msk instead */
+#define MCAN_IR_EP_Pos                      23                                             /**< (MCAN_IR) Error Passive Position */
+#define MCAN_IR_EP_Msk                      (_U_(0x1) << MCAN_IR_EP_Pos)                   /**< (MCAN_IR) Error Passive Mask */
+#define MCAN_IR_EP                          MCAN_IR_EP_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_EP_Msk instead */
+#define MCAN_IR_EW_Pos                      24                                             /**< (MCAN_IR) Warning Status Position */
+#define MCAN_IR_EW_Msk                      (_U_(0x1) << MCAN_IR_EW_Pos)                   /**< (MCAN_IR) Warning Status Mask */
+#define MCAN_IR_EW                          MCAN_IR_EW_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_EW_Msk instead */
+#define MCAN_IR_BO_Pos                      25                                             /**< (MCAN_IR) Bus_Off Status Position */
+#define MCAN_IR_BO_Msk                      (_U_(0x1) << MCAN_IR_BO_Pos)                   /**< (MCAN_IR) Bus_Off Status Mask */
+#define MCAN_IR_BO                          MCAN_IR_BO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_BO_Msk instead */
+#define MCAN_IR_WDI_Pos                     26                                             /**< (MCAN_IR) Watchdog Interrupt Position */
+#define MCAN_IR_WDI_Msk                     (_U_(0x1) << MCAN_IR_WDI_Pos)                  /**< (MCAN_IR) Watchdog Interrupt Mask */
+#define MCAN_IR_WDI                         MCAN_IR_WDI_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_WDI_Msk instead */
+#define MCAN_IR_CRCE_Pos                    27                                             /**< (MCAN_IR) CRC Error Position */
+#define MCAN_IR_CRCE_Msk                    (_U_(0x1) << MCAN_IR_CRCE_Pos)                 /**< (MCAN_IR) CRC Error Mask */
+#define MCAN_IR_CRCE                        MCAN_IR_CRCE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_CRCE_Msk instead */
+#define MCAN_IR_BE_Pos                      28                                             /**< (MCAN_IR) Bit Error Position */
+#define MCAN_IR_BE_Msk                      (_U_(0x1) << MCAN_IR_BE_Pos)                   /**< (MCAN_IR) Bit Error Mask */
+#define MCAN_IR_BE                          MCAN_IR_BE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_BE_Msk instead */
+#define MCAN_IR_ACKE_Pos                    29                                             /**< (MCAN_IR) Acknowledge Error Position */
+#define MCAN_IR_ACKE_Msk                    (_U_(0x1) << MCAN_IR_ACKE_Pos)                 /**< (MCAN_IR) Acknowledge Error Mask */
+#define MCAN_IR_ACKE                        MCAN_IR_ACKE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_ACKE_Msk instead */
+#define MCAN_IR_FOE_Pos                     30                                             /**< (MCAN_IR) Format Error Position */
+#define MCAN_IR_FOE_Msk                     (_U_(0x1) << MCAN_IR_FOE_Pos)                  /**< (MCAN_IR) Format Error Mask */
+#define MCAN_IR_FOE                         MCAN_IR_FOE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_FOE_Msk instead */
+#define MCAN_IR_STE_Pos                     31                                             /**< (MCAN_IR) Stuff Error Position */
+#define MCAN_IR_STE_Msk                     (_U_(0x1) << MCAN_IR_STE_Pos)                  /**< (MCAN_IR) Stuff Error Mask */
+#define MCAN_IR_STE                         MCAN_IR_STE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_STE_Msk instead */
+#define MCAN_IR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_IR) Register MASK  (Use MCAN_IR_Msk instead)  */
+#define MCAN_IR_Msk                         _U_(0xFFFFFFFF)                                /**< (MCAN_IR) Register Mask  */
+
+
+/* -------- MCAN_IE : (MCAN Offset: 0x54) (R/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0NE:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Enable */
+    uint32_t RF0WE:1;                   /**< bit:      1  Receive FIFO 0 Watermark Reached Interrupt Enable */
+    uint32_t RF0FE:1;                   /**< bit:      2  Receive FIFO 0 Full Interrupt Enable     */
+    uint32_t RF0LE:1;                   /**< bit:      3  Receive FIFO 0 Message Lost Interrupt Enable */
+    uint32_t RF1NE:1;                   /**< bit:      4  Receive FIFO 1 New Message Interrupt Enable */
+    uint32_t RF1WE:1;                   /**< bit:      5  Receive FIFO 1 Watermark Reached Interrupt Enable */
+    uint32_t RF1FE:1;                   /**< bit:      6  Receive FIFO 1 Full Interrupt Enable     */
+    uint32_t RF1LE:1;                   /**< bit:      7  Receive FIFO 1 Message Lost Interrupt Enable */
+    uint32_t HPME:1;                    /**< bit:      8  High Priority Message Interrupt Enable   */
+    uint32_t TCE:1;                     /**< bit:      9  Transmission Completed Interrupt Enable  */
+    uint32_t TCFE:1;                    /**< bit:     10  Transmission Cancellation Finished Interrupt Enable */
+    uint32_t TFEE:1;                    /**< bit:     11  Tx FIFO Empty Interrupt Enable           */
+    uint32_t TEFNE:1;                   /**< bit:     12  Tx Event FIFO New Entry Interrupt Enable */
+    uint32_t TEFWE:1;                   /**< bit:     13  Tx Event FIFO Watermark Reached Interrupt Enable */
+    uint32_t TEFFE:1;                   /**< bit:     14  Tx Event FIFO Full Interrupt Enable      */
+    uint32_t TEFLE:1;                   /**< bit:     15  Tx Event FIFO Event Lost Interrupt Enable */
+    uint32_t TSWE:1;                    /**< bit:     16  Timestamp Wraparound Interrupt Enable    */
+    uint32_t MRAFE:1;                   /**< bit:     17  Message RAM Access Failure Interrupt Enable */
+    uint32_t TOOE:1;                    /**< bit:     18  Timeout Occurred Interrupt Enable        */
+    uint32_t DRXE:1;                    /**< bit:     19  Message stored to Dedicated Receive Buffer Interrupt Enable */
+    uint32_t BECE:1;                    /**< bit:     20  Bit Error Corrected Interrupt Enable     */
+    uint32_t BEUE:1;                    /**< bit:     21  Bit Error Uncorrected Interrupt Enable   */
+    uint32_t ELOE:1;                    /**< bit:     22  Error Logging Overflow Interrupt Enable  */
+    uint32_t EPE:1;                     /**< bit:     23  Error Passive Interrupt Enable           */
+    uint32_t EWE:1;                     /**< bit:     24  Warning Status Interrupt Enable          */
+    uint32_t BOE:1;                     /**< bit:     25  Bus_Off Status Interrupt Enable          */
+    uint32_t WDIE:1;                    /**< bit:     26  Watchdog Interrupt Enable                */
+    uint32_t CRCEE:1;                   /**< bit:     27  CRC Error Interrupt Enable               */
+    uint32_t BEE:1;                     /**< bit:     28  Bit Error Interrupt Enable               */
+    uint32_t ACKEE:1;                   /**< bit:     29  Acknowledge Error Interrupt Enable       */
+    uint32_t FOEE:1;                    /**< bit:     30  Format Error Interrupt Enable            */
+    uint32_t STEE:1;                    /**< bit:     31  Stuff Error Interrupt Enable             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_IE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_IE_OFFSET                      (0x54)                                        /**<  (MCAN_IE) Interrupt Enable Register  Offset */
+
+#define MCAN_IE_RF0NE_Pos                   0                                              /**< (MCAN_IE) Receive FIFO 0 New Message Interrupt Enable Position */
+#define MCAN_IE_RF0NE_Msk                   (_U_(0x1) << MCAN_IE_RF0NE_Pos)                /**< (MCAN_IE) Receive FIFO 0 New Message Interrupt Enable Mask */
+#define MCAN_IE_RF0NE                       MCAN_IE_RF0NE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0NE_Msk instead */
+#define MCAN_IE_RF0WE_Pos                   1                                              /**< (MCAN_IE) Receive FIFO 0 Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_RF0WE_Msk                   (_U_(0x1) << MCAN_IE_RF0WE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_RF0WE                       MCAN_IE_RF0WE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0WE_Msk instead */
+#define MCAN_IE_RF0FE_Pos                   2                                              /**< (MCAN_IE) Receive FIFO 0 Full Interrupt Enable Position */
+#define MCAN_IE_RF0FE_Msk                   (_U_(0x1) << MCAN_IE_RF0FE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Full Interrupt Enable Mask */
+#define MCAN_IE_RF0FE                       MCAN_IE_RF0FE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0FE_Msk instead */
+#define MCAN_IE_RF0LE_Pos                   3                                              /**< (MCAN_IE) Receive FIFO 0 Message Lost Interrupt Enable Position */
+#define MCAN_IE_RF0LE_Msk                   (_U_(0x1) << MCAN_IE_RF0LE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Message Lost Interrupt Enable Mask */
+#define MCAN_IE_RF0LE                       MCAN_IE_RF0LE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0LE_Msk instead */
+#define MCAN_IE_RF1NE_Pos                   4                                              /**< (MCAN_IE) Receive FIFO 1 New Message Interrupt Enable Position */
+#define MCAN_IE_RF1NE_Msk                   (_U_(0x1) << MCAN_IE_RF1NE_Pos)                /**< (MCAN_IE) Receive FIFO 1 New Message Interrupt Enable Mask */
+#define MCAN_IE_RF1NE                       MCAN_IE_RF1NE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1NE_Msk instead */
+#define MCAN_IE_RF1WE_Pos                   5                                              /**< (MCAN_IE) Receive FIFO 1 Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_RF1WE_Msk                   (_U_(0x1) << MCAN_IE_RF1WE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_RF1WE                       MCAN_IE_RF1WE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1WE_Msk instead */
+#define MCAN_IE_RF1FE_Pos                   6                                              /**< (MCAN_IE) Receive FIFO 1 Full Interrupt Enable Position */
+#define MCAN_IE_RF1FE_Msk                   (_U_(0x1) << MCAN_IE_RF1FE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Full Interrupt Enable Mask */
+#define MCAN_IE_RF1FE                       MCAN_IE_RF1FE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1FE_Msk instead */
+#define MCAN_IE_RF1LE_Pos                   7                                              /**< (MCAN_IE) Receive FIFO 1 Message Lost Interrupt Enable Position */
+#define MCAN_IE_RF1LE_Msk                   (_U_(0x1) << MCAN_IE_RF1LE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Message Lost Interrupt Enable Mask */
+#define MCAN_IE_RF1LE                       MCAN_IE_RF1LE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1LE_Msk instead */
+#define MCAN_IE_HPME_Pos                    8                                              /**< (MCAN_IE) High Priority Message Interrupt Enable Position */
+#define MCAN_IE_HPME_Msk                    (_U_(0x1) << MCAN_IE_HPME_Pos)                 /**< (MCAN_IE) High Priority Message Interrupt Enable Mask */
+#define MCAN_IE_HPME                        MCAN_IE_HPME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_HPME_Msk instead */
+#define MCAN_IE_TCE_Pos                     9                                              /**< (MCAN_IE) Transmission Completed Interrupt Enable Position */
+#define MCAN_IE_TCE_Msk                     (_U_(0x1) << MCAN_IE_TCE_Pos)                  /**< (MCAN_IE) Transmission Completed Interrupt Enable Mask */
+#define MCAN_IE_TCE                         MCAN_IE_TCE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TCE_Msk instead */
+#define MCAN_IE_TCFE_Pos                    10                                             /**< (MCAN_IE) Transmission Cancellation Finished Interrupt Enable Position */
+#define MCAN_IE_TCFE_Msk                    (_U_(0x1) << MCAN_IE_TCFE_Pos)                 /**< (MCAN_IE) Transmission Cancellation Finished Interrupt Enable Mask */
+#define MCAN_IE_TCFE                        MCAN_IE_TCFE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TCFE_Msk instead */
+#define MCAN_IE_TFEE_Pos                    11                                             /**< (MCAN_IE) Tx FIFO Empty Interrupt Enable Position */
+#define MCAN_IE_TFEE_Msk                    (_U_(0x1) << MCAN_IE_TFEE_Pos)                 /**< (MCAN_IE) Tx FIFO Empty Interrupt Enable Mask */
+#define MCAN_IE_TFEE                        MCAN_IE_TFEE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TFEE_Msk instead */
+#define MCAN_IE_TEFNE_Pos                   12                                             /**< (MCAN_IE) Tx Event FIFO New Entry Interrupt Enable Position */
+#define MCAN_IE_TEFNE_Msk                   (_U_(0x1) << MCAN_IE_TEFNE_Pos)                /**< (MCAN_IE) Tx Event FIFO New Entry Interrupt Enable Mask */
+#define MCAN_IE_TEFNE                       MCAN_IE_TEFNE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFNE_Msk instead */
+#define MCAN_IE_TEFWE_Pos                   13                                             /**< (MCAN_IE) Tx Event FIFO Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_TEFWE_Msk                   (_U_(0x1) << MCAN_IE_TEFWE_Pos)                /**< (MCAN_IE) Tx Event FIFO Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_TEFWE                       MCAN_IE_TEFWE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFWE_Msk instead */
+#define MCAN_IE_TEFFE_Pos                   14                                             /**< (MCAN_IE) Tx Event FIFO Full Interrupt Enable Position */
+#define MCAN_IE_TEFFE_Msk                   (_U_(0x1) << MCAN_IE_TEFFE_Pos)                /**< (MCAN_IE) Tx Event FIFO Full Interrupt Enable Mask */
+#define MCAN_IE_TEFFE                       MCAN_IE_TEFFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFFE_Msk instead */
+#define MCAN_IE_TEFLE_Pos                   15                                             /**< (MCAN_IE) Tx Event FIFO Event Lost Interrupt Enable Position */
+#define MCAN_IE_TEFLE_Msk                   (_U_(0x1) << MCAN_IE_TEFLE_Pos)                /**< (MCAN_IE) Tx Event FIFO Event Lost Interrupt Enable Mask */
+#define MCAN_IE_TEFLE                       MCAN_IE_TEFLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFLE_Msk instead */
+#define MCAN_IE_TSWE_Pos                    16                                             /**< (MCAN_IE) Timestamp Wraparound Interrupt Enable Position */
+#define MCAN_IE_TSWE_Msk                    (_U_(0x1) << MCAN_IE_TSWE_Pos)                 /**< (MCAN_IE) Timestamp Wraparound Interrupt Enable Mask */
+#define MCAN_IE_TSWE                        MCAN_IE_TSWE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TSWE_Msk instead */
+#define MCAN_IE_MRAFE_Pos                   17                                             /**< (MCAN_IE) Message RAM Access Failure Interrupt Enable Position */
+#define MCAN_IE_MRAFE_Msk                   (_U_(0x1) << MCAN_IE_MRAFE_Pos)                /**< (MCAN_IE) Message RAM Access Failure Interrupt Enable Mask */
+#define MCAN_IE_MRAFE                       MCAN_IE_MRAFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_MRAFE_Msk instead */
+#define MCAN_IE_TOOE_Pos                    18                                             /**< (MCAN_IE) Timeout Occurred Interrupt Enable Position */
+#define MCAN_IE_TOOE_Msk                    (_U_(0x1) << MCAN_IE_TOOE_Pos)                 /**< (MCAN_IE) Timeout Occurred Interrupt Enable Mask */
+#define MCAN_IE_TOOE                        MCAN_IE_TOOE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TOOE_Msk instead */
+#define MCAN_IE_DRXE_Pos                    19                                             /**< (MCAN_IE) Message stored to Dedicated Receive Buffer Interrupt Enable Position */
+#define MCAN_IE_DRXE_Msk                    (_U_(0x1) << MCAN_IE_DRXE_Pos)                 /**< (MCAN_IE) Message stored to Dedicated Receive Buffer Interrupt Enable Mask */
+#define MCAN_IE_DRXE                        MCAN_IE_DRXE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_DRXE_Msk instead */
+#define MCAN_IE_BECE_Pos                    20                                             /**< (MCAN_IE) Bit Error Corrected Interrupt Enable Position */
+#define MCAN_IE_BECE_Msk                    (_U_(0x1) << MCAN_IE_BECE_Pos)                 /**< (MCAN_IE) Bit Error Corrected Interrupt Enable Mask */
+#define MCAN_IE_BECE                        MCAN_IE_BECE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_BECE_Msk instead */
+#define MCAN_IE_BEUE_Pos                    21                                             /**< (MCAN_IE) Bit Error Uncorrected Interrupt Enable Position */
+#define MCAN_IE_BEUE_Msk                    (_U_(0x1) << MCAN_IE_BEUE_Pos)                 /**< (MCAN_IE) Bit Error Uncorrected Interrupt Enable Mask */
+#define MCAN_IE_BEUE                        MCAN_IE_BEUE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_BEUE_Msk instead */
+#define MCAN_IE_ELOE_Pos                    22                                             /**< (MCAN_IE) Error Logging Overflow Interrupt Enable Position */
+#define MCAN_IE_ELOE_Msk                    (_U_(0x1) << MCAN_IE_ELOE_Pos)                 /**< (MCAN_IE) Error Logging Overflow Interrupt Enable Mask */
+#define MCAN_IE_ELOE                        MCAN_IE_ELOE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_ELOE_Msk instead */
+#define MCAN_IE_EPE_Pos                     23                                             /**< (MCAN_IE) Error Passive Interrupt Enable Position */
+#define MCAN_IE_EPE_Msk                     (_U_(0x1) << MCAN_IE_EPE_Pos)                  /**< (MCAN_IE) Error Passive Interrupt Enable Mask */
+#define MCAN_IE_EPE                         MCAN_IE_EPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_EPE_Msk instead */
+#define MCAN_IE_EWE_Pos                     24                                             /**< (MCAN_IE) Warning Status Interrupt Enable Position */
+#define MCAN_IE_EWE_Msk                     (_U_(0x1) << MCAN_IE_EWE_Pos)                  /**< (MCAN_IE) Warning Status Interrupt Enable Mask */
+#define MCAN_IE_EWE                         MCAN_IE_EWE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_EWE_Msk instead */
+#define MCAN_IE_BOE_Pos                     25                                             /**< (MCAN_IE) Bus_Off Status Interrupt Enable Position */
+#define MCAN_IE_BOE_Msk                     (_U_(0x1) << MCAN_IE_BOE_Pos)                  /**< (MCAN_IE) Bus_Off Status Interrupt Enable Mask */
+#define MCAN_IE_BOE                         MCAN_IE_BOE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_BOE_Msk instead */
+#define MCAN_IE_WDIE_Pos                    26                                             /**< (MCAN_IE) Watchdog Interrupt Enable Position */
+#define MCAN_IE_WDIE_Msk                    (_U_(0x1) << MCAN_IE_WDIE_Pos)                 /**< (MCAN_IE) Watchdog Interrupt Enable Mask */
+#define MCAN_IE_WDIE                        MCAN_IE_WDIE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_WDIE_Msk instead */
+#define MCAN_IE_CRCEE_Pos                   27                                             /**< (MCAN_IE) CRC Error Interrupt Enable Position */
+#define MCAN_IE_CRCEE_Msk                   (_U_(0x1) << MCAN_IE_CRCEE_Pos)                /**< (MCAN_IE) CRC Error Interrupt Enable Mask */
+#define MCAN_IE_CRCEE                       MCAN_IE_CRCEE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_CRCEE_Msk instead */
+#define MCAN_IE_BEE_Pos                     28                                             /**< (MCAN_IE) Bit Error Interrupt Enable Position */
+#define MCAN_IE_BEE_Msk                     (_U_(0x1) << MCAN_IE_BEE_Pos)                  /**< (MCAN_IE) Bit Error Interrupt Enable Mask */
+#define MCAN_IE_BEE                         MCAN_IE_BEE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_BEE_Msk instead */
+#define MCAN_IE_ACKEE_Pos                   29                                             /**< (MCAN_IE) Acknowledge Error Interrupt Enable Position */
+#define MCAN_IE_ACKEE_Msk                   (_U_(0x1) << MCAN_IE_ACKEE_Pos)                /**< (MCAN_IE) Acknowledge Error Interrupt Enable Mask */
+#define MCAN_IE_ACKEE                       MCAN_IE_ACKEE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_ACKEE_Msk instead */
+#define MCAN_IE_FOEE_Pos                    30                                             /**< (MCAN_IE) Format Error Interrupt Enable Position */
+#define MCAN_IE_FOEE_Msk                    (_U_(0x1) << MCAN_IE_FOEE_Pos)                 /**< (MCAN_IE) Format Error Interrupt Enable Mask */
+#define MCAN_IE_FOEE                        MCAN_IE_FOEE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_FOEE_Msk instead */
+#define MCAN_IE_STEE_Pos                    31                                             /**< (MCAN_IE) Stuff Error Interrupt Enable Position */
+#define MCAN_IE_STEE_Msk                    (_U_(0x1) << MCAN_IE_STEE_Pos)                 /**< (MCAN_IE) Stuff Error Interrupt Enable Mask */
+#define MCAN_IE_STEE                        MCAN_IE_STEE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_STEE_Msk instead */
+#define MCAN_IE_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_IE) Register MASK  (Use MCAN_IE_Msk instead)  */
+#define MCAN_IE_Msk                         _U_(0xFFFFFFFF)                                /**< (MCAN_IE) Register Mask  */
+
+
+/* -------- MCAN_ILS : (MCAN Offset: 0x58) (R/W 32) Interrupt Line Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0NL:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Line */
+    uint32_t RF0WL:1;                   /**< bit:      1  Receive FIFO 0 Watermark Reached Interrupt Line */
+    uint32_t RF0FL:1;                   /**< bit:      2  Receive FIFO 0 Full Interrupt Line       */
+    uint32_t RF0LL:1;                   /**< bit:      3  Receive FIFO 0 Message Lost Interrupt Line */
+    uint32_t RF1NL:1;                   /**< bit:      4  Receive FIFO 1 New Message Interrupt Line */
+    uint32_t RF1WL:1;                   /**< bit:      5  Receive FIFO 1 Watermark Reached Interrupt Line */
+    uint32_t RF1FL:1;                   /**< bit:      6  Receive FIFO 1 Full Interrupt Line       */
+    uint32_t RF1LL:1;                   /**< bit:      7  Receive FIFO 1 Message Lost Interrupt Line */
+    uint32_t HPML:1;                    /**< bit:      8  High Priority Message Interrupt Line     */
+    uint32_t TCL:1;                     /**< bit:      9  Transmission Completed Interrupt Line    */
+    uint32_t TCFL:1;                    /**< bit:     10  Transmission Cancellation Finished Interrupt Line */
+    uint32_t TFEL:1;                    /**< bit:     11  Tx FIFO Empty Interrupt Line             */
+    uint32_t TEFNL:1;                   /**< bit:     12  Tx Event FIFO New Entry Interrupt Line   */
+    uint32_t TEFWL:1;                   /**< bit:     13  Tx Event FIFO Watermark Reached Interrupt Line */
+    uint32_t TEFFL:1;                   /**< bit:     14  Tx Event FIFO Full Interrupt Line        */
+    uint32_t TEFLL:1;                   /**< bit:     15  Tx Event FIFO Event Lost Interrupt Line  */
+    uint32_t TSWL:1;                    /**< bit:     16  Timestamp Wraparound Interrupt Line      */
+    uint32_t MRAFL:1;                   /**< bit:     17  Message RAM Access Failure Interrupt Line */
+    uint32_t TOOL:1;                    /**< bit:     18  Timeout Occurred Interrupt Line          */
+    uint32_t DRXL:1;                    /**< bit:     19  Message stored to Dedicated Receive Buffer Interrupt Line */
+    uint32_t BECL:1;                    /**< bit:     20  Bit Error Corrected Interrupt Line       */
+    uint32_t BEUL:1;                    /**< bit:     21  Bit Error Uncorrected Interrupt Line     */
+    uint32_t ELOL:1;                    /**< bit:     22  Error Logging Overflow Interrupt Line    */
+    uint32_t EPL:1;                     /**< bit:     23  Error Passive Interrupt Line             */
+    uint32_t EWL:1;                     /**< bit:     24  Warning Status Interrupt Line            */
+    uint32_t BOL:1;                     /**< bit:     25  Bus_Off Status Interrupt Line            */
+    uint32_t WDIL:1;                    /**< bit:     26  Watchdog Interrupt Line                  */
+    uint32_t CRCEL:1;                   /**< bit:     27  CRC Error Interrupt Line                 */
+    uint32_t BEL:1;                     /**< bit:     28  Bit Error Interrupt Line                 */
+    uint32_t ACKEL:1;                   /**< bit:     29  Acknowledge Error Interrupt Line         */
+    uint32_t FOEL:1;                    /**< bit:     30  Format Error Interrupt Line              */
+    uint32_t STEL:1;                    /**< bit:     31  Stuff Error Interrupt Line               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ILS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ILS_OFFSET                     (0x58)                                        /**<  (MCAN_ILS) Interrupt Line Select Register  Offset */
+
+#define MCAN_ILS_RF0NL_Pos                  0                                              /**< (MCAN_ILS) Receive FIFO 0 New Message Interrupt Line Position */
+#define MCAN_ILS_RF0NL_Msk                  (_U_(0x1) << MCAN_ILS_RF0NL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 New Message Interrupt Line Mask */
+#define MCAN_ILS_RF0NL                      MCAN_ILS_RF0NL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0NL_Msk instead */
+#define MCAN_ILS_RF0WL_Pos                  1                                              /**< (MCAN_ILS) Receive FIFO 0 Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_RF0WL_Msk                  (_U_(0x1) << MCAN_ILS_RF0WL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_RF0WL                      MCAN_ILS_RF0WL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0WL_Msk instead */
+#define MCAN_ILS_RF0FL_Pos                  2                                              /**< (MCAN_ILS) Receive FIFO 0 Full Interrupt Line Position */
+#define MCAN_ILS_RF0FL_Msk                  (_U_(0x1) << MCAN_ILS_RF0FL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Full Interrupt Line Mask */
+#define MCAN_ILS_RF0FL                      MCAN_ILS_RF0FL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0FL_Msk instead */
+#define MCAN_ILS_RF0LL_Pos                  3                                              /**< (MCAN_ILS) Receive FIFO 0 Message Lost Interrupt Line Position */
+#define MCAN_ILS_RF0LL_Msk                  (_U_(0x1) << MCAN_ILS_RF0LL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Message Lost Interrupt Line Mask */
+#define MCAN_ILS_RF0LL                      MCAN_ILS_RF0LL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0LL_Msk instead */
+#define MCAN_ILS_RF1NL_Pos                  4                                              /**< (MCAN_ILS) Receive FIFO 1 New Message Interrupt Line Position */
+#define MCAN_ILS_RF1NL_Msk                  (_U_(0x1) << MCAN_ILS_RF1NL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 New Message Interrupt Line Mask */
+#define MCAN_ILS_RF1NL                      MCAN_ILS_RF1NL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1NL_Msk instead */
+#define MCAN_ILS_RF1WL_Pos                  5                                              /**< (MCAN_ILS) Receive FIFO 1 Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_RF1WL_Msk                  (_U_(0x1) << MCAN_ILS_RF1WL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_RF1WL                      MCAN_ILS_RF1WL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1WL_Msk instead */
+#define MCAN_ILS_RF1FL_Pos                  6                                              /**< (MCAN_ILS) Receive FIFO 1 Full Interrupt Line Position */
+#define MCAN_ILS_RF1FL_Msk                  (_U_(0x1) << MCAN_ILS_RF1FL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Full Interrupt Line Mask */
+#define MCAN_ILS_RF1FL                      MCAN_ILS_RF1FL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1FL_Msk instead */
+#define MCAN_ILS_RF1LL_Pos                  7                                              /**< (MCAN_ILS) Receive FIFO 1 Message Lost Interrupt Line Position */
+#define MCAN_ILS_RF1LL_Msk                  (_U_(0x1) << MCAN_ILS_RF1LL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Message Lost Interrupt Line Mask */
+#define MCAN_ILS_RF1LL                      MCAN_ILS_RF1LL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1LL_Msk instead */
+#define MCAN_ILS_HPML_Pos                   8                                              /**< (MCAN_ILS) High Priority Message Interrupt Line Position */
+#define MCAN_ILS_HPML_Msk                   (_U_(0x1) << MCAN_ILS_HPML_Pos)                /**< (MCAN_ILS) High Priority Message Interrupt Line Mask */
+#define MCAN_ILS_HPML                       MCAN_ILS_HPML_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_HPML_Msk instead */
+#define MCAN_ILS_TCL_Pos                    9                                              /**< (MCAN_ILS) Transmission Completed Interrupt Line Position */
+#define MCAN_ILS_TCL_Msk                    (_U_(0x1) << MCAN_ILS_TCL_Pos)                 /**< (MCAN_ILS) Transmission Completed Interrupt Line Mask */
+#define MCAN_ILS_TCL                        MCAN_ILS_TCL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TCL_Msk instead */
+#define MCAN_ILS_TCFL_Pos                   10                                             /**< (MCAN_ILS) Transmission Cancellation Finished Interrupt Line Position */
+#define MCAN_ILS_TCFL_Msk                   (_U_(0x1) << MCAN_ILS_TCFL_Pos)                /**< (MCAN_ILS) Transmission Cancellation Finished Interrupt Line Mask */
+#define MCAN_ILS_TCFL                       MCAN_ILS_TCFL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TCFL_Msk instead */
+#define MCAN_ILS_TFEL_Pos                   11                                             /**< (MCAN_ILS) Tx FIFO Empty Interrupt Line Position */
+#define MCAN_ILS_TFEL_Msk                   (_U_(0x1) << MCAN_ILS_TFEL_Pos)                /**< (MCAN_ILS) Tx FIFO Empty Interrupt Line Mask */
+#define MCAN_ILS_TFEL                       MCAN_ILS_TFEL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TFEL_Msk instead */
+#define MCAN_ILS_TEFNL_Pos                  12                                             /**< (MCAN_ILS) Tx Event FIFO New Entry Interrupt Line Position */
+#define MCAN_ILS_TEFNL_Msk                  (_U_(0x1) << MCAN_ILS_TEFNL_Pos)               /**< (MCAN_ILS) Tx Event FIFO New Entry Interrupt Line Mask */
+#define MCAN_ILS_TEFNL                      MCAN_ILS_TEFNL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFNL_Msk instead */
+#define MCAN_ILS_TEFWL_Pos                  13                                             /**< (MCAN_ILS) Tx Event FIFO Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_TEFWL_Msk                  (_U_(0x1) << MCAN_ILS_TEFWL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_TEFWL                      MCAN_ILS_TEFWL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFWL_Msk instead */
+#define MCAN_ILS_TEFFL_Pos                  14                                             /**< (MCAN_ILS) Tx Event FIFO Full Interrupt Line Position */
+#define MCAN_ILS_TEFFL_Msk                  (_U_(0x1) << MCAN_ILS_TEFFL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Full Interrupt Line Mask */
+#define MCAN_ILS_TEFFL                      MCAN_ILS_TEFFL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFFL_Msk instead */
+#define MCAN_ILS_TEFLL_Pos                  15                                             /**< (MCAN_ILS) Tx Event FIFO Event Lost Interrupt Line Position */
+#define MCAN_ILS_TEFLL_Msk                  (_U_(0x1) << MCAN_ILS_TEFLL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Event Lost Interrupt Line Mask */
+#define MCAN_ILS_TEFLL                      MCAN_ILS_TEFLL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFLL_Msk instead */
+#define MCAN_ILS_TSWL_Pos                   16                                             /**< (MCAN_ILS) Timestamp Wraparound Interrupt Line Position */
+#define MCAN_ILS_TSWL_Msk                   (_U_(0x1) << MCAN_ILS_TSWL_Pos)                /**< (MCAN_ILS) Timestamp Wraparound Interrupt Line Mask */
+#define MCAN_ILS_TSWL                       MCAN_ILS_TSWL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TSWL_Msk instead */
+#define MCAN_ILS_MRAFL_Pos                  17                                             /**< (MCAN_ILS) Message RAM Access Failure Interrupt Line Position */
+#define MCAN_ILS_MRAFL_Msk                  (_U_(0x1) << MCAN_ILS_MRAFL_Pos)               /**< (MCAN_ILS) Message RAM Access Failure Interrupt Line Mask */
+#define MCAN_ILS_MRAFL                      MCAN_ILS_MRAFL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_MRAFL_Msk instead */
+#define MCAN_ILS_TOOL_Pos                   18                                             /**< (MCAN_ILS) Timeout Occurred Interrupt Line Position */
+#define MCAN_ILS_TOOL_Msk                   (_U_(0x1) << MCAN_ILS_TOOL_Pos)                /**< (MCAN_ILS) Timeout Occurred Interrupt Line Mask */
+#define MCAN_ILS_TOOL                       MCAN_ILS_TOOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TOOL_Msk instead */
+#define MCAN_ILS_DRXL_Pos                   19                                             /**< (MCAN_ILS) Message stored to Dedicated Receive Buffer Interrupt Line Position */
+#define MCAN_ILS_DRXL_Msk                   (_U_(0x1) << MCAN_ILS_DRXL_Pos)                /**< (MCAN_ILS) Message stored to Dedicated Receive Buffer Interrupt Line Mask */
+#define MCAN_ILS_DRXL                       MCAN_ILS_DRXL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_DRXL_Msk instead */
+#define MCAN_ILS_BECL_Pos                   20                                             /**< (MCAN_ILS) Bit Error Corrected Interrupt Line Position */
+#define MCAN_ILS_BECL_Msk                   (_U_(0x1) << MCAN_ILS_BECL_Pos)                /**< (MCAN_ILS) Bit Error Corrected Interrupt Line Mask */
+#define MCAN_ILS_BECL                       MCAN_ILS_BECL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_BECL_Msk instead */
+#define MCAN_ILS_BEUL_Pos                   21                                             /**< (MCAN_ILS) Bit Error Uncorrected Interrupt Line Position */
+#define MCAN_ILS_BEUL_Msk                   (_U_(0x1) << MCAN_ILS_BEUL_Pos)                /**< (MCAN_ILS) Bit Error Uncorrected Interrupt Line Mask */
+#define MCAN_ILS_BEUL                       MCAN_ILS_BEUL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_BEUL_Msk instead */
+#define MCAN_ILS_ELOL_Pos                   22                                             /**< (MCAN_ILS) Error Logging Overflow Interrupt Line Position */
+#define MCAN_ILS_ELOL_Msk                   (_U_(0x1) << MCAN_ILS_ELOL_Pos)                /**< (MCAN_ILS) Error Logging Overflow Interrupt Line Mask */
+#define MCAN_ILS_ELOL                       MCAN_ILS_ELOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_ELOL_Msk instead */
+#define MCAN_ILS_EPL_Pos                    23                                             /**< (MCAN_ILS) Error Passive Interrupt Line Position */
+#define MCAN_ILS_EPL_Msk                    (_U_(0x1) << MCAN_ILS_EPL_Pos)                 /**< (MCAN_ILS) Error Passive Interrupt Line Mask */
+#define MCAN_ILS_EPL                        MCAN_ILS_EPL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_EPL_Msk instead */
+#define MCAN_ILS_EWL_Pos                    24                                             /**< (MCAN_ILS) Warning Status Interrupt Line Position */
+#define MCAN_ILS_EWL_Msk                    (_U_(0x1) << MCAN_ILS_EWL_Pos)                 /**< (MCAN_ILS) Warning Status Interrupt Line Mask */
+#define MCAN_ILS_EWL                        MCAN_ILS_EWL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_EWL_Msk instead */
+#define MCAN_ILS_BOL_Pos                    25                                             /**< (MCAN_ILS) Bus_Off Status Interrupt Line Position */
+#define MCAN_ILS_BOL_Msk                    (_U_(0x1) << MCAN_ILS_BOL_Pos)                 /**< (MCAN_ILS) Bus_Off Status Interrupt Line Mask */
+#define MCAN_ILS_BOL                        MCAN_ILS_BOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_BOL_Msk instead */
+#define MCAN_ILS_WDIL_Pos                   26                                             /**< (MCAN_ILS) Watchdog Interrupt Line Position */
+#define MCAN_ILS_WDIL_Msk                   (_U_(0x1) << MCAN_ILS_WDIL_Pos)                /**< (MCAN_ILS) Watchdog Interrupt Line Mask */
+#define MCAN_ILS_WDIL                       MCAN_ILS_WDIL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_WDIL_Msk instead */
+#define MCAN_ILS_CRCEL_Pos                  27                                             /**< (MCAN_ILS) CRC Error Interrupt Line Position */
+#define MCAN_ILS_CRCEL_Msk                  (_U_(0x1) << MCAN_ILS_CRCEL_Pos)               /**< (MCAN_ILS) CRC Error Interrupt Line Mask */
+#define MCAN_ILS_CRCEL                      MCAN_ILS_CRCEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_CRCEL_Msk instead */
+#define MCAN_ILS_BEL_Pos                    28                                             /**< (MCAN_ILS) Bit Error Interrupt Line Position */
+#define MCAN_ILS_BEL_Msk                    (_U_(0x1) << MCAN_ILS_BEL_Pos)                 /**< (MCAN_ILS) Bit Error Interrupt Line Mask */
+#define MCAN_ILS_BEL                        MCAN_ILS_BEL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_BEL_Msk instead */
+#define MCAN_ILS_ACKEL_Pos                  29                                             /**< (MCAN_ILS) Acknowledge Error Interrupt Line Position */
+#define MCAN_ILS_ACKEL_Msk                  (_U_(0x1) << MCAN_ILS_ACKEL_Pos)               /**< (MCAN_ILS) Acknowledge Error Interrupt Line Mask */
+#define MCAN_ILS_ACKEL                      MCAN_ILS_ACKEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_ACKEL_Msk instead */
+#define MCAN_ILS_FOEL_Pos                   30                                             /**< (MCAN_ILS) Format Error Interrupt Line Position */
+#define MCAN_ILS_FOEL_Msk                   (_U_(0x1) << MCAN_ILS_FOEL_Pos)                /**< (MCAN_ILS) Format Error Interrupt Line Mask */
+#define MCAN_ILS_FOEL                       MCAN_ILS_FOEL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_FOEL_Msk instead */
+#define MCAN_ILS_STEL_Pos                   31                                             /**< (MCAN_ILS) Stuff Error Interrupt Line Position */
+#define MCAN_ILS_STEL_Msk                   (_U_(0x1) << MCAN_ILS_STEL_Pos)                /**< (MCAN_ILS) Stuff Error Interrupt Line Mask */
+#define MCAN_ILS_STEL                       MCAN_ILS_STEL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_STEL_Msk instead */
+#define MCAN_ILS_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_ILS) Register MASK  (Use MCAN_ILS_Msk instead)  */
+#define MCAN_ILS_Msk                        _U_(0xFFFFFFFF)                                /**< (MCAN_ILS) Register Mask  */
+
+
+/* -------- MCAN_ILE : (MCAN Offset: 0x5c) (R/W 32) Interrupt Line Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EINT0:1;                   /**< bit:      0  Enable Interrupt Line 0                  */
+    uint32_t EINT1:1;                   /**< bit:      1  Enable Interrupt Line 1                  */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EINT:2;                    /**< bit:   0..1  Enable Interrupt Line x                  */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ILE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ILE_OFFSET                     (0x5C)                                        /**<  (MCAN_ILE) Interrupt Line Enable Register  Offset */
+
+#define MCAN_ILE_EINT0_Pos                  0                                              /**< (MCAN_ILE) Enable Interrupt Line 0 Position */
+#define MCAN_ILE_EINT0_Msk                  (_U_(0x1) << MCAN_ILE_EINT0_Pos)               /**< (MCAN_ILE) Enable Interrupt Line 0 Mask */
+#define MCAN_ILE_EINT0                      MCAN_ILE_EINT0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILE_EINT0_Msk instead */
+#define MCAN_ILE_EINT1_Pos                  1                                              /**< (MCAN_ILE) Enable Interrupt Line 1 Position */
+#define MCAN_ILE_EINT1_Msk                  (_U_(0x1) << MCAN_ILE_EINT1_Pos)               /**< (MCAN_ILE) Enable Interrupt Line 1 Mask */
+#define MCAN_ILE_EINT1                      MCAN_ILE_EINT1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILE_EINT1_Msk instead */
+#define MCAN_ILE_MASK                       _U_(0x03)                                      /**< \deprecated (MCAN_ILE) Register MASK  (Use MCAN_ILE_Msk instead)  */
+#define MCAN_ILE_Msk                        _U_(0x03)                                      /**< (MCAN_ILE) Register Mask  */
+
+#define MCAN_ILE_EINT_Pos                   0                                              /**< (MCAN_ILE Position) Enable Interrupt Line x */
+#define MCAN_ILE_EINT_Msk                   (_U_(0x3) << MCAN_ILE_EINT_Pos)                /**< (MCAN_ILE Mask) EINT */
+#define MCAN_ILE_EINT(value)                (MCAN_ILE_EINT_Msk & ((value) << MCAN_ILE_EINT_Pos))  
+
+/* -------- MCAN_GFC : (MCAN Offset: 0x80) (R/W 32) Global Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RRFE:1;                    /**< bit:      0  Reject Remote Frames Extended            */
+    uint32_t RRFS:1;                    /**< bit:      1  Reject Remote Frames Standard            */
+    uint32_t ANFE:2;                    /**< bit:   2..3  Accept Non-matching Frames Extended      */
+    uint32_t ANFS:2;                    /**< bit:   4..5  Accept Non-matching Frames Standard      */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_GFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_GFC_OFFSET                     (0x80)                                        /**<  (MCAN_GFC) Global Filter Configuration Register  Offset */
+
+#define MCAN_GFC_RRFE_Pos                   0                                              /**< (MCAN_GFC) Reject Remote Frames Extended Position */
+#define MCAN_GFC_RRFE_Msk                   (_U_(0x1) << MCAN_GFC_RRFE_Pos)                /**< (MCAN_GFC) Reject Remote Frames Extended Mask */
+#define MCAN_GFC_RRFE                       MCAN_GFC_RRFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_GFC_RRFE_Msk instead */
+#define   MCAN_GFC_RRFE_FILTER_Val          _U_(0x0)                                       /**< (MCAN_GFC) Filter remote frames with 29-bit extended IDs.  */
+#define   MCAN_GFC_RRFE_REJECT_Val          _U_(0x1)                                       /**< (MCAN_GFC) Reject all remote frames with 29-bit extended IDs.  */
+#define MCAN_GFC_RRFE_FILTER                (MCAN_GFC_RRFE_FILTER_Val << MCAN_GFC_RRFE_Pos)  /**< (MCAN_GFC) Filter remote frames with 29-bit extended IDs. Position  */
+#define MCAN_GFC_RRFE_REJECT                (MCAN_GFC_RRFE_REJECT_Val << MCAN_GFC_RRFE_Pos)  /**< (MCAN_GFC) Reject all remote frames with 29-bit extended IDs. Position  */
+#define MCAN_GFC_RRFS_Pos                   1                                              /**< (MCAN_GFC) Reject Remote Frames Standard Position */
+#define MCAN_GFC_RRFS_Msk                   (_U_(0x1) << MCAN_GFC_RRFS_Pos)                /**< (MCAN_GFC) Reject Remote Frames Standard Mask */
+#define MCAN_GFC_RRFS                       MCAN_GFC_RRFS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_GFC_RRFS_Msk instead */
+#define   MCAN_GFC_RRFS_FILTER_Val          _U_(0x0)                                       /**< (MCAN_GFC) Filter remote frames with 11-bit standard IDs.  */
+#define   MCAN_GFC_RRFS_REJECT_Val          _U_(0x1)                                       /**< (MCAN_GFC) Reject all remote frames with 11-bit standard IDs.  */
+#define MCAN_GFC_RRFS_FILTER                (MCAN_GFC_RRFS_FILTER_Val << MCAN_GFC_RRFS_Pos)  /**< (MCAN_GFC) Filter remote frames with 11-bit standard IDs. Position  */
+#define MCAN_GFC_RRFS_REJECT                (MCAN_GFC_RRFS_REJECT_Val << MCAN_GFC_RRFS_Pos)  /**< (MCAN_GFC) Reject all remote frames with 11-bit standard IDs. Position  */
+#define MCAN_GFC_ANFE_Pos                   2                                              /**< (MCAN_GFC) Accept Non-matching Frames Extended Position */
+#define MCAN_GFC_ANFE_Msk                   (_U_(0x3) << MCAN_GFC_ANFE_Pos)                /**< (MCAN_GFC) Accept Non-matching Frames Extended Mask */
+#define MCAN_GFC_ANFE(value)                (MCAN_GFC_ANFE_Msk & ((value) << MCAN_GFC_ANFE_Pos))
+#define   MCAN_GFC_ANFE_RX_FIFO_0_Val       _U_(0x0)                                       /**< (MCAN_GFC) Message stored in Receive FIFO 0  */
+#define   MCAN_GFC_ANFE_RX_FIFO_1_Val       _U_(0x1)                                       /**< (MCAN_GFC) Message stored in Receive FIFO 1  */
+#define MCAN_GFC_ANFE_RX_FIFO_0             (MCAN_GFC_ANFE_RX_FIFO_0_Val << MCAN_GFC_ANFE_Pos)  /**< (MCAN_GFC) Message stored in Receive FIFO 0 Position  */
+#define MCAN_GFC_ANFE_RX_FIFO_1             (MCAN_GFC_ANFE_RX_FIFO_1_Val << MCAN_GFC_ANFE_Pos)  /**< (MCAN_GFC) Message stored in Receive FIFO 1 Position  */
+#define MCAN_GFC_ANFS_Pos                   4                                              /**< (MCAN_GFC) Accept Non-matching Frames Standard Position */
+#define MCAN_GFC_ANFS_Msk                   (_U_(0x3) << MCAN_GFC_ANFS_Pos)                /**< (MCAN_GFC) Accept Non-matching Frames Standard Mask */
+#define MCAN_GFC_ANFS(value)                (MCAN_GFC_ANFS_Msk & ((value) << MCAN_GFC_ANFS_Pos))
+#define   MCAN_GFC_ANFS_RX_FIFO_0_Val       _U_(0x0)                                       /**< (MCAN_GFC) Message stored in Receive FIFO 0  */
+#define   MCAN_GFC_ANFS_RX_FIFO_1_Val       _U_(0x1)                                       /**< (MCAN_GFC) Message stored in Receive FIFO 1  */
+#define MCAN_GFC_ANFS_RX_FIFO_0             (MCAN_GFC_ANFS_RX_FIFO_0_Val << MCAN_GFC_ANFS_Pos)  /**< (MCAN_GFC) Message stored in Receive FIFO 0 Position  */
+#define MCAN_GFC_ANFS_RX_FIFO_1             (MCAN_GFC_ANFS_RX_FIFO_1_Val << MCAN_GFC_ANFS_Pos)  /**< (MCAN_GFC) Message stored in Receive FIFO 1 Position  */
+#define MCAN_GFC_MASK                       _U_(0x3F)                                      /**< \deprecated (MCAN_GFC) Register MASK  (Use MCAN_GFC_Msk instead)  */
+#define MCAN_GFC_Msk                        _U_(0x3F)                                      /**< (MCAN_GFC) Register Mask  */
+
+
+/* -------- MCAN_SIDFC : (MCAN Offset: 0x84) (R/W 32) Standard ID Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t FLSSA:14;                  /**< bit:  2..15  Filter List Standard Start Address       */
+    uint32_t LSS:8;                     /**< bit: 16..23  List Size Standard                       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_SIDFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_SIDFC_OFFSET                   (0x84)                                        /**<  (MCAN_SIDFC) Standard ID Filter Configuration Register  Offset */
+
+#define MCAN_SIDFC_FLSSA_Pos                2                                              /**< (MCAN_SIDFC) Filter List Standard Start Address Position */
+#define MCAN_SIDFC_FLSSA_Msk                (_U_(0x3FFF) << MCAN_SIDFC_FLSSA_Pos)          /**< (MCAN_SIDFC) Filter List Standard Start Address Mask */
+#define MCAN_SIDFC_FLSSA(value)             (MCAN_SIDFC_FLSSA_Msk & ((value) << MCAN_SIDFC_FLSSA_Pos))
+#define MCAN_SIDFC_LSS_Pos                  16                                             /**< (MCAN_SIDFC) List Size Standard Position */
+#define MCAN_SIDFC_LSS_Msk                  (_U_(0xFF) << MCAN_SIDFC_LSS_Pos)              /**< (MCAN_SIDFC) List Size Standard Mask */
+#define MCAN_SIDFC_LSS(value)               (MCAN_SIDFC_LSS_Msk & ((value) << MCAN_SIDFC_LSS_Pos))
+#define MCAN_SIDFC_MASK                     _U_(0xFFFFFC)                                  /**< \deprecated (MCAN_SIDFC) Register MASK  (Use MCAN_SIDFC_Msk instead)  */
+#define MCAN_SIDFC_Msk                      _U_(0xFFFFFC)                                  /**< (MCAN_SIDFC) Register Mask  */
+
+
+/* -------- MCAN_XIDFC : (MCAN Offset: 0x88) (R/W 32) Extended ID Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t FLESA:14;                  /**< bit:  2..15  Filter List Extended Start Address       */
+    uint32_t LSE:7;                     /**< bit: 16..22  List Size Extended                       */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFC_OFFSET                   (0x88)                                        /**<  (MCAN_XIDFC) Extended ID Filter Configuration Register  Offset */
+
+#define MCAN_XIDFC_FLESA_Pos                2                                              /**< (MCAN_XIDFC) Filter List Extended Start Address Position */
+#define MCAN_XIDFC_FLESA_Msk                (_U_(0x3FFF) << MCAN_XIDFC_FLESA_Pos)          /**< (MCAN_XIDFC) Filter List Extended Start Address Mask */
+#define MCAN_XIDFC_FLESA(value)             (MCAN_XIDFC_FLESA_Msk & ((value) << MCAN_XIDFC_FLESA_Pos))
+#define MCAN_XIDFC_LSE_Pos                  16                                             /**< (MCAN_XIDFC) List Size Extended Position */
+#define MCAN_XIDFC_LSE_Msk                  (_U_(0x7F) << MCAN_XIDFC_LSE_Pos)              /**< (MCAN_XIDFC) List Size Extended Mask */
+#define MCAN_XIDFC_LSE(value)               (MCAN_XIDFC_LSE_Msk & ((value) << MCAN_XIDFC_LSE_Pos))
+#define MCAN_XIDFC_MASK                     _U_(0x7FFFFC)                                  /**< \deprecated (MCAN_XIDFC) Register MASK  (Use MCAN_XIDFC_Msk instead)  */
+#define MCAN_XIDFC_Msk                      _U_(0x7FFFFC)                                  /**< (MCAN_XIDFC) Register Mask  */
+
+
+/* -------- MCAN_XIDAM : (MCAN Offset: 0x90) (R/W 32) Extended ID AND Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EIDM:29;                   /**< bit:  0..28  Extended ID Mask                         */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDAM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDAM_OFFSET                   (0x90)                                        /**<  (MCAN_XIDAM) Extended ID AND Mask Register  Offset */
+
+#define MCAN_XIDAM_EIDM_Pos                 0                                              /**< (MCAN_XIDAM) Extended ID Mask Position */
+#define MCAN_XIDAM_EIDM_Msk                 (_U_(0x1FFFFFFF) << MCAN_XIDAM_EIDM_Pos)       /**< (MCAN_XIDAM) Extended ID Mask Mask */
+#define MCAN_XIDAM_EIDM(value)              (MCAN_XIDAM_EIDM_Msk & ((value) << MCAN_XIDAM_EIDM_Pos))
+#define MCAN_XIDAM_MASK                     _U_(0x1FFFFFFF)                                /**< \deprecated (MCAN_XIDAM) Register MASK  (Use MCAN_XIDAM_Msk instead)  */
+#define MCAN_XIDAM_Msk                      _U_(0x1FFFFFFF)                                /**< (MCAN_XIDAM) Register Mask  */
+
+
+/* -------- MCAN_HPMS : (MCAN Offset: 0x94) (R/ 32) High Priority Message Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIDX:6;                    /**< bit:   0..5  Buffer Index                             */
+    uint32_t MSI:2;                     /**< bit:   6..7  Message Storage Indicator                */
+    uint32_t FIDX:7;                    /**< bit:  8..14  Filter Index                             */
+    uint32_t FLST:1;                    /**< bit:     15  Filter List                              */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_HPMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_HPMS_OFFSET                    (0x94)                                        /**<  (MCAN_HPMS) High Priority Message Status Register  Offset */
+
+#define MCAN_HPMS_BIDX_Pos                  0                                              /**< (MCAN_HPMS) Buffer Index Position */
+#define MCAN_HPMS_BIDX_Msk                  (_U_(0x3F) << MCAN_HPMS_BIDX_Pos)              /**< (MCAN_HPMS) Buffer Index Mask */
+#define MCAN_HPMS_BIDX(value)               (MCAN_HPMS_BIDX_Msk & ((value) << MCAN_HPMS_BIDX_Pos))
+#define MCAN_HPMS_MSI_Pos                   6                                              /**< (MCAN_HPMS) Message Storage Indicator Position */
+#define MCAN_HPMS_MSI_Msk                   (_U_(0x3) << MCAN_HPMS_MSI_Pos)                /**< (MCAN_HPMS) Message Storage Indicator Mask */
+#define MCAN_HPMS_MSI(value)                (MCAN_HPMS_MSI_Msk & ((value) << MCAN_HPMS_MSI_Pos))
+#define   MCAN_HPMS_MSI_NO_FIFO_SEL_Val     _U_(0x0)                                       /**< (MCAN_HPMS) No FIFO selected.  */
+#define   MCAN_HPMS_MSI_LOST_Val            _U_(0x1)                                       /**< (MCAN_HPMS) FIFO message.  */
+#define   MCAN_HPMS_MSI_FIFO_0_Val          _U_(0x2)                                       /**< (MCAN_HPMS) Message stored in FIFO 0.  */
+#define   MCAN_HPMS_MSI_FIFO_1_Val          _U_(0x3)                                       /**< (MCAN_HPMS) Message stored in FIFO 1.  */
+#define MCAN_HPMS_MSI_NO_FIFO_SEL           (MCAN_HPMS_MSI_NO_FIFO_SEL_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) No FIFO selected. Position  */
+#define MCAN_HPMS_MSI_LOST                  (MCAN_HPMS_MSI_LOST_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) FIFO message. Position  */
+#define MCAN_HPMS_MSI_FIFO_0                (MCAN_HPMS_MSI_FIFO_0_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) Message stored in FIFO 0. Position  */
+#define MCAN_HPMS_MSI_FIFO_1                (MCAN_HPMS_MSI_FIFO_1_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) Message stored in FIFO 1. Position  */
+#define MCAN_HPMS_FIDX_Pos                  8                                              /**< (MCAN_HPMS) Filter Index Position */
+#define MCAN_HPMS_FIDX_Msk                  (_U_(0x7F) << MCAN_HPMS_FIDX_Pos)              /**< (MCAN_HPMS) Filter Index Mask */
+#define MCAN_HPMS_FIDX(value)               (MCAN_HPMS_FIDX_Msk & ((value) << MCAN_HPMS_FIDX_Pos))
+#define MCAN_HPMS_FLST_Pos                  15                                             /**< (MCAN_HPMS) Filter List Position */
+#define MCAN_HPMS_FLST_Msk                  (_U_(0x1) << MCAN_HPMS_FLST_Pos)               /**< (MCAN_HPMS) Filter List Mask */
+#define MCAN_HPMS_FLST                      MCAN_HPMS_FLST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_HPMS_FLST_Msk instead */
+#define MCAN_HPMS_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_HPMS) Register MASK  (Use MCAN_HPMS_Msk instead)  */
+#define MCAN_HPMS_Msk                       _U_(0xFFFF)                                    /**< (MCAN_HPMS) Register Mask  */
+
+
+/* -------- MCAN_NDAT1 : (MCAN Offset: 0x98) (R/W 32) New Data 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ND0:1;                     /**< bit:      0  New Data                                 */
+    uint32_t ND1:1;                     /**< bit:      1  New Data                                 */
+    uint32_t ND2:1;                     /**< bit:      2  New Data                                 */
+    uint32_t ND3:1;                     /**< bit:      3  New Data                                 */
+    uint32_t ND4:1;                     /**< bit:      4  New Data                                 */
+    uint32_t ND5:1;                     /**< bit:      5  New Data                                 */
+    uint32_t ND6:1;                     /**< bit:      6  New Data                                 */
+    uint32_t ND7:1;                     /**< bit:      7  New Data                                 */
+    uint32_t ND8:1;                     /**< bit:      8  New Data                                 */
+    uint32_t ND9:1;                     /**< bit:      9  New Data                                 */
+    uint32_t ND10:1;                    /**< bit:     10  New Data                                 */
+    uint32_t ND11:1;                    /**< bit:     11  New Data                                 */
+    uint32_t ND12:1;                    /**< bit:     12  New Data                                 */
+    uint32_t ND13:1;                    /**< bit:     13  New Data                                 */
+    uint32_t ND14:1;                    /**< bit:     14  New Data                                 */
+    uint32_t ND15:1;                    /**< bit:     15  New Data                                 */
+    uint32_t ND16:1;                    /**< bit:     16  New Data                                 */
+    uint32_t ND17:1;                    /**< bit:     17  New Data                                 */
+    uint32_t ND18:1;                    /**< bit:     18  New Data                                 */
+    uint32_t ND19:1;                    /**< bit:     19  New Data                                 */
+    uint32_t ND20:1;                    /**< bit:     20  New Data                                 */
+    uint32_t ND21:1;                    /**< bit:     21  New Data                                 */
+    uint32_t ND22:1;                    /**< bit:     22  New Data                                 */
+    uint32_t ND23:1;                    /**< bit:     23  New Data                                 */
+    uint32_t ND24:1;                    /**< bit:     24  New Data                                 */
+    uint32_t ND25:1;                    /**< bit:     25  New Data                                 */
+    uint32_t ND26:1;                    /**< bit:     26  New Data                                 */
+    uint32_t ND27:1;                    /**< bit:     27  New Data                                 */
+    uint32_t ND28:1;                    /**< bit:     28  New Data                                 */
+    uint32_t ND29:1;                    /**< bit:     29  New Data                                 */
+    uint32_t ND30:1;                    /**< bit:     30  New Data                                 */
+    uint32_t ND31:1;                    /**< bit:     31  New Data                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ND:32;                     /**< bit:  0..31  New Data                                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_NDAT1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_NDAT1_OFFSET                   (0x98)                                        /**<  (MCAN_NDAT1) New Data 1 Register  Offset */
+
+#define MCAN_NDAT1_ND0_Pos                  0                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND0_Msk                  (_U_(0x1) << MCAN_NDAT1_ND0_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND0                      MCAN_NDAT1_ND0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND0_Msk instead */
+#define MCAN_NDAT1_ND1_Pos                  1                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND1_Msk                  (_U_(0x1) << MCAN_NDAT1_ND1_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND1                      MCAN_NDAT1_ND1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND1_Msk instead */
+#define MCAN_NDAT1_ND2_Pos                  2                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND2_Msk                  (_U_(0x1) << MCAN_NDAT1_ND2_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND2                      MCAN_NDAT1_ND2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND2_Msk instead */
+#define MCAN_NDAT1_ND3_Pos                  3                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND3_Msk                  (_U_(0x1) << MCAN_NDAT1_ND3_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND3                      MCAN_NDAT1_ND3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND3_Msk instead */
+#define MCAN_NDAT1_ND4_Pos                  4                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND4_Msk                  (_U_(0x1) << MCAN_NDAT1_ND4_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND4                      MCAN_NDAT1_ND4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND4_Msk instead */
+#define MCAN_NDAT1_ND5_Pos                  5                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND5_Msk                  (_U_(0x1) << MCAN_NDAT1_ND5_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND5                      MCAN_NDAT1_ND5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND5_Msk instead */
+#define MCAN_NDAT1_ND6_Pos                  6                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND6_Msk                  (_U_(0x1) << MCAN_NDAT1_ND6_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND6                      MCAN_NDAT1_ND6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND6_Msk instead */
+#define MCAN_NDAT1_ND7_Pos                  7                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND7_Msk                  (_U_(0x1) << MCAN_NDAT1_ND7_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND7                      MCAN_NDAT1_ND7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND7_Msk instead */
+#define MCAN_NDAT1_ND8_Pos                  8                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND8_Msk                  (_U_(0x1) << MCAN_NDAT1_ND8_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND8                      MCAN_NDAT1_ND8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND8_Msk instead */
+#define MCAN_NDAT1_ND9_Pos                  9                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND9_Msk                  (_U_(0x1) << MCAN_NDAT1_ND9_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND9                      MCAN_NDAT1_ND9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND9_Msk instead */
+#define MCAN_NDAT1_ND10_Pos                 10                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND10_Msk                 (_U_(0x1) << MCAN_NDAT1_ND10_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND10                     MCAN_NDAT1_ND10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND10_Msk instead */
+#define MCAN_NDAT1_ND11_Pos                 11                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND11_Msk                 (_U_(0x1) << MCAN_NDAT1_ND11_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND11                     MCAN_NDAT1_ND11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND11_Msk instead */
+#define MCAN_NDAT1_ND12_Pos                 12                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND12_Msk                 (_U_(0x1) << MCAN_NDAT1_ND12_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND12                     MCAN_NDAT1_ND12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND12_Msk instead */
+#define MCAN_NDAT1_ND13_Pos                 13                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND13_Msk                 (_U_(0x1) << MCAN_NDAT1_ND13_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND13                     MCAN_NDAT1_ND13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND13_Msk instead */
+#define MCAN_NDAT1_ND14_Pos                 14                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND14_Msk                 (_U_(0x1) << MCAN_NDAT1_ND14_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND14                     MCAN_NDAT1_ND14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND14_Msk instead */
+#define MCAN_NDAT1_ND15_Pos                 15                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND15_Msk                 (_U_(0x1) << MCAN_NDAT1_ND15_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND15                     MCAN_NDAT1_ND15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND15_Msk instead */
+#define MCAN_NDAT1_ND16_Pos                 16                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND16_Msk                 (_U_(0x1) << MCAN_NDAT1_ND16_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND16                     MCAN_NDAT1_ND16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND16_Msk instead */
+#define MCAN_NDAT1_ND17_Pos                 17                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND17_Msk                 (_U_(0x1) << MCAN_NDAT1_ND17_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND17                     MCAN_NDAT1_ND17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND17_Msk instead */
+#define MCAN_NDAT1_ND18_Pos                 18                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND18_Msk                 (_U_(0x1) << MCAN_NDAT1_ND18_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND18                     MCAN_NDAT1_ND18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND18_Msk instead */
+#define MCAN_NDAT1_ND19_Pos                 19                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND19_Msk                 (_U_(0x1) << MCAN_NDAT1_ND19_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND19                     MCAN_NDAT1_ND19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND19_Msk instead */
+#define MCAN_NDAT1_ND20_Pos                 20                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND20_Msk                 (_U_(0x1) << MCAN_NDAT1_ND20_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND20                     MCAN_NDAT1_ND20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND20_Msk instead */
+#define MCAN_NDAT1_ND21_Pos                 21                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND21_Msk                 (_U_(0x1) << MCAN_NDAT1_ND21_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND21                     MCAN_NDAT1_ND21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND21_Msk instead */
+#define MCAN_NDAT1_ND22_Pos                 22                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND22_Msk                 (_U_(0x1) << MCAN_NDAT1_ND22_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND22                     MCAN_NDAT1_ND22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND22_Msk instead */
+#define MCAN_NDAT1_ND23_Pos                 23                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND23_Msk                 (_U_(0x1) << MCAN_NDAT1_ND23_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND23                     MCAN_NDAT1_ND23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND23_Msk instead */
+#define MCAN_NDAT1_ND24_Pos                 24                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND24_Msk                 (_U_(0x1) << MCAN_NDAT1_ND24_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND24                     MCAN_NDAT1_ND24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND24_Msk instead */
+#define MCAN_NDAT1_ND25_Pos                 25                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND25_Msk                 (_U_(0x1) << MCAN_NDAT1_ND25_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND25                     MCAN_NDAT1_ND25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND25_Msk instead */
+#define MCAN_NDAT1_ND26_Pos                 26                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND26_Msk                 (_U_(0x1) << MCAN_NDAT1_ND26_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND26                     MCAN_NDAT1_ND26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND26_Msk instead */
+#define MCAN_NDAT1_ND27_Pos                 27                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND27_Msk                 (_U_(0x1) << MCAN_NDAT1_ND27_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND27                     MCAN_NDAT1_ND27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND27_Msk instead */
+#define MCAN_NDAT1_ND28_Pos                 28                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND28_Msk                 (_U_(0x1) << MCAN_NDAT1_ND28_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND28                     MCAN_NDAT1_ND28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND28_Msk instead */
+#define MCAN_NDAT1_ND29_Pos                 29                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND29_Msk                 (_U_(0x1) << MCAN_NDAT1_ND29_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND29                     MCAN_NDAT1_ND29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND29_Msk instead */
+#define MCAN_NDAT1_ND30_Pos                 30                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND30_Msk                 (_U_(0x1) << MCAN_NDAT1_ND30_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND30                     MCAN_NDAT1_ND30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND30_Msk instead */
+#define MCAN_NDAT1_ND31_Pos                 31                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND31_Msk                 (_U_(0x1) << MCAN_NDAT1_ND31_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND31                     MCAN_NDAT1_ND31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND31_Msk instead */
+#define MCAN_NDAT1_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_NDAT1) Register MASK  (Use MCAN_NDAT1_Msk instead)  */
+#define MCAN_NDAT1_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_NDAT1) Register Mask  */
+
+#define MCAN_NDAT1_ND_Pos                   0                                              /**< (MCAN_NDAT1 Position) New Data */
+#define MCAN_NDAT1_ND_Msk                   (_U_(0xFFFFFFFF) << MCAN_NDAT1_ND_Pos)         /**< (MCAN_NDAT1 Mask) ND */
+#define MCAN_NDAT1_ND(value)                (MCAN_NDAT1_ND_Msk & ((value) << MCAN_NDAT1_ND_Pos))  
+
+/* -------- MCAN_NDAT2 : (MCAN Offset: 0x9c) (R/W 32) New Data 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ND32:1;                    /**< bit:      0  New Data                                 */
+    uint32_t ND33:1;                    /**< bit:      1  New Data                                 */
+    uint32_t ND34:1;                    /**< bit:      2  New Data                                 */
+    uint32_t ND35:1;                    /**< bit:      3  New Data                                 */
+    uint32_t ND36:1;                    /**< bit:      4  New Data                                 */
+    uint32_t ND37:1;                    /**< bit:      5  New Data                                 */
+    uint32_t ND38:1;                    /**< bit:      6  New Data                                 */
+    uint32_t ND39:1;                    /**< bit:      7  New Data                                 */
+    uint32_t ND40:1;                    /**< bit:      8  New Data                                 */
+    uint32_t ND41:1;                    /**< bit:      9  New Data                                 */
+    uint32_t ND42:1;                    /**< bit:     10  New Data                                 */
+    uint32_t ND43:1;                    /**< bit:     11  New Data                                 */
+    uint32_t ND44:1;                    /**< bit:     12  New Data                                 */
+    uint32_t ND45:1;                    /**< bit:     13  New Data                                 */
+    uint32_t ND46:1;                    /**< bit:     14  New Data                                 */
+    uint32_t ND47:1;                    /**< bit:     15  New Data                                 */
+    uint32_t ND48:1;                    /**< bit:     16  New Data                                 */
+    uint32_t ND49:1;                    /**< bit:     17  New Data                                 */
+    uint32_t ND50:1;                    /**< bit:     18  New Data                                 */
+    uint32_t ND51:1;                    /**< bit:     19  New Data                                 */
+    uint32_t ND52:1;                    /**< bit:     20  New Data                                 */
+    uint32_t ND53:1;                    /**< bit:     21  New Data                                 */
+    uint32_t ND54:1;                    /**< bit:     22  New Data                                 */
+    uint32_t ND55:1;                    /**< bit:     23  New Data                                 */
+    uint32_t ND56:1;                    /**< bit:     24  New Data                                 */
+    uint32_t ND57:1;                    /**< bit:     25  New Data                                 */
+    uint32_t ND58:1;                    /**< bit:     26  New Data                                 */
+    uint32_t ND59:1;                    /**< bit:     27  New Data                                 */
+    uint32_t ND60:1;                    /**< bit:     28  New Data                                 */
+    uint32_t ND61:1;                    /**< bit:     29  New Data                                 */
+    uint32_t ND62:1;                    /**< bit:     30  New Data                                 */
+    uint32_t ND63:1;                    /**< bit:     31  New Data                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ND:32;                     /**< bit:  0..31  New Data                                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_NDAT2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_NDAT2_OFFSET                   (0x9C)                                        /**<  (MCAN_NDAT2) New Data 2 Register  Offset */
+
+#define MCAN_NDAT2_ND32_Pos                 0                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND32_Msk                 (_U_(0x1) << MCAN_NDAT2_ND32_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND32                     MCAN_NDAT2_ND32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND32_Msk instead */
+#define MCAN_NDAT2_ND33_Pos                 1                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND33_Msk                 (_U_(0x1) << MCAN_NDAT2_ND33_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND33                     MCAN_NDAT2_ND33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND33_Msk instead */
+#define MCAN_NDAT2_ND34_Pos                 2                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND34_Msk                 (_U_(0x1) << MCAN_NDAT2_ND34_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND34                     MCAN_NDAT2_ND34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND34_Msk instead */
+#define MCAN_NDAT2_ND35_Pos                 3                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND35_Msk                 (_U_(0x1) << MCAN_NDAT2_ND35_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND35                     MCAN_NDAT2_ND35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND35_Msk instead */
+#define MCAN_NDAT2_ND36_Pos                 4                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND36_Msk                 (_U_(0x1) << MCAN_NDAT2_ND36_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND36                     MCAN_NDAT2_ND36_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND36_Msk instead */
+#define MCAN_NDAT2_ND37_Pos                 5                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND37_Msk                 (_U_(0x1) << MCAN_NDAT2_ND37_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND37                     MCAN_NDAT2_ND37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND37_Msk instead */
+#define MCAN_NDAT2_ND38_Pos                 6                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND38_Msk                 (_U_(0x1) << MCAN_NDAT2_ND38_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND38                     MCAN_NDAT2_ND38_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND38_Msk instead */
+#define MCAN_NDAT2_ND39_Pos                 7                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND39_Msk                 (_U_(0x1) << MCAN_NDAT2_ND39_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND39                     MCAN_NDAT2_ND39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND39_Msk instead */
+#define MCAN_NDAT2_ND40_Pos                 8                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND40_Msk                 (_U_(0x1) << MCAN_NDAT2_ND40_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND40                     MCAN_NDAT2_ND40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND40_Msk instead */
+#define MCAN_NDAT2_ND41_Pos                 9                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND41_Msk                 (_U_(0x1) << MCAN_NDAT2_ND41_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND41                     MCAN_NDAT2_ND41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND41_Msk instead */
+#define MCAN_NDAT2_ND42_Pos                 10                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND42_Msk                 (_U_(0x1) << MCAN_NDAT2_ND42_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND42                     MCAN_NDAT2_ND42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND42_Msk instead */
+#define MCAN_NDAT2_ND43_Pos                 11                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND43_Msk                 (_U_(0x1) << MCAN_NDAT2_ND43_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND43                     MCAN_NDAT2_ND43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND43_Msk instead */
+#define MCAN_NDAT2_ND44_Pos                 12                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND44_Msk                 (_U_(0x1) << MCAN_NDAT2_ND44_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND44                     MCAN_NDAT2_ND44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND44_Msk instead */
+#define MCAN_NDAT2_ND45_Pos                 13                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND45_Msk                 (_U_(0x1) << MCAN_NDAT2_ND45_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND45                     MCAN_NDAT2_ND45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND45_Msk instead */
+#define MCAN_NDAT2_ND46_Pos                 14                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND46_Msk                 (_U_(0x1) << MCAN_NDAT2_ND46_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND46                     MCAN_NDAT2_ND46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND46_Msk instead */
+#define MCAN_NDAT2_ND47_Pos                 15                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND47_Msk                 (_U_(0x1) << MCAN_NDAT2_ND47_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND47                     MCAN_NDAT2_ND47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND47_Msk instead */
+#define MCAN_NDAT2_ND48_Pos                 16                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND48_Msk                 (_U_(0x1) << MCAN_NDAT2_ND48_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND48                     MCAN_NDAT2_ND48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND48_Msk instead */
+#define MCAN_NDAT2_ND49_Pos                 17                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND49_Msk                 (_U_(0x1) << MCAN_NDAT2_ND49_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND49                     MCAN_NDAT2_ND49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND49_Msk instead */
+#define MCAN_NDAT2_ND50_Pos                 18                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND50_Msk                 (_U_(0x1) << MCAN_NDAT2_ND50_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND50                     MCAN_NDAT2_ND50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND50_Msk instead */
+#define MCAN_NDAT2_ND51_Pos                 19                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND51_Msk                 (_U_(0x1) << MCAN_NDAT2_ND51_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND51                     MCAN_NDAT2_ND51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND51_Msk instead */
+#define MCAN_NDAT2_ND52_Pos                 20                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND52_Msk                 (_U_(0x1) << MCAN_NDAT2_ND52_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND52                     MCAN_NDAT2_ND52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND52_Msk instead */
+#define MCAN_NDAT2_ND53_Pos                 21                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND53_Msk                 (_U_(0x1) << MCAN_NDAT2_ND53_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND53                     MCAN_NDAT2_ND53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND53_Msk instead */
+#define MCAN_NDAT2_ND54_Pos                 22                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND54_Msk                 (_U_(0x1) << MCAN_NDAT2_ND54_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND54                     MCAN_NDAT2_ND54_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND54_Msk instead */
+#define MCAN_NDAT2_ND55_Pos                 23                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND55_Msk                 (_U_(0x1) << MCAN_NDAT2_ND55_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND55                     MCAN_NDAT2_ND55_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND55_Msk instead */
+#define MCAN_NDAT2_ND56_Pos                 24                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND56_Msk                 (_U_(0x1) << MCAN_NDAT2_ND56_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND56                     MCAN_NDAT2_ND56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND56_Msk instead */
+#define MCAN_NDAT2_ND57_Pos                 25                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND57_Msk                 (_U_(0x1) << MCAN_NDAT2_ND57_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND57                     MCAN_NDAT2_ND57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND57_Msk instead */
+#define MCAN_NDAT2_ND58_Pos                 26                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND58_Msk                 (_U_(0x1) << MCAN_NDAT2_ND58_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND58                     MCAN_NDAT2_ND58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND58_Msk instead */
+#define MCAN_NDAT2_ND59_Pos                 27                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND59_Msk                 (_U_(0x1) << MCAN_NDAT2_ND59_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND59                     MCAN_NDAT2_ND59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND59_Msk instead */
+#define MCAN_NDAT2_ND60_Pos                 28                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND60_Msk                 (_U_(0x1) << MCAN_NDAT2_ND60_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND60                     MCAN_NDAT2_ND60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND60_Msk instead */
+#define MCAN_NDAT2_ND61_Pos                 29                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND61_Msk                 (_U_(0x1) << MCAN_NDAT2_ND61_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND61                     MCAN_NDAT2_ND61_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND61_Msk instead */
+#define MCAN_NDAT2_ND62_Pos                 30                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND62_Msk                 (_U_(0x1) << MCAN_NDAT2_ND62_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND62                     MCAN_NDAT2_ND62_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND62_Msk instead */
+#define MCAN_NDAT2_ND63_Pos                 31                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND63_Msk                 (_U_(0x1) << MCAN_NDAT2_ND63_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND63                     MCAN_NDAT2_ND63_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND63_Msk instead */
+#define MCAN_NDAT2_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_NDAT2) Register MASK  (Use MCAN_NDAT2_Msk instead)  */
+#define MCAN_NDAT2_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_NDAT2) Register Mask  */
+
+#define MCAN_NDAT2_ND_Pos                   0                                              /**< (MCAN_NDAT2 Position) New Data */
+#define MCAN_NDAT2_ND_Msk                   (_U_(0xFFFFFFFF) << MCAN_NDAT2_ND_Pos)         /**< (MCAN_NDAT2 Mask) ND */
+#define MCAN_NDAT2_ND(value)                (MCAN_NDAT2_ND_Msk & ((value) << MCAN_NDAT2_ND_Pos))  
+
+/* -------- MCAN_RXF0C : (MCAN Offset: 0xa0) (R/W 32) Receive FIFO 0 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t F0SA:14;                   /**< bit:  2..15  Receive FIFO 0 Start Address             */
+    uint32_t F0S:7;                     /**< bit: 16..22  Receive FIFO 0 Start Address             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t F0WM:7;                    /**< bit: 24..30  Receive FIFO 0 Watermark                 */
+    uint32_t F0OM:1;                    /**< bit:     31  FIFO 0 Operation Mode                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0C_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0C_OFFSET                   (0xA0)                                        /**<  (MCAN_RXF0C) Receive FIFO 0 Configuration Register  Offset */
+
+#define MCAN_RXF0C_F0SA_Pos                 2                                              /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Position */
+#define MCAN_RXF0C_F0SA_Msk                 (_U_(0x3FFF) << MCAN_RXF0C_F0SA_Pos)           /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Mask */
+#define MCAN_RXF0C_F0SA(value)              (MCAN_RXF0C_F0SA_Msk & ((value) << MCAN_RXF0C_F0SA_Pos))
+#define MCAN_RXF0C_F0S_Pos                  16                                             /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Position */
+#define MCAN_RXF0C_F0S_Msk                  (_U_(0x7F) << MCAN_RXF0C_F0S_Pos)              /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Mask */
+#define MCAN_RXF0C_F0S(value)               (MCAN_RXF0C_F0S_Msk & ((value) << MCAN_RXF0C_F0S_Pos))
+#define MCAN_RXF0C_F0WM_Pos                 24                                             /**< (MCAN_RXF0C) Receive FIFO 0 Watermark Position */
+#define MCAN_RXF0C_F0WM_Msk                 (_U_(0x7F) << MCAN_RXF0C_F0WM_Pos)             /**< (MCAN_RXF0C) Receive FIFO 0 Watermark Mask */
+#define MCAN_RXF0C_F0WM(value)              (MCAN_RXF0C_F0WM_Msk & ((value) << MCAN_RXF0C_F0WM_Pos))
+#define MCAN_RXF0C_F0OM_Pos                 31                                             /**< (MCAN_RXF0C) FIFO 0 Operation Mode Position */
+#define MCAN_RXF0C_F0OM_Msk                 (_U_(0x1) << MCAN_RXF0C_F0OM_Pos)              /**< (MCAN_RXF0C) FIFO 0 Operation Mode Mask */
+#define MCAN_RXF0C_F0OM                     MCAN_RXF0C_F0OM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0C_F0OM_Msk instead */
+#define MCAN_RXF0C_MASK                     _U_(0xFF7FFFFC)                                /**< \deprecated (MCAN_RXF0C) Register MASK  (Use MCAN_RXF0C_Msk instead)  */
+#define MCAN_RXF0C_Msk                      _U_(0xFF7FFFFC)                                /**< (MCAN_RXF0C) Register Mask  */
+
+
+/* -------- MCAN_RXF0S : (MCAN Offset: 0xa4) (R/ 32) Receive FIFO 0 Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0FL:7;                    /**< bit:   0..6  Receive FIFO 0 Fill Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t F0GI:6;                    /**< bit:  8..13  Receive FIFO 0 Get Index                 */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t F0PI:6;                    /**< bit: 16..21  Receive FIFO 0 Put Index                 */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t F0F:1;                     /**< bit:     24  Receive FIFO 0 Fill Level                */
+    uint32_t RF0L:1;                    /**< bit:     25  Receive FIFO 0 Message Lost              */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0S_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0S_OFFSET                   (0xA4)                                        /**<  (MCAN_RXF0S) Receive FIFO 0 Status Register  Offset */
+
+#define MCAN_RXF0S_F0FL_Pos                 0                                              /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Position */
+#define MCAN_RXF0S_F0FL_Msk                 (_U_(0x7F) << MCAN_RXF0S_F0FL_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Mask */
+#define MCAN_RXF0S_F0FL(value)              (MCAN_RXF0S_F0FL_Msk & ((value) << MCAN_RXF0S_F0FL_Pos))
+#define MCAN_RXF0S_F0GI_Pos                 8                                              /**< (MCAN_RXF0S) Receive FIFO 0 Get Index Position */
+#define MCAN_RXF0S_F0GI_Msk                 (_U_(0x3F) << MCAN_RXF0S_F0GI_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Get Index Mask */
+#define MCAN_RXF0S_F0GI(value)              (MCAN_RXF0S_F0GI_Msk & ((value) << MCAN_RXF0S_F0GI_Pos))
+#define MCAN_RXF0S_F0PI_Pos                 16                                             /**< (MCAN_RXF0S) Receive FIFO 0 Put Index Position */
+#define MCAN_RXF0S_F0PI_Msk                 (_U_(0x3F) << MCAN_RXF0S_F0PI_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Put Index Mask */
+#define MCAN_RXF0S_F0PI(value)              (MCAN_RXF0S_F0PI_Msk & ((value) << MCAN_RXF0S_F0PI_Pos))
+#define MCAN_RXF0S_F0F_Pos                  24                                             /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Position */
+#define MCAN_RXF0S_F0F_Msk                  (_U_(0x1) << MCAN_RXF0S_F0F_Pos)               /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Mask */
+#define MCAN_RXF0S_F0F                      MCAN_RXF0S_F0F_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0S_F0F_Msk instead */
+#define MCAN_RXF0S_RF0L_Pos                 25                                             /**< (MCAN_RXF0S) Receive FIFO 0 Message Lost Position */
+#define MCAN_RXF0S_RF0L_Msk                 (_U_(0x1) << MCAN_RXF0S_RF0L_Pos)              /**< (MCAN_RXF0S) Receive FIFO 0 Message Lost Mask */
+#define MCAN_RXF0S_RF0L                     MCAN_RXF0S_RF0L_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0S_RF0L_Msk instead */
+#define MCAN_RXF0S_MASK                     _U_(0x33F3F7F)                                 /**< \deprecated (MCAN_RXF0S) Register MASK  (Use MCAN_RXF0S_Msk instead)  */
+#define MCAN_RXF0S_Msk                      _U_(0x33F3F7F)                                 /**< (MCAN_RXF0S) Register Mask  */
+
+
+/* -------- MCAN_RXF0A : (MCAN Offset: 0xa8) (R/W 32) Receive FIFO 0 Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0AI:6;                    /**< bit:   0..5  Receive FIFO 0 Acknowledge Index         */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0A_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0A_OFFSET                   (0xA8)                                        /**<  (MCAN_RXF0A) Receive FIFO 0 Acknowledge Register  Offset */
+
+#define MCAN_RXF0A_F0AI_Pos                 0                                              /**< (MCAN_RXF0A) Receive FIFO 0 Acknowledge Index Position */
+#define MCAN_RXF0A_F0AI_Msk                 (_U_(0x3F) << MCAN_RXF0A_F0AI_Pos)             /**< (MCAN_RXF0A) Receive FIFO 0 Acknowledge Index Mask */
+#define MCAN_RXF0A_F0AI(value)              (MCAN_RXF0A_F0AI_Msk & ((value) << MCAN_RXF0A_F0AI_Pos))
+#define MCAN_RXF0A_MASK                     _U_(0x3F)                                      /**< \deprecated (MCAN_RXF0A) Register MASK  (Use MCAN_RXF0A_Msk instead)  */
+#define MCAN_RXF0A_Msk                      _U_(0x3F)                                      /**< (MCAN_RXF0A) Register Mask  */
+
+
+/* -------- MCAN_RXBC : (MCAN Offset: 0xac) (R/W 32) Receive Rx Buffer Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RBSA:14;                   /**< bit:  2..15  Receive Buffer Start Address             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBC_OFFSET                    (0xAC)                                        /**<  (MCAN_RXBC) Receive Rx Buffer Configuration Register  Offset */
+
+#define MCAN_RXBC_RBSA_Pos                  2                                              /**< (MCAN_RXBC) Receive Buffer Start Address Position */
+#define MCAN_RXBC_RBSA_Msk                  (_U_(0x3FFF) << MCAN_RXBC_RBSA_Pos)            /**< (MCAN_RXBC) Receive Buffer Start Address Mask */
+#define MCAN_RXBC_RBSA(value)               (MCAN_RXBC_RBSA_Msk & ((value) << MCAN_RXBC_RBSA_Pos))
+#define MCAN_RXBC_MASK                      _U_(0xFFFC)                                    /**< \deprecated (MCAN_RXBC) Register MASK  (Use MCAN_RXBC_Msk instead)  */
+#define MCAN_RXBC_Msk                       _U_(0xFFFC)                                    /**< (MCAN_RXBC) Register Mask  */
+
+
+/* -------- MCAN_RXF1C : (MCAN Offset: 0xb0) (R/W 32) Receive FIFO 1 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t F1SA:14;                   /**< bit:  2..15  Receive FIFO 1 Start Address             */
+    uint32_t F1S:7;                     /**< bit: 16..22  Receive FIFO 1 Start Address             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t F1WM:7;                    /**< bit: 24..30  Receive FIFO 1 Watermark                 */
+    uint32_t F1OM:1;                    /**< bit:     31  FIFO 1 Operation Mode                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1C_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1C_OFFSET                   (0xB0)                                        /**<  (MCAN_RXF1C) Receive FIFO 1 Configuration Register  Offset */
+
+#define MCAN_RXF1C_F1SA_Pos                 2                                              /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Position */
+#define MCAN_RXF1C_F1SA_Msk                 (_U_(0x3FFF) << MCAN_RXF1C_F1SA_Pos)           /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Mask */
+#define MCAN_RXF1C_F1SA(value)              (MCAN_RXF1C_F1SA_Msk & ((value) << MCAN_RXF1C_F1SA_Pos))
+#define MCAN_RXF1C_F1S_Pos                  16                                             /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Position */
+#define MCAN_RXF1C_F1S_Msk                  (_U_(0x7F) << MCAN_RXF1C_F1S_Pos)              /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Mask */
+#define MCAN_RXF1C_F1S(value)               (MCAN_RXF1C_F1S_Msk & ((value) << MCAN_RXF1C_F1S_Pos))
+#define MCAN_RXF1C_F1WM_Pos                 24                                             /**< (MCAN_RXF1C) Receive FIFO 1 Watermark Position */
+#define MCAN_RXF1C_F1WM_Msk                 (_U_(0x7F) << MCAN_RXF1C_F1WM_Pos)             /**< (MCAN_RXF1C) Receive FIFO 1 Watermark Mask */
+#define MCAN_RXF1C_F1WM(value)              (MCAN_RXF1C_F1WM_Msk & ((value) << MCAN_RXF1C_F1WM_Pos))
+#define MCAN_RXF1C_F1OM_Pos                 31                                             /**< (MCAN_RXF1C) FIFO 1 Operation Mode Position */
+#define MCAN_RXF1C_F1OM_Msk                 (_U_(0x1) << MCAN_RXF1C_F1OM_Pos)              /**< (MCAN_RXF1C) FIFO 1 Operation Mode Mask */
+#define MCAN_RXF1C_F1OM                     MCAN_RXF1C_F1OM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1C_F1OM_Msk instead */
+#define MCAN_RXF1C_MASK                     _U_(0xFF7FFFFC)                                /**< \deprecated (MCAN_RXF1C) Register MASK  (Use MCAN_RXF1C_Msk instead)  */
+#define MCAN_RXF1C_Msk                      _U_(0xFF7FFFFC)                                /**< (MCAN_RXF1C) Register Mask  */
+
+
+/* -------- MCAN_RXF1S : (MCAN Offset: 0xb4) (R/ 32) Receive FIFO 1 Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F1FL:7;                    /**< bit:   0..6  Receive FIFO 1 Fill Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t F1GI:6;                    /**< bit:  8..13  Receive FIFO 1 Get Index                 */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t F1PI:6;                    /**< bit: 16..21  Receive FIFO 1 Put Index                 */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t F1F:1;                     /**< bit:     24  Receive FIFO 1 Fill Level                */
+    uint32_t RF1L:1;                    /**< bit:     25  Receive FIFO 1 Message Lost              */
+    uint32_t :4;                        /**< bit: 26..29  Reserved */
+    uint32_t DMS:2;                     /**< bit: 30..31  Debug Message Status                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1S_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1S_OFFSET                   (0xB4)                                        /**<  (MCAN_RXF1S) Receive FIFO 1 Status Register  Offset */
+
+#define MCAN_RXF1S_F1FL_Pos                 0                                              /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Position */
+#define MCAN_RXF1S_F1FL_Msk                 (_U_(0x7F) << MCAN_RXF1S_F1FL_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Mask */
+#define MCAN_RXF1S_F1FL(value)              (MCAN_RXF1S_F1FL_Msk & ((value) << MCAN_RXF1S_F1FL_Pos))
+#define MCAN_RXF1S_F1GI_Pos                 8                                              /**< (MCAN_RXF1S) Receive FIFO 1 Get Index Position */
+#define MCAN_RXF1S_F1GI_Msk                 (_U_(0x3F) << MCAN_RXF1S_F1GI_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Get Index Mask */
+#define MCAN_RXF1S_F1GI(value)              (MCAN_RXF1S_F1GI_Msk & ((value) << MCAN_RXF1S_F1GI_Pos))
+#define MCAN_RXF1S_F1PI_Pos                 16                                             /**< (MCAN_RXF1S) Receive FIFO 1 Put Index Position */
+#define MCAN_RXF1S_F1PI_Msk                 (_U_(0x3F) << MCAN_RXF1S_F1PI_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Put Index Mask */
+#define MCAN_RXF1S_F1PI(value)              (MCAN_RXF1S_F1PI_Msk & ((value) << MCAN_RXF1S_F1PI_Pos))
+#define MCAN_RXF1S_F1F_Pos                  24                                             /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Position */
+#define MCAN_RXF1S_F1F_Msk                  (_U_(0x1) << MCAN_RXF1S_F1F_Pos)               /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Mask */
+#define MCAN_RXF1S_F1F                      MCAN_RXF1S_F1F_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1S_F1F_Msk instead */
+#define MCAN_RXF1S_RF1L_Pos                 25                                             /**< (MCAN_RXF1S) Receive FIFO 1 Message Lost Position */
+#define MCAN_RXF1S_RF1L_Msk                 (_U_(0x1) << MCAN_RXF1S_RF1L_Pos)              /**< (MCAN_RXF1S) Receive FIFO 1 Message Lost Mask */
+#define MCAN_RXF1S_RF1L                     MCAN_RXF1S_RF1L_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1S_RF1L_Msk instead */
+#define MCAN_RXF1S_DMS_Pos                  30                                             /**< (MCAN_RXF1S) Debug Message Status Position */
+#define MCAN_RXF1S_DMS_Msk                  (_U_(0x3) << MCAN_RXF1S_DMS_Pos)               /**< (MCAN_RXF1S) Debug Message Status Mask */
+#define MCAN_RXF1S_DMS(value)               (MCAN_RXF1S_DMS_Msk & ((value) << MCAN_RXF1S_DMS_Pos))
+#define   MCAN_RXF1S_DMS_IDLE_Val           _U_(0x0)                                       /**< (MCAN_RXF1S) Idle state, wait for reception of debug messages, DMA request is cleared.  */
+#define   MCAN_RXF1S_DMS_MSG_A_Val          _U_(0x1)                                       /**< (MCAN_RXF1S) Debug message A received.  */
+#define   MCAN_RXF1S_DMS_MSG_AB_Val         _U_(0x2)                                       /**< (MCAN_RXF1S) Debug messages A, B received.  */
+#define   MCAN_RXF1S_DMS_MSG_ABC_Val        _U_(0x3)                                       /**< (MCAN_RXF1S) Debug messages A, B, C received, DMA request is set.  */
+#define MCAN_RXF1S_DMS_IDLE                 (MCAN_RXF1S_DMS_IDLE_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Idle state, wait for reception of debug messages, DMA request is cleared. Position  */
+#define MCAN_RXF1S_DMS_MSG_A                (MCAN_RXF1S_DMS_MSG_A_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug message A received. Position  */
+#define MCAN_RXF1S_DMS_MSG_AB               (MCAN_RXF1S_DMS_MSG_AB_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug messages A, B received. Position  */
+#define MCAN_RXF1S_DMS_MSG_ABC              (MCAN_RXF1S_DMS_MSG_ABC_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug messages A, B, C received, DMA request is set. Position  */
+#define MCAN_RXF1S_MASK                     _U_(0xC33F3F7F)                                /**< \deprecated (MCAN_RXF1S) Register MASK  (Use MCAN_RXF1S_Msk instead)  */
+#define MCAN_RXF1S_Msk                      _U_(0xC33F3F7F)                                /**< (MCAN_RXF1S) Register Mask  */
+
+
+/* -------- MCAN_RXF1A : (MCAN Offset: 0xb8) (R/W 32) Receive FIFO 1 Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F1AI:6;                    /**< bit:   0..5  Receive FIFO 1 Acknowledge Index         */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1A_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1A_OFFSET                   (0xB8)                                        /**<  (MCAN_RXF1A) Receive FIFO 1 Acknowledge Register  Offset */
+
+#define MCAN_RXF1A_F1AI_Pos                 0                                              /**< (MCAN_RXF1A) Receive FIFO 1 Acknowledge Index Position */
+#define MCAN_RXF1A_F1AI_Msk                 (_U_(0x3F) << MCAN_RXF1A_F1AI_Pos)             /**< (MCAN_RXF1A) Receive FIFO 1 Acknowledge Index Mask */
+#define MCAN_RXF1A_F1AI(value)              (MCAN_RXF1A_F1AI_Msk & ((value) << MCAN_RXF1A_F1AI_Pos))
+#define MCAN_RXF1A_MASK                     _U_(0x3F)                                      /**< \deprecated (MCAN_RXF1A) Register MASK  (Use MCAN_RXF1A_Msk instead)  */
+#define MCAN_RXF1A_Msk                      _U_(0x3F)                                      /**< (MCAN_RXF1A) Register Mask  */
+
+
+/* -------- MCAN_RXESC : (MCAN Offset: 0xbc) (R/W 32) Receive Buffer / FIFO Element Size Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0DS:3;                    /**< bit:   0..2  Receive FIFO 0 Data Field Size           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t F1DS:3;                    /**< bit:   4..6  Receive FIFO 1 Data Field Size           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t RBDS:3;                    /**< bit:  8..10  Receive Buffer Data Field Size           */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXESC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXESC_OFFSET                   (0xBC)                                        /**<  (MCAN_RXESC) Receive Buffer / FIFO Element Size Configuration Register  Offset */
+
+#define MCAN_RXESC_F0DS_Pos                 0                                              /**< (MCAN_RXESC) Receive FIFO 0 Data Field Size Position */
+#define MCAN_RXESC_F0DS_Msk                 (_U_(0x7) << MCAN_RXESC_F0DS_Pos)              /**< (MCAN_RXESC) Receive FIFO 0 Data Field Size Mask */
+#define MCAN_RXESC_F0DS(value)              (MCAN_RXESC_F0DS_Msk & ((value) << MCAN_RXESC_F0DS_Pos))
+#define   MCAN_RXESC_F0DS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_F0DS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_F0DS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_F0DS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_F0DS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_F0DS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_F0DS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_F0DS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_F0DS_8_BYTE              (MCAN_RXESC_F0DS_8_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_F0DS_12_BYTE             (MCAN_RXESC_F0DS_12_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_F0DS_16_BYTE             (MCAN_RXESC_F0DS_16_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_F0DS_20_BYTE             (MCAN_RXESC_F0DS_20_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_F0DS_24_BYTE             (MCAN_RXESC_F0DS_24_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_F0DS_32_BYTE             (MCAN_RXESC_F0DS_32_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_F0DS_48_BYTE             (MCAN_RXESC_F0DS_48_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_F0DS_64_BYTE             (MCAN_RXESC_F0DS_64_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_F1DS_Pos                 4                                              /**< (MCAN_RXESC) Receive FIFO 1 Data Field Size Position */
+#define MCAN_RXESC_F1DS_Msk                 (_U_(0x7) << MCAN_RXESC_F1DS_Pos)              /**< (MCAN_RXESC) Receive FIFO 1 Data Field Size Mask */
+#define MCAN_RXESC_F1DS(value)              (MCAN_RXESC_F1DS_Msk & ((value) << MCAN_RXESC_F1DS_Pos))
+#define   MCAN_RXESC_F1DS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_F1DS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_F1DS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_F1DS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_F1DS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_F1DS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_F1DS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_F1DS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_F1DS_8_BYTE              (MCAN_RXESC_F1DS_8_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_F1DS_12_BYTE             (MCAN_RXESC_F1DS_12_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_F1DS_16_BYTE             (MCAN_RXESC_F1DS_16_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_F1DS_20_BYTE             (MCAN_RXESC_F1DS_20_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_F1DS_24_BYTE             (MCAN_RXESC_F1DS_24_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_F1DS_32_BYTE             (MCAN_RXESC_F1DS_32_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_F1DS_48_BYTE             (MCAN_RXESC_F1DS_48_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_F1DS_64_BYTE             (MCAN_RXESC_F1DS_64_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_RBDS_Pos                 8                                              /**< (MCAN_RXESC) Receive Buffer Data Field Size Position */
+#define MCAN_RXESC_RBDS_Msk                 (_U_(0x7) << MCAN_RXESC_RBDS_Pos)              /**< (MCAN_RXESC) Receive Buffer Data Field Size Mask */
+#define MCAN_RXESC_RBDS(value)              (MCAN_RXESC_RBDS_Msk & ((value) << MCAN_RXESC_RBDS_Pos))
+#define   MCAN_RXESC_RBDS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_RBDS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_RBDS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_RBDS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_RBDS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_RBDS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_RBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_RBDS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_RBDS_8_BYTE              (MCAN_RXESC_RBDS_8_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_RBDS_12_BYTE             (MCAN_RXESC_RBDS_12_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_RBDS_16_BYTE             (MCAN_RXESC_RBDS_16_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_RBDS_20_BYTE             (MCAN_RXESC_RBDS_20_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_RBDS_24_BYTE             (MCAN_RXESC_RBDS_24_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_RBDS_32_BYTE             (MCAN_RXESC_RBDS_32_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_RBDS_48_BYTE             (MCAN_RXESC_RBDS_48_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_RBDS_64_BYTE             (MCAN_RXESC_RBDS_64_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_MASK                     _U_(0x777)                                     /**< \deprecated (MCAN_RXESC) Register MASK  (Use MCAN_RXESC_Msk instead)  */
+#define MCAN_RXESC_Msk                      _U_(0x777)                                     /**< (MCAN_RXESC) Register Mask  */
+
+
+/* -------- MCAN_TXBC : (MCAN Offset: 0xc0) (R/W 32) Transmit Buffer Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TBSA:14;                   /**< bit:  2..15  Tx Buffers Start Address                 */
+    uint32_t NDTB:6;                    /**< bit: 16..21  Number of Dedicated Transmit Buffers     */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t TFQS:6;                    /**< bit: 24..29  Transmit FIFO/Queue Size                 */
+    uint32_t TFQM:1;                    /**< bit:     30  Tx FIFO/Queue Mode                       */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBC_OFFSET                    (0xC0)                                        /**<  (MCAN_TXBC) Transmit Buffer Configuration Register  Offset */
+
+#define MCAN_TXBC_TBSA_Pos                  2                                              /**< (MCAN_TXBC) Tx Buffers Start Address Position */
+#define MCAN_TXBC_TBSA_Msk                  (_U_(0x3FFF) << MCAN_TXBC_TBSA_Pos)            /**< (MCAN_TXBC) Tx Buffers Start Address Mask */
+#define MCAN_TXBC_TBSA(value)               (MCAN_TXBC_TBSA_Msk & ((value) << MCAN_TXBC_TBSA_Pos))
+#define MCAN_TXBC_NDTB_Pos                  16                                             /**< (MCAN_TXBC) Number of Dedicated Transmit Buffers Position */
+#define MCAN_TXBC_NDTB_Msk                  (_U_(0x3F) << MCAN_TXBC_NDTB_Pos)              /**< (MCAN_TXBC) Number of Dedicated Transmit Buffers Mask */
+#define MCAN_TXBC_NDTB(value)               (MCAN_TXBC_NDTB_Msk & ((value) << MCAN_TXBC_NDTB_Pos))
+#define MCAN_TXBC_TFQS_Pos                  24                                             /**< (MCAN_TXBC) Transmit FIFO/Queue Size Position */
+#define MCAN_TXBC_TFQS_Msk                  (_U_(0x3F) << MCAN_TXBC_TFQS_Pos)              /**< (MCAN_TXBC) Transmit FIFO/Queue Size Mask */
+#define MCAN_TXBC_TFQS(value)               (MCAN_TXBC_TFQS_Msk & ((value) << MCAN_TXBC_TFQS_Pos))
+#define MCAN_TXBC_TFQM_Pos                  30                                             /**< (MCAN_TXBC) Tx FIFO/Queue Mode Position */
+#define MCAN_TXBC_TFQM_Msk                  (_U_(0x1) << MCAN_TXBC_TFQM_Pos)               /**< (MCAN_TXBC) Tx FIFO/Queue Mode Mask */
+#define MCAN_TXBC_TFQM                      MCAN_TXBC_TFQM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBC_TFQM_Msk instead */
+#define MCAN_TXBC_MASK                      _U_(0x7F3FFFFC)                                /**< \deprecated (MCAN_TXBC) Register MASK  (Use MCAN_TXBC_Msk instead)  */
+#define MCAN_TXBC_Msk                       _U_(0x7F3FFFFC)                                /**< (MCAN_TXBC) Register Mask  */
+
+
+/* -------- MCAN_TXFQS : (MCAN Offset: 0xc4) (R/ 32) Transmit FIFO/Queue Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TFFL:6;                    /**< bit:   0..5  Tx FIFO Free Level                       */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t TFGI:5;                    /**< bit:  8..12  Tx FIFO Get Index                        */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TFQPI:5;                   /**< bit: 16..20  Tx FIFO/Queue Put Index                  */
+    uint32_t TFQF:1;                    /**< bit:     21  Tx FIFO/Queue Full                       */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXFQS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXFQS_OFFSET                   (0xC4)                                        /**<  (MCAN_TXFQS) Transmit FIFO/Queue Status Register  Offset */
+
+#define MCAN_TXFQS_TFFL_Pos                 0                                              /**< (MCAN_TXFQS) Tx FIFO Free Level Position */
+#define MCAN_TXFQS_TFFL_Msk                 (_U_(0x3F) << MCAN_TXFQS_TFFL_Pos)             /**< (MCAN_TXFQS) Tx FIFO Free Level Mask */
+#define MCAN_TXFQS_TFFL(value)              (MCAN_TXFQS_TFFL_Msk & ((value) << MCAN_TXFQS_TFFL_Pos))
+#define MCAN_TXFQS_TFGI_Pos                 8                                              /**< (MCAN_TXFQS) Tx FIFO Get Index Position */
+#define MCAN_TXFQS_TFGI_Msk                 (_U_(0x1F) << MCAN_TXFQS_TFGI_Pos)             /**< (MCAN_TXFQS) Tx FIFO Get Index Mask */
+#define MCAN_TXFQS_TFGI(value)              (MCAN_TXFQS_TFGI_Msk & ((value) << MCAN_TXFQS_TFGI_Pos))
+#define MCAN_TXFQS_TFQPI_Pos                16                                             /**< (MCAN_TXFQS) Tx FIFO/Queue Put Index Position */
+#define MCAN_TXFQS_TFQPI_Msk                (_U_(0x1F) << MCAN_TXFQS_TFQPI_Pos)            /**< (MCAN_TXFQS) Tx FIFO/Queue Put Index Mask */
+#define MCAN_TXFQS_TFQPI(value)             (MCAN_TXFQS_TFQPI_Msk & ((value) << MCAN_TXFQS_TFQPI_Pos))
+#define MCAN_TXFQS_TFQF_Pos                 21                                             /**< (MCAN_TXFQS) Tx FIFO/Queue Full Position */
+#define MCAN_TXFQS_TFQF_Msk                 (_U_(0x1) << MCAN_TXFQS_TFQF_Pos)              /**< (MCAN_TXFQS) Tx FIFO/Queue Full Mask */
+#define MCAN_TXFQS_TFQF                     MCAN_TXFQS_TFQF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXFQS_TFQF_Msk instead */
+#define MCAN_TXFQS_MASK                     _U_(0x3F1F3F)                                  /**< \deprecated (MCAN_TXFQS) Register MASK  (Use MCAN_TXFQS_Msk instead)  */
+#define MCAN_TXFQS_Msk                      _U_(0x3F1F3F)                                  /**< (MCAN_TXFQS) Register Mask  */
+
+
+/* -------- MCAN_TXESC : (MCAN Offset: 0xc8) (R/W 32) Transmit Buffer Element Size Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TBDS:3;                    /**< bit:   0..2  Tx Buffer Data Field Size                */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXESC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXESC_OFFSET                   (0xC8)                                        /**<  (MCAN_TXESC) Transmit Buffer Element Size Configuration Register  Offset */
+
+#define MCAN_TXESC_TBDS_Pos                 0                                              /**< (MCAN_TXESC) Tx Buffer Data Field Size Position */
+#define MCAN_TXESC_TBDS_Msk                 (_U_(0x7) << MCAN_TXESC_TBDS_Pos)              /**< (MCAN_TXESC) Tx Buffer Data Field Size Mask */
+#define MCAN_TXESC_TBDS(value)              (MCAN_TXESC_TBDS_Msk & ((value) << MCAN_TXESC_TBDS_Pos))
+#define   MCAN_TXESC_TBDS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_TXESC) 8-byte data field  */
+#define   MCAN_TXESC_TBDS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_TXESC) 12-byte data field  */
+#define   MCAN_TXESC_TBDS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_TXESC) 16-byte data field  */
+#define   MCAN_TXESC_TBDS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_TXESC) 20-byte data field  */
+#define   MCAN_TXESC_TBDS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_TXESC) 24-byte data field  */
+#define   MCAN_TXESC_TBDS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_TXESC) 32-byte data field  */
+#define   MCAN_TXESC_TBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_TXESC) 48- byte data field  */
+#define   MCAN_TXESC_TBDS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_TXESC) 64-byte data field  */
+#define MCAN_TXESC_TBDS_8_BYTE              (MCAN_TXESC_TBDS_8_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 8-byte data field Position  */
+#define MCAN_TXESC_TBDS_12_BYTE             (MCAN_TXESC_TBDS_12_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 12-byte data field Position  */
+#define MCAN_TXESC_TBDS_16_BYTE             (MCAN_TXESC_TBDS_16_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 16-byte data field Position  */
+#define MCAN_TXESC_TBDS_20_BYTE             (MCAN_TXESC_TBDS_20_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 20-byte data field Position  */
+#define MCAN_TXESC_TBDS_24_BYTE             (MCAN_TXESC_TBDS_24_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 24-byte data field Position  */
+#define MCAN_TXESC_TBDS_32_BYTE             (MCAN_TXESC_TBDS_32_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 32-byte data field Position  */
+#define MCAN_TXESC_TBDS_48_BYTE             (MCAN_TXESC_TBDS_48_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 48- byte data field Position  */
+#define MCAN_TXESC_TBDS_64_BYTE             (MCAN_TXESC_TBDS_64_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 64-byte data field Position  */
+#define MCAN_TXESC_MASK                     _U_(0x07)                                      /**< \deprecated (MCAN_TXESC) Register MASK  (Use MCAN_TXESC_Msk instead)  */
+#define MCAN_TXESC_Msk                      _U_(0x07)                                      /**< (MCAN_TXESC) Register Mask  */
+
+
+/* -------- MCAN_TXBRP : (MCAN Offset: 0xcc) (R/ 32) Transmit Buffer Request Pending Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRP0:1;                    /**< bit:      0  Transmission Request Pending for Buffer 0 */
+    uint32_t TRP1:1;                    /**< bit:      1  Transmission Request Pending for Buffer 1 */
+    uint32_t TRP2:1;                    /**< bit:      2  Transmission Request Pending for Buffer 2 */
+    uint32_t TRP3:1;                    /**< bit:      3  Transmission Request Pending for Buffer 3 */
+    uint32_t TRP4:1;                    /**< bit:      4  Transmission Request Pending for Buffer 4 */
+    uint32_t TRP5:1;                    /**< bit:      5  Transmission Request Pending for Buffer 5 */
+    uint32_t TRP6:1;                    /**< bit:      6  Transmission Request Pending for Buffer 6 */
+    uint32_t TRP7:1;                    /**< bit:      7  Transmission Request Pending for Buffer 7 */
+    uint32_t TRP8:1;                    /**< bit:      8  Transmission Request Pending for Buffer 8 */
+    uint32_t TRP9:1;                    /**< bit:      9  Transmission Request Pending for Buffer 9 */
+    uint32_t TRP10:1;                   /**< bit:     10  Transmission Request Pending for Buffer 10 */
+    uint32_t TRP11:1;                   /**< bit:     11  Transmission Request Pending for Buffer 11 */
+    uint32_t TRP12:1;                   /**< bit:     12  Transmission Request Pending for Buffer 12 */
+    uint32_t TRP13:1;                   /**< bit:     13  Transmission Request Pending for Buffer 13 */
+    uint32_t TRP14:1;                   /**< bit:     14  Transmission Request Pending for Buffer 14 */
+    uint32_t TRP15:1;                   /**< bit:     15  Transmission Request Pending for Buffer 15 */
+    uint32_t TRP16:1;                   /**< bit:     16  Transmission Request Pending for Buffer 16 */
+    uint32_t TRP17:1;                   /**< bit:     17  Transmission Request Pending for Buffer 17 */
+    uint32_t TRP18:1;                   /**< bit:     18  Transmission Request Pending for Buffer 18 */
+    uint32_t TRP19:1;                   /**< bit:     19  Transmission Request Pending for Buffer 19 */
+    uint32_t TRP20:1;                   /**< bit:     20  Transmission Request Pending for Buffer 20 */
+    uint32_t TRP21:1;                   /**< bit:     21  Transmission Request Pending for Buffer 21 */
+    uint32_t TRP22:1;                   /**< bit:     22  Transmission Request Pending for Buffer 22 */
+    uint32_t TRP23:1;                   /**< bit:     23  Transmission Request Pending for Buffer 23 */
+    uint32_t TRP24:1;                   /**< bit:     24  Transmission Request Pending for Buffer 24 */
+    uint32_t TRP25:1;                   /**< bit:     25  Transmission Request Pending for Buffer 25 */
+    uint32_t TRP26:1;                   /**< bit:     26  Transmission Request Pending for Buffer 26 */
+    uint32_t TRP27:1;                   /**< bit:     27  Transmission Request Pending for Buffer 27 */
+    uint32_t TRP28:1;                   /**< bit:     28  Transmission Request Pending for Buffer 28 */
+    uint32_t TRP29:1;                   /**< bit:     29  Transmission Request Pending for Buffer 29 */
+    uint32_t TRP30:1;                   /**< bit:     30  Transmission Request Pending for Buffer 30 */
+    uint32_t TRP31:1;                   /**< bit:     31  Transmission Request Pending for Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TRP:32;                    /**< bit:  0..31  Transmission Request Pending for Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBRP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBRP_OFFSET                   (0xCC)                                        /**<  (MCAN_TXBRP) Transmit Buffer Request Pending Register  Offset */
+
+#define MCAN_TXBRP_TRP0_Pos                 0                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 0 Position */
+#define MCAN_TXBRP_TRP0_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP0_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 0 Mask */
+#define MCAN_TXBRP_TRP0                     MCAN_TXBRP_TRP0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP0_Msk instead */
+#define MCAN_TXBRP_TRP1_Pos                 1                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 1 Position */
+#define MCAN_TXBRP_TRP1_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP1_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 1 Mask */
+#define MCAN_TXBRP_TRP1                     MCAN_TXBRP_TRP1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP1_Msk instead */
+#define MCAN_TXBRP_TRP2_Pos                 2                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 2 Position */
+#define MCAN_TXBRP_TRP2_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP2_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 2 Mask */
+#define MCAN_TXBRP_TRP2                     MCAN_TXBRP_TRP2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP2_Msk instead */
+#define MCAN_TXBRP_TRP3_Pos                 3                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 3 Position */
+#define MCAN_TXBRP_TRP3_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP3_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 3 Mask */
+#define MCAN_TXBRP_TRP3                     MCAN_TXBRP_TRP3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP3_Msk instead */
+#define MCAN_TXBRP_TRP4_Pos                 4                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 4 Position */
+#define MCAN_TXBRP_TRP4_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP4_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 4 Mask */
+#define MCAN_TXBRP_TRP4                     MCAN_TXBRP_TRP4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP4_Msk instead */
+#define MCAN_TXBRP_TRP5_Pos                 5                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 5 Position */
+#define MCAN_TXBRP_TRP5_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP5_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 5 Mask */
+#define MCAN_TXBRP_TRP5                     MCAN_TXBRP_TRP5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP5_Msk instead */
+#define MCAN_TXBRP_TRP6_Pos                 6                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 6 Position */
+#define MCAN_TXBRP_TRP6_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP6_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 6 Mask */
+#define MCAN_TXBRP_TRP6                     MCAN_TXBRP_TRP6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP6_Msk instead */
+#define MCAN_TXBRP_TRP7_Pos                 7                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 7 Position */
+#define MCAN_TXBRP_TRP7_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP7_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 7 Mask */
+#define MCAN_TXBRP_TRP7                     MCAN_TXBRP_TRP7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP7_Msk instead */
+#define MCAN_TXBRP_TRP8_Pos                 8                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 8 Position */
+#define MCAN_TXBRP_TRP8_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP8_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 8 Mask */
+#define MCAN_TXBRP_TRP8                     MCAN_TXBRP_TRP8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP8_Msk instead */
+#define MCAN_TXBRP_TRP9_Pos                 9                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 9 Position */
+#define MCAN_TXBRP_TRP9_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP9_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 9 Mask */
+#define MCAN_TXBRP_TRP9                     MCAN_TXBRP_TRP9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP9_Msk instead */
+#define MCAN_TXBRP_TRP10_Pos                10                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 10 Position */
+#define MCAN_TXBRP_TRP10_Msk                (_U_(0x1) << MCAN_TXBRP_TRP10_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 10 Mask */
+#define MCAN_TXBRP_TRP10                    MCAN_TXBRP_TRP10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP10_Msk instead */
+#define MCAN_TXBRP_TRP11_Pos                11                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 11 Position */
+#define MCAN_TXBRP_TRP11_Msk                (_U_(0x1) << MCAN_TXBRP_TRP11_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 11 Mask */
+#define MCAN_TXBRP_TRP11                    MCAN_TXBRP_TRP11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP11_Msk instead */
+#define MCAN_TXBRP_TRP12_Pos                12                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 12 Position */
+#define MCAN_TXBRP_TRP12_Msk                (_U_(0x1) << MCAN_TXBRP_TRP12_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 12 Mask */
+#define MCAN_TXBRP_TRP12                    MCAN_TXBRP_TRP12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP12_Msk instead */
+#define MCAN_TXBRP_TRP13_Pos                13                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 13 Position */
+#define MCAN_TXBRP_TRP13_Msk                (_U_(0x1) << MCAN_TXBRP_TRP13_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 13 Mask */
+#define MCAN_TXBRP_TRP13                    MCAN_TXBRP_TRP13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP13_Msk instead */
+#define MCAN_TXBRP_TRP14_Pos                14                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 14 Position */
+#define MCAN_TXBRP_TRP14_Msk                (_U_(0x1) << MCAN_TXBRP_TRP14_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 14 Mask */
+#define MCAN_TXBRP_TRP14                    MCAN_TXBRP_TRP14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP14_Msk instead */
+#define MCAN_TXBRP_TRP15_Pos                15                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 15 Position */
+#define MCAN_TXBRP_TRP15_Msk                (_U_(0x1) << MCAN_TXBRP_TRP15_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 15 Mask */
+#define MCAN_TXBRP_TRP15                    MCAN_TXBRP_TRP15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP15_Msk instead */
+#define MCAN_TXBRP_TRP16_Pos                16                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 16 Position */
+#define MCAN_TXBRP_TRP16_Msk                (_U_(0x1) << MCAN_TXBRP_TRP16_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 16 Mask */
+#define MCAN_TXBRP_TRP16                    MCAN_TXBRP_TRP16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP16_Msk instead */
+#define MCAN_TXBRP_TRP17_Pos                17                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 17 Position */
+#define MCAN_TXBRP_TRP17_Msk                (_U_(0x1) << MCAN_TXBRP_TRP17_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 17 Mask */
+#define MCAN_TXBRP_TRP17                    MCAN_TXBRP_TRP17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP17_Msk instead */
+#define MCAN_TXBRP_TRP18_Pos                18                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 18 Position */
+#define MCAN_TXBRP_TRP18_Msk                (_U_(0x1) << MCAN_TXBRP_TRP18_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 18 Mask */
+#define MCAN_TXBRP_TRP18                    MCAN_TXBRP_TRP18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP18_Msk instead */
+#define MCAN_TXBRP_TRP19_Pos                19                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 19 Position */
+#define MCAN_TXBRP_TRP19_Msk                (_U_(0x1) << MCAN_TXBRP_TRP19_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 19 Mask */
+#define MCAN_TXBRP_TRP19                    MCAN_TXBRP_TRP19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP19_Msk instead */
+#define MCAN_TXBRP_TRP20_Pos                20                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 20 Position */
+#define MCAN_TXBRP_TRP20_Msk                (_U_(0x1) << MCAN_TXBRP_TRP20_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 20 Mask */
+#define MCAN_TXBRP_TRP20                    MCAN_TXBRP_TRP20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP20_Msk instead */
+#define MCAN_TXBRP_TRP21_Pos                21                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 21 Position */
+#define MCAN_TXBRP_TRP21_Msk                (_U_(0x1) << MCAN_TXBRP_TRP21_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 21 Mask */
+#define MCAN_TXBRP_TRP21                    MCAN_TXBRP_TRP21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP21_Msk instead */
+#define MCAN_TXBRP_TRP22_Pos                22                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 22 Position */
+#define MCAN_TXBRP_TRP22_Msk                (_U_(0x1) << MCAN_TXBRP_TRP22_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 22 Mask */
+#define MCAN_TXBRP_TRP22                    MCAN_TXBRP_TRP22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP22_Msk instead */
+#define MCAN_TXBRP_TRP23_Pos                23                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 23 Position */
+#define MCAN_TXBRP_TRP23_Msk                (_U_(0x1) << MCAN_TXBRP_TRP23_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 23 Mask */
+#define MCAN_TXBRP_TRP23                    MCAN_TXBRP_TRP23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP23_Msk instead */
+#define MCAN_TXBRP_TRP24_Pos                24                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 24 Position */
+#define MCAN_TXBRP_TRP24_Msk                (_U_(0x1) << MCAN_TXBRP_TRP24_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 24 Mask */
+#define MCAN_TXBRP_TRP24                    MCAN_TXBRP_TRP24_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP24_Msk instead */
+#define MCAN_TXBRP_TRP25_Pos                25                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 25 Position */
+#define MCAN_TXBRP_TRP25_Msk                (_U_(0x1) << MCAN_TXBRP_TRP25_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 25 Mask */
+#define MCAN_TXBRP_TRP25                    MCAN_TXBRP_TRP25_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP25_Msk instead */
+#define MCAN_TXBRP_TRP26_Pos                26                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 26 Position */
+#define MCAN_TXBRP_TRP26_Msk                (_U_(0x1) << MCAN_TXBRP_TRP26_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 26 Mask */
+#define MCAN_TXBRP_TRP26                    MCAN_TXBRP_TRP26_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP26_Msk instead */
+#define MCAN_TXBRP_TRP27_Pos                27                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 27 Position */
+#define MCAN_TXBRP_TRP27_Msk                (_U_(0x1) << MCAN_TXBRP_TRP27_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 27 Mask */
+#define MCAN_TXBRP_TRP27                    MCAN_TXBRP_TRP27_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP27_Msk instead */
+#define MCAN_TXBRP_TRP28_Pos                28                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 28 Position */
+#define MCAN_TXBRP_TRP28_Msk                (_U_(0x1) << MCAN_TXBRP_TRP28_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 28 Mask */
+#define MCAN_TXBRP_TRP28                    MCAN_TXBRP_TRP28_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP28_Msk instead */
+#define MCAN_TXBRP_TRP29_Pos                29                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 29 Position */
+#define MCAN_TXBRP_TRP29_Msk                (_U_(0x1) << MCAN_TXBRP_TRP29_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 29 Mask */
+#define MCAN_TXBRP_TRP29                    MCAN_TXBRP_TRP29_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP29_Msk instead */
+#define MCAN_TXBRP_TRP30_Pos                30                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 30 Position */
+#define MCAN_TXBRP_TRP30_Msk                (_U_(0x1) << MCAN_TXBRP_TRP30_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 30 Mask */
+#define MCAN_TXBRP_TRP30                    MCAN_TXBRP_TRP30_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP30_Msk instead */
+#define MCAN_TXBRP_TRP31_Pos                31                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 31 Position */
+#define MCAN_TXBRP_TRP31_Msk                (_U_(0x1) << MCAN_TXBRP_TRP31_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 31 Mask */
+#define MCAN_TXBRP_TRP31                    MCAN_TXBRP_TRP31_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP31_Msk instead */
+#define MCAN_TXBRP_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBRP) Register MASK  (Use MCAN_TXBRP_Msk instead)  */
+#define MCAN_TXBRP_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBRP) Register Mask  */
+
+#define MCAN_TXBRP_TRP_Pos                  0                                              /**< (MCAN_TXBRP Position) Transmission Request Pending for Buffer 3x */
+#define MCAN_TXBRP_TRP_Msk                  (_U_(0xFFFFFFFF) << MCAN_TXBRP_TRP_Pos)        /**< (MCAN_TXBRP Mask) TRP */
+#define MCAN_TXBRP_TRP(value)               (MCAN_TXBRP_TRP_Msk & ((value) << MCAN_TXBRP_TRP_Pos))  
+
+/* -------- MCAN_TXBAR : (MCAN Offset: 0xd0) (R/W 32) Transmit Buffer Add Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AR0:1;                     /**< bit:      0  Add Request for Transmit Buffer 0        */
+    uint32_t AR1:1;                     /**< bit:      1  Add Request for Transmit Buffer 1        */
+    uint32_t AR2:1;                     /**< bit:      2  Add Request for Transmit Buffer 2        */
+    uint32_t AR3:1;                     /**< bit:      3  Add Request for Transmit Buffer 3        */
+    uint32_t AR4:1;                     /**< bit:      4  Add Request for Transmit Buffer 4        */
+    uint32_t AR5:1;                     /**< bit:      5  Add Request for Transmit Buffer 5        */
+    uint32_t AR6:1;                     /**< bit:      6  Add Request for Transmit Buffer 6        */
+    uint32_t AR7:1;                     /**< bit:      7  Add Request for Transmit Buffer 7        */
+    uint32_t AR8:1;                     /**< bit:      8  Add Request for Transmit Buffer 8        */
+    uint32_t AR9:1;                     /**< bit:      9  Add Request for Transmit Buffer 9        */
+    uint32_t AR10:1;                    /**< bit:     10  Add Request for Transmit Buffer 10       */
+    uint32_t AR11:1;                    /**< bit:     11  Add Request for Transmit Buffer 11       */
+    uint32_t AR12:1;                    /**< bit:     12  Add Request for Transmit Buffer 12       */
+    uint32_t AR13:1;                    /**< bit:     13  Add Request for Transmit Buffer 13       */
+    uint32_t AR14:1;                    /**< bit:     14  Add Request for Transmit Buffer 14       */
+    uint32_t AR15:1;                    /**< bit:     15  Add Request for Transmit Buffer 15       */
+    uint32_t AR16:1;                    /**< bit:     16  Add Request for Transmit Buffer 16       */
+    uint32_t AR17:1;                    /**< bit:     17  Add Request for Transmit Buffer 17       */
+    uint32_t AR18:1;                    /**< bit:     18  Add Request for Transmit Buffer 18       */
+    uint32_t AR19:1;                    /**< bit:     19  Add Request for Transmit Buffer 19       */
+    uint32_t AR20:1;                    /**< bit:     20  Add Request for Transmit Buffer 20       */
+    uint32_t AR21:1;                    /**< bit:     21  Add Request for Transmit Buffer 21       */
+    uint32_t AR22:1;                    /**< bit:     22  Add Request for Transmit Buffer 22       */
+    uint32_t AR23:1;                    /**< bit:     23  Add Request for Transmit Buffer 23       */
+    uint32_t AR24:1;                    /**< bit:     24  Add Request for Transmit Buffer 24       */
+    uint32_t AR25:1;                    /**< bit:     25  Add Request for Transmit Buffer 25       */
+    uint32_t AR26:1;                    /**< bit:     26  Add Request for Transmit Buffer 26       */
+    uint32_t AR27:1;                    /**< bit:     27  Add Request for Transmit Buffer 27       */
+    uint32_t AR28:1;                    /**< bit:     28  Add Request for Transmit Buffer 28       */
+    uint32_t AR29:1;                    /**< bit:     29  Add Request for Transmit Buffer 29       */
+    uint32_t AR30:1;                    /**< bit:     30  Add Request for Transmit Buffer 30       */
+    uint32_t AR31:1;                    /**< bit:     31  Add Request for Transmit Buffer 31       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t AR:32;                     /**< bit:  0..31  Add Request for Transmit Buffer 3x       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBAR_OFFSET                   (0xD0)                                        /**<  (MCAN_TXBAR) Transmit Buffer Add Request Register  Offset */
+
+#define MCAN_TXBAR_AR0_Pos                  0                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 0 Position */
+#define MCAN_TXBAR_AR0_Msk                  (_U_(0x1) << MCAN_TXBAR_AR0_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 0 Mask */
+#define MCAN_TXBAR_AR0                      MCAN_TXBAR_AR0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR0_Msk instead */
+#define MCAN_TXBAR_AR1_Pos                  1                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 1 Position */
+#define MCAN_TXBAR_AR1_Msk                  (_U_(0x1) << MCAN_TXBAR_AR1_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 1 Mask */
+#define MCAN_TXBAR_AR1                      MCAN_TXBAR_AR1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR1_Msk instead */
+#define MCAN_TXBAR_AR2_Pos                  2                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 2 Position */
+#define MCAN_TXBAR_AR2_Msk                  (_U_(0x1) << MCAN_TXBAR_AR2_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 2 Mask */
+#define MCAN_TXBAR_AR2                      MCAN_TXBAR_AR2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR2_Msk instead */
+#define MCAN_TXBAR_AR3_Pos                  3                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 3 Position */
+#define MCAN_TXBAR_AR3_Msk                  (_U_(0x1) << MCAN_TXBAR_AR3_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 3 Mask */
+#define MCAN_TXBAR_AR3                      MCAN_TXBAR_AR3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR3_Msk instead */
+#define MCAN_TXBAR_AR4_Pos                  4                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 4 Position */
+#define MCAN_TXBAR_AR4_Msk                  (_U_(0x1) << MCAN_TXBAR_AR4_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 4 Mask */
+#define MCAN_TXBAR_AR4                      MCAN_TXBAR_AR4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR4_Msk instead */
+#define MCAN_TXBAR_AR5_Pos                  5                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 5 Position */
+#define MCAN_TXBAR_AR5_Msk                  (_U_(0x1) << MCAN_TXBAR_AR5_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 5 Mask */
+#define MCAN_TXBAR_AR5                      MCAN_TXBAR_AR5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR5_Msk instead */
+#define MCAN_TXBAR_AR6_Pos                  6                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 6 Position */
+#define MCAN_TXBAR_AR6_Msk                  (_U_(0x1) << MCAN_TXBAR_AR6_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 6 Mask */
+#define MCAN_TXBAR_AR6                      MCAN_TXBAR_AR6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR6_Msk instead */
+#define MCAN_TXBAR_AR7_Pos                  7                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 7 Position */
+#define MCAN_TXBAR_AR7_Msk                  (_U_(0x1) << MCAN_TXBAR_AR7_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 7 Mask */
+#define MCAN_TXBAR_AR7                      MCAN_TXBAR_AR7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR7_Msk instead */
+#define MCAN_TXBAR_AR8_Pos                  8                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 8 Position */
+#define MCAN_TXBAR_AR8_Msk                  (_U_(0x1) << MCAN_TXBAR_AR8_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 8 Mask */
+#define MCAN_TXBAR_AR8                      MCAN_TXBAR_AR8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR8_Msk instead */
+#define MCAN_TXBAR_AR9_Pos                  9                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 9 Position */
+#define MCAN_TXBAR_AR9_Msk                  (_U_(0x1) << MCAN_TXBAR_AR9_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 9 Mask */
+#define MCAN_TXBAR_AR9                      MCAN_TXBAR_AR9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR9_Msk instead */
+#define MCAN_TXBAR_AR10_Pos                 10                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 10 Position */
+#define MCAN_TXBAR_AR10_Msk                 (_U_(0x1) << MCAN_TXBAR_AR10_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 10 Mask */
+#define MCAN_TXBAR_AR10                     MCAN_TXBAR_AR10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR10_Msk instead */
+#define MCAN_TXBAR_AR11_Pos                 11                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 11 Position */
+#define MCAN_TXBAR_AR11_Msk                 (_U_(0x1) << MCAN_TXBAR_AR11_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 11 Mask */
+#define MCAN_TXBAR_AR11                     MCAN_TXBAR_AR11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR11_Msk instead */
+#define MCAN_TXBAR_AR12_Pos                 12                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 12 Position */
+#define MCAN_TXBAR_AR12_Msk                 (_U_(0x1) << MCAN_TXBAR_AR12_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 12 Mask */
+#define MCAN_TXBAR_AR12                     MCAN_TXBAR_AR12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR12_Msk instead */
+#define MCAN_TXBAR_AR13_Pos                 13                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 13 Position */
+#define MCAN_TXBAR_AR13_Msk                 (_U_(0x1) << MCAN_TXBAR_AR13_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 13 Mask */
+#define MCAN_TXBAR_AR13                     MCAN_TXBAR_AR13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR13_Msk instead */
+#define MCAN_TXBAR_AR14_Pos                 14                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 14 Position */
+#define MCAN_TXBAR_AR14_Msk                 (_U_(0x1) << MCAN_TXBAR_AR14_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 14 Mask */
+#define MCAN_TXBAR_AR14                     MCAN_TXBAR_AR14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR14_Msk instead */
+#define MCAN_TXBAR_AR15_Pos                 15                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 15 Position */
+#define MCAN_TXBAR_AR15_Msk                 (_U_(0x1) << MCAN_TXBAR_AR15_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 15 Mask */
+#define MCAN_TXBAR_AR15                     MCAN_TXBAR_AR15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR15_Msk instead */
+#define MCAN_TXBAR_AR16_Pos                 16                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 16 Position */
+#define MCAN_TXBAR_AR16_Msk                 (_U_(0x1) << MCAN_TXBAR_AR16_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 16 Mask */
+#define MCAN_TXBAR_AR16                     MCAN_TXBAR_AR16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR16_Msk instead */
+#define MCAN_TXBAR_AR17_Pos                 17                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 17 Position */
+#define MCAN_TXBAR_AR17_Msk                 (_U_(0x1) << MCAN_TXBAR_AR17_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 17 Mask */
+#define MCAN_TXBAR_AR17                     MCAN_TXBAR_AR17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR17_Msk instead */
+#define MCAN_TXBAR_AR18_Pos                 18                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 18 Position */
+#define MCAN_TXBAR_AR18_Msk                 (_U_(0x1) << MCAN_TXBAR_AR18_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 18 Mask */
+#define MCAN_TXBAR_AR18                     MCAN_TXBAR_AR18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR18_Msk instead */
+#define MCAN_TXBAR_AR19_Pos                 19                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 19 Position */
+#define MCAN_TXBAR_AR19_Msk                 (_U_(0x1) << MCAN_TXBAR_AR19_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 19 Mask */
+#define MCAN_TXBAR_AR19                     MCAN_TXBAR_AR19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR19_Msk instead */
+#define MCAN_TXBAR_AR20_Pos                 20                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 20 Position */
+#define MCAN_TXBAR_AR20_Msk                 (_U_(0x1) << MCAN_TXBAR_AR20_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 20 Mask */
+#define MCAN_TXBAR_AR20                     MCAN_TXBAR_AR20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR20_Msk instead */
+#define MCAN_TXBAR_AR21_Pos                 21                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 21 Position */
+#define MCAN_TXBAR_AR21_Msk                 (_U_(0x1) << MCAN_TXBAR_AR21_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 21 Mask */
+#define MCAN_TXBAR_AR21                     MCAN_TXBAR_AR21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR21_Msk instead */
+#define MCAN_TXBAR_AR22_Pos                 22                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 22 Position */
+#define MCAN_TXBAR_AR22_Msk                 (_U_(0x1) << MCAN_TXBAR_AR22_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 22 Mask */
+#define MCAN_TXBAR_AR22                     MCAN_TXBAR_AR22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR22_Msk instead */
+#define MCAN_TXBAR_AR23_Pos                 23                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 23 Position */
+#define MCAN_TXBAR_AR23_Msk                 (_U_(0x1) << MCAN_TXBAR_AR23_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 23 Mask */
+#define MCAN_TXBAR_AR23                     MCAN_TXBAR_AR23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR23_Msk instead */
+#define MCAN_TXBAR_AR24_Pos                 24                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 24 Position */
+#define MCAN_TXBAR_AR24_Msk                 (_U_(0x1) << MCAN_TXBAR_AR24_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 24 Mask */
+#define MCAN_TXBAR_AR24                     MCAN_TXBAR_AR24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR24_Msk instead */
+#define MCAN_TXBAR_AR25_Pos                 25                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 25 Position */
+#define MCAN_TXBAR_AR25_Msk                 (_U_(0x1) << MCAN_TXBAR_AR25_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 25 Mask */
+#define MCAN_TXBAR_AR25                     MCAN_TXBAR_AR25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR25_Msk instead */
+#define MCAN_TXBAR_AR26_Pos                 26                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 26 Position */
+#define MCAN_TXBAR_AR26_Msk                 (_U_(0x1) << MCAN_TXBAR_AR26_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 26 Mask */
+#define MCAN_TXBAR_AR26                     MCAN_TXBAR_AR26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR26_Msk instead */
+#define MCAN_TXBAR_AR27_Pos                 27                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 27 Position */
+#define MCAN_TXBAR_AR27_Msk                 (_U_(0x1) << MCAN_TXBAR_AR27_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 27 Mask */
+#define MCAN_TXBAR_AR27                     MCAN_TXBAR_AR27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR27_Msk instead */
+#define MCAN_TXBAR_AR28_Pos                 28                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 28 Position */
+#define MCAN_TXBAR_AR28_Msk                 (_U_(0x1) << MCAN_TXBAR_AR28_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 28 Mask */
+#define MCAN_TXBAR_AR28                     MCAN_TXBAR_AR28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR28_Msk instead */
+#define MCAN_TXBAR_AR29_Pos                 29                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 29 Position */
+#define MCAN_TXBAR_AR29_Msk                 (_U_(0x1) << MCAN_TXBAR_AR29_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 29 Mask */
+#define MCAN_TXBAR_AR29                     MCAN_TXBAR_AR29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR29_Msk instead */
+#define MCAN_TXBAR_AR30_Pos                 30                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 30 Position */
+#define MCAN_TXBAR_AR30_Msk                 (_U_(0x1) << MCAN_TXBAR_AR30_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 30 Mask */
+#define MCAN_TXBAR_AR30                     MCAN_TXBAR_AR30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR30_Msk instead */
+#define MCAN_TXBAR_AR31_Pos                 31                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 31 Position */
+#define MCAN_TXBAR_AR31_Msk                 (_U_(0x1) << MCAN_TXBAR_AR31_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 31 Mask */
+#define MCAN_TXBAR_AR31                     MCAN_TXBAR_AR31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR31_Msk instead */
+#define MCAN_TXBAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBAR) Register MASK  (Use MCAN_TXBAR_Msk instead)  */
+#define MCAN_TXBAR_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBAR) Register Mask  */
+
+#define MCAN_TXBAR_AR_Pos                   0                                              /**< (MCAN_TXBAR Position) Add Request for Transmit Buffer 3x */
+#define MCAN_TXBAR_AR_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBAR_AR_Pos)         /**< (MCAN_TXBAR Mask) AR */
+#define MCAN_TXBAR_AR(value)                (MCAN_TXBAR_AR_Msk & ((value) << MCAN_TXBAR_AR_Pos))  
+
+/* -------- MCAN_TXBCR : (MCAN Offset: 0xd4) (R/W 32) Transmit Buffer Cancellation Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CR0:1;                     /**< bit:      0  Cancellation Request for Transmit Buffer 0 */
+    uint32_t CR1:1;                     /**< bit:      1  Cancellation Request for Transmit Buffer 1 */
+    uint32_t CR2:1;                     /**< bit:      2  Cancellation Request for Transmit Buffer 2 */
+    uint32_t CR3:1;                     /**< bit:      3  Cancellation Request for Transmit Buffer 3 */
+    uint32_t CR4:1;                     /**< bit:      4  Cancellation Request for Transmit Buffer 4 */
+    uint32_t CR5:1;                     /**< bit:      5  Cancellation Request for Transmit Buffer 5 */
+    uint32_t CR6:1;                     /**< bit:      6  Cancellation Request for Transmit Buffer 6 */
+    uint32_t CR7:1;                     /**< bit:      7  Cancellation Request for Transmit Buffer 7 */
+    uint32_t CR8:1;                     /**< bit:      8  Cancellation Request for Transmit Buffer 8 */
+    uint32_t CR9:1;                     /**< bit:      9  Cancellation Request for Transmit Buffer 9 */
+    uint32_t CR10:1;                    /**< bit:     10  Cancellation Request for Transmit Buffer 10 */
+    uint32_t CR11:1;                    /**< bit:     11  Cancellation Request for Transmit Buffer 11 */
+    uint32_t CR12:1;                    /**< bit:     12  Cancellation Request for Transmit Buffer 12 */
+    uint32_t CR13:1;                    /**< bit:     13  Cancellation Request for Transmit Buffer 13 */
+    uint32_t CR14:1;                    /**< bit:     14  Cancellation Request for Transmit Buffer 14 */
+    uint32_t CR15:1;                    /**< bit:     15  Cancellation Request for Transmit Buffer 15 */
+    uint32_t CR16:1;                    /**< bit:     16  Cancellation Request for Transmit Buffer 16 */
+    uint32_t CR17:1;                    /**< bit:     17  Cancellation Request for Transmit Buffer 17 */
+    uint32_t CR18:1;                    /**< bit:     18  Cancellation Request for Transmit Buffer 18 */
+    uint32_t CR19:1;                    /**< bit:     19  Cancellation Request for Transmit Buffer 19 */
+    uint32_t CR20:1;                    /**< bit:     20  Cancellation Request for Transmit Buffer 20 */
+    uint32_t CR21:1;                    /**< bit:     21  Cancellation Request for Transmit Buffer 21 */
+    uint32_t CR22:1;                    /**< bit:     22  Cancellation Request for Transmit Buffer 22 */
+    uint32_t CR23:1;                    /**< bit:     23  Cancellation Request for Transmit Buffer 23 */
+    uint32_t CR24:1;                    /**< bit:     24  Cancellation Request for Transmit Buffer 24 */
+    uint32_t CR25:1;                    /**< bit:     25  Cancellation Request for Transmit Buffer 25 */
+    uint32_t CR26:1;                    /**< bit:     26  Cancellation Request for Transmit Buffer 26 */
+    uint32_t CR27:1;                    /**< bit:     27  Cancellation Request for Transmit Buffer 27 */
+    uint32_t CR28:1;                    /**< bit:     28  Cancellation Request for Transmit Buffer 28 */
+    uint32_t CR29:1;                    /**< bit:     29  Cancellation Request for Transmit Buffer 29 */
+    uint32_t CR30:1;                    /**< bit:     30  Cancellation Request for Transmit Buffer 30 */
+    uint32_t CR31:1;                    /**< bit:     31  Cancellation Request for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CR:32;                     /**< bit:  0..31  Cancellation Request for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCR_OFFSET                   (0xD4)                                        /**<  (MCAN_TXBCR) Transmit Buffer Cancellation Request Register  Offset */
+
+#define MCAN_TXBCR_CR0_Pos                  0                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 0 Position */
+#define MCAN_TXBCR_CR0_Msk                  (_U_(0x1) << MCAN_TXBCR_CR0_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 0 Mask */
+#define MCAN_TXBCR_CR0                      MCAN_TXBCR_CR0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR0_Msk instead */
+#define MCAN_TXBCR_CR1_Pos                  1                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 1 Position */
+#define MCAN_TXBCR_CR1_Msk                  (_U_(0x1) << MCAN_TXBCR_CR1_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 1 Mask */
+#define MCAN_TXBCR_CR1                      MCAN_TXBCR_CR1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR1_Msk instead */
+#define MCAN_TXBCR_CR2_Pos                  2                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 2 Position */
+#define MCAN_TXBCR_CR2_Msk                  (_U_(0x1) << MCAN_TXBCR_CR2_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 2 Mask */
+#define MCAN_TXBCR_CR2                      MCAN_TXBCR_CR2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR2_Msk instead */
+#define MCAN_TXBCR_CR3_Pos                  3                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 3 Position */
+#define MCAN_TXBCR_CR3_Msk                  (_U_(0x1) << MCAN_TXBCR_CR3_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 3 Mask */
+#define MCAN_TXBCR_CR3                      MCAN_TXBCR_CR3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR3_Msk instead */
+#define MCAN_TXBCR_CR4_Pos                  4                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 4 Position */
+#define MCAN_TXBCR_CR4_Msk                  (_U_(0x1) << MCAN_TXBCR_CR4_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 4 Mask */
+#define MCAN_TXBCR_CR4                      MCAN_TXBCR_CR4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR4_Msk instead */
+#define MCAN_TXBCR_CR5_Pos                  5                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 5 Position */
+#define MCAN_TXBCR_CR5_Msk                  (_U_(0x1) << MCAN_TXBCR_CR5_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 5 Mask */
+#define MCAN_TXBCR_CR5                      MCAN_TXBCR_CR5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR5_Msk instead */
+#define MCAN_TXBCR_CR6_Pos                  6                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 6 Position */
+#define MCAN_TXBCR_CR6_Msk                  (_U_(0x1) << MCAN_TXBCR_CR6_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 6 Mask */
+#define MCAN_TXBCR_CR6                      MCAN_TXBCR_CR6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR6_Msk instead */
+#define MCAN_TXBCR_CR7_Pos                  7                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 7 Position */
+#define MCAN_TXBCR_CR7_Msk                  (_U_(0x1) << MCAN_TXBCR_CR7_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 7 Mask */
+#define MCAN_TXBCR_CR7                      MCAN_TXBCR_CR7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR7_Msk instead */
+#define MCAN_TXBCR_CR8_Pos                  8                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 8 Position */
+#define MCAN_TXBCR_CR8_Msk                  (_U_(0x1) << MCAN_TXBCR_CR8_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 8 Mask */
+#define MCAN_TXBCR_CR8                      MCAN_TXBCR_CR8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR8_Msk instead */
+#define MCAN_TXBCR_CR9_Pos                  9                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 9 Position */
+#define MCAN_TXBCR_CR9_Msk                  (_U_(0x1) << MCAN_TXBCR_CR9_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 9 Mask */
+#define MCAN_TXBCR_CR9                      MCAN_TXBCR_CR9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR9_Msk instead */
+#define MCAN_TXBCR_CR10_Pos                 10                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 10 Position */
+#define MCAN_TXBCR_CR10_Msk                 (_U_(0x1) << MCAN_TXBCR_CR10_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 10 Mask */
+#define MCAN_TXBCR_CR10                     MCAN_TXBCR_CR10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR10_Msk instead */
+#define MCAN_TXBCR_CR11_Pos                 11                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 11 Position */
+#define MCAN_TXBCR_CR11_Msk                 (_U_(0x1) << MCAN_TXBCR_CR11_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 11 Mask */
+#define MCAN_TXBCR_CR11                     MCAN_TXBCR_CR11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR11_Msk instead */
+#define MCAN_TXBCR_CR12_Pos                 12                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 12 Position */
+#define MCAN_TXBCR_CR12_Msk                 (_U_(0x1) << MCAN_TXBCR_CR12_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 12 Mask */
+#define MCAN_TXBCR_CR12                     MCAN_TXBCR_CR12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR12_Msk instead */
+#define MCAN_TXBCR_CR13_Pos                 13                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 13 Position */
+#define MCAN_TXBCR_CR13_Msk                 (_U_(0x1) << MCAN_TXBCR_CR13_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 13 Mask */
+#define MCAN_TXBCR_CR13                     MCAN_TXBCR_CR13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR13_Msk instead */
+#define MCAN_TXBCR_CR14_Pos                 14                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 14 Position */
+#define MCAN_TXBCR_CR14_Msk                 (_U_(0x1) << MCAN_TXBCR_CR14_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 14 Mask */
+#define MCAN_TXBCR_CR14                     MCAN_TXBCR_CR14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR14_Msk instead */
+#define MCAN_TXBCR_CR15_Pos                 15                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 15 Position */
+#define MCAN_TXBCR_CR15_Msk                 (_U_(0x1) << MCAN_TXBCR_CR15_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 15 Mask */
+#define MCAN_TXBCR_CR15                     MCAN_TXBCR_CR15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR15_Msk instead */
+#define MCAN_TXBCR_CR16_Pos                 16                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 16 Position */
+#define MCAN_TXBCR_CR16_Msk                 (_U_(0x1) << MCAN_TXBCR_CR16_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 16 Mask */
+#define MCAN_TXBCR_CR16                     MCAN_TXBCR_CR16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR16_Msk instead */
+#define MCAN_TXBCR_CR17_Pos                 17                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 17 Position */
+#define MCAN_TXBCR_CR17_Msk                 (_U_(0x1) << MCAN_TXBCR_CR17_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 17 Mask */
+#define MCAN_TXBCR_CR17                     MCAN_TXBCR_CR17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR17_Msk instead */
+#define MCAN_TXBCR_CR18_Pos                 18                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 18 Position */
+#define MCAN_TXBCR_CR18_Msk                 (_U_(0x1) << MCAN_TXBCR_CR18_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 18 Mask */
+#define MCAN_TXBCR_CR18                     MCAN_TXBCR_CR18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR18_Msk instead */
+#define MCAN_TXBCR_CR19_Pos                 19                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 19 Position */
+#define MCAN_TXBCR_CR19_Msk                 (_U_(0x1) << MCAN_TXBCR_CR19_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 19 Mask */
+#define MCAN_TXBCR_CR19                     MCAN_TXBCR_CR19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR19_Msk instead */
+#define MCAN_TXBCR_CR20_Pos                 20                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 20 Position */
+#define MCAN_TXBCR_CR20_Msk                 (_U_(0x1) << MCAN_TXBCR_CR20_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 20 Mask */
+#define MCAN_TXBCR_CR20                     MCAN_TXBCR_CR20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR20_Msk instead */
+#define MCAN_TXBCR_CR21_Pos                 21                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 21 Position */
+#define MCAN_TXBCR_CR21_Msk                 (_U_(0x1) << MCAN_TXBCR_CR21_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 21 Mask */
+#define MCAN_TXBCR_CR21                     MCAN_TXBCR_CR21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR21_Msk instead */
+#define MCAN_TXBCR_CR22_Pos                 22                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 22 Position */
+#define MCAN_TXBCR_CR22_Msk                 (_U_(0x1) << MCAN_TXBCR_CR22_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 22 Mask */
+#define MCAN_TXBCR_CR22                     MCAN_TXBCR_CR22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR22_Msk instead */
+#define MCAN_TXBCR_CR23_Pos                 23                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 23 Position */
+#define MCAN_TXBCR_CR23_Msk                 (_U_(0x1) << MCAN_TXBCR_CR23_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 23 Mask */
+#define MCAN_TXBCR_CR23                     MCAN_TXBCR_CR23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR23_Msk instead */
+#define MCAN_TXBCR_CR24_Pos                 24                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 24 Position */
+#define MCAN_TXBCR_CR24_Msk                 (_U_(0x1) << MCAN_TXBCR_CR24_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 24 Mask */
+#define MCAN_TXBCR_CR24                     MCAN_TXBCR_CR24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR24_Msk instead */
+#define MCAN_TXBCR_CR25_Pos                 25                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 25 Position */
+#define MCAN_TXBCR_CR25_Msk                 (_U_(0x1) << MCAN_TXBCR_CR25_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 25 Mask */
+#define MCAN_TXBCR_CR25                     MCAN_TXBCR_CR25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR25_Msk instead */
+#define MCAN_TXBCR_CR26_Pos                 26                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 26 Position */
+#define MCAN_TXBCR_CR26_Msk                 (_U_(0x1) << MCAN_TXBCR_CR26_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 26 Mask */
+#define MCAN_TXBCR_CR26                     MCAN_TXBCR_CR26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR26_Msk instead */
+#define MCAN_TXBCR_CR27_Pos                 27                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 27 Position */
+#define MCAN_TXBCR_CR27_Msk                 (_U_(0x1) << MCAN_TXBCR_CR27_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 27 Mask */
+#define MCAN_TXBCR_CR27                     MCAN_TXBCR_CR27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR27_Msk instead */
+#define MCAN_TXBCR_CR28_Pos                 28                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 28 Position */
+#define MCAN_TXBCR_CR28_Msk                 (_U_(0x1) << MCAN_TXBCR_CR28_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 28 Mask */
+#define MCAN_TXBCR_CR28                     MCAN_TXBCR_CR28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR28_Msk instead */
+#define MCAN_TXBCR_CR29_Pos                 29                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 29 Position */
+#define MCAN_TXBCR_CR29_Msk                 (_U_(0x1) << MCAN_TXBCR_CR29_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 29 Mask */
+#define MCAN_TXBCR_CR29                     MCAN_TXBCR_CR29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR29_Msk instead */
+#define MCAN_TXBCR_CR30_Pos                 30                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 30 Position */
+#define MCAN_TXBCR_CR30_Msk                 (_U_(0x1) << MCAN_TXBCR_CR30_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 30 Mask */
+#define MCAN_TXBCR_CR30                     MCAN_TXBCR_CR30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR30_Msk instead */
+#define MCAN_TXBCR_CR31_Pos                 31                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 31 Position */
+#define MCAN_TXBCR_CR31_Msk                 (_U_(0x1) << MCAN_TXBCR_CR31_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 31 Mask */
+#define MCAN_TXBCR_CR31                     MCAN_TXBCR_CR31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR31_Msk instead */
+#define MCAN_TXBCR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCR) Register MASK  (Use MCAN_TXBCR_Msk instead)  */
+#define MCAN_TXBCR_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCR) Register Mask  */
+
+#define MCAN_TXBCR_CR_Pos                   0                                              /**< (MCAN_TXBCR Position) Cancellation Request for Transmit Buffer 3x */
+#define MCAN_TXBCR_CR_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBCR_CR_Pos)         /**< (MCAN_TXBCR Mask) CR */
+#define MCAN_TXBCR_CR(value)                (MCAN_TXBCR_CR_Msk & ((value) << MCAN_TXBCR_CR_Pos))  
+
+/* -------- MCAN_TXBTO : (MCAN Offset: 0xd8) (R/ 32) Transmit Buffer Transmission Occurred Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TO0:1;                     /**< bit:      0  Transmission Occurred for Buffer 0       */
+    uint32_t TO1:1;                     /**< bit:      1  Transmission Occurred for Buffer 1       */
+    uint32_t TO2:1;                     /**< bit:      2  Transmission Occurred for Buffer 2       */
+    uint32_t TO3:1;                     /**< bit:      3  Transmission Occurred for Buffer 3       */
+    uint32_t TO4:1;                     /**< bit:      4  Transmission Occurred for Buffer 4       */
+    uint32_t TO5:1;                     /**< bit:      5  Transmission Occurred for Buffer 5       */
+    uint32_t TO6:1;                     /**< bit:      6  Transmission Occurred for Buffer 6       */
+    uint32_t TO7:1;                     /**< bit:      7  Transmission Occurred for Buffer 7       */
+    uint32_t TO8:1;                     /**< bit:      8  Transmission Occurred for Buffer 8       */
+    uint32_t TO9:1;                     /**< bit:      9  Transmission Occurred for Buffer 9       */
+    uint32_t TO10:1;                    /**< bit:     10  Transmission Occurred for Buffer 10      */
+    uint32_t TO11:1;                    /**< bit:     11  Transmission Occurred for Buffer 11      */
+    uint32_t TO12:1;                    /**< bit:     12  Transmission Occurred for Buffer 12      */
+    uint32_t TO13:1;                    /**< bit:     13  Transmission Occurred for Buffer 13      */
+    uint32_t TO14:1;                    /**< bit:     14  Transmission Occurred for Buffer 14      */
+    uint32_t TO15:1;                    /**< bit:     15  Transmission Occurred for Buffer 15      */
+    uint32_t TO16:1;                    /**< bit:     16  Transmission Occurred for Buffer 16      */
+    uint32_t TO17:1;                    /**< bit:     17  Transmission Occurred for Buffer 17      */
+    uint32_t TO18:1;                    /**< bit:     18  Transmission Occurred for Buffer 18      */
+    uint32_t TO19:1;                    /**< bit:     19  Transmission Occurred for Buffer 19      */
+    uint32_t TO20:1;                    /**< bit:     20  Transmission Occurred for Buffer 20      */
+    uint32_t TO21:1;                    /**< bit:     21  Transmission Occurred for Buffer 21      */
+    uint32_t TO22:1;                    /**< bit:     22  Transmission Occurred for Buffer 22      */
+    uint32_t TO23:1;                    /**< bit:     23  Transmission Occurred for Buffer 23      */
+    uint32_t TO24:1;                    /**< bit:     24  Transmission Occurred for Buffer 24      */
+    uint32_t TO25:1;                    /**< bit:     25  Transmission Occurred for Buffer 25      */
+    uint32_t TO26:1;                    /**< bit:     26  Transmission Occurred for Buffer 26      */
+    uint32_t TO27:1;                    /**< bit:     27  Transmission Occurred for Buffer 27      */
+    uint32_t TO28:1;                    /**< bit:     28  Transmission Occurred for Buffer 28      */
+    uint32_t TO29:1;                    /**< bit:     29  Transmission Occurred for Buffer 29      */
+    uint32_t TO30:1;                    /**< bit:     30  Transmission Occurred for Buffer 30      */
+    uint32_t TO31:1;                    /**< bit:     31  Transmission Occurred for Buffer 31      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TO:32;                     /**< bit:  0..31  Transmission Occurred for Buffer 3x      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBTO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBTO_OFFSET                   (0xD8)                                        /**<  (MCAN_TXBTO) Transmit Buffer Transmission Occurred Register  Offset */
+
+#define MCAN_TXBTO_TO0_Pos                  0                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 0 Position */
+#define MCAN_TXBTO_TO0_Msk                  (_U_(0x1) << MCAN_TXBTO_TO0_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 0 Mask */
+#define MCAN_TXBTO_TO0                      MCAN_TXBTO_TO0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO0_Msk instead */
+#define MCAN_TXBTO_TO1_Pos                  1                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 1 Position */
+#define MCAN_TXBTO_TO1_Msk                  (_U_(0x1) << MCAN_TXBTO_TO1_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 1 Mask */
+#define MCAN_TXBTO_TO1                      MCAN_TXBTO_TO1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO1_Msk instead */
+#define MCAN_TXBTO_TO2_Pos                  2                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 2 Position */
+#define MCAN_TXBTO_TO2_Msk                  (_U_(0x1) << MCAN_TXBTO_TO2_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 2 Mask */
+#define MCAN_TXBTO_TO2                      MCAN_TXBTO_TO2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO2_Msk instead */
+#define MCAN_TXBTO_TO3_Pos                  3                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 3 Position */
+#define MCAN_TXBTO_TO3_Msk                  (_U_(0x1) << MCAN_TXBTO_TO3_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 3 Mask */
+#define MCAN_TXBTO_TO3                      MCAN_TXBTO_TO3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO3_Msk instead */
+#define MCAN_TXBTO_TO4_Pos                  4                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 4 Position */
+#define MCAN_TXBTO_TO4_Msk                  (_U_(0x1) << MCAN_TXBTO_TO4_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 4 Mask */
+#define MCAN_TXBTO_TO4                      MCAN_TXBTO_TO4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO4_Msk instead */
+#define MCAN_TXBTO_TO5_Pos                  5                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 5 Position */
+#define MCAN_TXBTO_TO5_Msk                  (_U_(0x1) << MCAN_TXBTO_TO5_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 5 Mask */
+#define MCAN_TXBTO_TO5                      MCAN_TXBTO_TO5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO5_Msk instead */
+#define MCAN_TXBTO_TO6_Pos                  6                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 6 Position */
+#define MCAN_TXBTO_TO6_Msk                  (_U_(0x1) << MCAN_TXBTO_TO6_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 6 Mask */
+#define MCAN_TXBTO_TO6                      MCAN_TXBTO_TO6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO6_Msk instead */
+#define MCAN_TXBTO_TO7_Pos                  7                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 7 Position */
+#define MCAN_TXBTO_TO7_Msk                  (_U_(0x1) << MCAN_TXBTO_TO7_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 7 Mask */
+#define MCAN_TXBTO_TO7                      MCAN_TXBTO_TO7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO7_Msk instead */
+#define MCAN_TXBTO_TO8_Pos                  8                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 8 Position */
+#define MCAN_TXBTO_TO8_Msk                  (_U_(0x1) << MCAN_TXBTO_TO8_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 8 Mask */
+#define MCAN_TXBTO_TO8                      MCAN_TXBTO_TO8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO8_Msk instead */
+#define MCAN_TXBTO_TO9_Pos                  9                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 9 Position */
+#define MCAN_TXBTO_TO9_Msk                  (_U_(0x1) << MCAN_TXBTO_TO9_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 9 Mask */
+#define MCAN_TXBTO_TO9                      MCAN_TXBTO_TO9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO9_Msk instead */
+#define MCAN_TXBTO_TO10_Pos                 10                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 10 Position */
+#define MCAN_TXBTO_TO10_Msk                 (_U_(0x1) << MCAN_TXBTO_TO10_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 10 Mask */
+#define MCAN_TXBTO_TO10                     MCAN_TXBTO_TO10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO10_Msk instead */
+#define MCAN_TXBTO_TO11_Pos                 11                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 11 Position */
+#define MCAN_TXBTO_TO11_Msk                 (_U_(0x1) << MCAN_TXBTO_TO11_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 11 Mask */
+#define MCAN_TXBTO_TO11                     MCAN_TXBTO_TO11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO11_Msk instead */
+#define MCAN_TXBTO_TO12_Pos                 12                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 12 Position */
+#define MCAN_TXBTO_TO12_Msk                 (_U_(0x1) << MCAN_TXBTO_TO12_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 12 Mask */
+#define MCAN_TXBTO_TO12                     MCAN_TXBTO_TO12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO12_Msk instead */
+#define MCAN_TXBTO_TO13_Pos                 13                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 13 Position */
+#define MCAN_TXBTO_TO13_Msk                 (_U_(0x1) << MCAN_TXBTO_TO13_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 13 Mask */
+#define MCAN_TXBTO_TO13                     MCAN_TXBTO_TO13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO13_Msk instead */
+#define MCAN_TXBTO_TO14_Pos                 14                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 14 Position */
+#define MCAN_TXBTO_TO14_Msk                 (_U_(0x1) << MCAN_TXBTO_TO14_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 14 Mask */
+#define MCAN_TXBTO_TO14                     MCAN_TXBTO_TO14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO14_Msk instead */
+#define MCAN_TXBTO_TO15_Pos                 15                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 15 Position */
+#define MCAN_TXBTO_TO15_Msk                 (_U_(0x1) << MCAN_TXBTO_TO15_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 15 Mask */
+#define MCAN_TXBTO_TO15                     MCAN_TXBTO_TO15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO15_Msk instead */
+#define MCAN_TXBTO_TO16_Pos                 16                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 16 Position */
+#define MCAN_TXBTO_TO16_Msk                 (_U_(0x1) << MCAN_TXBTO_TO16_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 16 Mask */
+#define MCAN_TXBTO_TO16                     MCAN_TXBTO_TO16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO16_Msk instead */
+#define MCAN_TXBTO_TO17_Pos                 17                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 17 Position */
+#define MCAN_TXBTO_TO17_Msk                 (_U_(0x1) << MCAN_TXBTO_TO17_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 17 Mask */
+#define MCAN_TXBTO_TO17                     MCAN_TXBTO_TO17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO17_Msk instead */
+#define MCAN_TXBTO_TO18_Pos                 18                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 18 Position */
+#define MCAN_TXBTO_TO18_Msk                 (_U_(0x1) << MCAN_TXBTO_TO18_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 18 Mask */
+#define MCAN_TXBTO_TO18                     MCAN_TXBTO_TO18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO18_Msk instead */
+#define MCAN_TXBTO_TO19_Pos                 19                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 19 Position */
+#define MCAN_TXBTO_TO19_Msk                 (_U_(0x1) << MCAN_TXBTO_TO19_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 19 Mask */
+#define MCAN_TXBTO_TO19                     MCAN_TXBTO_TO19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO19_Msk instead */
+#define MCAN_TXBTO_TO20_Pos                 20                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 20 Position */
+#define MCAN_TXBTO_TO20_Msk                 (_U_(0x1) << MCAN_TXBTO_TO20_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 20 Mask */
+#define MCAN_TXBTO_TO20                     MCAN_TXBTO_TO20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO20_Msk instead */
+#define MCAN_TXBTO_TO21_Pos                 21                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 21 Position */
+#define MCAN_TXBTO_TO21_Msk                 (_U_(0x1) << MCAN_TXBTO_TO21_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 21 Mask */
+#define MCAN_TXBTO_TO21                     MCAN_TXBTO_TO21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO21_Msk instead */
+#define MCAN_TXBTO_TO22_Pos                 22                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 22 Position */
+#define MCAN_TXBTO_TO22_Msk                 (_U_(0x1) << MCAN_TXBTO_TO22_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 22 Mask */
+#define MCAN_TXBTO_TO22                     MCAN_TXBTO_TO22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO22_Msk instead */
+#define MCAN_TXBTO_TO23_Pos                 23                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 23 Position */
+#define MCAN_TXBTO_TO23_Msk                 (_U_(0x1) << MCAN_TXBTO_TO23_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 23 Mask */
+#define MCAN_TXBTO_TO23                     MCAN_TXBTO_TO23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO23_Msk instead */
+#define MCAN_TXBTO_TO24_Pos                 24                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 24 Position */
+#define MCAN_TXBTO_TO24_Msk                 (_U_(0x1) << MCAN_TXBTO_TO24_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 24 Mask */
+#define MCAN_TXBTO_TO24                     MCAN_TXBTO_TO24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO24_Msk instead */
+#define MCAN_TXBTO_TO25_Pos                 25                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 25 Position */
+#define MCAN_TXBTO_TO25_Msk                 (_U_(0x1) << MCAN_TXBTO_TO25_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 25 Mask */
+#define MCAN_TXBTO_TO25                     MCAN_TXBTO_TO25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO25_Msk instead */
+#define MCAN_TXBTO_TO26_Pos                 26                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 26 Position */
+#define MCAN_TXBTO_TO26_Msk                 (_U_(0x1) << MCAN_TXBTO_TO26_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 26 Mask */
+#define MCAN_TXBTO_TO26                     MCAN_TXBTO_TO26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO26_Msk instead */
+#define MCAN_TXBTO_TO27_Pos                 27                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 27 Position */
+#define MCAN_TXBTO_TO27_Msk                 (_U_(0x1) << MCAN_TXBTO_TO27_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 27 Mask */
+#define MCAN_TXBTO_TO27                     MCAN_TXBTO_TO27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO27_Msk instead */
+#define MCAN_TXBTO_TO28_Pos                 28                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 28 Position */
+#define MCAN_TXBTO_TO28_Msk                 (_U_(0x1) << MCAN_TXBTO_TO28_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 28 Mask */
+#define MCAN_TXBTO_TO28                     MCAN_TXBTO_TO28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO28_Msk instead */
+#define MCAN_TXBTO_TO29_Pos                 29                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 29 Position */
+#define MCAN_TXBTO_TO29_Msk                 (_U_(0x1) << MCAN_TXBTO_TO29_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 29 Mask */
+#define MCAN_TXBTO_TO29                     MCAN_TXBTO_TO29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO29_Msk instead */
+#define MCAN_TXBTO_TO30_Pos                 30                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 30 Position */
+#define MCAN_TXBTO_TO30_Msk                 (_U_(0x1) << MCAN_TXBTO_TO30_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 30 Mask */
+#define MCAN_TXBTO_TO30                     MCAN_TXBTO_TO30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO30_Msk instead */
+#define MCAN_TXBTO_TO31_Pos                 31                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 31 Position */
+#define MCAN_TXBTO_TO31_Msk                 (_U_(0x1) << MCAN_TXBTO_TO31_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 31 Mask */
+#define MCAN_TXBTO_TO31                     MCAN_TXBTO_TO31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO31_Msk instead */
+#define MCAN_TXBTO_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBTO) Register MASK  (Use MCAN_TXBTO_Msk instead)  */
+#define MCAN_TXBTO_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBTO) Register Mask  */
+
+#define MCAN_TXBTO_TO_Pos                   0                                              /**< (MCAN_TXBTO Position) Transmission Occurred for Buffer 3x */
+#define MCAN_TXBTO_TO_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBTO_TO_Pos)         /**< (MCAN_TXBTO Mask) TO */
+#define MCAN_TXBTO_TO(value)                (MCAN_TXBTO_TO_Msk & ((value) << MCAN_TXBTO_TO_Pos))  
+
+/* -------- MCAN_TXBCF : (MCAN Offset: 0xdc) (R/ 32) Transmit Buffer Cancellation Finished Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CF0:1;                     /**< bit:      0  Cancellation Finished for Transmit Buffer 0 */
+    uint32_t CF1:1;                     /**< bit:      1  Cancellation Finished for Transmit Buffer 1 */
+    uint32_t CF2:1;                     /**< bit:      2  Cancellation Finished for Transmit Buffer 2 */
+    uint32_t CF3:1;                     /**< bit:      3  Cancellation Finished for Transmit Buffer 3 */
+    uint32_t CF4:1;                     /**< bit:      4  Cancellation Finished for Transmit Buffer 4 */
+    uint32_t CF5:1;                     /**< bit:      5  Cancellation Finished for Transmit Buffer 5 */
+    uint32_t CF6:1;                     /**< bit:      6  Cancellation Finished for Transmit Buffer 6 */
+    uint32_t CF7:1;                     /**< bit:      7  Cancellation Finished for Transmit Buffer 7 */
+    uint32_t CF8:1;                     /**< bit:      8  Cancellation Finished for Transmit Buffer 8 */
+    uint32_t CF9:1;                     /**< bit:      9  Cancellation Finished for Transmit Buffer 9 */
+    uint32_t CF10:1;                    /**< bit:     10  Cancellation Finished for Transmit Buffer 10 */
+    uint32_t CF11:1;                    /**< bit:     11  Cancellation Finished for Transmit Buffer 11 */
+    uint32_t CF12:1;                    /**< bit:     12  Cancellation Finished for Transmit Buffer 12 */
+    uint32_t CF13:1;                    /**< bit:     13  Cancellation Finished for Transmit Buffer 13 */
+    uint32_t CF14:1;                    /**< bit:     14  Cancellation Finished for Transmit Buffer 14 */
+    uint32_t CF15:1;                    /**< bit:     15  Cancellation Finished for Transmit Buffer 15 */
+    uint32_t CF16:1;                    /**< bit:     16  Cancellation Finished for Transmit Buffer 16 */
+    uint32_t CF17:1;                    /**< bit:     17  Cancellation Finished for Transmit Buffer 17 */
+    uint32_t CF18:1;                    /**< bit:     18  Cancellation Finished for Transmit Buffer 18 */
+    uint32_t CF19:1;                    /**< bit:     19  Cancellation Finished for Transmit Buffer 19 */
+    uint32_t CF20:1;                    /**< bit:     20  Cancellation Finished for Transmit Buffer 20 */
+    uint32_t CF21:1;                    /**< bit:     21  Cancellation Finished for Transmit Buffer 21 */
+    uint32_t CF22:1;                    /**< bit:     22  Cancellation Finished for Transmit Buffer 22 */
+    uint32_t CF23:1;                    /**< bit:     23  Cancellation Finished for Transmit Buffer 23 */
+    uint32_t CF24:1;                    /**< bit:     24  Cancellation Finished for Transmit Buffer 24 */
+    uint32_t CF25:1;                    /**< bit:     25  Cancellation Finished for Transmit Buffer 25 */
+    uint32_t CF26:1;                    /**< bit:     26  Cancellation Finished for Transmit Buffer 26 */
+    uint32_t CF27:1;                    /**< bit:     27  Cancellation Finished for Transmit Buffer 27 */
+    uint32_t CF28:1;                    /**< bit:     28  Cancellation Finished for Transmit Buffer 28 */
+    uint32_t CF29:1;                    /**< bit:     29  Cancellation Finished for Transmit Buffer 29 */
+    uint32_t CF30:1;                    /**< bit:     30  Cancellation Finished for Transmit Buffer 30 */
+    uint32_t CF31:1;                    /**< bit:     31  Cancellation Finished for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CF:32;                     /**< bit:  0..31  Cancellation Finished for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCF_OFFSET                   (0xDC)                                        /**<  (MCAN_TXBCF) Transmit Buffer Cancellation Finished Register  Offset */
+
+#define MCAN_TXBCF_CF0_Pos                  0                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 0 Position */
+#define MCAN_TXBCF_CF0_Msk                  (_U_(0x1) << MCAN_TXBCF_CF0_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 0 Mask */
+#define MCAN_TXBCF_CF0                      MCAN_TXBCF_CF0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF0_Msk instead */
+#define MCAN_TXBCF_CF1_Pos                  1                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 1 Position */
+#define MCAN_TXBCF_CF1_Msk                  (_U_(0x1) << MCAN_TXBCF_CF1_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 1 Mask */
+#define MCAN_TXBCF_CF1                      MCAN_TXBCF_CF1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF1_Msk instead */
+#define MCAN_TXBCF_CF2_Pos                  2                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 2 Position */
+#define MCAN_TXBCF_CF2_Msk                  (_U_(0x1) << MCAN_TXBCF_CF2_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 2 Mask */
+#define MCAN_TXBCF_CF2                      MCAN_TXBCF_CF2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF2_Msk instead */
+#define MCAN_TXBCF_CF3_Pos                  3                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 3 Position */
+#define MCAN_TXBCF_CF3_Msk                  (_U_(0x1) << MCAN_TXBCF_CF3_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 3 Mask */
+#define MCAN_TXBCF_CF3                      MCAN_TXBCF_CF3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF3_Msk instead */
+#define MCAN_TXBCF_CF4_Pos                  4                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 4 Position */
+#define MCAN_TXBCF_CF4_Msk                  (_U_(0x1) << MCAN_TXBCF_CF4_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 4 Mask */
+#define MCAN_TXBCF_CF4                      MCAN_TXBCF_CF4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF4_Msk instead */
+#define MCAN_TXBCF_CF5_Pos                  5                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 5 Position */
+#define MCAN_TXBCF_CF5_Msk                  (_U_(0x1) << MCAN_TXBCF_CF5_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 5 Mask */
+#define MCAN_TXBCF_CF5                      MCAN_TXBCF_CF5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF5_Msk instead */
+#define MCAN_TXBCF_CF6_Pos                  6                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 6 Position */
+#define MCAN_TXBCF_CF6_Msk                  (_U_(0x1) << MCAN_TXBCF_CF6_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 6 Mask */
+#define MCAN_TXBCF_CF6                      MCAN_TXBCF_CF6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF6_Msk instead */
+#define MCAN_TXBCF_CF7_Pos                  7                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 7 Position */
+#define MCAN_TXBCF_CF7_Msk                  (_U_(0x1) << MCAN_TXBCF_CF7_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 7 Mask */
+#define MCAN_TXBCF_CF7                      MCAN_TXBCF_CF7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF7_Msk instead */
+#define MCAN_TXBCF_CF8_Pos                  8                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 8 Position */
+#define MCAN_TXBCF_CF8_Msk                  (_U_(0x1) << MCAN_TXBCF_CF8_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 8 Mask */
+#define MCAN_TXBCF_CF8                      MCAN_TXBCF_CF8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF8_Msk instead */
+#define MCAN_TXBCF_CF9_Pos                  9                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 9 Position */
+#define MCAN_TXBCF_CF9_Msk                  (_U_(0x1) << MCAN_TXBCF_CF9_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 9 Mask */
+#define MCAN_TXBCF_CF9                      MCAN_TXBCF_CF9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF9_Msk instead */
+#define MCAN_TXBCF_CF10_Pos                 10                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 10 Position */
+#define MCAN_TXBCF_CF10_Msk                 (_U_(0x1) << MCAN_TXBCF_CF10_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 10 Mask */
+#define MCAN_TXBCF_CF10                     MCAN_TXBCF_CF10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF10_Msk instead */
+#define MCAN_TXBCF_CF11_Pos                 11                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 11 Position */
+#define MCAN_TXBCF_CF11_Msk                 (_U_(0x1) << MCAN_TXBCF_CF11_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 11 Mask */
+#define MCAN_TXBCF_CF11                     MCAN_TXBCF_CF11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF11_Msk instead */
+#define MCAN_TXBCF_CF12_Pos                 12                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 12 Position */
+#define MCAN_TXBCF_CF12_Msk                 (_U_(0x1) << MCAN_TXBCF_CF12_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 12 Mask */
+#define MCAN_TXBCF_CF12                     MCAN_TXBCF_CF12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF12_Msk instead */
+#define MCAN_TXBCF_CF13_Pos                 13                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 13 Position */
+#define MCAN_TXBCF_CF13_Msk                 (_U_(0x1) << MCAN_TXBCF_CF13_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 13 Mask */
+#define MCAN_TXBCF_CF13                     MCAN_TXBCF_CF13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF13_Msk instead */
+#define MCAN_TXBCF_CF14_Pos                 14                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 14 Position */
+#define MCAN_TXBCF_CF14_Msk                 (_U_(0x1) << MCAN_TXBCF_CF14_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 14 Mask */
+#define MCAN_TXBCF_CF14                     MCAN_TXBCF_CF14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF14_Msk instead */
+#define MCAN_TXBCF_CF15_Pos                 15                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 15 Position */
+#define MCAN_TXBCF_CF15_Msk                 (_U_(0x1) << MCAN_TXBCF_CF15_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 15 Mask */
+#define MCAN_TXBCF_CF15                     MCAN_TXBCF_CF15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF15_Msk instead */
+#define MCAN_TXBCF_CF16_Pos                 16                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 16 Position */
+#define MCAN_TXBCF_CF16_Msk                 (_U_(0x1) << MCAN_TXBCF_CF16_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 16 Mask */
+#define MCAN_TXBCF_CF16                     MCAN_TXBCF_CF16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF16_Msk instead */
+#define MCAN_TXBCF_CF17_Pos                 17                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 17 Position */
+#define MCAN_TXBCF_CF17_Msk                 (_U_(0x1) << MCAN_TXBCF_CF17_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 17 Mask */
+#define MCAN_TXBCF_CF17                     MCAN_TXBCF_CF17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF17_Msk instead */
+#define MCAN_TXBCF_CF18_Pos                 18                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 18 Position */
+#define MCAN_TXBCF_CF18_Msk                 (_U_(0x1) << MCAN_TXBCF_CF18_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 18 Mask */
+#define MCAN_TXBCF_CF18                     MCAN_TXBCF_CF18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF18_Msk instead */
+#define MCAN_TXBCF_CF19_Pos                 19                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 19 Position */
+#define MCAN_TXBCF_CF19_Msk                 (_U_(0x1) << MCAN_TXBCF_CF19_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 19 Mask */
+#define MCAN_TXBCF_CF19                     MCAN_TXBCF_CF19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF19_Msk instead */
+#define MCAN_TXBCF_CF20_Pos                 20                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 20 Position */
+#define MCAN_TXBCF_CF20_Msk                 (_U_(0x1) << MCAN_TXBCF_CF20_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 20 Mask */
+#define MCAN_TXBCF_CF20                     MCAN_TXBCF_CF20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF20_Msk instead */
+#define MCAN_TXBCF_CF21_Pos                 21                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 21 Position */
+#define MCAN_TXBCF_CF21_Msk                 (_U_(0x1) << MCAN_TXBCF_CF21_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 21 Mask */
+#define MCAN_TXBCF_CF21                     MCAN_TXBCF_CF21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF21_Msk instead */
+#define MCAN_TXBCF_CF22_Pos                 22                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 22 Position */
+#define MCAN_TXBCF_CF22_Msk                 (_U_(0x1) << MCAN_TXBCF_CF22_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 22 Mask */
+#define MCAN_TXBCF_CF22                     MCAN_TXBCF_CF22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF22_Msk instead */
+#define MCAN_TXBCF_CF23_Pos                 23                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 23 Position */
+#define MCAN_TXBCF_CF23_Msk                 (_U_(0x1) << MCAN_TXBCF_CF23_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 23 Mask */
+#define MCAN_TXBCF_CF23                     MCAN_TXBCF_CF23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF23_Msk instead */
+#define MCAN_TXBCF_CF24_Pos                 24                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 24 Position */
+#define MCAN_TXBCF_CF24_Msk                 (_U_(0x1) << MCAN_TXBCF_CF24_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 24 Mask */
+#define MCAN_TXBCF_CF24                     MCAN_TXBCF_CF24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF24_Msk instead */
+#define MCAN_TXBCF_CF25_Pos                 25                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 25 Position */
+#define MCAN_TXBCF_CF25_Msk                 (_U_(0x1) << MCAN_TXBCF_CF25_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 25 Mask */
+#define MCAN_TXBCF_CF25                     MCAN_TXBCF_CF25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF25_Msk instead */
+#define MCAN_TXBCF_CF26_Pos                 26                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 26 Position */
+#define MCAN_TXBCF_CF26_Msk                 (_U_(0x1) << MCAN_TXBCF_CF26_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 26 Mask */
+#define MCAN_TXBCF_CF26                     MCAN_TXBCF_CF26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF26_Msk instead */
+#define MCAN_TXBCF_CF27_Pos                 27                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 27 Position */
+#define MCAN_TXBCF_CF27_Msk                 (_U_(0x1) << MCAN_TXBCF_CF27_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 27 Mask */
+#define MCAN_TXBCF_CF27                     MCAN_TXBCF_CF27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF27_Msk instead */
+#define MCAN_TXBCF_CF28_Pos                 28                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 28 Position */
+#define MCAN_TXBCF_CF28_Msk                 (_U_(0x1) << MCAN_TXBCF_CF28_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 28 Mask */
+#define MCAN_TXBCF_CF28                     MCAN_TXBCF_CF28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF28_Msk instead */
+#define MCAN_TXBCF_CF29_Pos                 29                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 29 Position */
+#define MCAN_TXBCF_CF29_Msk                 (_U_(0x1) << MCAN_TXBCF_CF29_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 29 Mask */
+#define MCAN_TXBCF_CF29                     MCAN_TXBCF_CF29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF29_Msk instead */
+#define MCAN_TXBCF_CF30_Pos                 30                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 30 Position */
+#define MCAN_TXBCF_CF30_Msk                 (_U_(0x1) << MCAN_TXBCF_CF30_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 30 Mask */
+#define MCAN_TXBCF_CF30                     MCAN_TXBCF_CF30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF30_Msk instead */
+#define MCAN_TXBCF_CF31_Pos                 31                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 31 Position */
+#define MCAN_TXBCF_CF31_Msk                 (_U_(0x1) << MCAN_TXBCF_CF31_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 31 Mask */
+#define MCAN_TXBCF_CF31                     MCAN_TXBCF_CF31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF31_Msk instead */
+#define MCAN_TXBCF_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCF) Register MASK  (Use MCAN_TXBCF_Msk instead)  */
+#define MCAN_TXBCF_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCF) Register Mask  */
+
+#define MCAN_TXBCF_CF_Pos                   0                                              /**< (MCAN_TXBCF Position) Cancellation Finished for Transmit Buffer 3x */
+#define MCAN_TXBCF_CF_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBCF_CF_Pos)         /**< (MCAN_TXBCF Mask) CF */
+#define MCAN_TXBCF_CF(value)                (MCAN_TXBCF_CF_Msk & ((value) << MCAN_TXBCF_CF_Pos))  
+
+/* -------- MCAN_TXBTIE : (MCAN Offset: 0xe0) (R/W 32) Transmit Buffer Transmission Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TIE0:1;                    /**< bit:      0  Transmission Interrupt Enable for Buffer 0 */
+    uint32_t TIE1:1;                    /**< bit:      1  Transmission Interrupt Enable for Buffer 1 */
+    uint32_t TIE2:1;                    /**< bit:      2  Transmission Interrupt Enable for Buffer 2 */
+    uint32_t TIE3:1;                    /**< bit:      3  Transmission Interrupt Enable for Buffer 3 */
+    uint32_t TIE4:1;                    /**< bit:      4  Transmission Interrupt Enable for Buffer 4 */
+    uint32_t TIE5:1;                    /**< bit:      5  Transmission Interrupt Enable for Buffer 5 */
+    uint32_t TIE6:1;                    /**< bit:      6  Transmission Interrupt Enable for Buffer 6 */
+    uint32_t TIE7:1;                    /**< bit:      7  Transmission Interrupt Enable for Buffer 7 */
+    uint32_t TIE8:1;                    /**< bit:      8  Transmission Interrupt Enable for Buffer 8 */
+    uint32_t TIE9:1;                    /**< bit:      9  Transmission Interrupt Enable for Buffer 9 */
+    uint32_t TIE10:1;                   /**< bit:     10  Transmission Interrupt Enable for Buffer 10 */
+    uint32_t TIE11:1;                   /**< bit:     11  Transmission Interrupt Enable for Buffer 11 */
+    uint32_t TIE12:1;                   /**< bit:     12  Transmission Interrupt Enable for Buffer 12 */
+    uint32_t TIE13:1;                   /**< bit:     13  Transmission Interrupt Enable for Buffer 13 */
+    uint32_t TIE14:1;                   /**< bit:     14  Transmission Interrupt Enable for Buffer 14 */
+    uint32_t TIE15:1;                   /**< bit:     15  Transmission Interrupt Enable for Buffer 15 */
+    uint32_t TIE16:1;                   /**< bit:     16  Transmission Interrupt Enable for Buffer 16 */
+    uint32_t TIE17:1;                   /**< bit:     17  Transmission Interrupt Enable for Buffer 17 */
+    uint32_t TIE18:1;                   /**< bit:     18  Transmission Interrupt Enable for Buffer 18 */
+    uint32_t TIE19:1;                   /**< bit:     19  Transmission Interrupt Enable for Buffer 19 */
+    uint32_t TIE20:1;                   /**< bit:     20  Transmission Interrupt Enable for Buffer 20 */
+    uint32_t TIE21:1;                   /**< bit:     21  Transmission Interrupt Enable for Buffer 21 */
+    uint32_t TIE22:1;                   /**< bit:     22  Transmission Interrupt Enable for Buffer 22 */
+    uint32_t TIE23:1;                   /**< bit:     23  Transmission Interrupt Enable for Buffer 23 */
+    uint32_t TIE24:1;                   /**< bit:     24  Transmission Interrupt Enable for Buffer 24 */
+    uint32_t TIE25:1;                   /**< bit:     25  Transmission Interrupt Enable for Buffer 25 */
+    uint32_t TIE26:1;                   /**< bit:     26  Transmission Interrupt Enable for Buffer 26 */
+    uint32_t TIE27:1;                   /**< bit:     27  Transmission Interrupt Enable for Buffer 27 */
+    uint32_t TIE28:1;                   /**< bit:     28  Transmission Interrupt Enable for Buffer 28 */
+    uint32_t TIE29:1;                   /**< bit:     29  Transmission Interrupt Enable for Buffer 29 */
+    uint32_t TIE30:1;                   /**< bit:     30  Transmission Interrupt Enable for Buffer 30 */
+    uint32_t TIE31:1;                   /**< bit:     31  Transmission Interrupt Enable for Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TIE:32;                    /**< bit:  0..31  Transmission Interrupt Enable for Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBTIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBTIE_OFFSET                  (0xE0)                                        /**<  (MCAN_TXBTIE) Transmit Buffer Transmission Interrupt Enable Register  Offset */
+
+#define MCAN_TXBTIE_TIE0_Pos                0                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 0 Position */
+#define MCAN_TXBTIE_TIE0_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE0_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 0 Mask */
+#define MCAN_TXBTIE_TIE0                    MCAN_TXBTIE_TIE0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE0_Msk instead */
+#define MCAN_TXBTIE_TIE1_Pos                1                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 1 Position */
+#define MCAN_TXBTIE_TIE1_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE1_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 1 Mask */
+#define MCAN_TXBTIE_TIE1                    MCAN_TXBTIE_TIE1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE1_Msk instead */
+#define MCAN_TXBTIE_TIE2_Pos                2                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 2 Position */
+#define MCAN_TXBTIE_TIE2_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE2_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 2 Mask */
+#define MCAN_TXBTIE_TIE2                    MCAN_TXBTIE_TIE2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE2_Msk instead */
+#define MCAN_TXBTIE_TIE3_Pos                3                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 3 Position */
+#define MCAN_TXBTIE_TIE3_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE3_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 3 Mask */
+#define MCAN_TXBTIE_TIE3                    MCAN_TXBTIE_TIE3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE3_Msk instead */
+#define MCAN_TXBTIE_TIE4_Pos                4                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 4 Position */
+#define MCAN_TXBTIE_TIE4_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE4_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 4 Mask */
+#define MCAN_TXBTIE_TIE4                    MCAN_TXBTIE_TIE4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE4_Msk instead */
+#define MCAN_TXBTIE_TIE5_Pos                5                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 5 Position */
+#define MCAN_TXBTIE_TIE5_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE5_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 5 Mask */
+#define MCAN_TXBTIE_TIE5                    MCAN_TXBTIE_TIE5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE5_Msk instead */
+#define MCAN_TXBTIE_TIE6_Pos                6                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 6 Position */
+#define MCAN_TXBTIE_TIE6_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE6_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 6 Mask */
+#define MCAN_TXBTIE_TIE6                    MCAN_TXBTIE_TIE6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE6_Msk instead */
+#define MCAN_TXBTIE_TIE7_Pos                7                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 7 Position */
+#define MCAN_TXBTIE_TIE7_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE7_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 7 Mask */
+#define MCAN_TXBTIE_TIE7                    MCAN_TXBTIE_TIE7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE7_Msk instead */
+#define MCAN_TXBTIE_TIE8_Pos                8                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 8 Position */
+#define MCAN_TXBTIE_TIE8_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE8_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 8 Mask */
+#define MCAN_TXBTIE_TIE8                    MCAN_TXBTIE_TIE8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE8_Msk instead */
+#define MCAN_TXBTIE_TIE9_Pos                9                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 9 Position */
+#define MCAN_TXBTIE_TIE9_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE9_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 9 Mask */
+#define MCAN_TXBTIE_TIE9                    MCAN_TXBTIE_TIE9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE9_Msk instead */
+#define MCAN_TXBTIE_TIE10_Pos               10                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 10 Position */
+#define MCAN_TXBTIE_TIE10_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE10_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 10 Mask */
+#define MCAN_TXBTIE_TIE10                   MCAN_TXBTIE_TIE10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE10_Msk instead */
+#define MCAN_TXBTIE_TIE11_Pos               11                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 11 Position */
+#define MCAN_TXBTIE_TIE11_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE11_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 11 Mask */
+#define MCAN_TXBTIE_TIE11                   MCAN_TXBTIE_TIE11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE11_Msk instead */
+#define MCAN_TXBTIE_TIE12_Pos               12                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 12 Position */
+#define MCAN_TXBTIE_TIE12_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE12_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 12 Mask */
+#define MCAN_TXBTIE_TIE12                   MCAN_TXBTIE_TIE12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE12_Msk instead */
+#define MCAN_TXBTIE_TIE13_Pos               13                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 13 Position */
+#define MCAN_TXBTIE_TIE13_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE13_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 13 Mask */
+#define MCAN_TXBTIE_TIE13                   MCAN_TXBTIE_TIE13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE13_Msk instead */
+#define MCAN_TXBTIE_TIE14_Pos               14                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 14 Position */
+#define MCAN_TXBTIE_TIE14_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE14_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 14 Mask */
+#define MCAN_TXBTIE_TIE14                   MCAN_TXBTIE_TIE14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE14_Msk instead */
+#define MCAN_TXBTIE_TIE15_Pos               15                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 15 Position */
+#define MCAN_TXBTIE_TIE15_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE15_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 15 Mask */
+#define MCAN_TXBTIE_TIE15                   MCAN_TXBTIE_TIE15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE15_Msk instead */
+#define MCAN_TXBTIE_TIE16_Pos               16                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 16 Position */
+#define MCAN_TXBTIE_TIE16_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE16_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 16 Mask */
+#define MCAN_TXBTIE_TIE16                   MCAN_TXBTIE_TIE16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE16_Msk instead */
+#define MCAN_TXBTIE_TIE17_Pos               17                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 17 Position */
+#define MCAN_TXBTIE_TIE17_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE17_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 17 Mask */
+#define MCAN_TXBTIE_TIE17                   MCAN_TXBTIE_TIE17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE17_Msk instead */
+#define MCAN_TXBTIE_TIE18_Pos               18                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 18 Position */
+#define MCAN_TXBTIE_TIE18_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE18_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 18 Mask */
+#define MCAN_TXBTIE_TIE18                   MCAN_TXBTIE_TIE18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE18_Msk instead */
+#define MCAN_TXBTIE_TIE19_Pos               19                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 19 Position */
+#define MCAN_TXBTIE_TIE19_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE19_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 19 Mask */
+#define MCAN_TXBTIE_TIE19                   MCAN_TXBTIE_TIE19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE19_Msk instead */
+#define MCAN_TXBTIE_TIE20_Pos               20                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 20 Position */
+#define MCAN_TXBTIE_TIE20_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE20_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 20 Mask */
+#define MCAN_TXBTIE_TIE20                   MCAN_TXBTIE_TIE20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE20_Msk instead */
+#define MCAN_TXBTIE_TIE21_Pos               21                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 21 Position */
+#define MCAN_TXBTIE_TIE21_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE21_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 21 Mask */
+#define MCAN_TXBTIE_TIE21                   MCAN_TXBTIE_TIE21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE21_Msk instead */
+#define MCAN_TXBTIE_TIE22_Pos               22                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 22 Position */
+#define MCAN_TXBTIE_TIE22_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE22_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 22 Mask */
+#define MCAN_TXBTIE_TIE22                   MCAN_TXBTIE_TIE22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE22_Msk instead */
+#define MCAN_TXBTIE_TIE23_Pos               23                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 23 Position */
+#define MCAN_TXBTIE_TIE23_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE23_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 23 Mask */
+#define MCAN_TXBTIE_TIE23                   MCAN_TXBTIE_TIE23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE23_Msk instead */
+#define MCAN_TXBTIE_TIE24_Pos               24                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 24 Position */
+#define MCAN_TXBTIE_TIE24_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE24_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 24 Mask */
+#define MCAN_TXBTIE_TIE24                   MCAN_TXBTIE_TIE24_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE24_Msk instead */
+#define MCAN_TXBTIE_TIE25_Pos               25                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 25 Position */
+#define MCAN_TXBTIE_TIE25_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE25_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 25 Mask */
+#define MCAN_TXBTIE_TIE25                   MCAN_TXBTIE_TIE25_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE25_Msk instead */
+#define MCAN_TXBTIE_TIE26_Pos               26                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 26 Position */
+#define MCAN_TXBTIE_TIE26_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE26_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 26 Mask */
+#define MCAN_TXBTIE_TIE26                   MCAN_TXBTIE_TIE26_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE26_Msk instead */
+#define MCAN_TXBTIE_TIE27_Pos               27                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 27 Position */
+#define MCAN_TXBTIE_TIE27_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE27_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 27 Mask */
+#define MCAN_TXBTIE_TIE27                   MCAN_TXBTIE_TIE27_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE27_Msk instead */
+#define MCAN_TXBTIE_TIE28_Pos               28                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 28 Position */
+#define MCAN_TXBTIE_TIE28_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE28_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 28 Mask */
+#define MCAN_TXBTIE_TIE28                   MCAN_TXBTIE_TIE28_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE28_Msk instead */
+#define MCAN_TXBTIE_TIE29_Pos               29                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 29 Position */
+#define MCAN_TXBTIE_TIE29_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE29_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 29 Mask */
+#define MCAN_TXBTIE_TIE29                   MCAN_TXBTIE_TIE29_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE29_Msk instead */
+#define MCAN_TXBTIE_TIE30_Pos               30                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 30 Position */
+#define MCAN_TXBTIE_TIE30_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE30_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 30 Mask */
+#define MCAN_TXBTIE_TIE30                   MCAN_TXBTIE_TIE30_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE30_Msk instead */
+#define MCAN_TXBTIE_TIE31_Pos               31                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 31 Position */
+#define MCAN_TXBTIE_TIE31_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE31_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 31 Mask */
+#define MCAN_TXBTIE_TIE31                   MCAN_TXBTIE_TIE31_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE31_Msk instead */
+#define MCAN_TXBTIE_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBTIE) Register MASK  (Use MCAN_TXBTIE_Msk instead)  */
+#define MCAN_TXBTIE_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBTIE) Register Mask  */
+
+#define MCAN_TXBTIE_TIE_Pos                 0                                              /**< (MCAN_TXBTIE Position) Transmission Interrupt Enable for Buffer 3x */
+#define MCAN_TXBTIE_TIE_Msk                 (_U_(0xFFFFFFFF) << MCAN_TXBTIE_TIE_Pos)       /**< (MCAN_TXBTIE Mask) TIE */
+#define MCAN_TXBTIE_TIE(value)              (MCAN_TXBTIE_TIE_Msk & ((value) << MCAN_TXBTIE_TIE_Pos))  
+
+/* -------- MCAN_TXBCIE : (MCAN Offset: 0xe4) (R/W 32) Transmit Buffer Cancellation Finished Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CFIE0:1;                   /**< bit:      0  Cancellation Finished Interrupt Enable for Transmit Buffer 0 */
+    uint32_t CFIE1:1;                   /**< bit:      1  Cancellation Finished Interrupt Enable for Transmit Buffer 1 */
+    uint32_t CFIE2:1;                   /**< bit:      2  Cancellation Finished Interrupt Enable for Transmit Buffer 2 */
+    uint32_t CFIE3:1;                   /**< bit:      3  Cancellation Finished Interrupt Enable for Transmit Buffer 3 */
+    uint32_t CFIE4:1;                   /**< bit:      4  Cancellation Finished Interrupt Enable for Transmit Buffer 4 */
+    uint32_t CFIE5:1;                   /**< bit:      5  Cancellation Finished Interrupt Enable for Transmit Buffer 5 */
+    uint32_t CFIE6:1;                   /**< bit:      6  Cancellation Finished Interrupt Enable for Transmit Buffer 6 */
+    uint32_t CFIE7:1;                   /**< bit:      7  Cancellation Finished Interrupt Enable for Transmit Buffer 7 */
+    uint32_t CFIE8:1;                   /**< bit:      8  Cancellation Finished Interrupt Enable for Transmit Buffer 8 */
+    uint32_t CFIE9:1;                   /**< bit:      9  Cancellation Finished Interrupt Enable for Transmit Buffer 9 */
+    uint32_t CFIE10:1;                  /**< bit:     10  Cancellation Finished Interrupt Enable for Transmit Buffer 10 */
+    uint32_t CFIE11:1;                  /**< bit:     11  Cancellation Finished Interrupt Enable for Transmit Buffer 11 */
+    uint32_t CFIE12:1;                  /**< bit:     12  Cancellation Finished Interrupt Enable for Transmit Buffer 12 */
+    uint32_t CFIE13:1;                  /**< bit:     13  Cancellation Finished Interrupt Enable for Transmit Buffer 13 */
+    uint32_t CFIE14:1;                  /**< bit:     14  Cancellation Finished Interrupt Enable for Transmit Buffer 14 */
+    uint32_t CFIE15:1;                  /**< bit:     15  Cancellation Finished Interrupt Enable for Transmit Buffer 15 */
+    uint32_t CFIE16:1;                  /**< bit:     16  Cancellation Finished Interrupt Enable for Transmit Buffer 16 */
+    uint32_t CFIE17:1;                  /**< bit:     17  Cancellation Finished Interrupt Enable for Transmit Buffer 17 */
+    uint32_t CFIE18:1;                  /**< bit:     18  Cancellation Finished Interrupt Enable for Transmit Buffer 18 */
+    uint32_t CFIE19:1;                  /**< bit:     19  Cancellation Finished Interrupt Enable for Transmit Buffer 19 */
+    uint32_t CFIE20:1;                  /**< bit:     20  Cancellation Finished Interrupt Enable for Transmit Buffer 20 */
+    uint32_t CFIE21:1;                  /**< bit:     21  Cancellation Finished Interrupt Enable for Transmit Buffer 21 */
+    uint32_t CFIE22:1;                  /**< bit:     22  Cancellation Finished Interrupt Enable for Transmit Buffer 22 */
+    uint32_t CFIE23:1;                  /**< bit:     23  Cancellation Finished Interrupt Enable for Transmit Buffer 23 */
+    uint32_t CFIE24:1;                  /**< bit:     24  Cancellation Finished Interrupt Enable for Transmit Buffer 24 */
+    uint32_t CFIE25:1;                  /**< bit:     25  Cancellation Finished Interrupt Enable for Transmit Buffer 25 */
+    uint32_t CFIE26:1;                  /**< bit:     26  Cancellation Finished Interrupt Enable for Transmit Buffer 26 */
+    uint32_t CFIE27:1;                  /**< bit:     27  Cancellation Finished Interrupt Enable for Transmit Buffer 27 */
+    uint32_t CFIE28:1;                  /**< bit:     28  Cancellation Finished Interrupt Enable for Transmit Buffer 28 */
+    uint32_t CFIE29:1;                  /**< bit:     29  Cancellation Finished Interrupt Enable for Transmit Buffer 29 */
+    uint32_t CFIE30:1;                  /**< bit:     30  Cancellation Finished Interrupt Enable for Transmit Buffer 30 */
+    uint32_t CFIE31:1;                  /**< bit:     31  Cancellation Finished Interrupt Enable for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CFIE:32;                   /**< bit:  0..31  Cancellation Finished Interrupt Enable for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCIE_OFFSET                  (0xE4)                                        /**<  (MCAN_TXBCIE) Transmit Buffer Cancellation Finished Interrupt Enable Register  Offset */
+
+#define MCAN_TXBCIE_CFIE0_Pos               0                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 0 Position */
+#define MCAN_TXBCIE_CFIE0_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE0_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 0 Mask */
+#define MCAN_TXBCIE_CFIE0                   MCAN_TXBCIE_CFIE0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE0_Msk instead */
+#define MCAN_TXBCIE_CFIE1_Pos               1                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 1 Position */
+#define MCAN_TXBCIE_CFIE1_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE1_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 1 Mask */
+#define MCAN_TXBCIE_CFIE1                   MCAN_TXBCIE_CFIE1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE1_Msk instead */
+#define MCAN_TXBCIE_CFIE2_Pos               2                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 2 Position */
+#define MCAN_TXBCIE_CFIE2_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE2_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 2 Mask */
+#define MCAN_TXBCIE_CFIE2                   MCAN_TXBCIE_CFIE2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE2_Msk instead */
+#define MCAN_TXBCIE_CFIE3_Pos               3                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 3 Position */
+#define MCAN_TXBCIE_CFIE3_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE3_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 3 Mask */
+#define MCAN_TXBCIE_CFIE3                   MCAN_TXBCIE_CFIE3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE3_Msk instead */
+#define MCAN_TXBCIE_CFIE4_Pos               4                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 4 Position */
+#define MCAN_TXBCIE_CFIE4_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE4_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 4 Mask */
+#define MCAN_TXBCIE_CFIE4                   MCAN_TXBCIE_CFIE4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE4_Msk instead */
+#define MCAN_TXBCIE_CFIE5_Pos               5                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 5 Position */
+#define MCAN_TXBCIE_CFIE5_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE5_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 5 Mask */
+#define MCAN_TXBCIE_CFIE5                   MCAN_TXBCIE_CFIE5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE5_Msk instead */
+#define MCAN_TXBCIE_CFIE6_Pos               6                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 6 Position */
+#define MCAN_TXBCIE_CFIE6_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE6_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 6 Mask */
+#define MCAN_TXBCIE_CFIE6                   MCAN_TXBCIE_CFIE6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE6_Msk instead */
+#define MCAN_TXBCIE_CFIE7_Pos               7                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 7 Position */
+#define MCAN_TXBCIE_CFIE7_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE7_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 7 Mask */
+#define MCAN_TXBCIE_CFIE7                   MCAN_TXBCIE_CFIE7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE7_Msk instead */
+#define MCAN_TXBCIE_CFIE8_Pos               8                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 8 Position */
+#define MCAN_TXBCIE_CFIE8_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE8_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 8 Mask */
+#define MCAN_TXBCIE_CFIE8                   MCAN_TXBCIE_CFIE8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE8_Msk instead */
+#define MCAN_TXBCIE_CFIE9_Pos               9                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 9 Position */
+#define MCAN_TXBCIE_CFIE9_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE9_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 9 Mask */
+#define MCAN_TXBCIE_CFIE9                   MCAN_TXBCIE_CFIE9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE9_Msk instead */
+#define MCAN_TXBCIE_CFIE10_Pos              10                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 10 Position */
+#define MCAN_TXBCIE_CFIE10_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE10_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 10 Mask */
+#define MCAN_TXBCIE_CFIE10                  MCAN_TXBCIE_CFIE10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE10_Msk instead */
+#define MCAN_TXBCIE_CFIE11_Pos              11                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 11 Position */
+#define MCAN_TXBCIE_CFIE11_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE11_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 11 Mask */
+#define MCAN_TXBCIE_CFIE11                  MCAN_TXBCIE_CFIE11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE11_Msk instead */
+#define MCAN_TXBCIE_CFIE12_Pos              12                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 12 Position */
+#define MCAN_TXBCIE_CFIE12_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE12_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 12 Mask */
+#define MCAN_TXBCIE_CFIE12                  MCAN_TXBCIE_CFIE12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE12_Msk instead */
+#define MCAN_TXBCIE_CFIE13_Pos              13                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 13 Position */
+#define MCAN_TXBCIE_CFIE13_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE13_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 13 Mask */
+#define MCAN_TXBCIE_CFIE13                  MCAN_TXBCIE_CFIE13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE13_Msk instead */
+#define MCAN_TXBCIE_CFIE14_Pos              14                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 14 Position */
+#define MCAN_TXBCIE_CFIE14_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE14_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 14 Mask */
+#define MCAN_TXBCIE_CFIE14                  MCAN_TXBCIE_CFIE14_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE14_Msk instead */
+#define MCAN_TXBCIE_CFIE15_Pos              15                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 15 Position */
+#define MCAN_TXBCIE_CFIE15_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE15_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 15 Mask */
+#define MCAN_TXBCIE_CFIE15                  MCAN_TXBCIE_CFIE15_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE15_Msk instead */
+#define MCAN_TXBCIE_CFIE16_Pos              16                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 16 Position */
+#define MCAN_TXBCIE_CFIE16_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE16_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 16 Mask */
+#define MCAN_TXBCIE_CFIE16                  MCAN_TXBCIE_CFIE16_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE16_Msk instead */
+#define MCAN_TXBCIE_CFIE17_Pos              17                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 17 Position */
+#define MCAN_TXBCIE_CFIE17_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE17_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 17 Mask */
+#define MCAN_TXBCIE_CFIE17                  MCAN_TXBCIE_CFIE17_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE17_Msk instead */
+#define MCAN_TXBCIE_CFIE18_Pos              18                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 18 Position */
+#define MCAN_TXBCIE_CFIE18_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE18_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 18 Mask */
+#define MCAN_TXBCIE_CFIE18                  MCAN_TXBCIE_CFIE18_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE18_Msk instead */
+#define MCAN_TXBCIE_CFIE19_Pos              19                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 19 Position */
+#define MCAN_TXBCIE_CFIE19_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE19_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 19 Mask */
+#define MCAN_TXBCIE_CFIE19                  MCAN_TXBCIE_CFIE19_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE19_Msk instead */
+#define MCAN_TXBCIE_CFIE20_Pos              20                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 20 Position */
+#define MCAN_TXBCIE_CFIE20_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE20_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 20 Mask */
+#define MCAN_TXBCIE_CFIE20                  MCAN_TXBCIE_CFIE20_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE20_Msk instead */
+#define MCAN_TXBCIE_CFIE21_Pos              21                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 21 Position */
+#define MCAN_TXBCIE_CFIE21_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE21_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 21 Mask */
+#define MCAN_TXBCIE_CFIE21                  MCAN_TXBCIE_CFIE21_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE21_Msk instead */
+#define MCAN_TXBCIE_CFIE22_Pos              22                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 22 Position */
+#define MCAN_TXBCIE_CFIE22_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE22_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 22 Mask */
+#define MCAN_TXBCIE_CFIE22                  MCAN_TXBCIE_CFIE22_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE22_Msk instead */
+#define MCAN_TXBCIE_CFIE23_Pos              23                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 23 Position */
+#define MCAN_TXBCIE_CFIE23_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE23_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 23 Mask */
+#define MCAN_TXBCIE_CFIE23                  MCAN_TXBCIE_CFIE23_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE23_Msk instead */
+#define MCAN_TXBCIE_CFIE24_Pos              24                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 24 Position */
+#define MCAN_TXBCIE_CFIE24_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE24_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 24 Mask */
+#define MCAN_TXBCIE_CFIE24                  MCAN_TXBCIE_CFIE24_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE24_Msk instead */
+#define MCAN_TXBCIE_CFIE25_Pos              25                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 25 Position */
+#define MCAN_TXBCIE_CFIE25_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE25_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 25 Mask */
+#define MCAN_TXBCIE_CFIE25                  MCAN_TXBCIE_CFIE25_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE25_Msk instead */
+#define MCAN_TXBCIE_CFIE26_Pos              26                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 26 Position */
+#define MCAN_TXBCIE_CFIE26_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE26_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 26 Mask */
+#define MCAN_TXBCIE_CFIE26                  MCAN_TXBCIE_CFIE26_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE26_Msk instead */
+#define MCAN_TXBCIE_CFIE27_Pos              27                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 27 Position */
+#define MCAN_TXBCIE_CFIE27_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE27_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 27 Mask */
+#define MCAN_TXBCIE_CFIE27                  MCAN_TXBCIE_CFIE27_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE27_Msk instead */
+#define MCAN_TXBCIE_CFIE28_Pos              28                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 28 Position */
+#define MCAN_TXBCIE_CFIE28_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE28_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 28 Mask */
+#define MCAN_TXBCIE_CFIE28                  MCAN_TXBCIE_CFIE28_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE28_Msk instead */
+#define MCAN_TXBCIE_CFIE29_Pos              29                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 29 Position */
+#define MCAN_TXBCIE_CFIE29_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE29_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 29 Mask */
+#define MCAN_TXBCIE_CFIE29                  MCAN_TXBCIE_CFIE29_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE29_Msk instead */
+#define MCAN_TXBCIE_CFIE30_Pos              30                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 30 Position */
+#define MCAN_TXBCIE_CFIE30_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE30_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 30 Mask */
+#define MCAN_TXBCIE_CFIE30                  MCAN_TXBCIE_CFIE30_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE30_Msk instead */
+#define MCAN_TXBCIE_CFIE31_Pos              31                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 31 Position */
+#define MCAN_TXBCIE_CFIE31_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE31_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 31 Mask */
+#define MCAN_TXBCIE_CFIE31                  MCAN_TXBCIE_CFIE31_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE31_Msk instead */
+#define MCAN_TXBCIE_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCIE) Register MASK  (Use MCAN_TXBCIE_Msk instead)  */
+#define MCAN_TXBCIE_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCIE) Register Mask  */
+
+#define MCAN_TXBCIE_CFIE_Pos                0                                              /**< (MCAN_TXBCIE Position) Cancellation Finished Interrupt Enable for Transmit Buffer 3x */
+#define MCAN_TXBCIE_CFIE_Msk                (_U_(0xFFFFFFFF) << MCAN_TXBCIE_CFIE_Pos)      /**< (MCAN_TXBCIE Mask) CFIE */
+#define MCAN_TXBCIE_CFIE(value)             (MCAN_TXBCIE_CFIE_Msk & ((value) << MCAN_TXBCIE_CFIE_Pos))  
+
+/* -------- MCAN_TXEFC : (MCAN Offset: 0xf0) (R/W 32) Transmit Event FIFO Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t EFSA:14;                   /**< bit:  2..15  Event FIFO Start Address                 */
+    uint32_t EFS:6;                     /**< bit: 16..21  Event FIFO Size                          */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t EFWM:6;                    /**< bit: 24..29  Event FIFO Watermark                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFC_OFFSET                   (0xF0)                                        /**<  (MCAN_TXEFC) Transmit Event FIFO Configuration Register  Offset */
+
+#define MCAN_TXEFC_EFSA_Pos                 2                                              /**< (MCAN_TXEFC) Event FIFO Start Address Position */
+#define MCAN_TXEFC_EFSA_Msk                 (_U_(0x3FFF) << MCAN_TXEFC_EFSA_Pos)           /**< (MCAN_TXEFC) Event FIFO Start Address Mask */
+#define MCAN_TXEFC_EFSA(value)              (MCAN_TXEFC_EFSA_Msk & ((value) << MCAN_TXEFC_EFSA_Pos))
+#define MCAN_TXEFC_EFS_Pos                  16                                             /**< (MCAN_TXEFC) Event FIFO Size Position */
+#define MCAN_TXEFC_EFS_Msk                  (_U_(0x3F) << MCAN_TXEFC_EFS_Pos)              /**< (MCAN_TXEFC) Event FIFO Size Mask */
+#define MCAN_TXEFC_EFS(value)               (MCAN_TXEFC_EFS_Msk & ((value) << MCAN_TXEFC_EFS_Pos))
+#define MCAN_TXEFC_EFWM_Pos                 24                                             /**< (MCAN_TXEFC) Event FIFO Watermark Position */
+#define MCAN_TXEFC_EFWM_Msk                 (_U_(0x3F) << MCAN_TXEFC_EFWM_Pos)             /**< (MCAN_TXEFC) Event FIFO Watermark Mask */
+#define MCAN_TXEFC_EFWM(value)              (MCAN_TXEFC_EFWM_Msk & ((value) << MCAN_TXEFC_EFWM_Pos))
+#define MCAN_TXEFC_MASK                     _U_(0x3F3FFFFC)                                /**< \deprecated (MCAN_TXEFC) Register MASK  (Use MCAN_TXEFC_Msk instead)  */
+#define MCAN_TXEFC_Msk                      _U_(0x3F3FFFFC)                                /**< (MCAN_TXEFC) Register Mask  */
+
+
+/* -------- MCAN_TXEFS : (MCAN Offset: 0xf4) (R/ 32) Transmit Event FIFO Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFFL:6;                    /**< bit:   0..5  Event FIFO Fill Level                    */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t EFGI:5;                    /**< bit:  8..12  Event FIFO Get Index                     */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t EFPI:5;                    /**< bit: 16..20  Event FIFO Put Index                     */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t EFF:1;                     /**< bit:     24  Event FIFO Full                          */
+    uint32_t TEFL:1;                    /**< bit:     25  Tx Event FIFO Element Lost               */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFS_OFFSET                   (0xF4)                                        /**<  (MCAN_TXEFS) Transmit Event FIFO Status Register  Offset */
+
+#define MCAN_TXEFS_EFFL_Pos                 0                                              /**< (MCAN_TXEFS) Event FIFO Fill Level Position */
+#define MCAN_TXEFS_EFFL_Msk                 (_U_(0x3F) << MCAN_TXEFS_EFFL_Pos)             /**< (MCAN_TXEFS) Event FIFO Fill Level Mask */
+#define MCAN_TXEFS_EFFL(value)              (MCAN_TXEFS_EFFL_Msk & ((value) << MCAN_TXEFS_EFFL_Pos))
+#define MCAN_TXEFS_EFGI_Pos                 8                                              /**< (MCAN_TXEFS) Event FIFO Get Index Position */
+#define MCAN_TXEFS_EFGI_Msk                 (_U_(0x1F) << MCAN_TXEFS_EFGI_Pos)             /**< (MCAN_TXEFS) Event FIFO Get Index Mask */
+#define MCAN_TXEFS_EFGI(value)              (MCAN_TXEFS_EFGI_Msk & ((value) << MCAN_TXEFS_EFGI_Pos))
+#define MCAN_TXEFS_EFPI_Pos                 16                                             /**< (MCAN_TXEFS) Event FIFO Put Index Position */
+#define MCAN_TXEFS_EFPI_Msk                 (_U_(0x1F) << MCAN_TXEFS_EFPI_Pos)             /**< (MCAN_TXEFS) Event FIFO Put Index Mask */
+#define MCAN_TXEFS_EFPI(value)              (MCAN_TXEFS_EFPI_Msk & ((value) << MCAN_TXEFS_EFPI_Pos))
+#define MCAN_TXEFS_EFF_Pos                  24                                             /**< (MCAN_TXEFS) Event FIFO Full Position */
+#define MCAN_TXEFS_EFF_Msk                  (_U_(0x1) << MCAN_TXEFS_EFF_Pos)               /**< (MCAN_TXEFS) Event FIFO Full Mask */
+#define MCAN_TXEFS_EFF                      MCAN_TXEFS_EFF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFS_EFF_Msk instead */
+#define MCAN_TXEFS_TEFL_Pos                 25                                             /**< (MCAN_TXEFS) Tx Event FIFO Element Lost Position */
+#define MCAN_TXEFS_TEFL_Msk                 (_U_(0x1) << MCAN_TXEFS_TEFL_Pos)              /**< (MCAN_TXEFS) Tx Event FIFO Element Lost Mask */
+#define MCAN_TXEFS_TEFL                     MCAN_TXEFS_TEFL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFS_TEFL_Msk instead */
+#define MCAN_TXEFS_MASK                     _U_(0x31F1F3F)                                 /**< \deprecated (MCAN_TXEFS) Register MASK  (Use MCAN_TXEFS_Msk instead)  */
+#define MCAN_TXEFS_Msk                      _U_(0x31F1F3F)                                 /**< (MCAN_TXEFS) Register Mask  */
+
+
+/* -------- MCAN_TXEFA : (MCAN Offset: 0xf8) (R/W 32) Transmit Event FIFO Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFAI:5;                    /**< bit:   0..4  Event FIFO Acknowledge Index             */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFA_OFFSET                   (0xF8)                                        /**<  (MCAN_TXEFA) Transmit Event FIFO Acknowledge Register  Offset */
+
+#define MCAN_TXEFA_EFAI_Pos                 0                                              /**< (MCAN_TXEFA) Event FIFO Acknowledge Index Position */
+#define MCAN_TXEFA_EFAI_Msk                 (_U_(0x1F) << MCAN_TXEFA_EFAI_Pos)             /**< (MCAN_TXEFA) Event FIFO Acknowledge Index Mask */
+#define MCAN_TXEFA_EFAI(value)              (MCAN_TXEFA_EFAI_Msk & ((value) << MCAN_TXEFA_EFAI_Pos))
+#define MCAN_TXEFA_MASK                     _U_(0x1F)                                      /**< \deprecated (MCAN_TXEFA) Register MASK  (Use MCAN_TXEFA_Msk instead)  */
+#define MCAN_TXEFA_Msk                      _U_(0x1F)                                      /**< (MCAN_TXEFA) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MCAN hardware registers */
+typedef struct {  
+  __I  uint32_t MCAN_CREL;      /**< (MCAN Offset: 0x00) Core Release Register */
+  __I  uint32_t MCAN_ENDN;      /**< (MCAN Offset: 0x04) Endian Register */
+  __IO uint32_t MCAN_CUST;      /**< (MCAN Offset: 0x08) Customer Register */
+  __IO uint32_t MCAN_FBTP;      /**< (MCAN Offset: 0x0C) Fast Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TEST;      /**< (MCAN Offset: 0x10) Test Register */
+  __IO uint32_t MCAN_RWD;       /**< (MCAN Offset: 0x14) RAM Watchdog Register */
+  __IO uint32_t MCAN_CCCR;      /**< (MCAN Offset: 0x18) CC Control Register */
+  __IO uint32_t MCAN_BTP;       /**< (MCAN Offset: 0x1C) Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TSCC;      /**< (MCAN Offset: 0x20) Timestamp Counter Configuration Register */
+  __IO uint32_t MCAN_TSCV;      /**< (MCAN Offset: 0x24) Timestamp Counter Value Register */
+  __IO uint32_t MCAN_TOCC;      /**< (MCAN Offset: 0x28) Timeout Counter Configuration Register */
+  __IO uint32_t MCAN_TOCV;      /**< (MCAN Offset: 0x2C) Timeout Counter Value Register */
+  __I  uint8_t                        Reserved1[16];
+  __I  uint32_t MCAN_ECR;       /**< (MCAN Offset: 0x40) Error Counter Register */
+  __I  uint32_t MCAN_PSR;       /**< (MCAN Offset: 0x44) Protocol Status Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO uint32_t MCAN_IR;        /**< (MCAN Offset: 0x50) Interrupt Register */
+  __IO uint32_t MCAN_IE;        /**< (MCAN Offset: 0x54) Interrupt Enable Register */
+  __IO uint32_t MCAN_ILS;       /**< (MCAN Offset: 0x58) Interrupt Line Select Register */
+  __IO uint32_t MCAN_ILE;       /**< (MCAN Offset: 0x5C) Interrupt Line Enable Register */
+  __I  uint8_t                        Reserved3[32];
+  __IO uint32_t MCAN_GFC;       /**< (MCAN Offset: 0x80) Global Filter Configuration Register */
+  __IO uint32_t MCAN_SIDFC;     /**< (MCAN Offset: 0x84) Standard ID Filter Configuration Register */
+  __IO uint32_t MCAN_XIDFC;     /**< (MCAN Offset: 0x88) Extended ID Filter Configuration Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t MCAN_XIDAM;     /**< (MCAN Offset: 0x90) Extended ID AND Mask Register */
+  __I  uint32_t MCAN_HPMS;      /**< (MCAN Offset: 0x94) High Priority Message Status Register */
+  __IO uint32_t MCAN_NDAT1;     /**< (MCAN Offset: 0x98) New Data 1 Register */
+  __IO uint32_t MCAN_NDAT2;     /**< (MCAN Offset: 0x9C) New Data 2 Register */
+  __IO uint32_t MCAN_RXF0C;     /**< (MCAN Offset: 0xA0) Receive FIFO 0 Configuration Register */
+  __I  uint32_t MCAN_RXF0S;     /**< (MCAN Offset: 0xA4) Receive FIFO 0 Status Register */
+  __IO uint32_t MCAN_RXF0A;     /**< (MCAN Offset: 0xA8) Receive FIFO 0 Acknowledge Register */
+  __IO uint32_t MCAN_RXBC;      /**< (MCAN Offset: 0xAC) Receive Rx Buffer Configuration Register */
+  __IO uint32_t MCAN_RXF1C;     /**< (MCAN Offset: 0xB0) Receive FIFO 1 Configuration Register */
+  __I  uint32_t MCAN_RXF1S;     /**< (MCAN Offset: 0xB4) Receive FIFO 1 Status Register */
+  __IO uint32_t MCAN_RXF1A;     /**< (MCAN Offset: 0xB8) Receive FIFO 1 Acknowledge Register */
+  __IO uint32_t MCAN_RXESC;     /**< (MCAN Offset: 0xBC) Receive Buffer / FIFO Element Size Configuration Register */
+  __IO uint32_t MCAN_TXBC;      /**< (MCAN Offset: 0xC0) Transmit Buffer Configuration Register */
+  __I  uint32_t MCAN_TXFQS;     /**< (MCAN Offset: 0xC4) Transmit FIFO/Queue Status Register */
+  __IO uint32_t MCAN_TXESC;     /**< (MCAN Offset: 0xC8) Transmit Buffer Element Size Configuration Register */
+  __I  uint32_t MCAN_TXBRP;     /**< (MCAN Offset: 0xCC) Transmit Buffer Request Pending Register */
+  __IO uint32_t MCAN_TXBAR;     /**< (MCAN Offset: 0xD0) Transmit Buffer Add Request Register */
+  __IO uint32_t MCAN_TXBCR;     /**< (MCAN Offset: 0xD4) Transmit Buffer Cancellation Request Register */
+  __I  uint32_t MCAN_TXBTO;     /**< (MCAN Offset: 0xD8) Transmit Buffer Transmission Occurred Register */
+  __I  uint32_t MCAN_TXBCF;     /**< (MCAN Offset: 0xDC) Transmit Buffer Cancellation Finished Register */
+  __IO uint32_t MCAN_TXBTIE;    /**< (MCAN Offset: 0xE0) Transmit Buffer Transmission Interrupt Enable Register */
+  __IO uint32_t MCAN_TXBCIE;    /**< (MCAN Offset: 0xE4) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[8];
+  __IO uint32_t MCAN_TXEFC;     /**< (MCAN Offset: 0xF0) Transmit Event FIFO Configuration Register */
+  __I  uint32_t MCAN_TXEFS;     /**< (MCAN Offset: 0xF4) Transmit Event FIFO Status Register */
+  __IO uint32_t MCAN_TXEFA;     /**< (MCAN Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
+} Mcan;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MCAN hardware registers */
+typedef struct {  
+  __I  MCAN_CREL_Type                 MCAN_CREL;      /**< Offset: 0x00 (R/   32) Core Release Register */
+  __I  MCAN_ENDN_Type                 MCAN_ENDN;      /**< Offset: 0x04 (R/   32) Endian Register */
+  __IO MCAN_CUST_Type                 MCAN_CUST;      /**< Offset: 0x08 (R/W  32) Customer Register */
+  __IO MCAN_FBTP_Type                 MCAN_FBTP;      /**< Offset: 0x0C (R/W  32) Fast Bit Timing and Prescaler Register */
+  __IO MCAN_TEST_Type                 MCAN_TEST;      /**< Offset: 0x10 (R/W  32) Test Register */
+  __IO MCAN_RWD_Type                  MCAN_RWD;       /**< Offset: 0x14 (R/W  32) RAM Watchdog Register */
+  __IO MCAN_CCCR_Type                 MCAN_CCCR;      /**< Offset: 0x18 (R/W  32) CC Control Register */
+  __IO MCAN_BTP_Type                  MCAN_BTP;       /**< Offset: 0x1C (R/W  32) Bit Timing and Prescaler Register */
+  __IO MCAN_TSCC_Type                 MCAN_TSCC;      /**< Offset: 0x20 (R/W  32) Timestamp Counter Configuration Register */
+  __IO MCAN_TSCV_Type                 MCAN_TSCV;      /**< Offset: 0x24 (R/W  32) Timestamp Counter Value Register */
+  __IO MCAN_TOCC_Type                 MCAN_TOCC;      /**< Offset: 0x28 (R/W  32) Timeout Counter Configuration Register */
+  __IO MCAN_TOCV_Type                 MCAN_TOCV;      /**< Offset: 0x2C (R/W  32) Timeout Counter Value Register */
+  __I  uint8_t                        Reserved1[16];
+  __I  MCAN_ECR_Type                  MCAN_ECR;       /**< Offset: 0x40 (R/   32) Error Counter Register */
+  __I  MCAN_PSR_Type                  MCAN_PSR;       /**< Offset: 0x44 (R/   32) Protocol Status Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO MCAN_IR_Type                   MCAN_IR;        /**< Offset: 0x50 (R/W  32) Interrupt Register */
+  __IO MCAN_IE_Type                   MCAN_IE;        /**< Offset: 0x54 (R/W  32) Interrupt Enable Register */
+  __IO MCAN_ILS_Type                  MCAN_ILS;       /**< Offset: 0x58 (R/W  32) Interrupt Line Select Register */
+  __IO MCAN_ILE_Type                  MCAN_ILE;       /**< Offset: 0x5C (R/W  32) Interrupt Line Enable Register */
+  __I  uint8_t                        Reserved3[32];
+  __IO MCAN_GFC_Type                  MCAN_GFC;       /**< Offset: 0x80 (R/W  32) Global Filter Configuration Register */
+  __IO MCAN_SIDFC_Type                MCAN_SIDFC;     /**< Offset: 0x84 (R/W  32) Standard ID Filter Configuration Register */
+  __IO MCAN_XIDFC_Type                MCAN_XIDFC;     /**< Offset: 0x88 (R/W  32) Extended ID Filter Configuration Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO MCAN_XIDAM_Type                MCAN_XIDAM;     /**< Offset: 0x90 (R/W  32) Extended ID AND Mask Register */
+  __I  MCAN_HPMS_Type                 MCAN_HPMS;      /**< Offset: 0x94 (R/   32) High Priority Message Status Register */
+  __IO MCAN_NDAT1_Type                MCAN_NDAT1;     /**< Offset: 0x98 (R/W  32) New Data 1 Register */
+  __IO MCAN_NDAT2_Type                MCAN_NDAT2;     /**< Offset: 0x9C (R/W  32) New Data 2 Register */
+  __IO MCAN_RXF0C_Type                MCAN_RXF0C;     /**< Offset: 0xA0 (R/W  32) Receive FIFO 0 Configuration Register */
+  __I  MCAN_RXF0S_Type                MCAN_RXF0S;     /**< Offset: 0xA4 (R/   32) Receive FIFO 0 Status Register */
+  __IO MCAN_RXF0A_Type                MCAN_RXF0A;     /**< Offset: 0xA8 (R/W  32) Receive FIFO 0 Acknowledge Register */
+  __IO MCAN_RXBC_Type                 MCAN_RXBC;      /**< Offset: 0xAC (R/W  32) Receive Rx Buffer Configuration Register */
+  __IO MCAN_RXF1C_Type                MCAN_RXF1C;     /**< Offset: 0xB0 (R/W  32) Receive FIFO 1 Configuration Register */
+  __I  MCAN_RXF1S_Type                MCAN_RXF1S;     /**< Offset: 0xB4 (R/   32) Receive FIFO 1 Status Register */
+  __IO MCAN_RXF1A_Type                MCAN_RXF1A;     /**< Offset: 0xB8 (R/W  32) Receive FIFO 1 Acknowledge Register */
+  __IO MCAN_RXESC_Type                MCAN_RXESC;     /**< Offset: 0xBC (R/W  32) Receive Buffer / FIFO Element Size Configuration Register */
+  __IO MCAN_TXBC_Type                 MCAN_TXBC;      /**< Offset: 0xC0 (R/W  32) Transmit Buffer Configuration Register */
+  __I  MCAN_TXFQS_Type                MCAN_TXFQS;     /**< Offset: 0xC4 (R/   32) Transmit FIFO/Queue Status Register */
+  __IO MCAN_TXESC_Type                MCAN_TXESC;     /**< Offset: 0xC8 (R/W  32) Transmit Buffer Element Size Configuration Register */
+  __I  MCAN_TXBRP_Type                MCAN_TXBRP;     /**< Offset: 0xCC (R/   32) Transmit Buffer Request Pending Register */
+  __IO MCAN_TXBAR_Type                MCAN_TXBAR;     /**< Offset: 0xD0 (R/W  32) Transmit Buffer Add Request Register */
+  __IO MCAN_TXBCR_Type                MCAN_TXBCR;     /**< Offset: 0xD4 (R/W  32) Transmit Buffer Cancellation Request Register */
+  __I  MCAN_TXBTO_Type                MCAN_TXBTO;     /**< Offset: 0xD8 (R/   32) Transmit Buffer Transmission Occurred Register */
+  __I  MCAN_TXBCF_Type                MCAN_TXBCF;     /**< Offset: 0xDC (R/   32) Transmit Buffer Cancellation Finished Register */
+  __IO MCAN_TXBTIE_Type               MCAN_TXBTIE;    /**< Offset: 0xE0 (R/W  32) Transmit Buffer Transmission Interrupt Enable Register */
+  __IO MCAN_TXBCIE_Type               MCAN_TXBCIE;    /**< Offset: 0xE4 (R/W  32) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[8];
+  __IO MCAN_TXEFC_Type                MCAN_TXEFC;     /**< Offset: 0xF0 (R/W  32) Transmit Event FIFO Configuration Register */
+  __I  MCAN_TXEFS_Type                MCAN_TXEFS;     /**< Offset: 0xF4 (R/   32) Transmit Event FIFO Status Register */
+  __IO MCAN_TXEFA_Type                MCAN_TXEFA;     /**< Offset: 0xF8 (R/W  32) Transmit Event FIFO Acknowledge Register */
+} Mcan;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Controller Area Network */
+
+#endif /* _SAMV71_MCAN_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/mlb.h
+++ b/asf/sam/include/samv71/component/mlb.h
@@ -1,0 +1,699 @@
+/**
+ * \file
+ *
+ * \brief Component description for MLB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MLB_COMPONENT_H_
+#define _SAMV71_MLB_COMPONENT_H_
+#define _SAMV71_MLB_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 MediaLB
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MLB */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MLB_11287                      /**< (MLB) Module ID */
+#define REV_MLB C                      /**< (MLB) Module revision */
+
+/* -------- MLB_MLBC0 : (MLB Offset: 0x00) (R/W 32) MediaLB Control 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MLBEN:1;                   /**< bit:      0  MediaLB Enable                           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t MLBCLK:3;                  /**< bit:   2..4  MLBCLK (MediaLB clock) speed select      */
+    uint32_t ZERO:1;                    /**< bit:      5  Must be Written to 0                     */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MLBLK:1;                   /**< bit:      7  MediaLB Lock Status (read-only)          */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t ASYRETRY:1;                /**< bit:     12  Asynchronous Tx Packet Retry             */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CTLRETRY:1;                /**< bit:     14  Control Tx Packet Retry                  */
+    uint32_t FCNT:3;                    /**< bit: 15..17  The number of frames per sub-buffer for synchronous channels */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MLBC0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MLBC0_OFFSET                    (0x00)                                        /**<  (MLB_MLBC0) MediaLB Control 0 Register  Offset */
+
+#define MLB_MLBC0_MLBEN_Pos                 0                                              /**< (MLB_MLBC0) MediaLB Enable Position */
+#define MLB_MLBC0_MLBEN_Msk                 (_U_(0x1) << MLB_MLBC0_MLBEN_Pos)              /**< (MLB_MLBC0) MediaLB Enable Mask */
+#define MLB_MLBC0_MLBEN                     MLB_MLBC0_MLBEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_MLBEN_Msk instead */
+#define MLB_MLBC0_MLBCLK_Pos                2                                              /**< (MLB_MLBC0) MLBCLK (MediaLB clock) speed select Position */
+#define MLB_MLBC0_MLBCLK_Msk                (_U_(0x7) << MLB_MLBC0_MLBCLK_Pos)             /**< (MLB_MLBC0) MLBCLK (MediaLB clock) speed select Mask */
+#define MLB_MLBC0_MLBCLK(value)             (MLB_MLBC0_MLBCLK_Msk & ((value) << MLB_MLBC0_MLBCLK_Pos))
+#define   MLB_MLBC0_MLBCLK_256_FS_Val       _U_(0x0)                                       /**< (MLB_MLBC0) 256xFs (for MLBPEN = 0)  */
+#define   MLB_MLBC0_MLBCLK_512_FS_Val       _U_(0x1)                                       /**< (MLB_MLBC0) 512xFs (for MLBPEN = 0)  */
+#define   MLB_MLBC0_MLBCLK_1024_FS_Val      _U_(0x2)                                       /**< (MLB_MLBC0) 1024xFs (for MLBPEN = 0)  */
+#define MLB_MLBC0_MLBCLK_256_FS             (MLB_MLBC0_MLBCLK_256_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 256xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_MLBCLK_512_FS             (MLB_MLBC0_MLBCLK_512_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 512xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_MLBCLK_1024_FS            (MLB_MLBC0_MLBCLK_1024_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 1024xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_ZERO_Pos                  5                                              /**< (MLB_MLBC0) Must be Written to 0 Position */
+#define MLB_MLBC0_ZERO_Msk                  (_U_(0x1) << MLB_MLBC0_ZERO_Pos)               /**< (MLB_MLBC0) Must be Written to 0 Mask */
+#define MLB_MLBC0_ZERO                      MLB_MLBC0_ZERO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_ZERO_Msk instead */
+#define MLB_MLBC0_MLBLK_Pos                 7                                              /**< (MLB_MLBC0) MediaLB Lock Status (read-only) Position */
+#define MLB_MLBC0_MLBLK_Msk                 (_U_(0x1) << MLB_MLBC0_MLBLK_Pos)              /**< (MLB_MLBC0) MediaLB Lock Status (read-only) Mask */
+#define MLB_MLBC0_MLBLK                     MLB_MLBC0_MLBLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_MLBLK_Msk instead */
+#define MLB_MLBC0_ASYRETRY_Pos              12                                             /**< (MLB_MLBC0) Asynchronous Tx Packet Retry Position */
+#define MLB_MLBC0_ASYRETRY_Msk              (_U_(0x1) << MLB_MLBC0_ASYRETRY_Pos)           /**< (MLB_MLBC0) Asynchronous Tx Packet Retry Mask */
+#define MLB_MLBC0_ASYRETRY                  MLB_MLBC0_ASYRETRY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_ASYRETRY_Msk instead */
+#define MLB_MLBC0_CTLRETRY_Pos              14                                             /**< (MLB_MLBC0) Control Tx Packet Retry Position */
+#define MLB_MLBC0_CTLRETRY_Msk              (_U_(0x1) << MLB_MLBC0_CTLRETRY_Pos)           /**< (MLB_MLBC0) Control Tx Packet Retry Mask */
+#define MLB_MLBC0_CTLRETRY                  MLB_MLBC0_CTLRETRY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_CTLRETRY_Msk instead */
+#define MLB_MLBC0_FCNT_Pos                  15                                             /**< (MLB_MLBC0) The number of frames per sub-buffer for synchronous channels Position */
+#define MLB_MLBC0_FCNT_Msk                  (_U_(0x7) << MLB_MLBC0_FCNT_Pos)               /**< (MLB_MLBC0) The number of frames per sub-buffer for synchronous channels Mask */
+#define MLB_MLBC0_FCNT(value)               (MLB_MLBC0_FCNT_Msk & ((value) << MLB_MLBC0_FCNT_Pos))
+#define   MLB_MLBC0_FCNT_1_FRAME_Val        _U_(0x0)                                       /**< (MLB_MLBC0) 1 frame per sub-buffer (Operation is the same as Standard mode.)  */
+#define   MLB_MLBC0_FCNT_2_FRAMES_Val       _U_(0x1)                                       /**< (MLB_MLBC0) 2 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_4_FRAMES_Val       _U_(0x2)                                       /**< (MLB_MLBC0) 4 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_8_FRAMES_Val       _U_(0x3)                                       /**< (MLB_MLBC0) 8 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_16_FRAMES_Val      _U_(0x4)                                       /**< (MLB_MLBC0) 16 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_32_FRAMES_Val      _U_(0x5)                                       /**< (MLB_MLBC0) 32 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_64_FRAMES_Val      _U_(0x6)                                       /**< (MLB_MLBC0) 64 frames per sub-buffer  */
+#define MLB_MLBC0_FCNT_1_FRAME              (MLB_MLBC0_FCNT_1_FRAME_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 1 frame per sub-buffer (Operation is the same as Standard mode.) Position  */
+#define MLB_MLBC0_FCNT_2_FRAMES             (MLB_MLBC0_FCNT_2_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 2 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_4_FRAMES             (MLB_MLBC0_FCNT_4_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 4 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_8_FRAMES             (MLB_MLBC0_FCNT_8_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 8 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_16_FRAMES            (MLB_MLBC0_FCNT_16_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 16 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_32_FRAMES            (MLB_MLBC0_FCNT_32_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 32 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_64_FRAMES            (MLB_MLBC0_FCNT_64_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 64 frames per sub-buffer Position  */
+#define MLB_MLBC0_MASK                      _U_(0x3D0BD)                                   /**< \deprecated (MLB_MLBC0) Register MASK  (Use MLB_MLBC0_Msk instead)  */
+#define MLB_MLBC0_Msk                       _U_(0x3D0BD)                                   /**< (MLB_MLBC0) Register Mask  */
+
+
+/* -------- MLB_MS0 : (MLB Offset: 0x0c) (R/W 32) MediaLB Channel Status 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCS:32;                    /**< bit:  0..31  MediaLB Channel Status [31:0] (cleared by writing a 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MS0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MS0_OFFSET                      (0x0C)                                        /**<  (MLB_MS0) MediaLB Channel Status 0 Register  Offset */
+
+#define MLB_MS0_MCS_Pos                     0                                              /**< (MLB_MS0) MediaLB Channel Status [31:0] (cleared by writing a 0) Position */
+#define MLB_MS0_MCS_Msk                     (_U_(0xFFFFFFFF) << MLB_MS0_MCS_Pos)           /**< (MLB_MS0) MediaLB Channel Status [31:0] (cleared by writing a 0) Mask */
+#define MLB_MS0_MCS(value)                  (MLB_MS0_MCS_Msk & ((value) << MLB_MS0_MCS_Pos))
+#define MLB_MS0_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MS0) Register MASK  (Use MLB_MS0_Msk instead)  */
+#define MLB_MS0_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MS0) Register Mask  */
+
+
+/* -------- MLB_MS1 : (MLB Offset: 0x14) (R/W 32) MediaLB Channel Status1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCS:32;                    /**< bit:  0..31  MediaLB Channel Status [63:32] (cleared by writing a 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MS1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MS1_OFFSET                      (0x14)                                        /**<  (MLB_MS1) MediaLB Channel Status1 Register  Offset */
+
+#define MLB_MS1_MCS_Pos                     0                                              /**< (MLB_MS1) MediaLB Channel Status [63:32] (cleared by writing a 0) Position */
+#define MLB_MS1_MCS_Msk                     (_U_(0xFFFFFFFF) << MLB_MS1_MCS_Pos)           /**< (MLB_MS1) MediaLB Channel Status [63:32] (cleared by writing a 0) Mask */
+#define MLB_MS1_MCS(value)                  (MLB_MS1_MCS_Msk & ((value) << MLB_MS1_MCS_Pos))
+#define MLB_MS1_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MS1) Register MASK  (Use MLB_MS1_Msk instead)  */
+#define MLB_MS1_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MS1) Register Mask  */
+
+
+/* -------- MLB_MSS : (MLB Offset: 0x20) (R/W 32) MediaLB System Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSTSYSCMD:1;               /**< bit:      0  Reset System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t LKSYSCMD:1;                /**< bit:      1  Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t ULKSYSCMD:1;               /**< bit:      2  Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t CSSYSCMD:1;                /**< bit:      3  Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t SWSYSCMD:1;                /**< bit:      4  Software System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t SERVREQ:1;                 /**< bit:      5  Service Request Enabled                  */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MSS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MSS_OFFSET                      (0x20)                                        /**<  (MLB_MSS) MediaLB System Status Register  Offset */
+
+#define MLB_MSS_RSTSYSCMD_Pos               0                                              /**< (MLB_MSS) Reset System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_RSTSYSCMD_Msk               (_U_(0x1) << MLB_MSS_RSTSYSCMD_Pos)            /**< (MLB_MSS) Reset System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_RSTSYSCMD                   MLB_MSS_RSTSYSCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_RSTSYSCMD_Msk instead */
+#define MLB_MSS_LKSYSCMD_Pos                1                                              /**< (MLB_MSS) Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_LKSYSCMD_Msk                (_U_(0x1) << MLB_MSS_LKSYSCMD_Pos)             /**< (MLB_MSS) Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_LKSYSCMD                    MLB_MSS_LKSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_LKSYSCMD_Msk instead */
+#define MLB_MSS_ULKSYSCMD_Pos               2                                              /**< (MLB_MSS) Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_ULKSYSCMD_Msk               (_U_(0x1) << MLB_MSS_ULKSYSCMD_Pos)            /**< (MLB_MSS) Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_ULKSYSCMD                   MLB_MSS_ULKSYSCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_ULKSYSCMD_Msk instead */
+#define MLB_MSS_CSSYSCMD_Pos                3                                              /**< (MLB_MSS) Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_CSSYSCMD_Msk                (_U_(0x1) << MLB_MSS_CSSYSCMD_Pos)             /**< (MLB_MSS) Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_CSSYSCMD                    MLB_MSS_CSSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_CSSYSCMD_Msk instead */
+#define MLB_MSS_SWSYSCMD_Pos                4                                              /**< (MLB_MSS) Software System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_SWSYSCMD_Msk                (_U_(0x1) << MLB_MSS_SWSYSCMD_Pos)             /**< (MLB_MSS) Software System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_SWSYSCMD                    MLB_MSS_SWSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_SWSYSCMD_Msk instead */
+#define MLB_MSS_SERVREQ_Pos                 5                                              /**< (MLB_MSS) Service Request Enabled Position */
+#define MLB_MSS_SERVREQ_Msk                 (_U_(0x1) << MLB_MSS_SERVREQ_Pos)              /**< (MLB_MSS) Service Request Enabled Mask */
+#define MLB_MSS_SERVREQ                     MLB_MSS_SERVREQ_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_SERVREQ_Msk instead */
+#define MLB_MSS_MASK                        _U_(0x3F)                                      /**< \deprecated (MLB_MSS) Register MASK  (Use MLB_MSS_Msk instead)  */
+#define MLB_MSS_Msk                         _U_(0x3F)                                      /**< (MLB_MSS) Register Mask  */
+
+
+/* -------- MLB_MSD : (MLB Offset: 0x24) (R/ 32) MediaLB System Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SD0:8;                     /**< bit:   0..7  System Data (Byte 0)                     */
+    uint32_t SD1:8;                     /**< bit:  8..15  System Data (Byte 1)                     */
+    uint32_t SD2:8;                     /**< bit: 16..23  System Data (Byte 2)                     */
+    uint32_t SD3:8;                     /**< bit: 24..31  System Data (Byte 3)                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MSD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MSD_OFFSET                      (0x24)                                        /**<  (MLB_MSD) MediaLB System Data Register  Offset */
+
+#define MLB_MSD_SD0_Pos                     0                                              /**< (MLB_MSD) System Data (Byte 0) Position */
+#define MLB_MSD_SD0_Msk                     (_U_(0xFF) << MLB_MSD_SD0_Pos)                 /**< (MLB_MSD) System Data (Byte 0) Mask */
+#define MLB_MSD_SD0(value)                  (MLB_MSD_SD0_Msk & ((value) << MLB_MSD_SD0_Pos))
+#define MLB_MSD_SD1_Pos                     8                                              /**< (MLB_MSD) System Data (Byte 1) Position */
+#define MLB_MSD_SD1_Msk                     (_U_(0xFF) << MLB_MSD_SD1_Pos)                 /**< (MLB_MSD) System Data (Byte 1) Mask */
+#define MLB_MSD_SD1(value)                  (MLB_MSD_SD1_Msk & ((value) << MLB_MSD_SD1_Pos))
+#define MLB_MSD_SD2_Pos                     16                                             /**< (MLB_MSD) System Data (Byte 2) Position */
+#define MLB_MSD_SD2_Msk                     (_U_(0xFF) << MLB_MSD_SD2_Pos)                 /**< (MLB_MSD) System Data (Byte 2) Mask */
+#define MLB_MSD_SD2(value)                  (MLB_MSD_SD2_Msk & ((value) << MLB_MSD_SD2_Pos))
+#define MLB_MSD_SD3_Pos                     24                                             /**< (MLB_MSD) System Data (Byte 3) Position */
+#define MLB_MSD_SD3_Msk                     (_U_(0xFF) << MLB_MSD_SD3_Pos)                 /**< (MLB_MSD) System Data (Byte 3) Mask */
+#define MLB_MSD_SD3(value)                  (MLB_MSD_SD3_Msk & ((value) << MLB_MSD_SD3_Pos))
+#define MLB_MSD_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MSD) Register MASK  (Use MLB_MSD_Msk instead)  */
+#define MLB_MSD_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MSD) Register Mask  */
+
+
+/* -------- MLB_MIEN : (MLB Offset: 0x2c) (R/W 32) MediaLB Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISOC_PE:1;                 /**< bit:      0  Isochronous Rx Protocol Error Enable     */
+    uint32_t ISOC_BUFO:1;               /**< bit:      1  Isochronous Rx Buffer Overflow Enable    */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t SYNC_PE:1;                 /**< bit:     16  Synchronous Protocol Error Enable        */
+    uint32_t ARX_DONE:1;                /**< bit:     17  Asynchronous Rx Done Enable              */
+    uint32_t ARX_PE:1;                  /**< bit:     18  Asynchronous Rx Protocol Error Enable    */
+    uint32_t ARX_BREAK:1;               /**< bit:     19  Asynchronous Rx Break Enable             */
+    uint32_t ATX_DONE:1;                /**< bit:     20  Asynchronous Tx Packet Done Enable       */
+    uint32_t ATX_PE:1;                  /**< bit:     21  Asynchronous Tx Protocol Error Enable    */
+    uint32_t ATX_BREAK:1;               /**< bit:     22  Asynchronous Tx Break Enable             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t CRX_DONE:1;                /**< bit:     24  Control Rx Packet Done Enable            */
+    uint32_t CRX_PE:1;                  /**< bit:     25  Control Rx Protocol Error Enable         */
+    uint32_t CRX_BREAK:1;               /**< bit:     26  Control Rx Break Enable                  */
+    uint32_t CTX_DONE:1;                /**< bit:     27  Control Tx Packet Done Enable            */
+    uint32_t CTX_PE:1;                  /**< bit:     28  Control Tx Protocol Error Enable         */
+    uint32_t CTX_BREAK:1;               /**< bit:     29  Control Tx Break Enable                  */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MIEN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MIEN_OFFSET                     (0x2C)                                        /**<  (MLB_MIEN) MediaLB Interrupt Enable Register  Offset */
+
+#define MLB_MIEN_ISOC_PE_Pos                0                                              /**< (MLB_MIEN) Isochronous Rx Protocol Error Enable Position */
+#define MLB_MIEN_ISOC_PE_Msk                (_U_(0x1) << MLB_MIEN_ISOC_PE_Pos)             /**< (MLB_MIEN) Isochronous Rx Protocol Error Enable Mask */
+#define MLB_MIEN_ISOC_PE                    MLB_MIEN_ISOC_PE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ISOC_PE_Msk instead */
+#define MLB_MIEN_ISOC_BUFO_Pos              1                                              /**< (MLB_MIEN) Isochronous Rx Buffer Overflow Enable Position */
+#define MLB_MIEN_ISOC_BUFO_Msk              (_U_(0x1) << MLB_MIEN_ISOC_BUFO_Pos)           /**< (MLB_MIEN) Isochronous Rx Buffer Overflow Enable Mask */
+#define MLB_MIEN_ISOC_BUFO                  MLB_MIEN_ISOC_BUFO_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ISOC_BUFO_Msk instead */
+#define MLB_MIEN_SYNC_PE_Pos                16                                             /**< (MLB_MIEN) Synchronous Protocol Error Enable Position */
+#define MLB_MIEN_SYNC_PE_Msk                (_U_(0x1) << MLB_MIEN_SYNC_PE_Pos)             /**< (MLB_MIEN) Synchronous Protocol Error Enable Mask */
+#define MLB_MIEN_SYNC_PE                    MLB_MIEN_SYNC_PE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_SYNC_PE_Msk instead */
+#define MLB_MIEN_ARX_DONE_Pos               17                                             /**< (MLB_MIEN) Asynchronous Rx Done Enable Position */
+#define MLB_MIEN_ARX_DONE_Msk               (_U_(0x1) << MLB_MIEN_ARX_DONE_Pos)            /**< (MLB_MIEN) Asynchronous Rx Done Enable Mask */
+#define MLB_MIEN_ARX_DONE                   MLB_MIEN_ARX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_DONE_Msk instead */
+#define MLB_MIEN_ARX_PE_Pos                 18                                             /**< (MLB_MIEN) Asynchronous Rx Protocol Error Enable Position */
+#define MLB_MIEN_ARX_PE_Msk                 (_U_(0x1) << MLB_MIEN_ARX_PE_Pos)              /**< (MLB_MIEN) Asynchronous Rx Protocol Error Enable Mask */
+#define MLB_MIEN_ARX_PE                     MLB_MIEN_ARX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_PE_Msk instead */
+#define MLB_MIEN_ARX_BREAK_Pos              19                                             /**< (MLB_MIEN) Asynchronous Rx Break Enable Position */
+#define MLB_MIEN_ARX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_ARX_BREAK_Pos)           /**< (MLB_MIEN) Asynchronous Rx Break Enable Mask */
+#define MLB_MIEN_ARX_BREAK                  MLB_MIEN_ARX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_BREAK_Msk instead */
+#define MLB_MIEN_ATX_DONE_Pos               20                                             /**< (MLB_MIEN) Asynchronous Tx Packet Done Enable Position */
+#define MLB_MIEN_ATX_DONE_Msk               (_U_(0x1) << MLB_MIEN_ATX_DONE_Pos)            /**< (MLB_MIEN) Asynchronous Tx Packet Done Enable Mask */
+#define MLB_MIEN_ATX_DONE                   MLB_MIEN_ATX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_DONE_Msk instead */
+#define MLB_MIEN_ATX_PE_Pos                 21                                             /**< (MLB_MIEN) Asynchronous Tx Protocol Error Enable Position */
+#define MLB_MIEN_ATX_PE_Msk                 (_U_(0x1) << MLB_MIEN_ATX_PE_Pos)              /**< (MLB_MIEN) Asynchronous Tx Protocol Error Enable Mask */
+#define MLB_MIEN_ATX_PE                     MLB_MIEN_ATX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_PE_Msk instead */
+#define MLB_MIEN_ATX_BREAK_Pos              22                                             /**< (MLB_MIEN) Asynchronous Tx Break Enable Position */
+#define MLB_MIEN_ATX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_ATX_BREAK_Pos)           /**< (MLB_MIEN) Asynchronous Tx Break Enable Mask */
+#define MLB_MIEN_ATX_BREAK                  MLB_MIEN_ATX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_BREAK_Msk instead */
+#define MLB_MIEN_CRX_DONE_Pos               24                                             /**< (MLB_MIEN) Control Rx Packet Done Enable Position */
+#define MLB_MIEN_CRX_DONE_Msk               (_U_(0x1) << MLB_MIEN_CRX_DONE_Pos)            /**< (MLB_MIEN) Control Rx Packet Done Enable Mask */
+#define MLB_MIEN_CRX_DONE                   MLB_MIEN_CRX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_DONE_Msk instead */
+#define MLB_MIEN_CRX_PE_Pos                 25                                             /**< (MLB_MIEN) Control Rx Protocol Error Enable Position */
+#define MLB_MIEN_CRX_PE_Msk                 (_U_(0x1) << MLB_MIEN_CRX_PE_Pos)              /**< (MLB_MIEN) Control Rx Protocol Error Enable Mask */
+#define MLB_MIEN_CRX_PE                     MLB_MIEN_CRX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_PE_Msk instead */
+#define MLB_MIEN_CRX_BREAK_Pos              26                                             /**< (MLB_MIEN) Control Rx Break Enable Position */
+#define MLB_MIEN_CRX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_CRX_BREAK_Pos)           /**< (MLB_MIEN) Control Rx Break Enable Mask */
+#define MLB_MIEN_CRX_BREAK                  MLB_MIEN_CRX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_BREAK_Msk instead */
+#define MLB_MIEN_CTX_DONE_Pos               27                                             /**< (MLB_MIEN) Control Tx Packet Done Enable Position */
+#define MLB_MIEN_CTX_DONE_Msk               (_U_(0x1) << MLB_MIEN_CTX_DONE_Pos)            /**< (MLB_MIEN) Control Tx Packet Done Enable Mask */
+#define MLB_MIEN_CTX_DONE                   MLB_MIEN_CTX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_DONE_Msk instead */
+#define MLB_MIEN_CTX_PE_Pos                 28                                             /**< (MLB_MIEN) Control Tx Protocol Error Enable Position */
+#define MLB_MIEN_CTX_PE_Msk                 (_U_(0x1) << MLB_MIEN_CTX_PE_Pos)              /**< (MLB_MIEN) Control Tx Protocol Error Enable Mask */
+#define MLB_MIEN_CTX_PE                     MLB_MIEN_CTX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_PE_Msk instead */
+#define MLB_MIEN_CTX_BREAK_Pos              29                                             /**< (MLB_MIEN) Control Tx Break Enable Position */
+#define MLB_MIEN_CTX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_CTX_BREAK_Pos)           /**< (MLB_MIEN) Control Tx Break Enable Mask */
+#define MLB_MIEN_CTX_BREAK                  MLB_MIEN_CTX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_BREAK_Msk instead */
+#define MLB_MIEN_MASK                       _U_(0x3F7F0003)                                /**< \deprecated (MLB_MIEN) Register MASK  (Use MLB_MIEN_Msk instead)  */
+#define MLB_MIEN_Msk                        _U_(0x3F7F0003)                                /**< (MLB_MIEN) Register Mask  */
+
+
+/* -------- MLB_MLBC1 : (MLB Offset: 0x3c) (R/W 32) MediaLB Control 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LOCK:1;                    /**< bit:      6  MediaLB Lock Error Status (cleared by writing a 0) */
+    uint32_t CLKM:1;                    /**< bit:      7  MediaLB Clock Missing Status (cleared by writing a 0) */
+    uint32_t NDA:8;                     /**< bit:  8..15  Node Device Address                      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MLBC1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MLBC1_OFFSET                    (0x3C)                                        /**<  (MLB_MLBC1) MediaLB Control 1 Register  Offset */
+
+#define MLB_MLBC1_LOCK_Pos                  6                                              /**< (MLB_MLBC1) MediaLB Lock Error Status (cleared by writing a 0) Position */
+#define MLB_MLBC1_LOCK_Msk                  (_U_(0x1) << MLB_MLBC1_LOCK_Pos)               /**< (MLB_MLBC1) MediaLB Lock Error Status (cleared by writing a 0) Mask */
+#define MLB_MLBC1_LOCK                      MLB_MLBC1_LOCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC1_LOCK_Msk instead */
+#define MLB_MLBC1_CLKM_Pos                  7                                              /**< (MLB_MLBC1) MediaLB Clock Missing Status (cleared by writing a 0) Position */
+#define MLB_MLBC1_CLKM_Msk                  (_U_(0x1) << MLB_MLBC1_CLKM_Pos)               /**< (MLB_MLBC1) MediaLB Clock Missing Status (cleared by writing a 0) Mask */
+#define MLB_MLBC1_CLKM                      MLB_MLBC1_CLKM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC1_CLKM_Msk instead */
+#define MLB_MLBC1_NDA_Pos                   8                                              /**< (MLB_MLBC1) Node Device Address Position */
+#define MLB_MLBC1_NDA_Msk                   (_U_(0xFF) << MLB_MLBC1_NDA_Pos)               /**< (MLB_MLBC1) Node Device Address Mask */
+#define MLB_MLBC1_NDA(value)                (MLB_MLBC1_NDA_Msk & ((value) << MLB_MLBC1_NDA_Pos))
+#define MLB_MLBC1_MASK                      _U_(0xFFC0)                                    /**< \deprecated (MLB_MLBC1) Register MASK  (Use MLB_MLBC1_Msk instead)  */
+#define MLB_MLBC1_Msk                       _U_(0xFFC0)                                    /**< (MLB_MLBC1) Register Mask  */
+
+
+/* -------- MLB_HCTL : (MLB Offset: 0x80) (R/W 32) HBI Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RST0:1;                    /**< bit:      0  Address Generation Unit 0 Software Reset */
+    uint32_t RST1:1;                    /**< bit:      1  Address Generation Unit 1 Software Reset */
+    uint32_t :13;                       /**< bit:  2..14  Reserved */
+    uint32_t EN:1;                      /**< bit:     15  HBI Enable                               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RST:2;                     /**< bit:   0..1  Address Generation Unit x Software Reset */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCTL_OFFSET                     (0x80)                                        /**<  (MLB_HCTL) HBI Control Register  Offset */
+
+#define MLB_HCTL_RST0_Pos                   0                                              /**< (MLB_HCTL) Address Generation Unit 0 Software Reset Position */
+#define MLB_HCTL_RST0_Msk                   (_U_(0x1) << MLB_HCTL_RST0_Pos)                /**< (MLB_HCTL) Address Generation Unit 0 Software Reset Mask */
+#define MLB_HCTL_RST0                       MLB_HCTL_RST0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_RST0_Msk instead */
+#define MLB_HCTL_RST1_Pos                   1                                              /**< (MLB_HCTL) Address Generation Unit 1 Software Reset Position */
+#define MLB_HCTL_RST1_Msk                   (_U_(0x1) << MLB_HCTL_RST1_Pos)                /**< (MLB_HCTL) Address Generation Unit 1 Software Reset Mask */
+#define MLB_HCTL_RST1                       MLB_HCTL_RST1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_RST1_Msk instead */
+#define MLB_HCTL_EN_Pos                     15                                             /**< (MLB_HCTL) HBI Enable Position */
+#define MLB_HCTL_EN_Msk                     (_U_(0x1) << MLB_HCTL_EN_Pos)                  /**< (MLB_HCTL) HBI Enable Mask */
+#define MLB_HCTL_EN                         MLB_HCTL_EN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_EN_Msk instead */
+#define MLB_HCTL_MASK                       _U_(0x8003)                                    /**< \deprecated (MLB_HCTL) Register MASK  (Use MLB_HCTL_Msk instead)  */
+#define MLB_HCTL_Msk                        _U_(0x8003)                                    /**< (MLB_HCTL) Register Mask  */
+
+#define MLB_HCTL_RST_Pos                    0                                              /**< (MLB_HCTL Position) Address Generation Unit x Software Reset */
+#define MLB_HCTL_RST_Msk                    (_U_(0x3) << MLB_HCTL_RST_Pos)                 /**< (MLB_HCTL Mask) RST */
+#define MLB_HCTL_RST(value)                 (MLB_HCTL_RST_Msk & ((value) << MLB_HCTL_RST_Pos))  
+
+/* -------- MLB_HCMR : (MLB Offset: 0x88) (R/W 32) HBI Channel Mask 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHM:32;                    /**< bit:  0..31  Bitwise Channel Mask Bit [31:0]          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCMR_OFFSET                     (0x88)                                        /**<  (MLB_HCMR) HBI Channel Mask 0 Register 0  Offset */
+
+#define MLB_HCMR_CHM_Pos                    0                                              /**< (MLB_HCMR) Bitwise Channel Mask Bit [31:0] Position */
+#define MLB_HCMR_CHM_Msk                    (_U_(0xFFFFFFFF) << MLB_HCMR_CHM_Pos)          /**< (MLB_HCMR) Bitwise Channel Mask Bit [31:0] Mask */
+#define MLB_HCMR_CHM(value)                 (MLB_HCMR_CHM_Msk & ((value) << MLB_HCMR_CHM_Pos))
+#define MLB_HCMR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCMR) Register MASK  (Use MLB_HCMR_Msk instead)  */
+#define MLB_HCMR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCMR) Register Mask  */
+
+
+/* -------- MLB_HCER : (MLB Offset: 0x90) (R/ 32) HBI Channel Error 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CERR:32;                   /**< bit:  0..31  Bitwise Channel Error Bit [31:0]         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCER_OFFSET                     (0x90)                                        /**<  (MLB_HCER) HBI Channel Error 0 Register 0  Offset */
+
+#define MLB_HCER_CERR_Pos                   0                                              /**< (MLB_HCER) Bitwise Channel Error Bit [31:0] Position */
+#define MLB_HCER_CERR_Msk                   (_U_(0xFFFFFFFF) << MLB_HCER_CERR_Pos)         /**< (MLB_HCER) Bitwise Channel Error Bit [31:0] Mask */
+#define MLB_HCER_CERR(value)                (MLB_HCER_CERR_Msk & ((value) << MLB_HCER_CERR_Pos))
+#define MLB_HCER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCER) Register MASK  (Use MLB_HCER_Msk instead)  */
+#define MLB_HCER_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCER) Register Mask  */
+
+
+/* -------- MLB_HCBR : (MLB Offset: 0x98) (R/ 32) HBI Channel Busy 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHB:32;                    /**< bit:  0..31  Bitwise Channel Busy Bit [31:0]          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCBR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCBR_OFFSET                     (0x98)                                        /**<  (MLB_HCBR) HBI Channel Busy 0 Register 0  Offset */
+
+#define MLB_HCBR_CHB_Pos                    0                                              /**< (MLB_HCBR) Bitwise Channel Busy Bit [31:0] Position */
+#define MLB_HCBR_CHB_Msk                    (_U_(0xFFFFFFFF) << MLB_HCBR_CHB_Pos)          /**< (MLB_HCBR) Bitwise Channel Busy Bit [31:0] Mask */
+#define MLB_HCBR_CHB(value)                 (MLB_HCBR_CHB_Msk & ((value) << MLB_HCBR_CHB_Pos))
+#define MLB_HCBR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCBR) Register MASK  (Use MLB_HCBR_Msk instead)  */
+#define MLB_HCBR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCBR) Register Mask  */
+
+
+/* -------- MLB_MDAT : (MLB Offset: 0xc0) (R/W 32) MIF Data 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  CRT or DBR Data                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MDAT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MDAT_OFFSET                     (0xC0)                                        /**<  (MLB_MDAT) MIF Data 0 Register 0  Offset */
+
+#define MLB_MDAT_DATA_Pos                   0                                              /**< (MLB_MDAT) CRT or DBR Data Position */
+#define MLB_MDAT_DATA_Msk                   (_U_(0xFFFFFFFF) << MLB_MDAT_DATA_Pos)         /**< (MLB_MDAT) CRT or DBR Data Mask */
+#define MLB_MDAT_DATA(value)                (MLB_MDAT_DATA_Msk & ((value) << MLB_MDAT_DATA_Pos))
+#define MLB_MDAT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MDAT) Register MASK  (Use MLB_MDAT_Msk instead)  */
+#define MLB_MDAT_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_MDAT) Register Mask  */
+
+
+/* -------- MLB_MDWE : (MLB Offset: 0xd0) (R/W 32) MIF Data Write Enable 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASK:32;                   /**< bit:  0..31  Bitwise Write Enable for CTR Data - bits[31:0] */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MDWE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MDWE_OFFSET                     (0xD0)                                        /**<  (MLB_MDWE) MIF Data Write Enable 0 Register 0  Offset */
+
+#define MLB_MDWE_MASK_Pos                   0                                              /**< (MLB_MDWE) Bitwise Write Enable for CTR Data - bits[31:0] Position */
+#define MLB_MDWE_MASK_Msk                   (_U_(0xFFFFFFFF) << MLB_MDWE_MASK_Pos)         /**< (MLB_MDWE) Bitwise Write Enable for CTR Data - bits[31:0] Mask */
+#define MLB_MDWE_MASK(value)                (MLB_MDWE_MASK_Msk & ((value) << MLB_MDWE_MASK_Pos))
+#define MLB_MDWE_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_MDWE) Register Mask  */
+
+
+/* -------- MLB_MCTL : (MLB Offset: 0xe0) (R/W 32) MIF Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t XCMP:1;                    /**< bit:      0  Transfer Complete (Write 0 to Clear)     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MCTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MCTL_OFFSET                     (0xE0)                                        /**<  (MLB_MCTL) MIF Control Register  Offset */
+
+#define MLB_MCTL_XCMP_Pos                   0                                              /**< (MLB_MCTL) Transfer Complete (Write 0 to Clear) Position */
+#define MLB_MCTL_XCMP_Msk                   (_U_(0x1) << MLB_MCTL_XCMP_Pos)                /**< (MLB_MCTL) Transfer Complete (Write 0 to Clear) Mask */
+#define MLB_MCTL_XCMP                       MLB_MCTL_XCMP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MCTL_XCMP_Msk instead */
+#define MLB_MCTL_MASK                       _U_(0x01)                                      /**< \deprecated (MLB_MCTL) Register MASK  (Use MLB_MCTL_Msk instead)  */
+#define MLB_MCTL_Msk                        _U_(0x01)                                      /**< (MLB_MCTL) Register Mask  */
+
+
+/* -------- MLB_MADR : (MLB Offset: 0xe4) (R/W 32) MIF Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:14;                   /**< bit:  0..13  CTR or DBR Address                       */
+    uint32_t :16;                       /**< bit: 14..29  Reserved */
+    uint32_t TB:1;                      /**< bit:     30  Target Location Bit                      */
+    uint32_t WNR:1;                     /**< bit:     31  Write-Not-Read Selection                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MADR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MADR_OFFSET                     (0xE4)                                        /**<  (MLB_MADR) MIF Address Register  Offset */
+
+#define MLB_MADR_ADDR_Pos                   0                                              /**< (MLB_MADR) CTR or DBR Address Position */
+#define MLB_MADR_ADDR_Msk                   (_U_(0x3FFF) << MLB_MADR_ADDR_Pos)             /**< (MLB_MADR) CTR or DBR Address Mask */
+#define MLB_MADR_ADDR(value)                (MLB_MADR_ADDR_Msk & ((value) << MLB_MADR_ADDR_Pos))
+#define MLB_MADR_TB_Pos                     30                                             /**< (MLB_MADR) Target Location Bit Position */
+#define MLB_MADR_TB_Msk                     (_U_(0x1) << MLB_MADR_TB_Pos)                  /**< (MLB_MADR) Target Location Bit Mask */
+#define MLB_MADR_TB                         MLB_MADR_TB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MADR_TB_Msk instead */
+#define   MLB_MADR_TB_CTR_Val               _U_(0x0)                                       /**< (MLB_MADR) Selects CTR  */
+#define   MLB_MADR_TB_DBR_Val               _U_(0x1)                                       /**< (MLB_MADR) Selects DBR  */
+#define MLB_MADR_TB_CTR                     (MLB_MADR_TB_CTR_Val << MLB_MADR_TB_Pos)       /**< (MLB_MADR) Selects CTR Position  */
+#define MLB_MADR_TB_DBR                     (MLB_MADR_TB_DBR_Val << MLB_MADR_TB_Pos)       /**< (MLB_MADR) Selects DBR Position  */
+#define MLB_MADR_WNR_Pos                    31                                             /**< (MLB_MADR) Write-Not-Read Selection Position */
+#define MLB_MADR_WNR_Msk                    (_U_(0x1) << MLB_MADR_WNR_Pos)                 /**< (MLB_MADR) Write-Not-Read Selection Mask */
+#define MLB_MADR_WNR                        MLB_MADR_WNR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MADR_WNR_Msk instead */
+#define MLB_MADR_MASK                       _U_(0xC0003FFF)                                /**< \deprecated (MLB_MADR) Register MASK  (Use MLB_MADR_Msk instead)  */
+#define MLB_MADR_Msk                        _U_(0xC0003FFF)                                /**< (MLB_MADR) Register Mask  */
+
+
+/* -------- MLB_ACTL : (MLB Offset: 0x3c0) (R/W 32) AHB Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCE:1;                     /**< bit:      0  Software Clear Enable                    */
+    uint32_t SMX:1;                     /**< bit:      1  AHB Interrupt Mux Enable                 */
+    uint32_t DMA_MODE:1;                /**< bit:      2  DMA Mode                                 */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t MPB:1;                     /**< bit:      4  DMA Packet Buffering Mode                */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACTL_OFFSET                     (0x3C0)                                       /**<  (MLB_ACTL) AHB Control Register  Offset */
+
+#define MLB_ACTL_SCE_Pos                    0                                              /**< (MLB_ACTL) Software Clear Enable Position */
+#define MLB_ACTL_SCE_Msk                    (_U_(0x1) << MLB_ACTL_SCE_Pos)                 /**< (MLB_ACTL) Software Clear Enable Mask */
+#define MLB_ACTL_SCE                        MLB_ACTL_SCE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_SCE_Msk instead */
+#define MLB_ACTL_SMX_Pos                    1                                              /**< (MLB_ACTL) AHB Interrupt Mux Enable Position */
+#define MLB_ACTL_SMX_Msk                    (_U_(0x1) << MLB_ACTL_SMX_Pos)                 /**< (MLB_ACTL) AHB Interrupt Mux Enable Mask */
+#define MLB_ACTL_SMX                        MLB_ACTL_SMX_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_SMX_Msk instead */
+#define MLB_ACTL_DMA_MODE_Pos               2                                              /**< (MLB_ACTL) DMA Mode Position */
+#define MLB_ACTL_DMA_MODE_Msk               (_U_(0x1) << MLB_ACTL_DMA_MODE_Pos)            /**< (MLB_ACTL) DMA Mode Mask */
+#define MLB_ACTL_DMA_MODE                   MLB_ACTL_DMA_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_DMA_MODE_Msk instead */
+#define MLB_ACTL_MPB_Pos                    4                                              /**< (MLB_ACTL) DMA Packet Buffering Mode Position */
+#define MLB_ACTL_MPB_Msk                    (_U_(0x1) << MLB_ACTL_MPB_Pos)                 /**< (MLB_ACTL) DMA Packet Buffering Mode Mask */
+#define MLB_ACTL_MPB                        MLB_ACTL_MPB_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_MPB_Msk instead */
+#define   MLB_ACTL_MPB_SINGLE_PACKET_Val    _U_(0x0)                                       /**< (MLB_ACTL) Single-packet mode  */
+#define   MLB_ACTL_MPB_MULTIPLE_PACKET_Val  _U_(0x1)                                       /**< (MLB_ACTL) Multiple-packet mode  */
+#define MLB_ACTL_MPB_SINGLE_PACKET          (MLB_ACTL_MPB_SINGLE_PACKET_Val << MLB_ACTL_MPB_Pos)  /**< (MLB_ACTL) Single-packet mode Position  */
+#define MLB_ACTL_MPB_MULTIPLE_PACKET        (MLB_ACTL_MPB_MULTIPLE_PACKET_Val << MLB_ACTL_MPB_Pos)  /**< (MLB_ACTL) Multiple-packet mode Position  */
+#define MLB_ACTL_MASK                       _U_(0x17)                                      /**< \deprecated (MLB_ACTL) Register MASK  (Use MLB_ACTL_Msk instead)  */
+#define MLB_ACTL_Msk                        _U_(0x17)                                      /**< (MLB_ACTL) Register Mask  */
+
+
+/* -------- MLB_ACSR : (MLB Offset: 0x3d0) (R/W 32) AHB Channel Status 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHS:32;                    /**< bit:  0..31  Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACSR_OFFSET                     (0x3D0)                                       /**<  (MLB_ACSR) AHB Channel Status 0 Register 0  Offset */
+
+#define MLB_ACSR_CHS_Pos                    0                                              /**< (MLB_ACSR) Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) Position */
+#define MLB_ACSR_CHS_Msk                    (_U_(0xFFFFFFFF) << MLB_ACSR_CHS_Pos)          /**< (MLB_ACSR) Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) Mask */
+#define MLB_ACSR_CHS(value)                 (MLB_ACSR_CHS_Msk & ((value) << MLB_ACSR_CHS_Pos))
+#define MLB_ACSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_ACSR) Register MASK  (Use MLB_ACSR_Msk instead)  */
+#define MLB_ACSR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_ACSR) Register Mask  */
+
+
+/* -------- MLB_ACMR : (MLB Offset: 0x3d8) (R/W 32) AHB Channel Mask 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHM:32;                    /**< bit:  0..31  Bitwise Channel Mask Bits 31 to 0        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACMR_OFFSET                     (0x3D8)                                       /**<  (MLB_ACMR) AHB Channel Mask 0 Register 0  Offset */
+
+#define MLB_ACMR_CHM_Pos                    0                                              /**< (MLB_ACMR) Bitwise Channel Mask Bits 31 to 0 Position */
+#define MLB_ACMR_CHM_Msk                    (_U_(0xFFFFFFFF) << MLB_ACMR_CHM_Pos)          /**< (MLB_ACMR) Bitwise Channel Mask Bits 31 to 0 Mask */
+#define MLB_ACMR_CHM(value)                 (MLB_ACMR_CHM_Msk & ((value) << MLB_ACMR_CHM_Pos))
+#define MLB_ACMR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_ACMR) Register MASK  (Use MLB_ACMR_Msk instead)  */
+#define MLB_ACMR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_ACMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MLB hardware registers */
+typedef struct {  
+  __IO uint32_t MLB_MLBC0;      /**< (MLB Offset: 0x00) MediaLB Control 0 Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t MLB_MS0;        /**< (MLB Offset: 0x0C) MediaLB Channel Status 0 Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t MLB_MS1;        /**< (MLB Offset: 0x14) MediaLB Channel Status1 Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO uint32_t MLB_MSS;        /**< (MLB Offset: 0x20) MediaLB System Status Register */
+  __I  uint32_t MLB_MSD;        /**< (MLB Offset: 0x24) MediaLB System Data Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t MLB_MIEN;       /**< (MLB Offset: 0x2C) MediaLB Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO uint32_t MLB_MLBC1;      /**< (MLB Offset: 0x3C) MediaLB Control 1 Register */
+  __I  uint8_t                        Reserved6[64];
+  __IO uint32_t MLB_HCTL;       /**< (MLB Offset: 0x80) HBI Control Register */
+  __I  uint8_t                        Reserved7[4];
+  __IO uint32_t MLB_HCMR[2];    /**< (MLB Offset: 0x88) HBI Channel Mask 0 Register 0 */
+  __I  uint32_t MLB_HCER[2];    /**< (MLB Offset: 0x90) HBI Channel Error 0 Register 0 */
+  __I  uint32_t MLB_HCBR[2];    /**< (MLB Offset: 0x98) HBI Channel Busy 0 Register 0 */
+  __I  uint8_t                        Reserved8[32];
+  __IO uint32_t MLB_MDAT[4];    /**< (MLB Offset: 0xC0) MIF Data 0 Register 0 */
+  __IO uint32_t MLB_MDWE[4];    /**< (MLB Offset: 0xD0) MIF Data Write Enable 0 Register 0 */
+  __IO uint32_t MLB_MCTL;       /**< (MLB Offset: 0xE0) MIF Control Register */
+  __IO uint32_t MLB_MADR;       /**< (MLB Offset: 0xE4) MIF Address Register */
+  __I  uint8_t                        Reserved9[728];
+  __IO uint32_t MLB_ACTL;       /**< (MLB Offset: 0x3C0) AHB Control Register */
+  __I  uint8_t                        Reserved10[12];
+  __IO uint32_t MLB_ACSR[2];    /**< (MLB Offset: 0x3D0) AHB Channel Status 0 Register 0 */
+  __IO uint32_t MLB_ACMR[2];    /**< (MLB Offset: 0x3D8) AHB Channel Mask 0 Register 0 */
+} Mlb;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MLB hardware registers */
+typedef struct {  
+  __IO MLB_MLBC0_Type                 MLB_MLBC0;      /**< Offset: 0x00 (R/W  32) MediaLB Control 0 Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO MLB_MS0_Type                   MLB_MS0;        /**< Offset: 0x0C (R/W  32) MediaLB Channel Status 0 Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO MLB_MS1_Type                   MLB_MS1;        /**< Offset: 0x14 (R/W  32) MediaLB Channel Status1 Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO MLB_MSS_Type                   MLB_MSS;        /**< Offset: 0x20 (R/W  32) MediaLB System Status Register */
+  __I  MLB_MSD_Type                   MLB_MSD;        /**< Offset: 0x24 (R/   32) MediaLB System Data Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO MLB_MIEN_Type                  MLB_MIEN;       /**< Offset: 0x2C (R/W  32) MediaLB Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO MLB_MLBC1_Type                 MLB_MLBC1;      /**< Offset: 0x3C (R/W  32) MediaLB Control 1 Register */
+  __I  uint8_t                        Reserved6[64];
+  __IO MLB_HCTL_Type                  MLB_HCTL;       /**< Offset: 0x80 (R/W  32) HBI Control Register */
+  __I  uint8_t                        Reserved7[4];
+  __IO MLB_HCMR_Type                  MLB_HCMR[2];    /**< Offset: 0x88 (R/W  32) HBI Channel Mask 0 Register 0 */
+  __I  MLB_HCER_Type                  MLB_HCER[2];    /**< Offset: 0x90 (R/   32) HBI Channel Error 0 Register 0 */
+  __I  MLB_HCBR_Type                  MLB_HCBR[2];    /**< Offset: 0x98 (R/   32) HBI Channel Busy 0 Register 0 */
+  __I  uint8_t                        Reserved8[32];
+  __IO MLB_MDAT_Type                  MLB_MDAT[4];    /**< Offset: 0xC0 (R/W  32) MIF Data 0 Register 0 */
+  __IO MLB_MDWE_Type                  MLB_MDWE[4];    /**< Offset: 0xD0 (R/W  32) MIF Data Write Enable 0 Register 0 */
+  __IO MLB_MCTL_Type                  MLB_MCTL;       /**< Offset: 0xE0 (R/W  32) MIF Control Register */
+  __IO MLB_MADR_Type                  MLB_MADR;       /**< Offset: 0xE4 (R/W  32) MIF Address Register */
+  __I  uint8_t                        Reserved9[728];
+  __IO MLB_ACTL_Type                  MLB_ACTL;       /**< Offset: 0x3C0 (R/W  32) AHB Control Register */
+  __I  uint8_t                        Reserved10[12];
+  __IO MLB_ACSR_Type                  MLB_ACSR[2];    /**< Offset: 0x3D0 (R/W  32) AHB Channel Status 0 Register 0 */
+  __IO MLB_ACMR_Type                  MLB_ACMR[2];    /**< Offset: 0x3D8 (R/W  32) AHB Channel Mask 0 Register 0 */
+} Mlb;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of MediaLB */
+
+#endif /* _SAMV71_MLB_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/pio.h
+++ b/asf/sam/include/samv71/component/pio.h
@@ -1,0 +1,7426 @@
+/**
+ * \file
+ *
+ * \brief Component description for PIO
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIO_COMPONENT_H_
+#define _SAMV71_PIO_COMPONENT_H_
+#define _SAMV71_PIO_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Parallel Input/Output Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PIO */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PIO_11004                      /**< (PIO) Module ID */
+#define REV_PIO U                      /**< (PIO) Module revision */
+
+/* -------- PIO_PER : (PIO Offset: 0x00) (/W 32) PIO Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Enable                               */
+    uint32_t P1:1;                      /**< bit:      1  PIO Enable                               */
+    uint32_t P2:1;                      /**< bit:      2  PIO Enable                               */
+    uint32_t P3:1;                      /**< bit:      3  PIO Enable                               */
+    uint32_t P4:1;                      /**< bit:      4  PIO Enable                               */
+    uint32_t P5:1;                      /**< bit:      5  PIO Enable                               */
+    uint32_t P6:1;                      /**< bit:      6  PIO Enable                               */
+    uint32_t P7:1;                      /**< bit:      7  PIO Enable                               */
+    uint32_t P8:1;                      /**< bit:      8  PIO Enable                               */
+    uint32_t P9:1;                      /**< bit:      9  PIO Enable                               */
+    uint32_t P10:1;                     /**< bit:     10  PIO Enable                               */
+    uint32_t P11:1;                     /**< bit:     11  PIO Enable                               */
+    uint32_t P12:1;                     /**< bit:     12  PIO Enable                               */
+    uint32_t P13:1;                     /**< bit:     13  PIO Enable                               */
+    uint32_t P14:1;                     /**< bit:     14  PIO Enable                               */
+    uint32_t P15:1;                     /**< bit:     15  PIO Enable                               */
+    uint32_t P16:1;                     /**< bit:     16  PIO Enable                               */
+    uint32_t P17:1;                     /**< bit:     17  PIO Enable                               */
+    uint32_t P18:1;                     /**< bit:     18  PIO Enable                               */
+    uint32_t P19:1;                     /**< bit:     19  PIO Enable                               */
+    uint32_t P20:1;                     /**< bit:     20  PIO Enable                               */
+    uint32_t P21:1;                     /**< bit:     21  PIO Enable                               */
+    uint32_t P22:1;                     /**< bit:     22  PIO Enable                               */
+    uint32_t P23:1;                     /**< bit:     23  PIO Enable                               */
+    uint32_t P24:1;                     /**< bit:     24  PIO Enable                               */
+    uint32_t P25:1;                     /**< bit:     25  PIO Enable                               */
+    uint32_t P26:1;                     /**< bit:     26  PIO Enable                               */
+    uint32_t P27:1;                     /**< bit:     27  PIO Enable                               */
+    uint32_t P28:1;                     /**< bit:     28  PIO Enable                               */
+    uint32_t P29:1;                     /**< bit:     29  PIO Enable                               */
+    uint32_t P30:1;                     /**< bit:     30  PIO Enable                               */
+    uint32_t P31:1;                     /**< bit:     31  PIO Enable                               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Enable                               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PER_OFFSET                      (0x00)                                        /**<  (PIO_PER) PIO Enable Register  Offset */
+
+#define PIO_PER_P0_Pos                      0                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P0_Msk                      (_U_(0x1) << PIO_PER_P0_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P0                          PIO_PER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P0_Msk instead */
+#define PIO_PER_P1_Pos                      1                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P1_Msk                      (_U_(0x1) << PIO_PER_P1_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P1                          PIO_PER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P1_Msk instead */
+#define PIO_PER_P2_Pos                      2                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P2_Msk                      (_U_(0x1) << PIO_PER_P2_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P2                          PIO_PER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P2_Msk instead */
+#define PIO_PER_P3_Pos                      3                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P3_Msk                      (_U_(0x1) << PIO_PER_P3_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P3                          PIO_PER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P3_Msk instead */
+#define PIO_PER_P4_Pos                      4                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P4_Msk                      (_U_(0x1) << PIO_PER_P4_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P4                          PIO_PER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P4_Msk instead */
+#define PIO_PER_P5_Pos                      5                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P5_Msk                      (_U_(0x1) << PIO_PER_P5_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P5                          PIO_PER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P5_Msk instead */
+#define PIO_PER_P6_Pos                      6                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P6_Msk                      (_U_(0x1) << PIO_PER_P6_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P6                          PIO_PER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P6_Msk instead */
+#define PIO_PER_P7_Pos                      7                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P7_Msk                      (_U_(0x1) << PIO_PER_P7_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P7                          PIO_PER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P7_Msk instead */
+#define PIO_PER_P8_Pos                      8                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P8_Msk                      (_U_(0x1) << PIO_PER_P8_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P8                          PIO_PER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P8_Msk instead */
+#define PIO_PER_P9_Pos                      9                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P9_Msk                      (_U_(0x1) << PIO_PER_P9_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P9                          PIO_PER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P9_Msk instead */
+#define PIO_PER_P10_Pos                     10                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P10_Msk                     (_U_(0x1) << PIO_PER_P10_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P10                         PIO_PER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P10_Msk instead */
+#define PIO_PER_P11_Pos                     11                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P11_Msk                     (_U_(0x1) << PIO_PER_P11_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P11                         PIO_PER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P11_Msk instead */
+#define PIO_PER_P12_Pos                     12                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P12_Msk                     (_U_(0x1) << PIO_PER_P12_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P12                         PIO_PER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P12_Msk instead */
+#define PIO_PER_P13_Pos                     13                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P13_Msk                     (_U_(0x1) << PIO_PER_P13_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P13                         PIO_PER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P13_Msk instead */
+#define PIO_PER_P14_Pos                     14                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P14_Msk                     (_U_(0x1) << PIO_PER_P14_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P14                         PIO_PER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P14_Msk instead */
+#define PIO_PER_P15_Pos                     15                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P15_Msk                     (_U_(0x1) << PIO_PER_P15_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P15                         PIO_PER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P15_Msk instead */
+#define PIO_PER_P16_Pos                     16                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P16_Msk                     (_U_(0x1) << PIO_PER_P16_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P16                         PIO_PER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P16_Msk instead */
+#define PIO_PER_P17_Pos                     17                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P17_Msk                     (_U_(0x1) << PIO_PER_P17_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P17                         PIO_PER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P17_Msk instead */
+#define PIO_PER_P18_Pos                     18                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P18_Msk                     (_U_(0x1) << PIO_PER_P18_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P18                         PIO_PER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P18_Msk instead */
+#define PIO_PER_P19_Pos                     19                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P19_Msk                     (_U_(0x1) << PIO_PER_P19_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P19                         PIO_PER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P19_Msk instead */
+#define PIO_PER_P20_Pos                     20                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P20_Msk                     (_U_(0x1) << PIO_PER_P20_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P20                         PIO_PER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P20_Msk instead */
+#define PIO_PER_P21_Pos                     21                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P21_Msk                     (_U_(0x1) << PIO_PER_P21_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P21                         PIO_PER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P21_Msk instead */
+#define PIO_PER_P22_Pos                     22                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P22_Msk                     (_U_(0x1) << PIO_PER_P22_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P22                         PIO_PER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P22_Msk instead */
+#define PIO_PER_P23_Pos                     23                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P23_Msk                     (_U_(0x1) << PIO_PER_P23_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P23                         PIO_PER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P23_Msk instead */
+#define PIO_PER_P24_Pos                     24                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P24_Msk                     (_U_(0x1) << PIO_PER_P24_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P24                         PIO_PER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P24_Msk instead */
+#define PIO_PER_P25_Pos                     25                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P25_Msk                     (_U_(0x1) << PIO_PER_P25_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P25                         PIO_PER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P25_Msk instead */
+#define PIO_PER_P26_Pos                     26                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P26_Msk                     (_U_(0x1) << PIO_PER_P26_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P26                         PIO_PER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P26_Msk instead */
+#define PIO_PER_P27_Pos                     27                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P27_Msk                     (_U_(0x1) << PIO_PER_P27_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P27                         PIO_PER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P27_Msk instead */
+#define PIO_PER_P28_Pos                     28                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P28_Msk                     (_U_(0x1) << PIO_PER_P28_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P28                         PIO_PER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P28_Msk instead */
+#define PIO_PER_P29_Pos                     29                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P29_Msk                     (_U_(0x1) << PIO_PER_P29_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P29                         PIO_PER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P29_Msk instead */
+#define PIO_PER_P30_Pos                     30                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P30_Msk                     (_U_(0x1) << PIO_PER_P30_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P30                         PIO_PER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P30_Msk instead */
+#define PIO_PER_P31_Pos                     31                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P31_Msk                     (_U_(0x1) << PIO_PER_P31_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P31                         PIO_PER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P31_Msk instead */
+#define PIO_PER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PER) Register MASK  (Use PIO_PER_Msk instead)  */
+#define PIO_PER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PER) Register Mask  */
+
+#define PIO_PER_P_Pos                       0                                              /**< (PIO_PER Position) PIO Enable */
+#define PIO_PER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PER_P_Pos)             /**< (PIO_PER Mask) P */
+#define PIO_PER_P(value)                    (PIO_PER_P_Msk & ((value) << PIO_PER_P_Pos))   
+
+/* -------- PIO_PDR : (PIO Offset: 0x04) (/W 32) PIO Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Disable                              */
+    uint32_t P1:1;                      /**< bit:      1  PIO Disable                              */
+    uint32_t P2:1;                      /**< bit:      2  PIO Disable                              */
+    uint32_t P3:1;                      /**< bit:      3  PIO Disable                              */
+    uint32_t P4:1;                      /**< bit:      4  PIO Disable                              */
+    uint32_t P5:1;                      /**< bit:      5  PIO Disable                              */
+    uint32_t P6:1;                      /**< bit:      6  PIO Disable                              */
+    uint32_t P7:1;                      /**< bit:      7  PIO Disable                              */
+    uint32_t P8:1;                      /**< bit:      8  PIO Disable                              */
+    uint32_t P9:1;                      /**< bit:      9  PIO Disable                              */
+    uint32_t P10:1;                     /**< bit:     10  PIO Disable                              */
+    uint32_t P11:1;                     /**< bit:     11  PIO Disable                              */
+    uint32_t P12:1;                     /**< bit:     12  PIO Disable                              */
+    uint32_t P13:1;                     /**< bit:     13  PIO Disable                              */
+    uint32_t P14:1;                     /**< bit:     14  PIO Disable                              */
+    uint32_t P15:1;                     /**< bit:     15  PIO Disable                              */
+    uint32_t P16:1;                     /**< bit:     16  PIO Disable                              */
+    uint32_t P17:1;                     /**< bit:     17  PIO Disable                              */
+    uint32_t P18:1;                     /**< bit:     18  PIO Disable                              */
+    uint32_t P19:1;                     /**< bit:     19  PIO Disable                              */
+    uint32_t P20:1;                     /**< bit:     20  PIO Disable                              */
+    uint32_t P21:1;                     /**< bit:     21  PIO Disable                              */
+    uint32_t P22:1;                     /**< bit:     22  PIO Disable                              */
+    uint32_t P23:1;                     /**< bit:     23  PIO Disable                              */
+    uint32_t P24:1;                     /**< bit:     24  PIO Disable                              */
+    uint32_t P25:1;                     /**< bit:     25  PIO Disable                              */
+    uint32_t P26:1;                     /**< bit:     26  PIO Disable                              */
+    uint32_t P27:1;                     /**< bit:     27  PIO Disable                              */
+    uint32_t P28:1;                     /**< bit:     28  PIO Disable                              */
+    uint32_t P29:1;                     /**< bit:     29  PIO Disable                              */
+    uint32_t P30:1;                     /**< bit:     30  PIO Disable                              */
+    uint32_t P31:1;                     /**< bit:     31  PIO Disable                              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Disable                              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PDR_OFFSET                      (0x04)                                        /**<  (PIO_PDR) PIO Disable Register  Offset */
+
+#define PIO_PDR_P0_Pos                      0                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P0_Msk                      (_U_(0x1) << PIO_PDR_P0_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P0                          PIO_PDR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P0_Msk instead */
+#define PIO_PDR_P1_Pos                      1                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P1_Msk                      (_U_(0x1) << PIO_PDR_P1_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P1                          PIO_PDR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P1_Msk instead */
+#define PIO_PDR_P2_Pos                      2                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P2_Msk                      (_U_(0x1) << PIO_PDR_P2_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P2                          PIO_PDR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P2_Msk instead */
+#define PIO_PDR_P3_Pos                      3                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P3_Msk                      (_U_(0x1) << PIO_PDR_P3_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P3                          PIO_PDR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P3_Msk instead */
+#define PIO_PDR_P4_Pos                      4                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P4_Msk                      (_U_(0x1) << PIO_PDR_P4_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P4                          PIO_PDR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P4_Msk instead */
+#define PIO_PDR_P5_Pos                      5                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P5_Msk                      (_U_(0x1) << PIO_PDR_P5_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P5                          PIO_PDR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P5_Msk instead */
+#define PIO_PDR_P6_Pos                      6                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P6_Msk                      (_U_(0x1) << PIO_PDR_P6_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P6                          PIO_PDR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P6_Msk instead */
+#define PIO_PDR_P7_Pos                      7                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P7_Msk                      (_U_(0x1) << PIO_PDR_P7_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P7                          PIO_PDR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P7_Msk instead */
+#define PIO_PDR_P8_Pos                      8                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P8_Msk                      (_U_(0x1) << PIO_PDR_P8_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P8                          PIO_PDR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P8_Msk instead */
+#define PIO_PDR_P9_Pos                      9                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P9_Msk                      (_U_(0x1) << PIO_PDR_P9_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P9                          PIO_PDR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P9_Msk instead */
+#define PIO_PDR_P10_Pos                     10                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P10_Msk                     (_U_(0x1) << PIO_PDR_P10_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P10                         PIO_PDR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P10_Msk instead */
+#define PIO_PDR_P11_Pos                     11                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P11_Msk                     (_U_(0x1) << PIO_PDR_P11_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P11                         PIO_PDR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P11_Msk instead */
+#define PIO_PDR_P12_Pos                     12                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P12_Msk                     (_U_(0x1) << PIO_PDR_P12_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P12                         PIO_PDR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P12_Msk instead */
+#define PIO_PDR_P13_Pos                     13                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P13_Msk                     (_U_(0x1) << PIO_PDR_P13_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P13                         PIO_PDR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P13_Msk instead */
+#define PIO_PDR_P14_Pos                     14                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P14_Msk                     (_U_(0x1) << PIO_PDR_P14_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P14                         PIO_PDR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P14_Msk instead */
+#define PIO_PDR_P15_Pos                     15                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P15_Msk                     (_U_(0x1) << PIO_PDR_P15_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P15                         PIO_PDR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P15_Msk instead */
+#define PIO_PDR_P16_Pos                     16                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P16_Msk                     (_U_(0x1) << PIO_PDR_P16_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P16                         PIO_PDR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P16_Msk instead */
+#define PIO_PDR_P17_Pos                     17                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P17_Msk                     (_U_(0x1) << PIO_PDR_P17_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P17                         PIO_PDR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P17_Msk instead */
+#define PIO_PDR_P18_Pos                     18                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P18_Msk                     (_U_(0x1) << PIO_PDR_P18_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P18                         PIO_PDR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P18_Msk instead */
+#define PIO_PDR_P19_Pos                     19                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P19_Msk                     (_U_(0x1) << PIO_PDR_P19_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P19                         PIO_PDR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P19_Msk instead */
+#define PIO_PDR_P20_Pos                     20                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P20_Msk                     (_U_(0x1) << PIO_PDR_P20_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P20                         PIO_PDR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P20_Msk instead */
+#define PIO_PDR_P21_Pos                     21                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P21_Msk                     (_U_(0x1) << PIO_PDR_P21_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P21                         PIO_PDR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P21_Msk instead */
+#define PIO_PDR_P22_Pos                     22                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P22_Msk                     (_U_(0x1) << PIO_PDR_P22_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P22                         PIO_PDR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P22_Msk instead */
+#define PIO_PDR_P23_Pos                     23                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P23_Msk                     (_U_(0x1) << PIO_PDR_P23_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P23                         PIO_PDR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P23_Msk instead */
+#define PIO_PDR_P24_Pos                     24                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P24_Msk                     (_U_(0x1) << PIO_PDR_P24_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P24                         PIO_PDR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P24_Msk instead */
+#define PIO_PDR_P25_Pos                     25                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P25_Msk                     (_U_(0x1) << PIO_PDR_P25_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P25                         PIO_PDR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P25_Msk instead */
+#define PIO_PDR_P26_Pos                     26                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P26_Msk                     (_U_(0x1) << PIO_PDR_P26_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P26                         PIO_PDR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P26_Msk instead */
+#define PIO_PDR_P27_Pos                     27                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P27_Msk                     (_U_(0x1) << PIO_PDR_P27_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P27                         PIO_PDR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P27_Msk instead */
+#define PIO_PDR_P28_Pos                     28                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P28_Msk                     (_U_(0x1) << PIO_PDR_P28_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P28                         PIO_PDR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P28_Msk instead */
+#define PIO_PDR_P29_Pos                     29                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P29_Msk                     (_U_(0x1) << PIO_PDR_P29_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P29                         PIO_PDR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P29_Msk instead */
+#define PIO_PDR_P30_Pos                     30                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P30_Msk                     (_U_(0x1) << PIO_PDR_P30_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P30                         PIO_PDR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P30_Msk instead */
+#define PIO_PDR_P31_Pos                     31                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P31_Msk                     (_U_(0x1) << PIO_PDR_P31_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P31                         PIO_PDR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P31_Msk instead */
+#define PIO_PDR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PDR) Register MASK  (Use PIO_PDR_Msk instead)  */
+#define PIO_PDR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PDR) Register Mask  */
+
+#define PIO_PDR_P_Pos                       0                                              /**< (PIO_PDR Position) PIO Disable */
+#define PIO_PDR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PDR_P_Pos)             /**< (PIO_PDR Mask) P */
+#define PIO_PDR_P(value)                    (PIO_PDR_P_Msk & ((value) << PIO_PDR_P_Pos))   
+
+/* -------- PIO_PSR : (PIO Offset: 0x08) (R/ 32) PIO Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Status                               */
+    uint32_t P1:1;                      /**< bit:      1  PIO Status                               */
+    uint32_t P2:1;                      /**< bit:      2  PIO Status                               */
+    uint32_t P3:1;                      /**< bit:      3  PIO Status                               */
+    uint32_t P4:1;                      /**< bit:      4  PIO Status                               */
+    uint32_t P5:1;                      /**< bit:      5  PIO Status                               */
+    uint32_t P6:1;                      /**< bit:      6  PIO Status                               */
+    uint32_t P7:1;                      /**< bit:      7  PIO Status                               */
+    uint32_t P8:1;                      /**< bit:      8  PIO Status                               */
+    uint32_t P9:1;                      /**< bit:      9  PIO Status                               */
+    uint32_t P10:1;                     /**< bit:     10  PIO Status                               */
+    uint32_t P11:1;                     /**< bit:     11  PIO Status                               */
+    uint32_t P12:1;                     /**< bit:     12  PIO Status                               */
+    uint32_t P13:1;                     /**< bit:     13  PIO Status                               */
+    uint32_t P14:1;                     /**< bit:     14  PIO Status                               */
+    uint32_t P15:1;                     /**< bit:     15  PIO Status                               */
+    uint32_t P16:1;                     /**< bit:     16  PIO Status                               */
+    uint32_t P17:1;                     /**< bit:     17  PIO Status                               */
+    uint32_t P18:1;                     /**< bit:     18  PIO Status                               */
+    uint32_t P19:1;                     /**< bit:     19  PIO Status                               */
+    uint32_t P20:1;                     /**< bit:     20  PIO Status                               */
+    uint32_t P21:1;                     /**< bit:     21  PIO Status                               */
+    uint32_t P22:1;                     /**< bit:     22  PIO Status                               */
+    uint32_t P23:1;                     /**< bit:     23  PIO Status                               */
+    uint32_t P24:1;                     /**< bit:     24  PIO Status                               */
+    uint32_t P25:1;                     /**< bit:     25  PIO Status                               */
+    uint32_t P26:1;                     /**< bit:     26  PIO Status                               */
+    uint32_t P27:1;                     /**< bit:     27  PIO Status                               */
+    uint32_t P28:1;                     /**< bit:     28  PIO Status                               */
+    uint32_t P29:1;                     /**< bit:     29  PIO Status                               */
+    uint32_t P30:1;                     /**< bit:     30  PIO Status                               */
+    uint32_t P31:1;                     /**< bit:     31  PIO Status                               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Status                               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PSR_OFFSET                      (0x08)                                        /**<  (PIO_PSR) PIO Status Register  Offset */
+
+#define PIO_PSR_P0_Pos                      0                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P0_Msk                      (_U_(0x1) << PIO_PSR_P0_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P0                          PIO_PSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P0_Msk instead */
+#define PIO_PSR_P1_Pos                      1                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P1_Msk                      (_U_(0x1) << PIO_PSR_P1_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P1                          PIO_PSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P1_Msk instead */
+#define PIO_PSR_P2_Pos                      2                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P2_Msk                      (_U_(0x1) << PIO_PSR_P2_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P2                          PIO_PSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P2_Msk instead */
+#define PIO_PSR_P3_Pos                      3                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P3_Msk                      (_U_(0x1) << PIO_PSR_P3_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P3                          PIO_PSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P3_Msk instead */
+#define PIO_PSR_P4_Pos                      4                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P4_Msk                      (_U_(0x1) << PIO_PSR_P4_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P4                          PIO_PSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P4_Msk instead */
+#define PIO_PSR_P5_Pos                      5                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P5_Msk                      (_U_(0x1) << PIO_PSR_P5_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P5                          PIO_PSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P5_Msk instead */
+#define PIO_PSR_P6_Pos                      6                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P6_Msk                      (_U_(0x1) << PIO_PSR_P6_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P6                          PIO_PSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P6_Msk instead */
+#define PIO_PSR_P7_Pos                      7                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P7_Msk                      (_U_(0x1) << PIO_PSR_P7_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P7                          PIO_PSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P7_Msk instead */
+#define PIO_PSR_P8_Pos                      8                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P8_Msk                      (_U_(0x1) << PIO_PSR_P8_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P8                          PIO_PSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P8_Msk instead */
+#define PIO_PSR_P9_Pos                      9                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P9_Msk                      (_U_(0x1) << PIO_PSR_P9_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P9                          PIO_PSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P9_Msk instead */
+#define PIO_PSR_P10_Pos                     10                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P10_Msk                     (_U_(0x1) << PIO_PSR_P10_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P10                         PIO_PSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P10_Msk instead */
+#define PIO_PSR_P11_Pos                     11                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P11_Msk                     (_U_(0x1) << PIO_PSR_P11_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P11                         PIO_PSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P11_Msk instead */
+#define PIO_PSR_P12_Pos                     12                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P12_Msk                     (_U_(0x1) << PIO_PSR_P12_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P12                         PIO_PSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P12_Msk instead */
+#define PIO_PSR_P13_Pos                     13                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P13_Msk                     (_U_(0x1) << PIO_PSR_P13_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P13                         PIO_PSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P13_Msk instead */
+#define PIO_PSR_P14_Pos                     14                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P14_Msk                     (_U_(0x1) << PIO_PSR_P14_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P14                         PIO_PSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P14_Msk instead */
+#define PIO_PSR_P15_Pos                     15                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P15_Msk                     (_U_(0x1) << PIO_PSR_P15_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P15                         PIO_PSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P15_Msk instead */
+#define PIO_PSR_P16_Pos                     16                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P16_Msk                     (_U_(0x1) << PIO_PSR_P16_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P16                         PIO_PSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P16_Msk instead */
+#define PIO_PSR_P17_Pos                     17                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P17_Msk                     (_U_(0x1) << PIO_PSR_P17_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P17                         PIO_PSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P17_Msk instead */
+#define PIO_PSR_P18_Pos                     18                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P18_Msk                     (_U_(0x1) << PIO_PSR_P18_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P18                         PIO_PSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P18_Msk instead */
+#define PIO_PSR_P19_Pos                     19                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P19_Msk                     (_U_(0x1) << PIO_PSR_P19_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P19                         PIO_PSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P19_Msk instead */
+#define PIO_PSR_P20_Pos                     20                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P20_Msk                     (_U_(0x1) << PIO_PSR_P20_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P20                         PIO_PSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P20_Msk instead */
+#define PIO_PSR_P21_Pos                     21                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P21_Msk                     (_U_(0x1) << PIO_PSR_P21_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P21                         PIO_PSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P21_Msk instead */
+#define PIO_PSR_P22_Pos                     22                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P22_Msk                     (_U_(0x1) << PIO_PSR_P22_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P22                         PIO_PSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P22_Msk instead */
+#define PIO_PSR_P23_Pos                     23                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P23_Msk                     (_U_(0x1) << PIO_PSR_P23_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P23                         PIO_PSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P23_Msk instead */
+#define PIO_PSR_P24_Pos                     24                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P24_Msk                     (_U_(0x1) << PIO_PSR_P24_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P24                         PIO_PSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P24_Msk instead */
+#define PIO_PSR_P25_Pos                     25                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P25_Msk                     (_U_(0x1) << PIO_PSR_P25_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P25                         PIO_PSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P25_Msk instead */
+#define PIO_PSR_P26_Pos                     26                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P26_Msk                     (_U_(0x1) << PIO_PSR_P26_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P26                         PIO_PSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P26_Msk instead */
+#define PIO_PSR_P27_Pos                     27                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P27_Msk                     (_U_(0x1) << PIO_PSR_P27_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P27                         PIO_PSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P27_Msk instead */
+#define PIO_PSR_P28_Pos                     28                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P28_Msk                     (_U_(0x1) << PIO_PSR_P28_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P28                         PIO_PSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P28_Msk instead */
+#define PIO_PSR_P29_Pos                     29                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P29_Msk                     (_U_(0x1) << PIO_PSR_P29_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P29                         PIO_PSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P29_Msk instead */
+#define PIO_PSR_P30_Pos                     30                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P30_Msk                     (_U_(0x1) << PIO_PSR_P30_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P30                         PIO_PSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P30_Msk instead */
+#define PIO_PSR_P31_Pos                     31                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P31_Msk                     (_U_(0x1) << PIO_PSR_P31_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P31                         PIO_PSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P31_Msk instead */
+#define PIO_PSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PSR) Register MASK  (Use PIO_PSR_Msk instead)  */
+#define PIO_PSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PSR) Register Mask  */
+
+#define PIO_PSR_P_Pos                       0                                              /**< (PIO_PSR Position) PIO Status */
+#define PIO_PSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PSR_P_Pos)             /**< (PIO_PSR Mask) P */
+#define PIO_PSR_P(value)                    (PIO_PSR_P_Msk & ((value) << PIO_PSR_P_Pos))   
+
+/* -------- PIO_OER : (PIO Offset: 0x10) (/W 32) Output Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Enable                            */
+    uint32_t P1:1;                      /**< bit:      1  Output Enable                            */
+    uint32_t P2:1;                      /**< bit:      2  Output Enable                            */
+    uint32_t P3:1;                      /**< bit:      3  Output Enable                            */
+    uint32_t P4:1;                      /**< bit:      4  Output Enable                            */
+    uint32_t P5:1;                      /**< bit:      5  Output Enable                            */
+    uint32_t P6:1;                      /**< bit:      6  Output Enable                            */
+    uint32_t P7:1;                      /**< bit:      7  Output Enable                            */
+    uint32_t P8:1;                      /**< bit:      8  Output Enable                            */
+    uint32_t P9:1;                      /**< bit:      9  Output Enable                            */
+    uint32_t P10:1;                     /**< bit:     10  Output Enable                            */
+    uint32_t P11:1;                     /**< bit:     11  Output Enable                            */
+    uint32_t P12:1;                     /**< bit:     12  Output Enable                            */
+    uint32_t P13:1;                     /**< bit:     13  Output Enable                            */
+    uint32_t P14:1;                     /**< bit:     14  Output Enable                            */
+    uint32_t P15:1;                     /**< bit:     15  Output Enable                            */
+    uint32_t P16:1;                     /**< bit:     16  Output Enable                            */
+    uint32_t P17:1;                     /**< bit:     17  Output Enable                            */
+    uint32_t P18:1;                     /**< bit:     18  Output Enable                            */
+    uint32_t P19:1;                     /**< bit:     19  Output Enable                            */
+    uint32_t P20:1;                     /**< bit:     20  Output Enable                            */
+    uint32_t P21:1;                     /**< bit:     21  Output Enable                            */
+    uint32_t P22:1;                     /**< bit:     22  Output Enable                            */
+    uint32_t P23:1;                     /**< bit:     23  Output Enable                            */
+    uint32_t P24:1;                     /**< bit:     24  Output Enable                            */
+    uint32_t P25:1;                     /**< bit:     25  Output Enable                            */
+    uint32_t P26:1;                     /**< bit:     26  Output Enable                            */
+    uint32_t P27:1;                     /**< bit:     27  Output Enable                            */
+    uint32_t P28:1;                     /**< bit:     28  Output Enable                            */
+    uint32_t P29:1;                     /**< bit:     29  Output Enable                            */
+    uint32_t P30:1;                     /**< bit:     30  Output Enable                            */
+    uint32_t P31:1;                     /**< bit:     31  Output Enable                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Enable                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OER_OFFSET                      (0x10)                                        /**<  (PIO_OER) Output Enable Register  Offset */
+
+#define PIO_OER_P0_Pos                      0                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P0_Msk                      (_U_(0x1) << PIO_OER_P0_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P0                          PIO_OER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P0_Msk instead */
+#define PIO_OER_P1_Pos                      1                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P1_Msk                      (_U_(0x1) << PIO_OER_P1_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P1                          PIO_OER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P1_Msk instead */
+#define PIO_OER_P2_Pos                      2                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P2_Msk                      (_U_(0x1) << PIO_OER_P2_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P2                          PIO_OER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P2_Msk instead */
+#define PIO_OER_P3_Pos                      3                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P3_Msk                      (_U_(0x1) << PIO_OER_P3_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P3                          PIO_OER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P3_Msk instead */
+#define PIO_OER_P4_Pos                      4                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P4_Msk                      (_U_(0x1) << PIO_OER_P4_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P4                          PIO_OER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P4_Msk instead */
+#define PIO_OER_P5_Pos                      5                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P5_Msk                      (_U_(0x1) << PIO_OER_P5_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P5                          PIO_OER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P5_Msk instead */
+#define PIO_OER_P6_Pos                      6                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P6_Msk                      (_U_(0x1) << PIO_OER_P6_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P6                          PIO_OER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P6_Msk instead */
+#define PIO_OER_P7_Pos                      7                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P7_Msk                      (_U_(0x1) << PIO_OER_P7_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P7                          PIO_OER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P7_Msk instead */
+#define PIO_OER_P8_Pos                      8                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P8_Msk                      (_U_(0x1) << PIO_OER_P8_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P8                          PIO_OER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P8_Msk instead */
+#define PIO_OER_P9_Pos                      9                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P9_Msk                      (_U_(0x1) << PIO_OER_P9_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P9                          PIO_OER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P9_Msk instead */
+#define PIO_OER_P10_Pos                     10                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P10_Msk                     (_U_(0x1) << PIO_OER_P10_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P10                         PIO_OER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P10_Msk instead */
+#define PIO_OER_P11_Pos                     11                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P11_Msk                     (_U_(0x1) << PIO_OER_P11_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P11                         PIO_OER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P11_Msk instead */
+#define PIO_OER_P12_Pos                     12                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P12_Msk                     (_U_(0x1) << PIO_OER_P12_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P12                         PIO_OER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P12_Msk instead */
+#define PIO_OER_P13_Pos                     13                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P13_Msk                     (_U_(0x1) << PIO_OER_P13_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P13                         PIO_OER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P13_Msk instead */
+#define PIO_OER_P14_Pos                     14                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P14_Msk                     (_U_(0x1) << PIO_OER_P14_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P14                         PIO_OER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P14_Msk instead */
+#define PIO_OER_P15_Pos                     15                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P15_Msk                     (_U_(0x1) << PIO_OER_P15_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P15                         PIO_OER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P15_Msk instead */
+#define PIO_OER_P16_Pos                     16                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P16_Msk                     (_U_(0x1) << PIO_OER_P16_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P16                         PIO_OER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P16_Msk instead */
+#define PIO_OER_P17_Pos                     17                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P17_Msk                     (_U_(0x1) << PIO_OER_P17_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P17                         PIO_OER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P17_Msk instead */
+#define PIO_OER_P18_Pos                     18                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P18_Msk                     (_U_(0x1) << PIO_OER_P18_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P18                         PIO_OER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P18_Msk instead */
+#define PIO_OER_P19_Pos                     19                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P19_Msk                     (_U_(0x1) << PIO_OER_P19_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P19                         PIO_OER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P19_Msk instead */
+#define PIO_OER_P20_Pos                     20                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P20_Msk                     (_U_(0x1) << PIO_OER_P20_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P20                         PIO_OER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P20_Msk instead */
+#define PIO_OER_P21_Pos                     21                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P21_Msk                     (_U_(0x1) << PIO_OER_P21_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P21                         PIO_OER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P21_Msk instead */
+#define PIO_OER_P22_Pos                     22                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P22_Msk                     (_U_(0x1) << PIO_OER_P22_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P22                         PIO_OER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P22_Msk instead */
+#define PIO_OER_P23_Pos                     23                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P23_Msk                     (_U_(0x1) << PIO_OER_P23_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P23                         PIO_OER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P23_Msk instead */
+#define PIO_OER_P24_Pos                     24                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P24_Msk                     (_U_(0x1) << PIO_OER_P24_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P24                         PIO_OER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P24_Msk instead */
+#define PIO_OER_P25_Pos                     25                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P25_Msk                     (_U_(0x1) << PIO_OER_P25_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P25                         PIO_OER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P25_Msk instead */
+#define PIO_OER_P26_Pos                     26                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P26_Msk                     (_U_(0x1) << PIO_OER_P26_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P26                         PIO_OER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P26_Msk instead */
+#define PIO_OER_P27_Pos                     27                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P27_Msk                     (_U_(0x1) << PIO_OER_P27_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P27                         PIO_OER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P27_Msk instead */
+#define PIO_OER_P28_Pos                     28                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P28_Msk                     (_U_(0x1) << PIO_OER_P28_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P28                         PIO_OER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P28_Msk instead */
+#define PIO_OER_P29_Pos                     29                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P29_Msk                     (_U_(0x1) << PIO_OER_P29_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P29                         PIO_OER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P29_Msk instead */
+#define PIO_OER_P30_Pos                     30                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P30_Msk                     (_U_(0x1) << PIO_OER_P30_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P30                         PIO_OER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P30_Msk instead */
+#define PIO_OER_P31_Pos                     31                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P31_Msk                     (_U_(0x1) << PIO_OER_P31_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P31                         PIO_OER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P31_Msk instead */
+#define PIO_OER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OER) Register MASK  (Use PIO_OER_Msk instead)  */
+#define PIO_OER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_OER) Register Mask  */
+
+#define PIO_OER_P_Pos                       0                                              /**< (PIO_OER Position) Output Enable */
+#define PIO_OER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_OER_P_Pos)             /**< (PIO_OER Mask) P */
+#define PIO_OER_P(value)                    (PIO_OER_P_Msk & ((value) << PIO_OER_P_Pos))   
+
+/* -------- PIO_ODR : (PIO Offset: 0x14) (/W 32) Output Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Disable                           */
+    uint32_t P1:1;                      /**< bit:      1  Output Disable                           */
+    uint32_t P2:1;                      /**< bit:      2  Output Disable                           */
+    uint32_t P3:1;                      /**< bit:      3  Output Disable                           */
+    uint32_t P4:1;                      /**< bit:      4  Output Disable                           */
+    uint32_t P5:1;                      /**< bit:      5  Output Disable                           */
+    uint32_t P6:1;                      /**< bit:      6  Output Disable                           */
+    uint32_t P7:1;                      /**< bit:      7  Output Disable                           */
+    uint32_t P8:1;                      /**< bit:      8  Output Disable                           */
+    uint32_t P9:1;                      /**< bit:      9  Output Disable                           */
+    uint32_t P10:1;                     /**< bit:     10  Output Disable                           */
+    uint32_t P11:1;                     /**< bit:     11  Output Disable                           */
+    uint32_t P12:1;                     /**< bit:     12  Output Disable                           */
+    uint32_t P13:1;                     /**< bit:     13  Output Disable                           */
+    uint32_t P14:1;                     /**< bit:     14  Output Disable                           */
+    uint32_t P15:1;                     /**< bit:     15  Output Disable                           */
+    uint32_t P16:1;                     /**< bit:     16  Output Disable                           */
+    uint32_t P17:1;                     /**< bit:     17  Output Disable                           */
+    uint32_t P18:1;                     /**< bit:     18  Output Disable                           */
+    uint32_t P19:1;                     /**< bit:     19  Output Disable                           */
+    uint32_t P20:1;                     /**< bit:     20  Output Disable                           */
+    uint32_t P21:1;                     /**< bit:     21  Output Disable                           */
+    uint32_t P22:1;                     /**< bit:     22  Output Disable                           */
+    uint32_t P23:1;                     /**< bit:     23  Output Disable                           */
+    uint32_t P24:1;                     /**< bit:     24  Output Disable                           */
+    uint32_t P25:1;                     /**< bit:     25  Output Disable                           */
+    uint32_t P26:1;                     /**< bit:     26  Output Disable                           */
+    uint32_t P27:1;                     /**< bit:     27  Output Disable                           */
+    uint32_t P28:1;                     /**< bit:     28  Output Disable                           */
+    uint32_t P29:1;                     /**< bit:     29  Output Disable                           */
+    uint32_t P30:1;                     /**< bit:     30  Output Disable                           */
+    uint32_t P31:1;                     /**< bit:     31  Output Disable                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Disable                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ODR_OFFSET                      (0x14)                                        /**<  (PIO_ODR) Output Disable Register  Offset */
+
+#define PIO_ODR_P0_Pos                      0                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P0_Msk                      (_U_(0x1) << PIO_ODR_P0_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P0                          PIO_ODR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P0_Msk instead */
+#define PIO_ODR_P1_Pos                      1                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P1_Msk                      (_U_(0x1) << PIO_ODR_P1_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P1                          PIO_ODR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P1_Msk instead */
+#define PIO_ODR_P2_Pos                      2                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P2_Msk                      (_U_(0x1) << PIO_ODR_P2_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P2                          PIO_ODR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P2_Msk instead */
+#define PIO_ODR_P3_Pos                      3                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P3_Msk                      (_U_(0x1) << PIO_ODR_P3_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P3                          PIO_ODR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P3_Msk instead */
+#define PIO_ODR_P4_Pos                      4                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P4_Msk                      (_U_(0x1) << PIO_ODR_P4_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P4                          PIO_ODR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P4_Msk instead */
+#define PIO_ODR_P5_Pos                      5                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P5_Msk                      (_U_(0x1) << PIO_ODR_P5_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P5                          PIO_ODR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P5_Msk instead */
+#define PIO_ODR_P6_Pos                      6                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P6_Msk                      (_U_(0x1) << PIO_ODR_P6_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P6                          PIO_ODR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P6_Msk instead */
+#define PIO_ODR_P7_Pos                      7                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P7_Msk                      (_U_(0x1) << PIO_ODR_P7_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P7                          PIO_ODR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P7_Msk instead */
+#define PIO_ODR_P8_Pos                      8                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P8_Msk                      (_U_(0x1) << PIO_ODR_P8_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P8                          PIO_ODR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P8_Msk instead */
+#define PIO_ODR_P9_Pos                      9                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P9_Msk                      (_U_(0x1) << PIO_ODR_P9_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P9                          PIO_ODR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P9_Msk instead */
+#define PIO_ODR_P10_Pos                     10                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P10_Msk                     (_U_(0x1) << PIO_ODR_P10_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P10                         PIO_ODR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P10_Msk instead */
+#define PIO_ODR_P11_Pos                     11                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P11_Msk                     (_U_(0x1) << PIO_ODR_P11_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P11                         PIO_ODR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P11_Msk instead */
+#define PIO_ODR_P12_Pos                     12                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P12_Msk                     (_U_(0x1) << PIO_ODR_P12_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P12                         PIO_ODR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P12_Msk instead */
+#define PIO_ODR_P13_Pos                     13                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P13_Msk                     (_U_(0x1) << PIO_ODR_P13_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P13                         PIO_ODR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P13_Msk instead */
+#define PIO_ODR_P14_Pos                     14                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P14_Msk                     (_U_(0x1) << PIO_ODR_P14_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P14                         PIO_ODR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P14_Msk instead */
+#define PIO_ODR_P15_Pos                     15                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P15_Msk                     (_U_(0x1) << PIO_ODR_P15_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P15                         PIO_ODR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P15_Msk instead */
+#define PIO_ODR_P16_Pos                     16                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P16_Msk                     (_U_(0x1) << PIO_ODR_P16_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P16                         PIO_ODR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P16_Msk instead */
+#define PIO_ODR_P17_Pos                     17                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P17_Msk                     (_U_(0x1) << PIO_ODR_P17_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P17                         PIO_ODR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P17_Msk instead */
+#define PIO_ODR_P18_Pos                     18                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P18_Msk                     (_U_(0x1) << PIO_ODR_P18_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P18                         PIO_ODR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P18_Msk instead */
+#define PIO_ODR_P19_Pos                     19                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P19_Msk                     (_U_(0x1) << PIO_ODR_P19_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P19                         PIO_ODR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P19_Msk instead */
+#define PIO_ODR_P20_Pos                     20                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P20_Msk                     (_U_(0x1) << PIO_ODR_P20_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P20                         PIO_ODR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P20_Msk instead */
+#define PIO_ODR_P21_Pos                     21                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P21_Msk                     (_U_(0x1) << PIO_ODR_P21_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P21                         PIO_ODR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P21_Msk instead */
+#define PIO_ODR_P22_Pos                     22                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P22_Msk                     (_U_(0x1) << PIO_ODR_P22_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P22                         PIO_ODR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P22_Msk instead */
+#define PIO_ODR_P23_Pos                     23                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P23_Msk                     (_U_(0x1) << PIO_ODR_P23_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P23                         PIO_ODR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P23_Msk instead */
+#define PIO_ODR_P24_Pos                     24                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P24_Msk                     (_U_(0x1) << PIO_ODR_P24_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P24                         PIO_ODR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P24_Msk instead */
+#define PIO_ODR_P25_Pos                     25                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P25_Msk                     (_U_(0x1) << PIO_ODR_P25_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P25                         PIO_ODR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P25_Msk instead */
+#define PIO_ODR_P26_Pos                     26                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P26_Msk                     (_U_(0x1) << PIO_ODR_P26_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P26                         PIO_ODR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P26_Msk instead */
+#define PIO_ODR_P27_Pos                     27                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P27_Msk                     (_U_(0x1) << PIO_ODR_P27_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P27                         PIO_ODR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P27_Msk instead */
+#define PIO_ODR_P28_Pos                     28                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P28_Msk                     (_U_(0x1) << PIO_ODR_P28_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P28                         PIO_ODR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P28_Msk instead */
+#define PIO_ODR_P29_Pos                     29                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P29_Msk                     (_U_(0x1) << PIO_ODR_P29_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P29                         PIO_ODR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P29_Msk instead */
+#define PIO_ODR_P30_Pos                     30                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P30_Msk                     (_U_(0x1) << PIO_ODR_P30_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P30                         PIO_ODR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P30_Msk instead */
+#define PIO_ODR_P31_Pos                     31                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P31_Msk                     (_U_(0x1) << PIO_ODR_P31_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P31                         PIO_ODR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P31_Msk instead */
+#define PIO_ODR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ODR) Register MASK  (Use PIO_ODR_Msk instead)  */
+#define PIO_ODR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ODR) Register Mask  */
+
+#define PIO_ODR_P_Pos                       0                                              /**< (PIO_ODR Position) Output Disable */
+#define PIO_ODR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ODR_P_Pos)             /**< (PIO_ODR Mask) P */
+#define PIO_ODR_P(value)                    (PIO_ODR_P_Msk & ((value) << PIO_ODR_P_Pos))   
+
+/* -------- PIO_OSR : (PIO Offset: 0x18) (R/ 32) Output Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Status                            */
+    uint32_t P1:1;                      /**< bit:      1  Output Status                            */
+    uint32_t P2:1;                      /**< bit:      2  Output Status                            */
+    uint32_t P3:1;                      /**< bit:      3  Output Status                            */
+    uint32_t P4:1;                      /**< bit:      4  Output Status                            */
+    uint32_t P5:1;                      /**< bit:      5  Output Status                            */
+    uint32_t P6:1;                      /**< bit:      6  Output Status                            */
+    uint32_t P7:1;                      /**< bit:      7  Output Status                            */
+    uint32_t P8:1;                      /**< bit:      8  Output Status                            */
+    uint32_t P9:1;                      /**< bit:      9  Output Status                            */
+    uint32_t P10:1;                     /**< bit:     10  Output Status                            */
+    uint32_t P11:1;                     /**< bit:     11  Output Status                            */
+    uint32_t P12:1;                     /**< bit:     12  Output Status                            */
+    uint32_t P13:1;                     /**< bit:     13  Output Status                            */
+    uint32_t P14:1;                     /**< bit:     14  Output Status                            */
+    uint32_t P15:1;                     /**< bit:     15  Output Status                            */
+    uint32_t P16:1;                     /**< bit:     16  Output Status                            */
+    uint32_t P17:1;                     /**< bit:     17  Output Status                            */
+    uint32_t P18:1;                     /**< bit:     18  Output Status                            */
+    uint32_t P19:1;                     /**< bit:     19  Output Status                            */
+    uint32_t P20:1;                     /**< bit:     20  Output Status                            */
+    uint32_t P21:1;                     /**< bit:     21  Output Status                            */
+    uint32_t P22:1;                     /**< bit:     22  Output Status                            */
+    uint32_t P23:1;                     /**< bit:     23  Output Status                            */
+    uint32_t P24:1;                     /**< bit:     24  Output Status                            */
+    uint32_t P25:1;                     /**< bit:     25  Output Status                            */
+    uint32_t P26:1;                     /**< bit:     26  Output Status                            */
+    uint32_t P27:1;                     /**< bit:     27  Output Status                            */
+    uint32_t P28:1;                     /**< bit:     28  Output Status                            */
+    uint32_t P29:1;                     /**< bit:     29  Output Status                            */
+    uint32_t P30:1;                     /**< bit:     30  Output Status                            */
+    uint32_t P31:1;                     /**< bit:     31  Output Status                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Status                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OSR_OFFSET                      (0x18)                                        /**<  (PIO_OSR) Output Status Register  Offset */
+
+#define PIO_OSR_P0_Pos                      0                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P0_Msk                      (_U_(0x1) << PIO_OSR_P0_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P0                          PIO_OSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P0_Msk instead */
+#define PIO_OSR_P1_Pos                      1                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P1_Msk                      (_U_(0x1) << PIO_OSR_P1_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P1                          PIO_OSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P1_Msk instead */
+#define PIO_OSR_P2_Pos                      2                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P2_Msk                      (_U_(0x1) << PIO_OSR_P2_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P2                          PIO_OSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P2_Msk instead */
+#define PIO_OSR_P3_Pos                      3                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P3_Msk                      (_U_(0x1) << PIO_OSR_P3_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P3                          PIO_OSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P3_Msk instead */
+#define PIO_OSR_P4_Pos                      4                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P4_Msk                      (_U_(0x1) << PIO_OSR_P4_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P4                          PIO_OSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P4_Msk instead */
+#define PIO_OSR_P5_Pos                      5                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P5_Msk                      (_U_(0x1) << PIO_OSR_P5_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P5                          PIO_OSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P5_Msk instead */
+#define PIO_OSR_P6_Pos                      6                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P6_Msk                      (_U_(0x1) << PIO_OSR_P6_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P6                          PIO_OSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P6_Msk instead */
+#define PIO_OSR_P7_Pos                      7                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P7_Msk                      (_U_(0x1) << PIO_OSR_P7_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P7                          PIO_OSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P7_Msk instead */
+#define PIO_OSR_P8_Pos                      8                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P8_Msk                      (_U_(0x1) << PIO_OSR_P8_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P8                          PIO_OSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P8_Msk instead */
+#define PIO_OSR_P9_Pos                      9                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P9_Msk                      (_U_(0x1) << PIO_OSR_P9_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P9                          PIO_OSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P9_Msk instead */
+#define PIO_OSR_P10_Pos                     10                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P10_Msk                     (_U_(0x1) << PIO_OSR_P10_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P10                         PIO_OSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P10_Msk instead */
+#define PIO_OSR_P11_Pos                     11                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P11_Msk                     (_U_(0x1) << PIO_OSR_P11_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P11                         PIO_OSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P11_Msk instead */
+#define PIO_OSR_P12_Pos                     12                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P12_Msk                     (_U_(0x1) << PIO_OSR_P12_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P12                         PIO_OSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P12_Msk instead */
+#define PIO_OSR_P13_Pos                     13                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P13_Msk                     (_U_(0x1) << PIO_OSR_P13_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P13                         PIO_OSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P13_Msk instead */
+#define PIO_OSR_P14_Pos                     14                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P14_Msk                     (_U_(0x1) << PIO_OSR_P14_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P14                         PIO_OSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P14_Msk instead */
+#define PIO_OSR_P15_Pos                     15                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P15_Msk                     (_U_(0x1) << PIO_OSR_P15_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P15                         PIO_OSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P15_Msk instead */
+#define PIO_OSR_P16_Pos                     16                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P16_Msk                     (_U_(0x1) << PIO_OSR_P16_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P16                         PIO_OSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P16_Msk instead */
+#define PIO_OSR_P17_Pos                     17                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P17_Msk                     (_U_(0x1) << PIO_OSR_P17_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P17                         PIO_OSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P17_Msk instead */
+#define PIO_OSR_P18_Pos                     18                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P18_Msk                     (_U_(0x1) << PIO_OSR_P18_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P18                         PIO_OSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P18_Msk instead */
+#define PIO_OSR_P19_Pos                     19                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P19_Msk                     (_U_(0x1) << PIO_OSR_P19_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P19                         PIO_OSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P19_Msk instead */
+#define PIO_OSR_P20_Pos                     20                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P20_Msk                     (_U_(0x1) << PIO_OSR_P20_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P20                         PIO_OSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P20_Msk instead */
+#define PIO_OSR_P21_Pos                     21                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P21_Msk                     (_U_(0x1) << PIO_OSR_P21_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P21                         PIO_OSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P21_Msk instead */
+#define PIO_OSR_P22_Pos                     22                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P22_Msk                     (_U_(0x1) << PIO_OSR_P22_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P22                         PIO_OSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P22_Msk instead */
+#define PIO_OSR_P23_Pos                     23                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P23_Msk                     (_U_(0x1) << PIO_OSR_P23_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P23                         PIO_OSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P23_Msk instead */
+#define PIO_OSR_P24_Pos                     24                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P24_Msk                     (_U_(0x1) << PIO_OSR_P24_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P24                         PIO_OSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P24_Msk instead */
+#define PIO_OSR_P25_Pos                     25                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P25_Msk                     (_U_(0x1) << PIO_OSR_P25_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P25                         PIO_OSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P25_Msk instead */
+#define PIO_OSR_P26_Pos                     26                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P26_Msk                     (_U_(0x1) << PIO_OSR_P26_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P26                         PIO_OSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P26_Msk instead */
+#define PIO_OSR_P27_Pos                     27                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P27_Msk                     (_U_(0x1) << PIO_OSR_P27_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P27                         PIO_OSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P27_Msk instead */
+#define PIO_OSR_P28_Pos                     28                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P28_Msk                     (_U_(0x1) << PIO_OSR_P28_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P28                         PIO_OSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P28_Msk instead */
+#define PIO_OSR_P29_Pos                     29                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P29_Msk                     (_U_(0x1) << PIO_OSR_P29_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P29                         PIO_OSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P29_Msk instead */
+#define PIO_OSR_P30_Pos                     30                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P30_Msk                     (_U_(0x1) << PIO_OSR_P30_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P30                         PIO_OSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P30_Msk instead */
+#define PIO_OSR_P31_Pos                     31                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P31_Msk                     (_U_(0x1) << PIO_OSR_P31_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P31                         PIO_OSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P31_Msk instead */
+#define PIO_OSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OSR) Register MASK  (Use PIO_OSR_Msk instead)  */
+#define PIO_OSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_OSR) Register Mask  */
+
+#define PIO_OSR_P_Pos                       0                                              /**< (PIO_OSR Position) Output Status */
+#define PIO_OSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_OSR_P_Pos)             /**< (PIO_OSR Mask) P */
+#define PIO_OSR_P(value)                    (PIO_OSR_P_Msk & ((value) << PIO_OSR_P_Pos))   
+
+/* -------- PIO_IFER : (PIO Offset: 0x20) (/W 32) Glitch Input Filter Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Enable                      */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Enable                      */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Enable                      */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Enable                      */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Enable                      */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Enable                      */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Enable                      */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Enable                      */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Enable                      */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Enable                      */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Enable                      */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Enable                      */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Enable                      */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Enable                      */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Enable                      */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Enable                      */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Enable                      */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Enable                      */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Enable                      */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Enable                      */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Enable                      */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Enable                      */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Enable                      */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Enable                      */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Enable                      */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Enable                      */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Enable                      */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Enable                      */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Enable                      */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Enable                      */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Enable                      */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Enable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Enable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFER_OFFSET                     (0x20)                                        /**<  (PIO_IFER) Glitch Input Filter Enable Register  Offset */
+
+#define PIO_IFER_P0_Pos                     0                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P0_Msk                     (_U_(0x1) << PIO_IFER_P0_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P0                         PIO_IFER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P0_Msk instead */
+#define PIO_IFER_P1_Pos                     1                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P1_Msk                     (_U_(0x1) << PIO_IFER_P1_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P1                         PIO_IFER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P1_Msk instead */
+#define PIO_IFER_P2_Pos                     2                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P2_Msk                     (_U_(0x1) << PIO_IFER_P2_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P2                         PIO_IFER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P2_Msk instead */
+#define PIO_IFER_P3_Pos                     3                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P3_Msk                     (_U_(0x1) << PIO_IFER_P3_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P3                         PIO_IFER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P3_Msk instead */
+#define PIO_IFER_P4_Pos                     4                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P4_Msk                     (_U_(0x1) << PIO_IFER_P4_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P4                         PIO_IFER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P4_Msk instead */
+#define PIO_IFER_P5_Pos                     5                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P5_Msk                     (_U_(0x1) << PIO_IFER_P5_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P5                         PIO_IFER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P5_Msk instead */
+#define PIO_IFER_P6_Pos                     6                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P6_Msk                     (_U_(0x1) << PIO_IFER_P6_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P6                         PIO_IFER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P6_Msk instead */
+#define PIO_IFER_P7_Pos                     7                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P7_Msk                     (_U_(0x1) << PIO_IFER_P7_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P7                         PIO_IFER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P7_Msk instead */
+#define PIO_IFER_P8_Pos                     8                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P8_Msk                     (_U_(0x1) << PIO_IFER_P8_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P8                         PIO_IFER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P8_Msk instead */
+#define PIO_IFER_P9_Pos                     9                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P9_Msk                     (_U_(0x1) << PIO_IFER_P9_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P9                         PIO_IFER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P9_Msk instead */
+#define PIO_IFER_P10_Pos                    10                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P10_Msk                    (_U_(0x1) << PIO_IFER_P10_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P10                        PIO_IFER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P10_Msk instead */
+#define PIO_IFER_P11_Pos                    11                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P11_Msk                    (_U_(0x1) << PIO_IFER_P11_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P11                        PIO_IFER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P11_Msk instead */
+#define PIO_IFER_P12_Pos                    12                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P12_Msk                    (_U_(0x1) << PIO_IFER_P12_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P12                        PIO_IFER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P12_Msk instead */
+#define PIO_IFER_P13_Pos                    13                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P13_Msk                    (_U_(0x1) << PIO_IFER_P13_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P13                        PIO_IFER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P13_Msk instead */
+#define PIO_IFER_P14_Pos                    14                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P14_Msk                    (_U_(0x1) << PIO_IFER_P14_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P14                        PIO_IFER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P14_Msk instead */
+#define PIO_IFER_P15_Pos                    15                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P15_Msk                    (_U_(0x1) << PIO_IFER_P15_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P15                        PIO_IFER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P15_Msk instead */
+#define PIO_IFER_P16_Pos                    16                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P16_Msk                    (_U_(0x1) << PIO_IFER_P16_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P16                        PIO_IFER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P16_Msk instead */
+#define PIO_IFER_P17_Pos                    17                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P17_Msk                    (_U_(0x1) << PIO_IFER_P17_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P17                        PIO_IFER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P17_Msk instead */
+#define PIO_IFER_P18_Pos                    18                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P18_Msk                    (_U_(0x1) << PIO_IFER_P18_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P18                        PIO_IFER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P18_Msk instead */
+#define PIO_IFER_P19_Pos                    19                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P19_Msk                    (_U_(0x1) << PIO_IFER_P19_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P19                        PIO_IFER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P19_Msk instead */
+#define PIO_IFER_P20_Pos                    20                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P20_Msk                    (_U_(0x1) << PIO_IFER_P20_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P20                        PIO_IFER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P20_Msk instead */
+#define PIO_IFER_P21_Pos                    21                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P21_Msk                    (_U_(0x1) << PIO_IFER_P21_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P21                        PIO_IFER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P21_Msk instead */
+#define PIO_IFER_P22_Pos                    22                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P22_Msk                    (_U_(0x1) << PIO_IFER_P22_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P22                        PIO_IFER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P22_Msk instead */
+#define PIO_IFER_P23_Pos                    23                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P23_Msk                    (_U_(0x1) << PIO_IFER_P23_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P23                        PIO_IFER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P23_Msk instead */
+#define PIO_IFER_P24_Pos                    24                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P24_Msk                    (_U_(0x1) << PIO_IFER_P24_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P24                        PIO_IFER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P24_Msk instead */
+#define PIO_IFER_P25_Pos                    25                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P25_Msk                    (_U_(0x1) << PIO_IFER_P25_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P25                        PIO_IFER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P25_Msk instead */
+#define PIO_IFER_P26_Pos                    26                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P26_Msk                    (_U_(0x1) << PIO_IFER_P26_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P26                        PIO_IFER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P26_Msk instead */
+#define PIO_IFER_P27_Pos                    27                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P27_Msk                    (_U_(0x1) << PIO_IFER_P27_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P27                        PIO_IFER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P27_Msk instead */
+#define PIO_IFER_P28_Pos                    28                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P28_Msk                    (_U_(0x1) << PIO_IFER_P28_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P28                        PIO_IFER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P28_Msk instead */
+#define PIO_IFER_P29_Pos                    29                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P29_Msk                    (_U_(0x1) << PIO_IFER_P29_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P29                        PIO_IFER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P29_Msk instead */
+#define PIO_IFER_P30_Pos                    30                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P30_Msk                    (_U_(0x1) << PIO_IFER_P30_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P30                        PIO_IFER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P30_Msk instead */
+#define PIO_IFER_P31_Pos                    31                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P31_Msk                    (_U_(0x1) << PIO_IFER_P31_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P31                        PIO_IFER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P31_Msk instead */
+#define PIO_IFER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFER) Register MASK  (Use PIO_IFER_Msk instead)  */
+#define PIO_IFER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFER) Register Mask  */
+
+#define PIO_IFER_P_Pos                      0                                              /**< (PIO_IFER Position) Input Filter Enable */
+#define PIO_IFER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFER_P_Pos)            /**< (PIO_IFER Mask) P */
+#define PIO_IFER_P(value)                   (PIO_IFER_P_Msk & ((value) << PIO_IFER_P_Pos))  
+
+/* -------- PIO_IFDR : (PIO Offset: 0x24) (/W 32) Glitch Input Filter Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Disable                     */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Disable                     */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Disable                     */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Disable                     */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Disable                     */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Disable                     */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Disable                     */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Disable                     */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Disable                     */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Disable                     */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Disable                     */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Disable                     */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Disable                     */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Disable                     */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Disable                     */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Disable                     */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Disable                     */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Disable                     */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Disable                     */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Disable                     */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Disable                     */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Disable                     */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Disable                     */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Disable                     */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Disable                     */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Disable                     */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Disable                     */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Disable                     */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Disable                     */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Disable                     */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Disable                     */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Disable                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Disable                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFDR_OFFSET                     (0x24)                                        /**<  (PIO_IFDR) Glitch Input Filter Disable Register  Offset */
+
+#define PIO_IFDR_P0_Pos                     0                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P0_Msk                     (_U_(0x1) << PIO_IFDR_P0_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P0                         PIO_IFDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P0_Msk instead */
+#define PIO_IFDR_P1_Pos                     1                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P1_Msk                     (_U_(0x1) << PIO_IFDR_P1_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P1                         PIO_IFDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P1_Msk instead */
+#define PIO_IFDR_P2_Pos                     2                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P2_Msk                     (_U_(0x1) << PIO_IFDR_P2_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P2                         PIO_IFDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P2_Msk instead */
+#define PIO_IFDR_P3_Pos                     3                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P3_Msk                     (_U_(0x1) << PIO_IFDR_P3_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P3                         PIO_IFDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P3_Msk instead */
+#define PIO_IFDR_P4_Pos                     4                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P4_Msk                     (_U_(0x1) << PIO_IFDR_P4_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P4                         PIO_IFDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P4_Msk instead */
+#define PIO_IFDR_P5_Pos                     5                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P5_Msk                     (_U_(0x1) << PIO_IFDR_P5_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P5                         PIO_IFDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P5_Msk instead */
+#define PIO_IFDR_P6_Pos                     6                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P6_Msk                     (_U_(0x1) << PIO_IFDR_P6_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P6                         PIO_IFDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P6_Msk instead */
+#define PIO_IFDR_P7_Pos                     7                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P7_Msk                     (_U_(0x1) << PIO_IFDR_P7_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P7                         PIO_IFDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P7_Msk instead */
+#define PIO_IFDR_P8_Pos                     8                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P8_Msk                     (_U_(0x1) << PIO_IFDR_P8_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P8                         PIO_IFDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P8_Msk instead */
+#define PIO_IFDR_P9_Pos                     9                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P9_Msk                     (_U_(0x1) << PIO_IFDR_P9_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P9                         PIO_IFDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P9_Msk instead */
+#define PIO_IFDR_P10_Pos                    10                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P10_Msk                    (_U_(0x1) << PIO_IFDR_P10_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P10                        PIO_IFDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P10_Msk instead */
+#define PIO_IFDR_P11_Pos                    11                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P11_Msk                    (_U_(0x1) << PIO_IFDR_P11_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P11                        PIO_IFDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P11_Msk instead */
+#define PIO_IFDR_P12_Pos                    12                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P12_Msk                    (_U_(0x1) << PIO_IFDR_P12_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P12                        PIO_IFDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P12_Msk instead */
+#define PIO_IFDR_P13_Pos                    13                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P13_Msk                    (_U_(0x1) << PIO_IFDR_P13_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P13                        PIO_IFDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P13_Msk instead */
+#define PIO_IFDR_P14_Pos                    14                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P14_Msk                    (_U_(0x1) << PIO_IFDR_P14_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P14                        PIO_IFDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P14_Msk instead */
+#define PIO_IFDR_P15_Pos                    15                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P15_Msk                    (_U_(0x1) << PIO_IFDR_P15_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P15                        PIO_IFDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P15_Msk instead */
+#define PIO_IFDR_P16_Pos                    16                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P16_Msk                    (_U_(0x1) << PIO_IFDR_P16_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P16                        PIO_IFDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P16_Msk instead */
+#define PIO_IFDR_P17_Pos                    17                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P17_Msk                    (_U_(0x1) << PIO_IFDR_P17_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P17                        PIO_IFDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P17_Msk instead */
+#define PIO_IFDR_P18_Pos                    18                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P18_Msk                    (_U_(0x1) << PIO_IFDR_P18_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P18                        PIO_IFDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P18_Msk instead */
+#define PIO_IFDR_P19_Pos                    19                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P19_Msk                    (_U_(0x1) << PIO_IFDR_P19_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P19                        PIO_IFDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P19_Msk instead */
+#define PIO_IFDR_P20_Pos                    20                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P20_Msk                    (_U_(0x1) << PIO_IFDR_P20_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P20                        PIO_IFDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P20_Msk instead */
+#define PIO_IFDR_P21_Pos                    21                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P21_Msk                    (_U_(0x1) << PIO_IFDR_P21_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P21                        PIO_IFDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P21_Msk instead */
+#define PIO_IFDR_P22_Pos                    22                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P22_Msk                    (_U_(0x1) << PIO_IFDR_P22_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P22                        PIO_IFDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P22_Msk instead */
+#define PIO_IFDR_P23_Pos                    23                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P23_Msk                    (_U_(0x1) << PIO_IFDR_P23_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P23                        PIO_IFDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P23_Msk instead */
+#define PIO_IFDR_P24_Pos                    24                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P24_Msk                    (_U_(0x1) << PIO_IFDR_P24_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P24                        PIO_IFDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P24_Msk instead */
+#define PIO_IFDR_P25_Pos                    25                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P25_Msk                    (_U_(0x1) << PIO_IFDR_P25_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P25                        PIO_IFDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P25_Msk instead */
+#define PIO_IFDR_P26_Pos                    26                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P26_Msk                    (_U_(0x1) << PIO_IFDR_P26_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P26                        PIO_IFDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P26_Msk instead */
+#define PIO_IFDR_P27_Pos                    27                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P27_Msk                    (_U_(0x1) << PIO_IFDR_P27_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P27                        PIO_IFDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P27_Msk instead */
+#define PIO_IFDR_P28_Pos                    28                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P28_Msk                    (_U_(0x1) << PIO_IFDR_P28_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P28                        PIO_IFDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P28_Msk instead */
+#define PIO_IFDR_P29_Pos                    29                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P29_Msk                    (_U_(0x1) << PIO_IFDR_P29_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P29                        PIO_IFDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P29_Msk instead */
+#define PIO_IFDR_P30_Pos                    30                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P30_Msk                    (_U_(0x1) << PIO_IFDR_P30_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P30                        PIO_IFDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P30_Msk instead */
+#define PIO_IFDR_P31_Pos                    31                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P31_Msk                    (_U_(0x1) << PIO_IFDR_P31_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P31                        PIO_IFDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P31_Msk instead */
+#define PIO_IFDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFDR) Register MASK  (Use PIO_IFDR_Msk instead)  */
+#define PIO_IFDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFDR) Register Mask  */
+
+#define PIO_IFDR_P_Pos                      0                                              /**< (PIO_IFDR Position) Input Filter Disable */
+#define PIO_IFDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFDR_P_Pos)            /**< (PIO_IFDR Mask) P */
+#define PIO_IFDR_P(value)                   (PIO_IFDR_P_Msk & ((value) << PIO_IFDR_P_Pos))  
+
+/* -------- PIO_IFSR : (PIO Offset: 0x28) (R/ 32) Glitch Input Filter Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Status                      */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Status                      */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Status                      */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Status                      */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Status                      */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Status                      */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Status                      */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Status                      */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Status                      */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Status                      */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Status                      */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Status                      */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Status                      */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Status                      */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Status                      */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Status                      */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Status                      */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Status                      */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Status                      */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Status                      */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Status                      */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Status                      */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Status                      */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Status                      */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Status                      */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Status                      */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Status                      */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Status                      */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Status                      */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Status                      */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Status                      */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Status                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Status                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSR_OFFSET                     (0x28)                                        /**<  (PIO_IFSR) Glitch Input Filter Status Register  Offset */
+
+#define PIO_IFSR_P0_Pos                     0                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P0_Msk                     (_U_(0x1) << PIO_IFSR_P0_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P0                         PIO_IFSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P0_Msk instead */
+#define PIO_IFSR_P1_Pos                     1                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P1_Msk                     (_U_(0x1) << PIO_IFSR_P1_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P1                         PIO_IFSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P1_Msk instead */
+#define PIO_IFSR_P2_Pos                     2                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P2_Msk                     (_U_(0x1) << PIO_IFSR_P2_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P2                         PIO_IFSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P2_Msk instead */
+#define PIO_IFSR_P3_Pos                     3                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P3_Msk                     (_U_(0x1) << PIO_IFSR_P3_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P3                         PIO_IFSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P3_Msk instead */
+#define PIO_IFSR_P4_Pos                     4                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P4_Msk                     (_U_(0x1) << PIO_IFSR_P4_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P4                         PIO_IFSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P4_Msk instead */
+#define PIO_IFSR_P5_Pos                     5                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P5_Msk                     (_U_(0x1) << PIO_IFSR_P5_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P5                         PIO_IFSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P5_Msk instead */
+#define PIO_IFSR_P6_Pos                     6                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P6_Msk                     (_U_(0x1) << PIO_IFSR_P6_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P6                         PIO_IFSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P6_Msk instead */
+#define PIO_IFSR_P7_Pos                     7                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P7_Msk                     (_U_(0x1) << PIO_IFSR_P7_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P7                         PIO_IFSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P7_Msk instead */
+#define PIO_IFSR_P8_Pos                     8                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P8_Msk                     (_U_(0x1) << PIO_IFSR_P8_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P8                         PIO_IFSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P8_Msk instead */
+#define PIO_IFSR_P9_Pos                     9                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P9_Msk                     (_U_(0x1) << PIO_IFSR_P9_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P9                         PIO_IFSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P9_Msk instead */
+#define PIO_IFSR_P10_Pos                    10                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P10_Msk                    (_U_(0x1) << PIO_IFSR_P10_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P10                        PIO_IFSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P10_Msk instead */
+#define PIO_IFSR_P11_Pos                    11                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P11_Msk                    (_U_(0x1) << PIO_IFSR_P11_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P11                        PIO_IFSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P11_Msk instead */
+#define PIO_IFSR_P12_Pos                    12                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P12_Msk                    (_U_(0x1) << PIO_IFSR_P12_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P12                        PIO_IFSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P12_Msk instead */
+#define PIO_IFSR_P13_Pos                    13                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P13_Msk                    (_U_(0x1) << PIO_IFSR_P13_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P13                        PIO_IFSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P13_Msk instead */
+#define PIO_IFSR_P14_Pos                    14                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P14_Msk                    (_U_(0x1) << PIO_IFSR_P14_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P14                        PIO_IFSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P14_Msk instead */
+#define PIO_IFSR_P15_Pos                    15                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P15_Msk                    (_U_(0x1) << PIO_IFSR_P15_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P15                        PIO_IFSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P15_Msk instead */
+#define PIO_IFSR_P16_Pos                    16                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P16_Msk                    (_U_(0x1) << PIO_IFSR_P16_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P16                        PIO_IFSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P16_Msk instead */
+#define PIO_IFSR_P17_Pos                    17                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P17_Msk                    (_U_(0x1) << PIO_IFSR_P17_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P17                        PIO_IFSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P17_Msk instead */
+#define PIO_IFSR_P18_Pos                    18                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P18_Msk                    (_U_(0x1) << PIO_IFSR_P18_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P18                        PIO_IFSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P18_Msk instead */
+#define PIO_IFSR_P19_Pos                    19                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P19_Msk                    (_U_(0x1) << PIO_IFSR_P19_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P19                        PIO_IFSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P19_Msk instead */
+#define PIO_IFSR_P20_Pos                    20                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P20_Msk                    (_U_(0x1) << PIO_IFSR_P20_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P20                        PIO_IFSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P20_Msk instead */
+#define PIO_IFSR_P21_Pos                    21                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P21_Msk                    (_U_(0x1) << PIO_IFSR_P21_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P21                        PIO_IFSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P21_Msk instead */
+#define PIO_IFSR_P22_Pos                    22                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P22_Msk                    (_U_(0x1) << PIO_IFSR_P22_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P22                        PIO_IFSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P22_Msk instead */
+#define PIO_IFSR_P23_Pos                    23                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P23_Msk                    (_U_(0x1) << PIO_IFSR_P23_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P23                        PIO_IFSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P23_Msk instead */
+#define PIO_IFSR_P24_Pos                    24                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P24_Msk                    (_U_(0x1) << PIO_IFSR_P24_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P24                        PIO_IFSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P24_Msk instead */
+#define PIO_IFSR_P25_Pos                    25                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P25_Msk                    (_U_(0x1) << PIO_IFSR_P25_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P25                        PIO_IFSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P25_Msk instead */
+#define PIO_IFSR_P26_Pos                    26                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P26_Msk                    (_U_(0x1) << PIO_IFSR_P26_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P26                        PIO_IFSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P26_Msk instead */
+#define PIO_IFSR_P27_Pos                    27                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P27_Msk                    (_U_(0x1) << PIO_IFSR_P27_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P27                        PIO_IFSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P27_Msk instead */
+#define PIO_IFSR_P28_Pos                    28                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P28_Msk                    (_U_(0x1) << PIO_IFSR_P28_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P28                        PIO_IFSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P28_Msk instead */
+#define PIO_IFSR_P29_Pos                    29                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P29_Msk                    (_U_(0x1) << PIO_IFSR_P29_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P29                        PIO_IFSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P29_Msk instead */
+#define PIO_IFSR_P30_Pos                    30                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P30_Msk                    (_U_(0x1) << PIO_IFSR_P30_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P30                        PIO_IFSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P30_Msk instead */
+#define PIO_IFSR_P31_Pos                    31                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P31_Msk                    (_U_(0x1) << PIO_IFSR_P31_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P31                        PIO_IFSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P31_Msk instead */
+#define PIO_IFSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSR) Register MASK  (Use PIO_IFSR_Msk instead)  */
+#define PIO_IFSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFSR) Register Mask  */
+
+#define PIO_IFSR_P_Pos                      0                                              /**< (PIO_IFSR Position) Input Filter Status */
+#define PIO_IFSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFSR_P_Pos)            /**< (PIO_IFSR Mask) P */
+#define PIO_IFSR_P(value)                   (PIO_IFSR_P_Msk & ((value) << PIO_IFSR_P_Pos))  
+
+/* -------- PIO_SODR : (PIO Offset: 0x30) (/W 32) Set Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Set Output Data                          */
+    uint32_t P1:1;                      /**< bit:      1  Set Output Data                          */
+    uint32_t P2:1;                      /**< bit:      2  Set Output Data                          */
+    uint32_t P3:1;                      /**< bit:      3  Set Output Data                          */
+    uint32_t P4:1;                      /**< bit:      4  Set Output Data                          */
+    uint32_t P5:1;                      /**< bit:      5  Set Output Data                          */
+    uint32_t P6:1;                      /**< bit:      6  Set Output Data                          */
+    uint32_t P7:1;                      /**< bit:      7  Set Output Data                          */
+    uint32_t P8:1;                      /**< bit:      8  Set Output Data                          */
+    uint32_t P9:1;                      /**< bit:      9  Set Output Data                          */
+    uint32_t P10:1;                     /**< bit:     10  Set Output Data                          */
+    uint32_t P11:1;                     /**< bit:     11  Set Output Data                          */
+    uint32_t P12:1;                     /**< bit:     12  Set Output Data                          */
+    uint32_t P13:1;                     /**< bit:     13  Set Output Data                          */
+    uint32_t P14:1;                     /**< bit:     14  Set Output Data                          */
+    uint32_t P15:1;                     /**< bit:     15  Set Output Data                          */
+    uint32_t P16:1;                     /**< bit:     16  Set Output Data                          */
+    uint32_t P17:1;                     /**< bit:     17  Set Output Data                          */
+    uint32_t P18:1;                     /**< bit:     18  Set Output Data                          */
+    uint32_t P19:1;                     /**< bit:     19  Set Output Data                          */
+    uint32_t P20:1;                     /**< bit:     20  Set Output Data                          */
+    uint32_t P21:1;                     /**< bit:     21  Set Output Data                          */
+    uint32_t P22:1;                     /**< bit:     22  Set Output Data                          */
+    uint32_t P23:1;                     /**< bit:     23  Set Output Data                          */
+    uint32_t P24:1;                     /**< bit:     24  Set Output Data                          */
+    uint32_t P25:1;                     /**< bit:     25  Set Output Data                          */
+    uint32_t P26:1;                     /**< bit:     26  Set Output Data                          */
+    uint32_t P27:1;                     /**< bit:     27  Set Output Data                          */
+    uint32_t P28:1;                     /**< bit:     28  Set Output Data                          */
+    uint32_t P29:1;                     /**< bit:     29  Set Output Data                          */
+    uint32_t P30:1;                     /**< bit:     30  Set Output Data                          */
+    uint32_t P31:1;                     /**< bit:     31  Set Output Data                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Set Output Data                          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SODR_OFFSET                     (0x30)                                        /**<  (PIO_SODR) Set Output Data Register  Offset */
+
+#define PIO_SODR_P0_Pos                     0                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P0_Msk                     (_U_(0x1) << PIO_SODR_P0_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P0                         PIO_SODR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P0_Msk instead */
+#define PIO_SODR_P1_Pos                     1                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P1_Msk                     (_U_(0x1) << PIO_SODR_P1_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P1                         PIO_SODR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P1_Msk instead */
+#define PIO_SODR_P2_Pos                     2                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P2_Msk                     (_U_(0x1) << PIO_SODR_P2_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P2                         PIO_SODR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P2_Msk instead */
+#define PIO_SODR_P3_Pos                     3                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P3_Msk                     (_U_(0x1) << PIO_SODR_P3_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P3                         PIO_SODR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P3_Msk instead */
+#define PIO_SODR_P4_Pos                     4                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P4_Msk                     (_U_(0x1) << PIO_SODR_P4_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P4                         PIO_SODR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P4_Msk instead */
+#define PIO_SODR_P5_Pos                     5                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P5_Msk                     (_U_(0x1) << PIO_SODR_P5_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P5                         PIO_SODR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P5_Msk instead */
+#define PIO_SODR_P6_Pos                     6                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P6_Msk                     (_U_(0x1) << PIO_SODR_P6_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P6                         PIO_SODR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P6_Msk instead */
+#define PIO_SODR_P7_Pos                     7                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P7_Msk                     (_U_(0x1) << PIO_SODR_P7_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P7                         PIO_SODR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P7_Msk instead */
+#define PIO_SODR_P8_Pos                     8                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P8_Msk                     (_U_(0x1) << PIO_SODR_P8_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P8                         PIO_SODR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P8_Msk instead */
+#define PIO_SODR_P9_Pos                     9                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P9_Msk                     (_U_(0x1) << PIO_SODR_P9_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P9                         PIO_SODR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P9_Msk instead */
+#define PIO_SODR_P10_Pos                    10                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P10_Msk                    (_U_(0x1) << PIO_SODR_P10_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P10                        PIO_SODR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P10_Msk instead */
+#define PIO_SODR_P11_Pos                    11                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P11_Msk                    (_U_(0x1) << PIO_SODR_P11_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P11                        PIO_SODR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P11_Msk instead */
+#define PIO_SODR_P12_Pos                    12                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P12_Msk                    (_U_(0x1) << PIO_SODR_P12_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P12                        PIO_SODR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P12_Msk instead */
+#define PIO_SODR_P13_Pos                    13                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P13_Msk                    (_U_(0x1) << PIO_SODR_P13_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P13                        PIO_SODR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P13_Msk instead */
+#define PIO_SODR_P14_Pos                    14                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P14_Msk                    (_U_(0x1) << PIO_SODR_P14_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P14                        PIO_SODR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P14_Msk instead */
+#define PIO_SODR_P15_Pos                    15                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P15_Msk                    (_U_(0x1) << PIO_SODR_P15_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P15                        PIO_SODR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P15_Msk instead */
+#define PIO_SODR_P16_Pos                    16                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P16_Msk                    (_U_(0x1) << PIO_SODR_P16_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P16                        PIO_SODR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P16_Msk instead */
+#define PIO_SODR_P17_Pos                    17                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P17_Msk                    (_U_(0x1) << PIO_SODR_P17_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P17                        PIO_SODR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P17_Msk instead */
+#define PIO_SODR_P18_Pos                    18                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P18_Msk                    (_U_(0x1) << PIO_SODR_P18_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P18                        PIO_SODR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P18_Msk instead */
+#define PIO_SODR_P19_Pos                    19                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P19_Msk                    (_U_(0x1) << PIO_SODR_P19_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P19                        PIO_SODR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P19_Msk instead */
+#define PIO_SODR_P20_Pos                    20                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P20_Msk                    (_U_(0x1) << PIO_SODR_P20_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P20                        PIO_SODR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P20_Msk instead */
+#define PIO_SODR_P21_Pos                    21                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P21_Msk                    (_U_(0x1) << PIO_SODR_P21_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P21                        PIO_SODR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P21_Msk instead */
+#define PIO_SODR_P22_Pos                    22                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P22_Msk                    (_U_(0x1) << PIO_SODR_P22_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P22                        PIO_SODR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P22_Msk instead */
+#define PIO_SODR_P23_Pos                    23                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P23_Msk                    (_U_(0x1) << PIO_SODR_P23_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P23                        PIO_SODR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P23_Msk instead */
+#define PIO_SODR_P24_Pos                    24                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P24_Msk                    (_U_(0x1) << PIO_SODR_P24_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P24                        PIO_SODR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P24_Msk instead */
+#define PIO_SODR_P25_Pos                    25                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P25_Msk                    (_U_(0x1) << PIO_SODR_P25_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P25                        PIO_SODR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P25_Msk instead */
+#define PIO_SODR_P26_Pos                    26                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P26_Msk                    (_U_(0x1) << PIO_SODR_P26_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P26                        PIO_SODR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P26_Msk instead */
+#define PIO_SODR_P27_Pos                    27                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P27_Msk                    (_U_(0x1) << PIO_SODR_P27_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P27                        PIO_SODR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P27_Msk instead */
+#define PIO_SODR_P28_Pos                    28                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P28_Msk                    (_U_(0x1) << PIO_SODR_P28_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P28                        PIO_SODR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P28_Msk instead */
+#define PIO_SODR_P29_Pos                    29                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P29_Msk                    (_U_(0x1) << PIO_SODR_P29_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P29                        PIO_SODR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P29_Msk instead */
+#define PIO_SODR_P30_Pos                    30                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P30_Msk                    (_U_(0x1) << PIO_SODR_P30_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P30                        PIO_SODR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P30_Msk instead */
+#define PIO_SODR_P31_Pos                    31                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P31_Msk                    (_U_(0x1) << PIO_SODR_P31_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P31                        PIO_SODR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P31_Msk instead */
+#define PIO_SODR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_SODR) Register MASK  (Use PIO_SODR_Msk instead)  */
+#define PIO_SODR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_SODR) Register Mask  */
+
+#define PIO_SODR_P_Pos                      0                                              /**< (PIO_SODR Position) Set Output Data */
+#define PIO_SODR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_SODR_P_Pos)            /**< (PIO_SODR Mask) P */
+#define PIO_SODR_P(value)                   (PIO_SODR_P_Msk & ((value) << PIO_SODR_P_Pos))  
+
+/* -------- PIO_CODR : (PIO Offset: 0x34) (/W 32) Clear Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Clear Output Data                        */
+    uint32_t P1:1;                      /**< bit:      1  Clear Output Data                        */
+    uint32_t P2:1;                      /**< bit:      2  Clear Output Data                        */
+    uint32_t P3:1;                      /**< bit:      3  Clear Output Data                        */
+    uint32_t P4:1;                      /**< bit:      4  Clear Output Data                        */
+    uint32_t P5:1;                      /**< bit:      5  Clear Output Data                        */
+    uint32_t P6:1;                      /**< bit:      6  Clear Output Data                        */
+    uint32_t P7:1;                      /**< bit:      7  Clear Output Data                        */
+    uint32_t P8:1;                      /**< bit:      8  Clear Output Data                        */
+    uint32_t P9:1;                      /**< bit:      9  Clear Output Data                        */
+    uint32_t P10:1;                     /**< bit:     10  Clear Output Data                        */
+    uint32_t P11:1;                     /**< bit:     11  Clear Output Data                        */
+    uint32_t P12:1;                     /**< bit:     12  Clear Output Data                        */
+    uint32_t P13:1;                     /**< bit:     13  Clear Output Data                        */
+    uint32_t P14:1;                     /**< bit:     14  Clear Output Data                        */
+    uint32_t P15:1;                     /**< bit:     15  Clear Output Data                        */
+    uint32_t P16:1;                     /**< bit:     16  Clear Output Data                        */
+    uint32_t P17:1;                     /**< bit:     17  Clear Output Data                        */
+    uint32_t P18:1;                     /**< bit:     18  Clear Output Data                        */
+    uint32_t P19:1;                     /**< bit:     19  Clear Output Data                        */
+    uint32_t P20:1;                     /**< bit:     20  Clear Output Data                        */
+    uint32_t P21:1;                     /**< bit:     21  Clear Output Data                        */
+    uint32_t P22:1;                     /**< bit:     22  Clear Output Data                        */
+    uint32_t P23:1;                     /**< bit:     23  Clear Output Data                        */
+    uint32_t P24:1;                     /**< bit:     24  Clear Output Data                        */
+    uint32_t P25:1;                     /**< bit:     25  Clear Output Data                        */
+    uint32_t P26:1;                     /**< bit:     26  Clear Output Data                        */
+    uint32_t P27:1;                     /**< bit:     27  Clear Output Data                        */
+    uint32_t P28:1;                     /**< bit:     28  Clear Output Data                        */
+    uint32_t P29:1;                     /**< bit:     29  Clear Output Data                        */
+    uint32_t P30:1;                     /**< bit:     30  Clear Output Data                        */
+    uint32_t P31:1;                     /**< bit:     31  Clear Output Data                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Clear Output Data                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_CODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_CODR_OFFSET                     (0x34)                                        /**<  (PIO_CODR) Clear Output Data Register  Offset */
+
+#define PIO_CODR_P0_Pos                     0                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P0_Msk                     (_U_(0x1) << PIO_CODR_P0_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P0                         PIO_CODR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P0_Msk instead */
+#define PIO_CODR_P1_Pos                     1                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P1_Msk                     (_U_(0x1) << PIO_CODR_P1_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P1                         PIO_CODR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P1_Msk instead */
+#define PIO_CODR_P2_Pos                     2                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P2_Msk                     (_U_(0x1) << PIO_CODR_P2_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P2                         PIO_CODR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P2_Msk instead */
+#define PIO_CODR_P3_Pos                     3                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P3_Msk                     (_U_(0x1) << PIO_CODR_P3_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P3                         PIO_CODR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P3_Msk instead */
+#define PIO_CODR_P4_Pos                     4                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P4_Msk                     (_U_(0x1) << PIO_CODR_P4_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P4                         PIO_CODR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P4_Msk instead */
+#define PIO_CODR_P5_Pos                     5                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P5_Msk                     (_U_(0x1) << PIO_CODR_P5_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P5                         PIO_CODR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P5_Msk instead */
+#define PIO_CODR_P6_Pos                     6                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P6_Msk                     (_U_(0x1) << PIO_CODR_P6_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P6                         PIO_CODR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P6_Msk instead */
+#define PIO_CODR_P7_Pos                     7                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P7_Msk                     (_U_(0x1) << PIO_CODR_P7_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P7                         PIO_CODR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P7_Msk instead */
+#define PIO_CODR_P8_Pos                     8                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P8_Msk                     (_U_(0x1) << PIO_CODR_P8_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P8                         PIO_CODR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P8_Msk instead */
+#define PIO_CODR_P9_Pos                     9                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P9_Msk                     (_U_(0x1) << PIO_CODR_P9_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P9                         PIO_CODR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P9_Msk instead */
+#define PIO_CODR_P10_Pos                    10                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P10_Msk                    (_U_(0x1) << PIO_CODR_P10_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P10                        PIO_CODR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P10_Msk instead */
+#define PIO_CODR_P11_Pos                    11                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P11_Msk                    (_U_(0x1) << PIO_CODR_P11_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P11                        PIO_CODR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P11_Msk instead */
+#define PIO_CODR_P12_Pos                    12                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P12_Msk                    (_U_(0x1) << PIO_CODR_P12_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P12                        PIO_CODR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P12_Msk instead */
+#define PIO_CODR_P13_Pos                    13                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P13_Msk                    (_U_(0x1) << PIO_CODR_P13_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P13                        PIO_CODR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P13_Msk instead */
+#define PIO_CODR_P14_Pos                    14                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P14_Msk                    (_U_(0x1) << PIO_CODR_P14_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P14                        PIO_CODR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P14_Msk instead */
+#define PIO_CODR_P15_Pos                    15                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P15_Msk                    (_U_(0x1) << PIO_CODR_P15_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P15                        PIO_CODR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P15_Msk instead */
+#define PIO_CODR_P16_Pos                    16                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P16_Msk                    (_U_(0x1) << PIO_CODR_P16_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P16                        PIO_CODR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P16_Msk instead */
+#define PIO_CODR_P17_Pos                    17                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P17_Msk                    (_U_(0x1) << PIO_CODR_P17_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P17                        PIO_CODR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P17_Msk instead */
+#define PIO_CODR_P18_Pos                    18                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P18_Msk                    (_U_(0x1) << PIO_CODR_P18_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P18                        PIO_CODR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P18_Msk instead */
+#define PIO_CODR_P19_Pos                    19                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P19_Msk                    (_U_(0x1) << PIO_CODR_P19_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P19                        PIO_CODR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P19_Msk instead */
+#define PIO_CODR_P20_Pos                    20                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P20_Msk                    (_U_(0x1) << PIO_CODR_P20_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P20                        PIO_CODR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P20_Msk instead */
+#define PIO_CODR_P21_Pos                    21                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P21_Msk                    (_U_(0x1) << PIO_CODR_P21_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P21                        PIO_CODR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P21_Msk instead */
+#define PIO_CODR_P22_Pos                    22                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P22_Msk                    (_U_(0x1) << PIO_CODR_P22_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P22                        PIO_CODR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P22_Msk instead */
+#define PIO_CODR_P23_Pos                    23                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P23_Msk                    (_U_(0x1) << PIO_CODR_P23_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P23                        PIO_CODR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P23_Msk instead */
+#define PIO_CODR_P24_Pos                    24                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P24_Msk                    (_U_(0x1) << PIO_CODR_P24_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P24                        PIO_CODR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P24_Msk instead */
+#define PIO_CODR_P25_Pos                    25                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P25_Msk                    (_U_(0x1) << PIO_CODR_P25_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P25                        PIO_CODR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P25_Msk instead */
+#define PIO_CODR_P26_Pos                    26                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P26_Msk                    (_U_(0x1) << PIO_CODR_P26_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P26                        PIO_CODR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P26_Msk instead */
+#define PIO_CODR_P27_Pos                    27                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P27_Msk                    (_U_(0x1) << PIO_CODR_P27_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P27                        PIO_CODR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P27_Msk instead */
+#define PIO_CODR_P28_Pos                    28                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P28_Msk                    (_U_(0x1) << PIO_CODR_P28_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P28                        PIO_CODR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P28_Msk instead */
+#define PIO_CODR_P29_Pos                    29                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P29_Msk                    (_U_(0x1) << PIO_CODR_P29_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P29                        PIO_CODR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P29_Msk instead */
+#define PIO_CODR_P30_Pos                    30                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P30_Msk                    (_U_(0x1) << PIO_CODR_P30_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P30                        PIO_CODR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P30_Msk instead */
+#define PIO_CODR_P31_Pos                    31                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P31_Msk                    (_U_(0x1) << PIO_CODR_P31_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P31                        PIO_CODR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P31_Msk instead */
+#define PIO_CODR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_CODR) Register MASK  (Use PIO_CODR_Msk instead)  */
+#define PIO_CODR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_CODR) Register Mask  */
+
+#define PIO_CODR_P_Pos                      0                                              /**< (PIO_CODR Position) Clear Output Data */
+#define PIO_CODR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_CODR_P_Pos)            /**< (PIO_CODR Mask) P */
+#define PIO_CODR_P(value)                   (PIO_CODR_P_Msk & ((value) << PIO_CODR_P_Pos))  
+
+/* -------- PIO_ODSR : (PIO Offset: 0x38) (R/W 32) Output Data Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Output Data Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Output Data Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Output Data Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Output Data Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Output Data Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Output Data Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Output Data Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Output Data Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Output Data Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Output Data Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Output Data Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Output Data Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Output Data Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Output Data Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Output Data Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Output Data Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Output Data Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Output Data Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Output Data Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Output Data Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Output Data Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Output Data Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Output Data Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Output Data Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Output Data Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Output Data Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Output Data Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Output Data Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Output Data Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Output Data Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Output Data Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Data Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ODSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ODSR_OFFSET                     (0x38)                                        /**<  (PIO_ODSR) Output Data Status Register  Offset */
+
+#define PIO_ODSR_P0_Pos                     0                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P0_Msk                     (_U_(0x1) << PIO_ODSR_P0_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P0                         PIO_ODSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P0_Msk instead */
+#define PIO_ODSR_P1_Pos                     1                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P1_Msk                     (_U_(0x1) << PIO_ODSR_P1_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P1                         PIO_ODSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P1_Msk instead */
+#define PIO_ODSR_P2_Pos                     2                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P2_Msk                     (_U_(0x1) << PIO_ODSR_P2_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P2                         PIO_ODSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P2_Msk instead */
+#define PIO_ODSR_P3_Pos                     3                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P3_Msk                     (_U_(0x1) << PIO_ODSR_P3_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P3                         PIO_ODSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P3_Msk instead */
+#define PIO_ODSR_P4_Pos                     4                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P4_Msk                     (_U_(0x1) << PIO_ODSR_P4_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P4                         PIO_ODSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P4_Msk instead */
+#define PIO_ODSR_P5_Pos                     5                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P5_Msk                     (_U_(0x1) << PIO_ODSR_P5_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P5                         PIO_ODSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P5_Msk instead */
+#define PIO_ODSR_P6_Pos                     6                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P6_Msk                     (_U_(0x1) << PIO_ODSR_P6_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P6                         PIO_ODSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P6_Msk instead */
+#define PIO_ODSR_P7_Pos                     7                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P7_Msk                     (_U_(0x1) << PIO_ODSR_P7_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P7                         PIO_ODSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P7_Msk instead */
+#define PIO_ODSR_P8_Pos                     8                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P8_Msk                     (_U_(0x1) << PIO_ODSR_P8_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P8                         PIO_ODSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P8_Msk instead */
+#define PIO_ODSR_P9_Pos                     9                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P9_Msk                     (_U_(0x1) << PIO_ODSR_P9_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P9                         PIO_ODSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P9_Msk instead */
+#define PIO_ODSR_P10_Pos                    10                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P10_Msk                    (_U_(0x1) << PIO_ODSR_P10_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P10                        PIO_ODSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P10_Msk instead */
+#define PIO_ODSR_P11_Pos                    11                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P11_Msk                    (_U_(0x1) << PIO_ODSR_P11_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P11                        PIO_ODSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P11_Msk instead */
+#define PIO_ODSR_P12_Pos                    12                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P12_Msk                    (_U_(0x1) << PIO_ODSR_P12_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P12                        PIO_ODSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P12_Msk instead */
+#define PIO_ODSR_P13_Pos                    13                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P13_Msk                    (_U_(0x1) << PIO_ODSR_P13_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P13                        PIO_ODSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P13_Msk instead */
+#define PIO_ODSR_P14_Pos                    14                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P14_Msk                    (_U_(0x1) << PIO_ODSR_P14_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P14                        PIO_ODSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P14_Msk instead */
+#define PIO_ODSR_P15_Pos                    15                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P15_Msk                    (_U_(0x1) << PIO_ODSR_P15_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P15                        PIO_ODSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P15_Msk instead */
+#define PIO_ODSR_P16_Pos                    16                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P16_Msk                    (_U_(0x1) << PIO_ODSR_P16_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P16                        PIO_ODSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P16_Msk instead */
+#define PIO_ODSR_P17_Pos                    17                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P17_Msk                    (_U_(0x1) << PIO_ODSR_P17_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P17                        PIO_ODSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P17_Msk instead */
+#define PIO_ODSR_P18_Pos                    18                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P18_Msk                    (_U_(0x1) << PIO_ODSR_P18_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P18                        PIO_ODSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P18_Msk instead */
+#define PIO_ODSR_P19_Pos                    19                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P19_Msk                    (_U_(0x1) << PIO_ODSR_P19_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P19                        PIO_ODSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P19_Msk instead */
+#define PIO_ODSR_P20_Pos                    20                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P20_Msk                    (_U_(0x1) << PIO_ODSR_P20_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P20                        PIO_ODSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P20_Msk instead */
+#define PIO_ODSR_P21_Pos                    21                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P21_Msk                    (_U_(0x1) << PIO_ODSR_P21_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P21                        PIO_ODSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P21_Msk instead */
+#define PIO_ODSR_P22_Pos                    22                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P22_Msk                    (_U_(0x1) << PIO_ODSR_P22_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P22                        PIO_ODSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P22_Msk instead */
+#define PIO_ODSR_P23_Pos                    23                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P23_Msk                    (_U_(0x1) << PIO_ODSR_P23_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P23                        PIO_ODSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P23_Msk instead */
+#define PIO_ODSR_P24_Pos                    24                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P24_Msk                    (_U_(0x1) << PIO_ODSR_P24_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P24                        PIO_ODSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P24_Msk instead */
+#define PIO_ODSR_P25_Pos                    25                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P25_Msk                    (_U_(0x1) << PIO_ODSR_P25_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P25                        PIO_ODSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P25_Msk instead */
+#define PIO_ODSR_P26_Pos                    26                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P26_Msk                    (_U_(0x1) << PIO_ODSR_P26_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P26                        PIO_ODSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P26_Msk instead */
+#define PIO_ODSR_P27_Pos                    27                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P27_Msk                    (_U_(0x1) << PIO_ODSR_P27_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P27                        PIO_ODSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P27_Msk instead */
+#define PIO_ODSR_P28_Pos                    28                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P28_Msk                    (_U_(0x1) << PIO_ODSR_P28_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P28                        PIO_ODSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P28_Msk instead */
+#define PIO_ODSR_P29_Pos                    29                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P29_Msk                    (_U_(0x1) << PIO_ODSR_P29_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P29                        PIO_ODSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P29_Msk instead */
+#define PIO_ODSR_P30_Pos                    30                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P30_Msk                    (_U_(0x1) << PIO_ODSR_P30_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P30                        PIO_ODSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P30_Msk instead */
+#define PIO_ODSR_P31_Pos                    31                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P31_Msk                    (_U_(0x1) << PIO_ODSR_P31_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P31                        PIO_ODSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P31_Msk instead */
+#define PIO_ODSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ODSR) Register MASK  (Use PIO_ODSR_Msk instead)  */
+#define PIO_ODSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_ODSR) Register Mask  */
+
+#define PIO_ODSR_P_Pos                      0                                              /**< (PIO_ODSR Position) Output Data Status */
+#define PIO_ODSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_ODSR_P_Pos)            /**< (PIO_ODSR Mask) P */
+#define PIO_ODSR_P(value)                   (PIO_ODSR_P_Msk & ((value) << PIO_ODSR_P_Pos))  
+
+/* -------- PIO_PDSR : (PIO Offset: 0x3c) (R/ 32) Pin Data Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Output Data Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Output Data Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Output Data Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Output Data Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Output Data Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Output Data Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Output Data Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Output Data Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Output Data Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Output Data Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Output Data Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Output Data Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Output Data Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Output Data Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Output Data Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Output Data Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Output Data Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Output Data Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Output Data Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Output Data Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Output Data Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Output Data Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Output Data Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Output Data Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Output Data Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Output Data Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Output Data Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Output Data Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Output Data Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Output Data Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Output Data Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Data Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PDSR_OFFSET                     (0x3C)                                        /**<  (PIO_PDSR) Pin Data Status Register  Offset */
+
+#define PIO_PDSR_P0_Pos                     0                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P0_Msk                     (_U_(0x1) << PIO_PDSR_P0_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P0                         PIO_PDSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P0_Msk instead */
+#define PIO_PDSR_P1_Pos                     1                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P1_Msk                     (_U_(0x1) << PIO_PDSR_P1_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P1                         PIO_PDSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P1_Msk instead */
+#define PIO_PDSR_P2_Pos                     2                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P2_Msk                     (_U_(0x1) << PIO_PDSR_P2_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P2                         PIO_PDSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P2_Msk instead */
+#define PIO_PDSR_P3_Pos                     3                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P3_Msk                     (_U_(0x1) << PIO_PDSR_P3_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P3                         PIO_PDSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P3_Msk instead */
+#define PIO_PDSR_P4_Pos                     4                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P4_Msk                     (_U_(0x1) << PIO_PDSR_P4_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P4                         PIO_PDSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P4_Msk instead */
+#define PIO_PDSR_P5_Pos                     5                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P5_Msk                     (_U_(0x1) << PIO_PDSR_P5_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P5                         PIO_PDSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P5_Msk instead */
+#define PIO_PDSR_P6_Pos                     6                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P6_Msk                     (_U_(0x1) << PIO_PDSR_P6_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P6                         PIO_PDSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P6_Msk instead */
+#define PIO_PDSR_P7_Pos                     7                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P7_Msk                     (_U_(0x1) << PIO_PDSR_P7_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P7                         PIO_PDSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P7_Msk instead */
+#define PIO_PDSR_P8_Pos                     8                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P8_Msk                     (_U_(0x1) << PIO_PDSR_P8_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P8                         PIO_PDSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P8_Msk instead */
+#define PIO_PDSR_P9_Pos                     9                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P9_Msk                     (_U_(0x1) << PIO_PDSR_P9_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P9                         PIO_PDSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P9_Msk instead */
+#define PIO_PDSR_P10_Pos                    10                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P10_Msk                    (_U_(0x1) << PIO_PDSR_P10_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P10                        PIO_PDSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P10_Msk instead */
+#define PIO_PDSR_P11_Pos                    11                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P11_Msk                    (_U_(0x1) << PIO_PDSR_P11_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P11                        PIO_PDSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P11_Msk instead */
+#define PIO_PDSR_P12_Pos                    12                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P12_Msk                    (_U_(0x1) << PIO_PDSR_P12_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P12                        PIO_PDSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P12_Msk instead */
+#define PIO_PDSR_P13_Pos                    13                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P13_Msk                    (_U_(0x1) << PIO_PDSR_P13_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P13                        PIO_PDSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P13_Msk instead */
+#define PIO_PDSR_P14_Pos                    14                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P14_Msk                    (_U_(0x1) << PIO_PDSR_P14_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P14                        PIO_PDSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P14_Msk instead */
+#define PIO_PDSR_P15_Pos                    15                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P15_Msk                    (_U_(0x1) << PIO_PDSR_P15_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P15                        PIO_PDSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P15_Msk instead */
+#define PIO_PDSR_P16_Pos                    16                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P16_Msk                    (_U_(0x1) << PIO_PDSR_P16_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P16                        PIO_PDSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P16_Msk instead */
+#define PIO_PDSR_P17_Pos                    17                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P17_Msk                    (_U_(0x1) << PIO_PDSR_P17_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P17                        PIO_PDSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P17_Msk instead */
+#define PIO_PDSR_P18_Pos                    18                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P18_Msk                    (_U_(0x1) << PIO_PDSR_P18_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P18                        PIO_PDSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P18_Msk instead */
+#define PIO_PDSR_P19_Pos                    19                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P19_Msk                    (_U_(0x1) << PIO_PDSR_P19_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P19                        PIO_PDSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P19_Msk instead */
+#define PIO_PDSR_P20_Pos                    20                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P20_Msk                    (_U_(0x1) << PIO_PDSR_P20_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P20                        PIO_PDSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P20_Msk instead */
+#define PIO_PDSR_P21_Pos                    21                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P21_Msk                    (_U_(0x1) << PIO_PDSR_P21_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P21                        PIO_PDSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P21_Msk instead */
+#define PIO_PDSR_P22_Pos                    22                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P22_Msk                    (_U_(0x1) << PIO_PDSR_P22_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P22                        PIO_PDSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P22_Msk instead */
+#define PIO_PDSR_P23_Pos                    23                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P23_Msk                    (_U_(0x1) << PIO_PDSR_P23_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P23                        PIO_PDSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P23_Msk instead */
+#define PIO_PDSR_P24_Pos                    24                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P24_Msk                    (_U_(0x1) << PIO_PDSR_P24_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P24                        PIO_PDSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P24_Msk instead */
+#define PIO_PDSR_P25_Pos                    25                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P25_Msk                    (_U_(0x1) << PIO_PDSR_P25_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P25                        PIO_PDSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P25_Msk instead */
+#define PIO_PDSR_P26_Pos                    26                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P26_Msk                    (_U_(0x1) << PIO_PDSR_P26_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P26                        PIO_PDSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P26_Msk instead */
+#define PIO_PDSR_P27_Pos                    27                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P27_Msk                    (_U_(0x1) << PIO_PDSR_P27_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P27                        PIO_PDSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P27_Msk instead */
+#define PIO_PDSR_P28_Pos                    28                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P28_Msk                    (_U_(0x1) << PIO_PDSR_P28_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P28                        PIO_PDSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P28_Msk instead */
+#define PIO_PDSR_P29_Pos                    29                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P29_Msk                    (_U_(0x1) << PIO_PDSR_P29_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P29                        PIO_PDSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P29_Msk instead */
+#define PIO_PDSR_P30_Pos                    30                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P30_Msk                    (_U_(0x1) << PIO_PDSR_P30_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P30                        PIO_PDSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P30_Msk instead */
+#define PIO_PDSR_P31_Pos                    31                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P31_Msk                    (_U_(0x1) << PIO_PDSR_P31_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P31                        PIO_PDSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P31_Msk instead */
+#define PIO_PDSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PDSR) Register MASK  (Use PIO_PDSR_Msk instead)  */
+#define PIO_PDSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PDSR) Register Mask  */
+
+#define PIO_PDSR_P_Pos                      0                                              /**< (PIO_PDSR Position) Output Data Status */
+#define PIO_PDSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PDSR_P_Pos)            /**< (PIO_PDSR Mask) P */
+#define PIO_PDSR_P(value)                   (PIO_PDSR_P_Msk & ((value) << PIO_PDSR_P_Pos))  
+
+/* -------- PIO_IER : (PIO Offset: 0x40) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Enable            */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Enable            */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Enable            */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Enable            */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Enable            */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Enable            */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Enable            */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Enable            */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Enable            */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Enable            */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Enable            */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Enable            */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Enable            */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Enable            */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Enable            */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Enable            */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Enable            */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Enable            */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Enable            */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Enable            */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Enable            */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Enable            */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Enable            */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Enable            */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Enable            */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Enable            */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Enable            */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Enable            */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Enable            */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Enable            */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Enable            */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Enable            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Enable            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IER_OFFSET                      (0x40)                                        /**<  (PIO_IER) Interrupt Enable Register  Offset */
+
+#define PIO_IER_P0_Pos                      0                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P0_Msk                      (_U_(0x1) << PIO_IER_P0_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P0                          PIO_IER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P0_Msk instead */
+#define PIO_IER_P1_Pos                      1                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P1_Msk                      (_U_(0x1) << PIO_IER_P1_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P1                          PIO_IER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P1_Msk instead */
+#define PIO_IER_P2_Pos                      2                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P2_Msk                      (_U_(0x1) << PIO_IER_P2_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P2                          PIO_IER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P2_Msk instead */
+#define PIO_IER_P3_Pos                      3                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P3_Msk                      (_U_(0x1) << PIO_IER_P3_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P3                          PIO_IER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P3_Msk instead */
+#define PIO_IER_P4_Pos                      4                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P4_Msk                      (_U_(0x1) << PIO_IER_P4_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P4                          PIO_IER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P4_Msk instead */
+#define PIO_IER_P5_Pos                      5                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P5_Msk                      (_U_(0x1) << PIO_IER_P5_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P5                          PIO_IER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P5_Msk instead */
+#define PIO_IER_P6_Pos                      6                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P6_Msk                      (_U_(0x1) << PIO_IER_P6_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P6                          PIO_IER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P6_Msk instead */
+#define PIO_IER_P7_Pos                      7                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P7_Msk                      (_U_(0x1) << PIO_IER_P7_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P7                          PIO_IER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P7_Msk instead */
+#define PIO_IER_P8_Pos                      8                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P8_Msk                      (_U_(0x1) << PIO_IER_P8_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P8                          PIO_IER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P8_Msk instead */
+#define PIO_IER_P9_Pos                      9                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P9_Msk                      (_U_(0x1) << PIO_IER_P9_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P9                          PIO_IER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P9_Msk instead */
+#define PIO_IER_P10_Pos                     10                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P10_Msk                     (_U_(0x1) << PIO_IER_P10_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P10                         PIO_IER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P10_Msk instead */
+#define PIO_IER_P11_Pos                     11                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P11_Msk                     (_U_(0x1) << PIO_IER_P11_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P11                         PIO_IER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P11_Msk instead */
+#define PIO_IER_P12_Pos                     12                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P12_Msk                     (_U_(0x1) << PIO_IER_P12_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P12                         PIO_IER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P12_Msk instead */
+#define PIO_IER_P13_Pos                     13                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P13_Msk                     (_U_(0x1) << PIO_IER_P13_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P13                         PIO_IER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P13_Msk instead */
+#define PIO_IER_P14_Pos                     14                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P14_Msk                     (_U_(0x1) << PIO_IER_P14_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P14                         PIO_IER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P14_Msk instead */
+#define PIO_IER_P15_Pos                     15                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P15_Msk                     (_U_(0x1) << PIO_IER_P15_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P15                         PIO_IER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P15_Msk instead */
+#define PIO_IER_P16_Pos                     16                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P16_Msk                     (_U_(0x1) << PIO_IER_P16_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P16                         PIO_IER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P16_Msk instead */
+#define PIO_IER_P17_Pos                     17                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P17_Msk                     (_U_(0x1) << PIO_IER_P17_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P17                         PIO_IER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P17_Msk instead */
+#define PIO_IER_P18_Pos                     18                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P18_Msk                     (_U_(0x1) << PIO_IER_P18_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P18                         PIO_IER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P18_Msk instead */
+#define PIO_IER_P19_Pos                     19                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P19_Msk                     (_U_(0x1) << PIO_IER_P19_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P19                         PIO_IER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P19_Msk instead */
+#define PIO_IER_P20_Pos                     20                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P20_Msk                     (_U_(0x1) << PIO_IER_P20_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P20                         PIO_IER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P20_Msk instead */
+#define PIO_IER_P21_Pos                     21                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P21_Msk                     (_U_(0x1) << PIO_IER_P21_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P21                         PIO_IER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P21_Msk instead */
+#define PIO_IER_P22_Pos                     22                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P22_Msk                     (_U_(0x1) << PIO_IER_P22_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P22                         PIO_IER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P22_Msk instead */
+#define PIO_IER_P23_Pos                     23                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P23_Msk                     (_U_(0x1) << PIO_IER_P23_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P23                         PIO_IER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P23_Msk instead */
+#define PIO_IER_P24_Pos                     24                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P24_Msk                     (_U_(0x1) << PIO_IER_P24_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P24                         PIO_IER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P24_Msk instead */
+#define PIO_IER_P25_Pos                     25                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P25_Msk                     (_U_(0x1) << PIO_IER_P25_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P25                         PIO_IER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P25_Msk instead */
+#define PIO_IER_P26_Pos                     26                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P26_Msk                     (_U_(0x1) << PIO_IER_P26_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P26                         PIO_IER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P26_Msk instead */
+#define PIO_IER_P27_Pos                     27                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P27_Msk                     (_U_(0x1) << PIO_IER_P27_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P27                         PIO_IER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P27_Msk instead */
+#define PIO_IER_P28_Pos                     28                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P28_Msk                     (_U_(0x1) << PIO_IER_P28_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P28                         PIO_IER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P28_Msk instead */
+#define PIO_IER_P29_Pos                     29                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P29_Msk                     (_U_(0x1) << PIO_IER_P29_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P29                         PIO_IER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P29_Msk instead */
+#define PIO_IER_P30_Pos                     30                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P30_Msk                     (_U_(0x1) << PIO_IER_P30_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P30                         PIO_IER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P30_Msk instead */
+#define PIO_IER_P31_Pos                     31                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P31_Msk                     (_U_(0x1) << PIO_IER_P31_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P31                         PIO_IER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P31_Msk instead */
+#define PIO_IER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IER) Register MASK  (Use PIO_IER_Msk instead)  */
+#define PIO_IER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IER) Register Mask  */
+
+#define PIO_IER_P_Pos                       0                                              /**< (PIO_IER Position) Input Change Interrupt Enable */
+#define PIO_IER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IER_P_Pos)             /**< (PIO_IER Mask) P */
+#define PIO_IER_P(value)                    (PIO_IER_P_Msk & ((value) << PIO_IER_P_Pos))   
+
+/* -------- PIO_IDR : (PIO Offset: 0x44) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Disable           */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Disable           */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Disable           */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Disable           */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Disable           */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Disable           */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Disable           */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Disable           */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Disable           */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Disable           */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Disable           */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Disable           */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Disable           */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Disable           */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Disable           */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Disable           */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Disable           */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Disable           */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Disable           */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Disable           */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Disable           */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Disable           */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Disable           */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Disable           */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Disable           */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Disable           */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Disable           */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Disable           */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Disable           */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Disable           */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Disable           */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Disable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Disable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IDR_OFFSET                      (0x44)                                        /**<  (PIO_IDR) Interrupt Disable Register  Offset */
+
+#define PIO_IDR_P0_Pos                      0                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P0_Msk                      (_U_(0x1) << PIO_IDR_P0_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P0                          PIO_IDR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P0_Msk instead */
+#define PIO_IDR_P1_Pos                      1                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P1_Msk                      (_U_(0x1) << PIO_IDR_P1_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P1                          PIO_IDR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P1_Msk instead */
+#define PIO_IDR_P2_Pos                      2                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P2_Msk                      (_U_(0x1) << PIO_IDR_P2_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P2                          PIO_IDR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P2_Msk instead */
+#define PIO_IDR_P3_Pos                      3                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P3_Msk                      (_U_(0x1) << PIO_IDR_P3_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P3                          PIO_IDR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P3_Msk instead */
+#define PIO_IDR_P4_Pos                      4                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P4_Msk                      (_U_(0x1) << PIO_IDR_P4_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P4                          PIO_IDR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P4_Msk instead */
+#define PIO_IDR_P5_Pos                      5                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P5_Msk                      (_U_(0x1) << PIO_IDR_P5_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P5                          PIO_IDR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P5_Msk instead */
+#define PIO_IDR_P6_Pos                      6                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P6_Msk                      (_U_(0x1) << PIO_IDR_P6_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P6                          PIO_IDR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P6_Msk instead */
+#define PIO_IDR_P7_Pos                      7                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P7_Msk                      (_U_(0x1) << PIO_IDR_P7_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P7                          PIO_IDR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P7_Msk instead */
+#define PIO_IDR_P8_Pos                      8                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P8_Msk                      (_U_(0x1) << PIO_IDR_P8_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P8                          PIO_IDR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P8_Msk instead */
+#define PIO_IDR_P9_Pos                      9                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P9_Msk                      (_U_(0x1) << PIO_IDR_P9_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P9                          PIO_IDR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P9_Msk instead */
+#define PIO_IDR_P10_Pos                     10                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P10_Msk                     (_U_(0x1) << PIO_IDR_P10_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P10                         PIO_IDR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P10_Msk instead */
+#define PIO_IDR_P11_Pos                     11                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P11_Msk                     (_U_(0x1) << PIO_IDR_P11_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P11                         PIO_IDR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P11_Msk instead */
+#define PIO_IDR_P12_Pos                     12                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P12_Msk                     (_U_(0x1) << PIO_IDR_P12_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P12                         PIO_IDR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P12_Msk instead */
+#define PIO_IDR_P13_Pos                     13                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P13_Msk                     (_U_(0x1) << PIO_IDR_P13_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P13                         PIO_IDR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P13_Msk instead */
+#define PIO_IDR_P14_Pos                     14                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P14_Msk                     (_U_(0x1) << PIO_IDR_P14_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P14                         PIO_IDR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P14_Msk instead */
+#define PIO_IDR_P15_Pos                     15                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P15_Msk                     (_U_(0x1) << PIO_IDR_P15_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P15                         PIO_IDR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P15_Msk instead */
+#define PIO_IDR_P16_Pos                     16                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P16_Msk                     (_U_(0x1) << PIO_IDR_P16_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P16                         PIO_IDR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P16_Msk instead */
+#define PIO_IDR_P17_Pos                     17                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P17_Msk                     (_U_(0x1) << PIO_IDR_P17_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P17                         PIO_IDR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P17_Msk instead */
+#define PIO_IDR_P18_Pos                     18                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P18_Msk                     (_U_(0x1) << PIO_IDR_P18_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P18                         PIO_IDR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P18_Msk instead */
+#define PIO_IDR_P19_Pos                     19                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P19_Msk                     (_U_(0x1) << PIO_IDR_P19_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P19                         PIO_IDR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P19_Msk instead */
+#define PIO_IDR_P20_Pos                     20                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P20_Msk                     (_U_(0x1) << PIO_IDR_P20_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P20                         PIO_IDR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P20_Msk instead */
+#define PIO_IDR_P21_Pos                     21                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P21_Msk                     (_U_(0x1) << PIO_IDR_P21_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P21                         PIO_IDR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P21_Msk instead */
+#define PIO_IDR_P22_Pos                     22                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P22_Msk                     (_U_(0x1) << PIO_IDR_P22_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P22                         PIO_IDR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P22_Msk instead */
+#define PIO_IDR_P23_Pos                     23                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P23_Msk                     (_U_(0x1) << PIO_IDR_P23_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P23                         PIO_IDR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P23_Msk instead */
+#define PIO_IDR_P24_Pos                     24                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P24_Msk                     (_U_(0x1) << PIO_IDR_P24_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P24                         PIO_IDR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P24_Msk instead */
+#define PIO_IDR_P25_Pos                     25                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P25_Msk                     (_U_(0x1) << PIO_IDR_P25_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P25                         PIO_IDR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P25_Msk instead */
+#define PIO_IDR_P26_Pos                     26                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P26_Msk                     (_U_(0x1) << PIO_IDR_P26_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P26                         PIO_IDR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P26_Msk instead */
+#define PIO_IDR_P27_Pos                     27                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P27_Msk                     (_U_(0x1) << PIO_IDR_P27_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P27                         PIO_IDR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P27_Msk instead */
+#define PIO_IDR_P28_Pos                     28                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P28_Msk                     (_U_(0x1) << PIO_IDR_P28_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P28                         PIO_IDR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P28_Msk instead */
+#define PIO_IDR_P29_Pos                     29                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P29_Msk                     (_U_(0x1) << PIO_IDR_P29_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P29                         PIO_IDR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P29_Msk instead */
+#define PIO_IDR_P30_Pos                     30                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P30_Msk                     (_U_(0x1) << PIO_IDR_P30_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P30                         PIO_IDR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P30_Msk instead */
+#define PIO_IDR_P31_Pos                     31                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P31_Msk                     (_U_(0x1) << PIO_IDR_P31_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P31                         PIO_IDR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P31_Msk instead */
+#define PIO_IDR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IDR) Register MASK  (Use PIO_IDR_Msk instead)  */
+#define PIO_IDR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IDR) Register Mask  */
+
+#define PIO_IDR_P_Pos                       0                                              /**< (PIO_IDR Position) Input Change Interrupt Disable */
+#define PIO_IDR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IDR_P_Pos)             /**< (PIO_IDR Mask) P */
+#define PIO_IDR_P(value)                    (PIO_IDR_P_Msk & ((value) << PIO_IDR_P_Pos))   
+
+/* -------- PIO_IMR : (PIO Offset: 0x48) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Mask              */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Mask              */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Mask              */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Mask              */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Mask              */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Mask              */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Mask              */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Mask              */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Mask              */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Mask              */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Mask              */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Mask              */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Mask              */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Mask              */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Mask              */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Mask              */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Mask              */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Mask              */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Mask              */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Mask              */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Mask              */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Mask              */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Mask              */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Mask              */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Mask              */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Mask              */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Mask              */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Mask              */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Mask              */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Mask              */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Mask              */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Mask              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Mask              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IMR_OFFSET                      (0x48)                                        /**<  (PIO_IMR) Interrupt Mask Register  Offset */
+
+#define PIO_IMR_P0_Pos                      0                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P0_Msk                      (_U_(0x1) << PIO_IMR_P0_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P0                          PIO_IMR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P0_Msk instead */
+#define PIO_IMR_P1_Pos                      1                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P1_Msk                      (_U_(0x1) << PIO_IMR_P1_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P1                          PIO_IMR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P1_Msk instead */
+#define PIO_IMR_P2_Pos                      2                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P2_Msk                      (_U_(0x1) << PIO_IMR_P2_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P2                          PIO_IMR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P2_Msk instead */
+#define PIO_IMR_P3_Pos                      3                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P3_Msk                      (_U_(0x1) << PIO_IMR_P3_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P3                          PIO_IMR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P3_Msk instead */
+#define PIO_IMR_P4_Pos                      4                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P4_Msk                      (_U_(0x1) << PIO_IMR_P4_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P4                          PIO_IMR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P4_Msk instead */
+#define PIO_IMR_P5_Pos                      5                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P5_Msk                      (_U_(0x1) << PIO_IMR_P5_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P5                          PIO_IMR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P5_Msk instead */
+#define PIO_IMR_P6_Pos                      6                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P6_Msk                      (_U_(0x1) << PIO_IMR_P6_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P6                          PIO_IMR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P6_Msk instead */
+#define PIO_IMR_P7_Pos                      7                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P7_Msk                      (_U_(0x1) << PIO_IMR_P7_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P7                          PIO_IMR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P7_Msk instead */
+#define PIO_IMR_P8_Pos                      8                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P8_Msk                      (_U_(0x1) << PIO_IMR_P8_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P8                          PIO_IMR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P8_Msk instead */
+#define PIO_IMR_P9_Pos                      9                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P9_Msk                      (_U_(0x1) << PIO_IMR_P9_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P9                          PIO_IMR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P9_Msk instead */
+#define PIO_IMR_P10_Pos                     10                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P10_Msk                     (_U_(0x1) << PIO_IMR_P10_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P10                         PIO_IMR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P10_Msk instead */
+#define PIO_IMR_P11_Pos                     11                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P11_Msk                     (_U_(0x1) << PIO_IMR_P11_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P11                         PIO_IMR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P11_Msk instead */
+#define PIO_IMR_P12_Pos                     12                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P12_Msk                     (_U_(0x1) << PIO_IMR_P12_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P12                         PIO_IMR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P12_Msk instead */
+#define PIO_IMR_P13_Pos                     13                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P13_Msk                     (_U_(0x1) << PIO_IMR_P13_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P13                         PIO_IMR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P13_Msk instead */
+#define PIO_IMR_P14_Pos                     14                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P14_Msk                     (_U_(0x1) << PIO_IMR_P14_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P14                         PIO_IMR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P14_Msk instead */
+#define PIO_IMR_P15_Pos                     15                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P15_Msk                     (_U_(0x1) << PIO_IMR_P15_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P15                         PIO_IMR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P15_Msk instead */
+#define PIO_IMR_P16_Pos                     16                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P16_Msk                     (_U_(0x1) << PIO_IMR_P16_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P16                         PIO_IMR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P16_Msk instead */
+#define PIO_IMR_P17_Pos                     17                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P17_Msk                     (_U_(0x1) << PIO_IMR_P17_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P17                         PIO_IMR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P17_Msk instead */
+#define PIO_IMR_P18_Pos                     18                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P18_Msk                     (_U_(0x1) << PIO_IMR_P18_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P18                         PIO_IMR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P18_Msk instead */
+#define PIO_IMR_P19_Pos                     19                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P19_Msk                     (_U_(0x1) << PIO_IMR_P19_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P19                         PIO_IMR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P19_Msk instead */
+#define PIO_IMR_P20_Pos                     20                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P20_Msk                     (_U_(0x1) << PIO_IMR_P20_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P20                         PIO_IMR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P20_Msk instead */
+#define PIO_IMR_P21_Pos                     21                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P21_Msk                     (_U_(0x1) << PIO_IMR_P21_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P21                         PIO_IMR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P21_Msk instead */
+#define PIO_IMR_P22_Pos                     22                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P22_Msk                     (_U_(0x1) << PIO_IMR_P22_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P22                         PIO_IMR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P22_Msk instead */
+#define PIO_IMR_P23_Pos                     23                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P23_Msk                     (_U_(0x1) << PIO_IMR_P23_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P23                         PIO_IMR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P23_Msk instead */
+#define PIO_IMR_P24_Pos                     24                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P24_Msk                     (_U_(0x1) << PIO_IMR_P24_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P24                         PIO_IMR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P24_Msk instead */
+#define PIO_IMR_P25_Pos                     25                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P25_Msk                     (_U_(0x1) << PIO_IMR_P25_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P25                         PIO_IMR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P25_Msk instead */
+#define PIO_IMR_P26_Pos                     26                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P26_Msk                     (_U_(0x1) << PIO_IMR_P26_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P26                         PIO_IMR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P26_Msk instead */
+#define PIO_IMR_P27_Pos                     27                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P27_Msk                     (_U_(0x1) << PIO_IMR_P27_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P27                         PIO_IMR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P27_Msk instead */
+#define PIO_IMR_P28_Pos                     28                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P28_Msk                     (_U_(0x1) << PIO_IMR_P28_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P28                         PIO_IMR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P28_Msk instead */
+#define PIO_IMR_P29_Pos                     29                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P29_Msk                     (_U_(0x1) << PIO_IMR_P29_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P29                         PIO_IMR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P29_Msk instead */
+#define PIO_IMR_P30_Pos                     30                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P30_Msk                     (_U_(0x1) << PIO_IMR_P30_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P30                         PIO_IMR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P30_Msk instead */
+#define PIO_IMR_P31_Pos                     31                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P31_Msk                     (_U_(0x1) << PIO_IMR_P31_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P31                         PIO_IMR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P31_Msk instead */
+#define PIO_IMR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IMR) Register MASK  (Use PIO_IMR_Msk instead)  */
+#define PIO_IMR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IMR) Register Mask  */
+
+#define PIO_IMR_P_Pos                       0                                              /**< (PIO_IMR Position) Input Change Interrupt Mask */
+#define PIO_IMR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IMR_P_Pos)             /**< (PIO_IMR Mask) P */
+#define PIO_IMR_P(value)                    (PIO_IMR_P_Msk & ((value) << PIO_IMR_P_Pos))   
+
+/* -------- PIO_ISR : (PIO Offset: 0x4c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Status            */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Status            */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Status            */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Status            */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Status            */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Status            */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Status            */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Status            */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Status            */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Status            */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Status            */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Status            */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Status            */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Status            */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Status            */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Status            */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Status            */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Status            */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Status            */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Status            */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Status            */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Status            */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Status            */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Status            */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Status            */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Status            */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Status            */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Status            */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Status            */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Status            */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Status            */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Status            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Status            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ISR_OFFSET                      (0x4C)                                        /**<  (PIO_ISR) Interrupt Status Register  Offset */
+
+#define PIO_ISR_P0_Pos                      0                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P0_Msk                      (_U_(0x1) << PIO_ISR_P0_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P0                          PIO_ISR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P0_Msk instead */
+#define PIO_ISR_P1_Pos                      1                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P1_Msk                      (_U_(0x1) << PIO_ISR_P1_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P1                          PIO_ISR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P1_Msk instead */
+#define PIO_ISR_P2_Pos                      2                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P2_Msk                      (_U_(0x1) << PIO_ISR_P2_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P2                          PIO_ISR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P2_Msk instead */
+#define PIO_ISR_P3_Pos                      3                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P3_Msk                      (_U_(0x1) << PIO_ISR_P3_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P3                          PIO_ISR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P3_Msk instead */
+#define PIO_ISR_P4_Pos                      4                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P4_Msk                      (_U_(0x1) << PIO_ISR_P4_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P4                          PIO_ISR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P4_Msk instead */
+#define PIO_ISR_P5_Pos                      5                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P5_Msk                      (_U_(0x1) << PIO_ISR_P5_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P5                          PIO_ISR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P5_Msk instead */
+#define PIO_ISR_P6_Pos                      6                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P6_Msk                      (_U_(0x1) << PIO_ISR_P6_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P6                          PIO_ISR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P6_Msk instead */
+#define PIO_ISR_P7_Pos                      7                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P7_Msk                      (_U_(0x1) << PIO_ISR_P7_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P7                          PIO_ISR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P7_Msk instead */
+#define PIO_ISR_P8_Pos                      8                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P8_Msk                      (_U_(0x1) << PIO_ISR_P8_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P8                          PIO_ISR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P8_Msk instead */
+#define PIO_ISR_P9_Pos                      9                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P9_Msk                      (_U_(0x1) << PIO_ISR_P9_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P9                          PIO_ISR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P9_Msk instead */
+#define PIO_ISR_P10_Pos                     10                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P10_Msk                     (_U_(0x1) << PIO_ISR_P10_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P10                         PIO_ISR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P10_Msk instead */
+#define PIO_ISR_P11_Pos                     11                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P11_Msk                     (_U_(0x1) << PIO_ISR_P11_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P11                         PIO_ISR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P11_Msk instead */
+#define PIO_ISR_P12_Pos                     12                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P12_Msk                     (_U_(0x1) << PIO_ISR_P12_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P12                         PIO_ISR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P12_Msk instead */
+#define PIO_ISR_P13_Pos                     13                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P13_Msk                     (_U_(0x1) << PIO_ISR_P13_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P13                         PIO_ISR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P13_Msk instead */
+#define PIO_ISR_P14_Pos                     14                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P14_Msk                     (_U_(0x1) << PIO_ISR_P14_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P14                         PIO_ISR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P14_Msk instead */
+#define PIO_ISR_P15_Pos                     15                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P15_Msk                     (_U_(0x1) << PIO_ISR_P15_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P15                         PIO_ISR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P15_Msk instead */
+#define PIO_ISR_P16_Pos                     16                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P16_Msk                     (_U_(0x1) << PIO_ISR_P16_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P16                         PIO_ISR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P16_Msk instead */
+#define PIO_ISR_P17_Pos                     17                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P17_Msk                     (_U_(0x1) << PIO_ISR_P17_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P17                         PIO_ISR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P17_Msk instead */
+#define PIO_ISR_P18_Pos                     18                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P18_Msk                     (_U_(0x1) << PIO_ISR_P18_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P18                         PIO_ISR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P18_Msk instead */
+#define PIO_ISR_P19_Pos                     19                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P19_Msk                     (_U_(0x1) << PIO_ISR_P19_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P19                         PIO_ISR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P19_Msk instead */
+#define PIO_ISR_P20_Pos                     20                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P20_Msk                     (_U_(0x1) << PIO_ISR_P20_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P20                         PIO_ISR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P20_Msk instead */
+#define PIO_ISR_P21_Pos                     21                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P21_Msk                     (_U_(0x1) << PIO_ISR_P21_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P21                         PIO_ISR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P21_Msk instead */
+#define PIO_ISR_P22_Pos                     22                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P22_Msk                     (_U_(0x1) << PIO_ISR_P22_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P22                         PIO_ISR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P22_Msk instead */
+#define PIO_ISR_P23_Pos                     23                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P23_Msk                     (_U_(0x1) << PIO_ISR_P23_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P23                         PIO_ISR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P23_Msk instead */
+#define PIO_ISR_P24_Pos                     24                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P24_Msk                     (_U_(0x1) << PIO_ISR_P24_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P24                         PIO_ISR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P24_Msk instead */
+#define PIO_ISR_P25_Pos                     25                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P25_Msk                     (_U_(0x1) << PIO_ISR_P25_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P25                         PIO_ISR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P25_Msk instead */
+#define PIO_ISR_P26_Pos                     26                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P26_Msk                     (_U_(0x1) << PIO_ISR_P26_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P26                         PIO_ISR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P26_Msk instead */
+#define PIO_ISR_P27_Pos                     27                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P27_Msk                     (_U_(0x1) << PIO_ISR_P27_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P27                         PIO_ISR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P27_Msk instead */
+#define PIO_ISR_P28_Pos                     28                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P28_Msk                     (_U_(0x1) << PIO_ISR_P28_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P28                         PIO_ISR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P28_Msk instead */
+#define PIO_ISR_P29_Pos                     29                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P29_Msk                     (_U_(0x1) << PIO_ISR_P29_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P29                         PIO_ISR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P29_Msk instead */
+#define PIO_ISR_P30_Pos                     30                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P30_Msk                     (_U_(0x1) << PIO_ISR_P30_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P30                         PIO_ISR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P30_Msk instead */
+#define PIO_ISR_P31_Pos                     31                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P31_Msk                     (_U_(0x1) << PIO_ISR_P31_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P31                         PIO_ISR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P31_Msk instead */
+#define PIO_ISR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ISR) Register MASK  (Use PIO_ISR_Msk instead)  */
+#define PIO_ISR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ISR) Register Mask  */
+
+#define PIO_ISR_P_Pos                       0                                              /**< (PIO_ISR Position) Input Change Interrupt Status */
+#define PIO_ISR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ISR_P_Pos)             /**< (PIO_ISR Mask) P */
+#define PIO_ISR_P(value)                    (PIO_ISR_P_Msk & ((value) << PIO_ISR_P_Pos))   
+
+/* -------- PIO_MDER : (PIO Offset: 0x50) (/W 32) Multi-driver Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Enable                       */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Enable                       */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Enable                       */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Enable                       */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Enable                       */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Enable                       */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Enable                       */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Enable                       */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Enable                       */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Enable                       */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Enable                       */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Enable                       */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Enable                       */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Enable                       */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Enable                       */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Enable                       */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Enable                       */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Enable                       */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Enable                       */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Enable                       */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Enable                       */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Enable                       */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Enable                       */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Enable                       */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Enable                       */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Enable                       */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Enable                       */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Enable                       */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Enable                       */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Enable                       */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Enable                       */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Enable                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Enable                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDER_OFFSET                     (0x50)                                        /**<  (PIO_MDER) Multi-driver Enable Register  Offset */
+
+#define PIO_MDER_P0_Pos                     0                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P0_Msk                     (_U_(0x1) << PIO_MDER_P0_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P0                         PIO_MDER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P0_Msk instead */
+#define PIO_MDER_P1_Pos                     1                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P1_Msk                     (_U_(0x1) << PIO_MDER_P1_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P1                         PIO_MDER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P1_Msk instead */
+#define PIO_MDER_P2_Pos                     2                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P2_Msk                     (_U_(0x1) << PIO_MDER_P2_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P2                         PIO_MDER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P2_Msk instead */
+#define PIO_MDER_P3_Pos                     3                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P3_Msk                     (_U_(0x1) << PIO_MDER_P3_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P3                         PIO_MDER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P3_Msk instead */
+#define PIO_MDER_P4_Pos                     4                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P4_Msk                     (_U_(0x1) << PIO_MDER_P4_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P4                         PIO_MDER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P4_Msk instead */
+#define PIO_MDER_P5_Pos                     5                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P5_Msk                     (_U_(0x1) << PIO_MDER_P5_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P5                         PIO_MDER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P5_Msk instead */
+#define PIO_MDER_P6_Pos                     6                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P6_Msk                     (_U_(0x1) << PIO_MDER_P6_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P6                         PIO_MDER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P6_Msk instead */
+#define PIO_MDER_P7_Pos                     7                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P7_Msk                     (_U_(0x1) << PIO_MDER_P7_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P7                         PIO_MDER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P7_Msk instead */
+#define PIO_MDER_P8_Pos                     8                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P8_Msk                     (_U_(0x1) << PIO_MDER_P8_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P8                         PIO_MDER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P8_Msk instead */
+#define PIO_MDER_P9_Pos                     9                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P9_Msk                     (_U_(0x1) << PIO_MDER_P9_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P9                         PIO_MDER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P9_Msk instead */
+#define PIO_MDER_P10_Pos                    10                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P10_Msk                    (_U_(0x1) << PIO_MDER_P10_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P10                        PIO_MDER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P10_Msk instead */
+#define PIO_MDER_P11_Pos                    11                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P11_Msk                    (_U_(0x1) << PIO_MDER_P11_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P11                        PIO_MDER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P11_Msk instead */
+#define PIO_MDER_P12_Pos                    12                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P12_Msk                    (_U_(0x1) << PIO_MDER_P12_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P12                        PIO_MDER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P12_Msk instead */
+#define PIO_MDER_P13_Pos                    13                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P13_Msk                    (_U_(0x1) << PIO_MDER_P13_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P13                        PIO_MDER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P13_Msk instead */
+#define PIO_MDER_P14_Pos                    14                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P14_Msk                    (_U_(0x1) << PIO_MDER_P14_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P14                        PIO_MDER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P14_Msk instead */
+#define PIO_MDER_P15_Pos                    15                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P15_Msk                    (_U_(0x1) << PIO_MDER_P15_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P15                        PIO_MDER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P15_Msk instead */
+#define PIO_MDER_P16_Pos                    16                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P16_Msk                    (_U_(0x1) << PIO_MDER_P16_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P16                        PIO_MDER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P16_Msk instead */
+#define PIO_MDER_P17_Pos                    17                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P17_Msk                    (_U_(0x1) << PIO_MDER_P17_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P17                        PIO_MDER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P17_Msk instead */
+#define PIO_MDER_P18_Pos                    18                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P18_Msk                    (_U_(0x1) << PIO_MDER_P18_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P18                        PIO_MDER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P18_Msk instead */
+#define PIO_MDER_P19_Pos                    19                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P19_Msk                    (_U_(0x1) << PIO_MDER_P19_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P19                        PIO_MDER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P19_Msk instead */
+#define PIO_MDER_P20_Pos                    20                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P20_Msk                    (_U_(0x1) << PIO_MDER_P20_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P20                        PIO_MDER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P20_Msk instead */
+#define PIO_MDER_P21_Pos                    21                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P21_Msk                    (_U_(0x1) << PIO_MDER_P21_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P21                        PIO_MDER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P21_Msk instead */
+#define PIO_MDER_P22_Pos                    22                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P22_Msk                    (_U_(0x1) << PIO_MDER_P22_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P22                        PIO_MDER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P22_Msk instead */
+#define PIO_MDER_P23_Pos                    23                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P23_Msk                    (_U_(0x1) << PIO_MDER_P23_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P23                        PIO_MDER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P23_Msk instead */
+#define PIO_MDER_P24_Pos                    24                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P24_Msk                    (_U_(0x1) << PIO_MDER_P24_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P24                        PIO_MDER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P24_Msk instead */
+#define PIO_MDER_P25_Pos                    25                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P25_Msk                    (_U_(0x1) << PIO_MDER_P25_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P25                        PIO_MDER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P25_Msk instead */
+#define PIO_MDER_P26_Pos                    26                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P26_Msk                    (_U_(0x1) << PIO_MDER_P26_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P26                        PIO_MDER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P26_Msk instead */
+#define PIO_MDER_P27_Pos                    27                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P27_Msk                    (_U_(0x1) << PIO_MDER_P27_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P27                        PIO_MDER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P27_Msk instead */
+#define PIO_MDER_P28_Pos                    28                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P28_Msk                    (_U_(0x1) << PIO_MDER_P28_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P28                        PIO_MDER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P28_Msk instead */
+#define PIO_MDER_P29_Pos                    29                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P29_Msk                    (_U_(0x1) << PIO_MDER_P29_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P29                        PIO_MDER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P29_Msk instead */
+#define PIO_MDER_P30_Pos                    30                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P30_Msk                    (_U_(0x1) << PIO_MDER_P30_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P30                        PIO_MDER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P30_Msk instead */
+#define PIO_MDER_P31_Pos                    31                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P31_Msk                    (_U_(0x1) << PIO_MDER_P31_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P31                        PIO_MDER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P31_Msk instead */
+#define PIO_MDER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDER) Register MASK  (Use PIO_MDER_Msk instead)  */
+#define PIO_MDER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDER) Register Mask  */
+
+#define PIO_MDER_P_Pos                      0                                              /**< (PIO_MDER Position) Multi-drive Enable */
+#define PIO_MDER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDER_P_Pos)            /**< (PIO_MDER Mask) P */
+#define PIO_MDER_P(value)                   (PIO_MDER_P_Msk & ((value) << PIO_MDER_P_Pos))  
+
+/* -------- PIO_MDDR : (PIO Offset: 0x54) (/W 32) Multi-driver Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Disable                      */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Disable                      */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Disable                      */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Disable                      */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Disable                      */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Disable                      */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Disable                      */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Disable                      */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Disable                      */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Disable                      */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Disable                      */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Disable                      */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Disable                      */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Disable                      */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Disable                      */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Disable                      */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Disable                      */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Disable                      */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Disable                      */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Disable                      */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Disable                      */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Disable                      */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Disable                      */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Disable                      */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Disable                      */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Disable                      */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Disable                      */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Disable                      */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Disable                      */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Disable                      */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Disable                      */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Disable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Disable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDDR_OFFSET                     (0x54)                                        /**<  (PIO_MDDR) Multi-driver Disable Register  Offset */
+
+#define PIO_MDDR_P0_Pos                     0                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P0_Msk                     (_U_(0x1) << PIO_MDDR_P0_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P0                         PIO_MDDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P0_Msk instead */
+#define PIO_MDDR_P1_Pos                     1                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P1_Msk                     (_U_(0x1) << PIO_MDDR_P1_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P1                         PIO_MDDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P1_Msk instead */
+#define PIO_MDDR_P2_Pos                     2                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P2_Msk                     (_U_(0x1) << PIO_MDDR_P2_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P2                         PIO_MDDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P2_Msk instead */
+#define PIO_MDDR_P3_Pos                     3                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P3_Msk                     (_U_(0x1) << PIO_MDDR_P3_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P3                         PIO_MDDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P3_Msk instead */
+#define PIO_MDDR_P4_Pos                     4                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P4_Msk                     (_U_(0x1) << PIO_MDDR_P4_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P4                         PIO_MDDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P4_Msk instead */
+#define PIO_MDDR_P5_Pos                     5                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P5_Msk                     (_U_(0x1) << PIO_MDDR_P5_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P5                         PIO_MDDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P5_Msk instead */
+#define PIO_MDDR_P6_Pos                     6                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P6_Msk                     (_U_(0x1) << PIO_MDDR_P6_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P6                         PIO_MDDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P6_Msk instead */
+#define PIO_MDDR_P7_Pos                     7                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P7_Msk                     (_U_(0x1) << PIO_MDDR_P7_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P7                         PIO_MDDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P7_Msk instead */
+#define PIO_MDDR_P8_Pos                     8                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P8_Msk                     (_U_(0x1) << PIO_MDDR_P8_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P8                         PIO_MDDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P8_Msk instead */
+#define PIO_MDDR_P9_Pos                     9                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P9_Msk                     (_U_(0x1) << PIO_MDDR_P9_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P9                         PIO_MDDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P9_Msk instead */
+#define PIO_MDDR_P10_Pos                    10                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P10_Msk                    (_U_(0x1) << PIO_MDDR_P10_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P10                        PIO_MDDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P10_Msk instead */
+#define PIO_MDDR_P11_Pos                    11                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P11_Msk                    (_U_(0x1) << PIO_MDDR_P11_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P11                        PIO_MDDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P11_Msk instead */
+#define PIO_MDDR_P12_Pos                    12                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P12_Msk                    (_U_(0x1) << PIO_MDDR_P12_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P12                        PIO_MDDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P12_Msk instead */
+#define PIO_MDDR_P13_Pos                    13                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P13_Msk                    (_U_(0x1) << PIO_MDDR_P13_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P13                        PIO_MDDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P13_Msk instead */
+#define PIO_MDDR_P14_Pos                    14                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P14_Msk                    (_U_(0x1) << PIO_MDDR_P14_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P14                        PIO_MDDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P14_Msk instead */
+#define PIO_MDDR_P15_Pos                    15                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P15_Msk                    (_U_(0x1) << PIO_MDDR_P15_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P15                        PIO_MDDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P15_Msk instead */
+#define PIO_MDDR_P16_Pos                    16                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P16_Msk                    (_U_(0x1) << PIO_MDDR_P16_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P16                        PIO_MDDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P16_Msk instead */
+#define PIO_MDDR_P17_Pos                    17                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P17_Msk                    (_U_(0x1) << PIO_MDDR_P17_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P17                        PIO_MDDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P17_Msk instead */
+#define PIO_MDDR_P18_Pos                    18                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P18_Msk                    (_U_(0x1) << PIO_MDDR_P18_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P18                        PIO_MDDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P18_Msk instead */
+#define PIO_MDDR_P19_Pos                    19                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P19_Msk                    (_U_(0x1) << PIO_MDDR_P19_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P19                        PIO_MDDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P19_Msk instead */
+#define PIO_MDDR_P20_Pos                    20                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P20_Msk                    (_U_(0x1) << PIO_MDDR_P20_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P20                        PIO_MDDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P20_Msk instead */
+#define PIO_MDDR_P21_Pos                    21                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P21_Msk                    (_U_(0x1) << PIO_MDDR_P21_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P21                        PIO_MDDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P21_Msk instead */
+#define PIO_MDDR_P22_Pos                    22                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P22_Msk                    (_U_(0x1) << PIO_MDDR_P22_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P22                        PIO_MDDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P22_Msk instead */
+#define PIO_MDDR_P23_Pos                    23                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P23_Msk                    (_U_(0x1) << PIO_MDDR_P23_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P23                        PIO_MDDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P23_Msk instead */
+#define PIO_MDDR_P24_Pos                    24                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P24_Msk                    (_U_(0x1) << PIO_MDDR_P24_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P24                        PIO_MDDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P24_Msk instead */
+#define PIO_MDDR_P25_Pos                    25                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P25_Msk                    (_U_(0x1) << PIO_MDDR_P25_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P25                        PIO_MDDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P25_Msk instead */
+#define PIO_MDDR_P26_Pos                    26                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P26_Msk                    (_U_(0x1) << PIO_MDDR_P26_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P26                        PIO_MDDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P26_Msk instead */
+#define PIO_MDDR_P27_Pos                    27                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P27_Msk                    (_U_(0x1) << PIO_MDDR_P27_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P27                        PIO_MDDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P27_Msk instead */
+#define PIO_MDDR_P28_Pos                    28                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P28_Msk                    (_U_(0x1) << PIO_MDDR_P28_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P28                        PIO_MDDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P28_Msk instead */
+#define PIO_MDDR_P29_Pos                    29                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P29_Msk                    (_U_(0x1) << PIO_MDDR_P29_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P29                        PIO_MDDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P29_Msk instead */
+#define PIO_MDDR_P30_Pos                    30                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P30_Msk                    (_U_(0x1) << PIO_MDDR_P30_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P30                        PIO_MDDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P30_Msk instead */
+#define PIO_MDDR_P31_Pos                    31                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P31_Msk                    (_U_(0x1) << PIO_MDDR_P31_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P31                        PIO_MDDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P31_Msk instead */
+#define PIO_MDDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDDR) Register MASK  (Use PIO_MDDR_Msk instead)  */
+#define PIO_MDDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDDR) Register Mask  */
+
+#define PIO_MDDR_P_Pos                      0                                              /**< (PIO_MDDR Position) Multi-drive Disable */
+#define PIO_MDDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDDR_P_Pos)            /**< (PIO_MDDR Mask) P */
+#define PIO_MDDR_P(value)                   (PIO_MDDR_P_Msk & ((value) << PIO_MDDR_P_Pos))  
+
+/* -------- PIO_MDSR : (PIO Offset: 0x58) (R/ 32) Multi-driver Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDSR_OFFSET                     (0x58)                                        /**<  (PIO_MDSR) Multi-driver Status Register  Offset */
+
+#define PIO_MDSR_P0_Pos                     0                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P0_Msk                     (_U_(0x1) << PIO_MDSR_P0_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P0                         PIO_MDSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P0_Msk instead */
+#define PIO_MDSR_P1_Pos                     1                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P1_Msk                     (_U_(0x1) << PIO_MDSR_P1_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P1                         PIO_MDSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P1_Msk instead */
+#define PIO_MDSR_P2_Pos                     2                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P2_Msk                     (_U_(0x1) << PIO_MDSR_P2_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P2                         PIO_MDSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P2_Msk instead */
+#define PIO_MDSR_P3_Pos                     3                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P3_Msk                     (_U_(0x1) << PIO_MDSR_P3_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P3                         PIO_MDSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P3_Msk instead */
+#define PIO_MDSR_P4_Pos                     4                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P4_Msk                     (_U_(0x1) << PIO_MDSR_P4_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P4                         PIO_MDSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P4_Msk instead */
+#define PIO_MDSR_P5_Pos                     5                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P5_Msk                     (_U_(0x1) << PIO_MDSR_P5_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P5                         PIO_MDSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P5_Msk instead */
+#define PIO_MDSR_P6_Pos                     6                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P6_Msk                     (_U_(0x1) << PIO_MDSR_P6_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P6                         PIO_MDSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P6_Msk instead */
+#define PIO_MDSR_P7_Pos                     7                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P7_Msk                     (_U_(0x1) << PIO_MDSR_P7_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P7                         PIO_MDSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P7_Msk instead */
+#define PIO_MDSR_P8_Pos                     8                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P8_Msk                     (_U_(0x1) << PIO_MDSR_P8_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P8                         PIO_MDSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P8_Msk instead */
+#define PIO_MDSR_P9_Pos                     9                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P9_Msk                     (_U_(0x1) << PIO_MDSR_P9_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P9                         PIO_MDSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P9_Msk instead */
+#define PIO_MDSR_P10_Pos                    10                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P10_Msk                    (_U_(0x1) << PIO_MDSR_P10_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P10                        PIO_MDSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P10_Msk instead */
+#define PIO_MDSR_P11_Pos                    11                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P11_Msk                    (_U_(0x1) << PIO_MDSR_P11_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P11                        PIO_MDSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P11_Msk instead */
+#define PIO_MDSR_P12_Pos                    12                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P12_Msk                    (_U_(0x1) << PIO_MDSR_P12_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P12                        PIO_MDSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P12_Msk instead */
+#define PIO_MDSR_P13_Pos                    13                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P13_Msk                    (_U_(0x1) << PIO_MDSR_P13_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P13                        PIO_MDSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P13_Msk instead */
+#define PIO_MDSR_P14_Pos                    14                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P14_Msk                    (_U_(0x1) << PIO_MDSR_P14_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P14                        PIO_MDSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P14_Msk instead */
+#define PIO_MDSR_P15_Pos                    15                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P15_Msk                    (_U_(0x1) << PIO_MDSR_P15_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P15                        PIO_MDSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P15_Msk instead */
+#define PIO_MDSR_P16_Pos                    16                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P16_Msk                    (_U_(0x1) << PIO_MDSR_P16_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P16                        PIO_MDSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P16_Msk instead */
+#define PIO_MDSR_P17_Pos                    17                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P17_Msk                    (_U_(0x1) << PIO_MDSR_P17_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P17                        PIO_MDSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P17_Msk instead */
+#define PIO_MDSR_P18_Pos                    18                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P18_Msk                    (_U_(0x1) << PIO_MDSR_P18_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P18                        PIO_MDSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P18_Msk instead */
+#define PIO_MDSR_P19_Pos                    19                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P19_Msk                    (_U_(0x1) << PIO_MDSR_P19_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P19                        PIO_MDSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P19_Msk instead */
+#define PIO_MDSR_P20_Pos                    20                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P20_Msk                    (_U_(0x1) << PIO_MDSR_P20_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P20                        PIO_MDSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P20_Msk instead */
+#define PIO_MDSR_P21_Pos                    21                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P21_Msk                    (_U_(0x1) << PIO_MDSR_P21_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P21                        PIO_MDSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P21_Msk instead */
+#define PIO_MDSR_P22_Pos                    22                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P22_Msk                    (_U_(0x1) << PIO_MDSR_P22_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P22                        PIO_MDSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P22_Msk instead */
+#define PIO_MDSR_P23_Pos                    23                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P23_Msk                    (_U_(0x1) << PIO_MDSR_P23_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P23                        PIO_MDSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P23_Msk instead */
+#define PIO_MDSR_P24_Pos                    24                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P24_Msk                    (_U_(0x1) << PIO_MDSR_P24_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P24                        PIO_MDSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P24_Msk instead */
+#define PIO_MDSR_P25_Pos                    25                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P25_Msk                    (_U_(0x1) << PIO_MDSR_P25_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P25                        PIO_MDSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P25_Msk instead */
+#define PIO_MDSR_P26_Pos                    26                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P26_Msk                    (_U_(0x1) << PIO_MDSR_P26_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P26                        PIO_MDSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P26_Msk instead */
+#define PIO_MDSR_P27_Pos                    27                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P27_Msk                    (_U_(0x1) << PIO_MDSR_P27_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P27                        PIO_MDSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P27_Msk instead */
+#define PIO_MDSR_P28_Pos                    28                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P28_Msk                    (_U_(0x1) << PIO_MDSR_P28_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P28                        PIO_MDSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P28_Msk instead */
+#define PIO_MDSR_P29_Pos                    29                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P29_Msk                    (_U_(0x1) << PIO_MDSR_P29_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P29                        PIO_MDSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P29_Msk instead */
+#define PIO_MDSR_P30_Pos                    30                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P30_Msk                    (_U_(0x1) << PIO_MDSR_P30_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P30                        PIO_MDSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P30_Msk instead */
+#define PIO_MDSR_P31_Pos                    31                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P31_Msk                    (_U_(0x1) << PIO_MDSR_P31_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P31                        PIO_MDSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P31_Msk instead */
+#define PIO_MDSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDSR) Register MASK  (Use PIO_MDSR_Msk instead)  */
+#define PIO_MDSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDSR) Register Mask  */
+
+#define PIO_MDSR_P_Pos                      0                                              /**< (PIO_MDSR Position) Multi-drive Status */
+#define PIO_MDSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDSR_P_Pos)            /**< (PIO_MDSR Mask) P */
+#define PIO_MDSR_P(value)                   (PIO_MDSR_P_Msk & ((value) << PIO_MDSR_P_Pos))  
+
+/* -------- PIO_PUDR : (PIO Offset: 0x60) (/W 32) Pull-up Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Disable                          */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Disable                          */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Disable                          */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Disable                          */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Disable                          */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Disable                          */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Disable                          */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Disable                          */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Disable                          */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Disable                          */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Disable                          */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Disable                          */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Disable                          */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Disable                          */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Disable                          */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Disable                          */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Disable                          */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Disable                          */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Disable                          */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Disable                          */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Disable                          */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Disable                          */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Disable                          */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Disable                          */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Disable                          */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Disable                          */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Disable                          */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Disable                          */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Disable                          */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Disable                          */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Disable                          */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Disable                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Disable                          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUDR_OFFSET                     (0x60)                                        /**<  (PIO_PUDR) Pull-up Disable Register  Offset */
+
+#define PIO_PUDR_P0_Pos                     0                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P0_Msk                     (_U_(0x1) << PIO_PUDR_P0_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P0                         PIO_PUDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P0_Msk instead */
+#define PIO_PUDR_P1_Pos                     1                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P1_Msk                     (_U_(0x1) << PIO_PUDR_P1_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P1                         PIO_PUDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P1_Msk instead */
+#define PIO_PUDR_P2_Pos                     2                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P2_Msk                     (_U_(0x1) << PIO_PUDR_P2_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P2                         PIO_PUDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P2_Msk instead */
+#define PIO_PUDR_P3_Pos                     3                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P3_Msk                     (_U_(0x1) << PIO_PUDR_P3_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P3                         PIO_PUDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P3_Msk instead */
+#define PIO_PUDR_P4_Pos                     4                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P4_Msk                     (_U_(0x1) << PIO_PUDR_P4_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P4                         PIO_PUDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P4_Msk instead */
+#define PIO_PUDR_P5_Pos                     5                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P5_Msk                     (_U_(0x1) << PIO_PUDR_P5_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P5                         PIO_PUDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P5_Msk instead */
+#define PIO_PUDR_P6_Pos                     6                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P6_Msk                     (_U_(0x1) << PIO_PUDR_P6_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P6                         PIO_PUDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P6_Msk instead */
+#define PIO_PUDR_P7_Pos                     7                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P7_Msk                     (_U_(0x1) << PIO_PUDR_P7_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P7                         PIO_PUDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P7_Msk instead */
+#define PIO_PUDR_P8_Pos                     8                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P8_Msk                     (_U_(0x1) << PIO_PUDR_P8_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P8                         PIO_PUDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P8_Msk instead */
+#define PIO_PUDR_P9_Pos                     9                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P9_Msk                     (_U_(0x1) << PIO_PUDR_P9_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P9                         PIO_PUDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P9_Msk instead */
+#define PIO_PUDR_P10_Pos                    10                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P10_Msk                    (_U_(0x1) << PIO_PUDR_P10_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P10                        PIO_PUDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P10_Msk instead */
+#define PIO_PUDR_P11_Pos                    11                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P11_Msk                    (_U_(0x1) << PIO_PUDR_P11_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P11                        PIO_PUDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P11_Msk instead */
+#define PIO_PUDR_P12_Pos                    12                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P12_Msk                    (_U_(0x1) << PIO_PUDR_P12_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P12                        PIO_PUDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P12_Msk instead */
+#define PIO_PUDR_P13_Pos                    13                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P13_Msk                    (_U_(0x1) << PIO_PUDR_P13_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P13                        PIO_PUDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P13_Msk instead */
+#define PIO_PUDR_P14_Pos                    14                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P14_Msk                    (_U_(0x1) << PIO_PUDR_P14_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P14                        PIO_PUDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P14_Msk instead */
+#define PIO_PUDR_P15_Pos                    15                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P15_Msk                    (_U_(0x1) << PIO_PUDR_P15_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P15                        PIO_PUDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P15_Msk instead */
+#define PIO_PUDR_P16_Pos                    16                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P16_Msk                    (_U_(0x1) << PIO_PUDR_P16_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P16                        PIO_PUDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P16_Msk instead */
+#define PIO_PUDR_P17_Pos                    17                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P17_Msk                    (_U_(0x1) << PIO_PUDR_P17_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P17                        PIO_PUDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P17_Msk instead */
+#define PIO_PUDR_P18_Pos                    18                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P18_Msk                    (_U_(0x1) << PIO_PUDR_P18_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P18                        PIO_PUDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P18_Msk instead */
+#define PIO_PUDR_P19_Pos                    19                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P19_Msk                    (_U_(0x1) << PIO_PUDR_P19_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P19                        PIO_PUDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P19_Msk instead */
+#define PIO_PUDR_P20_Pos                    20                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P20_Msk                    (_U_(0x1) << PIO_PUDR_P20_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P20                        PIO_PUDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P20_Msk instead */
+#define PIO_PUDR_P21_Pos                    21                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P21_Msk                    (_U_(0x1) << PIO_PUDR_P21_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P21                        PIO_PUDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P21_Msk instead */
+#define PIO_PUDR_P22_Pos                    22                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P22_Msk                    (_U_(0x1) << PIO_PUDR_P22_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P22                        PIO_PUDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P22_Msk instead */
+#define PIO_PUDR_P23_Pos                    23                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P23_Msk                    (_U_(0x1) << PIO_PUDR_P23_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P23                        PIO_PUDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P23_Msk instead */
+#define PIO_PUDR_P24_Pos                    24                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P24_Msk                    (_U_(0x1) << PIO_PUDR_P24_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P24                        PIO_PUDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P24_Msk instead */
+#define PIO_PUDR_P25_Pos                    25                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P25_Msk                    (_U_(0x1) << PIO_PUDR_P25_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P25                        PIO_PUDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P25_Msk instead */
+#define PIO_PUDR_P26_Pos                    26                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P26_Msk                    (_U_(0x1) << PIO_PUDR_P26_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P26                        PIO_PUDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P26_Msk instead */
+#define PIO_PUDR_P27_Pos                    27                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P27_Msk                    (_U_(0x1) << PIO_PUDR_P27_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P27                        PIO_PUDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P27_Msk instead */
+#define PIO_PUDR_P28_Pos                    28                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P28_Msk                    (_U_(0x1) << PIO_PUDR_P28_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P28                        PIO_PUDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P28_Msk instead */
+#define PIO_PUDR_P29_Pos                    29                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P29_Msk                    (_U_(0x1) << PIO_PUDR_P29_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P29                        PIO_PUDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P29_Msk instead */
+#define PIO_PUDR_P30_Pos                    30                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P30_Msk                    (_U_(0x1) << PIO_PUDR_P30_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P30                        PIO_PUDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P30_Msk instead */
+#define PIO_PUDR_P31_Pos                    31                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P31_Msk                    (_U_(0x1) << PIO_PUDR_P31_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P31                        PIO_PUDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P31_Msk instead */
+#define PIO_PUDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUDR) Register MASK  (Use PIO_PUDR_Msk instead)  */
+#define PIO_PUDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUDR) Register Mask  */
+
+#define PIO_PUDR_P_Pos                      0                                              /**< (PIO_PUDR Position) Pull-Up Disable */
+#define PIO_PUDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUDR_P_Pos)            /**< (PIO_PUDR Mask) P */
+#define PIO_PUDR_P(value)                   (PIO_PUDR_P_Msk & ((value) << PIO_PUDR_P_Pos))  
+
+/* -------- PIO_PUER : (PIO Offset: 0x64) (/W 32) Pull-up Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Enable                           */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Enable                           */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Enable                           */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Enable                           */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Enable                           */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Enable                           */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Enable                           */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Enable                           */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Enable                           */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Enable                           */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Enable                           */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Enable                           */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Enable                           */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Enable                           */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Enable                           */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Enable                           */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Enable                           */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Enable                           */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Enable                           */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Enable                           */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Enable                           */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Enable                           */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Enable                           */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Enable                           */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Enable                           */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Enable                           */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Enable                           */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Enable                           */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Enable                           */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Enable                           */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Enable                           */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Enable                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Enable                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUER_OFFSET                     (0x64)                                        /**<  (PIO_PUER) Pull-up Enable Register  Offset */
+
+#define PIO_PUER_P0_Pos                     0                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P0_Msk                     (_U_(0x1) << PIO_PUER_P0_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P0                         PIO_PUER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P0_Msk instead */
+#define PIO_PUER_P1_Pos                     1                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P1_Msk                     (_U_(0x1) << PIO_PUER_P1_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P1                         PIO_PUER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P1_Msk instead */
+#define PIO_PUER_P2_Pos                     2                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P2_Msk                     (_U_(0x1) << PIO_PUER_P2_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P2                         PIO_PUER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P2_Msk instead */
+#define PIO_PUER_P3_Pos                     3                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P3_Msk                     (_U_(0x1) << PIO_PUER_P3_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P3                         PIO_PUER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P3_Msk instead */
+#define PIO_PUER_P4_Pos                     4                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P4_Msk                     (_U_(0x1) << PIO_PUER_P4_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P4                         PIO_PUER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P4_Msk instead */
+#define PIO_PUER_P5_Pos                     5                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P5_Msk                     (_U_(0x1) << PIO_PUER_P5_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P5                         PIO_PUER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P5_Msk instead */
+#define PIO_PUER_P6_Pos                     6                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P6_Msk                     (_U_(0x1) << PIO_PUER_P6_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P6                         PIO_PUER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P6_Msk instead */
+#define PIO_PUER_P7_Pos                     7                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P7_Msk                     (_U_(0x1) << PIO_PUER_P7_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P7                         PIO_PUER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P7_Msk instead */
+#define PIO_PUER_P8_Pos                     8                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P8_Msk                     (_U_(0x1) << PIO_PUER_P8_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P8                         PIO_PUER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P8_Msk instead */
+#define PIO_PUER_P9_Pos                     9                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P9_Msk                     (_U_(0x1) << PIO_PUER_P9_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P9                         PIO_PUER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P9_Msk instead */
+#define PIO_PUER_P10_Pos                    10                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P10_Msk                    (_U_(0x1) << PIO_PUER_P10_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P10                        PIO_PUER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P10_Msk instead */
+#define PIO_PUER_P11_Pos                    11                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P11_Msk                    (_U_(0x1) << PIO_PUER_P11_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P11                        PIO_PUER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P11_Msk instead */
+#define PIO_PUER_P12_Pos                    12                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P12_Msk                    (_U_(0x1) << PIO_PUER_P12_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P12                        PIO_PUER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P12_Msk instead */
+#define PIO_PUER_P13_Pos                    13                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P13_Msk                    (_U_(0x1) << PIO_PUER_P13_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P13                        PIO_PUER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P13_Msk instead */
+#define PIO_PUER_P14_Pos                    14                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P14_Msk                    (_U_(0x1) << PIO_PUER_P14_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P14                        PIO_PUER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P14_Msk instead */
+#define PIO_PUER_P15_Pos                    15                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P15_Msk                    (_U_(0x1) << PIO_PUER_P15_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P15                        PIO_PUER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P15_Msk instead */
+#define PIO_PUER_P16_Pos                    16                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P16_Msk                    (_U_(0x1) << PIO_PUER_P16_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P16                        PIO_PUER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P16_Msk instead */
+#define PIO_PUER_P17_Pos                    17                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P17_Msk                    (_U_(0x1) << PIO_PUER_P17_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P17                        PIO_PUER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P17_Msk instead */
+#define PIO_PUER_P18_Pos                    18                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P18_Msk                    (_U_(0x1) << PIO_PUER_P18_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P18                        PIO_PUER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P18_Msk instead */
+#define PIO_PUER_P19_Pos                    19                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P19_Msk                    (_U_(0x1) << PIO_PUER_P19_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P19                        PIO_PUER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P19_Msk instead */
+#define PIO_PUER_P20_Pos                    20                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P20_Msk                    (_U_(0x1) << PIO_PUER_P20_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P20                        PIO_PUER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P20_Msk instead */
+#define PIO_PUER_P21_Pos                    21                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P21_Msk                    (_U_(0x1) << PIO_PUER_P21_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P21                        PIO_PUER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P21_Msk instead */
+#define PIO_PUER_P22_Pos                    22                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P22_Msk                    (_U_(0x1) << PIO_PUER_P22_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P22                        PIO_PUER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P22_Msk instead */
+#define PIO_PUER_P23_Pos                    23                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P23_Msk                    (_U_(0x1) << PIO_PUER_P23_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P23                        PIO_PUER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P23_Msk instead */
+#define PIO_PUER_P24_Pos                    24                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P24_Msk                    (_U_(0x1) << PIO_PUER_P24_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P24                        PIO_PUER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P24_Msk instead */
+#define PIO_PUER_P25_Pos                    25                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P25_Msk                    (_U_(0x1) << PIO_PUER_P25_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P25                        PIO_PUER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P25_Msk instead */
+#define PIO_PUER_P26_Pos                    26                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P26_Msk                    (_U_(0x1) << PIO_PUER_P26_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P26                        PIO_PUER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P26_Msk instead */
+#define PIO_PUER_P27_Pos                    27                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P27_Msk                    (_U_(0x1) << PIO_PUER_P27_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P27                        PIO_PUER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P27_Msk instead */
+#define PIO_PUER_P28_Pos                    28                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P28_Msk                    (_U_(0x1) << PIO_PUER_P28_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P28                        PIO_PUER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P28_Msk instead */
+#define PIO_PUER_P29_Pos                    29                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P29_Msk                    (_U_(0x1) << PIO_PUER_P29_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P29                        PIO_PUER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P29_Msk instead */
+#define PIO_PUER_P30_Pos                    30                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P30_Msk                    (_U_(0x1) << PIO_PUER_P30_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P30                        PIO_PUER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P30_Msk instead */
+#define PIO_PUER_P31_Pos                    31                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P31_Msk                    (_U_(0x1) << PIO_PUER_P31_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P31                        PIO_PUER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P31_Msk instead */
+#define PIO_PUER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUER) Register MASK  (Use PIO_PUER_Msk instead)  */
+#define PIO_PUER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUER) Register Mask  */
+
+#define PIO_PUER_P_Pos                      0                                              /**< (PIO_PUER Position) Pull-Up Enable */
+#define PIO_PUER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUER_P_Pos)            /**< (PIO_PUER Mask) P */
+#define PIO_PUER_P(value)                   (PIO_PUER_P_Msk & ((value) << PIO_PUER_P_Pos))  
+
+/* -------- PIO_PUSR : (PIO Offset: 0x68) (R/ 32) Pad Pull-up Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Status                           */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Status                           */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Status                           */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Status                           */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Status                           */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Status                           */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Status                           */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Status                           */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Status                           */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Status                           */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Status                           */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Status                           */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Status                           */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Status                           */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Status                           */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Status                           */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Status                           */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Status                           */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Status                           */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Status                           */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Status                           */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Status                           */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Status                           */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Status                           */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Status                           */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Status                           */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Status                           */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Status                           */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Status                           */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Status                           */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Status                           */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Status                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Status                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUSR_OFFSET                     (0x68)                                        /**<  (PIO_PUSR) Pad Pull-up Status Register  Offset */
+
+#define PIO_PUSR_P0_Pos                     0                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P0_Msk                     (_U_(0x1) << PIO_PUSR_P0_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P0                         PIO_PUSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P0_Msk instead */
+#define PIO_PUSR_P1_Pos                     1                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P1_Msk                     (_U_(0x1) << PIO_PUSR_P1_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P1                         PIO_PUSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P1_Msk instead */
+#define PIO_PUSR_P2_Pos                     2                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P2_Msk                     (_U_(0x1) << PIO_PUSR_P2_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P2                         PIO_PUSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P2_Msk instead */
+#define PIO_PUSR_P3_Pos                     3                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P3_Msk                     (_U_(0x1) << PIO_PUSR_P3_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P3                         PIO_PUSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P3_Msk instead */
+#define PIO_PUSR_P4_Pos                     4                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P4_Msk                     (_U_(0x1) << PIO_PUSR_P4_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P4                         PIO_PUSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P4_Msk instead */
+#define PIO_PUSR_P5_Pos                     5                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P5_Msk                     (_U_(0x1) << PIO_PUSR_P5_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P5                         PIO_PUSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P5_Msk instead */
+#define PIO_PUSR_P6_Pos                     6                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P6_Msk                     (_U_(0x1) << PIO_PUSR_P6_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P6                         PIO_PUSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P6_Msk instead */
+#define PIO_PUSR_P7_Pos                     7                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P7_Msk                     (_U_(0x1) << PIO_PUSR_P7_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P7                         PIO_PUSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P7_Msk instead */
+#define PIO_PUSR_P8_Pos                     8                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P8_Msk                     (_U_(0x1) << PIO_PUSR_P8_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P8                         PIO_PUSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P8_Msk instead */
+#define PIO_PUSR_P9_Pos                     9                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P9_Msk                     (_U_(0x1) << PIO_PUSR_P9_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P9                         PIO_PUSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P9_Msk instead */
+#define PIO_PUSR_P10_Pos                    10                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P10_Msk                    (_U_(0x1) << PIO_PUSR_P10_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P10                        PIO_PUSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P10_Msk instead */
+#define PIO_PUSR_P11_Pos                    11                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P11_Msk                    (_U_(0x1) << PIO_PUSR_P11_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P11                        PIO_PUSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P11_Msk instead */
+#define PIO_PUSR_P12_Pos                    12                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P12_Msk                    (_U_(0x1) << PIO_PUSR_P12_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P12                        PIO_PUSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P12_Msk instead */
+#define PIO_PUSR_P13_Pos                    13                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P13_Msk                    (_U_(0x1) << PIO_PUSR_P13_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P13                        PIO_PUSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P13_Msk instead */
+#define PIO_PUSR_P14_Pos                    14                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P14_Msk                    (_U_(0x1) << PIO_PUSR_P14_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P14                        PIO_PUSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P14_Msk instead */
+#define PIO_PUSR_P15_Pos                    15                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P15_Msk                    (_U_(0x1) << PIO_PUSR_P15_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P15                        PIO_PUSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P15_Msk instead */
+#define PIO_PUSR_P16_Pos                    16                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P16_Msk                    (_U_(0x1) << PIO_PUSR_P16_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P16                        PIO_PUSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P16_Msk instead */
+#define PIO_PUSR_P17_Pos                    17                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P17_Msk                    (_U_(0x1) << PIO_PUSR_P17_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P17                        PIO_PUSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P17_Msk instead */
+#define PIO_PUSR_P18_Pos                    18                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P18_Msk                    (_U_(0x1) << PIO_PUSR_P18_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P18                        PIO_PUSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P18_Msk instead */
+#define PIO_PUSR_P19_Pos                    19                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P19_Msk                    (_U_(0x1) << PIO_PUSR_P19_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P19                        PIO_PUSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P19_Msk instead */
+#define PIO_PUSR_P20_Pos                    20                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P20_Msk                    (_U_(0x1) << PIO_PUSR_P20_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P20                        PIO_PUSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P20_Msk instead */
+#define PIO_PUSR_P21_Pos                    21                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P21_Msk                    (_U_(0x1) << PIO_PUSR_P21_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P21                        PIO_PUSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P21_Msk instead */
+#define PIO_PUSR_P22_Pos                    22                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P22_Msk                    (_U_(0x1) << PIO_PUSR_P22_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P22                        PIO_PUSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P22_Msk instead */
+#define PIO_PUSR_P23_Pos                    23                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P23_Msk                    (_U_(0x1) << PIO_PUSR_P23_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P23                        PIO_PUSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P23_Msk instead */
+#define PIO_PUSR_P24_Pos                    24                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P24_Msk                    (_U_(0x1) << PIO_PUSR_P24_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P24                        PIO_PUSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P24_Msk instead */
+#define PIO_PUSR_P25_Pos                    25                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P25_Msk                    (_U_(0x1) << PIO_PUSR_P25_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P25                        PIO_PUSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P25_Msk instead */
+#define PIO_PUSR_P26_Pos                    26                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P26_Msk                    (_U_(0x1) << PIO_PUSR_P26_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P26                        PIO_PUSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P26_Msk instead */
+#define PIO_PUSR_P27_Pos                    27                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P27_Msk                    (_U_(0x1) << PIO_PUSR_P27_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P27                        PIO_PUSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P27_Msk instead */
+#define PIO_PUSR_P28_Pos                    28                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P28_Msk                    (_U_(0x1) << PIO_PUSR_P28_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P28                        PIO_PUSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P28_Msk instead */
+#define PIO_PUSR_P29_Pos                    29                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P29_Msk                    (_U_(0x1) << PIO_PUSR_P29_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P29                        PIO_PUSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P29_Msk instead */
+#define PIO_PUSR_P30_Pos                    30                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P30_Msk                    (_U_(0x1) << PIO_PUSR_P30_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P30                        PIO_PUSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P30_Msk instead */
+#define PIO_PUSR_P31_Pos                    31                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P31_Msk                    (_U_(0x1) << PIO_PUSR_P31_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P31                        PIO_PUSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P31_Msk instead */
+#define PIO_PUSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUSR) Register MASK  (Use PIO_PUSR_Msk instead)  */
+#define PIO_PUSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUSR) Register Mask  */
+
+#define PIO_PUSR_P_Pos                      0                                              /**< (PIO_PUSR Position) Pull-Up Status */
+#define PIO_PUSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUSR_P_Pos)            /**< (PIO_PUSR Mask) P */
+#define PIO_PUSR_P(value)                   (PIO_PUSR_P_Msk & ((value) << PIO_PUSR_P_Pos))  
+
+/* -------- PIO_ABCDSR : (PIO Offset: 0x70) (R/W 32) Peripheral ABCD Select Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Peripheral Select                        */
+    uint32_t P1:1;                      /**< bit:      1  Peripheral Select                        */
+    uint32_t P2:1;                      /**< bit:      2  Peripheral Select                        */
+    uint32_t P3:1;                      /**< bit:      3  Peripheral Select                        */
+    uint32_t P4:1;                      /**< bit:      4  Peripheral Select                        */
+    uint32_t P5:1;                      /**< bit:      5  Peripheral Select                        */
+    uint32_t P6:1;                      /**< bit:      6  Peripheral Select                        */
+    uint32_t P7:1;                      /**< bit:      7  Peripheral Select                        */
+    uint32_t P8:1;                      /**< bit:      8  Peripheral Select                        */
+    uint32_t P9:1;                      /**< bit:      9  Peripheral Select                        */
+    uint32_t P10:1;                     /**< bit:     10  Peripheral Select                        */
+    uint32_t P11:1;                     /**< bit:     11  Peripheral Select                        */
+    uint32_t P12:1;                     /**< bit:     12  Peripheral Select                        */
+    uint32_t P13:1;                     /**< bit:     13  Peripheral Select                        */
+    uint32_t P14:1;                     /**< bit:     14  Peripheral Select                        */
+    uint32_t P15:1;                     /**< bit:     15  Peripheral Select                        */
+    uint32_t P16:1;                     /**< bit:     16  Peripheral Select                        */
+    uint32_t P17:1;                     /**< bit:     17  Peripheral Select                        */
+    uint32_t P18:1;                     /**< bit:     18  Peripheral Select                        */
+    uint32_t P19:1;                     /**< bit:     19  Peripheral Select                        */
+    uint32_t P20:1;                     /**< bit:     20  Peripheral Select                        */
+    uint32_t P21:1;                     /**< bit:     21  Peripheral Select                        */
+    uint32_t P22:1;                     /**< bit:     22  Peripheral Select                        */
+    uint32_t P23:1;                     /**< bit:     23  Peripheral Select                        */
+    uint32_t P24:1;                     /**< bit:     24  Peripheral Select                        */
+    uint32_t P25:1;                     /**< bit:     25  Peripheral Select                        */
+    uint32_t P26:1;                     /**< bit:     26  Peripheral Select                        */
+    uint32_t P27:1;                     /**< bit:     27  Peripheral Select                        */
+    uint32_t P28:1;                     /**< bit:     28  Peripheral Select                        */
+    uint32_t P29:1;                     /**< bit:     29  Peripheral Select                        */
+    uint32_t P30:1;                     /**< bit:     30  Peripheral Select                        */
+    uint32_t P31:1;                     /**< bit:     31  Peripheral Select                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Peripheral Select                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ABCDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ABCDSR_OFFSET                   (0x70)                                        /**<  (PIO_ABCDSR) Peripheral ABCD Select Register 0  Offset */
+
+#define PIO_ABCDSR_P0_Pos                   0                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P0_Msk                   (_U_(0x1) << PIO_ABCDSR_P0_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P0                       PIO_ABCDSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P0_Msk instead */
+#define PIO_ABCDSR_P1_Pos                   1                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P1_Msk                   (_U_(0x1) << PIO_ABCDSR_P1_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P1                       PIO_ABCDSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P1_Msk instead */
+#define PIO_ABCDSR_P2_Pos                   2                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P2_Msk                   (_U_(0x1) << PIO_ABCDSR_P2_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P2                       PIO_ABCDSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P2_Msk instead */
+#define PIO_ABCDSR_P3_Pos                   3                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P3_Msk                   (_U_(0x1) << PIO_ABCDSR_P3_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P3                       PIO_ABCDSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P3_Msk instead */
+#define PIO_ABCDSR_P4_Pos                   4                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P4_Msk                   (_U_(0x1) << PIO_ABCDSR_P4_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P4                       PIO_ABCDSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P4_Msk instead */
+#define PIO_ABCDSR_P5_Pos                   5                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P5_Msk                   (_U_(0x1) << PIO_ABCDSR_P5_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P5                       PIO_ABCDSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P5_Msk instead */
+#define PIO_ABCDSR_P6_Pos                   6                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P6_Msk                   (_U_(0x1) << PIO_ABCDSR_P6_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P6                       PIO_ABCDSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P6_Msk instead */
+#define PIO_ABCDSR_P7_Pos                   7                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P7_Msk                   (_U_(0x1) << PIO_ABCDSR_P7_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P7                       PIO_ABCDSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P7_Msk instead */
+#define PIO_ABCDSR_P8_Pos                   8                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P8_Msk                   (_U_(0x1) << PIO_ABCDSR_P8_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P8                       PIO_ABCDSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P8_Msk instead */
+#define PIO_ABCDSR_P9_Pos                   9                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P9_Msk                   (_U_(0x1) << PIO_ABCDSR_P9_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P9                       PIO_ABCDSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P9_Msk instead */
+#define PIO_ABCDSR_P10_Pos                  10                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P10_Msk                  (_U_(0x1) << PIO_ABCDSR_P10_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P10                      PIO_ABCDSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P10_Msk instead */
+#define PIO_ABCDSR_P11_Pos                  11                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P11_Msk                  (_U_(0x1) << PIO_ABCDSR_P11_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P11                      PIO_ABCDSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P11_Msk instead */
+#define PIO_ABCDSR_P12_Pos                  12                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P12_Msk                  (_U_(0x1) << PIO_ABCDSR_P12_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P12                      PIO_ABCDSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P12_Msk instead */
+#define PIO_ABCDSR_P13_Pos                  13                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P13_Msk                  (_U_(0x1) << PIO_ABCDSR_P13_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P13                      PIO_ABCDSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P13_Msk instead */
+#define PIO_ABCDSR_P14_Pos                  14                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P14_Msk                  (_U_(0x1) << PIO_ABCDSR_P14_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P14                      PIO_ABCDSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P14_Msk instead */
+#define PIO_ABCDSR_P15_Pos                  15                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P15_Msk                  (_U_(0x1) << PIO_ABCDSR_P15_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P15                      PIO_ABCDSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P15_Msk instead */
+#define PIO_ABCDSR_P16_Pos                  16                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P16_Msk                  (_U_(0x1) << PIO_ABCDSR_P16_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P16                      PIO_ABCDSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P16_Msk instead */
+#define PIO_ABCDSR_P17_Pos                  17                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P17_Msk                  (_U_(0x1) << PIO_ABCDSR_P17_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P17                      PIO_ABCDSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P17_Msk instead */
+#define PIO_ABCDSR_P18_Pos                  18                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P18_Msk                  (_U_(0x1) << PIO_ABCDSR_P18_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P18                      PIO_ABCDSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P18_Msk instead */
+#define PIO_ABCDSR_P19_Pos                  19                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P19_Msk                  (_U_(0x1) << PIO_ABCDSR_P19_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P19                      PIO_ABCDSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P19_Msk instead */
+#define PIO_ABCDSR_P20_Pos                  20                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P20_Msk                  (_U_(0x1) << PIO_ABCDSR_P20_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P20                      PIO_ABCDSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P20_Msk instead */
+#define PIO_ABCDSR_P21_Pos                  21                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P21_Msk                  (_U_(0x1) << PIO_ABCDSR_P21_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P21                      PIO_ABCDSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P21_Msk instead */
+#define PIO_ABCDSR_P22_Pos                  22                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P22_Msk                  (_U_(0x1) << PIO_ABCDSR_P22_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P22                      PIO_ABCDSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P22_Msk instead */
+#define PIO_ABCDSR_P23_Pos                  23                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P23_Msk                  (_U_(0x1) << PIO_ABCDSR_P23_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P23                      PIO_ABCDSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P23_Msk instead */
+#define PIO_ABCDSR_P24_Pos                  24                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P24_Msk                  (_U_(0x1) << PIO_ABCDSR_P24_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P24                      PIO_ABCDSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P24_Msk instead */
+#define PIO_ABCDSR_P25_Pos                  25                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P25_Msk                  (_U_(0x1) << PIO_ABCDSR_P25_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P25                      PIO_ABCDSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P25_Msk instead */
+#define PIO_ABCDSR_P26_Pos                  26                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P26_Msk                  (_U_(0x1) << PIO_ABCDSR_P26_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P26                      PIO_ABCDSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P26_Msk instead */
+#define PIO_ABCDSR_P27_Pos                  27                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P27_Msk                  (_U_(0x1) << PIO_ABCDSR_P27_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P27                      PIO_ABCDSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P27_Msk instead */
+#define PIO_ABCDSR_P28_Pos                  28                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P28_Msk                  (_U_(0x1) << PIO_ABCDSR_P28_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P28                      PIO_ABCDSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P28_Msk instead */
+#define PIO_ABCDSR_P29_Pos                  29                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P29_Msk                  (_U_(0x1) << PIO_ABCDSR_P29_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P29                      PIO_ABCDSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P29_Msk instead */
+#define PIO_ABCDSR_P30_Pos                  30                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P30_Msk                  (_U_(0x1) << PIO_ABCDSR_P30_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P30                      PIO_ABCDSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P30_Msk instead */
+#define PIO_ABCDSR_P31_Pos                  31                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P31_Msk                  (_U_(0x1) << PIO_ABCDSR_P31_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P31                      PIO_ABCDSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P31_Msk instead */
+#define PIO_ABCDSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ABCDSR) Register MASK  (Use PIO_ABCDSR_Msk instead)  */
+#define PIO_ABCDSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_ABCDSR) Register Mask  */
+
+#define PIO_ABCDSR_P_Pos                    0                                              /**< (PIO_ABCDSR Position) Peripheral Select */
+#define PIO_ABCDSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_ABCDSR_P_Pos)          /**< (PIO_ABCDSR Mask) P */
+#define PIO_ABCDSR_P(value)                 (PIO_ABCDSR_P_Msk & ((value) << PIO_ABCDSR_P_Pos))  
+
+/* -------- PIO_IFSCDR : (PIO Offset: 0x80) (/W 32) Input Filter Slow Clock Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Peripheral Clock Glitch Filtering Select */
+    uint32_t P1:1;                      /**< bit:      1  Peripheral Clock Glitch Filtering Select */
+    uint32_t P2:1;                      /**< bit:      2  Peripheral Clock Glitch Filtering Select */
+    uint32_t P3:1;                      /**< bit:      3  Peripheral Clock Glitch Filtering Select */
+    uint32_t P4:1;                      /**< bit:      4  Peripheral Clock Glitch Filtering Select */
+    uint32_t P5:1;                      /**< bit:      5  Peripheral Clock Glitch Filtering Select */
+    uint32_t P6:1;                      /**< bit:      6  Peripheral Clock Glitch Filtering Select */
+    uint32_t P7:1;                      /**< bit:      7  Peripheral Clock Glitch Filtering Select */
+    uint32_t P8:1;                      /**< bit:      8  Peripheral Clock Glitch Filtering Select */
+    uint32_t P9:1;                      /**< bit:      9  Peripheral Clock Glitch Filtering Select */
+    uint32_t P10:1;                     /**< bit:     10  Peripheral Clock Glitch Filtering Select */
+    uint32_t P11:1;                     /**< bit:     11  Peripheral Clock Glitch Filtering Select */
+    uint32_t P12:1;                     /**< bit:     12  Peripheral Clock Glitch Filtering Select */
+    uint32_t P13:1;                     /**< bit:     13  Peripheral Clock Glitch Filtering Select */
+    uint32_t P14:1;                     /**< bit:     14  Peripheral Clock Glitch Filtering Select */
+    uint32_t P15:1;                     /**< bit:     15  Peripheral Clock Glitch Filtering Select */
+    uint32_t P16:1;                     /**< bit:     16  Peripheral Clock Glitch Filtering Select */
+    uint32_t P17:1;                     /**< bit:     17  Peripheral Clock Glitch Filtering Select */
+    uint32_t P18:1;                     /**< bit:     18  Peripheral Clock Glitch Filtering Select */
+    uint32_t P19:1;                     /**< bit:     19  Peripheral Clock Glitch Filtering Select */
+    uint32_t P20:1;                     /**< bit:     20  Peripheral Clock Glitch Filtering Select */
+    uint32_t P21:1;                     /**< bit:     21  Peripheral Clock Glitch Filtering Select */
+    uint32_t P22:1;                     /**< bit:     22  Peripheral Clock Glitch Filtering Select */
+    uint32_t P23:1;                     /**< bit:     23  Peripheral Clock Glitch Filtering Select */
+    uint32_t P24:1;                     /**< bit:     24  Peripheral Clock Glitch Filtering Select */
+    uint32_t P25:1;                     /**< bit:     25  Peripheral Clock Glitch Filtering Select */
+    uint32_t P26:1;                     /**< bit:     26  Peripheral Clock Glitch Filtering Select */
+    uint32_t P27:1;                     /**< bit:     27  Peripheral Clock Glitch Filtering Select */
+    uint32_t P28:1;                     /**< bit:     28  Peripheral Clock Glitch Filtering Select */
+    uint32_t P29:1;                     /**< bit:     29  Peripheral Clock Glitch Filtering Select */
+    uint32_t P30:1;                     /**< bit:     30  Peripheral Clock Glitch Filtering Select */
+    uint32_t P31:1;                     /**< bit:     31  Peripheral Clock Glitch Filtering Select */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Peripheral Clock Glitch Filtering Select */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCDR_OFFSET                   (0x80)                                        /**<  (PIO_IFSCDR) Input Filter Slow Clock Disable Register  Offset */
+
+#define PIO_IFSCDR_P0_Pos                   0                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P0_Msk                   (_U_(0x1) << PIO_IFSCDR_P0_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P0                       PIO_IFSCDR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P0_Msk instead */
+#define PIO_IFSCDR_P1_Pos                   1                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P1_Msk                   (_U_(0x1) << PIO_IFSCDR_P1_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P1                       PIO_IFSCDR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P1_Msk instead */
+#define PIO_IFSCDR_P2_Pos                   2                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P2_Msk                   (_U_(0x1) << PIO_IFSCDR_P2_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P2                       PIO_IFSCDR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P2_Msk instead */
+#define PIO_IFSCDR_P3_Pos                   3                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P3_Msk                   (_U_(0x1) << PIO_IFSCDR_P3_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P3                       PIO_IFSCDR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P3_Msk instead */
+#define PIO_IFSCDR_P4_Pos                   4                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P4_Msk                   (_U_(0x1) << PIO_IFSCDR_P4_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P4                       PIO_IFSCDR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P4_Msk instead */
+#define PIO_IFSCDR_P5_Pos                   5                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P5_Msk                   (_U_(0x1) << PIO_IFSCDR_P5_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P5                       PIO_IFSCDR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P5_Msk instead */
+#define PIO_IFSCDR_P6_Pos                   6                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P6_Msk                   (_U_(0x1) << PIO_IFSCDR_P6_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P6                       PIO_IFSCDR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P6_Msk instead */
+#define PIO_IFSCDR_P7_Pos                   7                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P7_Msk                   (_U_(0x1) << PIO_IFSCDR_P7_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P7                       PIO_IFSCDR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P7_Msk instead */
+#define PIO_IFSCDR_P8_Pos                   8                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P8_Msk                   (_U_(0x1) << PIO_IFSCDR_P8_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P8                       PIO_IFSCDR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P8_Msk instead */
+#define PIO_IFSCDR_P9_Pos                   9                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P9_Msk                   (_U_(0x1) << PIO_IFSCDR_P9_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P9                       PIO_IFSCDR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P9_Msk instead */
+#define PIO_IFSCDR_P10_Pos                  10                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P10_Msk                  (_U_(0x1) << PIO_IFSCDR_P10_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P10                      PIO_IFSCDR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P10_Msk instead */
+#define PIO_IFSCDR_P11_Pos                  11                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P11_Msk                  (_U_(0x1) << PIO_IFSCDR_P11_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P11                      PIO_IFSCDR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P11_Msk instead */
+#define PIO_IFSCDR_P12_Pos                  12                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P12_Msk                  (_U_(0x1) << PIO_IFSCDR_P12_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P12                      PIO_IFSCDR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P12_Msk instead */
+#define PIO_IFSCDR_P13_Pos                  13                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P13_Msk                  (_U_(0x1) << PIO_IFSCDR_P13_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P13                      PIO_IFSCDR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P13_Msk instead */
+#define PIO_IFSCDR_P14_Pos                  14                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P14_Msk                  (_U_(0x1) << PIO_IFSCDR_P14_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P14                      PIO_IFSCDR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P14_Msk instead */
+#define PIO_IFSCDR_P15_Pos                  15                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P15_Msk                  (_U_(0x1) << PIO_IFSCDR_P15_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P15                      PIO_IFSCDR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P15_Msk instead */
+#define PIO_IFSCDR_P16_Pos                  16                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P16_Msk                  (_U_(0x1) << PIO_IFSCDR_P16_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P16                      PIO_IFSCDR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P16_Msk instead */
+#define PIO_IFSCDR_P17_Pos                  17                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P17_Msk                  (_U_(0x1) << PIO_IFSCDR_P17_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P17                      PIO_IFSCDR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P17_Msk instead */
+#define PIO_IFSCDR_P18_Pos                  18                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P18_Msk                  (_U_(0x1) << PIO_IFSCDR_P18_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P18                      PIO_IFSCDR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P18_Msk instead */
+#define PIO_IFSCDR_P19_Pos                  19                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P19_Msk                  (_U_(0x1) << PIO_IFSCDR_P19_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P19                      PIO_IFSCDR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P19_Msk instead */
+#define PIO_IFSCDR_P20_Pos                  20                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P20_Msk                  (_U_(0x1) << PIO_IFSCDR_P20_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P20                      PIO_IFSCDR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P20_Msk instead */
+#define PIO_IFSCDR_P21_Pos                  21                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P21_Msk                  (_U_(0x1) << PIO_IFSCDR_P21_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P21                      PIO_IFSCDR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P21_Msk instead */
+#define PIO_IFSCDR_P22_Pos                  22                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P22_Msk                  (_U_(0x1) << PIO_IFSCDR_P22_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P22                      PIO_IFSCDR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P22_Msk instead */
+#define PIO_IFSCDR_P23_Pos                  23                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P23_Msk                  (_U_(0x1) << PIO_IFSCDR_P23_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P23                      PIO_IFSCDR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P23_Msk instead */
+#define PIO_IFSCDR_P24_Pos                  24                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P24_Msk                  (_U_(0x1) << PIO_IFSCDR_P24_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P24                      PIO_IFSCDR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P24_Msk instead */
+#define PIO_IFSCDR_P25_Pos                  25                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P25_Msk                  (_U_(0x1) << PIO_IFSCDR_P25_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P25                      PIO_IFSCDR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P25_Msk instead */
+#define PIO_IFSCDR_P26_Pos                  26                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P26_Msk                  (_U_(0x1) << PIO_IFSCDR_P26_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P26                      PIO_IFSCDR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P26_Msk instead */
+#define PIO_IFSCDR_P27_Pos                  27                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P27_Msk                  (_U_(0x1) << PIO_IFSCDR_P27_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P27                      PIO_IFSCDR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P27_Msk instead */
+#define PIO_IFSCDR_P28_Pos                  28                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P28_Msk                  (_U_(0x1) << PIO_IFSCDR_P28_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P28                      PIO_IFSCDR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P28_Msk instead */
+#define PIO_IFSCDR_P29_Pos                  29                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P29_Msk                  (_U_(0x1) << PIO_IFSCDR_P29_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P29                      PIO_IFSCDR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P29_Msk instead */
+#define PIO_IFSCDR_P30_Pos                  30                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P30_Msk                  (_U_(0x1) << PIO_IFSCDR_P30_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P30                      PIO_IFSCDR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P30_Msk instead */
+#define PIO_IFSCDR_P31_Pos                  31                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P31_Msk                  (_U_(0x1) << PIO_IFSCDR_P31_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P31                      PIO_IFSCDR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P31_Msk instead */
+#define PIO_IFSCDR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCDR) Register MASK  (Use PIO_IFSCDR_Msk instead)  */
+#define PIO_IFSCDR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCDR) Register Mask  */
+
+#define PIO_IFSCDR_P_Pos                    0                                              /**< (PIO_IFSCDR Position) Peripheral Clock Glitch Filtering Select */
+#define PIO_IFSCDR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCDR_P_Pos)          /**< (PIO_IFSCDR Mask) P */
+#define PIO_IFSCDR_P(value)                 (PIO_IFSCDR_P_Msk & ((value) << PIO_IFSCDR_P_Pos))  
+
+/* -------- PIO_IFSCER : (PIO Offset: 0x84) (/W 32) Input Filter Slow Clock Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Slow Clock Debouncing Filtering Select   */
+    uint32_t P1:1;                      /**< bit:      1  Slow Clock Debouncing Filtering Select   */
+    uint32_t P2:1;                      /**< bit:      2  Slow Clock Debouncing Filtering Select   */
+    uint32_t P3:1;                      /**< bit:      3  Slow Clock Debouncing Filtering Select   */
+    uint32_t P4:1;                      /**< bit:      4  Slow Clock Debouncing Filtering Select   */
+    uint32_t P5:1;                      /**< bit:      5  Slow Clock Debouncing Filtering Select   */
+    uint32_t P6:1;                      /**< bit:      6  Slow Clock Debouncing Filtering Select   */
+    uint32_t P7:1;                      /**< bit:      7  Slow Clock Debouncing Filtering Select   */
+    uint32_t P8:1;                      /**< bit:      8  Slow Clock Debouncing Filtering Select   */
+    uint32_t P9:1;                      /**< bit:      9  Slow Clock Debouncing Filtering Select   */
+    uint32_t P10:1;                     /**< bit:     10  Slow Clock Debouncing Filtering Select   */
+    uint32_t P11:1;                     /**< bit:     11  Slow Clock Debouncing Filtering Select   */
+    uint32_t P12:1;                     /**< bit:     12  Slow Clock Debouncing Filtering Select   */
+    uint32_t P13:1;                     /**< bit:     13  Slow Clock Debouncing Filtering Select   */
+    uint32_t P14:1;                     /**< bit:     14  Slow Clock Debouncing Filtering Select   */
+    uint32_t P15:1;                     /**< bit:     15  Slow Clock Debouncing Filtering Select   */
+    uint32_t P16:1;                     /**< bit:     16  Slow Clock Debouncing Filtering Select   */
+    uint32_t P17:1;                     /**< bit:     17  Slow Clock Debouncing Filtering Select   */
+    uint32_t P18:1;                     /**< bit:     18  Slow Clock Debouncing Filtering Select   */
+    uint32_t P19:1;                     /**< bit:     19  Slow Clock Debouncing Filtering Select   */
+    uint32_t P20:1;                     /**< bit:     20  Slow Clock Debouncing Filtering Select   */
+    uint32_t P21:1;                     /**< bit:     21  Slow Clock Debouncing Filtering Select   */
+    uint32_t P22:1;                     /**< bit:     22  Slow Clock Debouncing Filtering Select   */
+    uint32_t P23:1;                     /**< bit:     23  Slow Clock Debouncing Filtering Select   */
+    uint32_t P24:1;                     /**< bit:     24  Slow Clock Debouncing Filtering Select   */
+    uint32_t P25:1;                     /**< bit:     25  Slow Clock Debouncing Filtering Select   */
+    uint32_t P26:1;                     /**< bit:     26  Slow Clock Debouncing Filtering Select   */
+    uint32_t P27:1;                     /**< bit:     27  Slow Clock Debouncing Filtering Select   */
+    uint32_t P28:1;                     /**< bit:     28  Slow Clock Debouncing Filtering Select   */
+    uint32_t P29:1;                     /**< bit:     29  Slow Clock Debouncing Filtering Select   */
+    uint32_t P30:1;                     /**< bit:     30  Slow Clock Debouncing Filtering Select   */
+    uint32_t P31:1;                     /**< bit:     31  Slow Clock Debouncing Filtering Select   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Slow Clock Debouncing Filtering Select   */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCER_OFFSET                   (0x84)                                        /**<  (PIO_IFSCER) Input Filter Slow Clock Enable Register  Offset */
+
+#define PIO_IFSCER_P0_Pos                   0                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P0_Msk                   (_U_(0x1) << PIO_IFSCER_P0_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P0                       PIO_IFSCER_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P0_Msk instead */
+#define PIO_IFSCER_P1_Pos                   1                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P1_Msk                   (_U_(0x1) << PIO_IFSCER_P1_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P1                       PIO_IFSCER_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P1_Msk instead */
+#define PIO_IFSCER_P2_Pos                   2                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P2_Msk                   (_U_(0x1) << PIO_IFSCER_P2_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P2                       PIO_IFSCER_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P2_Msk instead */
+#define PIO_IFSCER_P3_Pos                   3                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P3_Msk                   (_U_(0x1) << PIO_IFSCER_P3_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P3                       PIO_IFSCER_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P3_Msk instead */
+#define PIO_IFSCER_P4_Pos                   4                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P4_Msk                   (_U_(0x1) << PIO_IFSCER_P4_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P4                       PIO_IFSCER_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P4_Msk instead */
+#define PIO_IFSCER_P5_Pos                   5                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P5_Msk                   (_U_(0x1) << PIO_IFSCER_P5_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P5                       PIO_IFSCER_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P5_Msk instead */
+#define PIO_IFSCER_P6_Pos                   6                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P6_Msk                   (_U_(0x1) << PIO_IFSCER_P6_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P6                       PIO_IFSCER_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P6_Msk instead */
+#define PIO_IFSCER_P7_Pos                   7                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P7_Msk                   (_U_(0x1) << PIO_IFSCER_P7_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P7                       PIO_IFSCER_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P7_Msk instead */
+#define PIO_IFSCER_P8_Pos                   8                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P8_Msk                   (_U_(0x1) << PIO_IFSCER_P8_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P8                       PIO_IFSCER_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P8_Msk instead */
+#define PIO_IFSCER_P9_Pos                   9                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P9_Msk                   (_U_(0x1) << PIO_IFSCER_P9_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P9                       PIO_IFSCER_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P9_Msk instead */
+#define PIO_IFSCER_P10_Pos                  10                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P10_Msk                  (_U_(0x1) << PIO_IFSCER_P10_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P10                      PIO_IFSCER_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P10_Msk instead */
+#define PIO_IFSCER_P11_Pos                  11                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P11_Msk                  (_U_(0x1) << PIO_IFSCER_P11_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P11                      PIO_IFSCER_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P11_Msk instead */
+#define PIO_IFSCER_P12_Pos                  12                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P12_Msk                  (_U_(0x1) << PIO_IFSCER_P12_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P12                      PIO_IFSCER_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P12_Msk instead */
+#define PIO_IFSCER_P13_Pos                  13                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P13_Msk                  (_U_(0x1) << PIO_IFSCER_P13_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P13                      PIO_IFSCER_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P13_Msk instead */
+#define PIO_IFSCER_P14_Pos                  14                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P14_Msk                  (_U_(0x1) << PIO_IFSCER_P14_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P14                      PIO_IFSCER_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P14_Msk instead */
+#define PIO_IFSCER_P15_Pos                  15                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P15_Msk                  (_U_(0x1) << PIO_IFSCER_P15_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P15                      PIO_IFSCER_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P15_Msk instead */
+#define PIO_IFSCER_P16_Pos                  16                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P16_Msk                  (_U_(0x1) << PIO_IFSCER_P16_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P16                      PIO_IFSCER_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P16_Msk instead */
+#define PIO_IFSCER_P17_Pos                  17                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P17_Msk                  (_U_(0x1) << PIO_IFSCER_P17_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P17                      PIO_IFSCER_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P17_Msk instead */
+#define PIO_IFSCER_P18_Pos                  18                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P18_Msk                  (_U_(0x1) << PIO_IFSCER_P18_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P18                      PIO_IFSCER_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P18_Msk instead */
+#define PIO_IFSCER_P19_Pos                  19                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P19_Msk                  (_U_(0x1) << PIO_IFSCER_P19_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P19                      PIO_IFSCER_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P19_Msk instead */
+#define PIO_IFSCER_P20_Pos                  20                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P20_Msk                  (_U_(0x1) << PIO_IFSCER_P20_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P20                      PIO_IFSCER_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P20_Msk instead */
+#define PIO_IFSCER_P21_Pos                  21                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P21_Msk                  (_U_(0x1) << PIO_IFSCER_P21_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P21                      PIO_IFSCER_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P21_Msk instead */
+#define PIO_IFSCER_P22_Pos                  22                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P22_Msk                  (_U_(0x1) << PIO_IFSCER_P22_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P22                      PIO_IFSCER_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P22_Msk instead */
+#define PIO_IFSCER_P23_Pos                  23                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P23_Msk                  (_U_(0x1) << PIO_IFSCER_P23_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P23                      PIO_IFSCER_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P23_Msk instead */
+#define PIO_IFSCER_P24_Pos                  24                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P24_Msk                  (_U_(0x1) << PIO_IFSCER_P24_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P24                      PIO_IFSCER_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P24_Msk instead */
+#define PIO_IFSCER_P25_Pos                  25                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P25_Msk                  (_U_(0x1) << PIO_IFSCER_P25_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P25                      PIO_IFSCER_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P25_Msk instead */
+#define PIO_IFSCER_P26_Pos                  26                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P26_Msk                  (_U_(0x1) << PIO_IFSCER_P26_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P26                      PIO_IFSCER_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P26_Msk instead */
+#define PIO_IFSCER_P27_Pos                  27                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P27_Msk                  (_U_(0x1) << PIO_IFSCER_P27_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P27                      PIO_IFSCER_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P27_Msk instead */
+#define PIO_IFSCER_P28_Pos                  28                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P28_Msk                  (_U_(0x1) << PIO_IFSCER_P28_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P28                      PIO_IFSCER_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P28_Msk instead */
+#define PIO_IFSCER_P29_Pos                  29                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P29_Msk                  (_U_(0x1) << PIO_IFSCER_P29_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P29                      PIO_IFSCER_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P29_Msk instead */
+#define PIO_IFSCER_P30_Pos                  30                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P30_Msk                  (_U_(0x1) << PIO_IFSCER_P30_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P30                      PIO_IFSCER_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P30_Msk instead */
+#define PIO_IFSCER_P31_Pos                  31                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P31_Msk                  (_U_(0x1) << PIO_IFSCER_P31_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P31                      PIO_IFSCER_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P31_Msk instead */
+#define PIO_IFSCER_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCER) Register MASK  (Use PIO_IFSCER_Msk instead)  */
+#define PIO_IFSCER_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCER) Register Mask  */
+
+#define PIO_IFSCER_P_Pos                    0                                              /**< (PIO_IFSCER Position) Slow Clock Debouncing Filtering Select */
+#define PIO_IFSCER_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCER_P_Pos)          /**< (PIO_IFSCER Mask) P */
+#define PIO_IFSCER_P(value)                 (PIO_IFSCER_P_Msk & ((value) << PIO_IFSCER_P_Pos))  
+
+/* -------- PIO_IFSCSR : (PIO Offset: 0x88) (R/ 32) Input Filter Slow Clock Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Glitch or Debouncing Filter Selection Status */
+    uint32_t P1:1;                      /**< bit:      1  Glitch or Debouncing Filter Selection Status */
+    uint32_t P2:1;                      /**< bit:      2  Glitch or Debouncing Filter Selection Status */
+    uint32_t P3:1;                      /**< bit:      3  Glitch or Debouncing Filter Selection Status */
+    uint32_t P4:1;                      /**< bit:      4  Glitch or Debouncing Filter Selection Status */
+    uint32_t P5:1;                      /**< bit:      5  Glitch or Debouncing Filter Selection Status */
+    uint32_t P6:1;                      /**< bit:      6  Glitch or Debouncing Filter Selection Status */
+    uint32_t P7:1;                      /**< bit:      7  Glitch or Debouncing Filter Selection Status */
+    uint32_t P8:1;                      /**< bit:      8  Glitch or Debouncing Filter Selection Status */
+    uint32_t P9:1;                      /**< bit:      9  Glitch or Debouncing Filter Selection Status */
+    uint32_t P10:1;                     /**< bit:     10  Glitch or Debouncing Filter Selection Status */
+    uint32_t P11:1;                     /**< bit:     11  Glitch or Debouncing Filter Selection Status */
+    uint32_t P12:1;                     /**< bit:     12  Glitch or Debouncing Filter Selection Status */
+    uint32_t P13:1;                     /**< bit:     13  Glitch or Debouncing Filter Selection Status */
+    uint32_t P14:1;                     /**< bit:     14  Glitch or Debouncing Filter Selection Status */
+    uint32_t P15:1;                     /**< bit:     15  Glitch or Debouncing Filter Selection Status */
+    uint32_t P16:1;                     /**< bit:     16  Glitch or Debouncing Filter Selection Status */
+    uint32_t P17:1;                     /**< bit:     17  Glitch or Debouncing Filter Selection Status */
+    uint32_t P18:1;                     /**< bit:     18  Glitch or Debouncing Filter Selection Status */
+    uint32_t P19:1;                     /**< bit:     19  Glitch or Debouncing Filter Selection Status */
+    uint32_t P20:1;                     /**< bit:     20  Glitch or Debouncing Filter Selection Status */
+    uint32_t P21:1;                     /**< bit:     21  Glitch or Debouncing Filter Selection Status */
+    uint32_t P22:1;                     /**< bit:     22  Glitch or Debouncing Filter Selection Status */
+    uint32_t P23:1;                     /**< bit:     23  Glitch or Debouncing Filter Selection Status */
+    uint32_t P24:1;                     /**< bit:     24  Glitch or Debouncing Filter Selection Status */
+    uint32_t P25:1;                     /**< bit:     25  Glitch or Debouncing Filter Selection Status */
+    uint32_t P26:1;                     /**< bit:     26  Glitch or Debouncing Filter Selection Status */
+    uint32_t P27:1;                     /**< bit:     27  Glitch or Debouncing Filter Selection Status */
+    uint32_t P28:1;                     /**< bit:     28  Glitch or Debouncing Filter Selection Status */
+    uint32_t P29:1;                     /**< bit:     29  Glitch or Debouncing Filter Selection Status */
+    uint32_t P30:1;                     /**< bit:     30  Glitch or Debouncing Filter Selection Status */
+    uint32_t P31:1;                     /**< bit:     31  Glitch or Debouncing Filter Selection Status */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Glitch or Debouncing Filter Selection Status */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCSR_OFFSET                   (0x88)                                        /**<  (PIO_IFSCSR) Input Filter Slow Clock Status Register  Offset */
+
+#define PIO_IFSCSR_P0_Pos                   0                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P0_Msk                   (_U_(0x1) << PIO_IFSCSR_P0_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P0                       PIO_IFSCSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P0_Msk instead */
+#define PIO_IFSCSR_P1_Pos                   1                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P1_Msk                   (_U_(0x1) << PIO_IFSCSR_P1_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P1                       PIO_IFSCSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P1_Msk instead */
+#define PIO_IFSCSR_P2_Pos                   2                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P2_Msk                   (_U_(0x1) << PIO_IFSCSR_P2_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P2                       PIO_IFSCSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P2_Msk instead */
+#define PIO_IFSCSR_P3_Pos                   3                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P3_Msk                   (_U_(0x1) << PIO_IFSCSR_P3_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P3                       PIO_IFSCSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P3_Msk instead */
+#define PIO_IFSCSR_P4_Pos                   4                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P4_Msk                   (_U_(0x1) << PIO_IFSCSR_P4_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P4                       PIO_IFSCSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P4_Msk instead */
+#define PIO_IFSCSR_P5_Pos                   5                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P5_Msk                   (_U_(0x1) << PIO_IFSCSR_P5_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P5                       PIO_IFSCSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P5_Msk instead */
+#define PIO_IFSCSR_P6_Pos                   6                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P6_Msk                   (_U_(0x1) << PIO_IFSCSR_P6_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P6                       PIO_IFSCSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P6_Msk instead */
+#define PIO_IFSCSR_P7_Pos                   7                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P7_Msk                   (_U_(0x1) << PIO_IFSCSR_P7_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P7                       PIO_IFSCSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P7_Msk instead */
+#define PIO_IFSCSR_P8_Pos                   8                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P8_Msk                   (_U_(0x1) << PIO_IFSCSR_P8_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P8                       PIO_IFSCSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P8_Msk instead */
+#define PIO_IFSCSR_P9_Pos                   9                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P9_Msk                   (_U_(0x1) << PIO_IFSCSR_P9_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P9                       PIO_IFSCSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P9_Msk instead */
+#define PIO_IFSCSR_P10_Pos                  10                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P10_Msk                  (_U_(0x1) << PIO_IFSCSR_P10_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P10                      PIO_IFSCSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P10_Msk instead */
+#define PIO_IFSCSR_P11_Pos                  11                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P11_Msk                  (_U_(0x1) << PIO_IFSCSR_P11_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P11                      PIO_IFSCSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P11_Msk instead */
+#define PIO_IFSCSR_P12_Pos                  12                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P12_Msk                  (_U_(0x1) << PIO_IFSCSR_P12_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P12                      PIO_IFSCSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P12_Msk instead */
+#define PIO_IFSCSR_P13_Pos                  13                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P13_Msk                  (_U_(0x1) << PIO_IFSCSR_P13_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P13                      PIO_IFSCSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P13_Msk instead */
+#define PIO_IFSCSR_P14_Pos                  14                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P14_Msk                  (_U_(0x1) << PIO_IFSCSR_P14_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P14                      PIO_IFSCSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P14_Msk instead */
+#define PIO_IFSCSR_P15_Pos                  15                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P15_Msk                  (_U_(0x1) << PIO_IFSCSR_P15_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P15                      PIO_IFSCSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P15_Msk instead */
+#define PIO_IFSCSR_P16_Pos                  16                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P16_Msk                  (_U_(0x1) << PIO_IFSCSR_P16_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P16                      PIO_IFSCSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P16_Msk instead */
+#define PIO_IFSCSR_P17_Pos                  17                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P17_Msk                  (_U_(0x1) << PIO_IFSCSR_P17_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P17                      PIO_IFSCSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P17_Msk instead */
+#define PIO_IFSCSR_P18_Pos                  18                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P18_Msk                  (_U_(0x1) << PIO_IFSCSR_P18_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P18                      PIO_IFSCSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P18_Msk instead */
+#define PIO_IFSCSR_P19_Pos                  19                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P19_Msk                  (_U_(0x1) << PIO_IFSCSR_P19_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P19                      PIO_IFSCSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P19_Msk instead */
+#define PIO_IFSCSR_P20_Pos                  20                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P20_Msk                  (_U_(0x1) << PIO_IFSCSR_P20_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P20                      PIO_IFSCSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P20_Msk instead */
+#define PIO_IFSCSR_P21_Pos                  21                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P21_Msk                  (_U_(0x1) << PIO_IFSCSR_P21_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P21                      PIO_IFSCSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P21_Msk instead */
+#define PIO_IFSCSR_P22_Pos                  22                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P22_Msk                  (_U_(0x1) << PIO_IFSCSR_P22_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P22                      PIO_IFSCSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P22_Msk instead */
+#define PIO_IFSCSR_P23_Pos                  23                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P23_Msk                  (_U_(0x1) << PIO_IFSCSR_P23_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P23                      PIO_IFSCSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P23_Msk instead */
+#define PIO_IFSCSR_P24_Pos                  24                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P24_Msk                  (_U_(0x1) << PIO_IFSCSR_P24_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P24                      PIO_IFSCSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P24_Msk instead */
+#define PIO_IFSCSR_P25_Pos                  25                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P25_Msk                  (_U_(0x1) << PIO_IFSCSR_P25_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P25                      PIO_IFSCSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P25_Msk instead */
+#define PIO_IFSCSR_P26_Pos                  26                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P26_Msk                  (_U_(0x1) << PIO_IFSCSR_P26_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P26                      PIO_IFSCSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P26_Msk instead */
+#define PIO_IFSCSR_P27_Pos                  27                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P27_Msk                  (_U_(0x1) << PIO_IFSCSR_P27_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P27                      PIO_IFSCSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P27_Msk instead */
+#define PIO_IFSCSR_P28_Pos                  28                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P28_Msk                  (_U_(0x1) << PIO_IFSCSR_P28_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P28                      PIO_IFSCSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P28_Msk instead */
+#define PIO_IFSCSR_P29_Pos                  29                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P29_Msk                  (_U_(0x1) << PIO_IFSCSR_P29_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P29                      PIO_IFSCSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P29_Msk instead */
+#define PIO_IFSCSR_P30_Pos                  30                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P30_Msk                  (_U_(0x1) << PIO_IFSCSR_P30_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P30                      PIO_IFSCSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P30_Msk instead */
+#define PIO_IFSCSR_P31_Pos                  31                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P31_Msk                  (_U_(0x1) << PIO_IFSCSR_P31_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P31                      PIO_IFSCSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P31_Msk instead */
+#define PIO_IFSCSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCSR) Register MASK  (Use PIO_IFSCSR_Msk instead)  */
+#define PIO_IFSCSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCSR) Register Mask  */
+
+#define PIO_IFSCSR_P_Pos                    0                                              /**< (PIO_IFSCSR Position) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCSR_P_Pos)          /**< (PIO_IFSCSR Mask) P */
+#define PIO_IFSCSR_P(value)                 (PIO_IFSCSR_P_Msk & ((value) << PIO_IFSCSR_P_Pos))  
+
+/* -------- PIO_SCDR : (PIO Offset: 0x8c) (R/W 32) Slow Clock Divider Debouncing Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIV:14;                    /**< bit:  0..13  Slow Clock Divider Selection for Debouncing */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SCDR_OFFSET                     (0x8C)                                        /**<  (PIO_SCDR) Slow Clock Divider Debouncing Register  Offset */
+
+#define PIO_SCDR_DIV_Pos                    0                                              /**< (PIO_SCDR) Slow Clock Divider Selection for Debouncing Position */
+#define PIO_SCDR_DIV_Msk                    (_U_(0x3FFF) << PIO_SCDR_DIV_Pos)              /**< (PIO_SCDR) Slow Clock Divider Selection for Debouncing Mask */
+#define PIO_SCDR_DIV(value)                 (PIO_SCDR_DIV_Msk & ((value) << PIO_SCDR_DIV_Pos))
+#define PIO_SCDR_MASK                       _U_(0x3FFF)                                    /**< \deprecated (PIO_SCDR) Register MASK  (Use PIO_SCDR_Msk instead)  */
+#define PIO_SCDR_Msk                        _U_(0x3FFF)                                    /**< (PIO_SCDR) Register Mask  */
+
+
+/* -------- PIO_PPDDR : (PIO Offset: 0x90) (/W 32) Pad Pull-down Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Disable                        */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Disable                        */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Disable                        */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Disable                        */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Disable                        */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Disable                        */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Disable                        */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Disable                        */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Disable                        */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Disable                        */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Disable                        */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Disable                        */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Disable                        */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Disable                        */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Disable                        */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Disable                        */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Disable                        */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Disable                        */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Disable                        */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Disable                        */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Disable                        */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Disable                        */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Disable                        */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Disable                        */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Disable                        */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Disable                        */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Disable                        */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Disable                        */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Disable                        */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Disable                        */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Disable                        */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Disable                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Disable                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDDR_OFFSET                    (0x90)                                        /**<  (PIO_PPDDR) Pad Pull-down Disable Register  Offset */
+
+#define PIO_PPDDR_P0_Pos                    0                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P0_Msk                    (_U_(0x1) << PIO_PPDDR_P0_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P0                        PIO_PPDDR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P0_Msk instead */
+#define PIO_PPDDR_P1_Pos                    1                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P1_Msk                    (_U_(0x1) << PIO_PPDDR_P1_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P1                        PIO_PPDDR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P1_Msk instead */
+#define PIO_PPDDR_P2_Pos                    2                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P2_Msk                    (_U_(0x1) << PIO_PPDDR_P2_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P2                        PIO_PPDDR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P2_Msk instead */
+#define PIO_PPDDR_P3_Pos                    3                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P3_Msk                    (_U_(0x1) << PIO_PPDDR_P3_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P3                        PIO_PPDDR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P3_Msk instead */
+#define PIO_PPDDR_P4_Pos                    4                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P4_Msk                    (_U_(0x1) << PIO_PPDDR_P4_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P4                        PIO_PPDDR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P4_Msk instead */
+#define PIO_PPDDR_P5_Pos                    5                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P5_Msk                    (_U_(0x1) << PIO_PPDDR_P5_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P5                        PIO_PPDDR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P5_Msk instead */
+#define PIO_PPDDR_P6_Pos                    6                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P6_Msk                    (_U_(0x1) << PIO_PPDDR_P6_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P6                        PIO_PPDDR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P6_Msk instead */
+#define PIO_PPDDR_P7_Pos                    7                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P7_Msk                    (_U_(0x1) << PIO_PPDDR_P7_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P7                        PIO_PPDDR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P7_Msk instead */
+#define PIO_PPDDR_P8_Pos                    8                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P8_Msk                    (_U_(0x1) << PIO_PPDDR_P8_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P8                        PIO_PPDDR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P8_Msk instead */
+#define PIO_PPDDR_P9_Pos                    9                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P9_Msk                    (_U_(0x1) << PIO_PPDDR_P9_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P9                        PIO_PPDDR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P9_Msk instead */
+#define PIO_PPDDR_P10_Pos                   10                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P10_Msk                   (_U_(0x1) << PIO_PPDDR_P10_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P10                       PIO_PPDDR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P10_Msk instead */
+#define PIO_PPDDR_P11_Pos                   11                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P11_Msk                   (_U_(0x1) << PIO_PPDDR_P11_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P11                       PIO_PPDDR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P11_Msk instead */
+#define PIO_PPDDR_P12_Pos                   12                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P12_Msk                   (_U_(0x1) << PIO_PPDDR_P12_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P12                       PIO_PPDDR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P12_Msk instead */
+#define PIO_PPDDR_P13_Pos                   13                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P13_Msk                   (_U_(0x1) << PIO_PPDDR_P13_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P13                       PIO_PPDDR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P13_Msk instead */
+#define PIO_PPDDR_P14_Pos                   14                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P14_Msk                   (_U_(0x1) << PIO_PPDDR_P14_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P14                       PIO_PPDDR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P14_Msk instead */
+#define PIO_PPDDR_P15_Pos                   15                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P15_Msk                   (_U_(0x1) << PIO_PPDDR_P15_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P15                       PIO_PPDDR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P15_Msk instead */
+#define PIO_PPDDR_P16_Pos                   16                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P16_Msk                   (_U_(0x1) << PIO_PPDDR_P16_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P16                       PIO_PPDDR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P16_Msk instead */
+#define PIO_PPDDR_P17_Pos                   17                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P17_Msk                   (_U_(0x1) << PIO_PPDDR_P17_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P17                       PIO_PPDDR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P17_Msk instead */
+#define PIO_PPDDR_P18_Pos                   18                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P18_Msk                   (_U_(0x1) << PIO_PPDDR_P18_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P18                       PIO_PPDDR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P18_Msk instead */
+#define PIO_PPDDR_P19_Pos                   19                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P19_Msk                   (_U_(0x1) << PIO_PPDDR_P19_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P19                       PIO_PPDDR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P19_Msk instead */
+#define PIO_PPDDR_P20_Pos                   20                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P20_Msk                   (_U_(0x1) << PIO_PPDDR_P20_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P20                       PIO_PPDDR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P20_Msk instead */
+#define PIO_PPDDR_P21_Pos                   21                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P21_Msk                   (_U_(0x1) << PIO_PPDDR_P21_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P21                       PIO_PPDDR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P21_Msk instead */
+#define PIO_PPDDR_P22_Pos                   22                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P22_Msk                   (_U_(0x1) << PIO_PPDDR_P22_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P22                       PIO_PPDDR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P22_Msk instead */
+#define PIO_PPDDR_P23_Pos                   23                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P23_Msk                   (_U_(0x1) << PIO_PPDDR_P23_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P23                       PIO_PPDDR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P23_Msk instead */
+#define PIO_PPDDR_P24_Pos                   24                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P24_Msk                   (_U_(0x1) << PIO_PPDDR_P24_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P24                       PIO_PPDDR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P24_Msk instead */
+#define PIO_PPDDR_P25_Pos                   25                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P25_Msk                   (_U_(0x1) << PIO_PPDDR_P25_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P25                       PIO_PPDDR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P25_Msk instead */
+#define PIO_PPDDR_P26_Pos                   26                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P26_Msk                   (_U_(0x1) << PIO_PPDDR_P26_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P26                       PIO_PPDDR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P26_Msk instead */
+#define PIO_PPDDR_P27_Pos                   27                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P27_Msk                   (_U_(0x1) << PIO_PPDDR_P27_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P27                       PIO_PPDDR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P27_Msk instead */
+#define PIO_PPDDR_P28_Pos                   28                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P28_Msk                   (_U_(0x1) << PIO_PPDDR_P28_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P28                       PIO_PPDDR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P28_Msk instead */
+#define PIO_PPDDR_P29_Pos                   29                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P29_Msk                   (_U_(0x1) << PIO_PPDDR_P29_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P29                       PIO_PPDDR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P29_Msk instead */
+#define PIO_PPDDR_P30_Pos                   30                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P30_Msk                   (_U_(0x1) << PIO_PPDDR_P30_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P30                       PIO_PPDDR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P30_Msk instead */
+#define PIO_PPDDR_P31_Pos                   31                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P31_Msk                   (_U_(0x1) << PIO_PPDDR_P31_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P31                       PIO_PPDDR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P31_Msk instead */
+#define PIO_PPDDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDDR) Register MASK  (Use PIO_PPDDR_Msk instead)  */
+#define PIO_PPDDR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDDR) Register Mask  */
+
+#define PIO_PPDDR_P_Pos                     0                                              /**< (PIO_PPDDR Position) Pull-Down Disable */
+#define PIO_PPDDR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDDR_P_Pos)           /**< (PIO_PPDDR Mask) P */
+#define PIO_PPDDR_P(value)                  (PIO_PPDDR_P_Msk & ((value) << PIO_PPDDR_P_Pos))  
+
+/* -------- PIO_PPDER : (PIO Offset: 0x94) (/W 32) Pad Pull-down Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Enable                         */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Enable                         */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Enable                         */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Enable                         */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Enable                         */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Enable                         */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Enable                         */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Enable                         */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Enable                         */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Enable                         */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Enable                         */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Enable                         */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Enable                         */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Enable                         */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Enable                         */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Enable                         */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Enable                         */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Enable                         */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Enable                         */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Enable                         */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Enable                         */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Enable                         */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Enable                         */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Enable                         */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Enable                         */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Enable                         */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Enable                         */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Enable                         */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Enable                         */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Enable                         */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Enable                         */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Enable                         */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Enable                         */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDER_OFFSET                    (0x94)                                        /**<  (PIO_PPDER) Pad Pull-down Enable Register  Offset */
+
+#define PIO_PPDER_P0_Pos                    0                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P0_Msk                    (_U_(0x1) << PIO_PPDER_P0_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P0                        PIO_PPDER_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P0_Msk instead */
+#define PIO_PPDER_P1_Pos                    1                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P1_Msk                    (_U_(0x1) << PIO_PPDER_P1_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P1                        PIO_PPDER_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P1_Msk instead */
+#define PIO_PPDER_P2_Pos                    2                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P2_Msk                    (_U_(0x1) << PIO_PPDER_P2_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P2                        PIO_PPDER_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P2_Msk instead */
+#define PIO_PPDER_P3_Pos                    3                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P3_Msk                    (_U_(0x1) << PIO_PPDER_P3_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P3                        PIO_PPDER_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P3_Msk instead */
+#define PIO_PPDER_P4_Pos                    4                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P4_Msk                    (_U_(0x1) << PIO_PPDER_P4_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P4                        PIO_PPDER_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P4_Msk instead */
+#define PIO_PPDER_P5_Pos                    5                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P5_Msk                    (_U_(0x1) << PIO_PPDER_P5_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P5                        PIO_PPDER_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P5_Msk instead */
+#define PIO_PPDER_P6_Pos                    6                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P6_Msk                    (_U_(0x1) << PIO_PPDER_P6_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P6                        PIO_PPDER_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P6_Msk instead */
+#define PIO_PPDER_P7_Pos                    7                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P7_Msk                    (_U_(0x1) << PIO_PPDER_P7_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P7                        PIO_PPDER_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P7_Msk instead */
+#define PIO_PPDER_P8_Pos                    8                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P8_Msk                    (_U_(0x1) << PIO_PPDER_P8_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P8                        PIO_PPDER_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P8_Msk instead */
+#define PIO_PPDER_P9_Pos                    9                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P9_Msk                    (_U_(0x1) << PIO_PPDER_P9_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P9                        PIO_PPDER_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P9_Msk instead */
+#define PIO_PPDER_P10_Pos                   10                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P10_Msk                   (_U_(0x1) << PIO_PPDER_P10_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P10                       PIO_PPDER_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P10_Msk instead */
+#define PIO_PPDER_P11_Pos                   11                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P11_Msk                   (_U_(0x1) << PIO_PPDER_P11_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P11                       PIO_PPDER_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P11_Msk instead */
+#define PIO_PPDER_P12_Pos                   12                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P12_Msk                   (_U_(0x1) << PIO_PPDER_P12_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P12                       PIO_PPDER_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P12_Msk instead */
+#define PIO_PPDER_P13_Pos                   13                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P13_Msk                   (_U_(0x1) << PIO_PPDER_P13_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P13                       PIO_PPDER_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P13_Msk instead */
+#define PIO_PPDER_P14_Pos                   14                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P14_Msk                   (_U_(0x1) << PIO_PPDER_P14_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P14                       PIO_PPDER_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P14_Msk instead */
+#define PIO_PPDER_P15_Pos                   15                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P15_Msk                   (_U_(0x1) << PIO_PPDER_P15_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P15                       PIO_PPDER_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P15_Msk instead */
+#define PIO_PPDER_P16_Pos                   16                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P16_Msk                   (_U_(0x1) << PIO_PPDER_P16_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P16                       PIO_PPDER_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P16_Msk instead */
+#define PIO_PPDER_P17_Pos                   17                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P17_Msk                   (_U_(0x1) << PIO_PPDER_P17_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P17                       PIO_PPDER_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P17_Msk instead */
+#define PIO_PPDER_P18_Pos                   18                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P18_Msk                   (_U_(0x1) << PIO_PPDER_P18_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P18                       PIO_PPDER_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P18_Msk instead */
+#define PIO_PPDER_P19_Pos                   19                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P19_Msk                   (_U_(0x1) << PIO_PPDER_P19_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P19                       PIO_PPDER_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P19_Msk instead */
+#define PIO_PPDER_P20_Pos                   20                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P20_Msk                   (_U_(0x1) << PIO_PPDER_P20_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P20                       PIO_PPDER_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P20_Msk instead */
+#define PIO_PPDER_P21_Pos                   21                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P21_Msk                   (_U_(0x1) << PIO_PPDER_P21_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P21                       PIO_PPDER_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P21_Msk instead */
+#define PIO_PPDER_P22_Pos                   22                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P22_Msk                   (_U_(0x1) << PIO_PPDER_P22_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P22                       PIO_PPDER_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P22_Msk instead */
+#define PIO_PPDER_P23_Pos                   23                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P23_Msk                   (_U_(0x1) << PIO_PPDER_P23_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P23                       PIO_PPDER_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P23_Msk instead */
+#define PIO_PPDER_P24_Pos                   24                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P24_Msk                   (_U_(0x1) << PIO_PPDER_P24_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P24                       PIO_PPDER_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P24_Msk instead */
+#define PIO_PPDER_P25_Pos                   25                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P25_Msk                   (_U_(0x1) << PIO_PPDER_P25_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P25                       PIO_PPDER_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P25_Msk instead */
+#define PIO_PPDER_P26_Pos                   26                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P26_Msk                   (_U_(0x1) << PIO_PPDER_P26_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P26                       PIO_PPDER_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P26_Msk instead */
+#define PIO_PPDER_P27_Pos                   27                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P27_Msk                   (_U_(0x1) << PIO_PPDER_P27_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P27                       PIO_PPDER_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P27_Msk instead */
+#define PIO_PPDER_P28_Pos                   28                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P28_Msk                   (_U_(0x1) << PIO_PPDER_P28_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P28                       PIO_PPDER_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P28_Msk instead */
+#define PIO_PPDER_P29_Pos                   29                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P29_Msk                   (_U_(0x1) << PIO_PPDER_P29_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P29                       PIO_PPDER_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P29_Msk instead */
+#define PIO_PPDER_P30_Pos                   30                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P30_Msk                   (_U_(0x1) << PIO_PPDER_P30_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P30                       PIO_PPDER_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P30_Msk instead */
+#define PIO_PPDER_P31_Pos                   31                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P31_Msk                   (_U_(0x1) << PIO_PPDER_P31_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P31                       PIO_PPDER_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P31_Msk instead */
+#define PIO_PPDER_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDER) Register MASK  (Use PIO_PPDER_Msk instead)  */
+#define PIO_PPDER_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDER) Register Mask  */
+
+#define PIO_PPDER_P_Pos                     0                                              /**< (PIO_PPDER Position) Pull-Down Enable */
+#define PIO_PPDER_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDER_P_Pos)           /**< (PIO_PPDER Mask) P */
+#define PIO_PPDER_P(value)                  (PIO_PPDER_P_Msk & ((value) << PIO_PPDER_P_Pos))  
+
+/* -------- PIO_PPDSR : (PIO Offset: 0x98) (R/ 32) Pad Pull-down Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Status                         */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Status                         */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Status                         */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Status                         */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Status                         */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Status                         */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Status                         */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Status                         */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Status                         */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Status                         */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Status                         */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Status                         */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Status                         */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Status                         */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Status                         */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Status                         */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Status                         */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Status                         */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Status                         */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Status                         */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Status                         */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Status                         */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Status                         */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Status                         */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Status                         */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Status                         */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Status                         */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Status                         */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Status                         */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Status                         */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Status                         */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Status                         */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Status                         */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDSR_OFFSET                    (0x98)                                        /**<  (PIO_PPDSR) Pad Pull-down Status Register  Offset */
+
+#define PIO_PPDSR_P0_Pos                    0                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P0_Msk                    (_U_(0x1) << PIO_PPDSR_P0_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P0                        PIO_PPDSR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P0_Msk instead */
+#define PIO_PPDSR_P1_Pos                    1                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P1_Msk                    (_U_(0x1) << PIO_PPDSR_P1_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P1                        PIO_PPDSR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P1_Msk instead */
+#define PIO_PPDSR_P2_Pos                    2                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P2_Msk                    (_U_(0x1) << PIO_PPDSR_P2_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P2                        PIO_PPDSR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P2_Msk instead */
+#define PIO_PPDSR_P3_Pos                    3                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P3_Msk                    (_U_(0x1) << PIO_PPDSR_P3_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P3                        PIO_PPDSR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P3_Msk instead */
+#define PIO_PPDSR_P4_Pos                    4                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P4_Msk                    (_U_(0x1) << PIO_PPDSR_P4_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P4                        PIO_PPDSR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P4_Msk instead */
+#define PIO_PPDSR_P5_Pos                    5                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P5_Msk                    (_U_(0x1) << PIO_PPDSR_P5_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P5                        PIO_PPDSR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P5_Msk instead */
+#define PIO_PPDSR_P6_Pos                    6                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P6_Msk                    (_U_(0x1) << PIO_PPDSR_P6_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P6                        PIO_PPDSR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P6_Msk instead */
+#define PIO_PPDSR_P7_Pos                    7                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P7_Msk                    (_U_(0x1) << PIO_PPDSR_P7_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P7                        PIO_PPDSR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P7_Msk instead */
+#define PIO_PPDSR_P8_Pos                    8                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P8_Msk                    (_U_(0x1) << PIO_PPDSR_P8_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P8                        PIO_PPDSR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P8_Msk instead */
+#define PIO_PPDSR_P9_Pos                    9                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P9_Msk                    (_U_(0x1) << PIO_PPDSR_P9_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P9                        PIO_PPDSR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P9_Msk instead */
+#define PIO_PPDSR_P10_Pos                   10                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P10_Msk                   (_U_(0x1) << PIO_PPDSR_P10_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P10                       PIO_PPDSR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P10_Msk instead */
+#define PIO_PPDSR_P11_Pos                   11                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P11_Msk                   (_U_(0x1) << PIO_PPDSR_P11_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P11                       PIO_PPDSR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P11_Msk instead */
+#define PIO_PPDSR_P12_Pos                   12                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P12_Msk                   (_U_(0x1) << PIO_PPDSR_P12_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P12                       PIO_PPDSR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P12_Msk instead */
+#define PIO_PPDSR_P13_Pos                   13                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P13_Msk                   (_U_(0x1) << PIO_PPDSR_P13_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P13                       PIO_PPDSR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P13_Msk instead */
+#define PIO_PPDSR_P14_Pos                   14                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P14_Msk                   (_U_(0x1) << PIO_PPDSR_P14_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P14                       PIO_PPDSR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P14_Msk instead */
+#define PIO_PPDSR_P15_Pos                   15                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P15_Msk                   (_U_(0x1) << PIO_PPDSR_P15_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P15                       PIO_PPDSR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P15_Msk instead */
+#define PIO_PPDSR_P16_Pos                   16                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P16_Msk                   (_U_(0x1) << PIO_PPDSR_P16_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P16                       PIO_PPDSR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P16_Msk instead */
+#define PIO_PPDSR_P17_Pos                   17                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P17_Msk                   (_U_(0x1) << PIO_PPDSR_P17_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P17                       PIO_PPDSR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P17_Msk instead */
+#define PIO_PPDSR_P18_Pos                   18                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P18_Msk                   (_U_(0x1) << PIO_PPDSR_P18_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P18                       PIO_PPDSR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P18_Msk instead */
+#define PIO_PPDSR_P19_Pos                   19                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P19_Msk                   (_U_(0x1) << PIO_PPDSR_P19_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P19                       PIO_PPDSR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P19_Msk instead */
+#define PIO_PPDSR_P20_Pos                   20                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P20_Msk                   (_U_(0x1) << PIO_PPDSR_P20_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P20                       PIO_PPDSR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P20_Msk instead */
+#define PIO_PPDSR_P21_Pos                   21                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P21_Msk                   (_U_(0x1) << PIO_PPDSR_P21_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P21                       PIO_PPDSR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P21_Msk instead */
+#define PIO_PPDSR_P22_Pos                   22                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P22_Msk                   (_U_(0x1) << PIO_PPDSR_P22_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P22                       PIO_PPDSR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P22_Msk instead */
+#define PIO_PPDSR_P23_Pos                   23                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P23_Msk                   (_U_(0x1) << PIO_PPDSR_P23_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P23                       PIO_PPDSR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P23_Msk instead */
+#define PIO_PPDSR_P24_Pos                   24                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P24_Msk                   (_U_(0x1) << PIO_PPDSR_P24_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P24                       PIO_PPDSR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P24_Msk instead */
+#define PIO_PPDSR_P25_Pos                   25                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P25_Msk                   (_U_(0x1) << PIO_PPDSR_P25_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P25                       PIO_PPDSR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P25_Msk instead */
+#define PIO_PPDSR_P26_Pos                   26                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P26_Msk                   (_U_(0x1) << PIO_PPDSR_P26_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P26                       PIO_PPDSR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P26_Msk instead */
+#define PIO_PPDSR_P27_Pos                   27                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P27_Msk                   (_U_(0x1) << PIO_PPDSR_P27_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P27                       PIO_PPDSR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P27_Msk instead */
+#define PIO_PPDSR_P28_Pos                   28                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P28_Msk                   (_U_(0x1) << PIO_PPDSR_P28_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P28                       PIO_PPDSR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P28_Msk instead */
+#define PIO_PPDSR_P29_Pos                   29                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P29_Msk                   (_U_(0x1) << PIO_PPDSR_P29_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P29                       PIO_PPDSR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P29_Msk instead */
+#define PIO_PPDSR_P30_Pos                   30                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P30_Msk                   (_U_(0x1) << PIO_PPDSR_P30_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P30                       PIO_PPDSR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P30_Msk instead */
+#define PIO_PPDSR_P31_Pos                   31                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P31_Msk                   (_U_(0x1) << PIO_PPDSR_P31_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P31                       PIO_PPDSR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P31_Msk instead */
+#define PIO_PPDSR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDSR) Register MASK  (Use PIO_PPDSR_Msk instead)  */
+#define PIO_PPDSR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDSR) Register Mask  */
+
+#define PIO_PPDSR_P_Pos                     0                                              /**< (PIO_PPDSR Position) Pull-Down Status */
+#define PIO_PPDSR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDSR_P_Pos)           /**< (PIO_PPDSR Mask) P */
+#define PIO_PPDSR_P(value)                  (PIO_PPDSR_P_Msk & ((value) << PIO_PPDSR_P_Pos))  
+
+/* -------- PIO_OWER : (PIO Offset: 0xa0) (/W 32) Output Write Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Enable                      */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Enable                      */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Enable                      */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Enable                      */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Enable                      */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Enable                      */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Enable                      */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Enable                      */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Enable                      */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Enable                      */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Enable                      */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Enable                      */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Enable                      */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Enable                      */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Enable                      */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Enable                      */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Enable                      */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Enable                      */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Enable                      */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Enable                      */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Enable                      */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Enable                      */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Enable                      */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Enable                      */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Enable                      */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Enable                      */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Enable                      */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Enable                      */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Enable                      */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Enable                      */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Enable                      */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Enable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Enable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWER_OFFSET                     (0xA0)                                        /**<  (PIO_OWER) Output Write Enable  Offset */
+
+#define PIO_OWER_P0_Pos                     0                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P0_Msk                     (_U_(0x1) << PIO_OWER_P0_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P0                         PIO_OWER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P0_Msk instead */
+#define PIO_OWER_P1_Pos                     1                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P1_Msk                     (_U_(0x1) << PIO_OWER_P1_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P1                         PIO_OWER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P1_Msk instead */
+#define PIO_OWER_P2_Pos                     2                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P2_Msk                     (_U_(0x1) << PIO_OWER_P2_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P2                         PIO_OWER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P2_Msk instead */
+#define PIO_OWER_P3_Pos                     3                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P3_Msk                     (_U_(0x1) << PIO_OWER_P3_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P3                         PIO_OWER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P3_Msk instead */
+#define PIO_OWER_P4_Pos                     4                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P4_Msk                     (_U_(0x1) << PIO_OWER_P4_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P4                         PIO_OWER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P4_Msk instead */
+#define PIO_OWER_P5_Pos                     5                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P5_Msk                     (_U_(0x1) << PIO_OWER_P5_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P5                         PIO_OWER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P5_Msk instead */
+#define PIO_OWER_P6_Pos                     6                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P6_Msk                     (_U_(0x1) << PIO_OWER_P6_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P6                         PIO_OWER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P6_Msk instead */
+#define PIO_OWER_P7_Pos                     7                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P7_Msk                     (_U_(0x1) << PIO_OWER_P7_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P7                         PIO_OWER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P7_Msk instead */
+#define PIO_OWER_P8_Pos                     8                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P8_Msk                     (_U_(0x1) << PIO_OWER_P8_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P8                         PIO_OWER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P8_Msk instead */
+#define PIO_OWER_P9_Pos                     9                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P9_Msk                     (_U_(0x1) << PIO_OWER_P9_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P9                         PIO_OWER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P9_Msk instead */
+#define PIO_OWER_P10_Pos                    10                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P10_Msk                    (_U_(0x1) << PIO_OWER_P10_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P10                        PIO_OWER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P10_Msk instead */
+#define PIO_OWER_P11_Pos                    11                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P11_Msk                    (_U_(0x1) << PIO_OWER_P11_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P11                        PIO_OWER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P11_Msk instead */
+#define PIO_OWER_P12_Pos                    12                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P12_Msk                    (_U_(0x1) << PIO_OWER_P12_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P12                        PIO_OWER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P12_Msk instead */
+#define PIO_OWER_P13_Pos                    13                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P13_Msk                    (_U_(0x1) << PIO_OWER_P13_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P13                        PIO_OWER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P13_Msk instead */
+#define PIO_OWER_P14_Pos                    14                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P14_Msk                    (_U_(0x1) << PIO_OWER_P14_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P14                        PIO_OWER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P14_Msk instead */
+#define PIO_OWER_P15_Pos                    15                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P15_Msk                    (_U_(0x1) << PIO_OWER_P15_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P15                        PIO_OWER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P15_Msk instead */
+#define PIO_OWER_P16_Pos                    16                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P16_Msk                    (_U_(0x1) << PIO_OWER_P16_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P16                        PIO_OWER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P16_Msk instead */
+#define PIO_OWER_P17_Pos                    17                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P17_Msk                    (_U_(0x1) << PIO_OWER_P17_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P17                        PIO_OWER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P17_Msk instead */
+#define PIO_OWER_P18_Pos                    18                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P18_Msk                    (_U_(0x1) << PIO_OWER_P18_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P18                        PIO_OWER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P18_Msk instead */
+#define PIO_OWER_P19_Pos                    19                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P19_Msk                    (_U_(0x1) << PIO_OWER_P19_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P19                        PIO_OWER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P19_Msk instead */
+#define PIO_OWER_P20_Pos                    20                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P20_Msk                    (_U_(0x1) << PIO_OWER_P20_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P20                        PIO_OWER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P20_Msk instead */
+#define PIO_OWER_P21_Pos                    21                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P21_Msk                    (_U_(0x1) << PIO_OWER_P21_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P21                        PIO_OWER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P21_Msk instead */
+#define PIO_OWER_P22_Pos                    22                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P22_Msk                    (_U_(0x1) << PIO_OWER_P22_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P22                        PIO_OWER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P22_Msk instead */
+#define PIO_OWER_P23_Pos                    23                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P23_Msk                    (_U_(0x1) << PIO_OWER_P23_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P23                        PIO_OWER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P23_Msk instead */
+#define PIO_OWER_P24_Pos                    24                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P24_Msk                    (_U_(0x1) << PIO_OWER_P24_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P24                        PIO_OWER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P24_Msk instead */
+#define PIO_OWER_P25_Pos                    25                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P25_Msk                    (_U_(0x1) << PIO_OWER_P25_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P25                        PIO_OWER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P25_Msk instead */
+#define PIO_OWER_P26_Pos                    26                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P26_Msk                    (_U_(0x1) << PIO_OWER_P26_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P26                        PIO_OWER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P26_Msk instead */
+#define PIO_OWER_P27_Pos                    27                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P27_Msk                    (_U_(0x1) << PIO_OWER_P27_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P27                        PIO_OWER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P27_Msk instead */
+#define PIO_OWER_P28_Pos                    28                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P28_Msk                    (_U_(0x1) << PIO_OWER_P28_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P28                        PIO_OWER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P28_Msk instead */
+#define PIO_OWER_P29_Pos                    29                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P29_Msk                    (_U_(0x1) << PIO_OWER_P29_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P29                        PIO_OWER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P29_Msk instead */
+#define PIO_OWER_P30_Pos                    30                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P30_Msk                    (_U_(0x1) << PIO_OWER_P30_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P30                        PIO_OWER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P30_Msk instead */
+#define PIO_OWER_P31_Pos                    31                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P31_Msk                    (_U_(0x1) << PIO_OWER_P31_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P31                        PIO_OWER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P31_Msk instead */
+#define PIO_OWER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWER) Register MASK  (Use PIO_OWER_Msk instead)  */
+#define PIO_OWER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWER) Register Mask  */
+
+#define PIO_OWER_P_Pos                      0                                              /**< (PIO_OWER Position) Output Write Enable */
+#define PIO_OWER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWER_P_Pos)            /**< (PIO_OWER Mask) P */
+#define PIO_OWER_P(value)                   (PIO_OWER_P_Msk & ((value) << PIO_OWER_P_Pos))  
+
+/* -------- PIO_OWDR : (PIO Offset: 0xa4) (/W 32) Output Write Disable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Disable                     */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Disable                     */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Disable                     */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Disable                     */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Disable                     */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Disable                     */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Disable                     */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Disable                     */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Disable                     */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Disable                     */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Disable                     */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Disable                     */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Disable                     */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Disable                     */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Disable                     */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Disable                     */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Disable                     */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Disable                     */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Disable                     */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Disable                     */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Disable                     */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Disable                     */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Disable                     */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Disable                     */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Disable                     */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Disable                     */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Disable                     */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Disable                     */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Disable                     */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Disable                     */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Disable                     */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Disable                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Disable                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWDR_OFFSET                     (0xA4)                                        /**<  (PIO_OWDR) Output Write Disable  Offset */
+
+#define PIO_OWDR_P0_Pos                     0                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P0_Msk                     (_U_(0x1) << PIO_OWDR_P0_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P0                         PIO_OWDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P0_Msk instead */
+#define PIO_OWDR_P1_Pos                     1                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P1_Msk                     (_U_(0x1) << PIO_OWDR_P1_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P1                         PIO_OWDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P1_Msk instead */
+#define PIO_OWDR_P2_Pos                     2                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P2_Msk                     (_U_(0x1) << PIO_OWDR_P2_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P2                         PIO_OWDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P2_Msk instead */
+#define PIO_OWDR_P3_Pos                     3                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P3_Msk                     (_U_(0x1) << PIO_OWDR_P3_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P3                         PIO_OWDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P3_Msk instead */
+#define PIO_OWDR_P4_Pos                     4                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P4_Msk                     (_U_(0x1) << PIO_OWDR_P4_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P4                         PIO_OWDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P4_Msk instead */
+#define PIO_OWDR_P5_Pos                     5                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P5_Msk                     (_U_(0x1) << PIO_OWDR_P5_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P5                         PIO_OWDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P5_Msk instead */
+#define PIO_OWDR_P6_Pos                     6                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P6_Msk                     (_U_(0x1) << PIO_OWDR_P6_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P6                         PIO_OWDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P6_Msk instead */
+#define PIO_OWDR_P7_Pos                     7                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P7_Msk                     (_U_(0x1) << PIO_OWDR_P7_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P7                         PIO_OWDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P7_Msk instead */
+#define PIO_OWDR_P8_Pos                     8                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P8_Msk                     (_U_(0x1) << PIO_OWDR_P8_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P8                         PIO_OWDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P8_Msk instead */
+#define PIO_OWDR_P9_Pos                     9                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P9_Msk                     (_U_(0x1) << PIO_OWDR_P9_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P9                         PIO_OWDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P9_Msk instead */
+#define PIO_OWDR_P10_Pos                    10                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P10_Msk                    (_U_(0x1) << PIO_OWDR_P10_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P10                        PIO_OWDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P10_Msk instead */
+#define PIO_OWDR_P11_Pos                    11                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P11_Msk                    (_U_(0x1) << PIO_OWDR_P11_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P11                        PIO_OWDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P11_Msk instead */
+#define PIO_OWDR_P12_Pos                    12                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P12_Msk                    (_U_(0x1) << PIO_OWDR_P12_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P12                        PIO_OWDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P12_Msk instead */
+#define PIO_OWDR_P13_Pos                    13                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P13_Msk                    (_U_(0x1) << PIO_OWDR_P13_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P13                        PIO_OWDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P13_Msk instead */
+#define PIO_OWDR_P14_Pos                    14                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P14_Msk                    (_U_(0x1) << PIO_OWDR_P14_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P14                        PIO_OWDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P14_Msk instead */
+#define PIO_OWDR_P15_Pos                    15                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P15_Msk                    (_U_(0x1) << PIO_OWDR_P15_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P15                        PIO_OWDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P15_Msk instead */
+#define PIO_OWDR_P16_Pos                    16                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P16_Msk                    (_U_(0x1) << PIO_OWDR_P16_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P16                        PIO_OWDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P16_Msk instead */
+#define PIO_OWDR_P17_Pos                    17                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P17_Msk                    (_U_(0x1) << PIO_OWDR_P17_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P17                        PIO_OWDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P17_Msk instead */
+#define PIO_OWDR_P18_Pos                    18                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P18_Msk                    (_U_(0x1) << PIO_OWDR_P18_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P18                        PIO_OWDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P18_Msk instead */
+#define PIO_OWDR_P19_Pos                    19                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P19_Msk                    (_U_(0x1) << PIO_OWDR_P19_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P19                        PIO_OWDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P19_Msk instead */
+#define PIO_OWDR_P20_Pos                    20                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P20_Msk                    (_U_(0x1) << PIO_OWDR_P20_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P20                        PIO_OWDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P20_Msk instead */
+#define PIO_OWDR_P21_Pos                    21                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P21_Msk                    (_U_(0x1) << PIO_OWDR_P21_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P21                        PIO_OWDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P21_Msk instead */
+#define PIO_OWDR_P22_Pos                    22                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P22_Msk                    (_U_(0x1) << PIO_OWDR_P22_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P22                        PIO_OWDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P22_Msk instead */
+#define PIO_OWDR_P23_Pos                    23                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P23_Msk                    (_U_(0x1) << PIO_OWDR_P23_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P23                        PIO_OWDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P23_Msk instead */
+#define PIO_OWDR_P24_Pos                    24                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P24_Msk                    (_U_(0x1) << PIO_OWDR_P24_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P24                        PIO_OWDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P24_Msk instead */
+#define PIO_OWDR_P25_Pos                    25                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P25_Msk                    (_U_(0x1) << PIO_OWDR_P25_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P25                        PIO_OWDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P25_Msk instead */
+#define PIO_OWDR_P26_Pos                    26                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P26_Msk                    (_U_(0x1) << PIO_OWDR_P26_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P26                        PIO_OWDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P26_Msk instead */
+#define PIO_OWDR_P27_Pos                    27                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P27_Msk                    (_U_(0x1) << PIO_OWDR_P27_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P27                        PIO_OWDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P27_Msk instead */
+#define PIO_OWDR_P28_Pos                    28                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P28_Msk                    (_U_(0x1) << PIO_OWDR_P28_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P28                        PIO_OWDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P28_Msk instead */
+#define PIO_OWDR_P29_Pos                    29                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P29_Msk                    (_U_(0x1) << PIO_OWDR_P29_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P29                        PIO_OWDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P29_Msk instead */
+#define PIO_OWDR_P30_Pos                    30                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P30_Msk                    (_U_(0x1) << PIO_OWDR_P30_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P30                        PIO_OWDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P30_Msk instead */
+#define PIO_OWDR_P31_Pos                    31                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P31_Msk                    (_U_(0x1) << PIO_OWDR_P31_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P31                        PIO_OWDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P31_Msk instead */
+#define PIO_OWDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWDR) Register MASK  (Use PIO_OWDR_Msk instead)  */
+#define PIO_OWDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWDR) Register Mask  */
+
+#define PIO_OWDR_P_Pos                      0                                              /**< (PIO_OWDR Position) Output Write Disable */
+#define PIO_OWDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWDR_P_Pos)            /**< (PIO_OWDR Mask) P */
+#define PIO_OWDR_P(value)                   (PIO_OWDR_P_Msk & ((value) << PIO_OWDR_P_Pos))  
+
+/* -------- PIO_OWSR : (PIO Offset: 0xa8) (R/ 32) Output Write Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Status                      */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Status                      */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Status                      */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Status                      */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Status                      */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Status                      */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Status                      */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Status                      */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Status                      */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Status                      */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Status                      */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Status                      */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Status                      */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Status                      */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Status                      */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Status                      */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Status                      */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Status                      */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Status                      */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Status                      */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Status                      */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Status                      */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Status                      */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Status                      */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Status                      */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Status                      */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Status                      */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Status                      */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Status                      */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Status                      */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Status                      */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Status                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Status                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWSR_OFFSET                     (0xA8)                                        /**<  (PIO_OWSR) Output Write Status Register  Offset */
+
+#define PIO_OWSR_P0_Pos                     0                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P0_Msk                     (_U_(0x1) << PIO_OWSR_P0_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P0                         PIO_OWSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P0_Msk instead */
+#define PIO_OWSR_P1_Pos                     1                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P1_Msk                     (_U_(0x1) << PIO_OWSR_P1_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P1                         PIO_OWSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P1_Msk instead */
+#define PIO_OWSR_P2_Pos                     2                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P2_Msk                     (_U_(0x1) << PIO_OWSR_P2_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P2                         PIO_OWSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P2_Msk instead */
+#define PIO_OWSR_P3_Pos                     3                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P3_Msk                     (_U_(0x1) << PIO_OWSR_P3_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P3                         PIO_OWSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P3_Msk instead */
+#define PIO_OWSR_P4_Pos                     4                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P4_Msk                     (_U_(0x1) << PIO_OWSR_P4_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P4                         PIO_OWSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P4_Msk instead */
+#define PIO_OWSR_P5_Pos                     5                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P5_Msk                     (_U_(0x1) << PIO_OWSR_P5_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P5                         PIO_OWSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P5_Msk instead */
+#define PIO_OWSR_P6_Pos                     6                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P6_Msk                     (_U_(0x1) << PIO_OWSR_P6_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P6                         PIO_OWSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P6_Msk instead */
+#define PIO_OWSR_P7_Pos                     7                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P7_Msk                     (_U_(0x1) << PIO_OWSR_P7_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P7                         PIO_OWSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P7_Msk instead */
+#define PIO_OWSR_P8_Pos                     8                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P8_Msk                     (_U_(0x1) << PIO_OWSR_P8_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P8                         PIO_OWSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P8_Msk instead */
+#define PIO_OWSR_P9_Pos                     9                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P9_Msk                     (_U_(0x1) << PIO_OWSR_P9_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P9                         PIO_OWSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P9_Msk instead */
+#define PIO_OWSR_P10_Pos                    10                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P10_Msk                    (_U_(0x1) << PIO_OWSR_P10_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P10                        PIO_OWSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P10_Msk instead */
+#define PIO_OWSR_P11_Pos                    11                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P11_Msk                    (_U_(0x1) << PIO_OWSR_P11_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P11                        PIO_OWSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P11_Msk instead */
+#define PIO_OWSR_P12_Pos                    12                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P12_Msk                    (_U_(0x1) << PIO_OWSR_P12_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P12                        PIO_OWSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P12_Msk instead */
+#define PIO_OWSR_P13_Pos                    13                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P13_Msk                    (_U_(0x1) << PIO_OWSR_P13_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P13                        PIO_OWSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P13_Msk instead */
+#define PIO_OWSR_P14_Pos                    14                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P14_Msk                    (_U_(0x1) << PIO_OWSR_P14_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P14                        PIO_OWSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P14_Msk instead */
+#define PIO_OWSR_P15_Pos                    15                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P15_Msk                    (_U_(0x1) << PIO_OWSR_P15_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P15                        PIO_OWSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P15_Msk instead */
+#define PIO_OWSR_P16_Pos                    16                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P16_Msk                    (_U_(0x1) << PIO_OWSR_P16_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P16                        PIO_OWSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P16_Msk instead */
+#define PIO_OWSR_P17_Pos                    17                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P17_Msk                    (_U_(0x1) << PIO_OWSR_P17_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P17                        PIO_OWSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P17_Msk instead */
+#define PIO_OWSR_P18_Pos                    18                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P18_Msk                    (_U_(0x1) << PIO_OWSR_P18_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P18                        PIO_OWSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P18_Msk instead */
+#define PIO_OWSR_P19_Pos                    19                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P19_Msk                    (_U_(0x1) << PIO_OWSR_P19_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P19                        PIO_OWSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P19_Msk instead */
+#define PIO_OWSR_P20_Pos                    20                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P20_Msk                    (_U_(0x1) << PIO_OWSR_P20_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P20                        PIO_OWSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P20_Msk instead */
+#define PIO_OWSR_P21_Pos                    21                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P21_Msk                    (_U_(0x1) << PIO_OWSR_P21_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P21                        PIO_OWSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P21_Msk instead */
+#define PIO_OWSR_P22_Pos                    22                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P22_Msk                    (_U_(0x1) << PIO_OWSR_P22_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P22                        PIO_OWSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P22_Msk instead */
+#define PIO_OWSR_P23_Pos                    23                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P23_Msk                    (_U_(0x1) << PIO_OWSR_P23_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P23                        PIO_OWSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P23_Msk instead */
+#define PIO_OWSR_P24_Pos                    24                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P24_Msk                    (_U_(0x1) << PIO_OWSR_P24_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P24                        PIO_OWSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P24_Msk instead */
+#define PIO_OWSR_P25_Pos                    25                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P25_Msk                    (_U_(0x1) << PIO_OWSR_P25_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P25                        PIO_OWSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P25_Msk instead */
+#define PIO_OWSR_P26_Pos                    26                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P26_Msk                    (_U_(0x1) << PIO_OWSR_P26_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P26                        PIO_OWSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P26_Msk instead */
+#define PIO_OWSR_P27_Pos                    27                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P27_Msk                    (_U_(0x1) << PIO_OWSR_P27_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P27                        PIO_OWSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P27_Msk instead */
+#define PIO_OWSR_P28_Pos                    28                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P28_Msk                    (_U_(0x1) << PIO_OWSR_P28_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P28                        PIO_OWSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P28_Msk instead */
+#define PIO_OWSR_P29_Pos                    29                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P29_Msk                    (_U_(0x1) << PIO_OWSR_P29_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P29                        PIO_OWSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P29_Msk instead */
+#define PIO_OWSR_P30_Pos                    30                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P30_Msk                    (_U_(0x1) << PIO_OWSR_P30_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P30                        PIO_OWSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P30_Msk instead */
+#define PIO_OWSR_P31_Pos                    31                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P31_Msk                    (_U_(0x1) << PIO_OWSR_P31_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P31                        PIO_OWSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P31_Msk instead */
+#define PIO_OWSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWSR) Register MASK  (Use PIO_OWSR_Msk instead)  */
+#define PIO_OWSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWSR) Register Mask  */
+
+#define PIO_OWSR_P_Pos                      0                                              /**< (PIO_OWSR Position) Output Write Status */
+#define PIO_OWSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWSR_P_Pos)            /**< (PIO_OWSR Mask) P */
+#define PIO_OWSR_P(value)                   (PIO_OWSR_P_Msk & ((value) << PIO_OWSR_P_Pos))  
+
+/* -------- PIO_AIMER : (PIO Offset: 0xb0) (/W 32) Additional Interrupt Modes Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Enable        */
+    uint32_t P1:1;                      /**< bit:      1  Additional Interrupt Modes Enable        */
+    uint32_t P2:1;                      /**< bit:      2  Additional Interrupt Modes Enable        */
+    uint32_t P3:1;                      /**< bit:      3  Additional Interrupt Modes Enable        */
+    uint32_t P4:1;                      /**< bit:      4  Additional Interrupt Modes Enable        */
+    uint32_t P5:1;                      /**< bit:      5  Additional Interrupt Modes Enable        */
+    uint32_t P6:1;                      /**< bit:      6  Additional Interrupt Modes Enable        */
+    uint32_t P7:1;                      /**< bit:      7  Additional Interrupt Modes Enable        */
+    uint32_t P8:1;                      /**< bit:      8  Additional Interrupt Modes Enable        */
+    uint32_t P9:1;                      /**< bit:      9  Additional Interrupt Modes Enable        */
+    uint32_t P10:1;                     /**< bit:     10  Additional Interrupt Modes Enable        */
+    uint32_t P11:1;                     /**< bit:     11  Additional Interrupt Modes Enable        */
+    uint32_t P12:1;                     /**< bit:     12  Additional Interrupt Modes Enable        */
+    uint32_t P13:1;                     /**< bit:     13  Additional Interrupt Modes Enable        */
+    uint32_t P14:1;                     /**< bit:     14  Additional Interrupt Modes Enable        */
+    uint32_t P15:1;                     /**< bit:     15  Additional Interrupt Modes Enable        */
+    uint32_t P16:1;                     /**< bit:     16  Additional Interrupt Modes Enable        */
+    uint32_t P17:1;                     /**< bit:     17  Additional Interrupt Modes Enable        */
+    uint32_t P18:1;                     /**< bit:     18  Additional Interrupt Modes Enable        */
+    uint32_t P19:1;                     /**< bit:     19  Additional Interrupt Modes Enable        */
+    uint32_t P20:1;                     /**< bit:     20  Additional Interrupt Modes Enable        */
+    uint32_t P21:1;                     /**< bit:     21  Additional Interrupt Modes Enable        */
+    uint32_t P22:1;                     /**< bit:     22  Additional Interrupt Modes Enable        */
+    uint32_t P23:1;                     /**< bit:     23  Additional Interrupt Modes Enable        */
+    uint32_t P24:1;                     /**< bit:     24  Additional Interrupt Modes Enable        */
+    uint32_t P25:1;                     /**< bit:     25  Additional Interrupt Modes Enable        */
+    uint32_t P26:1;                     /**< bit:     26  Additional Interrupt Modes Enable        */
+    uint32_t P27:1;                     /**< bit:     27  Additional Interrupt Modes Enable        */
+    uint32_t P28:1;                     /**< bit:     28  Additional Interrupt Modes Enable        */
+    uint32_t P29:1;                     /**< bit:     29  Additional Interrupt Modes Enable        */
+    uint32_t P30:1;                     /**< bit:     30  Additional Interrupt Modes Enable        */
+    uint32_t P31:1;                     /**< bit:     31  Additional Interrupt Modes Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Additional Interrupt Modes Enable        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMER_OFFSET                    (0xB0)                                        /**<  (PIO_AIMER) Additional Interrupt Modes Enable Register  Offset */
+
+#define PIO_AIMER_P0_Pos                    0                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P0_Msk                    (_U_(0x1) << PIO_AIMER_P0_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P0                        PIO_AIMER_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P0_Msk instead */
+#define PIO_AIMER_P1_Pos                    1                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P1_Msk                    (_U_(0x1) << PIO_AIMER_P1_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P1                        PIO_AIMER_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P1_Msk instead */
+#define PIO_AIMER_P2_Pos                    2                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P2_Msk                    (_U_(0x1) << PIO_AIMER_P2_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P2                        PIO_AIMER_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P2_Msk instead */
+#define PIO_AIMER_P3_Pos                    3                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P3_Msk                    (_U_(0x1) << PIO_AIMER_P3_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P3                        PIO_AIMER_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P3_Msk instead */
+#define PIO_AIMER_P4_Pos                    4                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P4_Msk                    (_U_(0x1) << PIO_AIMER_P4_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P4                        PIO_AIMER_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P4_Msk instead */
+#define PIO_AIMER_P5_Pos                    5                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P5_Msk                    (_U_(0x1) << PIO_AIMER_P5_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P5                        PIO_AIMER_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P5_Msk instead */
+#define PIO_AIMER_P6_Pos                    6                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P6_Msk                    (_U_(0x1) << PIO_AIMER_P6_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P6                        PIO_AIMER_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P6_Msk instead */
+#define PIO_AIMER_P7_Pos                    7                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P7_Msk                    (_U_(0x1) << PIO_AIMER_P7_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P7                        PIO_AIMER_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P7_Msk instead */
+#define PIO_AIMER_P8_Pos                    8                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P8_Msk                    (_U_(0x1) << PIO_AIMER_P8_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P8                        PIO_AIMER_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P8_Msk instead */
+#define PIO_AIMER_P9_Pos                    9                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P9_Msk                    (_U_(0x1) << PIO_AIMER_P9_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P9                        PIO_AIMER_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P9_Msk instead */
+#define PIO_AIMER_P10_Pos                   10                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P10_Msk                   (_U_(0x1) << PIO_AIMER_P10_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P10                       PIO_AIMER_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P10_Msk instead */
+#define PIO_AIMER_P11_Pos                   11                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P11_Msk                   (_U_(0x1) << PIO_AIMER_P11_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P11                       PIO_AIMER_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P11_Msk instead */
+#define PIO_AIMER_P12_Pos                   12                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P12_Msk                   (_U_(0x1) << PIO_AIMER_P12_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P12                       PIO_AIMER_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P12_Msk instead */
+#define PIO_AIMER_P13_Pos                   13                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P13_Msk                   (_U_(0x1) << PIO_AIMER_P13_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P13                       PIO_AIMER_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P13_Msk instead */
+#define PIO_AIMER_P14_Pos                   14                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P14_Msk                   (_U_(0x1) << PIO_AIMER_P14_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P14                       PIO_AIMER_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P14_Msk instead */
+#define PIO_AIMER_P15_Pos                   15                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P15_Msk                   (_U_(0x1) << PIO_AIMER_P15_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P15                       PIO_AIMER_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P15_Msk instead */
+#define PIO_AIMER_P16_Pos                   16                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P16_Msk                   (_U_(0x1) << PIO_AIMER_P16_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P16                       PIO_AIMER_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P16_Msk instead */
+#define PIO_AIMER_P17_Pos                   17                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P17_Msk                   (_U_(0x1) << PIO_AIMER_P17_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P17                       PIO_AIMER_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P17_Msk instead */
+#define PIO_AIMER_P18_Pos                   18                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P18_Msk                   (_U_(0x1) << PIO_AIMER_P18_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P18                       PIO_AIMER_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P18_Msk instead */
+#define PIO_AIMER_P19_Pos                   19                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P19_Msk                   (_U_(0x1) << PIO_AIMER_P19_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P19                       PIO_AIMER_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P19_Msk instead */
+#define PIO_AIMER_P20_Pos                   20                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P20_Msk                   (_U_(0x1) << PIO_AIMER_P20_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P20                       PIO_AIMER_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P20_Msk instead */
+#define PIO_AIMER_P21_Pos                   21                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P21_Msk                   (_U_(0x1) << PIO_AIMER_P21_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P21                       PIO_AIMER_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P21_Msk instead */
+#define PIO_AIMER_P22_Pos                   22                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P22_Msk                   (_U_(0x1) << PIO_AIMER_P22_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P22                       PIO_AIMER_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P22_Msk instead */
+#define PIO_AIMER_P23_Pos                   23                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P23_Msk                   (_U_(0x1) << PIO_AIMER_P23_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P23                       PIO_AIMER_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P23_Msk instead */
+#define PIO_AIMER_P24_Pos                   24                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P24_Msk                   (_U_(0x1) << PIO_AIMER_P24_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P24                       PIO_AIMER_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P24_Msk instead */
+#define PIO_AIMER_P25_Pos                   25                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P25_Msk                   (_U_(0x1) << PIO_AIMER_P25_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P25                       PIO_AIMER_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P25_Msk instead */
+#define PIO_AIMER_P26_Pos                   26                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P26_Msk                   (_U_(0x1) << PIO_AIMER_P26_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P26                       PIO_AIMER_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P26_Msk instead */
+#define PIO_AIMER_P27_Pos                   27                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P27_Msk                   (_U_(0x1) << PIO_AIMER_P27_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P27                       PIO_AIMER_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P27_Msk instead */
+#define PIO_AIMER_P28_Pos                   28                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P28_Msk                   (_U_(0x1) << PIO_AIMER_P28_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P28                       PIO_AIMER_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P28_Msk instead */
+#define PIO_AIMER_P29_Pos                   29                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P29_Msk                   (_U_(0x1) << PIO_AIMER_P29_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P29                       PIO_AIMER_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P29_Msk instead */
+#define PIO_AIMER_P30_Pos                   30                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P30_Msk                   (_U_(0x1) << PIO_AIMER_P30_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P30                       PIO_AIMER_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P30_Msk instead */
+#define PIO_AIMER_P31_Pos                   31                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P31_Msk                   (_U_(0x1) << PIO_AIMER_P31_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P31                       PIO_AIMER_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P31_Msk instead */
+#define PIO_AIMER_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMER) Register MASK  (Use PIO_AIMER_Msk instead)  */
+#define PIO_AIMER_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMER) Register Mask  */
+
+#define PIO_AIMER_P_Pos                     0                                              /**< (PIO_AIMER Position) Additional Interrupt Modes Enable */
+#define PIO_AIMER_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMER_P_Pos)           /**< (PIO_AIMER Mask) P */
+#define PIO_AIMER_P(value)                  (PIO_AIMER_P_Msk & ((value) << PIO_AIMER_P_Pos))  
+
+/* -------- PIO_AIMDR : (PIO Offset: 0xb4) (/W 32) Additional Interrupt Modes Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Disable       */
+    uint32_t P1:1;                      /**< bit:      1  Additional Interrupt Modes Disable       */
+    uint32_t P2:1;                      /**< bit:      2  Additional Interrupt Modes Disable       */
+    uint32_t P3:1;                      /**< bit:      3  Additional Interrupt Modes Disable       */
+    uint32_t P4:1;                      /**< bit:      4  Additional Interrupt Modes Disable       */
+    uint32_t P5:1;                      /**< bit:      5  Additional Interrupt Modes Disable       */
+    uint32_t P6:1;                      /**< bit:      6  Additional Interrupt Modes Disable       */
+    uint32_t P7:1;                      /**< bit:      7  Additional Interrupt Modes Disable       */
+    uint32_t P8:1;                      /**< bit:      8  Additional Interrupt Modes Disable       */
+    uint32_t P9:1;                      /**< bit:      9  Additional Interrupt Modes Disable       */
+    uint32_t P10:1;                     /**< bit:     10  Additional Interrupt Modes Disable       */
+    uint32_t P11:1;                     /**< bit:     11  Additional Interrupt Modes Disable       */
+    uint32_t P12:1;                     /**< bit:     12  Additional Interrupt Modes Disable       */
+    uint32_t P13:1;                     /**< bit:     13  Additional Interrupt Modes Disable       */
+    uint32_t P14:1;                     /**< bit:     14  Additional Interrupt Modes Disable       */
+    uint32_t P15:1;                     /**< bit:     15  Additional Interrupt Modes Disable       */
+    uint32_t P16:1;                     /**< bit:     16  Additional Interrupt Modes Disable       */
+    uint32_t P17:1;                     /**< bit:     17  Additional Interrupt Modes Disable       */
+    uint32_t P18:1;                     /**< bit:     18  Additional Interrupt Modes Disable       */
+    uint32_t P19:1;                     /**< bit:     19  Additional Interrupt Modes Disable       */
+    uint32_t P20:1;                     /**< bit:     20  Additional Interrupt Modes Disable       */
+    uint32_t P21:1;                     /**< bit:     21  Additional Interrupt Modes Disable       */
+    uint32_t P22:1;                     /**< bit:     22  Additional Interrupt Modes Disable       */
+    uint32_t P23:1;                     /**< bit:     23  Additional Interrupt Modes Disable       */
+    uint32_t P24:1;                     /**< bit:     24  Additional Interrupt Modes Disable       */
+    uint32_t P25:1;                     /**< bit:     25  Additional Interrupt Modes Disable       */
+    uint32_t P26:1;                     /**< bit:     26  Additional Interrupt Modes Disable       */
+    uint32_t P27:1;                     /**< bit:     27  Additional Interrupt Modes Disable       */
+    uint32_t P28:1;                     /**< bit:     28  Additional Interrupt Modes Disable       */
+    uint32_t P29:1;                     /**< bit:     29  Additional Interrupt Modes Disable       */
+    uint32_t P30:1;                     /**< bit:     30  Additional Interrupt Modes Disable       */
+    uint32_t P31:1;                     /**< bit:     31  Additional Interrupt Modes Disable       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Additional Interrupt Modes Disable       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMDR_OFFSET                    (0xB4)                                        /**<  (PIO_AIMDR) Additional Interrupt Modes Disable Register  Offset */
+
+#define PIO_AIMDR_P0_Pos                    0                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P0_Msk                    (_U_(0x1) << PIO_AIMDR_P0_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P0                        PIO_AIMDR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P0_Msk instead */
+#define PIO_AIMDR_P1_Pos                    1                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P1_Msk                    (_U_(0x1) << PIO_AIMDR_P1_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P1                        PIO_AIMDR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P1_Msk instead */
+#define PIO_AIMDR_P2_Pos                    2                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P2_Msk                    (_U_(0x1) << PIO_AIMDR_P2_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P2                        PIO_AIMDR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P2_Msk instead */
+#define PIO_AIMDR_P3_Pos                    3                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P3_Msk                    (_U_(0x1) << PIO_AIMDR_P3_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P3                        PIO_AIMDR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P3_Msk instead */
+#define PIO_AIMDR_P4_Pos                    4                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P4_Msk                    (_U_(0x1) << PIO_AIMDR_P4_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P4                        PIO_AIMDR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P4_Msk instead */
+#define PIO_AIMDR_P5_Pos                    5                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P5_Msk                    (_U_(0x1) << PIO_AIMDR_P5_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P5                        PIO_AIMDR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P5_Msk instead */
+#define PIO_AIMDR_P6_Pos                    6                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P6_Msk                    (_U_(0x1) << PIO_AIMDR_P6_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P6                        PIO_AIMDR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P6_Msk instead */
+#define PIO_AIMDR_P7_Pos                    7                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P7_Msk                    (_U_(0x1) << PIO_AIMDR_P7_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P7                        PIO_AIMDR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P7_Msk instead */
+#define PIO_AIMDR_P8_Pos                    8                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P8_Msk                    (_U_(0x1) << PIO_AIMDR_P8_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P8                        PIO_AIMDR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P8_Msk instead */
+#define PIO_AIMDR_P9_Pos                    9                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P9_Msk                    (_U_(0x1) << PIO_AIMDR_P9_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P9                        PIO_AIMDR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P9_Msk instead */
+#define PIO_AIMDR_P10_Pos                   10                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P10_Msk                   (_U_(0x1) << PIO_AIMDR_P10_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P10                       PIO_AIMDR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P10_Msk instead */
+#define PIO_AIMDR_P11_Pos                   11                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P11_Msk                   (_U_(0x1) << PIO_AIMDR_P11_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P11                       PIO_AIMDR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P11_Msk instead */
+#define PIO_AIMDR_P12_Pos                   12                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P12_Msk                   (_U_(0x1) << PIO_AIMDR_P12_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P12                       PIO_AIMDR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P12_Msk instead */
+#define PIO_AIMDR_P13_Pos                   13                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P13_Msk                   (_U_(0x1) << PIO_AIMDR_P13_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P13                       PIO_AIMDR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P13_Msk instead */
+#define PIO_AIMDR_P14_Pos                   14                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P14_Msk                   (_U_(0x1) << PIO_AIMDR_P14_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P14                       PIO_AIMDR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P14_Msk instead */
+#define PIO_AIMDR_P15_Pos                   15                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P15_Msk                   (_U_(0x1) << PIO_AIMDR_P15_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P15                       PIO_AIMDR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P15_Msk instead */
+#define PIO_AIMDR_P16_Pos                   16                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P16_Msk                   (_U_(0x1) << PIO_AIMDR_P16_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P16                       PIO_AIMDR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P16_Msk instead */
+#define PIO_AIMDR_P17_Pos                   17                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P17_Msk                   (_U_(0x1) << PIO_AIMDR_P17_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P17                       PIO_AIMDR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P17_Msk instead */
+#define PIO_AIMDR_P18_Pos                   18                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P18_Msk                   (_U_(0x1) << PIO_AIMDR_P18_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P18                       PIO_AIMDR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P18_Msk instead */
+#define PIO_AIMDR_P19_Pos                   19                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P19_Msk                   (_U_(0x1) << PIO_AIMDR_P19_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P19                       PIO_AIMDR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P19_Msk instead */
+#define PIO_AIMDR_P20_Pos                   20                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P20_Msk                   (_U_(0x1) << PIO_AIMDR_P20_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P20                       PIO_AIMDR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P20_Msk instead */
+#define PIO_AIMDR_P21_Pos                   21                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P21_Msk                   (_U_(0x1) << PIO_AIMDR_P21_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P21                       PIO_AIMDR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P21_Msk instead */
+#define PIO_AIMDR_P22_Pos                   22                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P22_Msk                   (_U_(0x1) << PIO_AIMDR_P22_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P22                       PIO_AIMDR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P22_Msk instead */
+#define PIO_AIMDR_P23_Pos                   23                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P23_Msk                   (_U_(0x1) << PIO_AIMDR_P23_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P23                       PIO_AIMDR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P23_Msk instead */
+#define PIO_AIMDR_P24_Pos                   24                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P24_Msk                   (_U_(0x1) << PIO_AIMDR_P24_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P24                       PIO_AIMDR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P24_Msk instead */
+#define PIO_AIMDR_P25_Pos                   25                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P25_Msk                   (_U_(0x1) << PIO_AIMDR_P25_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P25                       PIO_AIMDR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P25_Msk instead */
+#define PIO_AIMDR_P26_Pos                   26                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P26_Msk                   (_U_(0x1) << PIO_AIMDR_P26_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P26                       PIO_AIMDR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P26_Msk instead */
+#define PIO_AIMDR_P27_Pos                   27                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P27_Msk                   (_U_(0x1) << PIO_AIMDR_P27_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P27                       PIO_AIMDR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P27_Msk instead */
+#define PIO_AIMDR_P28_Pos                   28                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P28_Msk                   (_U_(0x1) << PIO_AIMDR_P28_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P28                       PIO_AIMDR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P28_Msk instead */
+#define PIO_AIMDR_P29_Pos                   29                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P29_Msk                   (_U_(0x1) << PIO_AIMDR_P29_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P29                       PIO_AIMDR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P29_Msk instead */
+#define PIO_AIMDR_P30_Pos                   30                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P30_Msk                   (_U_(0x1) << PIO_AIMDR_P30_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P30                       PIO_AIMDR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P30_Msk instead */
+#define PIO_AIMDR_P31_Pos                   31                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P31_Msk                   (_U_(0x1) << PIO_AIMDR_P31_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P31                       PIO_AIMDR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P31_Msk instead */
+#define PIO_AIMDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMDR) Register MASK  (Use PIO_AIMDR_Msk instead)  */
+#define PIO_AIMDR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMDR) Register Mask  */
+
+#define PIO_AIMDR_P_Pos                     0                                              /**< (PIO_AIMDR Position) Additional Interrupt Modes Disable */
+#define PIO_AIMDR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMDR_P_Pos)           /**< (PIO_AIMDR Mask) P */
+#define PIO_AIMDR_P(value)                  (PIO_AIMDR_P_Msk & ((value) << PIO_AIMDR_P_Pos))  
+
+/* -------- PIO_AIMMR : (PIO Offset: 0xb8) (R/ 32) Additional Interrupt Modes Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  IO Line Index                            */
+    uint32_t P1:1;                      /**< bit:      1  IO Line Index                            */
+    uint32_t P2:1;                      /**< bit:      2  IO Line Index                            */
+    uint32_t P3:1;                      /**< bit:      3  IO Line Index                            */
+    uint32_t P4:1;                      /**< bit:      4  IO Line Index                            */
+    uint32_t P5:1;                      /**< bit:      5  IO Line Index                            */
+    uint32_t P6:1;                      /**< bit:      6  IO Line Index                            */
+    uint32_t P7:1;                      /**< bit:      7  IO Line Index                            */
+    uint32_t P8:1;                      /**< bit:      8  IO Line Index                            */
+    uint32_t P9:1;                      /**< bit:      9  IO Line Index                            */
+    uint32_t P10:1;                     /**< bit:     10  IO Line Index                            */
+    uint32_t P11:1;                     /**< bit:     11  IO Line Index                            */
+    uint32_t P12:1;                     /**< bit:     12  IO Line Index                            */
+    uint32_t P13:1;                     /**< bit:     13  IO Line Index                            */
+    uint32_t P14:1;                     /**< bit:     14  IO Line Index                            */
+    uint32_t P15:1;                     /**< bit:     15  IO Line Index                            */
+    uint32_t P16:1;                     /**< bit:     16  IO Line Index                            */
+    uint32_t P17:1;                     /**< bit:     17  IO Line Index                            */
+    uint32_t P18:1;                     /**< bit:     18  IO Line Index                            */
+    uint32_t P19:1;                     /**< bit:     19  IO Line Index                            */
+    uint32_t P20:1;                     /**< bit:     20  IO Line Index                            */
+    uint32_t P21:1;                     /**< bit:     21  IO Line Index                            */
+    uint32_t P22:1;                     /**< bit:     22  IO Line Index                            */
+    uint32_t P23:1;                     /**< bit:     23  IO Line Index                            */
+    uint32_t P24:1;                     /**< bit:     24  IO Line Index                            */
+    uint32_t P25:1;                     /**< bit:     25  IO Line Index                            */
+    uint32_t P26:1;                     /**< bit:     26  IO Line Index                            */
+    uint32_t P27:1;                     /**< bit:     27  IO Line Index                            */
+    uint32_t P28:1;                     /**< bit:     28  IO Line Index                            */
+    uint32_t P29:1;                     /**< bit:     29  IO Line Index                            */
+    uint32_t P30:1;                     /**< bit:     30  IO Line Index                            */
+    uint32_t P31:1;                     /**< bit:     31  IO Line Index                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  IO Line Index                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMMR_OFFSET                    (0xB8)                                        /**<  (PIO_AIMMR) Additional Interrupt Modes Mask Register  Offset */
+
+#define PIO_AIMMR_P0_Pos                    0                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P0_Msk                    (_U_(0x1) << PIO_AIMMR_P0_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P0                        PIO_AIMMR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P0_Msk instead */
+#define PIO_AIMMR_P1_Pos                    1                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P1_Msk                    (_U_(0x1) << PIO_AIMMR_P1_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P1                        PIO_AIMMR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P1_Msk instead */
+#define PIO_AIMMR_P2_Pos                    2                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P2_Msk                    (_U_(0x1) << PIO_AIMMR_P2_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P2                        PIO_AIMMR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P2_Msk instead */
+#define PIO_AIMMR_P3_Pos                    3                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P3_Msk                    (_U_(0x1) << PIO_AIMMR_P3_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P3                        PIO_AIMMR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P3_Msk instead */
+#define PIO_AIMMR_P4_Pos                    4                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P4_Msk                    (_U_(0x1) << PIO_AIMMR_P4_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P4                        PIO_AIMMR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P4_Msk instead */
+#define PIO_AIMMR_P5_Pos                    5                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P5_Msk                    (_U_(0x1) << PIO_AIMMR_P5_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P5                        PIO_AIMMR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P5_Msk instead */
+#define PIO_AIMMR_P6_Pos                    6                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P6_Msk                    (_U_(0x1) << PIO_AIMMR_P6_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P6                        PIO_AIMMR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P6_Msk instead */
+#define PIO_AIMMR_P7_Pos                    7                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P7_Msk                    (_U_(0x1) << PIO_AIMMR_P7_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P7                        PIO_AIMMR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P7_Msk instead */
+#define PIO_AIMMR_P8_Pos                    8                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P8_Msk                    (_U_(0x1) << PIO_AIMMR_P8_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P8                        PIO_AIMMR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P8_Msk instead */
+#define PIO_AIMMR_P9_Pos                    9                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P9_Msk                    (_U_(0x1) << PIO_AIMMR_P9_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P9                        PIO_AIMMR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P9_Msk instead */
+#define PIO_AIMMR_P10_Pos                   10                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P10_Msk                   (_U_(0x1) << PIO_AIMMR_P10_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P10                       PIO_AIMMR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P10_Msk instead */
+#define PIO_AIMMR_P11_Pos                   11                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P11_Msk                   (_U_(0x1) << PIO_AIMMR_P11_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P11                       PIO_AIMMR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P11_Msk instead */
+#define PIO_AIMMR_P12_Pos                   12                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P12_Msk                   (_U_(0x1) << PIO_AIMMR_P12_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P12                       PIO_AIMMR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P12_Msk instead */
+#define PIO_AIMMR_P13_Pos                   13                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P13_Msk                   (_U_(0x1) << PIO_AIMMR_P13_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P13                       PIO_AIMMR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P13_Msk instead */
+#define PIO_AIMMR_P14_Pos                   14                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P14_Msk                   (_U_(0x1) << PIO_AIMMR_P14_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P14                       PIO_AIMMR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P14_Msk instead */
+#define PIO_AIMMR_P15_Pos                   15                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P15_Msk                   (_U_(0x1) << PIO_AIMMR_P15_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P15                       PIO_AIMMR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P15_Msk instead */
+#define PIO_AIMMR_P16_Pos                   16                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P16_Msk                   (_U_(0x1) << PIO_AIMMR_P16_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P16                       PIO_AIMMR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P16_Msk instead */
+#define PIO_AIMMR_P17_Pos                   17                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P17_Msk                   (_U_(0x1) << PIO_AIMMR_P17_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P17                       PIO_AIMMR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P17_Msk instead */
+#define PIO_AIMMR_P18_Pos                   18                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P18_Msk                   (_U_(0x1) << PIO_AIMMR_P18_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P18                       PIO_AIMMR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P18_Msk instead */
+#define PIO_AIMMR_P19_Pos                   19                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P19_Msk                   (_U_(0x1) << PIO_AIMMR_P19_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P19                       PIO_AIMMR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P19_Msk instead */
+#define PIO_AIMMR_P20_Pos                   20                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P20_Msk                   (_U_(0x1) << PIO_AIMMR_P20_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P20                       PIO_AIMMR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P20_Msk instead */
+#define PIO_AIMMR_P21_Pos                   21                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P21_Msk                   (_U_(0x1) << PIO_AIMMR_P21_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P21                       PIO_AIMMR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P21_Msk instead */
+#define PIO_AIMMR_P22_Pos                   22                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P22_Msk                   (_U_(0x1) << PIO_AIMMR_P22_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P22                       PIO_AIMMR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P22_Msk instead */
+#define PIO_AIMMR_P23_Pos                   23                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P23_Msk                   (_U_(0x1) << PIO_AIMMR_P23_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P23                       PIO_AIMMR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P23_Msk instead */
+#define PIO_AIMMR_P24_Pos                   24                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P24_Msk                   (_U_(0x1) << PIO_AIMMR_P24_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P24                       PIO_AIMMR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P24_Msk instead */
+#define PIO_AIMMR_P25_Pos                   25                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P25_Msk                   (_U_(0x1) << PIO_AIMMR_P25_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P25                       PIO_AIMMR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P25_Msk instead */
+#define PIO_AIMMR_P26_Pos                   26                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P26_Msk                   (_U_(0x1) << PIO_AIMMR_P26_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P26                       PIO_AIMMR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P26_Msk instead */
+#define PIO_AIMMR_P27_Pos                   27                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P27_Msk                   (_U_(0x1) << PIO_AIMMR_P27_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P27                       PIO_AIMMR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P27_Msk instead */
+#define PIO_AIMMR_P28_Pos                   28                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P28_Msk                   (_U_(0x1) << PIO_AIMMR_P28_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P28                       PIO_AIMMR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P28_Msk instead */
+#define PIO_AIMMR_P29_Pos                   29                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P29_Msk                   (_U_(0x1) << PIO_AIMMR_P29_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P29                       PIO_AIMMR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P29_Msk instead */
+#define PIO_AIMMR_P30_Pos                   30                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P30_Msk                   (_U_(0x1) << PIO_AIMMR_P30_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P30                       PIO_AIMMR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P30_Msk instead */
+#define PIO_AIMMR_P31_Pos                   31                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P31_Msk                   (_U_(0x1) << PIO_AIMMR_P31_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P31                       PIO_AIMMR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P31_Msk instead */
+#define PIO_AIMMR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMMR) Register MASK  (Use PIO_AIMMR_Msk instead)  */
+#define PIO_AIMMR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMMR) Register Mask  */
+
+#define PIO_AIMMR_P_Pos                     0                                              /**< (PIO_AIMMR Position) IO Line Index */
+#define PIO_AIMMR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMMR_P_Pos)           /**< (PIO_AIMMR Mask) P */
+#define PIO_AIMMR_P(value)                  (PIO_AIMMR_P_Msk & ((value) << PIO_AIMMR_P_Pos))  
+
+/* -------- PIO_ESR : (PIO Offset: 0xc0) (/W 32) Edge Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge Interrupt Selection                 */
+    uint32_t P1:1;                      /**< bit:      1  Edge Interrupt Selection                 */
+    uint32_t P2:1;                      /**< bit:      2  Edge Interrupt Selection                 */
+    uint32_t P3:1;                      /**< bit:      3  Edge Interrupt Selection                 */
+    uint32_t P4:1;                      /**< bit:      4  Edge Interrupt Selection                 */
+    uint32_t P5:1;                      /**< bit:      5  Edge Interrupt Selection                 */
+    uint32_t P6:1;                      /**< bit:      6  Edge Interrupt Selection                 */
+    uint32_t P7:1;                      /**< bit:      7  Edge Interrupt Selection                 */
+    uint32_t P8:1;                      /**< bit:      8  Edge Interrupt Selection                 */
+    uint32_t P9:1;                      /**< bit:      9  Edge Interrupt Selection                 */
+    uint32_t P10:1;                     /**< bit:     10  Edge Interrupt Selection                 */
+    uint32_t P11:1;                     /**< bit:     11  Edge Interrupt Selection                 */
+    uint32_t P12:1;                     /**< bit:     12  Edge Interrupt Selection                 */
+    uint32_t P13:1;                     /**< bit:     13  Edge Interrupt Selection                 */
+    uint32_t P14:1;                     /**< bit:     14  Edge Interrupt Selection                 */
+    uint32_t P15:1;                     /**< bit:     15  Edge Interrupt Selection                 */
+    uint32_t P16:1;                     /**< bit:     16  Edge Interrupt Selection                 */
+    uint32_t P17:1;                     /**< bit:     17  Edge Interrupt Selection                 */
+    uint32_t P18:1;                     /**< bit:     18  Edge Interrupt Selection                 */
+    uint32_t P19:1;                     /**< bit:     19  Edge Interrupt Selection                 */
+    uint32_t P20:1;                     /**< bit:     20  Edge Interrupt Selection                 */
+    uint32_t P21:1;                     /**< bit:     21  Edge Interrupt Selection                 */
+    uint32_t P22:1;                     /**< bit:     22  Edge Interrupt Selection                 */
+    uint32_t P23:1;                     /**< bit:     23  Edge Interrupt Selection                 */
+    uint32_t P24:1;                     /**< bit:     24  Edge Interrupt Selection                 */
+    uint32_t P25:1;                     /**< bit:     25  Edge Interrupt Selection                 */
+    uint32_t P26:1;                     /**< bit:     26  Edge Interrupt Selection                 */
+    uint32_t P27:1;                     /**< bit:     27  Edge Interrupt Selection                 */
+    uint32_t P28:1;                     /**< bit:     28  Edge Interrupt Selection                 */
+    uint32_t P29:1;                     /**< bit:     29  Edge Interrupt Selection                 */
+    uint32_t P30:1;                     /**< bit:     30  Edge Interrupt Selection                 */
+    uint32_t P31:1;                     /**< bit:     31  Edge Interrupt Selection                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge Interrupt Selection                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ESR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ESR_OFFSET                      (0xC0)                                        /**<  (PIO_ESR) Edge Select Register  Offset */
+
+#define PIO_ESR_P0_Pos                      0                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P0_Msk                      (_U_(0x1) << PIO_ESR_P0_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P0                          PIO_ESR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P0_Msk instead */
+#define PIO_ESR_P1_Pos                      1                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P1_Msk                      (_U_(0x1) << PIO_ESR_P1_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P1                          PIO_ESR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P1_Msk instead */
+#define PIO_ESR_P2_Pos                      2                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P2_Msk                      (_U_(0x1) << PIO_ESR_P2_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P2                          PIO_ESR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P2_Msk instead */
+#define PIO_ESR_P3_Pos                      3                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P3_Msk                      (_U_(0x1) << PIO_ESR_P3_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P3                          PIO_ESR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P3_Msk instead */
+#define PIO_ESR_P4_Pos                      4                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P4_Msk                      (_U_(0x1) << PIO_ESR_P4_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P4                          PIO_ESR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P4_Msk instead */
+#define PIO_ESR_P5_Pos                      5                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P5_Msk                      (_U_(0x1) << PIO_ESR_P5_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P5                          PIO_ESR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P5_Msk instead */
+#define PIO_ESR_P6_Pos                      6                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P6_Msk                      (_U_(0x1) << PIO_ESR_P6_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P6                          PIO_ESR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P6_Msk instead */
+#define PIO_ESR_P7_Pos                      7                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P7_Msk                      (_U_(0x1) << PIO_ESR_P7_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P7                          PIO_ESR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P7_Msk instead */
+#define PIO_ESR_P8_Pos                      8                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P8_Msk                      (_U_(0x1) << PIO_ESR_P8_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P8                          PIO_ESR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P8_Msk instead */
+#define PIO_ESR_P9_Pos                      9                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P9_Msk                      (_U_(0x1) << PIO_ESR_P9_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P9                          PIO_ESR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P9_Msk instead */
+#define PIO_ESR_P10_Pos                     10                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P10_Msk                     (_U_(0x1) << PIO_ESR_P10_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P10                         PIO_ESR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P10_Msk instead */
+#define PIO_ESR_P11_Pos                     11                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P11_Msk                     (_U_(0x1) << PIO_ESR_P11_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P11                         PIO_ESR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P11_Msk instead */
+#define PIO_ESR_P12_Pos                     12                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P12_Msk                     (_U_(0x1) << PIO_ESR_P12_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P12                         PIO_ESR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P12_Msk instead */
+#define PIO_ESR_P13_Pos                     13                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P13_Msk                     (_U_(0x1) << PIO_ESR_P13_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P13                         PIO_ESR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P13_Msk instead */
+#define PIO_ESR_P14_Pos                     14                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P14_Msk                     (_U_(0x1) << PIO_ESR_P14_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P14                         PIO_ESR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P14_Msk instead */
+#define PIO_ESR_P15_Pos                     15                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P15_Msk                     (_U_(0x1) << PIO_ESR_P15_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P15                         PIO_ESR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P15_Msk instead */
+#define PIO_ESR_P16_Pos                     16                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P16_Msk                     (_U_(0x1) << PIO_ESR_P16_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P16                         PIO_ESR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P16_Msk instead */
+#define PIO_ESR_P17_Pos                     17                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P17_Msk                     (_U_(0x1) << PIO_ESR_P17_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P17                         PIO_ESR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P17_Msk instead */
+#define PIO_ESR_P18_Pos                     18                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P18_Msk                     (_U_(0x1) << PIO_ESR_P18_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P18                         PIO_ESR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P18_Msk instead */
+#define PIO_ESR_P19_Pos                     19                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P19_Msk                     (_U_(0x1) << PIO_ESR_P19_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P19                         PIO_ESR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P19_Msk instead */
+#define PIO_ESR_P20_Pos                     20                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P20_Msk                     (_U_(0x1) << PIO_ESR_P20_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P20                         PIO_ESR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P20_Msk instead */
+#define PIO_ESR_P21_Pos                     21                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P21_Msk                     (_U_(0x1) << PIO_ESR_P21_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P21                         PIO_ESR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P21_Msk instead */
+#define PIO_ESR_P22_Pos                     22                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P22_Msk                     (_U_(0x1) << PIO_ESR_P22_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P22                         PIO_ESR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P22_Msk instead */
+#define PIO_ESR_P23_Pos                     23                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P23_Msk                     (_U_(0x1) << PIO_ESR_P23_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P23                         PIO_ESR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P23_Msk instead */
+#define PIO_ESR_P24_Pos                     24                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P24_Msk                     (_U_(0x1) << PIO_ESR_P24_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P24                         PIO_ESR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P24_Msk instead */
+#define PIO_ESR_P25_Pos                     25                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P25_Msk                     (_U_(0x1) << PIO_ESR_P25_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P25                         PIO_ESR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P25_Msk instead */
+#define PIO_ESR_P26_Pos                     26                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P26_Msk                     (_U_(0x1) << PIO_ESR_P26_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P26                         PIO_ESR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P26_Msk instead */
+#define PIO_ESR_P27_Pos                     27                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P27_Msk                     (_U_(0x1) << PIO_ESR_P27_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P27                         PIO_ESR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P27_Msk instead */
+#define PIO_ESR_P28_Pos                     28                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P28_Msk                     (_U_(0x1) << PIO_ESR_P28_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P28                         PIO_ESR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P28_Msk instead */
+#define PIO_ESR_P29_Pos                     29                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P29_Msk                     (_U_(0x1) << PIO_ESR_P29_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P29                         PIO_ESR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P29_Msk instead */
+#define PIO_ESR_P30_Pos                     30                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P30_Msk                     (_U_(0x1) << PIO_ESR_P30_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P30                         PIO_ESR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P30_Msk instead */
+#define PIO_ESR_P31_Pos                     31                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P31_Msk                     (_U_(0x1) << PIO_ESR_P31_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P31                         PIO_ESR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P31_Msk instead */
+#define PIO_ESR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ESR) Register MASK  (Use PIO_ESR_Msk instead)  */
+#define PIO_ESR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ESR) Register Mask  */
+
+#define PIO_ESR_P_Pos                       0                                              /**< (PIO_ESR Position) Edge Interrupt Selection */
+#define PIO_ESR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ESR_P_Pos)             /**< (PIO_ESR Mask) P */
+#define PIO_ESR_P(value)                    (PIO_ESR_P_Msk & ((value) << PIO_ESR_P_Pos))   
+
+/* -------- PIO_LSR : (PIO Offset: 0xc4) (/W 32) Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Level Interrupt Selection                */
+    uint32_t P1:1;                      /**< bit:      1  Level Interrupt Selection                */
+    uint32_t P2:1;                      /**< bit:      2  Level Interrupt Selection                */
+    uint32_t P3:1;                      /**< bit:      3  Level Interrupt Selection                */
+    uint32_t P4:1;                      /**< bit:      4  Level Interrupt Selection                */
+    uint32_t P5:1;                      /**< bit:      5  Level Interrupt Selection                */
+    uint32_t P6:1;                      /**< bit:      6  Level Interrupt Selection                */
+    uint32_t P7:1;                      /**< bit:      7  Level Interrupt Selection                */
+    uint32_t P8:1;                      /**< bit:      8  Level Interrupt Selection                */
+    uint32_t P9:1;                      /**< bit:      9  Level Interrupt Selection                */
+    uint32_t P10:1;                     /**< bit:     10  Level Interrupt Selection                */
+    uint32_t P11:1;                     /**< bit:     11  Level Interrupt Selection                */
+    uint32_t P12:1;                     /**< bit:     12  Level Interrupt Selection                */
+    uint32_t P13:1;                     /**< bit:     13  Level Interrupt Selection                */
+    uint32_t P14:1;                     /**< bit:     14  Level Interrupt Selection                */
+    uint32_t P15:1;                     /**< bit:     15  Level Interrupt Selection                */
+    uint32_t P16:1;                     /**< bit:     16  Level Interrupt Selection                */
+    uint32_t P17:1;                     /**< bit:     17  Level Interrupt Selection                */
+    uint32_t P18:1;                     /**< bit:     18  Level Interrupt Selection                */
+    uint32_t P19:1;                     /**< bit:     19  Level Interrupt Selection                */
+    uint32_t P20:1;                     /**< bit:     20  Level Interrupt Selection                */
+    uint32_t P21:1;                     /**< bit:     21  Level Interrupt Selection                */
+    uint32_t P22:1;                     /**< bit:     22  Level Interrupt Selection                */
+    uint32_t P23:1;                     /**< bit:     23  Level Interrupt Selection                */
+    uint32_t P24:1;                     /**< bit:     24  Level Interrupt Selection                */
+    uint32_t P25:1;                     /**< bit:     25  Level Interrupt Selection                */
+    uint32_t P26:1;                     /**< bit:     26  Level Interrupt Selection                */
+    uint32_t P27:1;                     /**< bit:     27  Level Interrupt Selection                */
+    uint32_t P28:1;                     /**< bit:     28  Level Interrupt Selection                */
+    uint32_t P29:1;                     /**< bit:     29  Level Interrupt Selection                */
+    uint32_t P30:1;                     /**< bit:     30  Level Interrupt Selection                */
+    uint32_t P31:1;                     /**< bit:     31  Level Interrupt Selection                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Level Interrupt Selection                */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_LSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_LSR_OFFSET                      (0xC4)                                        /**<  (PIO_LSR) Level Select Register  Offset */
+
+#define PIO_LSR_P0_Pos                      0                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P0_Msk                      (_U_(0x1) << PIO_LSR_P0_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P0                          PIO_LSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P0_Msk instead */
+#define PIO_LSR_P1_Pos                      1                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P1_Msk                      (_U_(0x1) << PIO_LSR_P1_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P1                          PIO_LSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P1_Msk instead */
+#define PIO_LSR_P2_Pos                      2                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P2_Msk                      (_U_(0x1) << PIO_LSR_P2_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P2                          PIO_LSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P2_Msk instead */
+#define PIO_LSR_P3_Pos                      3                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P3_Msk                      (_U_(0x1) << PIO_LSR_P3_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P3                          PIO_LSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P3_Msk instead */
+#define PIO_LSR_P4_Pos                      4                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P4_Msk                      (_U_(0x1) << PIO_LSR_P4_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P4                          PIO_LSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P4_Msk instead */
+#define PIO_LSR_P5_Pos                      5                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P5_Msk                      (_U_(0x1) << PIO_LSR_P5_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P5                          PIO_LSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P5_Msk instead */
+#define PIO_LSR_P6_Pos                      6                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P6_Msk                      (_U_(0x1) << PIO_LSR_P6_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P6                          PIO_LSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P6_Msk instead */
+#define PIO_LSR_P7_Pos                      7                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P7_Msk                      (_U_(0x1) << PIO_LSR_P7_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P7                          PIO_LSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P7_Msk instead */
+#define PIO_LSR_P8_Pos                      8                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P8_Msk                      (_U_(0x1) << PIO_LSR_P8_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P8                          PIO_LSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P8_Msk instead */
+#define PIO_LSR_P9_Pos                      9                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P9_Msk                      (_U_(0x1) << PIO_LSR_P9_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P9                          PIO_LSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P9_Msk instead */
+#define PIO_LSR_P10_Pos                     10                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P10_Msk                     (_U_(0x1) << PIO_LSR_P10_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P10                         PIO_LSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P10_Msk instead */
+#define PIO_LSR_P11_Pos                     11                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P11_Msk                     (_U_(0x1) << PIO_LSR_P11_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P11                         PIO_LSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P11_Msk instead */
+#define PIO_LSR_P12_Pos                     12                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P12_Msk                     (_U_(0x1) << PIO_LSR_P12_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P12                         PIO_LSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P12_Msk instead */
+#define PIO_LSR_P13_Pos                     13                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P13_Msk                     (_U_(0x1) << PIO_LSR_P13_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P13                         PIO_LSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P13_Msk instead */
+#define PIO_LSR_P14_Pos                     14                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P14_Msk                     (_U_(0x1) << PIO_LSR_P14_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P14                         PIO_LSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P14_Msk instead */
+#define PIO_LSR_P15_Pos                     15                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P15_Msk                     (_U_(0x1) << PIO_LSR_P15_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P15                         PIO_LSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P15_Msk instead */
+#define PIO_LSR_P16_Pos                     16                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P16_Msk                     (_U_(0x1) << PIO_LSR_P16_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P16                         PIO_LSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P16_Msk instead */
+#define PIO_LSR_P17_Pos                     17                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P17_Msk                     (_U_(0x1) << PIO_LSR_P17_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P17                         PIO_LSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P17_Msk instead */
+#define PIO_LSR_P18_Pos                     18                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P18_Msk                     (_U_(0x1) << PIO_LSR_P18_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P18                         PIO_LSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P18_Msk instead */
+#define PIO_LSR_P19_Pos                     19                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P19_Msk                     (_U_(0x1) << PIO_LSR_P19_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P19                         PIO_LSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P19_Msk instead */
+#define PIO_LSR_P20_Pos                     20                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P20_Msk                     (_U_(0x1) << PIO_LSR_P20_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P20                         PIO_LSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P20_Msk instead */
+#define PIO_LSR_P21_Pos                     21                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P21_Msk                     (_U_(0x1) << PIO_LSR_P21_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P21                         PIO_LSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P21_Msk instead */
+#define PIO_LSR_P22_Pos                     22                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P22_Msk                     (_U_(0x1) << PIO_LSR_P22_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P22                         PIO_LSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P22_Msk instead */
+#define PIO_LSR_P23_Pos                     23                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P23_Msk                     (_U_(0x1) << PIO_LSR_P23_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P23                         PIO_LSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P23_Msk instead */
+#define PIO_LSR_P24_Pos                     24                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P24_Msk                     (_U_(0x1) << PIO_LSR_P24_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P24                         PIO_LSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P24_Msk instead */
+#define PIO_LSR_P25_Pos                     25                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P25_Msk                     (_U_(0x1) << PIO_LSR_P25_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P25                         PIO_LSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P25_Msk instead */
+#define PIO_LSR_P26_Pos                     26                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P26_Msk                     (_U_(0x1) << PIO_LSR_P26_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P26                         PIO_LSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P26_Msk instead */
+#define PIO_LSR_P27_Pos                     27                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P27_Msk                     (_U_(0x1) << PIO_LSR_P27_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P27                         PIO_LSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P27_Msk instead */
+#define PIO_LSR_P28_Pos                     28                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P28_Msk                     (_U_(0x1) << PIO_LSR_P28_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P28                         PIO_LSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P28_Msk instead */
+#define PIO_LSR_P29_Pos                     29                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P29_Msk                     (_U_(0x1) << PIO_LSR_P29_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P29                         PIO_LSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P29_Msk instead */
+#define PIO_LSR_P30_Pos                     30                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P30_Msk                     (_U_(0x1) << PIO_LSR_P30_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P30                         PIO_LSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P30_Msk instead */
+#define PIO_LSR_P31_Pos                     31                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P31_Msk                     (_U_(0x1) << PIO_LSR_P31_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P31                         PIO_LSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P31_Msk instead */
+#define PIO_LSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_LSR) Register MASK  (Use PIO_LSR_Msk instead)  */
+#define PIO_LSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_LSR) Register Mask  */
+
+#define PIO_LSR_P_Pos                       0                                              /**< (PIO_LSR Position) Level Interrupt Selection */
+#define PIO_LSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_LSR_P_Pos)             /**< (PIO_LSR Mask) P */
+#define PIO_LSR_P(value)                    (PIO_LSR_P_Msk & ((value) << PIO_LSR_P_Pos))   
+
+/* -------- PIO_ELSR : (PIO Offset: 0xc8) (R/ 32) Edge/Level Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
+    uint32_t P1:1;                      /**< bit:      1  Edge/Level Interrupt Source Selection    */
+    uint32_t P2:1;                      /**< bit:      2  Edge/Level Interrupt Source Selection    */
+    uint32_t P3:1;                      /**< bit:      3  Edge/Level Interrupt Source Selection    */
+    uint32_t P4:1;                      /**< bit:      4  Edge/Level Interrupt Source Selection    */
+    uint32_t P5:1;                      /**< bit:      5  Edge/Level Interrupt Source Selection    */
+    uint32_t P6:1;                      /**< bit:      6  Edge/Level Interrupt Source Selection    */
+    uint32_t P7:1;                      /**< bit:      7  Edge/Level Interrupt Source Selection    */
+    uint32_t P8:1;                      /**< bit:      8  Edge/Level Interrupt Source Selection    */
+    uint32_t P9:1;                      /**< bit:      9  Edge/Level Interrupt Source Selection    */
+    uint32_t P10:1;                     /**< bit:     10  Edge/Level Interrupt Source Selection    */
+    uint32_t P11:1;                     /**< bit:     11  Edge/Level Interrupt Source Selection    */
+    uint32_t P12:1;                     /**< bit:     12  Edge/Level Interrupt Source Selection    */
+    uint32_t P13:1;                     /**< bit:     13  Edge/Level Interrupt Source Selection    */
+    uint32_t P14:1;                     /**< bit:     14  Edge/Level Interrupt Source Selection    */
+    uint32_t P15:1;                     /**< bit:     15  Edge/Level Interrupt Source Selection    */
+    uint32_t P16:1;                     /**< bit:     16  Edge/Level Interrupt Source Selection    */
+    uint32_t P17:1;                     /**< bit:     17  Edge/Level Interrupt Source Selection    */
+    uint32_t P18:1;                     /**< bit:     18  Edge/Level Interrupt Source Selection    */
+    uint32_t P19:1;                     /**< bit:     19  Edge/Level Interrupt Source Selection    */
+    uint32_t P20:1;                     /**< bit:     20  Edge/Level Interrupt Source Selection    */
+    uint32_t P21:1;                     /**< bit:     21  Edge/Level Interrupt Source Selection    */
+    uint32_t P22:1;                     /**< bit:     22  Edge/Level Interrupt Source Selection    */
+    uint32_t P23:1;                     /**< bit:     23  Edge/Level Interrupt Source Selection    */
+    uint32_t P24:1;                     /**< bit:     24  Edge/Level Interrupt Source Selection    */
+    uint32_t P25:1;                     /**< bit:     25  Edge/Level Interrupt Source Selection    */
+    uint32_t P26:1;                     /**< bit:     26  Edge/Level Interrupt Source Selection    */
+    uint32_t P27:1;                     /**< bit:     27  Edge/Level Interrupt Source Selection    */
+    uint32_t P28:1;                     /**< bit:     28  Edge/Level Interrupt Source Selection    */
+    uint32_t P29:1;                     /**< bit:     29  Edge/Level Interrupt Source Selection    */
+    uint32_t P30:1;                     /**< bit:     30  Edge/Level Interrupt Source Selection    */
+    uint32_t P31:1;                     /**< bit:     31  Edge/Level Interrupt Source Selection    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge/Level Interrupt Source Selection    */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ELSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ELSR_OFFSET                     (0xC8)                                        /**<  (PIO_ELSR) Edge/Level Status Register  Offset */
+
+#define PIO_ELSR_P0_Pos                     0                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P0_Msk                     (_U_(0x1) << PIO_ELSR_P0_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P0                         PIO_ELSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P0_Msk instead */
+#define PIO_ELSR_P1_Pos                     1                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P1_Msk                     (_U_(0x1) << PIO_ELSR_P1_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P1                         PIO_ELSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P1_Msk instead */
+#define PIO_ELSR_P2_Pos                     2                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P2_Msk                     (_U_(0x1) << PIO_ELSR_P2_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P2                         PIO_ELSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P2_Msk instead */
+#define PIO_ELSR_P3_Pos                     3                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P3_Msk                     (_U_(0x1) << PIO_ELSR_P3_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P3                         PIO_ELSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P3_Msk instead */
+#define PIO_ELSR_P4_Pos                     4                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P4_Msk                     (_U_(0x1) << PIO_ELSR_P4_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P4                         PIO_ELSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P4_Msk instead */
+#define PIO_ELSR_P5_Pos                     5                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P5_Msk                     (_U_(0x1) << PIO_ELSR_P5_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P5                         PIO_ELSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P5_Msk instead */
+#define PIO_ELSR_P6_Pos                     6                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P6_Msk                     (_U_(0x1) << PIO_ELSR_P6_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P6                         PIO_ELSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P6_Msk instead */
+#define PIO_ELSR_P7_Pos                     7                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P7_Msk                     (_U_(0x1) << PIO_ELSR_P7_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P7                         PIO_ELSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P7_Msk instead */
+#define PIO_ELSR_P8_Pos                     8                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P8_Msk                     (_U_(0x1) << PIO_ELSR_P8_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P8                         PIO_ELSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P8_Msk instead */
+#define PIO_ELSR_P9_Pos                     9                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P9_Msk                     (_U_(0x1) << PIO_ELSR_P9_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P9                         PIO_ELSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P9_Msk instead */
+#define PIO_ELSR_P10_Pos                    10                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P10_Msk                    (_U_(0x1) << PIO_ELSR_P10_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P10                        PIO_ELSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P10_Msk instead */
+#define PIO_ELSR_P11_Pos                    11                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P11_Msk                    (_U_(0x1) << PIO_ELSR_P11_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P11                        PIO_ELSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P11_Msk instead */
+#define PIO_ELSR_P12_Pos                    12                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P12_Msk                    (_U_(0x1) << PIO_ELSR_P12_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P12                        PIO_ELSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P12_Msk instead */
+#define PIO_ELSR_P13_Pos                    13                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P13_Msk                    (_U_(0x1) << PIO_ELSR_P13_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P13                        PIO_ELSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P13_Msk instead */
+#define PIO_ELSR_P14_Pos                    14                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P14_Msk                    (_U_(0x1) << PIO_ELSR_P14_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P14                        PIO_ELSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P14_Msk instead */
+#define PIO_ELSR_P15_Pos                    15                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P15_Msk                    (_U_(0x1) << PIO_ELSR_P15_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P15                        PIO_ELSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P15_Msk instead */
+#define PIO_ELSR_P16_Pos                    16                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P16_Msk                    (_U_(0x1) << PIO_ELSR_P16_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P16                        PIO_ELSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P16_Msk instead */
+#define PIO_ELSR_P17_Pos                    17                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P17_Msk                    (_U_(0x1) << PIO_ELSR_P17_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P17                        PIO_ELSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P17_Msk instead */
+#define PIO_ELSR_P18_Pos                    18                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P18_Msk                    (_U_(0x1) << PIO_ELSR_P18_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P18                        PIO_ELSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P18_Msk instead */
+#define PIO_ELSR_P19_Pos                    19                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P19_Msk                    (_U_(0x1) << PIO_ELSR_P19_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P19                        PIO_ELSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P19_Msk instead */
+#define PIO_ELSR_P20_Pos                    20                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P20_Msk                    (_U_(0x1) << PIO_ELSR_P20_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P20                        PIO_ELSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P20_Msk instead */
+#define PIO_ELSR_P21_Pos                    21                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P21_Msk                    (_U_(0x1) << PIO_ELSR_P21_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P21                        PIO_ELSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P21_Msk instead */
+#define PIO_ELSR_P22_Pos                    22                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P22_Msk                    (_U_(0x1) << PIO_ELSR_P22_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P22                        PIO_ELSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P22_Msk instead */
+#define PIO_ELSR_P23_Pos                    23                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P23_Msk                    (_U_(0x1) << PIO_ELSR_P23_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P23                        PIO_ELSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P23_Msk instead */
+#define PIO_ELSR_P24_Pos                    24                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P24_Msk                    (_U_(0x1) << PIO_ELSR_P24_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P24                        PIO_ELSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P24_Msk instead */
+#define PIO_ELSR_P25_Pos                    25                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P25_Msk                    (_U_(0x1) << PIO_ELSR_P25_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P25                        PIO_ELSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P25_Msk instead */
+#define PIO_ELSR_P26_Pos                    26                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P26_Msk                    (_U_(0x1) << PIO_ELSR_P26_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P26                        PIO_ELSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P26_Msk instead */
+#define PIO_ELSR_P27_Pos                    27                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P27_Msk                    (_U_(0x1) << PIO_ELSR_P27_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P27                        PIO_ELSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P27_Msk instead */
+#define PIO_ELSR_P28_Pos                    28                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P28_Msk                    (_U_(0x1) << PIO_ELSR_P28_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P28                        PIO_ELSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P28_Msk instead */
+#define PIO_ELSR_P29_Pos                    29                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P29_Msk                    (_U_(0x1) << PIO_ELSR_P29_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P29                        PIO_ELSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P29_Msk instead */
+#define PIO_ELSR_P30_Pos                    30                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P30_Msk                    (_U_(0x1) << PIO_ELSR_P30_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P30                        PIO_ELSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P30_Msk instead */
+#define PIO_ELSR_P31_Pos                    31                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P31_Msk                    (_U_(0x1) << PIO_ELSR_P31_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P31                        PIO_ELSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P31_Msk instead */
+#define PIO_ELSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ELSR) Register MASK  (Use PIO_ELSR_Msk instead)  */
+#define PIO_ELSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_ELSR) Register Mask  */
+
+#define PIO_ELSR_P_Pos                      0                                              /**< (PIO_ELSR Position) Edge/Level Interrupt Source Selection */
+#define PIO_ELSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_ELSR_P_Pos)            /**< (PIO_ELSR Mask) P */
+#define PIO_ELSR_P(value)                   (PIO_ELSR_P_Msk & ((value) << PIO_ELSR_P_Pos))  
+
+/* -------- PIO_FELLSR : (PIO Offset: 0xd0) (/W 32) Falling Edge/Low-Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P1:1;                      /**< bit:      1  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P2:1;                      /**< bit:      2  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P3:1;                      /**< bit:      3  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P4:1;                      /**< bit:      4  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P5:1;                      /**< bit:      5  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P6:1;                      /**< bit:      6  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P7:1;                      /**< bit:      7  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P8:1;                      /**< bit:      8  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P9:1;                      /**< bit:      9  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P10:1;                     /**< bit:     10  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P11:1;                     /**< bit:     11  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P12:1;                     /**< bit:     12  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P13:1;                     /**< bit:     13  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P14:1;                     /**< bit:     14  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P15:1;                     /**< bit:     15  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P16:1;                     /**< bit:     16  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P17:1;                     /**< bit:     17  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P18:1;                     /**< bit:     18  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P19:1;                     /**< bit:     19  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P20:1;                     /**< bit:     20  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P21:1;                     /**< bit:     21  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P22:1;                     /**< bit:     22  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P23:1;                     /**< bit:     23  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P24:1;                     /**< bit:     24  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P25:1;                     /**< bit:     25  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P26:1;                     /**< bit:     26  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P27:1;                     /**< bit:     27  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P28:1;                     /**< bit:     28  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P29:1;                     /**< bit:     29  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P30:1;                     /**< bit:     30  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P31:1;                     /**< bit:     31  Falling Edge/Low-Level Interrupt Selection */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Falling Edge/Low-Level Interrupt Selection */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_FELLSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_FELLSR_OFFSET                   (0xD0)                                        /**<  (PIO_FELLSR) Falling Edge/Low-Level Select Register  Offset */
+
+#define PIO_FELLSR_P0_Pos                   0                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P0_Msk                   (_U_(0x1) << PIO_FELLSR_P0_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P0                       PIO_FELLSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P0_Msk instead */
+#define PIO_FELLSR_P1_Pos                   1                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P1_Msk                   (_U_(0x1) << PIO_FELLSR_P1_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P1                       PIO_FELLSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P1_Msk instead */
+#define PIO_FELLSR_P2_Pos                   2                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P2_Msk                   (_U_(0x1) << PIO_FELLSR_P2_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P2                       PIO_FELLSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P2_Msk instead */
+#define PIO_FELLSR_P3_Pos                   3                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P3_Msk                   (_U_(0x1) << PIO_FELLSR_P3_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P3                       PIO_FELLSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P3_Msk instead */
+#define PIO_FELLSR_P4_Pos                   4                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P4_Msk                   (_U_(0x1) << PIO_FELLSR_P4_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P4                       PIO_FELLSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P4_Msk instead */
+#define PIO_FELLSR_P5_Pos                   5                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P5_Msk                   (_U_(0x1) << PIO_FELLSR_P5_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P5                       PIO_FELLSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P5_Msk instead */
+#define PIO_FELLSR_P6_Pos                   6                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P6_Msk                   (_U_(0x1) << PIO_FELLSR_P6_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P6                       PIO_FELLSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P6_Msk instead */
+#define PIO_FELLSR_P7_Pos                   7                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P7_Msk                   (_U_(0x1) << PIO_FELLSR_P7_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P7                       PIO_FELLSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P7_Msk instead */
+#define PIO_FELLSR_P8_Pos                   8                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P8_Msk                   (_U_(0x1) << PIO_FELLSR_P8_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P8                       PIO_FELLSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P8_Msk instead */
+#define PIO_FELLSR_P9_Pos                   9                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P9_Msk                   (_U_(0x1) << PIO_FELLSR_P9_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P9                       PIO_FELLSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P9_Msk instead */
+#define PIO_FELLSR_P10_Pos                  10                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P10_Msk                  (_U_(0x1) << PIO_FELLSR_P10_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P10                      PIO_FELLSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P10_Msk instead */
+#define PIO_FELLSR_P11_Pos                  11                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P11_Msk                  (_U_(0x1) << PIO_FELLSR_P11_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P11                      PIO_FELLSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P11_Msk instead */
+#define PIO_FELLSR_P12_Pos                  12                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P12_Msk                  (_U_(0x1) << PIO_FELLSR_P12_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P12                      PIO_FELLSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P12_Msk instead */
+#define PIO_FELLSR_P13_Pos                  13                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P13_Msk                  (_U_(0x1) << PIO_FELLSR_P13_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P13                      PIO_FELLSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P13_Msk instead */
+#define PIO_FELLSR_P14_Pos                  14                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P14_Msk                  (_U_(0x1) << PIO_FELLSR_P14_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P14                      PIO_FELLSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P14_Msk instead */
+#define PIO_FELLSR_P15_Pos                  15                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P15_Msk                  (_U_(0x1) << PIO_FELLSR_P15_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P15                      PIO_FELLSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P15_Msk instead */
+#define PIO_FELLSR_P16_Pos                  16                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P16_Msk                  (_U_(0x1) << PIO_FELLSR_P16_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P16                      PIO_FELLSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P16_Msk instead */
+#define PIO_FELLSR_P17_Pos                  17                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P17_Msk                  (_U_(0x1) << PIO_FELLSR_P17_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P17                      PIO_FELLSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P17_Msk instead */
+#define PIO_FELLSR_P18_Pos                  18                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P18_Msk                  (_U_(0x1) << PIO_FELLSR_P18_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P18                      PIO_FELLSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P18_Msk instead */
+#define PIO_FELLSR_P19_Pos                  19                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P19_Msk                  (_U_(0x1) << PIO_FELLSR_P19_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P19                      PIO_FELLSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P19_Msk instead */
+#define PIO_FELLSR_P20_Pos                  20                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P20_Msk                  (_U_(0x1) << PIO_FELLSR_P20_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P20                      PIO_FELLSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P20_Msk instead */
+#define PIO_FELLSR_P21_Pos                  21                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P21_Msk                  (_U_(0x1) << PIO_FELLSR_P21_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P21                      PIO_FELLSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P21_Msk instead */
+#define PIO_FELLSR_P22_Pos                  22                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P22_Msk                  (_U_(0x1) << PIO_FELLSR_P22_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P22                      PIO_FELLSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P22_Msk instead */
+#define PIO_FELLSR_P23_Pos                  23                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P23_Msk                  (_U_(0x1) << PIO_FELLSR_P23_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P23                      PIO_FELLSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P23_Msk instead */
+#define PIO_FELLSR_P24_Pos                  24                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P24_Msk                  (_U_(0x1) << PIO_FELLSR_P24_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P24                      PIO_FELLSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P24_Msk instead */
+#define PIO_FELLSR_P25_Pos                  25                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P25_Msk                  (_U_(0x1) << PIO_FELLSR_P25_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P25                      PIO_FELLSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P25_Msk instead */
+#define PIO_FELLSR_P26_Pos                  26                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P26_Msk                  (_U_(0x1) << PIO_FELLSR_P26_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P26                      PIO_FELLSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P26_Msk instead */
+#define PIO_FELLSR_P27_Pos                  27                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P27_Msk                  (_U_(0x1) << PIO_FELLSR_P27_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P27                      PIO_FELLSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P27_Msk instead */
+#define PIO_FELLSR_P28_Pos                  28                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P28_Msk                  (_U_(0x1) << PIO_FELLSR_P28_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P28                      PIO_FELLSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P28_Msk instead */
+#define PIO_FELLSR_P29_Pos                  29                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P29_Msk                  (_U_(0x1) << PIO_FELLSR_P29_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P29                      PIO_FELLSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P29_Msk instead */
+#define PIO_FELLSR_P30_Pos                  30                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P30_Msk                  (_U_(0x1) << PIO_FELLSR_P30_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P30                      PIO_FELLSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P30_Msk instead */
+#define PIO_FELLSR_P31_Pos                  31                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P31_Msk                  (_U_(0x1) << PIO_FELLSR_P31_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P31                      PIO_FELLSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P31_Msk instead */
+#define PIO_FELLSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_FELLSR) Register MASK  (Use PIO_FELLSR_Msk instead)  */
+#define PIO_FELLSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_FELLSR) Register Mask  */
+
+#define PIO_FELLSR_P_Pos                    0                                              /**< (PIO_FELLSR Position) Falling Edge/Low-Level Interrupt Selection */
+#define PIO_FELLSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_FELLSR_P_Pos)          /**< (PIO_FELLSR Mask) P */
+#define PIO_FELLSR_P(value)                 (PIO_FELLSR_P_Msk & ((value) << PIO_FELLSR_P_Pos))  
+
+/* -------- PIO_REHLSR : (PIO Offset: 0xd4) (/W 32) Rising Edge/High-Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P1:1;                      /**< bit:      1  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P2:1;                      /**< bit:      2  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P3:1;                      /**< bit:      3  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P4:1;                      /**< bit:      4  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P5:1;                      /**< bit:      5  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P6:1;                      /**< bit:      6  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P7:1;                      /**< bit:      7  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P8:1;                      /**< bit:      8  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P9:1;                      /**< bit:      9  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P10:1;                     /**< bit:     10  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P11:1;                     /**< bit:     11  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P12:1;                     /**< bit:     12  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P13:1;                     /**< bit:     13  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P14:1;                     /**< bit:     14  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P15:1;                     /**< bit:     15  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P16:1;                     /**< bit:     16  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P17:1;                     /**< bit:     17  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P18:1;                     /**< bit:     18  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P19:1;                     /**< bit:     19  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P20:1;                     /**< bit:     20  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P21:1;                     /**< bit:     21  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P22:1;                     /**< bit:     22  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P23:1;                     /**< bit:     23  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P24:1;                     /**< bit:     24  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P25:1;                     /**< bit:     25  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P26:1;                     /**< bit:     26  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P27:1;                     /**< bit:     27  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P28:1;                     /**< bit:     28  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P29:1;                     /**< bit:     29  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P30:1;                     /**< bit:     30  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P31:1;                     /**< bit:     31  Rising Edge/High-Level Interrupt Selection */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Rising Edge/High-Level Interrupt Selection */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_REHLSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_REHLSR_OFFSET                   (0xD4)                                        /**<  (PIO_REHLSR) Rising Edge/High-Level Select Register  Offset */
+
+#define PIO_REHLSR_P0_Pos                   0                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P0_Msk                   (_U_(0x1) << PIO_REHLSR_P0_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P0                       PIO_REHLSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P0_Msk instead */
+#define PIO_REHLSR_P1_Pos                   1                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P1_Msk                   (_U_(0x1) << PIO_REHLSR_P1_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P1                       PIO_REHLSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P1_Msk instead */
+#define PIO_REHLSR_P2_Pos                   2                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P2_Msk                   (_U_(0x1) << PIO_REHLSR_P2_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P2                       PIO_REHLSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P2_Msk instead */
+#define PIO_REHLSR_P3_Pos                   3                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P3_Msk                   (_U_(0x1) << PIO_REHLSR_P3_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P3                       PIO_REHLSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P3_Msk instead */
+#define PIO_REHLSR_P4_Pos                   4                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P4_Msk                   (_U_(0x1) << PIO_REHLSR_P4_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P4                       PIO_REHLSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P4_Msk instead */
+#define PIO_REHLSR_P5_Pos                   5                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P5_Msk                   (_U_(0x1) << PIO_REHLSR_P5_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P5                       PIO_REHLSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P5_Msk instead */
+#define PIO_REHLSR_P6_Pos                   6                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P6_Msk                   (_U_(0x1) << PIO_REHLSR_P6_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P6                       PIO_REHLSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P6_Msk instead */
+#define PIO_REHLSR_P7_Pos                   7                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P7_Msk                   (_U_(0x1) << PIO_REHLSR_P7_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P7                       PIO_REHLSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P7_Msk instead */
+#define PIO_REHLSR_P8_Pos                   8                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P8_Msk                   (_U_(0x1) << PIO_REHLSR_P8_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P8                       PIO_REHLSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P8_Msk instead */
+#define PIO_REHLSR_P9_Pos                   9                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P9_Msk                   (_U_(0x1) << PIO_REHLSR_P9_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P9                       PIO_REHLSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P9_Msk instead */
+#define PIO_REHLSR_P10_Pos                  10                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P10_Msk                  (_U_(0x1) << PIO_REHLSR_P10_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P10                      PIO_REHLSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P10_Msk instead */
+#define PIO_REHLSR_P11_Pos                  11                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P11_Msk                  (_U_(0x1) << PIO_REHLSR_P11_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P11                      PIO_REHLSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P11_Msk instead */
+#define PIO_REHLSR_P12_Pos                  12                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P12_Msk                  (_U_(0x1) << PIO_REHLSR_P12_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P12                      PIO_REHLSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P12_Msk instead */
+#define PIO_REHLSR_P13_Pos                  13                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P13_Msk                  (_U_(0x1) << PIO_REHLSR_P13_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P13                      PIO_REHLSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P13_Msk instead */
+#define PIO_REHLSR_P14_Pos                  14                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P14_Msk                  (_U_(0x1) << PIO_REHLSR_P14_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P14                      PIO_REHLSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P14_Msk instead */
+#define PIO_REHLSR_P15_Pos                  15                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P15_Msk                  (_U_(0x1) << PIO_REHLSR_P15_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P15                      PIO_REHLSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P15_Msk instead */
+#define PIO_REHLSR_P16_Pos                  16                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P16_Msk                  (_U_(0x1) << PIO_REHLSR_P16_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P16                      PIO_REHLSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P16_Msk instead */
+#define PIO_REHLSR_P17_Pos                  17                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P17_Msk                  (_U_(0x1) << PIO_REHLSR_P17_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P17                      PIO_REHLSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P17_Msk instead */
+#define PIO_REHLSR_P18_Pos                  18                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P18_Msk                  (_U_(0x1) << PIO_REHLSR_P18_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P18                      PIO_REHLSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P18_Msk instead */
+#define PIO_REHLSR_P19_Pos                  19                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P19_Msk                  (_U_(0x1) << PIO_REHLSR_P19_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P19                      PIO_REHLSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P19_Msk instead */
+#define PIO_REHLSR_P20_Pos                  20                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P20_Msk                  (_U_(0x1) << PIO_REHLSR_P20_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P20                      PIO_REHLSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P20_Msk instead */
+#define PIO_REHLSR_P21_Pos                  21                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P21_Msk                  (_U_(0x1) << PIO_REHLSR_P21_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P21                      PIO_REHLSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P21_Msk instead */
+#define PIO_REHLSR_P22_Pos                  22                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P22_Msk                  (_U_(0x1) << PIO_REHLSR_P22_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P22                      PIO_REHLSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P22_Msk instead */
+#define PIO_REHLSR_P23_Pos                  23                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P23_Msk                  (_U_(0x1) << PIO_REHLSR_P23_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P23                      PIO_REHLSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P23_Msk instead */
+#define PIO_REHLSR_P24_Pos                  24                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P24_Msk                  (_U_(0x1) << PIO_REHLSR_P24_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P24                      PIO_REHLSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P24_Msk instead */
+#define PIO_REHLSR_P25_Pos                  25                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P25_Msk                  (_U_(0x1) << PIO_REHLSR_P25_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P25                      PIO_REHLSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P25_Msk instead */
+#define PIO_REHLSR_P26_Pos                  26                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P26_Msk                  (_U_(0x1) << PIO_REHLSR_P26_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P26                      PIO_REHLSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P26_Msk instead */
+#define PIO_REHLSR_P27_Pos                  27                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P27_Msk                  (_U_(0x1) << PIO_REHLSR_P27_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P27                      PIO_REHLSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P27_Msk instead */
+#define PIO_REHLSR_P28_Pos                  28                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P28_Msk                  (_U_(0x1) << PIO_REHLSR_P28_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P28                      PIO_REHLSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P28_Msk instead */
+#define PIO_REHLSR_P29_Pos                  29                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P29_Msk                  (_U_(0x1) << PIO_REHLSR_P29_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P29                      PIO_REHLSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P29_Msk instead */
+#define PIO_REHLSR_P30_Pos                  30                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P30_Msk                  (_U_(0x1) << PIO_REHLSR_P30_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P30                      PIO_REHLSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P30_Msk instead */
+#define PIO_REHLSR_P31_Pos                  31                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P31_Msk                  (_U_(0x1) << PIO_REHLSR_P31_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P31                      PIO_REHLSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P31_Msk instead */
+#define PIO_REHLSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_REHLSR) Register MASK  (Use PIO_REHLSR_Msk instead)  */
+#define PIO_REHLSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_REHLSR) Register Mask  */
+
+#define PIO_REHLSR_P_Pos                    0                                              /**< (PIO_REHLSR Position) Rising Edge/High-Level Interrupt Selection */
+#define PIO_REHLSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_REHLSR_P_Pos)          /**< (PIO_REHLSR Mask) P */
+#define PIO_REHLSR_P(value)                 (PIO_REHLSR_P_Msk & ((value) << PIO_REHLSR_P_Pos))  
+
+/* -------- PIO_FRLHSR : (PIO Offset: 0xd8) (R/ 32) Fall/Rise - Low/High Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
+    uint32_t P1:1;                      /**< bit:      1  Edge/Level Interrupt Source Selection    */
+    uint32_t P2:1;                      /**< bit:      2  Edge/Level Interrupt Source Selection    */
+    uint32_t P3:1;                      /**< bit:      3  Edge/Level Interrupt Source Selection    */
+    uint32_t P4:1;                      /**< bit:      4  Edge/Level Interrupt Source Selection    */
+    uint32_t P5:1;                      /**< bit:      5  Edge/Level Interrupt Source Selection    */
+    uint32_t P6:1;                      /**< bit:      6  Edge/Level Interrupt Source Selection    */
+    uint32_t P7:1;                      /**< bit:      7  Edge/Level Interrupt Source Selection    */
+    uint32_t P8:1;                      /**< bit:      8  Edge/Level Interrupt Source Selection    */
+    uint32_t P9:1;                      /**< bit:      9  Edge/Level Interrupt Source Selection    */
+    uint32_t P10:1;                     /**< bit:     10  Edge/Level Interrupt Source Selection    */
+    uint32_t P11:1;                     /**< bit:     11  Edge/Level Interrupt Source Selection    */
+    uint32_t P12:1;                     /**< bit:     12  Edge/Level Interrupt Source Selection    */
+    uint32_t P13:1;                     /**< bit:     13  Edge/Level Interrupt Source Selection    */
+    uint32_t P14:1;                     /**< bit:     14  Edge/Level Interrupt Source Selection    */
+    uint32_t P15:1;                     /**< bit:     15  Edge/Level Interrupt Source Selection    */
+    uint32_t P16:1;                     /**< bit:     16  Edge/Level Interrupt Source Selection    */
+    uint32_t P17:1;                     /**< bit:     17  Edge/Level Interrupt Source Selection    */
+    uint32_t P18:1;                     /**< bit:     18  Edge/Level Interrupt Source Selection    */
+    uint32_t P19:1;                     /**< bit:     19  Edge/Level Interrupt Source Selection    */
+    uint32_t P20:1;                     /**< bit:     20  Edge/Level Interrupt Source Selection    */
+    uint32_t P21:1;                     /**< bit:     21  Edge/Level Interrupt Source Selection    */
+    uint32_t P22:1;                     /**< bit:     22  Edge/Level Interrupt Source Selection    */
+    uint32_t P23:1;                     /**< bit:     23  Edge/Level Interrupt Source Selection    */
+    uint32_t P24:1;                     /**< bit:     24  Edge/Level Interrupt Source Selection    */
+    uint32_t P25:1;                     /**< bit:     25  Edge/Level Interrupt Source Selection    */
+    uint32_t P26:1;                     /**< bit:     26  Edge/Level Interrupt Source Selection    */
+    uint32_t P27:1;                     /**< bit:     27  Edge/Level Interrupt Source Selection    */
+    uint32_t P28:1;                     /**< bit:     28  Edge/Level Interrupt Source Selection    */
+    uint32_t P29:1;                     /**< bit:     29  Edge/Level Interrupt Source Selection    */
+    uint32_t P30:1;                     /**< bit:     30  Edge/Level Interrupt Source Selection    */
+    uint32_t P31:1;                     /**< bit:     31  Edge/Level Interrupt Source Selection    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge/Level Interrupt Source Selection    */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_FRLHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_FRLHSR_OFFSET                   (0xD8)                                        /**<  (PIO_FRLHSR) Fall/Rise - Low/High Status Register  Offset */
+
+#define PIO_FRLHSR_P0_Pos                   0                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P0_Msk                   (_U_(0x1) << PIO_FRLHSR_P0_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P0                       PIO_FRLHSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P0_Msk instead */
+#define PIO_FRLHSR_P1_Pos                   1                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P1_Msk                   (_U_(0x1) << PIO_FRLHSR_P1_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P1                       PIO_FRLHSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P1_Msk instead */
+#define PIO_FRLHSR_P2_Pos                   2                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P2_Msk                   (_U_(0x1) << PIO_FRLHSR_P2_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P2                       PIO_FRLHSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P2_Msk instead */
+#define PIO_FRLHSR_P3_Pos                   3                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P3_Msk                   (_U_(0x1) << PIO_FRLHSR_P3_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P3                       PIO_FRLHSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P3_Msk instead */
+#define PIO_FRLHSR_P4_Pos                   4                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P4_Msk                   (_U_(0x1) << PIO_FRLHSR_P4_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P4                       PIO_FRLHSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P4_Msk instead */
+#define PIO_FRLHSR_P5_Pos                   5                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P5_Msk                   (_U_(0x1) << PIO_FRLHSR_P5_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P5                       PIO_FRLHSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P5_Msk instead */
+#define PIO_FRLHSR_P6_Pos                   6                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P6_Msk                   (_U_(0x1) << PIO_FRLHSR_P6_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P6                       PIO_FRLHSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P6_Msk instead */
+#define PIO_FRLHSR_P7_Pos                   7                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P7_Msk                   (_U_(0x1) << PIO_FRLHSR_P7_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P7                       PIO_FRLHSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P7_Msk instead */
+#define PIO_FRLHSR_P8_Pos                   8                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P8_Msk                   (_U_(0x1) << PIO_FRLHSR_P8_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P8                       PIO_FRLHSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P8_Msk instead */
+#define PIO_FRLHSR_P9_Pos                   9                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P9_Msk                   (_U_(0x1) << PIO_FRLHSR_P9_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P9                       PIO_FRLHSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P9_Msk instead */
+#define PIO_FRLHSR_P10_Pos                  10                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P10_Msk                  (_U_(0x1) << PIO_FRLHSR_P10_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P10                      PIO_FRLHSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P10_Msk instead */
+#define PIO_FRLHSR_P11_Pos                  11                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P11_Msk                  (_U_(0x1) << PIO_FRLHSR_P11_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P11                      PIO_FRLHSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P11_Msk instead */
+#define PIO_FRLHSR_P12_Pos                  12                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P12_Msk                  (_U_(0x1) << PIO_FRLHSR_P12_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P12                      PIO_FRLHSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P12_Msk instead */
+#define PIO_FRLHSR_P13_Pos                  13                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P13_Msk                  (_U_(0x1) << PIO_FRLHSR_P13_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P13                      PIO_FRLHSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P13_Msk instead */
+#define PIO_FRLHSR_P14_Pos                  14                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P14_Msk                  (_U_(0x1) << PIO_FRLHSR_P14_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P14                      PIO_FRLHSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P14_Msk instead */
+#define PIO_FRLHSR_P15_Pos                  15                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P15_Msk                  (_U_(0x1) << PIO_FRLHSR_P15_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P15                      PIO_FRLHSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P15_Msk instead */
+#define PIO_FRLHSR_P16_Pos                  16                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P16_Msk                  (_U_(0x1) << PIO_FRLHSR_P16_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P16                      PIO_FRLHSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P16_Msk instead */
+#define PIO_FRLHSR_P17_Pos                  17                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P17_Msk                  (_U_(0x1) << PIO_FRLHSR_P17_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P17                      PIO_FRLHSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P17_Msk instead */
+#define PIO_FRLHSR_P18_Pos                  18                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P18_Msk                  (_U_(0x1) << PIO_FRLHSR_P18_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P18                      PIO_FRLHSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P18_Msk instead */
+#define PIO_FRLHSR_P19_Pos                  19                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P19_Msk                  (_U_(0x1) << PIO_FRLHSR_P19_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P19                      PIO_FRLHSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P19_Msk instead */
+#define PIO_FRLHSR_P20_Pos                  20                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P20_Msk                  (_U_(0x1) << PIO_FRLHSR_P20_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P20                      PIO_FRLHSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P20_Msk instead */
+#define PIO_FRLHSR_P21_Pos                  21                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P21_Msk                  (_U_(0x1) << PIO_FRLHSR_P21_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P21                      PIO_FRLHSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P21_Msk instead */
+#define PIO_FRLHSR_P22_Pos                  22                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P22_Msk                  (_U_(0x1) << PIO_FRLHSR_P22_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P22                      PIO_FRLHSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P22_Msk instead */
+#define PIO_FRLHSR_P23_Pos                  23                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P23_Msk                  (_U_(0x1) << PIO_FRLHSR_P23_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P23                      PIO_FRLHSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P23_Msk instead */
+#define PIO_FRLHSR_P24_Pos                  24                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P24_Msk                  (_U_(0x1) << PIO_FRLHSR_P24_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P24                      PIO_FRLHSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P24_Msk instead */
+#define PIO_FRLHSR_P25_Pos                  25                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P25_Msk                  (_U_(0x1) << PIO_FRLHSR_P25_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P25                      PIO_FRLHSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P25_Msk instead */
+#define PIO_FRLHSR_P26_Pos                  26                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P26_Msk                  (_U_(0x1) << PIO_FRLHSR_P26_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P26                      PIO_FRLHSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P26_Msk instead */
+#define PIO_FRLHSR_P27_Pos                  27                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P27_Msk                  (_U_(0x1) << PIO_FRLHSR_P27_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P27                      PIO_FRLHSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P27_Msk instead */
+#define PIO_FRLHSR_P28_Pos                  28                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P28_Msk                  (_U_(0x1) << PIO_FRLHSR_P28_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P28                      PIO_FRLHSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P28_Msk instead */
+#define PIO_FRLHSR_P29_Pos                  29                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P29_Msk                  (_U_(0x1) << PIO_FRLHSR_P29_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P29                      PIO_FRLHSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P29_Msk instead */
+#define PIO_FRLHSR_P30_Pos                  30                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P30_Msk                  (_U_(0x1) << PIO_FRLHSR_P30_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P30                      PIO_FRLHSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P30_Msk instead */
+#define PIO_FRLHSR_P31_Pos                  31                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P31_Msk                  (_U_(0x1) << PIO_FRLHSR_P31_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P31                      PIO_FRLHSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P31_Msk instead */
+#define PIO_FRLHSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_FRLHSR) Register MASK  (Use PIO_FRLHSR_Msk instead)  */
+#define PIO_FRLHSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_FRLHSR) Register Mask  */
+
+#define PIO_FRLHSR_P_Pos                    0                                              /**< (PIO_FRLHSR Position) Edge/Level Interrupt Source Selection */
+#define PIO_FRLHSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_FRLHSR_P_Pos)          /**< (PIO_FRLHSR Mask) P */
+#define PIO_FRLHSR_P(value)                 (PIO_FRLHSR_P_Msk & ((value) << PIO_FRLHSR_P_Pos))  
+
+/* -------- PIO_LOCKSR : (PIO Offset: 0xe0) (R/ 32) Lock Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Lock Status                              */
+    uint32_t P1:1;                      /**< bit:      1  Lock Status                              */
+    uint32_t P2:1;                      /**< bit:      2  Lock Status                              */
+    uint32_t P3:1;                      /**< bit:      3  Lock Status                              */
+    uint32_t P4:1;                      /**< bit:      4  Lock Status                              */
+    uint32_t P5:1;                      /**< bit:      5  Lock Status                              */
+    uint32_t P6:1;                      /**< bit:      6  Lock Status                              */
+    uint32_t P7:1;                      /**< bit:      7  Lock Status                              */
+    uint32_t P8:1;                      /**< bit:      8  Lock Status                              */
+    uint32_t P9:1;                      /**< bit:      9  Lock Status                              */
+    uint32_t P10:1;                     /**< bit:     10  Lock Status                              */
+    uint32_t P11:1;                     /**< bit:     11  Lock Status                              */
+    uint32_t P12:1;                     /**< bit:     12  Lock Status                              */
+    uint32_t P13:1;                     /**< bit:     13  Lock Status                              */
+    uint32_t P14:1;                     /**< bit:     14  Lock Status                              */
+    uint32_t P15:1;                     /**< bit:     15  Lock Status                              */
+    uint32_t P16:1;                     /**< bit:     16  Lock Status                              */
+    uint32_t P17:1;                     /**< bit:     17  Lock Status                              */
+    uint32_t P18:1;                     /**< bit:     18  Lock Status                              */
+    uint32_t P19:1;                     /**< bit:     19  Lock Status                              */
+    uint32_t P20:1;                     /**< bit:     20  Lock Status                              */
+    uint32_t P21:1;                     /**< bit:     21  Lock Status                              */
+    uint32_t P22:1;                     /**< bit:     22  Lock Status                              */
+    uint32_t P23:1;                     /**< bit:     23  Lock Status                              */
+    uint32_t P24:1;                     /**< bit:     24  Lock Status                              */
+    uint32_t P25:1;                     /**< bit:     25  Lock Status                              */
+    uint32_t P26:1;                     /**< bit:     26  Lock Status                              */
+    uint32_t P27:1;                     /**< bit:     27  Lock Status                              */
+    uint32_t P28:1;                     /**< bit:     28  Lock Status                              */
+    uint32_t P29:1;                     /**< bit:     29  Lock Status                              */
+    uint32_t P30:1;                     /**< bit:     30  Lock Status                              */
+    uint32_t P31:1;                     /**< bit:     31  Lock Status                              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Lock Status                              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_LOCKSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_LOCKSR_OFFSET                   (0xE0)                                        /**<  (PIO_LOCKSR) Lock Status  Offset */
+
+#define PIO_LOCKSR_P0_Pos                   0                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P0_Msk                   (_U_(0x1) << PIO_LOCKSR_P0_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P0                       PIO_LOCKSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P0_Msk instead */
+#define PIO_LOCKSR_P1_Pos                   1                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P1_Msk                   (_U_(0x1) << PIO_LOCKSR_P1_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P1                       PIO_LOCKSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P1_Msk instead */
+#define PIO_LOCKSR_P2_Pos                   2                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P2_Msk                   (_U_(0x1) << PIO_LOCKSR_P2_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P2                       PIO_LOCKSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P2_Msk instead */
+#define PIO_LOCKSR_P3_Pos                   3                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P3_Msk                   (_U_(0x1) << PIO_LOCKSR_P3_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P3                       PIO_LOCKSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P3_Msk instead */
+#define PIO_LOCKSR_P4_Pos                   4                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P4_Msk                   (_U_(0x1) << PIO_LOCKSR_P4_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P4                       PIO_LOCKSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P4_Msk instead */
+#define PIO_LOCKSR_P5_Pos                   5                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P5_Msk                   (_U_(0x1) << PIO_LOCKSR_P5_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P5                       PIO_LOCKSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P5_Msk instead */
+#define PIO_LOCKSR_P6_Pos                   6                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P6_Msk                   (_U_(0x1) << PIO_LOCKSR_P6_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P6                       PIO_LOCKSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P6_Msk instead */
+#define PIO_LOCKSR_P7_Pos                   7                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P7_Msk                   (_U_(0x1) << PIO_LOCKSR_P7_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P7                       PIO_LOCKSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P7_Msk instead */
+#define PIO_LOCKSR_P8_Pos                   8                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P8_Msk                   (_U_(0x1) << PIO_LOCKSR_P8_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P8                       PIO_LOCKSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P8_Msk instead */
+#define PIO_LOCKSR_P9_Pos                   9                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P9_Msk                   (_U_(0x1) << PIO_LOCKSR_P9_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P9                       PIO_LOCKSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P9_Msk instead */
+#define PIO_LOCKSR_P10_Pos                  10                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P10_Msk                  (_U_(0x1) << PIO_LOCKSR_P10_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P10                      PIO_LOCKSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P10_Msk instead */
+#define PIO_LOCKSR_P11_Pos                  11                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P11_Msk                  (_U_(0x1) << PIO_LOCKSR_P11_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P11                      PIO_LOCKSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P11_Msk instead */
+#define PIO_LOCKSR_P12_Pos                  12                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P12_Msk                  (_U_(0x1) << PIO_LOCKSR_P12_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P12                      PIO_LOCKSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P12_Msk instead */
+#define PIO_LOCKSR_P13_Pos                  13                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P13_Msk                  (_U_(0x1) << PIO_LOCKSR_P13_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P13                      PIO_LOCKSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P13_Msk instead */
+#define PIO_LOCKSR_P14_Pos                  14                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P14_Msk                  (_U_(0x1) << PIO_LOCKSR_P14_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P14                      PIO_LOCKSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P14_Msk instead */
+#define PIO_LOCKSR_P15_Pos                  15                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P15_Msk                  (_U_(0x1) << PIO_LOCKSR_P15_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P15                      PIO_LOCKSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P15_Msk instead */
+#define PIO_LOCKSR_P16_Pos                  16                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P16_Msk                  (_U_(0x1) << PIO_LOCKSR_P16_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P16                      PIO_LOCKSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P16_Msk instead */
+#define PIO_LOCKSR_P17_Pos                  17                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P17_Msk                  (_U_(0x1) << PIO_LOCKSR_P17_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P17                      PIO_LOCKSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P17_Msk instead */
+#define PIO_LOCKSR_P18_Pos                  18                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P18_Msk                  (_U_(0x1) << PIO_LOCKSR_P18_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P18                      PIO_LOCKSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P18_Msk instead */
+#define PIO_LOCKSR_P19_Pos                  19                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P19_Msk                  (_U_(0x1) << PIO_LOCKSR_P19_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P19                      PIO_LOCKSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P19_Msk instead */
+#define PIO_LOCKSR_P20_Pos                  20                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P20_Msk                  (_U_(0x1) << PIO_LOCKSR_P20_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P20                      PIO_LOCKSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P20_Msk instead */
+#define PIO_LOCKSR_P21_Pos                  21                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P21_Msk                  (_U_(0x1) << PIO_LOCKSR_P21_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P21                      PIO_LOCKSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P21_Msk instead */
+#define PIO_LOCKSR_P22_Pos                  22                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P22_Msk                  (_U_(0x1) << PIO_LOCKSR_P22_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P22                      PIO_LOCKSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P22_Msk instead */
+#define PIO_LOCKSR_P23_Pos                  23                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P23_Msk                  (_U_(0x1) << PIO_LOCKSR_P23_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P23                      PIO_LOCKSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P23_Msk instead */
+#define PIO_LOCKSR_P24_Pos                  24                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P24_Msk                  (_U_(0x1) << PIO_LOCKSR_P24_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P24                      PIO_LOCKSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P24_Msk instead */
+#define PIO_LOCKSR_P25_Pos                  25                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P25_Msk                  (_U_(0x1) << PIO_LOCKSR_P25_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P25                      PIO_LOCKSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P25_Msk instead */
+#define PIO_LOCKSR_P26_Pos                  26                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P26_Msk                  (_U_(0x1) << PIO_LOCKSR_P26_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P26                      PIO_LOCKSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P26_Msk instead */
+#define PIO_LOCKSR_P27_Pos                  27                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P27_Msk                  (_U_(0x1) << PIO_LOCKSR_P27_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P27                      PIO_LOCKSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P27_Msk instead */
+#define PIO_LOCKSR_P28_Pos                  28                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P28_Msk                  (_U_(0x1) << PIO_LOCKSR_P28_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P28                      PIO_LOCKSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P28_Msk instead */
+#define PIO_LOCKSR_P29_Pos                  29                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P29_Msk                  (_U_(0x1) << PIO_LOCKSR_P29_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P29                      PIO_LOCKSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P29_Msk instead */
+#define PIO_LOCKSR_P30_Pos                  30                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P30_Msk                  (_U_(0x1) << PIO_LOCKSR_P30_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P30                      PIO_LOCKSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P30_Msk instead */
+#define PIO_LOCKSR_P31_Pos                  31                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P31_Msk                  (_U_(0x1) << PIO_LOCKSR_P31_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P31                      PIO_LOCKSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P31_Msk instead */
+#define PIO_LOCKSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_LOCKSR) Register MASK  (Use PIO_LOCKSR_Msk instead)  */
+#define PIO_LOCKSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_LOCKSR) Register Mask  */
+
+#define PIO_LOCKSR_P_Pos                    0                                              /**< (PIO_LOCKSR Position) Lock Status */
+#define PIO_LOCKSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_LOCKSR_P_Pos)          /**< (PIO_LOCKSR Mask) P */
+#define PIO_LOCKSR_P(value)                 (PIO_LOCKSR_P_Msk & ((value) << PIO_LOCKSR_P_Pos))  
+
+/* -------- PIO_WPMR : (PIO Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_WPMR_OFFSET                     (0xE4)                                        /**<  (PIO_WPMR) Write Protection Mode Register  Offset */
+
+#define PIO_WPMR_WPEN_Pos                   0                                              /**< (PIO_WPMR) Write Protection Enable Position */
+#define PIO_WPMR_WPEN_Msk                   (_U_(0x1) << PIO_WPMR_WPEN_Pos)                /**< (PIO_WPMR) Write Protection Enable Mask */
+#define PIO_WPMR_WPEN                       PIO_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_WPMR_WPEN_Msk instead */
+#define PIO_WPMR_WPKEY_Pos                  8                                              /**< (PIO_WPMR) Write Protection Key Position */
+#define PIO_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << PIO_WPMR_WPKEY_Pos)          /**< (PIO_WPMR) Write Protection Key Mask */
+#define PIO_WPMR_WPKEY(value)               (PIO_WPMR_WPKEY_Msk & ((value) << PIO_WPMR_WPKEY_Pos))
+#define   PIO_WPMR_WPKEY_PASSWD_Val         _U_(0x50494F)                                  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define PIO_WPMR_WPKEY_PASSWD               (PIO_WPMR_WPKEY_PASSWD_Val << PIO_WPMR_WPKEY_Pos)  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define PIO_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (PIO_WPMR) Register MASK  (Use PIO_WPMR_Msk instead)  */
+#define PIO_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (PIO_WPMR) Register Mask  */
+
+
+/* -------- PIO_WPSR : (PIO Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_WPSR_OFFSET                     (0xE8)                                        /**<  (PIO_WPSR) Write Protection Status Register  Offset */
+
+#define PIO_WPSR_WPVS_Pos                   0                                              /**< (PIO_WPSR) Write Protection Violation Status Position */
+#define PIO_WPSR_WPVS_Msk                   (_U_(0x1) << PIO_WPSR_WPVS_Pos)                /**< (PIO_WPSR) Write Protection Violation Status Mask */
+#define PIO_WPSR_WPVS                       PIO_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_WPSR_WPVS_Msk instead */
+#define PIO_WPSR_WPVSRC_Pos                 8                                              /**< (PIO_WPSR) Write Protection Violation Source Position */
+#define PIO_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PIO_WPSR_WPVSRC_Pos)           /**< (PIO_WPSR) Write Protection Violation Source Mask */
+#define PIO_WPSR_WPVSRC(value)              (PIO_WPSR_WPVSRC_Msk & ((value) << PIO_WPSR_WPVSRC_Pos))
+#define PIO_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (PIO_WPSR) Register MASK  (Use PIO_WPSR_Msk instead)  */
+#define PIO_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (PIO_WPSR) Register Mask  */
+
+
+/* -------- PIO_VERSION : (PIO Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_VERSION_OFFSET                  (0xFC)                                        /**<  (PIO_VERSION) Version Register  Offset */
+
+#define PIO_VERSION_VERSION_Pos             0                                              /**< (PIO_VERSION) Hardware Module Version Position */
+#define PIO_VERSION_VERSION_Msk             (_U_(0xFFF) << PIO_VERSION_VERSION_Pos)        /**< (PIO_VERSION) Hardware Module Version Mask */
+#define PIO_VERSION_VERSION(value)          (PIO_VERSION_VERSION_Msk & ((value) << PIO_VERSION_VERSION_Pos))
+#define PIO_VERSION_MFN_Pos                 16                                             /**< (PIO_VERSION) Metal Fix Number Position */
+#define PIO_VERSION_MFN_Msk                 (_U_(0x7) << PIO_VERSION_MFN_Pos)              /**< (PIO_VERSION) Metal Fix Number Mask */
+#define PIO_VERSION_MFN(value)              (PIO_VERSION_MFN_Msk & ((value) << PIO_VERSION_MFN_Pos))
+#define PIO_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (PIO_VERSION) Register MASK  (Use PIO_VERSION_Msk instead)  */
+#define PIO_VERSION_Msk                     _U_(0x70FFF)                                   /**< (PIO_VERSION) Register Mask  */
+
+
+/* -------- PIO_SCHMITT : (PIO Offset: 0x100) (R/W 32) Schmitt Trigger Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCHMITT0:1;                /**< bit:      0  Schmitt Trigger Control                  */
+    uint32_t SCHMITT1:1;                /**< bit:      1  Schmitt Trigger Control                  */
+    uint32_t SCHMITT2:1;                /**< bit:      2  Schmitt Trigger Control                  */
+    uint32_t SCHMITT3:1;                /**< bit:      3  Schmitt Trigger Control                  */
+    uint32_t SCHMITT4:1;                /**< bit:      4  Schmitt Trigger Control                  */
+    uint32_t SCHMITT5:1;                /**< bit:      5  Schmitt Trigger Control                  */
+    uint32_t SCHMITT6:1;                /**< bit:      6  Schmitt Trigger Control                  */
+    uint32_t SCHMITT7:1;                /**< bit:      7  Schmitt Trigger Control                  */
+    uint32_t SCHMITT8:1;                /**< bit:      8  Schmitt Trigger Control                  */
+    uint32_t SCHMITT9:1;                /**< bit:      9  Schmitt Trigger Control                  */
+    uint32_t SCHMITT10:1;               /**< bit:     10  Schmitt Trigger Control                  */
+    uint32_t SCHMITT11:1;               /**< bit:     11  Schmitt Trigger Control                  */
+    uint32_t SCHMITT12:1;               /**< bit:     12  Schmitt Trigger Control                  */
+    uint32_t SCHMITT13:1;               /**< bit:     13  Schmitt Trigger Control                  */
+    uint32_t SCHMITT14:1;               /**< bit:     14  Schmitt Trigger Control                  */
+    uint32_t SCHMITT15:1;               /**< bit:     15  Schmitt Trigger Control                  */
+    uint32_t SCHMITT16:1;               /**< bit:     16  Schmitt Trigger Control                  */
+    uint32_t SCHMITT17:1;               /**< bit:     17  Schmitt Trigger Control                  */
+    uint32_t SCHMITT18:1;               /**< bit:     18  Schmitt Trigger Control                  */
+    uint32_t SCHMITT19:1;               /**< bit:     19  Schmitt Trigger Control                  */
+    uint32_t SCHMITT20:1;               /**< bit:     20  Schmitt Trigger Control                  */
+    uint32_t SCHMITT21:1;               /**< bit:     21  Schmitt Trigger Control                  */
+    uint32_t SCHMITT22:1;               /**< bit:     22  Schmitt Trigger Control                  */
+    uint32_t SCHMITT23:1;               /**< bit:     23  Schmitt Trigger Control                  */
+    uint32_t SCHMITT24:1;               /**< bit:     24  Schmitt Trigger Control                  */
+    uint32_t SCHMITT25:1;               /**< bit:     25  Schmitt Trigger Control                  */
+    uint32_t SCHMITT26:1;               /**< bit:     26  Schmitt Trigger Control                  */
+    uint32_t SCHMITT27:1;               /**< bit:     27  Schmitt Trigger Control                  */
+    uint32_t SCHMITT28:1;               /**< bit:     28  Schmitt Trigger Control                  */
+    uint32_t SCHMITT29:1;               /**< bit:     29  Schmitt Trigger Control                  */
+    uint32_t SCHMITT30:1;               /**< bit:     30  Schmitt Trigger Control                  */
+    uint32_t SCHMITT31:1;               /**< bit:     31  Schmitt Trigger Control                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SCHMITT:32;                /**< bit:  0..31  Schmitt Trigger Control                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SCHMITT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SCHMITT_OFFSET                  (0x100)                                       /**<  (PIO_SCHMITT) Schmitt Trigger Register  Offset */
+
+#define PIO_SCHMITT_SCHMITT0_Pos            0                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT0_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT0_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT0                PIO_SCHMITT_SCHMITT0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT0_Msk instead */
+#define PIO_SCHMITT_SCHMITT1_Pos            1                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT1_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT1_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT1                PIO_SCHMITT_SCHMITT1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT1_Msk instead */
+#define PIO_SCHMITT_SCHMITT2_Pos            2                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT2_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT2_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT2                PIO_SCHMITT_SCHMITT2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT2_Msk instead */
+#define PIO_SCHMITT_SCHMITT3_Pos            3                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT3_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT3_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT3                PIO_SCHMITT_SCHMITT3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT3_Msk instead */
+#define PIO_SCHMITT_SCHMITT4_Pos            4                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT4_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT4_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT4                PIO_SCHMITT_SCHMITT4_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT4_Msk instead */
+#define PIO_SCHMITT_SCHMITT5_Pos            5                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT5_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT5_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT5                PIO_SCHMITT_SCHMITT5_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT5_Msk instead */
+#define PIO_SCHMITT_SCHMITT6_Pos            6                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT6_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT6_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT6                PIO_SCHMITT_SCHMITT6_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT6_Msk instead */
+#define PIO_SCHMITT_SCHMITT7_Pos            7                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT7_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT7_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT7                PIO_SCHMITT_SCHMITT7_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT7_Msk instead */
+#define PIO_SCHMITT_SCHMITT8_Pos            8                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT8_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT8_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT8                PIO_SCHMITT_SCHMITT8_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT8_Msk instead */
+#define PIO_SCHMITT_SCHMITT9_Pos            9                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT9_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT9_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT9                PIO_SCHMITT_SCHMITT9_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT9_Msk instead */
+#define PIO_SCHMITT_SCHMITT10_Pos           10                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT10_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT10_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT10               PIO_SCHMITT_SCHMITT10_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT10_Msk instead */
+#define PIO_SCHMITT_SCHMITT11_Pos           11                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT11_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT11_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT11               PIO_SCHMITT_SCHMITT11_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT11_Msk instead */
+#define PIO_SCHMITT_SCHMITT12_Pos           12                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT12_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT12_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT12               PIO_SCHMITT_SCHMITT12_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT12_Msk instead */
+#define PIO_SCHMITT_SCHMITT13_Pos           13                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT13_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT13_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT13               PIO_SCHMITT_SCHMITT13_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT13_Msk instead */
+#define PIO_SCHMITT_SCHMITT14_Pos           14                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT14_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT14_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT14               PIO_SCHMITT_SCHMITT14_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT14_Msk instead */
+#define PIO_SCHMITT_SCHMITT15_Pos           15                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT15_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT15_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT15               PIO_SCHMITT_SCHMITT15_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT15_Msk instead */
+#define PIO_SCHMITT_SCHMITT16_Pos           16                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT16_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT16_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT16               PIO_SCHMITT_SCHMITT16_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT16_Msk instead */
+#define PIO_SCHMITT_SCHMITT17_Pos           17                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT17_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT17_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT17               PIO_SCHMITT_SCHMITT17_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT17_Msk instead */
+#define PIO_SCHMITT_SCHMITT18_Pos           18                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT18_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT18_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT18               PIO_SCHMITT_SCHMITT18_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT18_Msk instead */
+#define PIO_SCHMITT_SCHMITT19_Pos           19                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT19_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT19_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT19               PIO_SCHMITT_SCHMITT19_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT19_Msk instead */
+#define PIO_SCHMITT_SCHMITT20_Pos           20                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT20_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT20_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT20               PIO_SCHMITT_SCHMITT20_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT20_Msk instead */
+#define PIO_SCHMITT_SCHMITT21_Pos           21                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT21_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT21_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT21               PIO_SCHMITT_SCHMITT21_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT21_Msk instead */
+#define PIO_SCHMITT_SCHMITT22_Pos           22                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT22_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT22_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT22               PIO_SCHMITT_SCHMITT22_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT22_Msk instead */
+#define PIO_SCHMITT_SCHMITT23_Pos           23                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT23_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT23_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT23               PIO_SCHMITT_SCHMITT23_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT23_Msk instead */
+#define PIO_SCHMITT_SCHMITT24_Pos           24                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT24_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT24_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT24               PIO_SCHMITT_SCHMITT24_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT24_Msk instead */
+#define PIO_SCHMITT_SCHMITT25_Pos           25                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT25_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT25_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT25               PIO_SCHMITT_SCHMITT25_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT25_Msk instead */
+#define PIO_SCHMITT_SCHMITT26_Pos           26                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT26_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT26_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT26               PIO_SCHMITT_SCHMITT26_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT26_Msk instead */
+#define PIO_SCHMITT_SCHMITT27_Pos           27                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT27_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT27_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT27               PIO_SCHMITT_SCHMITT27_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT27_Msk instead */
+#define PIO_SCHMITT_SCHMITT28_Pos           28                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT28_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT28_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT28               PIO_SCHMITT_SCHMITT28_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT28_Msk instead */
+#define PIO_SCHMITT_SCHMITT29_Pos           29                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT29_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT29_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT29               PIO_SCHMITT_SCHMITT29_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT29_Msk instead */
+#define PIO_SCHMITT_SCHMITT30_Pos           30                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT30_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT30_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT30               PIO_SCHMITT_SCHMITT30_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT30_Msk instead */
+#define PIO_SCHMITT_SCHMITT31_Pos           31                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT31_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT31_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT31               PIO_SCHMITT_SCHMITT31_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT31_Msk instead */
+#define PIO_SCHMITT_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_SCHMITT) Register MASK  (Use PIO_SCHMITT_Msk instead)  */
+#define PIO_SCHMITT_Msk                     _U_(0xFFFFFFFF)                                /**< (PIO_SCHMITT) Register Mask  */
+
+#define PIO_SCHMITT_SCHMITT_Pos             0                                              /**< (PIO_SCHMITT Position) Schmitt Trigger Control */
+#define PIO_SCHMITT_SCHMITT_Msk             (_U_(0xFFFFFFFF) << PIO_SCHMITT_SCHMITT_Pos)   /**< (PIO_SCHMITT Mask) SCHMITT */
+#define PIO_SCHMITT_SCHMITT(value)          (PIO_SCHMITT_SCHMITT_Msk & ((value) << PIO_SCHMITT_SCHMITT_Pos))  
+
+/* -------- PIO_DRIVER : (PIO Offset: 0x118) (R/W 32) I/O Drive Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LINE0:1;                   /**< bit:      0  Drive of PIO Line 0                      */
+    uint32_t LINE1:1;                   /**< bit:      1  Drive of PIO Line 1                      */
+    uint32_t LINE2:1;                   /**< bit:      2  Drive of PIO Line 2                      */
+    uint32_t LINE3:1;                   /**< bit:      3  Drive of PIO Line 3                      */
+    uint32_t LINE4:1;                   /**< bit:      4  Drive of PIO Line 4                      */
+    uint32_t LINE5:1;                   /**< bit:      5  Drive of PIO Line 5                      */
+    uint32_t LINE6:1;                   /**< bit:      6  Drive of PIO Line 6                      */
+    uint32_t LINE7:1;                   /**< bit:      7  Drive of PIO Line 7                      */
+    uint32_t LINE8:1;                   /**< bit:      8  Drive of PIO Line 8                      */
+    uint32_t LINE9:1;                   /**< bit:      9  Drive of PIO Line 9                      */
+    uint32_t LINE10:1;                  /**< bit:     10  Drive of PIO Line 10                     */
+    uint32_t LINE11:1;                  /**< bit:     11  Drive of PIO Line 11                     */
+    uint32_t LINE12:1;                  /**< bit:     12  Drive of PIO Line 12                     */
+    uint32_t LINE13:1;                  /**< bit:     13  Drive of PIO Line 13                     */
+    uint32_t LINE14:1;                  /**< bit:     14  Drive of PIO Line 14                     */
+    uint32_t LINE15:1;                  /**< bit:     15  Drive of PIO Line 15                     */
+    uint32_t LINE16:1;                  /**< bit:     16  Drive of PIO Line 16                     */
+    uint32_t LINE17:1;                  /**< bit:     17  Drive of PIO Line 17                     */
+    uint32_t LINE18:1;                  /**< bit:     18  Drive of PIO Line 18                     */
+    uint32_t LINE19:1;                  /**< bit:     19  Drive of PIO Line 19                     */
+    uint32_t LINE20:1;                  /**< bit:     20  Drive of PIO Line 20                     */
+    uint32_t LINE21:1;                  /**< bit:     21  Drive of PIO Line 21                     */
+    uint32_t LINE22:1;                  /**< bit:     22  Drive of PIO Line 22                     */
+    uint32_t LINE23:1;                  /**< bit:     23  Drive of PIO Line 23                     */
+    uint32_t LINE24:1;                  /**< bit:     24  Drive of PIO Line 24                     */
+    uint32_t LINE25:1;                  /**< bit:     25  Drive of PIO Line 25                     */
+    uint32_t LINE26:1;                  /**< bit:     26  Drive of PIO Line 26                     */
+    uint32_t LINE27:1;                  /**< bit:     27  Drive of PIO Line 27                     */
+    uint32_t LINE28:1;                  /**< bit:     28  Drive of PIO Line 28                     */
+    uint32_t LINE29:1;                  /**< bit:     29  Drive of PIO Line 29                     */
+    uint32_t LINE30:1;                  /**< bit:     30  Drive of PIO Line 30                     */
+    uint32_t LINE31:1;                  /**< bit:     31  Drive of PIO Line 31                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t LINE:32;                   /**< bit:  0..31  Drive of PIO Line 3x                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_DRIVER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_DRIVER_OFFSET                   (0x118)                                       /**<  (PIO_DRIVER) I/O Drive Register  Offset */
+
+#define PIO_DRIVER_LINE0_Pos                0                                              /**< (PIO_DRIVER) Drive of PIO Line 0 Position */
+#define PIO_DRIVER_LINE0_Msk                (_U_(0x1) << PIO_DRIVER_LINE0_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 0 Mask */
+#define PIO_DRIVER_LINE0                    PIO_DRIVER_LINE0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE0_Msk instead */
+#define   PIO_DRIVER_LINE0_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE0_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE0_LOW_DRIVE          (PIO_DRIVER_LINE0_LOW_DRIVE_Val << PIO_DRIVER_LINE0_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE0_HIGH_DRIVE         (PIO_DRIVER_LINE0_HIGH_DRIVE_Val << PIO_DRIVER_LINE0_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE1_Pos                1                                              /**< (PIO_DRIVER) Drive of PIO Line 1 Position */
+#define PIO_DRIVER_LINE1_Msk                (_U_(0x1) << PIO_DRIVER_LINE1_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 1 Mask */
+#define PIO_DRIVER_LINE1                    PIO_DRIVER_LINE1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE1_Msk instead */
+#define   PIO_DRIVER_LINE1_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE1_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE1_LOW_DRIVE          (PIO_DRIVER_LINE1_LOW_DRIVE_Val << PIO_DRIVER_LINE1_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE1_HIGH_DRIVE         (PIO_DRIVER_LINE1_HIGH_DRIVE_Val << PIO_DRIVER_LINE1_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE2_Pos                2                                              /**< (PIO_DRIVER) Drive of PIO Line 2 Position */
+#define PIO_DRIVER_LINE2_Msk                (_U_(0x1) << PIO_DRIVER_LINE2_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 2 Mask */
+#define PIO_DRIVER_LINE2                    PIO_DRIVER_LINE2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE2_Msk instead */
+#define   PIO_DRIVER_LINE2_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE2_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE2_LOW_DRIVE          (PIO_DRIVER_LINE2_LOW_DRIVE_Val << PIO_DRIVER_LINE2_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE2_HIGH_DRIVE         (PIO_DRIVER_LINE2_HIGH_DRIVE_Val << PIO_DRIVER_LINE2_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE3_Pos                3                                              /**< (PIO_DRIVER) Drive of PIO Line 3 Position */
+#define PIO_DRIVER_LINE3_Msk                (_U_(0x1) << PIO_DRIVER_LINE3_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 3 Mask */
+#define PIO_DRIVER_LINE3                    PIO_DRIVER_LINE3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE3_Msk instead */
+#define   PIO_DRIVER_LINE3_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE3_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE3_LOW_DRIVE          (PIO_DRIVER_LINE3_LOW_DRIVE_Val << PIO_DRIVER_LINE3_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE3_HIGH_DRIVE         (PIO_DRIVER_LINE3_HIGH_DRIVE_Val << PIO_DRIVER_LINE3_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE4_Pos                4                                              /**< (PIO_DRIVER) Drive of PIO Line 4 Position */
+#define PIO_DRIVER_LINE4_Msk                (_U_(0x1) << PIO_DRIVER_LINE4_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 4 Mask */
+#define PIO_DRIVER_LINE4                    PIO_DRIVER_LINE4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE4_Msk instead */
+#define   PIO_DRIVER_LINE4_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE4_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE4_LOW_DRIVE          (PIO_DRIVER_LINE4_LOW_DRIVE_Val << PIO_DRIVER_LINE4_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE4_HIGH_DRIVE         (PIO_DRIVER_LINE4_HIGH_DRIVE_Val << PIO_DRIVER_LINE4_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE5_Pos                5                                              /**< (PIO_DRIVER) Drive of PIO Line 5 Position */
+#define PIO_DRIVER_LINE5_Msk                (_U_(0x1) << PIO_DRIVER_LINE5_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 5 Mask */
+#define PIO_DRIVER_LINE5                    PIO_DRIVER_LINE5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE5_Msk instead */
+#define   PIO_DRIVER_LINE5_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE5_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE5_LOW_DRIVE          (PIO_DRIVER_LINE5_LOW_DRIVE_Val << PIO_DRIVER_LINE5_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE5_HIGH_DRIVE         (PIO_DRIVER_LINE5_HIGH_DRIVE_Val << PIO_DRIVER_LINE5_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE6_Pos                6                                              /**< (PIO_DRIVER) Drive of PIO Line 6 Position */
+#define PIO_DRIVER_LINE6_Msk                (_U_(0x1) << PIO_DRIVER_LINE6_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 6 Mask */
+#define PIO_DRIVER_LINE6                    PIO_DRIVER_LINE6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE6_Msk instead */
+#define   PIO_DRIVER_LINE6_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE6_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE6_LOW_DRIVE          (PIO_DRIVER_LINE6_LOW_DRIVE_Val << PIO_DRIVER_LINE6_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE6_HIGH_DRIVE         (PIO_DRIVER_LINE6_HIGH_DRIVE_Val << PIO_DRIVER_LINE6_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE7_Pos                7                                              /**< (PIO_DRIVER) Drive of PIO Line 7 Position */
+#define PIO_DRIVER_LINE7_Msk                (_U_(0x1) << PIO_DRIVER_LINE7_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 7 Mask */
+#define PIO_DRIVER_LINE7                    PIO_DRIVER_LINE7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE7_Msk instead */
+#define   PIO_DRIVER_LINE7_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE7_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE7_LOW_DRIVE          (PIO_DRIVER_LINE7_LOW_DRIVE_Val << PIO_DRIVER_LINE7_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE7_HIGH_DRIVE         (PIO_DRIVER_LINE7_HIGH_DRIVE_Val << PIO_DRIVER_LINE7_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE8_Pos                8                                              /**< (PIO_DRIVER) Drive of PIO Line 8 Position */
+#define PIO_DRIVER_LINE8_Msk                (_U_(0x1) << PIO_DRIVER_LINE8_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 8 Mask */
+#define PIO_DRIVER_LINE8                    PIO_DRIVER_LINE8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE8_Msk instead */
+#define   PIO_DRIVER_LINE8_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE8_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE8_LOW_DRIVE          (PIO_DRIVER_LINE8_LOW_DRIVE_Val << PIO_DRIVER_LINE8_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE8_HIGH_DRIVE         (PIO_DRIVER_LINE8_HIGH_DRIVE_Val << PIO_DRIVER_LINE8_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE9_Pos                9                                              /**< (PIO_DRIVER) Drive of PIO Line 9 Position */
+#define PIO_DRIVER_LINE9_Msk                (_U_(0x1) << PIO_DRIVER_LINE9_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 9 Mask */
+#define PIO_DRIVER_LINE9                    PIO_DRIVER_LINE9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE9_Msk instead */
+#define   PIO_DRIVER_LINE9_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE9_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE9_LOW_DRIVE          (PIO_DRIVER_LINE9_LOW_DRIVE_Val << PIO_DRIVER_LINE9_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE9_HIGH_DRIVE         (PIO_DRIVER_LINE9_HIGH_DRIVE_Val << PIO_DRIVER_LINE9_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE10_Pos               10                                             /**< (PIO_DRIVER) Drive of PIO Line 10 Position */
+#define PIO_DRIVER_LINE10_Msk               (_U_(0x1) << PIO_DRIVER_LINE10_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 10 Mask */
+#define PIO_DRIVER_LINE10                   PIO_DRIVER_LINE10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE10_Msk instead */
+#define   PIO_DRIVER_LINE10_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE10_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE10_LOW_DRIVE         (PIO_DRIVER_LINE10_LOW_DRIVE_Val << PIO_DRIVER_LINE10_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE10_HIGH_DRIVE        (PIO_DRIVER_LINE10_HIGH_DRIVE_Val << PIO_DRIVER_LINE10_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE11_Pos               11                                             /**< (PIO_DRIVER) Drive of PIO Line 11 Position */
+#define PIO_DRIVER_LINE11_Msk               (_U_(0x1) << PIO_DRIVER_LINE11_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 11 Mask */
+#define PIO_DRIVER_LINE11                   PIO_DRIVER_LINE11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE11_Msk instead */
+#define   PIO_DRIVER_LINE11_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE11_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE11_LOW_DRIVE         (PIO_DRIVER_LINE11_LOW_DRIVE_Val << PIO_DRIVER_LINE11_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE11_HIGH_DRIVE        (PIO_DRIVER_LINE11_HIGH_DRIVE_Val << PIO_DRIVER_LINE11_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE12_Pos               12                                             /**< (PIO_DRIVER) Drive of PIO Line 12 Position */
+#define PIO_DRIVER_LINE12_Msk               (_U_(0x1) << PIO_DRIVER_LINE12_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 12 Mask */
+#define PIO_DRIVER_LINE12                   PIO_DRIVER_LINE12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE12_Msk instead */
+#define   PIO_DRIVER_LINE12_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE12_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE12_LOW_DRIVE         (PIO_DRIVER_LINE12_LOW_DRIVE_Val << PIO_DRIVER_LINE12_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE12_HIGH_DRIVE        (PIO_DRIVER_LINE12_HIGH_DRIVE_Val << PIO_DRIVER_LINE12_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE13_Pos               13                                             /**< (PIO_DRIVER) Drive of PIO Line 13 Position */
+#define PIO_DRIVER_LINE13_Msk               (_U_(0x1) << PIO_DRIVER_LINE13_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 13 Mask */
+#define PIO_DRIVER_LINE13                   PIO_DRIVER_LINE13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE13_Msk instead */
+#define   PIO_DRIVER_LINE13_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE13_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE13_LOW_DRIVE         (PIO_DRIVER_LINE13_LOW_DRIVE_Val << PIO_DRIVER_LINE13_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE13_HIGH_DRIVE        (PIO_DRIVER_LINE13_HIGH_DRIVE_Val << PIO_DRIVER_LINE13_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE14_Pos               14                                             /**< (PIO_DRIVER) Drive of PIO Line 14 Position */
+#define PIO_DRIVER_LINE14_Msk               (_U_(0x1) << PIO_DRIVER_LINE14_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 14 Mask */
+#define PIO_DRIVER_LINE14                   PIO_DRIVER_LINE14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE14_Msk instead */
+#define   PIO_DRIVER_LINE14_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE14_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE14_LOW_DRIVE         (PIO_DRIVER_LINE14_LOW_DRIVE_Val << PIO_DRIVER_LINE14_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE14_HIGH_DRIVE        (PIO_DRIVER_LINE14_HIGH_DRIVE_Val << PIO_DRIVER_LINE14_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE15_Pos               15                                             /**< (PIO_DRIVER) Drive of PIO Line 15 Position */
+#define PIO_DRIVER_LINE15_Msk               (_U_(0x1) << PIO_DRIVER_LINE15_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 15 Mask */
+#define PIO_DRIVER_LINE15                   PIO_DRIVER_LINE15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE15_Msk instead */
+#define   PIO_DRIVER_LINE15_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE15_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE15_LOW_DRIVE         (PIO_DRIVER_LINE15_LOW_DRIVE_Val << PIO_DRIVER_LINE15_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE15_HIGH_DRIVE        (PIO_DRIVER_LINE15_HIGH_DRIVE_Val << PIO_DRIVER_LINE15_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE16_Pos               16                                             /**< (PIO_DRIVER) Drive of PIO Line 16 Position */
+#define PIO_DRIVER_LINE16_Msk               (_U_(0x1) << PIO_DRIVER_LINE16_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 16 Mask */
+#define PIO_DRIVER_LINE16                   PIO_DRIVER_LINE16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE16_Msk instead */
+#define   PIO_DRIVER_LINE16_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE16_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE16_LOW_DRIVE         (PIO_DRIVER_LINE16_LOW_DRIVE_Val << PIO_DRIVER_LINE16_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE16_HIGH_DRIVE        (PIO_DRIVER_LINE16_HIGH_DRIVE_Val << PIO_DRIVER_LINE16_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE17_Pos               17                                             /**< (PIO_DRIVER) Drive of PIO Line 17 Position */
+#define PIO_DRIVER_LINE17_Msk               (_U_(0x1) << PIO_DRIVER_LINE17_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 17 Mask */
+#define PIO_DRIVER_LINE17                   PIO_DRIVER_LINE17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE17_Msk instead */
+#define   PIO_DRIVER_LINE17_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE17_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE17_LOW_DRIVE         (PIO_DRIVER_LINE17_LOW_DRIVE_Val << PIO_DRIVER_LINE17_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE17_HIGH_DRIVE        (PIO_DRIVER_LINE17_HIGH_DRIVE_Val << PIO_DRIVER_LINE17_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE18_Pos               18                                             /**< (PIO_DRIVER) Drive of PIO Line 18 Position */
+#define PIO_DRIVER_LINE18_Msk               (_U_(0x1) << PIO_DRIVER_LINE18_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 18 Mask */
+#define PIO_DRIVER_LINE18                   PIO_DRIVER_LINE18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE18_Msk instead */
+#define   PIO_DRIVER_LINE18_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE18_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE18_LOW_DRIVE         (PIO_DRIVER_LINE18_LOW_DRIVE_Val << PIO_DRIVER_LINE18_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE18_HIGH_DRIVE        (PIO_DRIVER_LINE18_HIGH_DRIVE_Val << PIO_DRIVER_LINE18_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE19_Pos               19                                             /**< (PIO_DRIVER) Drive of PIO Line 19 Position */
+#define PIO_DRIVER_LINE19_Msk               (_U_(0x1) << PIO_DRIVER_LINE19_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 19 Mask */
+#define PIO_DRIVER_LINE19                   PIO_DRIVER_LINE19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE19_Msk instead */
+#define   PIO_DRIVER_LINE19_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE19_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE19_LOW_DRIVE         (PIO_DRIVER_LINE19_LOW_DRIVE_Val << PIO_DRIVER_LINE19_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE19_HIGH_DRIVE        (PIO_DRIVER_LINE19_HIGH_DRIVE_Val << PIO_DRIVER_LINE19_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE20_Pos               20                                             /**< (PIO_DRIVER) Drive of PIO Line 20 Position */
+#define PIO_DRIVER_LINE20_Msk               (_U_(0x1) << PIO_DRIVER_LINE20_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 20 Mask */
+#define PIO_DRIVER_LINE20                   PIO_DRIVER_LINE20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE20_Msk instead */
+#define   PIO_DRIVER_LINE20_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE20_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE20_LOW_DRIVE         (PIO_DRIVER_LINE20_LOW_DRIVE_Val << PIO_DRIVER_LINE20_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE20_HIGH_DRIVE        (PIO_DRIVER_LINE20_HIGH_DRIVE_Val << PIO_DRIVER_LINE20_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE21_Pos               21                                             /**< (PIO_DRIVER) Drive of PIO Line 21 Position */
+#define PIO_DRIVER_LINE21_Msk               (_U_(0x1) << PIO_DRIVER_LINE21_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 21 Mask */
+#define PIO_DRIVER_LINE21                   PIO_DRIVER_LINE21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE21_Msk instead */
+#define   PIO_DRIVER_LINE21_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE21_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE21_LOW_DRIVE         (PIO_DRIVER_LINE21_LOW_DRIVE_Val << PIO_DRIVER_LINE21_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE21_HIGH_DRIVE        (PIO_DRIVER_LINE21_HIGH_DRIVE_Val << PIO_DRIVER_LINE21_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE22_Pos               22                                             /**< (PIO_DRIVER) Drive of PIO Line 22 Position */
+#define PIO_DRIVER_LINE22_Msk               (_U_(0x1) << PIO_DRIVER_LINE22_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 22 Mask */
+#define PIO_DRIVER_LINE22                   PIO_DRIVER_LINE22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE22_Msk instead */
+#define   PIO_DRIVER_LINE22_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE22_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE22_LOW_DRIVE         (PIO_DRIVER_LINE22_LOW_DRIVE_Val << PIO_DRIVER_LINE22_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE22_HIGH_DRIVE        (PIO_DRIVER_LINE22_HIGH_DRIVE_Val << PIO_DRIVER_LINE22_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE23_Pos               23                                             /**< (PIO_DRIVER) Drive of PIO Line 23 Position */
+#define PIO_DRIVER_LINE23_Msk               (_U_(0x1) << PIO_DRIVER_LINE23_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 23 Mask */
+#define PIO_DRIVER_LINE23                   PIO_DRIVER_LINE23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE23_Msk instead */
+#define   PIO_DRIVER_LINE23_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE23_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE23_LOW_DRIVE         (PIO_DRIVER_LINE23_LOW_DRIVE_Val << PIO_DRIVER_LINE23_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE23_HIGH_DRIVE        (PIO_DRIVER_LINE23_HIGH_DRIVE_Val << PIO_DRIVER_LINE23_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE24_Pos               24                                             /**< (PIO_DRIVER) Drive of PIO Line 24 Position */
+#define PIO_DRIVER_LINE24_Msk               (_U_(0x1) << PIO_DRIVER_LINE24_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 24 Mask */
+#define PIO_DRIVER_LINE24                   PIO_DRIVER_LINE24_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE24_Msk instead */
+#define   PIO_DRIVER_LINE24_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE24_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE24_LOW_DRIVE         (PIO_DRIVER_LINE24_LOW_DRIVE_Val << PIO_DRIVER_LINE24_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE24_HIGH_DRIVE        (PIO_DRIVER_LINE24_HIGH_DRIVE_Val << PIO_DRIVER_LINE24_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE25_Pos               25                                             /**< (PIO_DRIVER) Drive of PIO Line 25 Position */
+#define PIO_DRIVER_LINE25_Msk               (_U_(0x1) << PIO_DRIVER_LINE25_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 25 Mask */
+#define PIO_DRIVER_LINE25                   PIO_DRIVER_LINE25_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE25_Msk instead */
+#define   PIO_DRIVER_LINE25_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE25_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE25_LOW_DRIVE         (PIO_DRIVER_LINE25_LOW_DRIVE_Val << PIO_DRIVER_LINE25_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE25_HIGH_DRIVE        (PIO_DRIVER_LINE25_HIGH_DRIVE_Val << PIO_DRIVER_LINE25_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE26_Pos               26                                             /**< (PIO_DRIVER) Drive of PIO Line 26 Position */
+#define PIO_DRIVER_LINE26_Msk               (_U_(0x1) << PIO_DRIVER_LINE26_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 26 Mask */
+#define PIO_DRIVER_LINE26                   PIO_DRIVER_LINE26_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE26_Msk instead */
+#define   PIO_DRIVER_LINE26_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE26_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE26_LOW_DRIVE         (PIO_DRIVER_LINE26_LOW_DRIVE_Val << PIO_DRIVER_LINE26_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE26_HIGH_DRIVE        (PIO_DRIVER_LINE26_HIGH_DRIVE_Val << PIO_DRIVER_LINE26_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE27_Pos               27                                             /**< (PIO_DRIVER) Drive of PIO Line 27 Position */
+#define PIO_DRIVER_LINE27_Msk               (_U_(0x1) << PIO_DRIVER_LINE27_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 27 Mask */
+#define PIO_DRIVER_LINE27                   PIO_DRIVER_LINE27_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE27_Msk instead */
+#define   PIO_DRIVER_LINE27_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE27_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE27_LOW_DRIVE         (PIO_DRIVER_LINE27_LOW_DRIVE_Val << PIO_DRIVER_LINE27_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE27_HIGH_DRIVE        (PIO_DRIVER_LINE27_HIGH_DRIVE_Val << PIO_DRIVER_LINE27_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE28_Pos               28                                             /**< (PIO_DRIVER) Drive of PIO Line 28 Position */
+#define PIO_DRIVER_LINE28_Msk               (_U_(0x1) << PIO_DRIVER_LINE28_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 28 Mask */
+#define PIO_DRIVER_LINE28                   PIO_DRIVER_LINE28_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE28_Msk instead */
+#define   PIO_DRIVER_LINE28_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE28_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE28_LOW_DRIVE         (PIO_DRIVER_LINE28_LOW_DRIVE_Val << PIO_DRIVER_LINE28_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE28_HIGH_DRIVE        (PIO_DRIVER_LINE28_HIGH_DRIVE_Val << PIO_DRIVER_LINE28_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE29_Pos               29                                             /**< (PIO_DRIVER) Drive of PIO Line 29 Position */
+#define PIO_DRIVER_LINE29_Msk               (_U_(0x1) << PIO_DRIVER_LINE29_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 29 Mask */
+#define PIO_DRIVER_LINE29                   PIO_DRIVER_LINE29_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE29_Msk instead */
+#define   PIO_DRIVER_LINE29_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE29_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE29_LOW_DRIVE         (PIO_DRIVER_LINE29_LOW_DRIVE_Val << PIO_DRIVER_LINE29_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE29_HIGH_DRIVE        (PIO_DRIVER_LINE29_HIGH_DRIVE_Val << PIO_DRIVER_LINE29_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE30_Pos               30                                             /**< (PIO_DRIVER) Drive of PIO Line 30 Position */
+#define PIO_DRIVER_LINE30_Msk               (_U_(0x1) << PIO_DRIVER_LINE30_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 30 Mask */
+#define PIO_DRIVER_LINE30                   PIO_DRIVER_LINE30_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE30_Msk instead */
+#define   PIO_DRIVER_LINE30_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE30_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE30_LOW_DRIVE         (PIO_DRIVER_LINE30_LOW_DRIVE_Val << PIO_DRIVER_LINE30_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE30_HIGH_DRIVE        (PIO_DRIVER_LINE30_HIGH_DRIVE_Val << PIO_DRIVER_LINE30_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE31_Pos               31                                             /**< (PIO_DRIVER) Drive of PIO Line 31 Position */
+#define PIO_DRIVER_LINE31_Msk               (_U_(0x1) << PIO_DRIVER_LINE31_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 31 Mask */
+#define PIO_DRIVER_LINE31                   PIO_DRIVER_LINE31_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE31_Msk instead */
+#define   PIO_DRIVER_LINE31_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE31_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE31_LOW_DRIVE         (PIO_DRIVER_LINE31_LOW_DRIVE_Val << PIO_DRIVER_LINE31_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE31_HIGH_DRIVE        (PIO_DRIVER_LINE31_HIGH_DRIVE_Val << PIO_DRIVER_LINE31_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_DRIVER) Register MASK  (Use PIO_DRIVER_Msk instead)  */
+#define PIO_DRIVER_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_DRIVER) Register Mask  */
+
+#define PIO_DRIVER_LINE_Pos                 0                                              /**< (PIO_DRIVER Position) Drive of PIO Line 3x */
+#define PIO_DRIVER_LINE_Msk                 (_U_(0xFFFFFFFF) << PIO_DRIVER_LINE_Pos)       /**< (PIO_DRIVER Mask) LINE */
+#define PIO_DRIVER_LINE(value)              (PIO_DRIVER_LINE_Msk & ((value) << PIO_DRIVER_LINE_Pos))  
+
+/* -------- PIO_PCMR : (PIO Offset: 0x150) (R/W 32) Parallel Capture Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PCEN:1;                    /**< bit:      0  Parallel Capture Mode Enable             */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t DSIZE:2;                   /**< bit:   4..5  Parallel Capture Mode Data Size          */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t ALWYS:1;                   /**< bit:      9  Parallel Capture Mode Always Sampling    */
+    uint32_t HALFS:1;                   /**< bit:     10  Parallel Capture Mode Half Sampling      */
+    uint32_t FRSTS:1;                   /**< bit:     11  Parallel Capture Mode First Sample       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCMR_OFFSET                     (0x150)                                       /**<  (PIO_PCMR) Parallel Capture Mode Register  Offset */
+
+#define PIO_PCMR_PCEN_Pos                   0                                              /**< (PIO_PCMR) Parallel Capture Mode Enable Position */
+#define PIO_PCMR_PCEN_Msk                   (_U_(0x1) << PIO_PCMR_PCEN_Pos)                /**< (PIO_PCMR) Parallel Capture Mode Enable Mask */
+#define PIO_PCMR_PCEN                       PIO_PCMR_PCEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_PCEN_Msk instead */
+#define PIO_PCMR_DSIZE_Pos                  4                                              /**< (PIO_PCMR) Parallel Capture Mode Data Size Position */
+#define PIO_PCMR_DSIZE_Msk                  (_U_(0x3) << PIO_PCMR_DSIZE_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Data Size Mask */
+#define PIO_PCMR_DSIZE(value)               (PIO_PCMR_DSIZE_Msk & ((value) << PIO_PCMR_DSIZE_Pos))
+#define   PIO_PCMR_DSIZE_BYTE_Val           _U_(0x0)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a byte (8-bit)  */
+#define   PIO_PCMR_DSIZE_HALFWORD_Val       _U_(0x1)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a half-word (16-bit)  */
+#define   PIO_PCMR_DSIZE_WORD_Val           _U_(0x2)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a word (32-bit)  */
+#define PIO_PCMR_DSIZE_BYTE                 (PIO_PCMR_DSIZE_BYTE_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a byte (8-bit) Position  */
+#define PIO_PCMR_DSIZE_HALFWORD             (PIO_PCMR_DSIZE_HALFWORD_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a half-word (16-bit) Position  */
+#define PIO_PCMR_DSIZE_WORD                 (PIO_PCMR_DSIZE_WORD_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a word (32-bit) Position  */
+#define PIO_PCMR_ALWYS_Pos                  9                                              /**< (PIO_PCMR) Parallel Capture Mode Always Sampling Position */
+#define PIO_PCMR_ALWYS_Msk                  (_U_(0x1) << PIO_PCMR_ALWYS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Always Sampling Mask */
+#define PIO_PCMR_ALWYS                      PIO_PCMR_ALWYS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_ALWYS_Msk instead */
+#define PIO_PCMR_HALFS_Pos                  10                                             /**< (PIO_PCMR) Parallel Capture Mode Half Sampling Position */
+#define PIO_PCMR_HALFS_Msk                  (_U_(0x1) << PIO_PCMR_HALFS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Half Sampling Mask */
+#define PIO_PCMR_HALFS                      PIO_PCMR_HALFS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_HALFS_Msk instead */
+#define PIO_PCMR_FRSTS_Pos                  11                                             /**< (PIO_PCMR) Parallel Capture Mode First Sample Position */
+#define PIO_PCMR_FRSTS_Msk                  (_U_(0x1) << PIO_PCMR_FRSTS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode First Sample Mask */
+#define PIO_PCMR_FRSTS                      PIO_PCMR_FRSTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_FRSTS_Msk instead */
+#define PIO_PCMR_MASK                       _U_(0xE31)                                     /**< \deprecated (PIO_PCMR) Register MASK  (Use PIO_PCMR_Msk instead)  */
+#define PIO_PCMR_Msk                        _U_(0xE31)                                     /**< (PIO_PCMR) Register Mask  */
+
+
+/* -------- PIO_PCIER : (PIO Offset: 0x154) (/W 32) Parallel Capture Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Enable */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Enable */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Enable */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Enable   */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIER_OFFSET                    (0x154)                                       /**<  (PIO_PCIER) Parallel Capture Interrupt Enable Register  Offset */
+
+#define PIO_PCIER_DRDY_Pos                  0                                              /**< (PIO_PCIER) Parallel Capture Mode Data Ready Interrupt Enable Position */
+#define PIO_PCIER_DRDY_Msk                  (_U_(0x1) << PIO_PCIER_DRDY_Pos)               /**< (PIO_PCIER) Parallel Capture Mode Data Ready Interrupt Enable Mask */
+#define PIO_PCIER_DRDY                      PIO_PCIER_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_DRDY_Msk instead */
+#define PIO_PCIER_OVRE_Pos                  1                                              /**< (PIO_PCIER) Parallel Capture Mode Overrun Error Interrupt Enable Position */
+#define PIO_PCIER_OVRE_Msk                  (_U_(0x1) << PIO_PCIER_OVRE_Pos)               /**< (PIO_PCIER) Parallel Capture Mode Overrun Error Interrupt Enable Mask */
+#define PIO_PCIER_OVRE                      PIO_PCIER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_OVRE_Msk instead */
+#define PIO_PCIER_ENDRX_Pos                 2                                              /**< (PIO_PCIER) End of Reception Transfer Interrupt Enable Position */
+#define PIO_PCIER_ENDRX_Msk                 (_U_(0x1) << PIO_PCIER_ENDRX_Pos)              /**< (PIO_PCIER) End of Reception Transfer Interrupt Enable Mask */
+#define PIO_PCIER_ENDRX                     PIO_PCIER_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_ENDRX_Msk instead */
+#define PIO_PCIER_RXBUFF_Pos                3                                              /**< (PIO_PCIER) Reception Buffer Full Interrupt Enable Position */
+#define PIO_PCIER_RXBUFF_Msk                (_U_(0x1) << PIO_PCIER_RXBUFF_Pos)             /**< (PIO_PCIER) Reception Buffer Full Interrupt Enable Mask */
+#define PIO_PCIER_RXBUFF                    PIO_PCIER_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_RXBUFF_Msk instead */
+#define PIO_PCIER_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIER) Register MASK  (Use PIO_PCIER_Msk instead)  */
+#define PIO_PCIER_Msk                       _U_(0x0F)                                      /**< (PIO_PCIER) Register Mask  */
+
+
+/* -------- PIO_PCIDR : (PIO Offset: 0x158) (/W 32) Parallel Capture Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Disable */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Disable */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Disable */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Disable  */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIDR_OFFSET                    (0x158)                                       /**<  (PIO_PCIDR) Parallel Capture Interrupt Disable Register  Offset */
+
+#define PIO_PCIDR_DRDY_Pos                  0                                              /**< (PIO_PCIDR) Parallel Capture Mode Data Ready Interrupt Disable Position */
+#define PIO_PCIDR_DRDY_Msk                  (_U_(0x1) << PIO_PCIDR_DRDY_Pos)               /**< (PIO_PCIDR) Parallel Capture Mode Data Ready Interrupt Disable Mask */
+#define PIO_PCIDR_DRDY                      PIO_PCIDR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_DRDY_Msk instead */
+#define PIO_PCIDR_OVRE_Pos                  1                                              /**< (PIO_PCIDR) Parallel Capture Mode Overrun Error Interrupt Disable Position */
+#define PIO_PCIDR_OVRE_Msk                  (_U_(0x1) << PIO_PCIDR_OVRE_Pos)               /**< (PIO_PCIDR) Parallel Capture Mode Overrun Error Interrupt Disable Mask */
+#define PIO_PCIDR_OVRE                      PIO_PCIDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_OVRE_Msk instead */
+#define PIO_PCIDR_ENDRX_Pos                 2                                              /**< (PIO_PCIDR) End of Reception Transfer Interrupt Disable Position */
+#define PIO_PCIDR_ENDRX_Msk                 (_U_(0x1) << PIO_PCIDR_ENDRX_Pos)              /**< (PIO_PCIDR) End of Reception Transfer Interrupt Disable Mask */
+#define PIO_PCIDR_ENDRX                     PIO_PCIDR_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_ENDRX_Msk instead */
+#define PIO_PCIDR_RXBUFF_Pos                3                                              /**< (PIO_PCIDR) Reception Buffer Full Interrupt Disable Position */
+#define PIO_PCIDR_RXBUFF_Msk                (_U_(0x1) << PIO_PCIDR_RXBUFF_Pos)             /**< (PIO_PCIDR) Reception Buffer Full Interrupt Disable Mask */
+#define PIO_PCIDR_RXBUFF                    PIO_PCIDR_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_RXBUFF_Msk instead */
+#define PIO_PCIDR_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIDR) Register MASK  (Use PIO_PCIDR_Msk instead)  */
+#define PIO_PCIDR_Msk                       _U_(0x0F)                                      /**< (PIO_PCIDR) Register Mask  */
+
+
+/* -------- PIO_PCIMR : (PIO Offset: 0x15c) (R/ 32) Parallel Capture Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Mask */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Mask */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Mask */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Mask     */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIMR_OFFSET                    (0x15C)                                       /**<  (PIO_PCIMR) Parallel Capture Interrupt Mask Register  Offset */
+
+#define PIO_PCIMR_DRDY_Pos                  0                                              /**< (PIO_PCIMR) Parallel Capture Mode Data Ready Interrupt Mask Position */
+#define PIO_PCIMR_DRDY_Msk                  (_U_(0x1) << PIO_PCIMR_DRDY_Pos)               /**< (PIO_PCIMR) Parallel Capture Mode Data Ready Interrupt Mask Mask */
+#define PIO_PCIMR_DRDY                      PIO_PCIMR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_DRDY_Msk instead */
+#define PIO_PCIMR_OVRE_Pos                  1                                              /**< (PIO_PCIMR) Parallel Capture Mode Overrun Error Interrupt Mask Position */
+#define PIO_PCIMR_OVRE_Msk                  (_U_(0x1) << PIO_PCIMR_OVRE_Pos)               /**< (PIO_PCIMR) Parallel Capture Mode Overrun Error Interrupt Mask Mask */
+#define PIO_PCIMR_OVRE                      PIO_PCIMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_OVRE_Msk instead */
+#define PIO_PCIMR_ENDRX_Pos                 2                                              /**< (PIO_PCIMR) End of Reception Transfer Interrupt Mask Position */
+#define PIO_PCIMR_ENDRX_Msk                 (_U_(0x1) << PIO_PCIMR_ENDRX_Pos)              /**< (PIO_PCIMR) End of Reception Transfer Interrupt Mask Mask */
+#define PIO_PCIMR_ENDRX                     PIO_PCIMR_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_ENDRX_Msk instead */
+#define PIO_PCIMR_RXBUFF_Pos                3                                              /**< (PIO_PCIMR) Reception Buffer Full Interrupt Mask Position */
+#define PIO_PCIMR_RXBUFF_Msk                (_U_(0x1) << PIO_PCIMR_RXBUFF_Pos)             /**< (PIO_PCIMR) Reception Buffer Full Interrupt Mask Mask */
+#define PIO_PCIMR_RXBUFF                    PIO_PCIMR_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_RXBUFF_Msk instead */
+#define PIO_PCIMR_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIMR) Register MASK  (Use PIO_PCIMR_Msk instead)  */
+#define PIO_PCIMR_Msk                       _U_(0x0F)                                      /**< (PIO_PCIMR) Register Mask  */
+
+
+/* -------- PIO_PCISR : (PIO Offset: 0x160) (R/ 32) Parallel Capture Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready         */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error      */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCISR_OFFSET                    (0x160)                                       /**<  (PIO_PCISR) Parallel Capture Interrupt Status Register  Offset */
+
+#define PIO_PCISR_DRDY_Pos                  0                                              /**< (PIO_PCISR) Parallel Capture Mode Data Ready Position */
+#define PIO_PCISR_DRDY_Msk                  (_U_(0x1) << PIO_PCISR_DRDY_Pos)               /**< (PIO_PCISR) Parallel Capture Mode Data Ready Mask */
+#define PIO_PCISR_DRDY                      PIO_PCISR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCISR_DRDY_Msk instead */
+#define PIO_PCISR_OVRE_Pos                  1                                              /**< (PIO_PCISR) Parallel Capture Mode Overrun Error Position */
+#define PIO_PCISR_OVRE_Msk                  (_U_(0x1) << PIO_PCISR_OVRE_Pos)               /**< (PIO_PCISR) Parallel Capture Mode Overrun Error Mask */
+#define PIO_PCISR_OVRE                      PIO_PCISR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCISR_OVRE_Msk instead */
+#define PIO_PCISR_MASK                      _U_(0x03)                                      /**< \deprecated (PIO_PCISR) Register MASK  (Use PIO_PCISR_Msk instead)  */
+#define PIO_PCISR_Msk                       _U_(0x03)                                      /**< (PIO_PCISR) Register Mask  */
+
+
+/* -------- PIO_PCRHR : (PIO Offset: 0x164) (R/ 32) Parallel Capture Reception Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDATA:32;                  /**< bit:  0..31  Parallel Capture Mode Reception Data     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCRHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCRHR_OFFSET                    (0x164)                                       /**<  (PIO_PCRHR) Parallel Capture Reception Holding Register  Offset */
+
+#define PIO_PCRHR_RDATA_Pos                 0                                              /**< (PIO_PCRHR) Parallel Capture Mode Reception Data Position */
+#define PIO_PCRHR_RDATA_Msk                 (_U_(0xFFFFFFFF) << PIO_PCRHR_RDATA_Pos)       /**< (PIO_PCRHR) Parallel Capture Mode Reception Data Mask */
+#define PIO_PCRHR_RDATA(value)              (PIO_PCRHR_RDATA_Msk & ((value) << PIO_PCRHR_RDATA_Pos))
+#define PIO_PCRHR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PCRHR) Register MASK  (Use PIO_PCRHR_Msk instead)  */
+#define PIO_PCRHR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PCRHR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PIO hardware registers */
+typedef struct {  
+  __O  uint32_t PIO_PER;        /**< (PIO Offset: 0x00) PIO Enable Register */
+  __O  uint32_t PIO_PDR;        /**< (PIO Offset: 0x04) PIO Disable Register */
+  __I  uint32_t PIO_PSR;        /**< (PIO Offset: 0x08) PIO Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t PIO_OER;        /**< (PIO Offset: 0x10) Output Enable Register */
+  __O  uint32_t PIO_ODR;        /**< (PIO Offset: 0x14) Output Disable Register */
+  __I  uint32_t PIO_OSR;        /**< (PIO Offset: 0x18) Output Status Register */
+  __I  uint8_t                        Reserved2[4];
+  __O  uint32_t PIO_IFER;       /**< (PIO Offset: 0x20) Glitch Input Filter Enable Register */
+  __O  uint32_t PIO_IFDR;       /**< (PIO Offset: 0x24) Glitch Input Filter Disable Register */
+  __I  uint32_t PIO_IFSR;       /**< (PIO Offset: 0x28) Glitch Input Filter Status Register */
+  __I  uint8_t                        Reserved3[4];
+  __O  uint32_t PIO_SODR;       /**< (PIO Offset: 0x30) Set Output Data Register */
+  __O  uint32_t PIO_CODR;       /**< (PIO Offset: 0x34) Clear Output Data Register */
+  __IO uint32_t PIO_ODSR;       /**< (PIO Offset: 0x38) Output Data Status Register */
+  __I  uint32_t PIO_PDSR;       /**< (PIO Offset: 0x3C) Pin Data Status Register */
+  __O  uint32_t PIO_IER;        /**< (PIO Offset: 0x40) Interrupt Enable Register */
+  __O  uint32_t PIO_IDR;        /**< (PIO Offset: 0x44) Interrupt Disable Register */
+  __I  uint32_t PIO_IMR;        /**< (PIO Offset: 0x48) Interrupt Mask Register */
+  __I  uint32_t PIO_ISR;        /**< (PIO Offset: 0x4C) Interrupt Status Register */
+  __O  uint32_t PIO_MDER;       /**< (PIO Offset: 0x50) Multi-driver Enable Register */
+  __O  uint32_t PIO_MDDR;       /**< (PIO Offset: 0x54) Multi-driver Disable Register */
+  __I  uint32_t PIO_MDSR;       /**< (PIO Offset: 0x58) Multi-driver Status Register */
+  __I  uint8_t                        Reserved4[4];
+  __O  uint32_t PIO_PUDR;       /**< (PIO Offset: 0x60) Pull-up Disable Register */
+  __O  uint32_t PIO_PUER;       /**< (PIO Offset: 0x64) Pull-up Enable Register */
+  __I  uint32_t PIO_PUSR;       /**< (PIO Offset: 0x68) Pad Pull-up Status Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO uint32_t PIO_ABCDSR[2];  /**< (PIO Offset: 0x70) Peripheral ABCD Select Register 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  uint32_t PIO_IFSCDR;     /**< (PIO Offset: 0x80) Input Filter Slow Clock Disable Register */
+  __O  uint32_t PIO_IFSCER;     /**< (PIO Offset: 0x84) Input Filter Slow Clock Enable Register */
+  __I  uint32_t PIO_IFSCSR;     /**< (PIO Offset: 0x88) Input Filter Slow Clock Status Register */
+  __IO uint32_t PIO_SCDR;       /**< (PIO Offset: 0x8C) Slow Clock Divider Debouncing Register */
+  __O  uint32_t PIO_PPDDR;      /**< (PIO Offset: 0x90) Pad Pull-down Disable Register */
+  __O  uint32_t PIO_PPDER;      /**< (PIO Offset: 0x94) Pad Pull-down Enable Register */
+  __I  uint32_t PIO_PPDSR;      /**< (PIO Offset: 0x98) Pad Pull-down Status Register */
+  __I  uint8_t                        Reserved7[4];
+  __O  uint32_t PIO_OWER;       /**< (PIO Offset: 0xA0) Output Write Enable */
+  __O  uint32_t PIO_OWDR;       /**< (PIO Offset: 0xA4) Output Write Disable */
+  __I  uint32_t PIO_OWSR;       /**< (PIO Offset: 0xA8) Output Write Status Register */
+  __I  uint8_t                        Reserved8[4];
+  __O  uint32_t PIO_AIMER;      /**< (PIO Offset: 0xB0) Additional Interrupt Modes Enable Register */
+  __O  uint32_t PIO_AIMDR;      /**< (PIO Offset: 0xB4) Additional Interrupt Modes Disable Register */
+  __I  uint32_t PIO_AIMMR;      /**< (PIO Offset: 0xB8) Additional Interrupt Modes Mask Register */
+  __I  uint8_t                        Reserved9[4];
+  __O  uint32_t PIO_ESR;        /**< (PIO Offset: 0xC0) Edge Select Register */
+  __O  uint32_t PIO_LSR;        /**< (PIO Offset: 0xC4) Level Select Register */
+  __I  uint32_t PIO_ELSR;       /**< (PIO Offset: 0xC8) Edge/Level Status Register */
+  __I  uint8_t                        Reserved10[4];
+  __O  uint32_t PIO_FELLSR;     /**< (PIO Offset: 0xD0) Falling Edge/Low-Level Select Register */
+  __O  uint32_t PIO_REHLSR;     /**< (PIO Offset: 0xD4) Rising Edge/High-Level Select Register */
+  __I  uint32_t PIO_FRLHSR;     /**< (PIO Offset: 0xD8) Fall/Rise - Low/High Status Register */
+  __I  uint8_t                        Reserved11[4];
+  __I  uint32_t PIO_LOCKSR;     /**< (PIO Offset: 0xE0) Lock Status */
+  __IO uint32_t PIO_WPMR;       /**< (PIO Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t PIO_WPSR;       /**< (PIO Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved12[16];
+  __I  uint32_t PIO_VERSION;    /**< (PIO Offset: 0xFC) Version Register */
+  __IO uint32_t PIO_SCHMITT;    /**< (PIO Offset: 0x100) Schmitt Trigger Register */
+  __I  uint8_t                        Reserved13[20];
+  __IO uint32_t PIO_DRIVER;     /**< (PIO Offset: 0x118) I/O Drive Register */
+  __I  uint8_t                        Reserved14[52];
+  __IO uint32_t PIO_PCMR;       /**< (PIO Offset: 0x150) Parallel Capture Mode Register */
+  __O  uint32_t PIO_PCIER;      /**< (PIO Offset: 0x154) Parallel Capture Interrupt Enable Register */
+  __O  uint32_t PIO_PCIDR;      /**< (PIO Offset: 0x158) Parallel Capture Interrupt Disable Register */
+  __I  uint32_t PIO_PCIMR;      /**< (PIO Offset: 0x15C) Parallel Capture Interrupt Mask Register */
+  __I  uint32_t PIO_PCISR;      /**< (PIO Offset: 0x160) Parallel Capture Interrupt Status Register */
+  __I  uint32_t PIO_PCRHR;      /**< (PIO Offset: 0x164) Parallel Capture Reception Holding Register */
+} Pio;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PIO hardware registers */
+typedef struct {  
+  __O  PIO_PER_Type                   PIO_PER;        /**< Offset: 0x00 ( /W  32) PIO Enable Register */
+  __O  PIO_PDR_Type                   PIO_PDR;        /**< Offset: 0x04 ( /W  32) PIO Disable Register */
+  __I  PIO_PSR_Type                   PIO_PSR;        /**< Offset: 0x08 (R/   32) PIO Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  PIO_OER_Type                   PIO_OER;        /**< Offset: 0x10 ( /W  32) Output Enable Register */
+  __O  PIO_ODR_Type                   PIO_ODR;        /**< Offset: 0x14 ( /W  32) Output Disable Register */
+  __I  PIO_OSR_Type                   PIO_OSR;        /**< Offset: 0x18 (R/   32) Output Status Register */
+  __I  uint8_t                        Reserved2[4];
+  __O  PIO_IFER_Type                  PIO_IFER;       /**< Offset: 0x20 ( /W  32) Glitch Input Filter Enable Register */
+  __O  PIO_IFDR_Type                  PIO_IFDR;       /**< Offset: 0x24 ( /W  32) Glitch Input Filter Disable Register */
+  __I  PIO_IFSR_Type                  PIO_IFSR;       /**< Offset: 0x28 (R/   32) Glitch Input Filter Status Register */
+  __I  uint8_t                        Reserved3[4];
+  __O  PIO_SODR_Type                  PIO_SODR;       /**< Offset: 0x30 ( /W  32) Set Output Data Register */
+  __O  PIO_CODR_Type                  PIO_CODR;       /**< Offset: 0x34 ( /W  32) Clear Output Data Register */
+  __IO PIO_ODSR_Type                  PIO_ODSR;       /**< Offset: 0x38 (R/W  32) Output Data Status Register */
+  __I  PIO_PDSR_Type                  PIO_PDSR;       /**< Offset: 0x3C (R/   32) Pin Data Status Register */
+  __O  PIO_IER_Type                   PIO_IER;        /**< Offset: 0x40 ( /W  32) Interrupt Enable Register */
+  __O  PIO_IDR_Type                   PIO_IDR;        /**< Offset: 0x44 ( /W  32) Interrupt Disable Register */
+  __I  PIO_IMR_Type                   PIO_IMR;        /**< Offset: 0x48 (R/   32) Interrupt Mask Register */
+  __I  PIO_ISR_Type                   PIO_ISR;        /**< Offset: 0x4C (R/   32) Interrupt Status Register */
+  __O  PIO_MDER_Type                  PIO_MDER;       /**< Offset: 0x50 ( /W  32) Multi-driver Enable Register */
+  __O  PIO_MDDR_Type                  PIO_MDDR;       /**< Offset: 0x54 ( /W  32) Multi-driver Disable Register */
+  __I  PIO_MDSR_Type                  PIO_MDSR;       /**< Offset: 0x58 (R/   32) Multi-driver Status Register */
+  __I  uint8_t                        Reserved4[4];
+  __O  PIO_PUDR_Type                  PIO_PUDR;       /**< Offset: 0x60 ( /W  32) Pull-up Disable Register */
+  __O  PIO_PUER_Type                  PIO_PUER;       /**< Offset: 0x64 ( /W  32) Pull-up Enable Register */
+  __I  PIO_PUSR_Type                  PIO_PUSR;       /**< Offset: 0x68 (R/   32) Pad Pull-up Status Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO PIO_ABCDSR_Type                PIO_ABCDSR[2];  /**< Offset: 0x70 (R/W  32) Peripheral ABCD Select Register 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  PIO_IFSCDR_Type                PIO_IFSCDR;     /**< Offset: 0x80 ( /W  32) Input Filter Slow Clock Disable Register */
+  __O  PIO_IFSCER_Type                PIO_IFSCER;     /**< Offset: 0x84 ( /W  32) Input Filter Slow Clock Enable Register */
+  __I  PIO_IFSCSR_Type                PIO_IFSCSR;     /**< Offset: 0x88 (R/   32) Input Filter Slow Clock Status Register */
+  __IO PIO_SCDR_Type                  PIO_SCDR;       /**< Offset: 0x8C (R/W  32) Slow Clock Divider Debouncing Register */
+  __O  PIO_PPDDR_Type                 PIO_PPDDR;      /**< Offset: 0x90 ( /W  32) Pad Pull-down Disable Register */
+  __O  PIO_PPDER_Type                 PIO_PPDER;      /**< Offset: 0x94 ( /W  32) Pad Pull-down Enable Register */
+  __I  PIO_PPDSR_Type                 PIO_PPDSR;      /**< Offset: 0x98 (R/   32) Pad Pull-down Status Register */
+  __I  uint8_t                        Reserved7[4];
+  __O  PIO_OWER_Type                  PIO_OWER;       /**< Offset: 0xA0 ( /W  32) Output Write Enable */
+  __O  PIO_OWDR_Type                  PIO_OWDR;       /**< Offset: 0xA4 ( /W  32) Output Write Disable */
+  __I  PIO_OWSR_Type                  PIO_OWSR;       /**< Offset: 0xA8 (R/   32) Output Write Status Register */
+  __I  uint8_t                        Reserved8[4];
+  __O  PIO_AIMER_Type                 PIO_AIMER;      /**< Offset: 0xB0 ( /W  32) Additional Interrupt Modes Enable Register */
+  __O  PIO_AIMDR_Type                 PIO_AIMDR;      /**< Offset: 0xB4 ( /W  32) Additional Interrupt Modes Disable Register */
+  __I  PIO_AIMMR_Type                 PIO_AIMMR;      /**< Offset: 0xB8 (R/   32) Additional Interrupt Modes Mask Register */
+  __I  uint8_t                        Reserved9[4];
+  __O  PIO_ESR_Type                   PIO_ESR;        /**< Offset: 0xC0 ( /W  32) Edge Select Register */
+  __O  PIO_LSR_Type                   PIO_LSR;        /**< Offset: 0xC4 ( /W  32) Level Select Register */
+  __I  PIO_ELSR_Type                  PIO_ELSR;       /**< Offset: 0xC8 (R/   32) Edge/Level Status Register */
+  __I  uint8_t                        Reserved10[4];
+  __O  PIO_FELLSR_Type                PIO_FELLSR;     /**< Offset: 0xD0 ( /W  32) Falling Edge/Low-Level Select Register */
+  __O  PIO_REHLSR_Type                PIO_REHLSR;     /**< Offset: 0xD4 ( /W  32) Rising Edge/High-Level Select Register */
+  __I  PIO_FRLHSR_Type                PIO_FRLHSR;     /**< Offset: 0xD8 (R/   32) Fall/Rise - Low/High Status Register */
+  __I  uint8_t                        Reserved11[4];
+  __I  PIO_LOCKSR_Type                PIO_LOCKSR;     /**< Offset: 0xE0 (R/   32) Lock Status */
+  __IO PIO_WPMR_Type                  PIO_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  PIO_WPSR_Type                  PIO_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved12[16];
+  __I  PIO_VERSION_Type               PIO_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+  __IO PIO_SCHMITT_Type               PIO_SCHMITT;    /**< Offset: 0x100 (R/W  32) Schmitt Trigger Register */
+  __I  uint8_t                        Reserved13[20];
+  __IO PIO_DRIVER_Type                PIO_DRIVER;     /**< Offset: 0x118 (R/W  32) I/O Drive Register */
+  __I  uint8_t                        Reserved14[52];
+  __IO PIO_PCMR_Type                  PIO_PCMR;       /**< Offset: 0x150 (R/W  32) Parallel Capture Mode Register */
+  __O  PIO_PCIER_Type                 PIO_PCIER;      /**< Offset: 0x154 ( /W  32) Parallel Capture Interrupt Enable Register */
+  __O  PIO_PCIDR_Type                 PIO_PCIDR;      /**< Offset: 0x158 ( /W  32) Parallel Capture Interrupt Disable Register */
+  __I  PIO_PCIMR_Type                 PIO_PCIMR;      /**< Offset: 0x15C (R/   32) Parallel Capture Interrupt Mask Register */
+  __I  PIO_PCISR_Type                 PIO_PCISR;      /**< Offset: 0x160 (R/   32) Parallel Capture Interrupt Status Register */
+  __I  PIO_PCRHR_Type                 PIO_PCRHR;      /**< Offset: 0x164 (R/   32) Parallel Capture Reception Holding Register */
+} Pio;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Parallel Input/Output Controller */
+
+#endif /* _SAMV71_PIO_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/pmc.h
+++ b/asf/sam/include/samv71/component/pmc.h
@@ -1,0 +1,3315 @@
+/**
+ * \file
+ *
+ * \brief Component description for PMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PMC_COMPONENT_H_
+#define _SAMV71_PMC_COMPONENT_H_
+#define _SAMV71_PMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Power Management Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PMC_44006                      /**< (PMC) Module ID */
+#define REV_PMC K                      /**< (PMC) Module revision */
+
+/* -------- PMC_SCER : (PMC Offset: 0x00) (/W 32) System Clock Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  Enable USB FS Clock                      */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Enable       */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Enable       */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Enable       */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Enable       */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Enable       */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Enable       */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Enable       */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Enable       */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCER_OFFSET                     (0x00)                                        /**<  (PMC_SCER) System Clock Enable Register  Offset */
+
+#define PMC_SCER_USBCLK_Pos                 5                                              /**< (PMC_SCER) Enable USB FS Clock Position */
+#define PMC_SCER_USBCLK_Msk                 (_U_(0x1) << PMC_SCER_USBCLK_Pos)              /**< (PMC_SCER) Enable USB FS Clock Mask */
+#define PMC_SCER_USBCLK                     PMC_SCER_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_USBCLK_Msk instead */
+#define PMC_SCER_PCK0_Pos                   8                                              /**< (PMC_SCER) Programmable Clock 0 Output Enable Position */
+#define PMC_SCER_PCK0_Msk                   (_U_(0x1) << PMC_SCER_PCK0_Pos)                /**< (PMC_SCER) Programmable Clock 0 Output Enable Mask */
+#define PMC_SCER_PCK0                       PMC_SCER_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK0_Msk instead */
+#define PMC_SCER_PCK1_Pos                   9                                              /**< (PMC_SCER) Programmable Clock 1 Output Enable Position */
+#define PMC_SCER_PCK1_Msk                   (_U_(0x1) << PMC_SCER_PCK1_Pos)                /**< (PMC_SCER) Programmable Clock 1 Output Enable Mask */
+#define PMC_SCER_PCK1                       PMC_SCER_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK1_Msk instead */
+#define PMC_SCER_PCK2_Pos                   10                                             /**< (PMC_SCER) Programmable Clock 2 Output Enable Position */
+#define PMC_SCER_PCK2_Msk                   (_U_(0x1) << PMC_SCER_PCK2_Pos)                /**< (PMC_SCER) Programmable Clock 2 Output Enable Mask */
+#define PMC_SCER_PCK2                       PMC_SCER_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK2_Msk instead */
+#define PMC_SCER_PCK3_Pos                   11                                             /**< (PMC_SCER) Programmable Clock 3 Output Enable Position */
+#define PMC_SCER_PCK3_Msk                   (_U_(0x1) << PMC_SCER_PCK3_Pos)                /**< (PMC_SCER) Programmable Clock 3 Output Enable Mask */
+#define PMC_SCER_PCK3                       PMC_SCER_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK3_Msk instead */
+#define PMC_SCER_PCK4_Pos                   12                                             /**< (PMC_SCER) Programmable Clock 4 Output Enable Position */
+#define PMC_SCER_PCK4_Msk                   (_U_(0x1) << PMC_SCER_PCK4_Pos)                /**< (PMC_SCER) Programmable Clock 4 Output Enable Mask */
+#define PMC_SCER_PCK4                       PMC_SCER_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK4_Msk instead */
+#define PMC_SCER_PCK5_Pos                   13                                             /**< (PMC_SCER) Programmable Clock 5 Output Enable Position */
+#define PMC_SCER_PCK5_Msk                   (_U_(0x1) << PMC_SCER_PCK5_Pos)                /**< (PMC_SCER) Programmable Clock 5 Output Enable Mask */
+#define PMC_SCER_PCK5                       PMC_SCER_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK5_Msk instead */
+#define PMC_SCER_PCK6_Pos                   14                                             /**< (PMC_SCER) Programmable Clock 6 Output Enable Position */
+#define PMC_SCER_PCK6_Msk                   (_U_(0x1) << PMC_SCER_PCK6_Pos)                /**< (PMC_SCER) Programmable Clock 6 Output Enable Mask */
+#define PMC_SCER_PCK6                       PMC_SCER_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK6_Msk instead */
+#define PMC_SCER_MASK                       _U_(0x7F20)                                    /**< \deprecated (PMC_SCER) Register MASK  (Use PMC_SCER_Msk instead)  */
+#define PMC_SCER_Msk                        _U_(0x7F20)                                    /**< (PMC_SCER) Register Mask  */
+
+#define PMC_SCER_PCK_Pos                    8                                              /**< (PMC_SCER Position) Programmable Clock 6 Output Enable */
+#define PMC_SCER_PCK_Msk                    (_U_(0x7F) << PMC_SCER_PCK_Pos)                /**< (PMC_SCER Mask) PCK */
+#define PMC_SCER_PCK(value)                 (PMC_SCER_PCK_Msk & ((value) << PMC_SCER_PCK_Pos))  
+
+/* -------- PMC_SCDR : (PMC Offset: 0x04) (/W 32) System Clock Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  Disable USB FS Clock                     */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Disable      */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Disable      */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Disable      */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Disable      */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Disable      */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Disable      */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Disable      */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Disable      */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCDR_OFFSET                     (0x04)                                        /**<  (PMC_SCDR) System Clock Disable Register  Offset */
+
+#define PMC_SCDR_USBCLK_Pos                 5                                              /**< (PMC_SCDR) Disable USB FS Clock Position */
+#define PMC_SCDR_USBCLK_Msk                 (_U_(0x1) << PMC_SCDR_USBCLK_Pos)              /**< (PMC_SCDR) Disable USB FS Clock Mask */
+#define PMC_SCDR_USBCLK                     PMC_SCDR_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_USBCLK_Msk instead */
+#define PMC_SCDR_PCK0_Pos                   8                                              /**< (PMC_SCDR) Programmable Clock 0 Output Disable Position */
+#define PMC_SCDR_PCK0_Msk                   (_U_(0x1) << PMC_SCDR_PCK0_Pos)                /**< (PMC_SCDR) Programmable Clock 0 Output Disable Mask */
+#define PMC_SCDR_PCK0                       PMC_SCDR_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK0_Msk instead */
+#define PMC_SCDR_PCK1_Pos                   9                                              /**< (PMC_SCDR) Programmable Clock 1 Output Disable Position */
+#define PMC_SCDR_PCK1_Msk                   (_U_(0x1) << PMC_SCDR_PCK1_Pos)                /**< (PMC_SCDR) Programmable Clock 1 Output Disable Mask */
+#define PMC_SCDR_PCK1                       PMC_SCDR_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK1_Msk instead */
+#define PMC_SCDR_PCK2_Pos                   10                                             /**< (PMC_SCDR) Programmable Clock 2 Output Disable Position */
+#define PMC_SCDR_PCK2_Msk                   (_U_(0x1) << PMC_SCDR_PCK2_Pos)                /**< (PMC_SCDR) Programmable Clock 2 Output Disable Mask */
+#define PMC_SCDR_PCK2                       PMC_SCDR_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK2_Msk instead */
+#define PMC_SCDR_PCK3_Pos                   11                                             /**< (PMC_SCDR) Programmable Clock 3 Output Disable Position */
+#define PMC_SCDR_PCK3_Msk                   (_U_(0x1) << PMC_SCDR_PCK3_Pos)                /**< (PMC_SCDR) Programmable Clock 3 Output Disable Mask */
+#define PMC_SCDR_PCK3                       PMC_SCDR_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK3_Msk instead */
+#define PMC_SCDR_PCK4_Pos                   12                                             /**< (PMC_SCDR) Programmable Clock 4 Output Disable Position */
+#define PMC_SCDR_PCK4_Msk                   (_U_(0x1) << PMC_SCDR_PCK4_Pos)                /**< (PMC_SCDR) Programmable Clock 4 Output Disable Mask */
+#define PMC_SCDR_PCK4                       PMC_SCDR_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK4_Msk instead */
+#define PMC_SCDR_PCK5_Pos                   13                                             /**< (PMC_SCDR) Programmable Clock 5 Output Disable Position */
+#define PMC_SCDR_PCK5_Msk                   (_U_(0x1) << PMC_SCDR_PCK5_Pos)                /**< (PMC_SCDR) Programmable Clock 5 Output Disable Mask */
+#define PMC_SCDR_PCK5                       PMC_SCDR_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK5_Msk instead */
+#define PMC_SCDR_PCK6_Pos                   14                                             /**< (PMC_SCDR) Programmable Clock 6 Output Disable Position */
+#define PMC_SCDR_PCK6_Msk                   (_U_(0x1) << PMC_SCDR_PCK6_Pos)                /**< (PMC_SCDR) Programmable Clock 6 Output Disable Mask */
+#define PMC_SCDR_PCK6                       PMC_SCDR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK6_Msk instead */
+#define PMC_SCDR_MASK                       _U_(0x7F20)                                    /**< \deprecated (PMC_SCDR) Register MASK  (Use PMC_SCDR_Msk instead)  */
+#define PMC_SCDR_Msk                        _U_(0x7F20)                                    /**< (PMC_SCDR) Register Mask  */
+
+#define PMC_SCDR_PCK_Pos                    8                                              /**< (PMC_SCDR Position) Programmable Clock 6 Output Disable */
+#define PMC_SCDR_PCK_Msk                    (_U_(0x7F) << PMC_SCDR_PCK_Pos)                /**< (PMC_SCDR Mask) PCK */
+#define PMC_SCDR_PCK(value)                 (PMC_SCDR_PCK_Msk & ((value) << PMC_SCDR_PCK_Pos))  
+
+/* -------- PMC_SCSR : (PMC Offset: 0x08) (R/ 32) System Clock Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HCLKS:1;                   /**< bit:      0  HCLK Status                              */
+    uint32_t :4;                        /**< bit:   1..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  USB FS Clock Status                      */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Status       */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Status       */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Status       */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Status       */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Status       */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Status       */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Status       */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Status       */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCSR_OFFSET                     (0x08)                                        /**<  (PMC_SCSR) System Clock Status Register  Offset */
+
+#define PMC_SCSR_HCLKS_Pos                  0                                              /**< (PMC_SCSR) HCLK Status Position */
+#define PMC_SCSR_HCLKS_Msk                  (_U_(0x1) << PMC_SCSR_HCLKS_Pos)               /**< (PMC_SCSR) HCLK Status Mask */
+#define PMC_SCSR_HCLKS                      PMC_SCSR_HCLKS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_HCLKS_Msk instead */
+#define PMC_SCSR_USBCLK_Pos                 5                                              /**< (PMC_SCSR) USB FS Clock Status Position */
+#define PMC_SCSR_USBCLK_Msk                 (_U_(0x1) << PMC_SCSR_USBCLK_Pos)              /**< (PMC_SCSR) USB FS Clock Status Mask */
+#define PMC_SCSR_USBCLK                     PMC_SCSR_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_USBCLK_Msk instead */
+#define PMC_SCSR_PCK0_Pos                   8                                              /**< (PMC_SCSR) Programmable Clock 0 Output Status Position */
+#define PMC_SCSR_PCK0_Msk                   (_U_(0x1) << PMC_SCSR_PCK0_Pos)                /**< (PMC_SCSR) Programmable Clock 0 Output Status Mask */
+#define PMC_SCSR_PCK0                       PMC_SCSR_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK0_Msk instead */
+#define PMC_SCSR_PCK1_Pos                   9                                              /**< (PMC_SCSR) Programmable Clock 1 Output Status Position */
+#define PMC_SCSR_PCK1_Msk                   (_U_(0x1) << PMC_SCSR_PCK1_Pos)                /**< (PMC_SCSR) Programmable Clock 1 Output Status Mask */
+#define PMC_SCSR_PCK1                       PMC_SCSR_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK1_Msk instead */
+#define PMC_SCSR_PCK2_Pos                   10                                             /**< (PMC_SCSR) Programmable Clock 2 Output Status Position */
+#define PMC_SCSR_PCK2_Msk                   (_U_(0x1) << PMC_SCSR_PCK2_Pos)                /**< (PMC_SCSR) Programmable Clock 2 Output Status Mask */
+#define PMC_SCSR_PCK2                       PMC_SCSR_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK2_Msk instead */
+#define PMC_SCSR_PCK3_Pos                   11                                             /**< (PMC_SCSR) Programmable Clock 3 Output Status Position */
+#define PMC_SCSR_PCK3_Msk                   (_U_(0x1) << PMC_SCSR_PCK3_Pos)                /**< (PMC_SCSR) Programmable Clock 3 Output Status Mask */
+#define PMC_SCSR_PCK3                       PMC_SCSR_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK3_Msk instead */
+#define PMC_SCSR_PCK4_Pos                   12                                             /**< (PMC_SCSR) Programmable Clock 4 Output Status Position */
+#define PMC_SCSR_PCK4_Msk                   (_U_(0x1) << PMC_SCSR_PCK4_Pos)                /**< (PMC_SCSR) Programmable Clock 4 Output Status Mask */
+#define PMC_SCSR_PCK4                       PMC_SCSR_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK4_Msk instead */
+#define PMC_SCSR_PCK5_Pos                   13                                             /**< (PMC_SCSR) Programmable Clock 5 Output Status Position */
+#define PMC_SCSR_PCK5_Msk                   (_U_(0x1) << PMC_SCSR_PCK5_Pos)                /**< (PMC_SCSR) Programmable Clock 5 Output Status Mask */
+#define PMC_SCSR_PCK5                       PMC_SCSR_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK5_Msk instead */
+#define PMC_SCSR_PCK6_Pos                   14                                             /**< (PMC_SCSR) Programmable Clock 6 Output Status Position */
+#define PMC_SCSR_PCK6_Msk                   (_U_(0x1) << PMC_SCSR_PCK6_Pos)                /**< (PMC_SCSR) Programmable Clock 6 Output Status Mask */
+#define PMC_SCSR_PCK6                       PMC_SCSR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK6_Msk instead */
+#define PMC_SCSR_MASK                       _U_(0x7F21)                                    /**< \deprecated (PMC_SCSR) Register MASK  (Use PMC_SCSR_Msk instead)  */
+#define PMC_SCSR_Msk                        _U_(0x7F21)                                    /**< (PMC_SCSR) Register Mask  */
+
+#define PMC_SCSR_PCK_Pos                    8                                              /**< (PMC_SCSR Position) Programmable Clock 6 Output Status */
+#define PMC_SCSR_PCK_Msk                    (_U_(0x7F) << PMC_SCSR_PCK_Pos)                /**< (PMC_SCSR Mask) PCK */
+#define PMC_SCSR_PCK(value)                 (PMC_SCSR_PCK_Msk & ((value) << PMC_SCSR_PCK_Pos))  
+
+/* -------- PMC_PCER0 : (PMC Offset: 0x10) (/W 32) Peripheral Clock Enable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Enable                */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Enable                */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Enable                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Enable               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Enable               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Enable               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Enable               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Enable               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Enable               */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Enable               */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Enable               */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Enable               */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Enable               */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Enable               */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Enable               */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Enable               */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Enable               */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Enable               */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Enable               */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Enable               */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Enable               */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Enable               */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Enable               */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Enable               */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Enable               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Enable               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCER0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCER0_OFFSET                    (0x10)                                        /**<  (PMC_PCER0) Peripheral Clock Enable Register 0  Offset */
+
+#define PMC_PCER0_PID7_Pos                  7                                              /**< (PMC_PCER0) Peripheral Clock 7 Enable Position */
+#define PMC_PCER0_PID7_Msk                  (_U_(0x1) << PMC_PCER0_PID7_Pos)               /**< (PMC_PCER0) Peripheral Clock 7 Enable Mask */
+#define PMC_PCER0_PID7                      PMC_PCER0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID7_Msk instead */
+#define PMC_PCER0_PID8_Pos                  8                                              /**< (PMC_PCER0) Peripheral Clock 8 Enable Position */
+#define PMC_PCER0_PID8_Msk                  (_U_(0x1) << PMC_PCER0_PID8_Pos)               /**< (PMC_PCER0) Peripheral Clock 8 Enable Mask */
+#define PMC_PCER0_PID8                      PMC_PCER0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID8_Msk instead */
+#define PMC_PCER0_PID9_Pos                  9                                              /**< (PMC_PCER0) Peripheral Clock 9 Enable Position */
+#define PMC_PCER0_PID9_Msk                  (_U_(0x1) << PMC_PCER0_PID9_Pos)               /**< (PMC_PCER0) Peripheral Clock 9 Enable Mask */
+#define PMC_PCER0_PID9                      PMC_PCER0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID9_Msk instead */
+#define PMC_PCER0_PID10_Pos                 10                                             /**< (PMC_PCER0) Peripheral Clock 10 Enable Position */
+#define PMC_PCER0_PID10_Msk                 (_U_(0x1) << PMC_PCER0_PID10_Pos)              /**< (PMC_PCER0) Peripheral Clock 10 Enable Mask */
+#define PMC_PCER0_PID10                     PMC_PCER0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID10_Msk instead */
+#define PMC_PCER0_PID11_Pos                 11                                             /**< (PMC_PCER0) Peripheral Clock 11 Enable Position */
+#define PMC_PCER0_PID11_Msk                 (_U_(0x1) << PMC_PCER0_PID11_Pos)              /**< (PMC_PCER0) Peripheral Clock 11 Enable Mask */
+#define PMC_PCER0_PID11                     PMC_PCER0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID11_Msk instead */
+#define PMC_PCER0_PID12_Pos                 12                                             /**< (PMC_PCER0) Peripheral Clock 12 Enable Position */
+#define PMC_PCER0_PID12_Msk                 (_U_(0x1) << PMC_PCER0_PID12_Pos)              /**< (PMC_PCER0) Peripheral Clock 12 Enable Mask */
+#define PMC_PCER0_PID12                     PMC_PCER0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID12_Msk instead */
+#define PMC_PCER0_PID13_Pos                 13                                             /**< (PMC_PCER0) Peripheral Clock 13 Enable Position */
+#define PMC_PCER0_PID13_Msk                 (_U_(0x1) << PMC_PCER0_PID13_Pos)              /**< (PMC_PCER0) Peripheral Clock 13 Enable Mask */
+#define PMC_PCER0_PID13                     PMC_PCER0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID13_Msk instead */
+#define PMC_PCER0_PID14_Pos                 14                                             /**< (PMC_PCER0) Peripheral Clock 14 Enable Position */
+#define PMC_PCER0_PID14_Msk                 (_U_(0x1) << PMC_PCER0_PID14_Pos)              /**< (PMC_PCER0) Peripheral Clock 14 Enable Mask */
+#define PMC_PCER0_PID14                     PMC_PCER0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID14_Msk instead */
+#define PMC_PCER0_PID15_Pos                 15                                             /**< (PMC_PCER0) Peripheral Clock 15 Enable Position */
+#define PMC_PCER0_PID15_Msk                 (_U_(0x1) << PMC_PCER0_PID15_Pos)              /**< (PMC_PCER0) Peripheral Clock 15 Enable Mask */
+#define PMC_PCER0_PID15                     PMC_PCER0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID15_Msk instead */
+#define PMC_PCER0_PID16_Pos                 16                                             /**< (PMC_PCER0) Peripheral Clock 16 Enable Position */
+#define PMC_PCER0_PID16_Msk                 (_U_(0x1) << PMC_PCER0_PID16_Pos)              /**< (PMC_PCER0) Peripheral Clock 16 Enable Mask */
+#define PMC_PCER0_PID16                     PMC_PCER0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID16_Msk instead */
+#define PMC_PCER0_PID17_Pos                 17                                             /**< (PMC_PCER0) Peripheral Clock 17 Enable Position */
+#define PMC_PCER0_PID17_Msk                 (_U_(0x1) << PMC_PCER0_PID17_Pos)              /**< (PMC_PCER0) Peripheral Clock 17 Enable Mask */
+#define PMC_PCER0_PID17                     PMC_PCER0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID17_Msk instead */
+#define PMC_PCER0_PID18_Pos                 18                                             /**< (PMC_PCER0) Peripheral Clock 18 Enable Position */
+#define PMC_PCER0_PID18_Msk                 (_U_(0x1) << PMC_PCER0_PID18_Pos)              /**< (PMC_PCER0) Peripheral Clock 18 Enable Mask */
+#define PMC_PCER0_PID18                     PMC_PCER0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID18_Msk instead */
+#define PMC_PCER0_PID19_Pos                 19                                             /**< (PMC_PCER0) Peripheral Clock 19 Enable Position */
+#define PMC_PCER0_PID19_Msk                 (_U_(0x1) << PMC_PCER0_PID19_Pos)              /**< (PMC_PCER0) Peripheral Clock 19 Enable Mask */
+#define PMC_PCER0_PID19                     PMC_PCER0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID19_Msk instead */
+#define PMC_PCER0_PID20_Pos                 20                                             /**< (PMC_PCER0) Peripheral Clock 20 Enable Position */
+#define PMC_PCER0_PID20_Msk                 (_U_(0x1) << PMC_PCER0_PID20_Pos)              /**< (PMC_PCER0) Peripheral Clock 20 Enable Mask */
+#define PMC_PCER0_PID20                     PMC_PCER0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID20_Msk instead */
+#define PMC_PCER0_PID21_Pos                 21                                             /**< (PMC_PCER0) Peripheral Clock 21 Enable Position */
+#define PMC_PCER0_PID21_Msk                 (_U_(0x1) << PMC_PCER0_PID21_Pos)              /**< (PMC_PCER0) Peripheral Clock 21 Enable Mask */
+#define PMC_PCER0_PID21                     PMC_PCER0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID21_Msk instead */
+#define PMC_PCER0_PID22_Pos                 22                                             /**< (PMC_PCER0) Peripheral Clock 22 Enable Position */
+#define PMC_PCER0_PID22_Msk                 (_U_(0x1) << PMC_PCER0_PID22_Pos)              /**< (PMC_PCER0) Peripheral Clock 22 Enable Mask */
+#define PMC_PCER0_PID22                     PMC_PCER0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID22_Msk instead */
+#define PMC_PCER0_PID23_Pos                 23                                             /**< (PMC_PCER0) Peripheral Clock 23 Enable Position */
+#define PMC_PCER0_PID23_Msk                 (_U_(0x1) << PMC_PCER0_PID23_Pos)              /**< (PMC_PCER0) Peripheral Clock 23 Enable Mask */
+#define PMC_PCER0_PID23                     PMC_PCER0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID23_Msk instead */
+#define PMC_PCER0_PID24_Pos                 24                                             /**< (PMC_PCER0) Peripheral Clock 24 Enable Position */
+#define PMC_PCER0_PID24_Msk                 (_U_(0x1) << PMC_PCER0_PID24_Pos)              /**< (PMC_PCER0) Peripheral Clock 24 Enable Mask */
+#define PMC_PCER0_PID24                     PMC_PCER0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID24_Msk instead */
+#define PMC_PCER0_PID25_Pos                 25                                             /**< (PMC_PCER0) Peripheral Clock 25 Enable Position */
+#define PMC_PCER0_PID25_Msk                 (_U_(0x1) << PMC_PCER0_PID25_Pos)              /**< (PMC_PCER0) Peripheral Clock 25 Enable Mask */
+#define PMC_PCER0_PID25                     PMC_PCER0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID25_Msk instead */
+#define PMC_PCER0_PID26_Pos                 26                                             /**< (PMC_PCER0) Peripheral Clock 26 Enable Position */
+#define PMC_PCER0_PID26_Msk                 (_U_(0x1) << PMC_PCER0_PID26_Pos)              /**< (PMC_PCER0) Peripheral Clock 26 Enable Mask */
+#define PMC_PCER0_PID26                     PMC_PCER0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID26_Msk instead */
+#define PMC_PCER0_PID27_Pos                 27                                             /**< (PMC_PCER0) Peripheral Clock 27 Enable Position */
+#define PMC_PCER0_PID27_Msk                 (_U_(0x1) << PMC_PCER0_PID27_Pos)              /**< (PMC_PCER0) Peripheral Clock 27 Enable Mask */
+#define PMC_PCER0_PID27                     PMC_PCER0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID27_Msk instead */
+#define PMC_PCER0_PID28_Pos                 28                                             /**< (PMC_PCER0) Peripheral Clock 28 Enable Position */
+#define PMC_PCER0_PID28_Msk                 (_U_(0x1) << PMC_PCER0_PID28_Pos)              /**< (PMC_PCER0) Peripheral Clock 28 Enable Mask */
+#define PMC_PCER0_PID28                     PMC_PCER0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID28_Msk instead */
+#define PMC_PCER0_PID29_Pos                 29                                             /**< (PMC_PCER0) Peripheral Clock 29 Enable Position */
+#define PMC_PCER0_PID29_Msk                 (_U_(0x1) << PMC_PCER0_PID29_Pos)              /**< (PMC_PCER0) Peripheral Clock 29 Enable Mask */
+#define PMC_PCER0_PID29                     PMC_PCER0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID29_Msk instead */
+#define PMC_PCER0_PID30_Pos                 30                                             /**< (PMC_PCER0) Peripheral Clock 30 Enable Position */
+#define PMC_PCER0_PID30_Msk                 (_U_(0x1) << PMC_PCER0_PID30_Pos)              /**< (PMC_PCER0) Peripheral Clock 30 Enable Mask */
+#define PMC_PCER0_PID30                     PMC_PCER0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID30_Msk instead */
+#define PMC_PCER0_PID31_Pos                 31                                             /**< (PMC_PCER0) Peripheral Clock 31 Enable Position */
+#define PMC_PCER0_PID31_Msk                 (_U_(0x1) << PMC_PCER0_PID31_Pos)              /**< (PMC_PCER0) Peripheral Clock 31 Enable Mask */
+#define PMC_PCER0_PID31                     PMC_PCER0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID31_Msk instead */
+#define PMC_PCER0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
+#define PMC_PCER0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCER0) Register Mask  */
+
+#define PMC_PCER0_PID_Pos                   7                                              /**< (PMC_PCER0 Position) Peripheral Clock 3x Enable */
+#define PMC_PCER0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER0_PID_Pos)          /**< (PMC_PCER0 Mask) PID */
+#define PMC_PCER0_PID(value)                (PMC_PCER0_PID_Msk & ((value) << PMC_PCER0_PID_Pos))  
+
+/* -------- PMC_PCDR0 : (PMC Offset: 0x14) (/W 32) Peripheral Clock Disable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Disable               */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Disable               */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Disable               */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Disable              */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Disable              */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Disable              */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Disable              */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Disable              */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Disable              */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Disable              */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Disable              */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Disable              */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Disable              */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Disable              */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Disable              */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Disable              */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Disable              */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Disable              */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Disable              */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Disable              */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Disable              */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Disable              */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Disable              */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Disable              */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Disable              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Disable              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCDR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCDR0_OFFSET                    (0x14)                                        /**<  (PMC_PCDR0) Peripheral Clock Disable Register 0  Offset */
+
+#define PMC_PCDR0_PID7_Pos                  7                                              /**< (PMC_PCDR0) Peripheral Clock 7 Disable Position */
+#define PMC_PCDR0_PID7_Msk                  (_U_(0x1) << PMC_PCDR0_PID7_Pos)               /**< (PMC_PCDR0) Peripheral Clock 7 Disable Mask */
+#define PMC_PCDR0_PID7                      PMC_PCDR0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID7_Msk instead */
+#define PMC_PCDR0_PID8_Pos                  8                                              /**< (PMC_PCDR0) Peripheral Clock 8 Disable Position */
+#define PMC_PCDR0_PID8_Msk                  (_U_(0x1) << PMC_PCDR0_PID8_Pos)               /**< (PMC_PCDR0) Peripheral Clock 8 Disable Mask */
+#define PMC_PCDR0_PID8                      PMC_PCDR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID8_Msk instead */
+#define PMC_PCDR0_PID9_Pos                  9                                              /**< (PMC_PCDR0) Peripheral Clock 9 Disable Position */
+#define PMC_PCDR0_PID9_Msk                  (_U_(0x1) << PMC_PCDR0_PID9_Pos)               /**< (PMC_PCDR0) Peripheral Clock 9 Disable Mask */
+#define PMC_PCDR0_PID9                      PMC_PCDR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID9_Msk instead */
+#define PMC_PCDR0_PID10_Pos                 10                                             /**< (PMC_PCDR0) Peripheral Clock 10 Disable Position */
+#define PMC_PCDR0_PID10_Msk                 (_U_(0x1) << PMC_PCDR0_PID10_Pos)              /**< (PMC_PCDR0) Peripheral Clock 10 Disable Mask */
+#define PMC_PCDR0_PID10                     PMC_PCDR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID10_Msk instead */
+#define PMC_PCDR0_PID11_Pos                 11                                             /**< (PMC_PCDR0) Peripheral Clock 11 Disable Position */
+#define PMC_PCDR0_PID11_Msk                 (_U_(0x1) << PMC_PCDR0_PID11_Pos)              /**< (PMC_PCDR0) Peripheral Clock 11 Disable Mask */
+#define PMC_PCDR0_PID11                     PMC_PCDR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID11_Msk instead */
+#define PMC_PCDR0_PID12_Pos                 12                                             /**< (PMC_PCDR0) Peripheral Clock 12 Disable Position */
+#define PMC_PCDR0_PID12_Msk                 (_U_(0x1) << PMC_PCDR0_PID12_Pos)              /**< (PMC_PCDR0) Peripheral Clock 12 Disable Mask */
+#define PMC_PCDR0_PID12                     PMC_PCDR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID12_Msk instead */
+#define PMC_PCDR0_PID13_Pos                 13                                             /**< (PMC_PCDR0) Peripheral Clock 13 Disable Position */
+#define PMC_PCDR0_PID13_Msk                 (_U_(0x1) << PMC_PCDR0_PID13_Pos)              /**< (PMC_PCDR0) Peripheral Clock 13 Disable Mask */
+#define PMC_PCDR0_PID13                     PMC_PCDR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID13_Msk instead */
+#define PMC_PCDR0_PID14_Pos                 14                                             /**< (PMC_PCDR0) Peripheral Clock 14 Disable Position */
+#define PMC_PCDR0_PID14_Msk                 (_U_(0x1) << PMC_PCDR0_PID14_Pos)              /**< (PMC_PCDR0) Peripheral Clock 14 Disable Mask */
+#define PMC_PCDR0_PID14                     PMC_PCDR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID14_Msk instead */
+#define PMC_PCDR0_PID15_Pos                 15                                             /**< (PMC_PCDR0) Peripheral Clock 15 Disable Position */
+#define PMC_PCDR0_PID15_Msk                 (_U_(0x1) << PMC_PCDR0_PID15_Pos)              /**< (PMC_PCDR0) Peripheral Clock 15 Disable Mask */
+#define PMC_PCDR0_PID15                     PMC_PCDR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID15_Msk instead */
+#define PMC_PCDR0_PID16_Pos                 16                                             /**< (PMC_PCDR0) Peripheral Clock 16 Disable Position */
+#define PMC_PCDR0_PID16_Msk                 (_U_(0x1) << PMC_PCDR0_PID16_Pos)              /**< (PMC_PCDR0) Peripheral Clock 16 Disable Mask */
+#define PMC_PCDR0_PID16                     PMC_PCDR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID16_Msk instead */
+#define PMC_PCDR0_PID17_Pos                 17                                             /**< (PMC_PCDR0) Peripheral Clock 17 Disable Position */
+#define PMC_PCDR0_PID17_Msk                 (_U_(0x1) << PMC_PCDR0_PID17_Pos)              /**< (PMC_PCDR0) Peripheral Clock 17 Disable Mask */
+#define PMC_PCDR0_PID17                     PMC_PCDR0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID17_Msk instead */
+#define PMC_PCDR0_PID18_Pos                 18                                             /**< (PMC_PCDR0) Peripheral Clock 18 Disable Position */
+#define PMC_PCDR0_PID18_Msk                 (_U_(0x1) << PMC_PCDR0_PID18_Pos)              /**< (PMC_PCDR0) Peripheral Clock 18 Disable Mask */
+#define PMC_PCDR0_PID18                     PMC_PCDR0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID18_Msk instead */
+#define PMC_PCDR0_PID19_Pos                 19                                             /**< (PMC_PCDR0) Peripheral Clock 19 Disable Position */
+#define PMC_PCDR0_PID19_Msk                 (_U_(0x1) << PMC_PCDR0_PID19_Pos)              /**< (PMC_PCDR0) Peripheral Clock 19 Disable Mask */
+#define PMC_PCDR0_PID19                     PMC_PCDR0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID19_Msk instead */
+#define PMC_PCDR0_PID20_Pos                 20                                             /**< (PMC_PCDR0) Peripheral Clock 20 Disable Position */
+#define PMC_PCDR0_PID20_Msk                 (_U_(0x1) << PMC_PCDR0_PID20_Pos)              /**< (PMC_PCDR0) Peripheral Clock 20 Disable Mask */
+#define PMC_PCDR0_PID20                     PMC_PCDR0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID20_Msk instead */
+#define PMC_PCDR0_PID21_Pos                 21                                             /**< (PMC_PCDR0) Peripheral Clock 21 Disable Position */
+#define PMC_PCDR0_PID21_Msk                 (_U_(0x1) << PMC_PCDR0_PID21_Pos)              /**< (PMC_PCDR0) Peripheral Clock 21 Disable Mask */
+#define PMC_PCDR0_PID21                     PMC_PCDR0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID21_Msk instead */
+#define PMC_PCDR0_PID22_Pos                 22                                             /**< (PMC_PCDR0) Peripheral Clock 22 Disable Position */
+#define PMC_PCDR0_PID22_Msk                 (_U_(0x1) << PMC_PCDR0_PID22_Pos)              /**< (PMC_PCDR0) Peripheral Clock 22 Disable Mask */
+#define PMC_PCDR0_PID22                     PMC_PCDR0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID22_Msk instead */
+#define PMC_PCDR0_PID23_Pos                 23                                             /**< (PMC_PCDR0) Peripheral Clock 23 Disable Position */
+#define PMC_PCDR0_PID23_Msk                 (_U_(0x1) << PMC_PCDR0_PID23_Pos)              /**< (PMC_PCDR0) Peripheral Clock 23 Disable Mask */
+#define PMC_PCDR0_PID23                     PMC_PCDR0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID23_Msk instead */
+#define PMC_PCDR0_PID24_Pos                 24                                             /**< (PMC_PCDR0) Peripheral Clock 24 Disable Position */
+#define PMC_PCDR0_PID24_Msk                 (_U_(0x1) << PMC_PCDR0_PID24_Pos)              /**< (PMC_PCDR0) Peripheral Clock 24 Disable Mask */
+#define PMC_PCDR0_PID24                     PMC_PCDR0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID24_Msk instead */
+#define PMC_PCDR0_PID25_Pos                 25                                             /**< (PMC_PCDR0) Peripheral Clock 25 Disable Position */
+#define PMC_PCDR0_PID25_Msk                 (_U_(0x1) << PMC_PCDR0_PID25_Pos)              /**< (PMC_PCDR0) Peripheral Clock 25 Disable Mask */
+#define PMC_PCDR0_PID25                     PMC_PCDR0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID25_Msk instead */
+#define PMC_PCDR0_PID26_Pos                 26                                             /**< (PMC_PCDR0) Peripheral Clock 26 Disable Position */
+#define PMC_PCDR0_PID26_Msk                 (_U_(0x1) << PMC_PCDR0_PID26_Pos)              /**< (PMC_PCDR0) Peripheral Clock 26 Disable Mask */
+#define PMC_PCDR0_PID26                     PMC_PCDR0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID26_Msk instead */
+#define PMC_PCDR0_PID27_Pos                 27                                             /**< (PMC_PCDR0) Peripheral Clock 27 Disable Position */
+#define PMC_PCDR0_PID27_Msk                 (_U_(0x1) << PMC_PCDR0_PID27_Pos)              /**< (PMC_PCDR0) Peripheral Clock 27 Disable Mask */
+#define PMC_PCDR0_PID27                     PMC_PCDR0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID27_Msk instead */
+#define PMC_PCDR0_PID28_Pos                 28                                             /**< (PMC_PCDR0) Peripheral Clock 28 Disable Position */
+#define PMC_PCDR0_PID28_Msk                 (_U_(0x1) << PMC_PCDR0_PID28_Pos)              /**< (PMC_PCDR0) Peripheral Clock 28 Disable Mask */
+#define PMC_PCDR0_PID28                     PMC_PCDR0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID28_Msk instead */
+#define PMC_PCDR0_PID29_Pos                 29                                             /**< (PMC_PCDR0) Peripheral Clock 29 Disable Position */
+#define PMC_PCDR0_PID29_Msk                 (_U_(0x1) << PMC_PCDR0_PID29_Pos)              /**< (PMC_PCDR0) Peripheral Clock 29 Disable Mask */
+#define PMC_PCDR0_PID29                     PMC_PCDR0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID29_Msk instead */
+#define PMC_PCDR0_PID30_Pos                 30                                             /**< (PMC_PCDR0) Peripheral Clock 30 Disable Position */
+#define PMC_PCDR0_PID30_Msk                 (_U_(0x1) << PMC_PCDR0_PID30_Pos)              /**< (PMC_PCDR0) Peripheral Clock 30 Disable Mask */
+#define PMC_PCDR0_PID30                     PMC_PCDR0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID30_Msk instead */
+#define PMC_PCDR0_PID31_Pos                 31                                             /**< (PMC_PCDR0) Peripheral Clock 31 Disable Position */
+#define PMC_PCDR0_PID31_Msk                 (_U_(0x1) << PMC_PCDR0_PID31_Pos)              /**< (PMC_PCDR0) Peripheral Clock 31 Disable Mask */
+#define PMC_PCDR0_PID31                     PMC_PCDR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID31_Msk instead */
+#define PMC_PCDR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
+#define PMC_PCDR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCDR0) Register Mask  */
+
+#define PMC_PCDR0_PID_Pos                   7                                              /**< (PMC_PCDR0 Position) Peripheral Clock 3x Disable */
+#define PMC_PCDR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR0_PID_Pos)          /**< (PMC_PCDR0 Mask) PID */
+#define PMC_PCDR0_PID(value)                (PMC_PCDR0_PID_Msk & ((value) << PMC_PCDR0_PID_Pos))  
+
+/* -------- PMC_PCSR0 : (PMC Offset: 0x18) (R/ 32) Peripheral Clock Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Status                */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Status                */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Status                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Status               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Status               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Status               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Status               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Status               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Status               */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Status               */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Status               */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Status               */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Status               */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Status               */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Status               */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Status               */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Status               */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Status               */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Status               */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Status               */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Status               */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Status               */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Status               */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Status               */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Status               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Status               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCSR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCSR0_OFFSET                    (0x18)                                        /**<  (PMC_PCSR0) Peripheral Clock Status Register 0  Offset */
+
+#define PMC_PCSR0_PID7_Pos                  7                                              /**< (PMC_PCSR0) Peripheral Clock 7 Status Position */
+#define PMC_PCSR0_PID7_Msk                  (_U_(0x1) << PMC_PCSR0_PID7_Pos)               /**< (PMC_PCSR0) Peripheral Clock 7 Status Mask */
+#define PMC_PCSR0_PID7                      PMC_PCSR0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID7_Msk instead */
+#define PMC_PCSR0_PID8_Pos                  8                                              /**< (PMC_PCSR0) Peripheral Clock 8 Status Position */
+#define PMC_PCSR0_PID8_Msk                  (_U_(0x1) << PMC_PCSR0_PID8_Pos)               /**< (PMC_PCSR0) Peripheral Clock 8 Status Mask */
+#define PMC_PCSR0_PID8                      PMC_PCSR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID8_Msk instead */
+#define PMC_PCSR0_PID9_Pos                  9                                              /**< (PMC_PCSR0) Peripheral Clock 9 Status Position */
+#define PMC_PCSR0_PID9_Msk                  (_U_(0x1) << PMC_PCSR0_PID9_Pos)               /**< (PMC_PCSR0) Peripheral Clock 9 Status Mask */
+#define PMC_PCSR0_PID9                      PMC_PCSR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID9_Msk instead */
+#define PMC_PCSR0_PID10_Pos                 10                                             /**< (PMC_PCSR0) Peripheral Clock 10 Status Position */
+#define PMC_PCSR0_PID10_Msk                 (_U_(0x1) << PMC_PCSR0_PID10_Pos)              /**< (PMC_PCSR0) Peripheral Clock 10 Status Mask */
+#define PMC_PCSR0_PID10                     PMC_PCSR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID10_Msk instead */
+#define PMC_PCSR0_PID11_Pos                 11                                             /**< (PMC_PCSR0) Peripheral Clock 11 Status Position */
+#define PMC_PCSR0_PID11_Msk                 (_U_(0x1) << PMC_PCSR0_PID11_Pos)              /**< (PMC_PCSR0) Peripheral Clock 11 Status Mask */
+#define PMC_PCSR0_PID11                     PMC_PCSR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID11_Msk instead */
+#define PMC_PCSR0_PID12_Pos                 12                                             /**< (PMC_PCSR0) Peripheral Clock 12 Status Position */
+#define PMC_PCSR0_PID12_Msk                 (_U_(0x1) << PMC_PCSR0_PID12_Pos)              /**< (PMC_PCSR0) Peripheral Clock 12 Status Mask */
+#define PMC_PCSR0_PID12                     PMC_PCSR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID12_Msk instead */
+#define PMC_PCSR0_PID13_Pos                 13                                             /**< (PMC_PCSR0) Peripheral Clock 13 Status Position */
+#define PMC_PCSR0_PID13_Msk                 (_U_(0x1) << PMC_PCSR0_PID13_Pos)              /**< (PMC_PCSR0) Peripheral Clock 13 Status Mask */
+#define PMC_PCSR0_PID13                     PMC_PCSR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID13_Msk instead */
+#define PMC_PCSR0_PID14_Pos                 14                                             /**< (PMC_PCSR0) Peripheral Clock 14 Status Position */
+#define PMC_PCSR0_PID14_Msk                 (_U_(0x1) << PMC_PCSR0_PID14_Pos)              /**< (PMC_PCSR0) Peripheral Clock 14 Status Mask */
+#define PMC_PCSR0_PID14                     PMC_PCSR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID14_Msk instead */
+#define PMC_PCSR0_PID15_Pos                 15                                             /**< (PMC_PCSR0) Peripheral Clock 15 Status Position */
+#define PMC_PCSR0_PID15_Msk                 (_U_(0x1) << PMC_PCSR0_PID15_Pos)              /**< (PMC_PCSR0) Peripheral Clock 15 Status Mask */
+#define PMC_PCSR0_PID15                     PMC_PCSR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID15_Msk instead */
+#define PMC_PCSR0_PID16_Pos                 16                                             /**< (PMC_PCSR0) Peripheral Clock 16 Status Position */
+#define PMC_PCSR0_PID16_Msk                 (_U_(0x1) << PMC_PCSR0_PID16_Pos)              /**< (PMC_PCSR0) Peripheral Clock 16 Status Mask */
+#define PMC_PCSR0_PID16                     PMC_PCSR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID16_Msk instead */
+#define PMC_PCSR0_PID17_Pos                 17                                             /**< (PMC_PCSR0) Peripheral Clock 17 Status Position */
+#define PMC_PCSR0_PID17_Msk                 (_U_(0x1) << PMC_PCSR0_PID17_Pos)              /**< (PMC_PCSR0) Peripheral Clock 17 Status Mask */
+#define PMC_PCSR0_PID17                     PMC_PCSR0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID17_Msk instead */
+#define PMC_PCSR0_PID18_Pos                 18                                             /**< (PMC_PCSR0) Peripheral Clock 18 Status Position */
+#define PMC_PCSR0_PID18_Msk                 (_U_(0x1) << PMC_PCSR0_PID18_Pos)              /**< (PMC_PCSR0) Peripheral Clock 18 Status Mask */
+#define PMC_PCSR0_PID18                     PMC_PCSR0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID18_Msk instead */
+#define PMC_PCSR0_PID19_Pos                 19                                             /**< (PMC_PCSR0) Peripheral Clock 19 Status Position */
+#define PMC_PCSR0_PID19_Msk                 (_U_(0x1) << PMC_PCSR0_PID19_Pos)              /**< (PMC_PCSR0) Peripheral Clock 19 Status Mask */
+#define PMC_PCSR0_PID19                     PMC_PCSR0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID19_Msk instead */
+#define PMC_PCSR0_PID20_Pos                 20                                             /**< (PMC_PCSR0) Peripheral Clock 20 Status Position */
+#define PMC_PCSR0_PID20_Msk                 (_U_(0x1) << PMC_PCSR0_PID20_Pos)              /**< (PMC_PCSR0) Peripheral Clock 20 Status Mask */
+#define PMC_PCSR0_PID20                     PMC_PCSR0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID20_Msk instead */
+#define PMC_PCSR0_PID21_Pos                 21                                             /**< (PMC_PCSR0) Peripheral Clock 21 Status Position */
+#define PMC_PCSR0_PID21_Msk                 (_U_(0x1) << PMC_PCSR0_PID21_Pos)              /**< (PMC_PCSR0) Peripheral Clock 21 Status Mask */
+#define PMC_PCSR0_PID21                     PMC_PCSR0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID21_Msk instead */
+#define PMC_PCSR0_PID22_Pos                 22                                             /**< (PMC_PCSR0) Peripheral Clock 22 Status Position */
+#define PMC_PCSR0_PID22_Msk                 (_U_(0x1) << PMC_PCSR0_PID22_Pos)              /**< (PMC_PCSR0) Peripheral Clock 22 Status Mask */
+#define PMC_PCSR0_PID22                     PMC_PCSR0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID22_Msk instead */
+#define PMC_PCSR0_PID23_Pos                 23                                             /**< (PMC_PCSR0) Peripheral Clock 23 Status Position */
+#define PMC_PCSR0_PID23_Msk                 (_U_(0x1) << PMC_PCSR0_PID23_Pos)              /**< (PMC_PCSR0) Peripheral Clock 23 Status Mask */
+#define PMC_PCSR0_PID23                     PMC_PCSR0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID23_Msk instead */
+#define PMC_PCSR0_PID24_Pos                 24                                             /**< (PMC_PCSR0) Peripheral Clock 24 Status Position */
+#define PMC_PCSR0_PID24_Msk                 (_U_(0x1) << PMC_PCSR0_PID24_Pos)              /**< (PMC_PCSR0) Peripheral Clock 24 Status Mask */
+#define PMC_PCSR0_PID24                     PMC_PCSR0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID24_Msk instead */
+#define PMC_PCSR0_PID25_Pos                 25                                             /**< (PMC_PCSR0) Peripheral Clock 25 Status Position */
+#define PMC_PCSR0_PID25_Msk                 (_U_(0x1) << PMC_PCSR0_PID25_Pos)              /**< (PMC_PCSR0) Peripheral Clock 25 Status Mask */
+#define PMC_PCSR0_PID25                     PMC_PCSR0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID25_Msk instead */
+#define PMC_PCSR0_PID26_Pos                 26                                             /**< (PMC_PCSR0) Peripheral Clock 26 Status Position */
+#define PMC_PCSR0_PID26_Msk                 (_U_(0x1) << PMC_PCSR0_PID26_Pos)              /**< (PMC_PCSR0) Peripheral Clock 26 Status Mask */
+#define PMC_PCSR0_PID26                     PMC_PCSR0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID26_Msk instead */
+#define PMC_PCSR0_PID27_Pos                 27                                             /**< (PMC_PCSR0) Peripheral Clock 27 Status Position */
+#define PMC_PCSR0_PID27_Msk                 (_U_(0x1) << PMC_PCSR0_PID27_Pos)              /**< (PMC_PCSR0) Peripheral Clock 27 Status Mask */
+#define PMC_PCSR0_PID27                     PMC_PCSR0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID27_Msk instead */
+#define PMC_PCSR0_PID28_Pos                 28                                             /**< (PMC_PCSR0) Peripheral Clock 28 Status Position */
+#define PMC_PCSR0_PID28_Msk                 (_U_(0x1) << PMC_PCSR0_PID28_Pos)              /**< (PMC_PCSR0) Peripheral Clock 28 Status Mask */
+#define PMC_PCSR0_PID28                     PMC_PCSR0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID28_Msk instead */
+#define PMC_PCSR0_PID29_Pos                 29                                             /**< (PMC_PCSR0) Peripheral Clock 29 Status Position */
+#define PMC_PCSR0_PID29_Msk                 (_U_(0x1) << PMC_PCSR0_PID29_Pos)              /**< (PMC_PCSR0) Peripheral Clock 29 Status Mask */
+#define PMC_PCSR0_PID29                     PMC_PCSR0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID29_Msk instead */
+#define PMC_PCSR0_PID30_Pos                 30                                             /**< (PMC_PCSR0) Peripheral Clock 30 Status Position */
+#define PMC_PCSR0_PID30_Msk                 (_U_(0x1) << PMC_PCSR0_PID30_Pos)              /**< (PMC_PCSR0) Peripheral Clock 30 Status Mask */
+#define PMC_PCSR0_PID30                     PMC_PCSR0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID30_Msk instead */
+#define PMC_PCSR0_PID31_Pos                 31                                             /**< (PMC_PCSR0) Peripheral Clock 31 Status Position */
+#define PMC_PCSR0_PID31_Msk                 (_U_(0x1) << PMC_PCSR0_PID31_Pos)              /**< (PMC_PCSR0) Peripheral Clock 31 Status Mask */
+#define PMC_PCSR0_PID31                     PMC_PCSR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID31_Msk instead */
+#define PMC_PCSR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
+#define PMC_PCSR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCSR0) Register Mask  */
+
+#define PMC_PCSR0_PID_Pos                   7                                              /**< (PMC_PCSR0 Position) Peripheral Clock 3x Status */
+#define PMC_PCSR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR0_PID_Pos)          /**< (PMC_PCSR0 Mask) PID */
+#define PMC_PCSR0_PID(value)                (PMC_PCSR0_PID_Msk & ((value) << PMC_PCSR0_PID_Pos))  
+
+/* -------- CKGR_UCKR : (PMC Offset: 0x1c) (R/W 32) UTMI Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t UPLLEN:1;                  /**< bit:     16  UTMI PLL Enable                          */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t UPLLCOUNT:4;               /**< bit: 20..23  UTMI PLL Startup Time                    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_UCKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_UCKR_OFFSET                    (0x1C)                                        /**<  (CKGR_UCKR) UTMI Clock Register  Offset */
+
+#define CKGR_UCKR_UPLLEN_Pos                16                                             /**< (CKGR_UCKR) UTMI PLL Enable Position */
+#define CKGR_UCKR_UPLLEN_Msk                (_U_(0x1) << CKGR_UCKR_UPLLEN_Pos)             /**< (CKGR_UCKR) UTMI PLL Enable Mask */
+#define CKGR_UCKR_UPLLEN                    CKGR_UCKR_UPLLEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_UCKR_UPLLEN_Msk instead */
+#define CKGR_UCKR_UPLLCOUNT_Pos             20                                             /**< (CKGR_UCKR) UTMI PLL Startup Time Position */
+#define CKGR_UCKR_UPLLCOUNT_Msk             (_U_(0xF) << CKGR_UCKR_UPLLCOUNT_Pos)          /**< (CKGR_UCKR) UTMI PLL Startup Time Mask */
+#define CKGR_UCKR_UPLLCOUNT(value)          (CKGR_UCKR_UPLLCOUNT_Msk & ((value) << CKGR_UCKR_UPLLCOUNT_Pos))
+#define CKGR_UCKR_MASK                      _U_(0xF10000)                                  /**< \deprecated (CKGR_UCKR) Register MASK  (Use CKGR_UCKR_Msk instead)  */
+#define CKGR_UCKR_Msk                       _U_(0xF10000)                                  /**< (CKGR_UCKR) Register Mask  */
+
+
+/* -------- CKGR_MOR : (PMC Offset: 0x20) (R/W 32) Main Oscillator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTEN:1;                /**< bit:      0  Main Crystal Oscillator Enable           */
+    uint32_t MOSCXTBY:1;                /**< bit:      1  Main Crystal Oscillator Bypass           */
+    uint32_t WAITMODE:1;                /**< bit:      2  Wait Mode Command (Write-only)           */
+    uint32_t MOSCRCEN:1;                /**< bit:      3  Main RC Oscillator Enable                */
+    uint32_t MOSCRCF:3;                 /**< bit:   4..6  Main RC Oscillator Frequency Selection   */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MOSCXTST:8;                /**< bit:  8..15  Main Crystal Oscillator Startup Time     */
+    uint32_t KEY:8;                     /**< bit: 16..23  Write Access Password                    */
+    uint32_t MOSCSEL:1;                 /**< bit:     24  Main Clock Oscillator Selection          */
+    uint32_t CFDEN:1;                   /**< bit:     25  Clock Failure Detector Enable            */
+    uint32_t XT32KFME:1;                /**< bit:     26  32.768 kHz Crystal Oscillator Frequency Monitoring Enable */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_MOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_MOR_OFFSET                     (0x20)                                        /**<  (CKGR_MOR) Main Oscillator Register  Offset */
+
+#define CKGR_MOR_MOSCXTEN_Pos               0                                              /**< (CKGR_MOR) Main Crystal Oscillator Enable Position */
+#define CKGR_MOR_MOSCXTEN_Msk               (_U_(0x1) << CKGR_MOR_MOSCXTEN_Pos)            /**< (CKGR_MOR) Main Crystal Oscillator Enable Mask */
+#define CKGR_MOR_MOSCXTEN                   CKGR_MOR_MOSCXTEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCXTEN_Msk instead */
+#define CKGR_MOR_MOSCXTBY_Pos               1                                              /**< (CKGR_MOR) Main Crystal Oscillator Bypass Position */
+#define CKGR_MOR_MOSCXTBY_Msk               (_U_(0x1) << CKGR_MOR_MOSCXTBY_Pos)            /**< (CKGR_MOR) Main Crystal Oscillator Bypass Mask */
+#define CKGR_MOR_MOSCXTBY                   CKGR_MOR_MOSCXTBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCXTBY_Msk instead */
+#define CKGR_MOR_WAITMODE_Pos               2                                              /**< (CKGR_MOR) Wait Mode Command (Write-only) Position */
+#define CKGR_MOR_WAITMODE_Msk               (_U_(0x1) << CKGR_MOR_WAITMODE_Pos)            /**< (CKGR_MOR) Wait Mode Command (Write-only) Mask */
+#define CKGR_MOR_WAITMODE                   CKGR_MOR_WAITMODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_WAITMODE_Msk instead */
+#define CKGR_MOR_MOSCRCEN_Pos               3                                              /**< (CKGR_MOR) Main RC Oscillator Enable Position */
+#define CKGR_MOR_MOSCRCEN_Msk               (_U_(0x1) << CKGR_MOR_MOSCRCEN_Pos)            /**< (CKGR_MOR) Main RC Oscillator Enable Mask */
+#define CKGR_MOR_MOSCRCEN                   CKGR_MOR_MOSCRCEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCRCEN_Msk instead */
+#define CKGR_MOR_MOSCRCF_Pos                4                                              /**< (CKGR_MOR) Main RC Oscillator Frequency Selection Position */
+#define CKGR_MOR_MOSCRCF_Msk                (_U_(0x7) << CKGR_MOR_MOSCRCF_Pos)             /**< (CKGR_MOR) Main RC Oscillator Frequency Selection Mask */
+#define CKGR_MOR_MOSCRCF(value)             (CKGR_MOR_MOSCRCF_Msk & ((value) << CKGR_MOR_MOSCRCF_Pos))
+#define   CKGR_MOR_MOSCRCF_4_MHz_Val        _U_(0x0)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 4 MHz  */
+#define   CKGR_MOR_MOSCRCF_8_MHz_Val        _U_(0x1)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 8 MHz  */
+#define   CKGR_MOR_MOSCRCF_12_MHz_Val       _U_(0x2)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 12 MHz  */
+#define CKGR_MOR_MOSCRCF_4_MHz              (CKGR_MOR_MOSCRCF_4_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 4 MHz Position  */
+#define CKGR_MOR_MOSCRCF_8_MHz              (CKGR_MOR_MOSCRCF_8_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 8 MHz Position  */
+#define CKGR_MOR_MOSCRCF_12_MHz             (CKGR_MOR_MOSCRCF_12_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 12 MHz Position  */
+#define CKGR_MOR_MOSCXTST_Pos               8                                              /**< (CKGR_MOR) Main Crystal Oscillator Startup Time Position */
+#define CKGR_MOR_MOSCXTST_Msk               (_U_(0xFF) << CKGR_MOR_MOSCXTST_Pos)           /**< (CKGR_MOR) Main Crystal Oscillator Startup Time Mask */
+#define CKGR_MOR_MOSCXTST(value)            (CKGR_MOR_MOSCXTST_Msk & ((value) << CKGR_MOR_MOSCXTST_Pos))
+#define CKGR_MOR_KEY_Pos                    16                                             /**< (CKGR_MOR) Write Access Password Position */
+#define CKGR_MOR_KEY_Msk                    (_U_(0xFF) << CKGR_MOR_KEY_Pos)                /**< (CKGR_MOR) Write Access Password Mask */
+#define CKGR_MOR_KEY(value)                 (CKGR_MOR_KEY_Msk & ((value) << CKGR_MOR_KEY_Pos))
+#define   CKGR_MOR_KEY_PASSWD_Val           _U_(0x37)                                      /**< (CKGR_MOR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define CKGR_MOR_KEY_PASSWD                 (CKGR_MOR_KEY_PASSWD_Val << CKGR_MOR_KEY_Pos)  /**< (CKGR_MOR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define CKGR_MOR_MOSCSEL_Pos                24                                             /**< (CKGR_MOR) Main Clock Oscillator Selection Position */
+#define CKGR_MOR_MOSCSEL_Msk                (_U_(0x1) << CKGR_MOR_MOSCSEL_Pos)             /**< (CKGR_MOR) Main Clock Oscillator Selection Mask */
+#define CKGR_MOR_MOSCSEL                    CKGR_MOR_MOSCSEL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCSEL_Msk instead */
+#define CKGR_MOR_CFDEN_Pos                  25                                             /**< (CKGR_MOR) Clock Failure Detector Enable Position */
+#define CKGR_MOR_CFDEN_Msk                  (_U_(0x1) << CKGR_MOR_CFDEN_Pos)               /**< (CKGR_MOR) Clock Failure Detector Enable Mask */
+#define CKGR_MOR_CFDEN                      CKGR_MOR_CFDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_CFDEN_Msk instead */
+#define CKGR_MOR_XT32KFME_Pos               26                                             /**< (CKGR_MOR) 32.768 kHz Crystal Oscillator Frequency Monitoring Enable Position */
+#define CKGR_MOR_XT32KFME_Msk               (_U_(0x1) << CKGR_MOR_XT32KFME_Pos)            /**< (CKGR_MOR) 32.768 kHz Crystal Oscillator Frequency Monitoring Enable Mask */
+#define CKGR_MOR_XT32KFME                   CKGR_MOR_XT32KFME_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_XT32KFME_Msk instead */
+#define CKGR_MOR_MASK                       _U_(0x7FFFF7F)                                 /**< \deprecated (CKGR_MOR) Register MASK  (Use CKGR_MOR_Msk instead)  */
+#define CKGR_MOR_Msk                        _U_(0x7FFFF7F)                                 /**< (CKGR_MOR) Register Mask  */
+
+
+/* -------- CKGR_MCFR : (PMC Offset: 0x24) (R/W 32) Main Clock Frequency Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAINF:16;                  /**< bit:  0..15  Main Clock Frequency                     */
+    uint32_t MAINFRDY:1;                /**< bit:     16  Main Clock Frequency Measure Ready       */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t RCMEAS:1;                  /**< bit:     20  RC Oscillator Frequency Measure (write-only) */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t CCSS:1;                    /**< bit:     24  Counter Clock Source Selection           */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_MCFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_MCFR_OFFSET                    (0x24)                                        /**<  (CKGR_MCFR) Main Clock Frequency Register  Offset */
+
+#define CKGR_MCFR_MAINF_Pos                 0                                              /**< (CKGR_MCFR) Main Clock Frequency Position */
+#define CKGR_MCFR_MAINF_Msk                 (_U_(0xFFFF) << CKGR_MCFR_MAINF_Pos)           /**< (CKGR_MCFR) Main Clock Frequency Mask */
+#define CKGR_MCFR_MAINF(value)              (CKGR_MCFR_MAINF_Msk & ((value) << CKGR_MCFR_MAINF_Pos))
+#define CKGR_MCFR_MAINFRDY_Pos              16                                             /**< (CKGR_MCFR) Main Clock Frequency Measure Ready Position */
+#define CKGR_MCFR_MAINFRDY_Msk              (_U_(0x1) << CKGR_MCFR_MAINFRDY_Pos)           /**< (CKGR_MCFR) Main Clock Frequency Measure Ready Mask */
+#define CKGR_MCFR_MAINFRDY                  CKGR_MCFR_MAINFRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_MAINFRDY_Msk instead */
+#define CKGR_MCFR_RCMEAS_Pos                20                                             /**< (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) Position */
+#define CKGR_MCFR_RCMEAS_Msk                (_U_(0x1) << CKGR_MCFR_RCMEAS_Pos)             /**< (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) Mask */
+#define CKGR_MCFR_RCMEAS                    CKGR_MCFR_RCMEAS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_RCMEAS_Msk instead */
+#define CKGR_MCFR_CCSS_Pos                  24                                             /**< (CKGR_MCFR) Counter Clock Source Selection Position */
+#define CKGR_MCFR_CCSS_Msk                  (_U_(0x1) << CKGR_MCFR_CCSS_Pos)               /**< (CKGR_MCFR) Counter Clock Source Selection Mask */
+#define CKGR_MCFR_CCSS                      CKGR_MCFR_CCSS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_CCSS_Msk instead */
+#define CKGR_MCFR_MASK                      _U_(0x111FFFF)                                 /**< \deprecated (CKGR_MCFR) Register MASK  (Use CKGR_MCFR_Msk instead)  */
+#define CKGR_MCFR_Msk                       _U_(0x111FFFF)                                 /**< (CKGR_MCFR) Register Mask  */
+
+
+/* -------- CKGR_PLLAR : (PMC Offset: 0x28) (R/W 32) PLLA Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIVA:8;                    /**< bit:   0..7  PLLA Front End Divider                   */
+    uint32_t PLLACOUNT:6;               /**< bit:  8..13  PLLA Counter                             */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t MULA:11;                   /**< bit: 16..26  PLLA Multiplier                          */
+    uint32_t :2;                        /**< bit: 27..28  Reserved */
+    uint32_t ONE:1;                     /**< bit:     29  Must Be Set to 1                         */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_PLLAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_PLLAR_OFFSET                   (0x28)                                        /**<  (CKGR_PLLAR) PLLA Register  Offset */
+
+#define CKGR_PLLAR_DIVA_Pos                 0                                              /**< (CKGR_PLLAR) PLLA Front End Divider Position */
+#define CKGR_PLLAR_DIVA_Msk                 (_U_(0xFF) << CKGR_PLLAR_DIVA_Pos)             /**< (CKGR_PLLAR) PLLA Front End Divider Mask */
+#define CKGR_PLLAR_DIVA(value)              (CKGR_PLLAR_DIVA_Msk & ((value) << CKGR_PLLAR_DIVA_Pos))
+#define   CKGR_PLLAR_DIVA_0_Val             _U_(0x0)                                       /**< (CKGR_PLLAR) Divider output is 0 and PLLA is disabled.  */
+#define   CKGR_PLLAR_DIVA_BYPASS_Val        _U_(0x1)                                       /**< (CKGR_PLLAR) Divider is bypassed (divide by 1) and PLLA is enabled.  */
+#define CKGR_PLLAR_DIVA_0                   (CKGR_PLLAR_DIVA_0_Val << CKGR_PLLAR_DIVA_Pos)  /**< (CKGR_PLLAR) Divider output is 0 and PLLA is disabled. Position  */
+#define CKGR_PLLAR_DIVA_BYPASS              (CKGR_PLLAR_DIVA_BYPASS_Val << CKGR_PLLAR_DIVA_Pos)  /**< (CKGR_PLLAR) Divider is bypassed (divide by 1) and PLLA is enabled. Position  */
+#define CKGR_PLLAR_PLLACOUNT_Pos            8                                              /**< (CKGR_PLLAR) PLLA Counter Position */
+#define CKGR_PLLAR_PLLACOUNT_Msk            (_U_(0x3F) << CKGR_PLLAR_PLLACOUNT_Pos)        /**< (CKGR_PLLAR) PLLA Counter Mask */
+#define CKGR_PLLAR_PLLACOUNT(value)         (CKGR_PLLAR_PLLACOUNT_Msk & ((value) << CKGR_PLLAR_PLLACOUNT_Pos))
+#define CKGR_PLLAR_MULA_Pos                 16                                             /**< (CKGR_PLLAR) PLLA Multiplier Position */
+#define CKGR_PLLAR_MULA_Msk                 (_U_(0x7FF) << CKGR_PLLAR_MULA_Pos)            /**< (CKGR_PLLAR) PLLA Multiplier Mask */
+#define CKGR_PLLAR_MULA(value)              (CKGR_PLLAR_MULA_Msk & ((value) << CKGR_PLLAR_MULA_Pos))
+#define CKGR_PLLAR_ONE_Pos                  29                                             /**< (CKGR_PLLAR) Must Be Set to 1 Position */
+#define CKGR_PLLAR_ONE_Msk                  (_U_(0x1) << CKGR_PLLAR_ONE_Pos)               /**< (CKGR_PLLAR) Must Be Set to 1 Mask */
+#define CKGR_PLLAR_ONE                      CKGR_PLLAR_ONE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_PLLAR_ONE_Msk instead */
+#define CKGR_PLLAR_MASK                     _U_(0x27FF3FFF)                                /**< \deprecated (CKGR_PLLAR) Register MASK  (Use CKGR_PLLAR_Msk instead)  */
+#define CKGR_PLLAR_Msk                      _U_(0x27FF3FFF)                                /**< (CKGR_PLLAR) Register Mask  */
+
+
+/* -------- PMC_MCKR : (PMC Offset: 0x30) (R/W 32) Master Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSS:2;                     /**< bit:   0..1  Master Clock Source Selection            */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t PRES:3;                    /**< bit:   4..6  Processor Clock Prescaler                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDIV:2;                    /**< bit:   8..9  Master Clock Division                    */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t UPLLDIV2:1;                /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t UPLLDIV:1;                 /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_MCKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_MCKR_OFFSET                     (0x30)                                        /**<  (PMC_MCKR) Master Clock Register  Offset */
+
+#define PMC_MCKR_CSS_Pos                    0                                              /**< (PMC_MCKR) Master Clock Source Selection Position */
+#define PMC_MCKR_CSS_Msk                    (_U_(0x3) << PMC_MCKR_CSS_Pos)                 /**< (PMC_MCKR) Master Clock Source Selection Mask */
+#define PMC_MCKR_CSS(value)                 (PMC_MCKR_CSS_Msk & ((value) << PMC_MCKR_CSS_Pos))
+#define   PMC_MCKR_CSS_SLOW_CLK_Val         _U_(0x0)                                       /**< (PMC_MCKR) SLCK is selected  */
+#define   PMC_MCKR_CSS_MAIN_CLK_Val         _U_(0x1)                                       /**< (PMC_MCKR) MAINCK is selected  */
+#define   PMC_MCKR_CSS_PLLA_CLK_Val         _U_(0x2)                                       /**< (PMC_MCKR) PLLACK is selected  */
+#define   PMC_MCKR_CSS_UPLL_CLK_Val         _U_(0x3)                                       /**< (PMC_MCKR) UPPLLCKDIV is selected  */
+#define PMC_MCKR_CSS_SLOW_CLK               (PMC_MCKR_CSS_SLOW_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) SLCK is selected Position  */
+#define PMC_MCKR_CSS_MAIN_CLK               (PMC_MCKR_CSS_MAIN_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) MAINCK is selected Position  */
+#define PMC_MCKR_CSS_PLLA_CLK               (PMC_MCKR_CSS_PLLA_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) PLLACK is selected Position  */
+#define PMC_MCKR_CSS_UPLL_CLK               (PMC_MCKR_CSS_UPLL_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) UPPLLCKDIV is selected Position  */
+#define PMC_MCKR_PRES_Pos                   4                                              /**< (PMC_MCKR) Processor Clock Prescaler Position */
+#define PMC_MCKR_PRES_Msk                   (_U_(0x7) << PMC_MCKR_PRES_Pos)                /**< (PMC_MCKR) Processor Clock Prescaler Mask */
+#define PMC_MCKR_PRES(value)                (PMC_MCKR_PRES_Msk & ((value) << PMC_MCKR_PRES_Pos))
+#define   PMC_MCKR_PRES_CLK_1_Val           _U_(0x0)                                       /**< (PMC_MCKR) Selected clock  */
+#define   PMC_MCKR_PRES_CLK_2_Val           _U_(0x1)                                       /**< (PMC_MCKR) Selected clock divided by 2  */
+#define   PMC_MCKR_PRES_CLK_4_Val           _U_(0x2)                                       /**< (PMC_MCKR) Selected clock divided by 4  */
+#define   PMC_MCKR_PRES_CLK_8_Val           _U_(0x3)                                       /**< (PMC_MCKR) Selected clock divided by 8  */
+#define   PMC_MCKR_PRES_CLK_16_Val          _U_(0x4)                                       /**< (PMC_MCKR) Selected clock divided by 16  */
+#define   PMC_MCKR_PRES_CLK_32_Val          _U_(0x5)                                       /**< (PMC_MCKR) Selected clock divided by 32  */
+#define   PMC_MCKR_PRES_CLK_64_Val          _U_(0x6)                                       /**< (PMC_MCKR) Selected clock divided by 64  */
+#define   PMC_MCKR_PRES_CLK_3_Val           _U_(0x7)                                       /**< (PMC_MCKR) Selected clock divided by 3  */
+#define PMC_MCKR_PRES_CLK_1                 (PMC_MCKR_PRES_CLK_1_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock Position  */
+#define PMC_MCKR_PRES_CLK_2                 (PMC_MCKR_PRES_CLK_2_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 2 Position  */
+#define PMC_MCKR_PRES_CLK_4                 (PMC_MCKR_PRES_CLK_4_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 4 Position  */
+#define PMC_MCKR_PRES_CLK_8                 (PMC_MCKR_PRES_CLK_8_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 8 Position  */
+#define PMC_MCKR_PRES_CLK_16                (PMC_MCKR_PRES_CLK_16_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 16 Position  */
+#define PMC_MCKR_PRES_CLK_32                (PMC_MCKR_PRES_CLK_32_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 32 Position  */
+#define PMC_MCKR_PRES_CLK_64                (PMC_MCKR_PRES_CLK_64_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 64 Position  */
+#define PMC_MCKR_PRES_CLK_3                 (PMC_MCKR_PRES_CLK_3_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 3 Position  */
+#define PMC_MCKR_MDIV_Pos                   8                                              /**< (PMC_MCKR) Master Clock Division Position */
+#define PMC_MCKR_MDIV_Msk                   (_U_(0x3) << PMC_MCKR_MDIV_Pos)                /**< (PMC_MCKR) Master Clock Division Mask */
+#define PMC_MCKR_MDIV(value)                (PMC_MCKR_MDIV_Msk & ((value) << PMC_MCKR_MDIV_Pos))
+#define   PMC_MCKR_MDIV_EQ_PCK_Val          _U_(0x0)                                       /**< (PMC_MCKR) MCK is FCLK divided by 1.  */
+#define   PMC_MCKR_MDIV_PCK_DIV2_Val        _U_(0x1)                                       /**< (PMC_MCKR) MCK is FCLK divided by 2.  */
+#define   PMC_MCKR_MDIV_PCK_DIV4_Val        _U_(0x2)                                       /**< (PMC_MCKR) MCK is FCLK divided by 4.  */
+#define   PMC_MCKR_MDIV_PCK_DIV3_Val        _U_(0x3)                                       /**< (PMC_MCKR) MCK is FCLK divided by 3.  */
+#define PMC_MCKR_MDIV_EQ_PCK                (PMC_MCKR_MDIV_EQ_PCK_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) MCK is FCLK divided by 1. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV2              (PMC_MCKR_MDIV_PCK_DIV2_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) MCK is FCLK divided by 2. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV4              (PMC_MCKR_MDIV_PCK_DIV4_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) MCK is FCLK divided by 4. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV3              (PMC_MCKR_MDIV_PCK_DIV3_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) MCK is FCLK divided by 3. Position  */
+#define PMC_MCKR_UPLLDIV2_Pos               13                                             /**< (PMC_MCKR) UPLL Divider by 2 Position */
+#define PMC_MCKR_UPLLDIV2_Msk               (_U_(0x1) << PMC_MCKR_UPLLDIV2_Pos)            /**< (PMC_MCKR) UPLL Divider by 2 Mask */
+#define PMC_MCKR_UPLLDIV2                   PMC_MCKR_UPLLDIV2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_MCKR_UPLLDIV2_Msk instead */
+#define PMC_MCKR_MASK                       _U_(0x2373)                                    /**< \deprecated (PMC_MCKR) Register MASK  (Use PMC_MCKR_Msk instead)  */
+#define PMC_MCKR_Msk                        _U_(0x2373)                                    /**< (PMC_MCKR) Register Mask  */
+
+#define PMC_MCKR_UPLLDIV_Pos                13                                             /**< (PMC_MCKR Position) UPLL Divider by 2 */
+#define PMC_MCKR_UPLLDIV_Msk                (_U_(0x1) << PMC_MCKR_UPLLDIV_Pos)             /**< (PMC_MCKR Mask) UPLLDIV */
+#define PMC_MCKR_UPLLDIV(value)             (PMC_MCKR_UPLLDIV_Msk & ((value) << PMC_MCKR_UPLLDIV_Pos))  
+
+/* -------- PMC_USB : (PMC Offset: 0x38) (R/W 32) USB Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USBS:1;                    /**< bit:      0  USB Input Clock Selection                */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t USBDIV:4;                  /**< bit:  8..11  Divider for USB_48M                      */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_USB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_USB_OFFSET                      (0x38)                                        /**<  (PMC_USB) USB Clock Register  Offset */
+
+#define PMC_USB_USBS_Pos                    0                                              /**< (PMC_USB) USB Input Clock Selection Position */
+#define PMC_USB_USBS_Msk                    (_U_(0x1) << PMC_USB_USBS_Pos)                 /**< (PMC_USB) USB Input Clock Selection Mask */
+#define PMC_USB_USBS                        PMC_USB_USBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_USB_USBS_Msk instead */
+#define PMC_USB_USBDIV_Pos                  8                                              /**< (PMC_USB) Divider for USB_48M Position */
+#define PMC_USB_USBDIV_Msk                  (_U_(0xF) << PMC_USB_USBDIV_Pos)               /**< (PMC_USB) Divider for USB_48M Mask */
+#define PMC_USB_USBDIV(value)               (PMC_USB_USBDIV_Msk & ((value) << PMC_USB_USBDIV_Pos))
+#define PMC_USB_MASK                        _U_(0xF01)                                     /**< \deprecated (PMC_USB) Register MASK  (Use PMC_USB_Msk instead)  */
+#define PMC_USB_Msk                         _U_(0xF01)                                     /**< (PMC_USB) Register Mask  */
+
+
+/* -------- PMC_PCK : (PMC Offset: 0x40) (R/W 32) Programmable Clock Register (chid = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSS:3;                     /**< bit:   0..2  Programmable Clock Source Selection      */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t PRES:8;                    /**< bit:  4..11  Programmable Clock Prescaler             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCK_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCK_OFFSET                      (0x40)                                        /**<  (PMC_PCK) Programmable Clock Register (chid = 0) 0  Offset */
+
+#define PMC_PCK_CSS_Pos                     0                                              /**< (PMC_PCK) Programmable Clock Source Selection Position */
+#define PMC_PCK_CSS_Msk                     (_U_(0x7) << PMC_PCK_CSS_Pos)                  /**< (PMC_PCK) Programmable Clock Source Selection Mask */
+#define PMC_PCK_CSS(value)                  (PMC_PCK_CSS_Msk & ((value) << PMC_PCK_CSS_Pos))
+#define   PMC_PCK_CSS_SLOW_CLK_Val          _U_(0x0)                                       /**< (PMC_PCK) SLCK is selected  */
+#define   PMC_PCK_CSS_MAIN_CLK_Val          _U_(0x1)                                       /**< (PMC_PCK) MAINCK is selected  */
+#define   PMC_PCK_CSS_PLLA_CLK_Val          _U_(0x2)                                       /**< (PMC_PCK) PLLACK is selected  */
+#define   PMC_PCK_CSS_UPLL_CLK_Val          _U_(0x3)                                       /**< (PMC_PCK) UPLLCKDIV is selected  */
+#define   PMC_PCK_CSS_MCK_Val               _U_(0x4)                                       /**< (PMC_PCK) MCK is selected  */
+#define PMC_PCK_CSS_SLOW_CLK                (PMC_PCK_CSS_SLOW_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) SLCK is selected Position  */
+#define PMC_PCK_CSS_MAIN_CLK                (PMC_PCK_CSS_MAIN_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) MAINCK is selected Position  */
+#define PMC_PCK_CSS_PLLA_CLK                (PMC_PCK_CSS_PLLA_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) PLLACK is selected Position  */
+#define PMC_PCK_CSS_UPLL_CLK                (PMC_PCK_CSS_UPLL_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) UPLLCKDIV is selected Position  */
+#define PMC_PCK_CSS_MCK                     (PMC_PCK_CSS_MCK_Val << PMC_PCK_CSS_Pos)       /**< (PMC_PCK) MCK is selected Position  */
+#define PMC_PCK_PRES_Pos                    4                                              /**< (PMC_PCK) Programmable Clock Prescaler Position */
+#define PMC_PCK_PRES_Msk                    (_U_(0xFF) << PMC_PCK_PRES_Pos)                /**< (PMC_PCK) Programmable Clock Prescaler Mask */
+#define PMC_PCK_PRES(value)                 (PMC_PCK_PRES_Msk & ((value) << PMC_PCK_PRES_Pos))
+#define PMC_PCK_MASK                        _U_(0xFF7)                                     /**< \deprecated (PMC_PCK) Register MASK  (Use PMC_PCK_Msk instead)  */
+#define PMC_PCK_Msk                         _U_(0xFF7)                                     /**< (PMC_PCK) Register Mask  */
+
+
+/* -------- PMC_IER : (PMC Offset: 0x60) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Enable */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Enable               */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Enable      */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Enable */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Enable */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Enable */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Enable */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Enable */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Enable */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Enable */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Enable */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status Interrupt Enable */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Enable */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Enable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Enable */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IER_OFFSET                      (0x60)                                        /**<  (PMC_IER) Interrupt Enable Register  Offset */
+
+#define PMC_IER_MOSCXTS_Pos                 0                                              /**< (PMC_IER) Main Crystal Oscillator Status Interrupt Enable Position */
+#define PMC_IER_MOSCXTS_Msk                 (_U_(0x1) << PMC_IER_MOSCXTS_Pos)              /**< (PMC_IER) Main Crystal Oscillator Status Interrupt Enable Mask */
+#define PMC_IER_MOSCXTS                     PMC_IER_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCXTS_Msk instead */
+#define PMC_IER_LOCKA_Pos                   1                                              /**< (PMC_IER) PLLA Lock Interrupt Enable Position */
+#define PMC_IER_LOCKA_Msk                   (_U_(0x1) << PMC_IER_LOCKA_Pos)                /**< (PMC_IER) PLLA Lock Interrupt Enable Mask */
+#define PMC_IER_LOCKA                       PMC_IER_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_LOCKA_Msk instead */
+#define PMC_IER_MCKRDY_Pos                  3                                              /**< (PMC_IER) Master Clock Ready Interrupt Enable Position */
+#define PMC_IER_MCKRDY_Msk                  (_U_(0x1) << PMC_IER_MCKRDY_Pos)               /**< (PMC_IER) Master Clock Ready Interrupt Enable Mask */
+#define PMC_IER_MCKRDY                      PMC_IER_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MCKRDY_Msk instead */
+#define PMC_IER_LOCKU_Pos                   6                                              /**< (PMC_IER) UTMI PLL Lock Interrupt Enable Position */
+#define PMC_IER_LOCKU_Msk                   (_U_(0x1) << PMC_IER_LOCKU_Pos)                /**< (PMC_IER) UTMI PLL Lock Interrupt Enable Mask */
+#define PMC_IER_LOCKU                       PMC_IER_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_LOCKU_Msk instead */
+#define PMC_IER_PCKRDY0_Pos                 8                                              /**< (PMC_IER) Programmable Clock Ready 0 Interrupt Enable Position */
+#define PMC_IER_PCKRDY0_Msk                 (_U_(0x1) << PMC_IER_PCKRDY0_Pos)              /**< (PMC_IER) Programmable Clock Ready 0 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY0                     PMC_IER_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY0_Msk instead */
+#define PMC_IER_PCKRDY1_Pos                 9                                              /**< (PMC_IER) Programmable Clock Ready 1 Interrupt Enable Position */
+#define PMC_IER_PCKRDY1_Msk                 (_U_(0x1) << PMC_IER_PCKRDY1_Pos)              /**< (PMC_IER) Programmable Clock Ready 1 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY1                     PMC_IER_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY1_Msk instead */
+#define PMC_IER_PCKRDY2_Pos                 10                                             /**< (PMC_IER) Programmable Clock Ready 2 Interrupt Enable Position */
+#define PMC_IER_PCKRDY2_Msk                 (_U_(0x1) << PMC_IER_PCKRDY2_Pos)              /**< (PMC_IER) Programmable Clock Ready 2 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY2                     PMC_IER_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY2_Msk instead */
+#define PMC_IER_PCKRDY3_Pos                 11                                             /**< (PMC_IER) Programmable Clock Ready 3 Interrupt Enable Position */
+#define PMC_IER_PCKRDY3_Msk                 (_U_(0x1) << PMC_IER_PCKRDY3_Pos)              /**< (PMC_IER) Programmable Clock Ready 3 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY3                     PMC_IER_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY3_Msk instead */
+#define PMC_IER_PCKRDY4_Pos                 12                                             /**< (PMC_IER) Programmable Clock Ready 4 Interrupt Enable Position */
+#define PMC_IER_PCKRDY4_Msk                 (_U_(0x1) << PMC_IER_PCKRDY4_Pos)              /**< (PMC_IER) Programmable Clock Ready 4 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY4                     PMC_IER_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY4_Msk instead */
+#define PMC_IER_PCKRDY5_Pos                 13                                             /**< (PMC_IER) Programmable Clock Ready 5 Interrupt Enable Position */
+#define PMC_IER_PCKRDY5_Msk                 (_U_(0x1) << PMC_IER_PCKRDY5_Pos)              /**< (PMC_IER) Programmable Clock Ready 5 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY5                     PMC_IER_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY5_Msk instead */
+#define PMC_IER_PCKRDY6_Pos                 14                                             /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Position */
+#define PMC_IER_PCKRDY6_Msk                 (_U_(0x1) << PMC_IER_PCKRDY6_Pos)              /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY6                     PMC_IER_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY6_Msk instead */
+#define PMC_IER_MOSCSELS_Pos                16                                             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Position */
+#define PMC_IER_MOSCSELS_Msk                (_U_(0x1) << PMC_IER_MOSCSELS_Pos)             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Mask */
+#define PMC_IER_MOSCSELS                    PMC_IER_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCSELS_Msk instead */
+#define PMC_IER_MOSCRCS_Pos                 17                                             /**< (PMC_IER) Main RC Oscillator Status Interrupt Enable Position */
+#define PMC_IER_MOSCRCS_Msk                 (_U_(0x1) << PMC_IER_MOSCRCS_Pos)              /**< (PMC_IER) Main RC Oscillator Status Interrupt Enable Mask */
+#define PMC_IER_MOSCRCS                     PMC_IER_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCRCS_Msk instead */
+#define PMC_IER_CFDEV_Pos                   18                                             /**< (PMC_IER) Clock Failure Detector Event Interrupt Enable Position */
+#define PMC_IER_CFDEV_Msk                   (_U_(0x1) << PMC_IER_CFDEV_Pos)                /**< (PMC_IER) Clock Failure Detector Event Interrupt Enable Mask */
+#define PMC_IER_CFDEV                       PMC_IER_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_CFDEV_Msk instead */
+#define PMC_IER_XT32KERR_Pos                21                                             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Position */
+#define PMC_IER_XT32KERR_Msk                (_U_(0x1) << PMC_IER_XT32KERR_Pos)             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Mask */
+#define PMC_IER_XT32KERR                    PMC_IER_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_XT32KERR_Msk instead */
+#define PMC_IER_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IER) Register MASK  (Use PMC_IER_Msk instead)  */
+#define PMC_IER_Msk                         _U_(0x277F4B)                                  /**< (PMC_IER) Register Mask  */
+
+#define PMC_IER_PCKRDY_Pos                  8                                              /**< (PMC_IER Position) Programmable Clock Ready x Interrupt Enable */
+#define PMC_IER_PCKRDY_Msk                  (_U_(0x7F) << PMC_IER_PCKRDY_Pos)              /**< (PMC_IER Mask) PCKRDY */
+#define PMC_IER_PCKRDY(value)               (PMC_IER_PCKRDY_Msk & ((value) << PMC_IER_PCKRDY_Pos))  
+
+/* -------- PMC_IDR : (PMC Offset: 0x64) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Disable */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Disable              */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Disable     */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Disable          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Disable */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Disable */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Disable */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Disable */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Disable */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Disable */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Disable */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Disable */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Disable         */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Disable */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Disable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Disable */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IDR_OFFSET                      (0x64)                                        /**<  (PMC_IDR) Interrupt Disable Register  Offset */
+
+#define PMC_IDR_MOSCXTS_Pos                 0                                              /**< (PMC_IDR) Main Crystal Oscillator Status Interrupt Disable Position */
+#define PMC_IDR_MOSCXTS_Msk                 (_U_(0x1) << PMC_IDR_MOSCXTS_Pos)              /**< (PMC_IDR) Main Crystal Oscillator Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCXTS                     PMC_IDR_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCXTS_Msk instead */
+#define PMC_IDR_LOCKA_Pos                   1                                              /**< (PMC_IDR) PLLA Lock Interrupt Disable Position */
+#define PMC_IDR_LOCKA_Msk                   (_U_(0x1) << PMC_IDR_LOCKA_Pos)                /**< (PMC_IDR) PLLA Lock Interrupt Disable Mask */
+#define PMC_IDR_LOCKA                       PMC_IDR_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_LOCKA_Msk instead */
+#define PMC_IDR_MCKRDY_Pos                  3                                              /**< (PMC_IDR) Master Clock Ready Interrupt Disable Position */
+#define PMC_IDR_MCKRDY_Msk                  (_U_(0x1) << PMC_IDR_MCKRDY_Pos)               /**< (PMC_IDR) Master Clock Ready Interrupt Disable Mask */
+#define PMC_IDR_MCKRDY                      PMC_IDR_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MCKRDY_Msk instead */
+#define PMC_IDR_LOCKU_Pos                   6                                              /**< (PMC_IDR) UTMI PLL Lock Interrupt Disable Position */
+#define PMC_IDR_LOCKU_Msk                   (_U_(0x1) << PMC_IDR_LOCKU_Pos)                /**< (PMC_IDR) UTMI PLL Lock Interrupt Disable Mask */
+#define PMC_IDR_LOCKU                       PMC_IDR_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_LOCKU_Msk instead */
+#define PMC_IDR_PCKRDY0_Pos                 8                                              /**< (PMC_IDR) Programmable Clock Ready 0 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY0_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY0_Pos)              /**< (PMC_IDR) Programmable Clock Ready 0 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY0                     PMC_IDR_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY0_Msk instead */
+#define PMC_IDR_PCKRDY1_Pos                 9                                              /**< (PMC_IDR) Programmable Clock Ready 1 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY1_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY1_Pos)              /**< (PMC_IDR) Programmable Clock Ready 1 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY1                     PMC_IDR_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY1_Msk instead */
+#define PMC_IDR_PCKRDY2_Pos                 10                                             /**< (PMC_IDR) Programmable Clock Ready 2 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY2_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY2_Pos)              /**< (PMC_IDR) Programmable Clock Ready 2 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY2                     PMC_IDR_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY2_Msk instead */
+#define PMC_IDR_PCKRDY3_Pos                 11                                             /**< (PMC_IDR) Programmable Clock Ready 3 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY3_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY3_Pos)              /**< (PMC_IDR) Programmable Clock Ready 3 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY3                     PMC_IDR_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY3_Msk instead */
+#define PMC_IDR_PCKRDY4_Pos                 12                                             /**< (PMC_IDR) Programmable Clock Ready 4 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY4_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY4_Pos)              /**< (PMC_IDR) Programmable Clock Ready 4 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY4                     PMC_IDR_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY4_Msk instead */
+#define PMC_IDR_PCKRDY5_Pos                 13                                             /**< (PMC_IDR) Programmable Clock Ready 5 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY5_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY5_Pos)              /**< (PMC_IDR) Programmable Clock Ready 5 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY5                     PMC_IDR_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY5_Msk instead */
+#define PMC_IDR_PCKRDY6_Pos                 14                                             /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY6_Pos)              /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY6                     PMC_IDR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY6_Msk instead */
+#define PMC_IDR_MOSCSELS_Pos                16                                             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Position */
+#define PMC_IDR_MOSCSELS_Msk                (_U_(0x1) << PMC_IDR_MOSCSELS_Pos)             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCSELS                    PMC_IDR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCSELS_Msk instead */
+#define PMC_IDR_MOSCRCS_Pos                 17                                             /**< (PMC_IDR) Main RC Status Interrupt Disable Position */
+#define PMC_IDR_MOSCRCS_Msk                 (_U_(0x1) << PMC_IDR_MOSCRCS_Pos)              /**< (PMC_IDR) Main RC Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCRCS                     PMC_IDR_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCRCS_Msk instead */
+#define PMC_IDR_CFDEV_Pos                   18                                             /**< (PMC_IDR) Clock Failure Detector Event Interrupt Disable Position */
+#define PMC_IDR_CFDEV_Msk                   (_U_(0x1) << PMC_IDR_CFDEV_Pos)                /**< (PMC_IDR) Clock Failure Detector Event Interrupt Disable Mask */
+#define PMC_IDR_CFDEV                       PMC_IDR_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_CFDEV_Msk instead */
+#define PMC_IDR_XT32KERR_Pos                21                                             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Position */
+#define PMC_IDR_XT32KERR_Msk                (_U_(0x1) << PMC_IDR_XT32KERR_Pos)             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Mask */
+#define PMC_IDR_XT32KERR                    PMC_IDR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_XT32KERR_Msk instead */
+#define PMC_IDR_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IDR) Register MASK  (Use PMC_IDR_Msk instead)  */
+#define PMC_IDR_Msk                         _U_(0x277F4B)                                  /**< (PMC_IDR) Register Mask  */
+
+#define PMC_IDR_PCKRDY_Pos                  8                                              /**< (PMC_IDR Position) Programmable Clock Ready x Interrupt Disable */
+#define PMC_IDR_PCKRDY_Msk                  (_U_(0x7F) << PMC_IDR_PCKRDY_Pos)              /**< (PMC_IDR Mask) PCKRDY */
+#define PMC_IDR_PCKRDY(value)               (PMC_IDR_PCKRDY_Msk & ((value) << PMC_IDR_PCKRDY_Pos))  
+
+/* -------- PMC_SR : (PMC Offset: 0x68) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status           */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Status                         */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Status                      */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Status                     */
+    uint32_t OSCSELS:1;                 /**< bit:      7  Slow Clock Source Oscillator Selection   */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready Status          */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready Status          */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready Status          */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready Status          */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready Status          */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready Status          */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready Status          */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status                */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event             */
+    uint32_t CFDS:1;                    /**< bit:     19  Clock Failure Detector Status            */
+    uint32_t FOS:1;                     /**< bit:     20  Clock Failure Detector Fault Output Status */
+    uint32_t XT32KERR:1;                /**< bit:     21  Slow Crystal Oscillator Error            */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready Status          */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SR_OFFSET                       (0x68)                                        /**<  (PMC_SR) Status Register  Offset */
+
+#define PMC_SR_MOSCXTS_Pos                  0                                              /**< (PMC_SR) Main Crystal Oscillator Status Position */
+#define PMC_SR_MOSCXTS_Msk                  (_U_(0x1) << PMC_SR_MOSCXTS_Pos)               /**< (PMC_SR) Main Crystal Oscillator Status Mask */
+#define PMC_SR_MOSCXTS                      PMC_SR_MOSCXTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCXTS_Msk instead */
+#define PMC_SR_LOCKA_Pos                    1                                              /**< (PMC_SR) PLLA Lock Status Position */
+#define PMC_SR_LOCKA_Msk                    (_U_(0x1) << PMC_SR_LOCKA_Pos)                 /**< (PMC_SR) PLLA Lock Status Mask */
+#define PMC_SR_LOCKA                        PMC_SR_LOCKA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_LOCKA_Msk instead */
+#define PMC_SR_MCKRDY_Pos                   3                                              /**< (PMC_SR) Master Clock Status Position */
+#define PMC_SR_MCKRDY_Msk                   (_U_(0x1) << PMC_SR_MCKRDY_Pos)                /**< (PMC_SR) Master Clock Status Mask */
+#define PMC_SR_MCKRDY                       PMC_SR_MCKRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MCKRDY_Msk instead */
+#define PMC_SR_LOCKU_Pos                    6                                              /**< (PMC_SR) UTMI PLL Lock Status Position */
+#define PMC_SR_LOCKU_Msk                    (_U_(0x1) << PMC_SR_LOCKU_Pos)                 /**< (PMC_SR) UTMI PLL Lock Status Mask */
+#define PMC_SR_LOCKU                        PMC_SR_LOCKU_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_LOCKU_Msk instead */
+#define PMC_SR_OSCSELS_Pos                  7                                              /**< (PMC_SR) Slow Clock Source Oscillator Selection Position */
+#define PMC_SR_OSCSELS_Msk                  (_U_(0x1) << PMC_SR_OSCSELS_Pos)               /**< (PMC_SR) Slow Clock Source Oscillator Selection Mask */
+#define PMC_SR_OSCSELS                      PMC_SR_OSCSELS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_OSCSELS_Msk instead */
+#define PMC_SR_PCKRDY0_Pos                  8                                              /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY0_Msk                  (_U_(0x1) << PMC_SR_PCKRDY0_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY0                      PMC_SR_PCKRDY0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY0_Msk instead */
+#define PMC_SR_PCKRDY1_Pos                  9                                              /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY1_Msk                  (_U_(0x1) << PMC_SR_PCKRDY1_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY1                      PMC_SR_PCKRDY1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY1_Msk instead */
+#define PMC_SR_PCKRDY2_Pos                  10                                             /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY2_Msk                  (_U_(0x1) << PMC_SR_PCKRDY2_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY2                      PMC_SR_PCKRDY2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY2_Msk instead */
+#define PMC_SR_PCKRDY3_Pos                  11                                             /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY3_Msk                  (_U_(0x1) << PMC_SR_PCKRDY3_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY3                      PMC_SR_PCKRDY3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY3_Msk instead */
+#define PMC_SR_PCKRDY4_Pos                  12                                             /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY4_Msk                  (_U_(0x1) << PMC_SR_PCKRDY4_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY4                      PMC_SR_PCKRDY4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY4_Msk instead */
+#define PMC_SR_PCKRDY5_Pos                  13                                             /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY5_Msk                  (_U_(0x1) << PMC_SR_PCKRDY5_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY5                      PMC_SR_PCKRDY5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY5_Msk instead */
+#define PMC_SR_PCKRDY6_Pos                  14                                             /**< (PMC_SR) Programmable Clock Ready Status Position */
+#define PMC_SR_PCKRDY6_Msk                  (_U_(0x1) << PMC_SR_PCKRDY6_Pos)               /**< (PMC_SR) Programmable Clock Ready Status Mask */
+#define PMC_SR_PCKRDY6                      PMC_SR_PCKRDY6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY6_Msk instead */
+#define PMC_SR_MOSCSELS_Pos                 16                                             /**< (PMC_SR) Main Clock Source Oscillator Selection Status Position */
+#define PMC_SR_MOSCSELS_Msk                 (_U_(0x1) << PMC_SR_MOSCSELS_Pos)              /**< (PMC_SR) Main Clock Source Oscillator Selection Status Mask */
+#define PMC_SR_MOSCSELS                     PMC_SR_MOSCSELS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCSELS_Msk instead */
+#define PMC_SR_MOSCRCS_Pos                  17                                             /**< (PMC_SR) Main RC Oscillator Status Position */
+#define PMC_SR_MOSCRCS_Msk                  (_U_(0x1) << PMC_SR_MOSCRCS_Pos)               /**< (PMC_SR) Main RC Oscillator Status Mask */
+#define PMC_SR_MOSCRCS                      PMC_SR_MOSCRCS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCRCS_Msk instead */
+#define PMC_SR_CFDEV_Pos                    18                                             /**< (PMC_SR) Clock Failure Detector Event Position */
+#define PMC_SR_CFDEV_Msk                    (_U_(0x1) << PMC_SR_CFDEV_Pos)                 /**< (PMC_SR) Clock Failure Detector Event Mask */
+#define PMC_SR_CFDEV                        PMC_SR_CFDEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_CFDEV_Msk instead */
+#define PMC_SR_CFDS_Pos                     19                                             /**< (PMC_SR) Clock Failure Detector Status Position */
+#define PMC_SR_CFDS_Msk                     (_U_(0x1) << PMC_SR_CFDS_Pos)                  /**< (PMC_SR) Clock Failure Detector Status Mask */
+#define PMC_SR_CFDS                         PMC_SR_CFDS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_CFDS_Msk instead */
+#define PMC_SR_FOS_Pos                      20                                             /**< (PMC_SR) Clock Failure Detector Fault Output Status Position */
+#define PMC_SR_FOS_Msk                      (_U_(0x1) << PMC_SR_FOS_Pos)                   /**< (PMC_SR) Clock Failure Detector Fault Output Status Mask */
+#define PMC_SR_FOS                          PMC_SR_FOS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_FOS_Msk instead */
+#define PMC_SR_XT32KERR_Pos                 21                                             /**< (PMC_SR) Slow Crystal Oscillator Error Position */
+#define PMC_SR_XT32KERR_Msk                 (_U_(0x1) << PMC_SR_XT32KERR_Pos)              /**< (PMC_SR) Slow Crystal Oscillator Error Mask */
+#define PMC_SR_XT32KERR                     PMC_SR_XT32KERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_XT32KERR_Msk instead */
+#define PMC_SR_MASK                         _U_(0x3F7FCB)                                  /**< \deprecated (PMC_SR) Register MASK  (Use PMC_SR_Msk instead)  */
+#define PMC_SR_Msk                          _U_(0x3F7FCB)                                  /**< (PMC_SR) Register Mask  */
+
+#define PMC_SR_PCKRDY_Pos                   8                                              /**< (PMC_SR Position) Programmable Clock Ready Status */
+#define PMC_SR_PCKRDY_Msk                   (_U_(0x7F) << PMC_SR_PCKRDY_Pos)               /**< (PMC_SR Mask) PCKRDY */
+#define PMC_SR_PCKRDY(value)                (PMC_SR_PCKRDY_Msk & ((value) << PMC_SR_PCKRDY_Pos))  
+
+/* -------- PMC_IMR : (PMC Offset: 0x6c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Mask */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Mask                 */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Mask        */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Mask             */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Mask */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Mask */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Mask */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Mask */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Mask */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Mask */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Mask */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Mask */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Mask            */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Mask */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Mask */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Mask */
+    uint32_t :17;                       /**< bit: 15..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IMR_OFFSET                      (0x6C)                                        /**<  (PMC_IMR) Interrupt Mask Register  Offset */
+
+#define PMC_IMR_MOSCXTS_Pos                 0                                              /**< (PMC_IMR) Main Crystal Oscillator Status Interrupt Mask Position */
+#define PMC_IMR_MOSCXTS_Msk                 (_U_(0x1) << PMC_IMR_MOSCXTS_Pos)              /**< (PMC_IMR) Main Crystal Oscillator Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCXTS                     PMC_IMR_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCXTS_Msk instead */
+#define PMC_IMR_LOCKA_Pos                   1                                              /**< (PMC_IMR) PLLA Lock Interrupt Mask Position */
+#define PMC_IMR_LOCKA_Msk                   (_U_(0x1) << PMC_IMR_LOCKA_Pos)                /**< (PMC_IMR) PLLA Lock Interrupt Mask Mask */
+#define PMC_IMR_LOCKA                       PMC_IMR_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_LOCKA_Msk instead */
+#define PMC_IMR_MCKRDY_Pos                  3                                              /**< (PMC_IMR) Master Clock Ready Interrupt Mask Position */
+#define PMC_IMR_MCKRDY_Msk                  (_U_(0x1) << PMC_IMR_MCKRDY_Pos)               /**< (PMC_IMR) Master Clock Ready Interrupt Mask Mask */
+#define PMC_IMR_MCKRDY                      PMC_IMR_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MCKRDY_Msk instead */
+#define PMC_IMR_LOCKU_Pos                   6                                              /**< (PMC_IMR) UTMI PLL Lock Interrupt Mask Position */
+#define PMC_IMR_LOCKU_Msk                   (_U_(0x1) << PMC_IMR_LOCKU_Pos)                /**< (PMC_IMR) UTMI PLL Lock Interrupt Mask Mask */
+#define PMC_IMR_LOCKU                       PMC_IMR_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_LOCKU_Msk instead */
+#define PMC_IMR_PCKRDY0_Pos                 8                                              /**< (PMC_IMR) Programmable Clock Ready 0 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY0_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY0_Pos)              /**< (PMC_IMR) Programmable Clock Ready 0 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY0                     PMC_IMR_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY0_Msk instead */
+#define PMC_IMR_PCKRDY1_Pos                 9                                              /**< (PMC_IMR) Programmable Clock Ready 1 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY1_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY1_Pos)              /**< (PMC_IMR) Programmable Clock Ready 1 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY1                     PMC_IMR_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY1_Msk instead */
+#define PMC_IMR_PCKRDY2_Pos                 10                                             /**< (PMC_IMR) Programmable Clock Ready 2 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY2_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY2_Pos)              /**< (PMC_IMR) Programmable Clock Ready 2 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY2                     PMC_IMR_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY2_Msk instead */
+#define PMC_IMR_PCKRDY3_Pos                 11                                             /**< (PMC_IMR) Programmable Clock Ready 3 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY3_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY3_Pos)              /**< (PMC_IMR) Programmable Clock Ready 3 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY3                     PMC_IMR_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY3_Msk instead */
+#define PMC_IMR_PCKRDY4_Pos                 12                                             /**< (PMC_IMR) Programmable Clock Ready 4 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY4_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY4_Pos)              /**< (PMC_IMR) Programmable Clock Ready 4 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY4                     PMC_IMR_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY4_Msk instead */
+#define PMC_IMR_PCKRDY5_Pos                 13                                             /**< (PMC_IMR) Programmable Clock Ready 5 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY5_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY5_Pos)              /**< (PMC_IMR) Programmable Clock Ready 5 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY5                     PMC_IMR_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY5_Msk instead */
+#define PMC_IMR_PCKRDY6_Pos                 14                                             /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY6_Pos)              /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY6                     PMC_IMR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY6_Msk instead */
+#define PMC_IMR_MOSCSELS_Pos                16                                             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Position */
+#define PMC_IMR_MOSCSELS_Msk                (_U_(0x1) << PMC_IMR_MOSCSELS_Pos)             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCSELS                    PMC_IMR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCSELS_Msk instead */
+#define PMC_IMR_MOSCRCS_Pos                 17                                             /**< (PMC_IMR) Main RC Status Interrupt Mask Position */
+#define PMC_IMR_MOSCRCS_Msk                 (_U_(0x1) << PMC_IMR_MOSCRCS_Pos)              /**< (PMC_IMR) Main RC Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCRCS                     PMC_IMR_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCRCS_Msk instead */
+#define PMC_IMR_CFDEV_Pos                   18                                             /**< (PMC_IMR) Clock Failure Detector Event Interrupt Mask Position */
+#define PMC_IMR_CFDEV_Msk                   (_U_(0x1) << PMC_IMR_CFDEV_Pos)                /**< (PMC_IMR) Clock Failure Detector Event Interrupt Mask Mask */
+#define PMC_IMR_CFDEV                       PMC_IMR_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_CFDEV_Msk instead */
+#define PMC_IMR_XT32KERR_Pos                21                                             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Position */
+#define PMC_IMR_XT32KERR_Msk                (_U_(0x1) << PMC_IMR_XT32KERR_Pos)             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Mask */
+#define PMC_IMR_XT32KERR                    PMC_IMR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_XT32KERR_Msk instead */
+#define PMC_IMR_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IMR) Register MASK  (Use PMC_IMR_Msk instead)  */
+#define PMC_IMR_Msk                         _U_(0x277F4B)                                  /**< (PMC_IMR) Register Mask  */
+
+#define PMC_IMR_PCKRDY_Pos                  8                                              /**< (PMC_IMR Position) Programmable Clock Ready x Interrupt Mask */
+#define PMC_IMR_PCKRDY_Msk                  (_U_(0x7F) << PMC_IMR_PCKRDY_Pos)              /**< (PMC_IMR Mask) PCKRDY */
+#define PMC_IMR_PCKRDY(value)               (PMC_IMR_PCKRDY_Msk & ((value) << PMC_IMR_PCKRDY_Pos))  
+
+/* -------- PMC_FSMR : (PMC Offset: 0x70) (R/W 32) Fast Startup Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FSTT0:1;                   /**< bit:      0  Fast Startup Input Enable 0              */
+    uint32_t FSTT1:1;                   /**< bit:      1  Fast Startup Input Enable 1              */
+    uint32_t FSTT2:1;                   /**< bit:      2  Fast Startup Input Enable 2              */
+    uint32_t FSTT3:1;                   /**< bit:      3  Fast Startup Input Enable 3              */
+    uint32_t FSTT4:1;                   /**< bit:      4  Fast Startup Input Enable 4              */
+    uint32_t FSTT5:1;                   /**< bit:      5  Fast Startup Input Enable 5              */
+    uint32_t FSTT6:1;                   /**< bit:      6  Fast Startup Input Enable 6              */
+    uint32_t FSTT7:1;                   /**< bit:      7  Fast Startup Input Enable 7              */
+    uint32_t FSTT8:1;                   /**< bit:      8  Fast Startup Input Enable 8              */
+    uint32_t FSTT9:1;                   /**< bit:      9  Fast Startup Input Enable 9              */
+    uint32_t FSTT10:1;                  /**< bit:     10  Fast Startup Input Enable 10             */
+    uint32_t FSTT11:1;                  /**< bit:     11  Fast Startup Input Enable 11             */
+    uint32_t FSTT12:1;                  /**< bit:     12  Fast Startup Input Enable 12             */
+    uint32_t FSTT13:1;                  /**< bit:     13  Fast Startup Input Enable 13             */
+    uint32_t FSTT14:1;                  /**< bit:     14  Fast Startup Input Enable 14             */
+    uint32_t FSTT15:1;                  /**< bit:     15  Fast Startup Input Enable 15             */
+    uint32_t RTTAL:1;                   /**< bit:     16  RTT Alarm Enable                         */
+    uint32_t RTCAL:1;                   /**< bit:     17  RTC Alarm Enable                         */
+    uint32_t USBAL:1;                   /**< bit:     18  USB Alarm Enable                         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t LPM:1;                     /**< bit:     20  Low-power Mode                           */
+    uint32_t FLPM:2;                    /**< bit: 21..22  Flash Low-power Mode                     */
+    uint32_t FFLPM:1;                   /**< bit:     23  Force Flash Low-power Mode               */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FSTT:16;                   /**< bit:  0..15  Fast Startup Input Enable x              */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FSMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FSMR_OFFSET                     (0x70)                                        /**<  (PMC_FSMR) Fast Startup Mode Register  Offset */
+
+#define PMC_FSMR_FSTT0_Pos                  0                                              /**< (PMC_FSMR) Fast Startup Input Enable 0 Position */
+#define PMC_FSMR_FSTT0_Msk                  (_U_(0x1) << PMC_FSMR_FSTT0_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 0 Mask */
+#define PMC_FSMR_FSTT0                      PMC_FSMR_FSTT0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT0_Msk instead */
+#define PMC_FSMR_FSTT1_Pos                  1                                              /**< (PMC_FSMR) Fast Startup Input Enable 1 Position */
+#define PMC_FSMR_FSTT1_Msk                  (_U_(0x1) << PMC_FSMR_FSTT1_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 1 Mask */
+#define PMC_FSMR_FSTT1                      PMC_FSMR_FSTT1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT1_Msk instead */
+#define PMC_FSMR_FSTT2_Pos                  2                                              /**< (PMC_FSMR) Fast Startup Input Enable 2 Position */
+#define PMC_FSMR_FSTT2_Msk                  (_U_(0x1) << PMC_FSMR_FSTT2_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 2 Mask */
+#define PMC_FSMR_FSTT2                      PMC_FSMR_FSTT2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT2_Msk instead */
+#define PMC_FSMR_FSTT3_Pos                  3                                              /**< (PMC_FSMR) Fast Startup Input Enable 3 Position */
+#define PMC_FSMR_FSTT3_Msk                  (_U_(0x1) << PMC_FSMR_FSTT3_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 3 Mask */
+#define PMC_FSMR_FSTT3                      PMC_FSMR_FSTT3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT3_Msk instead */
+#define PMC_FSMR_FSTT4_Pos                  4                                              /**< (PMC_FSMR) Fast Startup Input Enable 4 Position */
+#define PMC_FSMR_FSTT4_Msk                  (_U_(0x1) << PMC_FSMR_FSTT4_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 4 Mask */
+#define PMC_FSMR_FSTT4                      PMC_FSMR_FSTT4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT4_Msk instead */
+#define PMC_FSMR_FSTT5_Pos                  5                                              /**< (PMC_FSMR) Fast Startup Input Enable 5 Position */
+#define PMC_FSMR_FSTT5_Msk                  (_U_(0x1) << PMC_FSMR_FSTT5_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 5 Mask */
+#define PMC_FSMR_FSTT5                      PMC_FSMR_FSTT5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT5_Msk instead */
+#define PMC_FSMR_FSTT6_Pos                  6                                              /**< (PMC_FSMR) Fast Startup Input Enable 6 Position */
+#define PMC_FSMR_FSTT6_Msk                  (_U_(0x1) << PMC_FSMR_FSTT6_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 6 Mask */
+#define PMC_FSMR_FSTT6                      PMC_FSMR_FSTT6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT6_Msk instead */
+#define PMC_FSMR_FSTT7_Pos                  7                                              /**< (PMC_FSMR) Fast Startup Input Enable 7 Position */
+#define PMC_FSMR_FSTT7_Msk                  (_U_(0x1) << PMC_FSMR_FSTT7_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 7 Mask */
+#define PMC_FSMR_FSTT7                      PMC_FSMR_FSTT7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT7_Msk instead */
+#define PMC_FSMR_FSTT8_Pos                  8                                              /**< (PMC_FSMR) Fast Startup Input Enable 8 Position */
+#define PMC_FSMR_FSTT8_Msk                  (_U_(0x1) << PMC_FSMR_FSTT8_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 8 Mask */
+#define PMC_FSMR_FSTT8                      PMC_FSMR_FSTT8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT8_Msk instead */
+#define PMC_FSMR_FSTT9_Pos                  9                                              /**< (PMC_FSMR) Fast Startup Input Enable 9 Position */
+#define PMC_FSMR_FSTT9_Msk                  (_U_(0x1) << PMC_FSMR_FSTT9_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 9 Mask */
+#define PMC_FSMR_FSTT9                      PMC_FSMR_FSTT9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT9_Msk instead */
+#define PMC_FSMR_FSTT10_Pos                 10                                             /**< (PMC_FSMR) Fast Startup Input Enable 10 Position */
+#define PMC_FSMR_FSTT10_Msk                 (_U_(0x1) << PMC_FSMR_FSTT10_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 10 Mask */
+#define PMC_FSMR_FSTT10                     PMC_FSMR_FSTT10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT10_Msk instead */
+#define PMC_FSMR_FSTT11_Pos                 11                                             /**< (PMC_FSMR) Fast Startup Input Enable 11 Position */
+#define PMC_FSMR_FSTT11_Msk                 (_U_(0x1) << PMC_FSMR_FSTT11_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 11 Mask */
+#define PMC_FSMR_FSTT11                     PMC_FSMR_FSTT11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT11_Msk instead */
+#define PMC_FSMR_FSTT12_Pos                 12                                             /**< (PMC_FSMR) Fast Startup Input Enable 12 Position */
+#define PMC_FSMR_FSTT12_Msk                 (_U_(0x1) << PMC_FSMR_FSTT12_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 12 Mask */
+#define PMC_FSMR_FSTT12                     PMC_FSMR_FSTT12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT12_Msk instead */
+#define PMC_FSMR_FSTT13_Pos                 13                                             /**< (PMC_FSMR) Fast Startup Input Enable 13 Position */
+#define PMC_FSMR_FSTT13_Msk                 (_U_(0x1) << PMC_FSMR_FSTT13_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 13 Mask */
+#define PMC_FSMR_FSTT13                     PMC_FSMR_FSTT13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT13_Msk instead */
+#define PMC_FSMR_FSTT14_Pos                 14                                             /**< (PMC_FSMR) Fast Startup Input Enable 14 Position */
+#define PMC_FSMR_FSTT14_Msk                 (_U_(0x1) << PMC_FSMR_FSTT14_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 14 Mask */
+#define PMC_FSMR_FSTT14                     PMC_FSMR_FSTT14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT14_Msk instead */
+#define PMC_FSMR_FSTT15_Pos                 15                                             /**< (PMC_FSMR) Fast Startup Input Enable 15 Position */
+#define PMC_FSMR_FSTT15_Msk                 (_U_(0x1) << PMC_FSMR_FSTT15_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 15 Mask */
+#define PMC_FSMR_FSTT15                     PMC_FSMR_FSTT15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT15_Msk instead */
+#define PMC_FSMR_RTTAL_Pos                  16                                             /**< (PMC_FSMR) RTT Alarm Enable Position */
+#define PMC_FSMR_RTTAL_Msk                  (_U_(0x1) << PMC_FSMR_RTTAL_Pos)               /**< (PMC_FSMR) RTT Alarm Enable Mask */
+#define PMC_FSMR_RTTAL                      PMC_FSMR_RTTAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_RTTAL_Msk instead */
+#define PMC_FSMR_RTCAL_Pos                  17                                             /**< (PMC_FSMR) RTC Alarm Enable Position */
+#define PMC_FSMR_RTCAL_Msk                  (_U_(0x1) << PMC_FSMR_RTCAL_Pos)               /**< (PMC_FSMR) RTC Alarm Enable Mask */
+#define PMC_FSMR_RTCAL                      PMC_FSMR_RTCAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_RTCAL_Msk instead */
+#define PMC_FSMR_USBAL_Pos                  18                                             /**< (PMC_FSMR) USB Alarm Enable Position */
+#define PMC_FSMR_USBAL_Msk                  (_U_(0x1) << PMC_FSMR_USBAL_Pos)               /**< (PMC_FSMR) USB Alarm Enable Mask */
+#define PMC_FSMR_USBAL                      PMC_FSMR_USBAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_USBAL_Msk instead */
+#define PMC_FSMR_LPM_Pos                    20                                             /**< (PMC_FSMR) Low-power Mode Position */
+#define PMC_FSMR_LPM_Msk                    (_U_(0x1) << PMC_FSMR_LPM_Pos)                 /**< (PMC_FSMR) Low-power Mode Mask */
+#define PMC_FSMR_LPM                        PMC_FSMR_LPM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_LPM_Msk instead */
+#define PMC_FSMR_FLPM_Pos                   21                                             /**< (PMC_FSMR) Flash Low-power Mode Position */
+#define PMC_FSMR_FLPM_Msk                   (_U_(0x3) << PMC_FSMR_FLPM_Pos)                /**< (PMC_FSMR) Flash Low-power Mode Mask */
+#define PMC_FSMR_FLPM(value)                (PMC_FSMR_FLPM_Msk & ((value) << PMC_FSMR_FLPM_Pos))
+#define   PMC_FSMR_FLPM_FLASH_STANDBY_Val   _U_(0x0)                                       /**< (PMC_FSMR) Flash is in Standby Mode when system enters Wait Mode  */
+#define   PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN_Val _U_(0x1)                                       /**< (PMC_FSMR) Flash is in Deep-power-down mode when system enters Wait Mode  */
+#define   PMC_FSMR_FLPM_FLASH_IDLE_Val      _U_(0x2)                                       /**< (PMC_FSMR) Idle mode  */
+#define PMC_FSMR_FLPM_FLASH_STANDBY         (PMC_FSMR_FLPM_FLASH_STANDBY_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Flash is in Standby Mode when system enters Wait Mode Position  */
+#define PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN  (PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Flash is in Deep-power-down mode when system enters Wait Mode Position  */
+#define PMC_FSMR_FLPM_FLASH_IDLE            (PMC_FSMR_FLPM_FLASH_IDLE_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Idle mode Position  */
+#define PMC_FSMR_FFLPM_Pos                  23                                             /**< (PMC_FSMR) Force Flash Low-power Mode Position */
+#define PMC_FSMR_FFLPM_Msk                  (_U_(0x1) << PMC_FSMR_FFLPM_Pos)               /**< (PMC_FSMR) Force Flash Low-power Mode Mask */
+#define PMC_FSMR_FFLPM                      PMC_FSMR_FFLPM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FFLPM_Msk instead */
+#define PMC_FSMR_MASK                       _U_(0xF7FFFF)                                  /**< \deprecated (PMC_FSMR) Register MASK  (Use PMC_FSMR_Msk instead)  */
+#define PMC_FSMR_Msk                        _U_(0xF7FFFF)                                  /**< (PMC_FSMR) Register Mask  */
+
+#define PMC_FSMR_FSTT_Pos                   0                                              /**< (PMC_FSMR Position) Fast Startup Input Enable x */
+#define PMC_FSMR_FSTT_Msk                   (_U_(0xFFFF) << PMC_FSMR_FSTT_Pos)             /**< (PMC_FSMR Mask) FSTT */
+#define PMC_FSMR_FSTT(value)                (PMC_FSMR_FSTT_Msk & ((value) << PMC_FSMR_FSTT_Pos))  
+
+/* -------- PMC_FSPR : (PMC Offset: 0x74) (R/W 32) Fast Startup Polarity Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FSTP0:1;                   /**< bit:      0  Fast Startup Input Polarity 0            */
+    uint32_t FSTP1:1;                   /**< bit:      1  Fast Startup Input Polarity 1            */
+    uint32_t FSTP2:1;                   /**< bit:      2  Fast Startup Input Polarity 2            */
+    uint32_t FSTP3:1;                   /**< bit:      3  Fast Startup Input Polarity 3            */
+    uint32_t FSTP4:1;                   /**< bit:      4  Fast Startup Input Polarity 4            */
+    uint32_t FSTP5:1;                   /**< bit:      5  Fast Startup Input Polarity 5            */
+    uint32_t FSTP6:1;                   /**< bit:      6  Fast Startup Input Polarity 6            */
+    uint32_t FSTP7:1;                   /**< bit:      7  Fast Startup Input Polarity 7            */
+    uint32_t FSTP8:1;                   /**< bit:      8  Fast Startup Input Polarity 8            */
+    uint32_t FSTP9:1;                   /**< bit:      9  Fast Startup Input Polarity 9            */
+    uint32_t FSTP10:1;                  /**< bit:     10  Fast Startup Input Polarity 10           */
+    uint32_t FSTP11:1;                  /**< bit:     11  Fast Startup Input Polarity 11           */
+    uint32_t FSTP12:1;                  /**< bit:     12  Fast Startup Input Polarity 12           */
+    uint32_t FSTP13:1;                  /**< bit:     13  Fast Startup Input Polarity 13           */
+    uint32_t FSTP14:1;                  /**< bit:     14  Fast Startup Input Polarity 14           */
+    uint32_t FSTP15:1;                  /**< bit:     15  Fast Startup Input Polarity 15           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FSTP:16;                   /**< bit:  0..15  Fast Startup Input Polarity x5           */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FSPR_OFFSET                     (0x74)                                        /**<  (PMC_FSPR) Fast Startup Polarity Register  Offset */
+
+#define PMC_FSPR_FSTP0_Pos                  0                                              /**< (PMC_FSPR) Fast Startup Input Polarity 0 Position */
+#define PMC_FSPR_FSTP0_Msk                  (_U_(0x1) << PMC_FSPR_FSTP0_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 0 Mask */
+#define PMC_FSPR_FSTP0                      PMC_FSPR_FSTP0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP0_Msk instead */
+#define PMC_FSPR_FSTP1_Pos                  1                                              /**< (PMC_FSPR) Fast Startup Input Polarity 1 Position */
+#define PMC_FSPR_FSTP1_Msk                  (_U_(0x1) << PMC_FSPR_FSTP1_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 1 Mask */
+#define PMC_FSPR_FSTP1                      PMC_FSPR_FSTP1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP1_Msk instead */
+#define PMC_FSPR_FSTP2_Pos                  2                                              /**< (PMC_FSPR) Fast Startup Input Polarity 2 Position */
+#define PMC_FSPR_FSTP2_Msk                  (_U_(0x1) << PMC_FSPR_FSTP2_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 2 Mask */
+#define PMC_FSPR_FSTP2                      PMC_FSPR_FSTP2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP2_Msk instead */
+#define PMC_FSPR_FSTP3_Pos                  3                                              /**< (PMC_FSPR) Fast Startup Input Polarity 3 Position */
+#define PMC_FSPR_FSTP3_Msk                  (_U_(0x1) << PMC_FSPR_FSTP3_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 3 Mask */
+#define PMC_FSPR_FSTP3                      PMC_FSPR_FSTP3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP3_Msk instead */
+#define PMC_FSPR_FSTP4_Pos                  4                                              /**< (PMC_FSPR) Fast Startup Input Polarity 4 Position */
+#define PMC_FSPR_FSTP4_Msk                  (_U_(0x1) << PMC_FSPR_FSTP4_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 4 Mask */
+#define PMC_FSPR_FSTP4                      PMC_FSPR_FSTP4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP4_Msk instead */
+#define PMC_FSPR_FSTP5_Pos                  5                                              /**< (PMC_FSPR) Fast Startup Input Polarity 5 Position */
+#define PMC_FSPR_FSTP5_Msk                  (_U_(0x1) << PMC_FSPR_FSTP5_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 5 Mask */
+#define PMC_FSPR_FSTP5                      PMC_FSPR_FSTP5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP5_Msk instead */
+#define PMC_FSPR_FSTP6_Pos                  6                                              /**< (PMC_FSPR) Fast Startup Input Polarity 6 Position */
+#define PMC_FSPR_FSTP6_Msk                  (_U_(0x1) << PMC_FSPR_FSTP6_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 6 Mask */
+#define PMC_FSPR_FSTP6                      PMC_FSPR_FSTP6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP6_Msk instead */
+#define PMC_FSPR_FSTP7_Pos                  7                                              /**< (PMC_FSPR) Fast Startup Input Polarity 7 Position */
+#define PMC_FSPR_FSTP7_Msk                  (_U_(0x1) << PMC_FSPR_FSTP7_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 7 Mask */
+#define PMC_FSPR_FSTP7                      PMC_FSPR_FSTP7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP7_Msk instead */
+#define PMC_FSPR_FSTP8_Pos                  8                                              /**< (PMC_FSPR) Fast Startup Input Polarity 8 Position */
+#define PMC_FSPR_FSTP8_Msk                  (_U_(0x1) << PMC_FSPR_FSTP8_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 8 Mask */
+#define PMC_FSPR_FSTP8                      PMC_FSPR_FSTP8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP8_Msk instead */
+#define PMC_FSPR_FSTP9_Pos                  9                                              /**< (PMC_FSPR) Fast Startup Input Polarity 9 Position */
+#define PMC_FSPR_FSTP9_Msk                  (_U_(0x1) << PMC_FSPR_FSTP9_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 9 Mask */
+#define PMC_FSPR_FSTP9                      PMC_FSPR_FSTP9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP9_Msk instead */
+#define PMC_FSPR_FSTP10_Pos                 10                                             /**< (PMC_FSPR) Fast Startup Input Polarity 10 Position */
+#define PMC_FSPR_FSTP10_Msk                 (_U_(0x1) << PMC_FSPR_FSTP10_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 10 Mask */
+#define PMC_FSPR_FSTP10                     PMC_FSPR_FSTP10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP10_Msk instead */
+#define PMC_FSPR_FSTP11_Pos                 11                                             /**< (PMC_FSPR) Fast Startup Input Polarity 11 Position */
+#define PMC_FSPR_FSTP11_Msk                 (_U_(0x1) << PMC_FSPR_FSTP11_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 11 Mask */
+#define PMC_FSPR_FSTP11                     PMC_FSPR_FSTP11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP11_Msk instead */
+#define PMC_FSPR_FSTP12_Pos                 12                                             /**< (PMC_FSPR) Fast Startup Input Polarity 12 Position */
+#define PMC_FSPR_FSTP12_Msk                 (_U_(0x1) << PMC_FSPR_FSTP12_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 12 Mask */
+#define PMC_FSPR_FSTP12                     PMC_FSPR_FSTP12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP12_Msk instead */
+#define PMC_FSPR_FSTP13_Pos                 13                                             /**< (PMC_FSPR) Fast Startup Input Polarity 13 Position */
+#define PMC_FSPR_FSTP13_Msk                 (_U_(0x1) << PMC_FSPR_FSTP13_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 13 Mask */
+#define PMC_FSPR_FSTP13                     PMC_FSPR_FSTP13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP13_Msk instead */
+#define PMC_FSPR_FSTP14_Pos                 14                                             /**< (PMC_FSPR) Fast Startup Input Polarity 14 Position */
+#define PMC_FSPR_FSTP14_Msk                 (_U_(0x1) << PMC_FSPR_FSTP14_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 14 Mask */
+#define PMC_FSPR_FSTP14                     PMC_FSPR_FSTP14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP14_Msk instead */
+#define PMC_FSPR_FSTP15_Pos                 15                                             /**< (PMC_FSPR) Fast Startup Input Polarity 15 Position */
+#define PMC_FSPR_FSTP15_Msk                 (_U_(0x1) << PMC_FSPR_FSTP15_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 15 Mask */
+#define PMC_FSPR_FSTP15                     PMC_FSPR_FSTP15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP15_Msk instead */
+#define PMC_FSPR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (PMC_FSPR) Register MASK  (Use PMC_FSPR_Msk instead)  */
+#define PMC_FSPR_Msk                        _U_(0xFFFF)                                    /**< (PMC_FSPR) Register Mask  */
+
+#define PMC_FSPR_FSTP_Pos                   0                                              /**< (PMC_FSPR Position) Fast Startup Input Polarity x5 */
+#define PMC_FSPR_FSTP_Msk                   (_U_(0xFFFF) << PMC_FSPR_FSTP_Pos)             /**< (PMC_FSPR Mask) FSTP */
+#define PMC_FSPR_FSTP(value)                (PMC_FSPR_FSTP_Msk & ((value) << PMC_FSPR_FSTP_Pos))  
+
+/* -------- PMC_FOCR : (PMC Offset: 0x78) (/W 32) Fault Output Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FOCLR:1;                   /**< bit:      0  Fault Output Clear                       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FOCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FOCR_OFFSET                     (0x78)                                        /**<  (PMC_FOCR) Fault Output Clear Register  Offset */
+
+#define PMC_FOCR_FOCLR_Pos                  0                                              /**< (PMC_FOCR) Fault Output Clear Position */
+#define PMC_FOCR_FOCLR_Msk                  (_U_(0x1) << PMC_FOCR_FOCLR_Pos)               /**< (PMC_FOCR) Fault Output Clear Mask */
+#define PMC_FOCR_FOCLR                      PMC_FOCR_FOCLR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FOCR_FOCLR_Msk instead */
+#define PMC_FOCR_MASK                       _U_(0x01)                                      /**< \deprecated (PMC_FOCR) Register MASK  (Use PMC_FOCR_Msk instead)  */
+#define PMC_FOCR_Msk                        _U_(0x01)                                      /**< (PMC_FOCR) Register Mask  */
+
+
+/* -------- PMC_WPMR : (PMC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_WPMR_OFFSET                     (0xE4)                                        /**<  (PMC_WPMR) Write Protection Mode Register  Offset */
+
+#define PMC_WPMR_WPEN_Pos                   0                                              /**< (PMC_WPMR) Write Protection Enable Position */
+#define PMC_WPMR_WPEN_Msk                   (_U_(0x1) << PMC_WPMR_WPEN_Pos)                /**< (PMC_WPMR) Write Protection Enable Mask */
+#define PMC_WPMR_WPEN                       PMC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_WPMR_WPEN_Msk instead */
+#define PMC_WPMR_WPKEY_Pos                  8                                              /**< (PMC_WPMR) Write Protection Key Position */
+#define PMC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << PMC_WPMR_WPKEY_Pos)          /**< (PMC_WPMR) Write Protection Key Mask */
+#define PMC_WPMR_WPKEY(value)               (PMC_WPMR_WPKEY_Msk & ((value) << PMC_WPMR_WPKEY_Pos))
+#define   PMC_WPMR_WPKEY_PASSWD_Val         _U_(0x504D43)                                  /**< (PMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define PMC_WPMR_WPKEY_PASSWD               (PMC_WPMR_WPKEY_PASSWD_Val << PMC_WPMR_WPKEY_Pos)  /**< (PMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define PMC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (PMC_WPMR) Register MASK  (Use PMC_WPMR_Msk instead)  */
+#define PMC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (PMC_WPMR) Register Mask  */
+
+
+/* -------- PMC_WPSR : (PMC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_WPSR_OFFSET                     (0xE8)                                        /**<  (PMC_WPSR) Write Protection Status Register  Offset */
+
+#define PMC_WPSR_WPVS_Pos                   0                                              /**< (PMC_WPSR) Write Protection Violation Status Position */
+#define PMC_WPSR_WPVS_Msk                   (_U_(0x1) << PMC_WPSR_WPVS_Pos)                /**< (PMC_WPSR) Write Protection Violation Status Mask */
+#define PMC_WPSR_WPVS                       PMC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_WPSR_WPVS_Msk instead */
+#define PMC_WPSR_WPVSRC_Pos                 8                                              /**< (PMC_WPSR) Write Protection Violation Source Position */
+#define PMC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PMC_WPSR_WPVSRC_Pos)           /**< (PMC_WPSR) Write Protection Violation Source Mask */
+#define PMC_WPSR_WPVSRC(value)              (PMC_WPSR_WPVSRC_Msk & ((value) << PMC_WPSR_WPVSRC_Pos))
+#define PMC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (PMC_WPSR) Register MASK  (Use PMC_WPSR_Msk instead)  */
+#define PMC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (PMC_WPSR) Register Mask  */
+
+
+/* -------- PMC_VERSION : (PMC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_VERSION_OFFSET                  (0xFC)                                        /**<  (PMC_VERSION) Version Register  Offset */
+
+#define PMC_VERSION_VERSION_Pos             0                                              /**< (PMC_VERSION) Version of the Hardware Module Position */
+#define PMC_VERSION_VERSION_Msk             (_U_(0xFFF) << PMC_VERSION_VERSION_Pos)        /**< (PMC_VERSION) Version of the Hardware Module Mask */
+#define PMC_VERSION_VERSION(value)          (PMC_VERSION_VERSION_Msk & ((value) << PMC_VERSION_VERSION_Pos))
+#define PMC_VERSION_MFN_Pos                 16                                             /**< (PMC_VERSION) Metal Fix Number Position */
+#define PMC_VERSION_MFN_Msk                 (_U_(0x7) << PMC_VERSION_MFN_Pos)              /**< (PMC_VERSION) Metal Fix Number Mask */
+#define PMC_VERSION_MFN(value)              (PMC_VERSION_MFN_Msk & ((value) << PMC_VERSION_MFN_Pos))
+#define PMC_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (PMC_VERSION) Register MASK  (Use PMC_VERSION_Msk instead)  */
+#define PMC_VERSION_Msk                     _U_(0x70FFF)                                   /**< (PMC_VERSION) Register Mask  */
+
+
+/* -------- PMC_PCER1 : (PMC Offset: 0x100) (/W 32) Peripheral Clock Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Enable               */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Enable               */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Enable               */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Enable               */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Enable               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Enable               */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Enable               */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Enable               */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Enable               */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Enable               */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Enable               */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Enable               */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Enable               */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Enable               */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Enable               */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Enable               */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Enable               */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Enable               */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Enable               */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Enable               */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Enable               */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Enable               */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Enable               */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Enable               */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Enable               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Enable               */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCER1_OFFSET                    (0x100)                                       /**<  (PMC_PCER1) Peripheral Clock Enable Register 1  Offset */
+
+#define PMC_PCER1_PID32_Pos                 0                                              /**< (PMC_PCER1) Peripheral Clock 32 Enable Position */
+#define PMC_PCER1_PID32_Msk                 (_U_(0x1) << PMC_PCER1_PID32_Pos)              /**< (PMC_PCER1) Peripheral Clock 32 Enable Mask */
+#define PMC_PCER1_PID32                     PMC_PCER1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID32_Msk instead */
+#define PMC_PCER1_PID33_Pos                 1                                              /**< (PMC_PCER1) Peripheral Clock 33 Enable Position */
+#define PMC_PCER1_PID33_Msk                 (_U_(0x1) << PMC_PCER1_PID33_Pos)              /**< (PMC_PCER1) Peripheral Clock 33 Enable Mask */
+#define PMC_PCER1_PID33                     PMC_PCER1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID33_Msk instead */
+#define PMC_PCER1_PID34_Pos                 2                                              /**< (PMC_PCER1) Peripheral Clock 34 Enable Position */
+#define PMC_PCER1_PID34_Msk                 (_U_(0x1) << PMC_PCER1_PID34_Pos)              /**< (PMC_PCER1) Peripheral Clock 34 Enable Mask */
+#define PMC_PCER1_PID34                     PMC_PCER1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID34_Msk instead */
+#define PMC_PCER1_PID35_Pos                 3                                              /**< (PMC_PCER1) Peripheral Clock 35 Enable Position */
+#define PMC_PCER1_PID35_Msk                 (_U_(0x1) << PMC_PCER1_PID35_Pos)              /**< (PMC_PCER1) Peripheral Clock 35 Enable Mask */
+#define PMC_PCER1_PID35                     PMC_PCER1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID35_Msk instead */
+#define PMC_PCER1_PID37_Pos                 5                                              /**< (PMC_PCER1) Peripheral Clock 37 Enable Position */
+#define PMC_PCER1_PID37_Msk                 (_U_(0x1) << PMC_PCER1_PID37_Pos)              /**< (PMC_PCER1) Peripheral Clock 37 Enable Mask */
+#define PMC_PCER1_PID37                     PMC_PCER1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID37_Msk instead */
+#define PMC_PCER1_PID39_Pos                 7                                              /**< (PMC_PCER1) Peripheral Clock 39 Enable Position */
+#define PMC_PCER1_PID39_Msk                 (_U_(0x1) << PMC_PCER1_PID39_Pos)              /**< (PMC_PCER1) Peripheral Clock 39 Enable Mask */
+#define PMC_PCER1_PID39                     PMC_PCER1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID39_Msk instead */
+#define PMC_PCER1_PID40_Pos                 8                                              /**< (PMC_PCER1) Peripheral Clock 40 Enable Position */
+#define PMC_PCER1_PID40_Msk                 (_U_(0x1) << PMC_PCER1_PID40_Pos)              /**< (PMC_PCER1) Peripheral Clock 40 Enable Mask */
+#define PMC_PCER1_PID40                     PMC_PCER1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID40_Msk instead */
+#define PMC_PCER1_PID41_Pos                 9                                              /**< (PMC_PCER1) Peripheral Clock 41 Enable Position */
+#define PMC_PCER1_PID41_Msk                 (_U_(0x1) << PMC_PCER1_PID41_Pos)              /**< (PMC_PCER1) Peripheral Clock 41 Enable Mask */
+#define PMC_PCER1_PID41                     PMC_PCER1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID41_Msk instead */
+#define PMC_PCER1_PID42_Pos                 10                                             /**< (PMC_PCER1) Peripheral Clock 42 Enable Position */
+#define PMC_PCER1_PID42_Msk                 (_U_(0x1) << PMC_PCER1_PID42_Pos)              /**< (PMC_PCER1) Peripheral Clock 42 Enable Mask */
+#define PMC_PCER1_PID42                     PMC_PCER1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID42_Msk instead */
+#define PMC_PCER1_PID43_Pos                 11                                             /**< (PMC_PCER1) Peripheral Clock 43 Enable Position */
+#define PMC_PCER1_PID43_Msk                 (_U_(0x1) << PMC_PCER1_PID43_Pos)              /**< (PMC_PCER1) Peripheral Clock 43 Enable Mask */
+#define PMC_PCER1_PID43                     PMC_PCER1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID43_Msk instead */
+#define PMC_PCER1_PID44_Pos                 12                                             /**< (PMC_PCER1) Peripheral Clock 44 Enable Position */
+#define PMC_PCER1_PID44_Msk                 (_U_(0x1) << PMC_PCER1_PID44_Pos)              /**< (PMC_PCER1) Peripheral Clock 44 Enable Mask */
+#define PMC_PCER1_PID44                     PMC_PCER1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID44_Msk instead */
+#define PMC_PCER1_PID45_Pos                 13                                             /**< (PMC_PCER1) Peripheral Clock 45 Enable Position */
+#define PMC_PCER1_PID45_Msk                 (_U_(0x1) << PMC_PCER1_PID45_Pos)              /**< (PMC_PCER1) Peripheral Clock 45 Enable Mask */
+#define PMC_PCER1_PID45                     PMC_PCER1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID45_Msk instead */
+#define PMC_PCER1_PID46_Pos                 14                                             /**< (PMC_PCER1) Peripheral Clock 46 Enable Position */
+#define PMC_PCER1_PID46_Msk                 (_U_(0x1) << PMC_PCER1_PID46_Pos)              /**< (PMC_PCER1) Peripheral Clock 46 Enable Mask */
+#define PMC_PCER1_PID46                     PMC_PCER1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID46_Msk instead */
+#define PMC_PCER1_PID47_Pos                 15                                             /**< (PMC_PCER1) Peripheral Clock 47 Enable Position */
+#define PMC_PCER1_PID47_Msk                 (_U_(0x1) << PMC_PCER1_PID47_Pos)              /**< (PMC_PCER1) Peripheral Clock 47 Enable Mask */
+#define PMC_PCER1_PID47                     PMC_PCER1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID47_Msk instead */
+#define PMC_PCER1_PID48_Pos                 16                                             /**< (PMC_PCER1) Peripheral Clock 48 Enable Position */
+#define PMC_PCER1_PID48_Msk                 (_U_(0x1) << PMC_PCER1_PID48_Pos)              /**< (PMC_PCER1) Peripheral Clock 48 Enable Mask */
+#define PMC_PCER1_PID48                     PMC_PCER1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID48_Msk instead */
+#define PMC_PCER1_PID49_Pos                 17                                             /**< (PMC_PCER1) Peripheral Clock 49 Enable Position */
+#define PMC_PCER1_PID49_Msk                 (_U_(0x1) << PMC_PCER1_PID49_Pos)              /**< (PMC_PCER1) Peripheral Clock 49 Enable Mask */
+#define PMC_PCER1_PID49                     PMC_PCER1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID49_Msk instead */
+#define PMC_PCER1_PID50_Pos                 18                                             /**< (PMC_PCER1) Peripheral Clock 50 Enable Position */
+#define PMC_PCER1_PID50_Msk                 (_U_(0x1) << PMC_PCER1_PID50_Pos)              /**< (PMC_PCER1) Peripheral Clock 50 Enable Mask */
+#define PMC_PCER1_PID50                     PMC_PCER1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID50_Msk instead */
+#define PMC_PCER1_PID51_Pos                 19                                             /**< (PMC_PCER1) Peripheral Clock 51 Enable Position */
+#define PMC_PCER1_PID51_Msk                 (_U_(0x1) << PMC_PCER1_PID51_Pos)              /**< (PMC_PCER1) Peripheral Clock 51 Enable Mask */
+#define PMC_PCER1_PID51                     PMC_PCER1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID51_Msk instead */
+#define PMC_PCER1_PID52_Pos                 20                                             /**< (PMC_PCER1) Peripheral Clock 52 Enable Position */
+#define PMC_PCER1_PID52_Msk                 (_U_(0x1) << PMC_PCER1_PID52_Pos)              /**< (PMC_PCER1) Peripheral Clock 52 Enable Mask */
+#define PMC_PCER1_PID52                     PMC_PCER1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID52_Msk instead */
+#define PMC_PCER1_PID53_Pos                 21                                             /**< (PMC_PCER1) Peripheral Clock 53 Enable Position */
+#define PMC_PCER1_PID53_Msk                 (_U_(0x1) << PMC_PCER1_PID53_Pos)              /**< (PMC_PCER1) Peripheral Clock 53 Enable Mask */
+#define PMC_PCER1_PID53                     PMC_PCER1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID53_Msk instead */
+#define PMC_PCER1_PID56_Pos                 24                                             /**< (PMC_PCER1) Peripheral Clock 56 Enable Position */
+#define PMC_PCER1_PID56_Msk                 (_U_(0x1) << PMC_PCER1_PID56_Pos)              /**< (PMC_PCER1) Peripheral Clock 56 Enable Mask */
+#define PMC_PCER1_PID56                     PMC_PCER1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID56_Msk instead */
+#define PMC_PCER1_PID57_Pos                 25                                             /**< (PMC_PCER1) Peripheral Clock 57 Enable Position */
+#define PMC_PCER1_PID57_Msk                 (_U_(0x1) << PMC_PCER1_PID57_Pos)              /**< (PMC_PCER1) Peripheral Clock 57 Enable Mask */
+#define PMC_PCER1_PID57                     PMC_PCER1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID57_Msk instead */
+#define PMC_PCER1_PID58_Pos                 26                                             /**< (PMC_PCER1) Peripheral Clock 58 Enable Position */
+#define PMC_PCER1_PID58_Msk                 (_U_(0x1) << PMC_PCER1_PID58_Pos)              /**< (PMC_PCER1) Peripheral Clock 58 Enable Mask */
+#define PMC_PCER1_PID58                     PMC_PCER1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID58_Msk instead */
+#define PMC_PCER1_PID59_Pos                 27                                             /**< (PMC_PCER1) Peripheral Clock 59 Enable Position */
+#define PMC_PCER1_PID59_Msk                 (_U_(0x1) << PMC_PCER1_PID59_Pos)              /**< (PMC_PCER1) Peripheral Clock 59 Enable Mask */
+#define PMC_PCER1_PID59                     PMC_PCER1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID59_Msk instead */
+#define PMC_PCER1_PID60_Pos                 28                                             /**< (PMC_PCER1) Peripheral Clock 60 Enable Position */
+#define PMC_PCER1_PID60_Msk                 (_U_(0x1) << PMC_PCER1_PID60_Pos)              /**< (PMC_PCER1) Peripheral Clock 60 Enable Mask */
+#define PMC_PCER1_PID60                     PMC_PCER1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID60_Msk instead */
+#define PMC_PCER1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCER1) Register MASK  (Use PMC_PCER1_Msk instead)  */
+#define PMC_PCER1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCER1) Register Mask  */
+
+#define PMC_PCER1_PID_Pos                   0                                              /**< (PMC_PCER1 Position) Peripheral Clock 6x Enable */
+#define PMC_PCER1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER1_PID_Pos)          /**< (PMC_PCER1 Mask) PID */
+#define PMC_PCER1_PID(value)                (PMC_PCER1_PID_Msk & ((value) << PMC_PCER1_PID_Pos))  
+
+/* -------- PMC_PCDR1 : (PMC Offset: 0x104) (/W 32) Peripheral Clock Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Disable              */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Disable              */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Disable              */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Disable              */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Disable              */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Disable              */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Disable              */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Disable              */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Disable              */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Disable              */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Disable              */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Disable              */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Disable              */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Disable              */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Disable              */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Disable              */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Disable              */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Disable              */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Disable              */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Disable              */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Disable              */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Disable              */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Disable              */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Disable              */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Disable              */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Disable              */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCDR1_OFFSET                    (0x104)                                       /**<  (PMC_PCDR1) Peripheral Clock Disable Register 1  Offset */
+
+#define PMC_PCDR1_PID32_Pos                 0                                              /**< (PMC_PCDR1) Peripheral Clock 32 Disable Position */
+#define PMC_PCDR1_PID32_Msk                 (_U_(0x1) << PMC_PCDR1_PID32_Pos)              /**< (PMC_PCDR1) Peripheral Clock 32 Disable Mask */
+#define PMC_PCDR1_PID32                     PMC_PCDR1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID32_Msk instead */
+#define PMC_PCDR1_PID33_Pos                 1                                              /**< (PMC_PCDR1) Peripheral Clock 33 Disable Position */
+#define PMC_PCDR1_PID33_Msk                 (_U_(0x1) << PMC_PCDR1_PID33_Pos)              /**< (PMC_PCDR1) Peripheral Clock 33 Disable Mask */
+#define PMC_PCDR1_PID33                     PMC_PCDR1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID33_Msk instead */
+#define PMC_PCDR1_PID34_Pos                 2                                              /**< (PMC_PCDR1) Peripheral Clock 34 Disable Position */
+#define PMC_PCDR1_PID34_Msk                 (_U_(0x1) << PMC_PCDR1_PID34_Pos)              /**< (PMC_PCDR1) Peripheral Clock 34 Disable Mask */
+#define PMC_PCDR1_PID34                     PMC_PCDR1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID34_Msk instead */
+#define PMC_PCDR1_PID35_Pos                 3                                              /**< (PMC_PCDR1) Peripheral Clock 35 Disable Position */
+#define PMC_PCDR1_PID35_Msk                 (_U_(0x1) << PMC_PCDR1_PID35_Pos)              /**< (PMC_PCDR1) Peripheral Clock 35 Disable Mask */
+#define PMC_PCDR1_PID35                     PMC_PCDR1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID35_Msk instead */
+#define PMC_PCDR1_PID37_Pos                 5                                              /**< (PMC_PCDR1) Peripheral Clock 37 Disable Position */
+#define PMC_PCDR1_PID37_Msk                 (_U_(0x1) << PMC_PCDR1_PID37_Pos)              /**< (PMC_PCDR1) Peripheral Clock 37 Disable Mask */
+#define PMC_PCDR1_PID37                     PMC_PCDR1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID37_Msk instead */
+#define PMC_PCDR1_PID39_Pos                 7                                              /**< (PMC_PCDR1) Peripheral Clock 39 Disable Position */
+#define PMC_PCDR1_PID39_Msk                 (_U_(0x1) << PMC_PCDR1_PID39_Pos)              /**< (PMC_PCDR1) Peripheral Clock 39 Disable Mask */
+#define PMC_PCDR1_PID39                     PMC_PCDR1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID39_Msk instead */
+#define PMC_PCDR1_PID40_Pos                 8                                              /**< (PMC_PCDR1) Peripheral Clock 40 Disable Position */
+#define PMC_PCDR1_PID40_Msk                 (_U_(0x1) << PMC_PCDR1_PID40_Pos)              /**< (PMC_PCDR1) Peripheral Clock 40 Disable Mask */
+#define PMC_PCDR1_PID40                     PMC_PCDR1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID40_Msk instead */
+#define PMC_PCDR1_PID41_Pos                 9                                              /**< (PMC_PCDR1) Peripheral Clock 41 Disable Position */
+#define PMC_PCDR1_PID41_Msk                 (_U_(0x1) << PMC_PCDR1_PID41_Pos)              /**< (PMC_PCDR1) Peripheral Clock 41 Disable Mask */
+#define PMC_PCDR1_PID41                     PMC_PCDR1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID41_Msk instead */
+#define PMC_PCDR1_PID42_Pos                 10                                             /**< (PMC_PCDR1) Peripheral Clock 42 Disable Position */
+#define PMC_PCDR1_PID42_Msk                 (_U_(0x1) << PMC_PCDR1_PID42_Pos)              /**< (PMC_PCDR1) Peripheral Clock 42 Disable Mask */
+#define PMC_PCDR1_PID42                     PMC_PCDR1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID42_Msk instead */
+#define PMC_PCDR1_PID43_Pos                 11                                             /**< (PMC_PCDR1) Peripheral Clock 43 Disable Position */
+#define PMC_PCDR1_PID43_Msk                 (_U_(0x1) << PMC_PCDR1_PID43_Pos)              /**< (PMC_PCDR1) Peripheral Clock 43 Disable Mask */
+#define PMC_PCDR1_PID43                     PMC_PCDR1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID43_Msk instead */
+#define PMC_PCDR1_PID44_Pos                 12                                             /**< (PMC_PCDR1) Peripheral Clock 44 Disable Position */
+#define PMC_PCDR1_PID44_Msk                 (_U_(0x1) << PMC_PCDR1_PID44_Pos)              /**< (PMC_PCDR1) Peripheral Clock 44 Disable Mask */
+#define PMC_PCDR1_PID44                     PMC_PCDR1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID44_Msk instead */
+#define PMC_PCDR1_PID45_Pos                 13                                             /**< (PMC_PCDR1) Peripheral Clock 45 Disable Position */
+#define PMC_PCDR1_PID45_Msk                 (_U_(0x1) << PMC_PCDR1_PID45_Pos)              /**< (PMC_PCDR1) Peripheral Clock 45 Disable Mask */
+#define PMC_PCDR1_PID45                     PMC_PCDR1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID45_Msk instead */
+#define PMC_PCDR1_PID46_Pos                 14                                             /**< (PMC_PCDR1) Peripheral Clock 46 Disable Position */
+#define PMC_PCDR1_PID46_Msk                 (_U_(0x1) << PMC_PCDR1_PID46_Pos)              /**< (PMC_PCDR1) Peripheral Clock 46 Disable Mask */
+#define PMC_PCDR1_PID46                     PMC_PCDR1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID46_Msk instead */
+#define PMC_PCDR1_PID47_Pos                 15                                             /**< (PMC_PCDR1) Peripheral Clock 47 Disable Position */
+#define PMC_PCDR1_PID47_Msk                 (_U_(0x1) << PMC_PCDR1_PID47_Pos)              /**< (PMC_PCDR1) Peripheral Clock 47 Disable Mask */
+#define PMC_PCDR1_PID47                     PMC_PCDR1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID47_Msk instead */
+#define PMC_PCDR1_PID48_Pos                 16                                             /**< (PMC_PCDR1) Peripheral Clock 48 Disable Position */
+#define PMC_PCDR1_PID48_Msk                 (_U_(0x1) << PMC_PCDR1_PID48_Pos)              /**< (PMC_PCDR1) Peripheral Clock 48 Disable Mask */
+#define PMC_PCDR1_PID48                     PMC_PCDR1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID48_Msk instead */
+#define PMC_PCDR1_PID49_Pos                 17                                             /**< (PMC_PCDR1) Peripheral Clock 49 Disable Position */
+#define PMC_PCDR1_PID49_Msk                 (_U_(0x1) << PMC_PCDR1_PID49_Pos)              /**< (PMC_PCDR1) Peripheral Clock 49 Disable Mask */
+#define PMC_PCDR1_PID49                     PMC_PCDR1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID49_Msk instead */
+#define PMC_PCDR1_PID50_Pos                 18                                             /**< (PMC_PCDR1) Peripheral Clock 50 Disable Position */
+#define PMC_PCDR1_PID50_Msk                 (_U_(0x1) << PMC_PCDR1_PID50_Pos)              /**< (PMC_PCDR1) Peripheral Clock 50 Disable Mask */
+#define PMC_PCDR1_PID50                     PMC_PCDR1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID50_Msk instead */
+#define PMC_PCDR1_PID51_Pos                 19                                             /**< (PMC_PCDR1) Peripheral Clock 51 Disable Position */
+#define PMC_PCDR1_PID51_Msk                 (_U_(0x1) << PMC_PCDR1_PID51_Pos)              /**< (PMC_PCDR1) Peripheral Clock 51 Disable Mask */
+#define PMC_PCDR1_PID51                     PMC_PCDR1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID51_Msk instead */
+#define PMC_PCDR1_PID52_Pos                 20                                             /**< (PMC_PCDR1) Peripheral Clock 52 Disable Position */
+#define PMC_PCDR1_PID52_Msk                 (_U_(0x1) << PMC_PCDR1_PID52_Pos)              /**< (PMC_PCDR1) Peripheral Clock 52 Disable Mask */
+#define PMC_PCDR1_PID52                     PMC_PCDR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID52_Msk instead */
+#define PMC_PCDR1_PID53_Pos                 21                                             /**< (PMC_PCDR1) Peripheral Clock 53 Disable Position */
+#define PMC_PCDR1_PID53_Msk                 (_U_(0x1) << PMC_PCDR1_PID53_Pos)              /**< (PMC_PCDR1) Peripheral Clock 53 Disable Mask */
+#define PMC_PCDR1_PID53                     PMC_PCDR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID53_Msk instead */
+#define PMC_PCDR1_PID56_Pos                 24                                             /**< (PMC_PCDR1) Peripheral Clock 56 Disable Position */
+#define PMC_PCDR1_PID56_Msk                 (_U_(0x1) << PMC_PCDR1_PID56_Pos)              /**< (PMC_PCDR1) Peripheral Clock 56 Disable Mask */
+#define PMC_PCDR1_PID56                     PMC_PCDR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID56_Msk instead */
+#define PMC_PCDR1_PID57_Pos                 25                                             /**< (PMC_PCDR1) Peripheral Clock 57 Disable Position */
+#define PMC_PCDR1_PID57_Msk                 (_U_(0x1) << PMC_PCDR1_PID57_Pos)              /**< (PMC_PCDR1) Peripheral Clock 57 Disable Mask */
+#define PMC_PCDR1_PID57                     PMC_PCDR1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID57_Msk instead */
+#define PMC_PCDR1_PID58_Pos                 26                                             /**< (PMC_PCDR1) Peripheral Clock 58 Disable Position */
+#define PMC_PCDR1_PID58_Msk                 (_U_(0x1) << PMC_PCDR1_PID58_Pos)              /**< (PMC_PCDR1) Peripheral Clock 58 Disable Mask */
+#define PMC_PCDR1_PID58                     PMC_PCDR1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID58_Msk instead */
+#define PMC_PCDR1_PID59_Pos                 27                                             /**< (PMC_PCDR1) Peripheral Clock 59 Disable Position */
+#define PMC_PCDR1_PID59_Msk                 (_U_(0x1) << PMC_PCDR1_PID59_Pos)              /**< (PMC_PCDR1) Peripheral Clock 59 Disable Mask */
+#define PMC_PCDR1_PID59                     PMC_PCDR1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID59_Msk instead */
+#define PMC_PCDR1_PID60_Pos                 28                                             /**< (PMC_PCDR1) Peripheral Clock 60 Disable Position */
+#define PMC_PCDR1_PID60_Msk                 (_U_(0x1) << PMC_PCDR1_PID60_Pos)              /**< (PMC_PCDR1) Peripheral Clock 60 Disable Mask */
+#define PMC_PCDR1_PID60                     PMC_PCDR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID60_Msk instead */
+#define PMC_PCDR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCDR1) Register MASK  (Use PMC_PCDR1_Msk instead)  */
+#define PMC_PCDR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCDR1) Register Mask  */
+
+#define PMC_PCDR1_PID_Pos                   0                                              /**< (PMC_PCDR1 Position) Peripheral Clock 6x Disable */
+#define PMC_PCDR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR1_PID_Pos)          /**< (PMC_PCDR1 Mask) PID */
+#define PMC_PCDR1_PID(value)                (PMC_PCDR1_PID_Msk & ((value) << PMC_PCDR1_PID_Pos))  
+
+/* -------- PMC_PCSR1 : (PMC Offset: 0x108) (R/ 32) Peripheral Clock Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Status               */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Status               */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Status               */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Status               */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Status               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Status               */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Status               */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Status               */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Status               */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Status               */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Status               */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Status               */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Status               */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Status               */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Status               */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Status               */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Status               */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Status               */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Status               */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Status               */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Status               */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Status               */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Status               */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Status               */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Status               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Status               */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCSR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCSR1_OFFSET                    (0x108)                                       /**<  (PMC_PCSR1) Peripheral Clock Status Register 1  Offset */
+
+#define PMC_PCSR1_PID32_Pos                 0                                              /**< (PMC_PCSR1) Peripheral Clock 32 Status Position */
+#define PMC_PCSR1_PID32_Msk                 (_U_(0x1) << PMC_PCSR1_PID32_Pos)              /**< (PMC_PCSR1) Peripheral Clock 32 Status Mask */
+#define PMC_PCSR1_PID32                     PMC_PCSR1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID32_Msk instead */
+#define PMC_PCSR1_PID33_Pos                 1                                              /**< (PMC_PCSR1) Peripheral Clock 33 Status Position */
+#define PMC_PCSR1_PID33_Msk                 (_U_(0x1) << PMC_PCSR1_PID33_Pos)              /**< (PMC_PCSR1) Peripheral Clock 33 Status Mask */
+#define PMC_PCSR1_PID33                     PMC_PCSR1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID33_Msk instead */
+#define PMC_PCSR1_PID34_Pos                 2                                              /**< (PMC_PCSR1) Peripheral Clock 34 Status Position */
+#define PMC_PCSR1_PID34_Msk                 (_U_(0x1) << PMC_PCSR1_PID34_Pos)              /**< (PMC_PCSR1) Peripheral Clock 34 Status Mask */
+#define PMC_PCSR1_PID34                     PMC_PCSR1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID34_Msk instead */
+#define PMC_PCSR1_PID35_Pos                 3                                              /**< (PMC_PCSR1) Peripheral Clock 35 Status Position */
+#define PMC_PCSR1_PID35_Msk                 (_U_(0x1) << PMC_PCSR1_PID35_Pos)              /**< (PMC_PCSR1) Peripheral Clock 35 Status Mask */
+#define PMC_PCSR1_PID35                     PMC_PCSR1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID35_Msk instead */
+#define PMC_PCSR1_PID37_Pos                 5                                              /**< (PMC_PCSR1) Peripheral Clock 37 Status Position */
+#define PMC_PCSR1_PID37_Msk                 (_U_(0x1) << PMC_PCSR1_PID37_Pos)              /**< (PMC_PCSR1) Peripheral Clock 37 Status Mask */
+#define PMC_PCSR1_PID37                     PMC_PCSR1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID37_Msk instead */
+#define PMC_PCSR1_PID39_Pos                 7                                              /**< (PMC_PCSR1) Peripheral Clock 39 Status Position */
+#define PMC_PCSR1_PID39_Msk                 (_U_(0x1) << PMC_PCSR1_PID39_Pos)              /**< (PMC_PCSR1) Peripheral Clock 39 Status Mask */
+#define PMC_PCSR1_PID39                     PMC_PCSR1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID39_Msk instead */
+#define PMC_PCSR1_PID40_Pos                 8                                              /**< (PMC_PCSR1) Peripheral Clock 40 Status Position */
+#define PMC_PCSR1_PID40_Msk                 (_U_(0x1) << PMC_PCSR1_PID40_Pos)              /**< (PMC_PCSR1) Peripheral Clock 40 Status Mask */
+#define PMC_PCSR1_PID40                     PMC_PCSR1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID40_Msk instead */
+#define PMC_PCSR1_PID41_Pos                 9                                              /**< (PMC_PCSR1) Peripheral Clock 41 Status Position */
+#define PMC_PCSR1_PID41_Msk                 (_U_(0x1) << PMC_PCSR1_PID41_Pos)              /**< (PMC_PCSR1) Peripheral Clock 41 Status Mask */
+#define PMC_PCSR1_PID41                     PMC_PCSR1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID41_Msk instead */
+#define PMC_PCSR1_PID42_Pos                 10                                             /**< (PMC_PCSR1) Peripheral Clock 42 Status Position */
+#define PMC_PCSR1_PID42_Msk                 (_U_(0x1) << PMC_PCSR1_PID42_Pos)              /**< (PMC_PCSR1) Peripheral Clock 42 Status Mask */
+#define PMC_PCSR1_PID42                     PMC_PCSR1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID42_Msk instead */
+#define PMC_PCSR1_PID43_Pos                 11                                             /**< (PMC_PCSR1) Peripheral Clock 43 Status Position */
+#define PMC_PCSR1_PID43_Msk                 (_U_(0x1) << PMC_PCSR1_PID43_Pos)              /**< (PMC_PCSR1) Peripheral Clock 43 Status Mask */
+#define PMC_PCSR1_PID43                     PMC_PCSR1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID43_Msk instead */
+#define PMC_PCSR1_PID44_Pos                 12                                             /**< (PMC_PCSR1) Peripheral Clock 44 Status Position */
+#define PMC_PCSR1_PID44_Msk                 (_U_(0x1) << PMC_PCSR1_PID44_Pos)              /**< (PMC_PCSR1) Peripheral Clock 44 Status Mask */
+#define PMC_PCSR1_PID44                     PMC_PCSR1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID44_Msk instead */
+#define PMC_PCSR1_PID45_Pos                 13                                             /**< (PMC_PCSR1) Peripheral Clock 45 Status Position */
+#define PMC_PCSR1_PID45_Msk                 (_U_(0x1) << PMC_PCSR1_PID45_Pos)              /**< (PMC_PCSR1) Peripheral Clock 45 Status Mask */
+#define PMC_PCSR1_PID45                     PMC_PCSR1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID45_Msk instead */
+#define PMC_PCSR1_PID46_Pos                 14                                             /**< (PMC_PCSR1) Peripheral Clock 46 Status Position */
+#define PMC_PCSR1_PID46_Msk                 (_U_(0x1) << PMC_PCSR1_PID46_Pos)              /**< (PMC_PCSR1) Peripheral Clock 46 Status Mask */
+#define PMC_PCSR1_PID46                     PMC_PCSR1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID46_Msk instead */
+#define PMC_PCSR1_PID47_Pos                 15                                             /**< (PMC_PCSR1) Peripheral Clock 47 Status Position */
+#define PMC_PCSR1_PID47_Msk                 (_U_(0x1) << PMC_PCSR1_PID47_Pos)              /**< (PMC_PCSR1) Peripheral Clock 47 Status Mask */
+#define PMC_PCSR1_PID47                     PMC_PCSR1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID47_Msk instead */
+#define PMC_PCSR1_PID48_Pos                 16                                             /**< (PMC_PCSR1) Peripheral Clock 48 Status Position */
+#define PMC_PCSR1_PID48_Msk                 (_U_(0x1) << PMC_PCSR1_PID48_Pos)              /**< (PMC_PCSR1) Peripheral Clock 48 Status Mask */
+#define PMC_PCSR1_PID48                     PMC_PCSR1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID48_Msk instead */
+#define PMC_PCSR1_PID49_Pos                 17                                             /**< (PMC_PCSR1) Peripheral Clock 49 Status Position */
+#define PMC_PCSR1_PID49_Msk                 (_U_(0x1) << PMC_PCSR1_PID49_Pos)              /**< (PMC_PCSR1) Peripheral Clock 49 Status Mask */
+#define PMC_PCSR1_PID49                     PMC_PCSR1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID49_Msk instead */
+#define PMC_PCSR1_PID50_Pos                 18                                             /**< (PMC_PCSR1) Peripheral Clock 50 Status Position */
+#define PMC_PCSR1_PID50_Msk                 (_U_(0x1) << PMC_PCSR1_PID50_Pos)              /**< (PMC_PCSR1) Peripheral Clock 50 Status Mask */
+#define PMC_PCSR1_PID50                     PMC_PCSR1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID50_Msk instead */
+#define PMC_PCSR1_PID51_Pos                 19                                             /**< (PMC_PCSR1) Peripheral Clock 51 Status Position */
+#define PMC_PCSR1_PID51_Msk                 (_U_(0x1) << PMC_PCSR1_PID51_Pos)              /**< (PMC_PCSR1) Peripheral Clock 51 Status Mask */
+#define PMC_PCSR1_PID51                     PMC_PCSR1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID51_Msk instead */
+#define PMC_PCSR1_PID52_Pos                 20                                             /**< (PMC_PCSR1) Peripheral Clock 52 Status Position */
+#define PMC_PCSR1_PID52_Msk                 (_U_(0x1) << PMC_PCSR1_PID52_Pos)              /**< (PMC_PCSR1) Peripheral Clock 52 Status Mask */
+#define PMC_PCSR1_PID52                     PMC_PCSR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID52_Msk instead */
+#define PMC_PCSR1_PID53_Pos                 21                                             /**< (PMC_PCSR1) Peripheral Clock 53 Status Position */
+#define PMC_PCSR1_PID53_Msk                 (_U_(0x1) << PMC_PCSR1_PID53_Pos)              /**< (PMC_PCSR1) Peripheral Clock 53 Status Mask */
+#define PMC_PCSR1_PID53                     PMC_PCSR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID53_Msk instead */
+#define PMC_PCSR1_PID56_Pos                 24                                             /**< (PMC_PCSR1) Peripheral Clock 56 Status Position */
+#define PMC_PCSR1_PID56_Msk                 (_U_(0x1) << PMC_PCSR1_PID56_Pos)              /**< (PMC_PCSR1) Peripheral Clock 56 Status Mask */
+#define PMC_PCSR1_PID56                     PMC_PCSR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID56_Msk instead */
+#define PMC_PCSR1_PID57_Pos                 25                                             /**< (PMC_PCSR1) Peripheral Clock 57 Status Position */
+#define PMC_PCSR1_PID57_Msk                 (_U_(0x1) << PMC_PCSR1_PID57_Pos)              /**< (PMC_PCSR1) Peripheral Clock 57 Status Mask */
+#define PMC_PCSR1_PID57                     PMC_PCSR1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID57_Msk instead */
+#define PMC_PCSR1_PID58_Pos                 26                                             /**< (PMC_PCSR1) Peripheral Clock 58 Status Position */
+#define PMC_PCSR1_PID58_Msk                 (_U_(0x1) << PMC_PCSR1_PID58_Pos)              /**< (PMC_PCSR1) Peripheral Clock 58 Status Mask */
+#define PMC_PCSR1_PID58                     PMC_PCSR1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID58_Msk instead */
+#define PMC_PCSR1_PID59_Pos                 27                                             /**< (PMC_PCSR1) Peripheral Clock 59 Status Position */
+#define PMC_PCSR1_PID59_Msk                 (_U_(0x1) << PMC_PCSR1_PID59_Pos)              /**< (PMC_PCSR1) Peripheral Clock 59 Status Mask */
+#define PMC_PCSR1_PID59                     PMC_PCSR1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID59_Msk instead */
+#define PMC_PCSR1_PID60_Pos                 28                                             /**< (PMC_PCSR1) Peripheral Clock 60 Status Position */
+#define PMC_PCSR1_PID60_Msk                 (_U_(0x1) << PMC_PCSR1_PID60_Pos)              /**< (PMC_PCSR1) Peripheral Clock 60 Status Mask */
+#define PMC_PCSR1_PID60                     PMC_PCSR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID60_Msk instead */
+#define PMC_PCSR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCSR1) Register MASK  (Use PMC_PCSR1_Msk instead)  */
+#define PMC_PCSR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCSR1) Register Mask  */
+
+#define PMC_PCSR1_PID_Pos                   0                                              /**< (PMC_PCSR1 Position) Peripheral Clock 6x Status */
+#define PMC_PCSR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR1_PID_Pos)          /**< (PMC_PCSR1 Mask) PID */
+#define PMC_PCSR1_PID(value)                (PMC_PCSR1_PID_Msk & ((value) << PMC_PCSR1_PID_Pos))  
+
+/* -------- PMC_PCR : (PMC Offset: 0x10c) (R/W 32) Peripheral Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID:7;                     /**< bit:   0..6  Peripheral ID                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t GCLKCSS:3;                 /**< bit:  8..10  Generic Clock Source Selection           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t CMD:1;                     /**< bit:     12  Command                                  */
+    uint32_t :7;                        /**< bit: 13..19  Reserved */
+    uint32_t GCLKDIV:8;                 /**< bit: 20..27  Generic Clock Division Ratio             */
+    uint32_t EN:1;                      /**< bit:     28  Enable                                   */
+    uint32_t GCLKEN:1;                  /**< bit:     29  Generic Clock Enable                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCR_OFFSET                      (0x10C)                                       /**<  (PMC_PCR) Peripheral Control Register  Offset */
+
+#define PMC_PCR_PID_Pos                     0                                              /**< (PMC_PCR) Peripheral ID Position */
+#define PMC_PCR_PID_Msk                     (_U_(0x7F) << PMC_PCR_PID_Pos)                 /**< (PMC_PCR) Peripheral ID Mask */
+#define PMC_PCR_PID(value)                  (PMC_PCR_PID_Msk & ((value) << PMC_PCR_PID_Pos))
+#define PMC_PCR_GCLKCSS_Pos                 8                                              /**< (PMC_PCR) Generic Clock Source Selection Position */
+#define PMC_PCR_GCLKCSS_Msk                 (_U_(0x7) << PMC_PCR_GCLKCSS_Pos)              /**< (PMC_PCR) Generic Clock Source Selection Mask */
+#define PMC_PCR_GCLKCSS(value)              (PMC_PCR_GCLKCSS_Msk & ((value) << PMC_PCR_GCLKCSS_Pos))
+#define   PMC_PCR_GCLKCSS_SLOW_CLK_Val      _U_(0x0)                                       /**< (PMC_PCR) SLCK is selected  */
+#define   PMC_PCR_GCLKCSS_MAIN_CLK_Val      _U_(0x1)                                       /**< (PMC_PCR) MAINCK is selected  */
+#define   PMC_PCR_GCLKCSS_PLLA_CLK_Val      _U_(0x2)                                       /**< (PMC_PCR) PLLACK is selected  */
+#define   PMC_PCR_GCLKCSS_UPLL_CLK_Val      _U_(0x3)                                       /**< (PMC_PCR) UPLLCK is selected  */
+#define   PMC_PCR_GCLKCSS_MCK_CLK_Val       _U_(0x4)                                       /**< (PMC_PCR) MCK is selected  */
+#define PMC_PCR_GCLKCSS_SLOW_CLK            (PMC_PCR_GCLKCSS_SLOW_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) SLCK is selected Position  */
+#define PMC_PCR_GCLKCSS_MAIN_CLK            (PMC_PCR_GCLKCSS_MAIN_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) MAINCK is selected Position  */
+#define PMC_PCR_GCLKCSS_PLLA_CLK            (PMC_PCR_GCLKCSS_PLLA_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) PLLACK is selected Position  */
+#define PMC_PCR_GCLKCSS_UPLL_CLK            (PMC_PCR_GCLKCSS_UPLL_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) UPLLCK is selected Position  */
+#define PMC_PCR_GCLKCSS_MCK_CLK             (PMC_PCR_GCLKCSS_MCK_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) MCK is selected Position  */
+#define PMC_PCR_CMD_Pos                     12                                             /**< (PMC_PCR) Command Position */
+#define PMC_PCR_CMD_Msk                     (_U_(0x1) << PMC_PCR_CMD_Pos)                  /**< (PMC_PCR) Command Mask */
+#define PMC_PCR_CMD                         PMC_PCR_CMD_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_CMD_Msk instead */
+#define PMC_PCR_GCLKDIV_Pos                 20                                             /**< (PMC_PCR) Generic Clock Division Ratio Position */
+#define PMC_PCR_GCLKDIV_Msk                 (_U_(0xFF) << PMC_PCR_GCLKDIV_Pos)             /**< (PMC_PCR) Generic Clock Division Ratio Mask */
+#define PMC_PCR_GCLKDIV(value)              (PMC_PCR_GCLKDIV_Msk & ((value) << PMC_PCR_GCLKDIV_Pos))
+#define PMC_PCR_EN_Pos                      28                                             /**< (PMC_PCR) Enable Position */
+#define PMC_PCR_EN_Msk                      (_U_(0x1) << PMC_PCR_EN_Pos)                   /**< (PMC_PCR) Enable Mask */
+#define PMC_PCR_EN                          PMC_PCR_EN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_EN_Msk instead */
+#define PMC_PCR_GCLKEN_Pos                  29                                             /**< (PMC_PCR) Generic Clock Enable Position */
+#define PMC_PCR_GCLKEN_Msk                  (_U_(0x1) << PMC_PCR_GCLKEN_Pos)               /**< (PMC_PCR) Generic Clock Enable Mask */
+#define PMC_PCR_GCLKEN                      PMC_PCR_GCLKEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_GCLKEN_Msk instead */
+#define PMC_PCR_MASK                        _U_(0x3FF0177F)                                /**< \deprecated (PMC_PCR) Register MASK  (Use PMC_PCR_Msk instead)  */
+#define PMC_PCR_Msk                         _U_(0x3FF0177F)                                /**< (PMC_PCR) Register Mask  */
+
+
+/* -------- PMC_OCR : (PMC Offset: 0x110) (R/W 32) Oscillator Calibration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CAL4:7;                    /**< bit:   0..6  Main RC Oscillator Calibration Bits for 4 MHz */
+    uint32_t SEL4:1;                    /**< bit:      7  Selection of Main RC Oscillator Calibration Bits for 4 MHz */
+    uint32_t CAL8:7;                    /**< bit:  8..14  Main RC Oscillator Calibration Bits for 8 MHz */
+    uint32_t SEL8:1;                    /**< bit:     15  Selection of Main RC Oscillator Calibration Bits for 8 MHz */
+    uint32_t CAL12:7;                   /**< bit: 16..22  Main RC Oscillator Calibration Bits for 12 MHz */
+    uint32_t SEL12:1;                   /**< bit:     23  Selection of Main RC Oscillator Calibration Bits for 12 MHz */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_OCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_OCR_OFFSET                      (0x110)                                       /**<  (PMC_OCR) Oscillator Calibration Register  Offset */
+
+#define PMC_OCR_CAL4_Pos                    0                                              /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 4 MHz Position */
+#define PMC_OCR_CAL4_Msk                    (_U_(0x7F) << PMC_OCR_CAL4_Pos)                /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 4 MHz Mask */
+#define PMC_OCR_CAL4(value)                 (PMC_OCR_CAL4_Msk & ((value) << PMC_OCR_CAL4_Pos))
+#define PMC_OCR_SEL4_Pos                    7                                              /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 4 MHz Position */
+#define PMC_OCR_SEL4_Msk                    (_U_(0x1) << PMC_OCR_SEL4_Pos)                 /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 4 MHz Mask */
+#define PMC_OCR_SEL4                        PMC_OCR_SEL4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL4_Msk instead */
+#define PMC_OCR_CAL8_Pos                    8                                              /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 8 MHz Position */
+#define PMC_OCR_CAL8_Msk                    (_U_(0x7F) << PMC_OCR_CAL8_Pos)                /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 8 MHz Mask */
+#define PMC_OCR_CAL8(value)                 (PMC_OCR_CAL8_Msk & ((value) << PMC_OCR_CAL8_Pos))
+#define PMC_OCR_SEL8_Pos                    15                                             /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 8 MHz Position */
+#define PMC_OCR_SEL8_Msk                    (_U_(0x1) << PMC_OCR_SEL8_Pos)                 /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 8 MHz Mask */
+#define PMC_OCR_SEL8                        PMC_OCR_SEL8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL8_Msk instead */
+#define PMC_OCR_CAL12_Pos                   16                                             /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 12 MHz Position */
+#define PMC_OCR_CAL12_Msk                   (_U_(0x7F) << PMC_OCR_CAL12_Pos)               /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 12 MHz Mask */
+#define PMC_OCR_CAL12(value)                (PMC_OCR_CAL12_Msk & ((value) << PMC_OCR_CAL12_Pos))
+#define PMC_OCR_SEL12_Pos                   23                                             /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 12 MHz Position */
+#define PMC_OCR_SEL12_Msk                   (_U_(0x1) << PMC_OCR_SEL12_Pos)                /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 12 MHz Mask */
+#define PMC_OCR_SEL12                       PMC_OCR_SEL12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL12_Msk instead */
+#define PMC_OCR_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (PMC_OCR) Register MASK  (Use PMC_OCR_Msk instead)  */
+#define PMC_OCR_Msk                         _U_(0xFFFFFF)                                  /**< (PMC_OCR) Register Mask  */
+
+
+/* -------- PMC_SLPWK_ER0 : (PMC Offset: 0x114) (/W 32) SleepWalking Enable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Enable         */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Enable         */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Enable         */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Enable        */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Enable        */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Enable        */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Enable        */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Enable        */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Enable        */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Enable        */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Enable        */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Enable        */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Enable        */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Enable        */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Enable        */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Enable        */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Enable        */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Enable        */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Enable        */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Enable        */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Enable        */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Enable        */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Enable        */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Enable        */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Enable        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ER0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ER0_OFFSET                (0x114)                                       /**<  (PMC_SLPWK_ER0) SleepWalking Enable Register 0  Offset */
+
+#define PMC_SLPWK_ER0_PID7_Pos              7                                              /**< (PMC_SLPWK_ER0) Peripheral 7 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID7_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 7 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID7                  PMC_SLPWK_ER0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID7_Msk instead */
+#define PMC_SLPWK_ER0_PID8_Pos              8                                              /**< (PMC_SLPWK_ER0) Peripheral 8 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID8_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 8 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID8                  PMC_SLPWK_ER0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID8_Msk instead */
+#define PMC_SLPWK_ER0_PID9_Pos              9                                              /**< (PMC_SLPWK_ER0) Peripheral 9 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID9_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 9 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID9                  PMC_SLPWK_ER0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID9_Msk instead */
+#define PMC_SLPWK_ER0_PID10_Pos             10                                             /**< (PMC_SLPWK_ER0) Peripheral 10 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID10_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 10 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID10                 PMC_SLPWK_ER0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID10_Msk instead */
+#define PMC_SLPWK_ER0_PID11_Pos             11                                             /**< (PMC_SLPWK_ER0) Peripheral 11 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID11_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 11 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID11                 PMC_SLPWK_ER0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID11_Msk instead */
+#define PMC_SLPWK_ER0_PID12_Pos             12                                             /**< (PMC_SLPWK_ER0) Peripheral 12 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID12_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 12 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID12                 PMC_SLPWK_ER0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID12_Msk instead */
+#define PMC_SLPWK_ER0_PID13_Pos             13                                             /**< (PMC_SLPWK_ER0) Peripheral 13 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID13_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 13 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID13                 PMC_SLPWK_ER0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID13_Msk instead */
+#define PMC_SLPWK_ER0_PID14_Pos             14                                             /**< (PMC_SLPWK_ER0) Peripheral 14 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID14_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 14 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID14                 PMC_SLPWK_ER0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID14_Msk instead */
+#define PMC_SLPWK_ER0_PID15_Pos             15                                             /**< (PMC_SLPWK_ER0) Peripheral 15 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID15_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 15 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID15                 PMC_SLPWK_ER0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID15_Msk instead */
+#define PMC_SLPWK_ER0_PID16_Pos             16                                             /**< (PMC_SLPWK_ER0) Peripheral 16 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID16_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 16 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID16                 PMC_SLPWK_ER0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID16_Msk instead */
+#define PMC_SLPWK_ER0_PID17_Pos             17                                             /**< (PMC_SLPWK_ER0) Peripheral 17 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID17_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 17 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID17                 PMC_SLPWK_ER0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID17_Msk instead */
+#define PMC_SLPWK_ER0_PID18_Pos             18                                             /**< (PMC_SLPWK_ER0) Peripheral 18 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID18_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 18 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID18                 PMC_SLPWK_ER0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID18_Msk instead */
+#define PMC_SLPWK_ER0_PID19_Pos             19                                             /**< (PMC_SLPWK_ER0) Peripheral 19 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID19_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 19 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID19                 PMC_SLPWK_ER0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID19_Msk instead */
+#define PMC_SLPWK_ER0_PID20_Pos             20                                             /**< (PMC_SLPWK_ER0) Peripheral 20 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID20_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 20 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID20                 PMC_SLPWK_ER0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID20_Msk instead */
+#define PMC_SLPWK_ER0_PID21_Pos             21                                             /**< (PMC_SLPWK_ER0) Peripheral 21 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID21_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 21 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID21                 PMC_SLPWK_ER0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID21_Msk instead */
+#define PMC_SLPWK_ER0_PID22_Pos             22                                             /**< (PMC_SLPWK_ER0) Peripheral 22 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID22_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 22 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID22                 PMC_SLPWK_ER0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID22_Msk instead */
+#define PMC_SLPWK_ER0_PID23_Pos             23                                             /**< (PMC_SLPWK_ER0) Peripheral 23 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID23_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 23 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID23                 PMC_SLPWK_ER0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID23_Msk instead */
+#define PMC_SLPWK_ER0_PID24_Pos             24                                             /**< (PMC_SLPWK_ER0) Peripheral 24 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID24_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 24 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID24                 PMC_SLPWK_ER0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID24_Msk instead */
+#define PMC_SLPWK_ER0_PID25_Pos             25                                             /**< (PMC_SLPWK_ER0) Peripheral 25 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID25_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 25 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID25                 PMC_SLPWK_ER0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID25_Msk instead */
+#define PMC_SLPWK_ER0_PID26_Pos             26                                             /**< (PMC_SLPWK_ER0) Peripheral 26 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID26_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 26 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID26                 PMC_SLPWK_ER0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID26_Msk instead */
+#define PMC_SLPWK_ER0_PID27_Pos             27                                             /**< (PMC_SLPWK_ER0) Peripheral 27 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID27_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 27 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID27                 PMC_SLPWK_ER0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID27_Msk instead */
+#define PMC_SLPWK_ER0_PID28_Pos             28                                             /**< (PMC_SLPWK_ER0) Peripheral 28 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID28_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 28 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID28                 PMC_SLPWK_ER0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID28_Msk instead */
+#define PMC_SLPWK_ER0_PID29_Pos             29                                             /**< (PMC_SLPWK_ER0) Peripheral 29 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID29_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 29 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID29                 PMC_SLPWK_ER0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID29_Msk instead */
+#define PMC_SLPWK_ER0_PID30_Pos             30                                             /**< (PMC_SLPWK_ER0) Peripheral 30 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID30_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 30 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID30                 PMC_SLPWK_ER0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID30_Msk instead */
+#define PMC_SLPWK_ER0_PID31_Pos             31                                             /**< (PMC_SLPWK_ER0) Peripheral 31 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID31_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 31 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID31                 PMC_SLPWK_ER0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID31_Msk instead */
+#define PMC_SLPWK_ER0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_ER0) Register MASK  (Use PMC_SLPWK_ER0_Msk instead)  */
+#define PMC_SLPWK_ER0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_ER0) Register Mask  */
+
+#define PMC_SLPWK_ER0_PID_Pos               7                                              /**< (PMC_SLPWK_ER0 Position) Peripheral 3x SleepWalking Enable */
+#define PMC_SLPWK_ER0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_ER0_PID_Pos)      /**< (PMC_SLPWK_ER0 Mask) PID */
+#define PMC_SLPWK_ER0_PID(value)            (PMC_SLPWK_ER0_PID_Msk & ((value) << PMC_SLPWK_ER0_PID_Pos))  
+
+/* -------- PMC_SLPWK_DR0 : (PMC Offset: 0x118) (/W 32) SleepWalking Disable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Disable        */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Disable        */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Disable        */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Disable       */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Disable       */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Disable       */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Disable       */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Disable       */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Disable       */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Disable       */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Disable       */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Disable       */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Disable       */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Disable       */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Disable       */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Disable       */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Disable       */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Disable       */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Disable       */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Disable       */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Disable       */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Disable       */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Disable       */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Disable       */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Disable       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Disable       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_DR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_DR0_OFFSET                (0x118)                                       /**<  (PMC_SLPWK_DR0) SleepWalking Disable Register 0  Offset */
+
+#define PMC_SLPWK_DR0_PID7_Pos              7                                              /**< (PMC_SLPWK_DR0) Peripheral 7 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID7_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 7 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID7                  PMC_SLPWK_DR0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID7_Msk instead */
+#define PMC_SLPWK_DR0_PID8_Pos              8                                              /**< (PMC_SLPWK_DR0) Peripheral 8 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID8_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 8 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID8                  PMC_SLPWK_DR0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID8_Msk instead */
+#define PMC_SLPWK_DR0_PID9_Pos              9                                              /**< (PMC_SLPWK_DR0) Peripheral 9 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID9_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 9 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID9                  PMC_SLPWK_DR0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID9_Msk instead */
+#define PMC_SLPWK_DR0_PID10_Pos             10                                             /**< (PMC_SLPWK_DR0) Peripheral 10 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID10_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 10 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID10                 PMC_SLPWK_DR0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID10_Msk instead */
+#define PMC_SLPWK_DR0_PID11_Pos             11                                             /**< (PMC_SLPWK_DR0) Peripheral 11 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID11_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 11 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID11                 PMC_SLPWK_DR0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID11_Msk instead */
+#define PMC_SLPWK_DR0_PID12_Pos             12                                             /**< (PMC_SLPWK_DR0) Peripheral 12 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID12_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 12 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID12                 PMC_SLPWK_DR0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID12_Msk instead */
+#define PMC_SLPWK_DR0_PID13_Pos             13                                             /**< (PMC_SLPWK_DR0) Peripheral 13 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID13_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 13 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID13                 PMC_SLPWK_DR0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID13_Msk instead */
+#define PMC_SLPWK_DR0_PID14_Pos             14                                             /**< (PMC_SLPWK_DR0) Peripheral 14 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID14_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 14 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID14                 PMC_SLPWK_DR0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID14_Msk instead */
+#define PMC_SLPWK_DR0_PID15_Pos             15                                             /**< (PMC_SLPWK_DR0) Peripheral 15 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID15_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 15 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID15                 PMC_SLPWK_DR0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID15_Msk instead */
+#define PMC_SLPWK_DR0_PID16_Pos             16                                             /**< (PMC_SLPWK_DR0) Peripheral 16 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID16_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 16 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID16                 PMC_SLPWK_DR0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID16_Msk instead */
+#define PMC_SLPWK_DR0_PID17_Pos             17                                             /**< (PMC_SLPWK_DR0) Peripheral 17 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID17_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 17 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID17                 PMC_SLPWK_DR0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID17_Msk instead */
+#define PMC_SLPWK_DR0_PID18_Pos             18                                             /**< (PMC_SLPWK_DR0) Peripheral 18 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID18_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 18 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID18                 PMC_SLPWK_DR0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID18_Msk instead */
+#define PMC_SLPWK_DR0_PID19_Pos             19                                             /**< (PMC_SLPWK_DR0) Peripheral 19 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID19_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 19 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID19                 PMC_SLPWK_DR0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID19_Msk instead */
+#define PMC_SLPWK_DR0_PID20_Pos             20                                             /**< (PMC_SLPWK_DR0) Peripheral 20 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID20_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 20 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID20                 PMC_SLPWK_DR0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID20_Msk instead */
+#define PMC_SLPWK_DR0_PID21_Pos             21                                             /**< (PMC_SLPWK_DR0) Peripheral 21 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID21_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 21 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID21                 PMC_SLPWK_DR0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID21_Msk instead */
+#define PMC_SLPWK_DR0_PID22_Pos             22                                             /**< (PMC_SLPWK_DR0) Peripheral 22 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID22_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 22 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID22                 PMC_SLPWK_DR0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID22_Msk instead */
+#define PMC_SLPWK_DR0_PID23_Pos             23                                             /**< (PMC_SLPWK_DR0) Peripheral 23 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID23_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 23 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID23                 PMC_SLPWK_DR0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID23_Msk instead */
+#define PMC_SLPWK_DR0_PID24_Pos             24                                             /**< (PMC_SLPWK_DR0) Peripheral 24 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID24_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 24 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID24                 PMC_SLPWK_DR0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID24_Msk instead */
+#define PMC_SLPWK_DR0_PID25_Pos             25                                             /**< (PMC_SLPWK_DR0) Peripheral 25 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID25_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 25 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID25                 PMC_SLPWK_DR0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID25_Msk instead */
+#define PMC_SLPWK_DR0_PID26_Pos             26                                             /**< (PMC_SLPWK_DR0) Peripheral 26 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID26_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 26 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID26                 PMC_SLPWK_DR0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID26_Msk instead */
+#define PMC_SLPWK_DR0_PID27_Pos             27                                             /**< (PMC_SLPWK_DR0) Peripheral 27 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID27_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 27 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID27                 PMC_SLPWK_DR0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID27_Msk instead */
+#define PMC_SLPWK_DR0_PID28_Pos             28                                             /**< (PMC_SLPWK_DR0) Peripheral 28 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID28_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 28 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID28                 PMC_SLPWK_DR0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID28_Msk instead */
+#define PMC_SLPWK_DR0_PID29_Pos             29                                             /**< (PMC_SLPWK_DR0) Peripheral 29 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID29_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 29 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID29                 PMC_SLPWK_DR0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID29_Msk instead */
+#define PMC_SLPWK_DR0_PID30_Pos             30                                             /**< (PMC_SLPWK_DR0) Peripheral 30 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID30_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 30 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID30                 PMC_SLPWK_DR0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID30_Msk instead */
+#define PMC_SLPWK_DR0_PID31_Pos             31                                             /**< (PMC_SLPWK_DR0) Peripheral 31 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID31_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 31 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID31                 PMC_SLPWK_DR0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID31_Msk instead */
+#define PMC_SLPWK_DR0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_DR0) Register MASK  (Use PMC_SLPWK_DR0_Msk instead)  */
+#define PMC_SLPWK_DR0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_DR0) Register Mask  */
+
+#define PMC_SLPWK_DR0_PID_Pos               7                                              /**< (PMC_SLPWK_DR0 Position) Peripheral 3x SleepWalking Disable */
+#define PMC_SLPWK_DR0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_DR0_PID_Pos)      /**< (PMC_SLPWK_DR0 Mask) PID */
+#define PMC_SLPWK_DR0_PID(value)            (PMC_SLPWK_DR0_PID_Msk & ((value) << PMC_SLPWK_DR0_PID_Pos))  
+
+/* -------- PMC_SLPWK_SR0 : (PMC Offset: 0x11c) (R/ 32) SleepWalking Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Status         */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Status         */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Status         */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Status        */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Status        */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Status        */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Status        */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Status        */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Status        */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Status        */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Status        */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Status        */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Status        */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Status        */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Status        */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Status        */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Status        */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Status        */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Status        */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Status        */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Status        */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Status        */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Status        */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Status        */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Status        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Status        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_SR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_SR0_OFFSET                (0x11C)                                       /**<  (PMC_SLPWK_SR0) SleepWalking Status Register 0  Offset */
+
+#define PMC_SLPWK_SR0_PID7_Pos              7                                              /**< (PMC_SLPWK_SR0) Peripheral 7 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID7_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 7 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID7                  PMC_SLPWK_SR0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID7_Msk instead */
+#define PMC_SLPWK_SR0_PID8_Pos              8                                              /**< (PMC_SLPWK_SR0) Peripheral 8 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID8_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 8 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID8                  PMC_SLPWK_SR0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID8_Msk instead */
+#define PMC_SLPWK_SR0_PID9_Pos              9                                              /**< (PMC_SLPWK_SR0) Peripheral 9 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID9_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 9 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID9                  PMC_SLPWK_SR0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID9_Msk instead */
+#define PMC_SLPWK_SR0_PID10_Pos             10                                             /**< (PMC_SLPWK_SR0) Peripheral 10 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID10_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 10 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID10                 PMC_SLPWK_SR0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID10_Msk instead */
+#define PMC_SLPWK_SR0_PID11_Pos             11                                             /**< (PMC_SLPWK_SR0) Peripheral 11 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID11_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 11 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID11                 PMC_SLPWK_SR0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID11_Msk instead */
+#define PMC_SLPWK_SR0_PID12_Pos             12                                             /**< (PMC_SLPWK_SR0) Peripheral 12 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID12_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 12 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID12                 PMC_SLPWK_SR0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID12_Msk instead */
+#define PMC_SLPWK_SR0_PID13_Pos             13                                             /**< (PMC_SLPWK_SR0) Peripheral 13 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID13_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 13 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID13                 PMC_SLPWK_SR0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID13_Msk instead */
+#define PMC_SLPWK_SR0_PID14_Pos             14                                             /**< (PMC_SLPWK_SR0) Peripheral 14 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID14_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 14 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID14                 PMC_SLPWK_SR0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID14_Msk instead */
+#define PMC_SLPWK_SR0_PID15_Pos             15                                             /**< (PMC_SLPWK_SR0) Peripheral 15 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID15_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 15 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID15                 PMC_SLPWK_SR0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID15_Msk instead */
+#define PMC_SLPWK_SR0_PID16_Pos             16                                             /**< (PMC_SLPWK_SR0) Peripheral 16 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID16_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 16 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID16                 PMC_SLPWK_SR0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID16_Msk instead */
+#define PMC_SLPWK_SR0_PID17_Pos             17                                             /**< (PMC_SLPWK_SR0) Peripheral 17 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID17_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 17 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID17                 PMC_SLPWK_SR0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID17_Msk instead */
+#define PMC_SLPWK_SR0_PID18_Pos             18                                             /**< (PMC_SLPWK_SR0) Peripheral 18 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID18_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 18 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID18                 PMC_SLPWK_SR0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID18_Msk instead */
+#define PMC_SLPWK_SR0_PID19_Pos             19                                             /**< (PMC_SLPWK_SR0) Peripheral 19 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID19_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 19 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID19                 PMC_SLPWK_SR0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID19_Msk instead */
+#define PMC_SLPWK_SR0_PID20_Pos             20                                             /**< (PMC_SLPWK_SR0) Peripheral 20 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID20_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 20 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID20                 PMC_SLPWK_SR0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID20_Msk instead */
+#define PMC_SLPWK_SR0_PID21_Pos             21                                             /**< (PMC_SLPWK_SR0) Peripheral 21 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID21_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 21 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID21                 PMC_SLPWK_SR0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID21_Msk instead */
+#define PMC_SLPWK_SR0_PID22_Pos             22                                             /**< (PMC_SLPWK_SR0) Peripheral 22 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID22_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 22 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID22                 PMC_SLPWK_SR0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID22_Msk instead */
+#define PMC_SLPWK_SR0_PID23_Pos             23                                             /**< (PMC_SLPWK_SR0) Peripheral 23 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID23_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 23 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID23                 PMC_SLPWK_SR0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID23_Msk instead */
+#define PMC_SLPWK_SR0_PID24_Pos             24                                             /**< (PMC_SLPWK_SR0) Peripheral 24 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID24_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 24 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID24                 PMC_SLPWK_SR0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID24_Msk instead */
+#define PMC_SLPWK_SR0_PID25_Pos             25                                             /**< (PMC_SLPWK_SR0) Peripheral 25 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID25_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 25 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID25                 PMC_SLPWK_SR0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID25_Msk instead */
+#define PMC_SLPWK_SR0_PID26_Pos             26                                             /**< (PMC_SLPWK_SR0) Peripheral 26 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID26_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 26 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID26                 PMC_SLPWK_SR0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID26_Msk instead */
+#define PMC_SLPWK_SR0_PID27_Pos             27                                             /**< (PMC_SLPWK_SR0) Peripheral 27 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID27_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 27 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID27                 PMC_SLPWK_SR0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID27_Msk instead */
+#define PMC_SLPWK_SR0_PID28_Pos             28                                             /**< (PMC_SLPWK_SR0) Peripheral 28 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID28_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 28 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID28                 PMC_SLPWK_SR0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID28_Msk instead */
+#define PMC_SLPWK_SR0_PID29_Pos             29                                             /**< (PMC_SLPWK_SR0) Peripheral 29 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID29_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 29 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID29                 PMC_SLPWK_SR0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID29_Msk instead */
+#define PMC_SLPWK_SR0_PID30_Pos             30                                             /**< (PMC_SLPWK_SR0) Peripheral 30 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID30_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 30 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID30                 PMC_SLPWK_SR0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID30_Msk instead */
+#define PMC_SLPWK_SR0_PID31_Pos             31                                             /**< (PMC_SLPWK_SR0) Peripheral 31 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID31_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 31 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID31                 PMC_SLPWK_SR0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID31_Msk instead */
+#define PMC_SLPWK_SR0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_SR0) Register MASK  (Use PMC_SLPWK_SR0_Msk instead)  */
+#define PMC_SLPWK_SR0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_SR0) Register Mask  */
+
+#define PMC_SLPWK_SR0_PID_Pos               7                                              /**< (PMC_SLPWK_SR0 Position) Peripheral 3x SleepWalking Status */
+#define PMC_SLPWK_SR0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_SR0_PID_Pos)      /**< (PMC_SLPWK_SR0 Mask) PID */
+#define PMC_SLPWK_SR0_PID(value)            (PMC_SLPWK_SR0_PID_Msk & ((value) << PMC_SLPWK_SR0_PID_Pos))  
+
+/* -------- PMC_SLPWK_ASR0 : (PMC Offset: 0x120) (R/ 32) SleepWalking Activity Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 Activity Status             */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 Activity Status             */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 Activity Status             */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 Activity Status            */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 Activity Status            */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 Activity Status            */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 Activity Status            */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 Activity Status            */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 Activity Status            */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 Activity Status            */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 Activity Status            */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 Activity Status            */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 Activity Status            */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 Activity Status            */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 Activity Status            */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 Activity Status            */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 Activity Status            */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 Activity Status            */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 Activity Status            */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 Activity Status            */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 Activity Status            */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 Activity Status            */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 Activity Status            */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 Activity Status            */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 Activity Status            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x Activity Status            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ASR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ASR0_OFFSET               (0x120)                                       /**<  (PMC_SLPWK_ASR0) SleepWalking Activity Status Register 0  Offset */
+
+#define PMC_SLPWK_ASR0_PID7_Pos             7                                              /**< (PMC_SLPWK_ASR0) Peripheral 7 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID7_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID7_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 7 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID7                 PMC_SLPWK_ASR0_PID7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID7_Msk instead */
+#define PMC_SLPWK_ASR0_PID8_Pos             8                                              /**< (PMC_SLPWK_ASR0) Peripheral 8 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID8_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID8_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 8 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID8                 PMC_SLPWK_ASR0_PID8_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID8_Msk instead */
+#define PMC_SLPWK_ASR0_PID9_Pos             9                                              /**< (PMC_SLPWK_ASR0) Peripheral 9 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID9_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID9_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 9 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID9                 PMC_SLPWK_ASR0_PID9_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID9_Msk instead */
+#define PMC_SLPWK_ASR0_PID10_Pos            10                                             /**< (PMC_SLPWK_ASR0) Peripheral 10 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID10_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID10_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 10 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID10                PMC_SLPWK_ASR0_PID10_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID10_Msk instead */
+#define PMC_SLPWK_ASR0_PID11_Pos            11                                             /**< (PMC_SLPWK_ASR0) Peripheral 11 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID11_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID11_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 11 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID11                PMC_SLPWK_ASR0_PID11_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID11_Msk instead */
+#define PMC_SLPWK_ASR0_PID12_Pos            12                                             /**< (PMC_SLPWK_ASR0) Peripheral 12 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID12_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID12_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 12 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID12                PMC_SLPWK_ASR0_PID12_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID12_Msk instead */
+#define PMC_SLPWK_ASR0_PID13_Pos            13                                             /**< (PMC_SLPWK_ASR0) Peripheral 13 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID13_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID13_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 13 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID13                PMC_SLPWK_ASR0_PID13_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID13_Msk instead */
+#define PMC_SLPWK_ASR0_PID14_Pos            14                                             /**< (PMC_SLPWK_ASR0) Peripheral 14 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID14_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID14_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 14 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID14                PMC_SLPWK_ASR0_PID14_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID14_Msk instead */
+#define PMC_SLPWK_ASR0_PID15_Pos            15                                             /**< (PMC_SLPWK_ASR0) Peripheral 15 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID15_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID15_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 15 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID15                PMC_SLPWK_ASR0_PID15_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID15_Msk instead */
+#define PMC_SLPWK_ASR0_PID16_Pos            16                                             /**< (PMC_SLPWK_ASR0) Peripheral 16 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID16_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID16_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 16 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID16                PMC_SLPWK_ASR0_PID16_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID16_Msk instead */
+#define PMC_SLPWK_ASR0_PID17_Pos            17                                             /**< (PMC_SLPWK_ASR0) Peripheral 17 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID17_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID17_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 17 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID17                PMC_SLPWK_ASR0_PID17_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID17_Msk instead */
+#define PMC_SLPWK_ASR0_PID18_Pos            18                                             /**< (PMC_SLPWK_ASR0) Peripheral 18 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID18_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID18_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 18 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID18                PMC_SLPWK_ASR0_PID18_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID18_Msk instead */
+#define PMC_SLPWK_ASR0_PID19_Pos            19                                             /**< (PMC_SLPWK_ASR0) Peripheral 19 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID19_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID19_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 19 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID19                PMC_SLPWK_ASR0_PID19_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID19_Msk instead */
+#define PMC_SLPWK_ASR0_PID20_Pos            20                                             /**< (PMC_SLPWK_ASR0) Peripheral 20 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID20_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID20_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 20 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID20                PMC_SLPWK_ASR0_PID20_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID20_Msk instead */
+#define PMC_SLPWK_ASR0_PID21_Pos            21                                             /**< (PMC_SLPWK_ASR0) Peripheral 21 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID21_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID21_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 21 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID21                PMC_SLPWK_ASR0_PID21_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID21_Msk instead */
+#define PMC_SLPWK_ASR0_PID22_Pos            22                                             /**< (PMC_SLPWK_ASR0) Peripheral 22 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID22_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID22_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 22 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID22                PMC_SLPWK_ASR0_PID22_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID22_Msk instead */
+#define PMC_SLPWK_ASR0_PID23_Pos            23                                             /**< (PMC_SLPWK_ASR0) Peripheral 23 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID23_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID23_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 23 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID23                PMC_SLPWK_ASR0_PID23_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID23_Msk instead */
+#define PMC_SLPWK_ASR0_PID24_Pos            24                                             /**< (PMC_SLPWK_ASR0) Peripheral 24 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID24_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID24_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 24 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID24                PMC_SLPWK_ASR0_PID24_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID24_Msk instead */
+#define PMC_SLPWK_ASR0_PID25_Pos            25                                             /**< (PMC_SLPWK_ASR0) Peripheral 25 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID25_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID25_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 25 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID25                PMC_SLPWK_ASR0_PID25_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID25_Msk instead */
+#define PMC_SLPWK_ASR0_PID26_Pos            26                                             /**< (PMC_SLPWK_ASR0) Peripheral 26 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID26_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID26_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 26 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID26                PMC_SLPWK_ASR0_PID26_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID26_Msk instead */
+#define PMC_SLPWK_ASR0_PID27_Pos            27                                             /**< (PMC_SLPWK_ASR0) Peripheral 27 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID27_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID27_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 27 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID27                PMC_SLPWK_ASR0_PID27_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID27_Msk instead */
+#define PMC_SLPWK_ASR0_PID28_Pos            28                                             /**< (PMC_SLPWK_ASR0) Peripheral 28 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID28_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID28_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 28 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID28                PMC_SLPWK_ASR0_PID28_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID28_Msk instead */
+#define PMC_SLPWK_ASR0_PID29_Pos            29                                             /**< (PMC_SLPWK_ASR0) Peripheral 29 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID29_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID29_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 29 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID29                PMC_SLPWK_ASR0_PID29_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID29_Msk instead */
+#define PMC_SLPWK_ASR0_PID30_Pos            30                                             /**< (PMC_SLPWK_ASR0) Peripheral 30 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID30_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID30_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 30 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID30                PMC_SLPWK_ASR0_PID30_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID30_Msk instead */
+#define PMC_SLPWK_ASR0_PID31_Pos            31                                             /**< (PMC_SLPWK_ASR0) Peripheral 31 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID31_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID31_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 31 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID31                PMC_SLPWK_ASR0_PID31_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID31_Msk instead */
+#define PMC_SLPWK_ASR0_MASK                 _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_ASR0) Register MASK  (Use PMC_SLPWK_ASR0_Msk instead)  */
+#define PMC_SLPWK_ASR0_Msk                  _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_ASR0) Register Mask  */
+
+#define PMC_SLPWK_ASR0_PID_Pos              7                                              /**< (PMC_SLPWK_ASR0 Position) Peripheral 3x Activity Status */
+#define PMC_SLPWK_ASR0_PID_Msk              (_U_(0x1FFFFFF) << PMC_SLPWK_ASR0_PID_Pos)     /**< (PMC_SLPWK_ASR0 Mask) PID */
+#define PMC_SLPWK_ASR0_PID(value)           (PMC_SLPWK_ASR0_PID_Msk & ((value) << PMC_SLPWK_ASR0_PID_Pos))  
+
+/* -------- PMC_PMMR : (PMC Offset: 0x130) (R/W 32) PLL Maximum Multiplier Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PLLA_MMAX:11;              /**< bit:  0..10  PLLA Maximum Allowed Multiplier Value    */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PMMR_OFFSET                     (0x130)                                       /**<  (PMC_PMMR) PLL Maximum Multiplier Value Register  Offset */
+
+#define PMC_PMMR_PLLA_MMAX_Pos              0                                              /**< (PMC_PMMR) PLLA Maximum Allowed Multiplier Value Position */
+#define PMC_PMMR_PLLA_MMAX_Msk              (_U_(0x7FF) << PMC_PMMR_PLLA_MMAX_Pos)         /**< (PMC_PMMR) PLLA Maximum Allowed Multiplier Value Mask */
+#define PMC_PMMR_PLLA_MMAX(value)           (PMC_PMMR_PLLA_MMAX_Msk & ((value) << PMC_PMMR_PLLA_MMAX_Pos))
+#define PMC_PMMR_MASK                       _U_(0x7FF)                                     /**< \deprecated (PMC_PMMR) Register MASK  (Use PMC_PMMR_Msk instead)  */
+#define PMC_PMMR_Msk                        _U_(0x7FF)                                     /**< (PMC_PMMR) Register Mask  */
+
+
+/* -------- PMC_SLPWK_ER1 : (PMC Offset: 0x134) (/W 32) SleepWalking Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Enable        */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Enable        */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Enable        */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Enable        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Enable        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Enable        */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Enable        */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Enable        */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Enable        */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Enable        */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Enable        */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Enable        */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Enable        */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Enable        */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Enable        */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Enable        */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Enable        */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Enable        */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Enable        */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Enable        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Enable        */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Enable        */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Enable        */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Enable        */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Enable        */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Enable        */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ER1_OFFSET                (0x134)                                       /**<  (PMC_SLPWK_ER1) SleepWalking Enable Register 1  Offset */
+
+#define PMC_SLPWK_ER1_PID32_Pos             0                                              /**< (PMC_SLPWK_ER1) Peripheral 32 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID32_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 32 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID32                 PMC_SLPWK_ER1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID32_Msk instead */
+#define PMC_SLPWK_ER1_PID33_Pos             1                                              /**< (PMC_SLPWK_ER1) Peripheral 33 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID33_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 33 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID33                 PMC_SLPWK_ER1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID33_Msk instead */
+#define PMC_SLPWK_ER1_PID34_Pos             2                                              /**< (PMC_SLPWK_ER1) Peripheral 34 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID34_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 34 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID34                 PMC_SLPWK_ER1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID34_Msk instead */
+#define PMC_SLPWK_ER1_PID35_Pos             3                                              /**< (PMC_SLPWK_ER1) Peripheral 35 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID35_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 35 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID35                 PMC_SLPWK_ER1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID35_Msk instead */
+#define PMC_SLPWK_ER1_PID37_Pos             5                                              /**< (PMC_SLPWK_ER1) Peripheral 37 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID37_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 37 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID37                 PMC_SLPWK_ER1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID37_Msk instead */
+#define PMC_SLPWK_ER1_PID39_Pos             7                                              /**< (PMC_SLPWK_ER1) Peripheral 39 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID39_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 39 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID39                 PMC_SLPWK_ER1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID39_Msk instead */
+#define PMC_SLPWK_ER1_PID40_Pos             8                                              /**< (PMC_SLPWK_ER1) Peripheral 40 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID40_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 40 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID40                 PMC_SLPWK_ER1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID40_Msk instead */
+#define PMC_SLPWK_ER1_PID41_Pos             9                                              /**< (PMC_SLPWK_ER1) Peripheral 41 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID41_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 41 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID41                 PMC_SLPWK_ER1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID41_Msk instead */
+#define PMC_SLPWK_ER1_PID42_Pos             10                                             /**< (PMC_SLPWK_ER1) Peripheral 42 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID42_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 42 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID42                 PMC_SLPWK_ER1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID42_Msk instead */
+#define PMC_SLPWK_ER1_PID43_Pos             11                                             /**< (PMC_SLPWK_ER1) Peripheral 43 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID43_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 43 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID43                 PMC_SLPWK_ER1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID43_Msk instead */
+#define PMC_SLPWK_ER1_PID44_Pos             12                                             /**< (PMC_SLPWK_ER1) Peripheral 44 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID44_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 44 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID44                 PMC_SLPWK_ER1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID44_Msk instead */
+#define PMC_SLPWK_ER1_PID45_Pos             13                                             /**< (PMC_SLPWK_ER1) Peripheral 45 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID45_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 45 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID45                 PMC_SLPWK_ER1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID45_Msk instead */
+#define PMC_SLPWK_ER1_PID46_Pos             14                                             /**< (PMC_SLPWK_ER1) Peripheral 46 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID46_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 46 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID46                 PMC_SLPWK_ER1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID46_Msk instead */
+#define PMC_SLPWK_ER1_PID47_Pos             15                                             /**< (PMC_SLPWK_ER1) Peripheral 47 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID47_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 47 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID47                 PMC_SLPWK_ER1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID47_Msk instead */
+#define PMC_SLPWK_ER1_PID48_Pos             16                                             /**< (PMC_SLPWK_ER1) Peripheral 48 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID48_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 48 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID48                 PMC_SLPWK_ER1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID48_Msk instead */
+#define PMC_SLPWK_ER1_PID49_Pos             17                                             /**< (PMC_SLPWK_ER1) Peripheral 49 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID49_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 49 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID49                 PMC_SLPWK_ER1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID49_Msk instead */
+#define PMC_SLPWK_ER1_PID50_Pos             18                                             /**< (PMC_SLPWK_ER1) Peripheral 50 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID50_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 50 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID50                 PMC_SLPWK_ER1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID50_Msk instead */
+#define PMC_SLPWK_ER1_PID51_Pos             19                                             /**< (PMC_SLPWK_ER1) Peripheral 51 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID51_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 51 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID51                 PMC_SLPWK_ER1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID51_Msk instead */
+#define PMC_SLPWK_ER1_PID52_Pos             20                                             /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID52_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID52                 PMC_SLPWK_ER1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID52_Msk instead */
+#define PMC_SLPWK_ER1_PID53_Pos             21                                             /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID53_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID53                 PMC_SLPWK_ER1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID53_Msk instead */
+#define PMC_SLPWK_ER1_PID56_Pos             24                                             /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID56_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID56                 PMC_SLPWK_ER1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID56_Msk instead */
+#define PMC_SLPWK_ER1_PID57_Pos             25                                             /**< (PMC_SLPWK_ER1) Peripheral 57 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID57_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 57 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID57                 PMC_SLPWK_ER1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID57_Msk instead */
+#define PMC_SLPWK_ER1_PID58_Pos             26                                             /**< (PMC_SLPWK_ER1) Peripheral 58 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID58_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 58 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID58                 PMC_SLPWK_ER1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID58_Msk instead */
+#define PMC_SLPWK_ER1_PID59_Pos             27                                             /**< (PMC_SLPWK_ER1) Peripheral 59 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID59_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 59 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID59                 PMC_SLPWK_ER1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID59_Msk instead */
+#define PMC_SLPWK_ER1_PID60_Pos             28                                             /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID60_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID60                 PMC_SLPWK_ER1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID60_Msk instead */
+#define PMC_SLPWK_ER1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ER1) Register MASK  (Use PMC_SLPWK_ER1_Msk instead)  */
+#define PMC_SLPWK_ER1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ER1) Register Mask  */
+
+#define PMC_SLPWK_ER1_PID_Pos               0                                              /**< (PMC_SLPWK_ER1 Position) Peripheral 6x SleepWalking Enable */
+#define PMC_SLPWK_ER1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_ER1_PID_Pos)      /**< (PMC_SLPWK_ER1 Mask) PID */
+#define PMC_SLPWK_ER1_PID(value)            (PMC_SLPWK_ER1_PID_Msk & ((value) << PMC_SLPWK_ER1_PID_Pos))  
+
+/* -------- PMC_SLPWK_DR1 : (PMC Offset: 0x138) (/W 32) SleepWalking Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Disable       */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Disable       */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Disable       */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Disable       */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Disable       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Disable       */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Disable       */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Disable       */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Disable       */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Disable       */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Disable       */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Disable       */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Disable       */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Disable       */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Disable       */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Disable       */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Disable       */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Disable       */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Disable       */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Disable       */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Disable       */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Disable       */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Disable       */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Disable       */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Disable       */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Disable       */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_DR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_DR1_OFFSET                (0x138)                                       /**<  (PMC_SLPWK_DR1) SleepWalking Disable Register 1  Offset */
+
+#define PMC_SLPWK_DR1_PID32_Pos             0                                              /**< (PMC_SLPWK_DR1) Peripheral 32 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID32_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 32 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID32                 PMC_SLPWK_DR1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID32_Msk instead */
+#define PMC_SLPWK_DR1_PID33_Pos             1                                              /**< (PMC_SLPWK_DR1) Peripheral 33 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID33_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 33 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID33                 PMC_SLPWK_DR1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID33_Msk instead */
+#define PMC_SLPWK_DR1_PID34_Pos             2                                              /**< (PMC_SLPWK_DR1) Peripheral 34 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID34_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 34 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID34                 PMC_SLPWK_DR1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID34_Msk instead */
+#define PMC_SLPWK_DR1_PID35_Pos             3                                              /**< (PMC_SLPWK_DR1) Peripheral 35 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID35_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 35 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID35                 PMC_SLPWK_DR1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID35_Msk instead */
+#define PMC_SLPWK_DR1_PID37_Pos             5                                              /**< (PMC_SLPWK_DR1) Peripheral 37 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID37_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 37 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID37                 PMC_SLPWK_DR1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID37_Msk instead */
+#define PMC_SLPWK_DR1_PID39_Pos             7                                              /**< (PMC_SLPWK_DR1) Peripheral 39 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID39_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 39 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID39                 PMC_SLPWK_DR1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID39_Msk instead */
+#define PMC_SLPWK_DR1_PID40_Pos             8                                              /**< (PMC_SLPWK_DR1) Peripheral 40 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID40_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 40 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID40                 PMC_SLPWK_DR1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID40_Msk instead */
+#define PMC_SLPWK_DR1_PID41_Pos             9                                              /**< (PMC_SLPWK_DR1) Peripheral 41 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID41_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 41 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID41                 PMC_SLPWK_DR1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID41_Msk instead */
+#define PMC_SLPWK_DR1_PID42_Pos             10                                             /**< (PMC_SLPWK_DR1) Peripheral 42 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID42_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 42 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID42                 PMC_SLPWK_DR1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID42_Msk instead */
+#define PMC_SLPWK_DR1_PID43_Pos             11                                             /**< (PMC_SLPWK_DR1) Peripheral 43 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID43_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 43 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID43                 PMC_SLPWK_DR1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID43_Msk instead */
+#define PMC_SLPWK_DR1_PID44_Pos             12                                             /**< (PMC_SLPWK_DR1) Peripheral 44 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID44_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 44 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID44                 PMC_SLPWK_DR1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID44_Msk instead */
+#define PMC_SLPWK_DR1_PID45_Pos             13                                             /**< (PMC_SLPWK_DR1) Peripheral 45 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID45_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 45 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID45                 PMC_SLPWK_DR1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID45_Msk instead */
+#define PMC_SLPWK_DR1_PID46_Pos             14                                             /**< (PMC_SLPWK_DR1) Peripheral 46 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID46_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 46 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID46                 PMC_SLPWK_DR1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID46_Msk instead */
+#define PMC_SLPWK_DR1_PID47_Pos             15                                             /**< (PMC_SLPWK_DR1) Peripheral 47 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID47_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 47 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID47                 PMC_SLPWK_DR1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID47_Msk instead */
+#define PMC_SLPWK_DR1_PID48_Pos             16                                             /**< (PMC_SLPWK_DR1) Peripheral 48 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID48_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 48 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID48                 PMC_SLPWK_DR1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID48_Msk instead */
+#define PMC_SLPWK_DR1_PID49_Pos             17                                             /**< (PMC_SLPWK_DR1) Peripheral 49 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID49_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 49 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID49                 PMC_SLPWK_DR1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID49_Msk instead */
+#define PMC_SLPWK_DR1_PID50_Pos             18                                             /**< (PMC_SLPWK_DR1) Peripheral 50 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID50_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 50 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID50                 PMC_SLPWK_DR1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID50_Msk instead */
+#define PMC_SLPWK_DR1_PID51_Pos             19                                             /**< (PMC_SLPWK_DR1) Peripheral 51 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID51_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 51 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID51                 PMC_SLPWK_DR1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID51_Msk instead */
+#define PMC_SLPWK_DR1_PID52_Pos             20                                             /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID52_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID52                 PMC_SLPWK_DR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID52_Msk instead */
+#define PMC_SLPWK_DR1_PID53_Pos             21                                             /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID53_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID53                 PMC_SLPWK_DR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID53_Msk instead */
+#define PMC_SLPWK_DR1_PID56_Pos             24                                             /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID56_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID56                 PMC_SLPWK_DR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID56_Msk instead */
+#define PMC_SLPWK_DR1_PID57_Pos             25                                             /**< (PMC_SLPWK_DR1) Peripheral 57 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID57_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 57 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID57                 PMC_SLPWK_DR1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID57_Msk instead */
+#define PMC_SLPWK_DR1_PID58_Pos             26                                             /**< (PMC_SLPWK_DR1) Peripheral 58 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID58_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 58 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID58                 PMC_SLPWK_DR1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID58_Msk instead */
+#define PMC_SLPWK_DR1_PID59_Pos             27                                             /**< (PMC_SLPWK_DR1) Peripheral 59 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID59_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 59 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID59                 PMC_SLPWK_DR1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID59_Msk instead */
+#define PMC_SLPWK_DR1_PID60_Pos             28                                             /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID60_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID60                 PMC_SLPWK_DR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID60_Msk instead */
+#define PMC_SLPWK_DR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_DR1) Register MASK  (Use PMC_SLPWK_DR1_Msk instead)  */
+#define PMC_SLPWK_DR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_DR1) Register Mask  */
+
+#define PMC_SLPWK_DR1_PID_Pos               0                                              /**< (PMC_SLPWK_DR1 Position) Peripheral 6x SleepWalking Disable */
+#define PMC_SLPWK_DR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_DR1_PID_Pos)      /**< (PMC_SLPWK_DR1 Mask) PID */
+#define PMC_SLPWK_DR1_PID(value)            (PMC_SLPWK_DR1_PID_Msk & ((value) << PMC_SLPWK_DR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_SR1 : (PMC Offset: 0x13c) (R/ 32) SleepWalking Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Status        */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Status        */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Status        */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Status        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Status        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Status        */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Status        */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Status        */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Status        */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Status        */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Status        */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Status        */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Status        */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Status        */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Status        */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Status        */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Status        */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Status        */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Status        */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Status        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Status        */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Status        */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Status        */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Status        */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Status        */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Status        */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_SR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_SR1_OFFSET                (0x13C)                                       /**<  (PMC_SLPWK_SR1) SleepWalking Status Register 1  Offset */
+
+#define PMC_SLPWK_SR1_PID32_Pos             0                                              /**< (PMC_SLPWK_SR1) Peripheral 32 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID32_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 32 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID32                 PMC_SLPWK_SR1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID32_Msk instead */
+#define PMC_SLPWK_SR1_PID33_Pos             1                                              /**< (PMC_SLPWK_SR1) Peripheral 33 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID33_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 33 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID33                 PMC_SLPWK_SR1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID33_Msk instead */
+#define PMC_SLPWK_SR1_PID34_Pos             2                                              /**< (PMC_SLPWK_SR1) Peripheral 34 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID34_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 34 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID34                 PMC_SLPWK_SR1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID34_Msk instead */
+#define PMC_SLPWK_SR1_PID35_Pos             3                                              /**< (PMC_SLPWK_SR1) Peripheral 35 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID35_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 35 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID35                 PMC_SLPWK_SR1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID35_Msk instead */
+#define PMC_SLPWK_SR1_PID37_Pos             5                                              /**< (PMC_SLPWK_SR1) Peripheral 37 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID37_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 37 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID37                 PMC_SLPWK_SR1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID37_Msk instead */
+#define PMC_SLPWK_SR1_PID39_Pos             7                                              /**< (PMC_SLPWK_SR1) Peripheral 39 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID39_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 39 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID39                 PMC_SLPWK_SR1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID39_Msk instead */
+#define PMC_SLPWK_SR1_PID40_Pos             8                                              /**< (PMC_SLPWK_SR1) Peripheral 40 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID40_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 40 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID40                 PMC_SLPWK_SR1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID40_Msk instead */
+#define PMC_SLPWK_SR1_PID41_Pos             9                                              /**< (PMC_SLPWK_SR1) Peripheral 41 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID41_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 41 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID41                 PMC_SLPWK_SR1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID41_Msk instead */
+#define PMC_SLPWK_SR1_PID42_Pos             10                                             /**< (PMC_SLPWK_SR1) Peripheral 42 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID42_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 42 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID42                 PMC_SLPWK_SR1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID42_Msk instead */
+#define PMC_SLPWK_SR1_PID43_Pos             11                                             /**< (PMC_SLPWK_SR1) Peripheral 43 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID43_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 43 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID43                 PMC_SLPWK_SR1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID43_Msk instead */
+#define PMC_SLPWK_SR1_PID44_Pos             12                                             /**< (PMC_SLPWK_SR1) Peripheral 44 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID44_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 44 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID44                 PMC_SLPWK_SR1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID44_Msk instead */
+#define PMC_SLPWK_SR1_PID45_Pos             13                                             /**< (PMC_SLPWK_SR1) Peripheral 45 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID45_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 45 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID45                 PMC_SLPWK_SR1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID45_Msk instead */
+#define PMC_SLPWK_SR1_PID46_Pos             14                                             /**< (PMC_SLPWK_SR1) Peripheral 46 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID46_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 46 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID46                 PMC_SLPWK_SR1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID46_Msk instead */
+#define PMC_SLPWK_SR1_PID47_Pos             15                                             /**< (PMC_SLPWK_SR1) Peripheral 47 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID47_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 47 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID47                 PMC_SLPWK_SR1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID47_Msk instead */
+#define PMC_SLPWK_SR1_PID48_Pos             16                                             /**< (PMC_SLPWK_SR1) Peripheral 48 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID48_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 48 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID48                 PMC_SLPWK_SR1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID48_Msk instead */
+#define PMC_SLPWK_SR1_PID49_Pos             17                                             /**< (PMC_SLPWK_SR1) Peripheral 49 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID49_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 49 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID49                 PMC_SLPWK_SR1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID49_Msk instead */
+#define PMC_SLPWK_SR1_PID50_Pos             18                                             /**< (PMC_SLPWK_SR1) Peripheral 50 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID50_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 50 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID50                 PMC_SLPWK_SR1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID50_Msk instead */
+#define PMC_SLPWK_SR1_PID51_Pos             19                                             /**< (PMC_SLPWK_SR1) Peripheral 51 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID51_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 51 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID51                 PMC_SLPWK_SR1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID51_Msk instead */
+#define PMC_SLPWK_SR1_PID52_Pos             20                                             /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID52_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID52                 PMC_SLPWK_SR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID52_Msk instead */
+#define PMC_SLPWK_SR1_PID53_Pos             21                                             /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID53_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID53                 PMC_SLPWK_SR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID53_Msk instead */
+#define PMC_SLPWK_SR1_PID56_Pos             24                                             /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID56_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID56                 PMC_SLPWK_SR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID56_Msk instead */
+#define PMC_SLPWK_SR1_PID57_Pos             25                                             /**< (PMC_SLPWK_SR1) Peripheral 57 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID57_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 57 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID57                 PMC_SLPWK_SR1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID57_Msk instead */
+#define PMC_SLPWK_SR1_PID58_Pos             26                                             /**< (PMC_SLPWK_SR1) Peripheral 58 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID58_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 58 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID58                 PMC_SLPWK_SR1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID58_Msk instead */
+#define PMC_SLPWK_SR1_PID59_Pos             27                                             /**< (PMC_SLPWK_SR1) Peripheral 59 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID59_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 59 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID59                 PMC_SLPWK_SR1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID59_Msk instead */
+#define PMC_SLPWK_SR1_PID60_Pos             28                                             /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID60_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID60                 PMC_SLPWK_SR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID60_Msk instead */
+#define PMC_SLPWK_SR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_SR1) Register MASK  (Use PMC_SLPWK_SR1_Msk instead)  */
+#define PMC_SLPWK_SR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_SR1) Register Mask  */
+
+#define PMC_SLPWK_SR1_PID_Pos               0                                              /**< (PMC_SLPWK_SR1 Position) Peripheral 6x SleepWalking Status */
+#define PMC_SLPWK_SR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_SR1_PID_Pos)      /**< (PMC_SLPWK_SR1 Mask) PID */
+#define PMC_SLPWK_SR1_PID(value)            (PMC_SLPWK_SR1_PID_Msk & ((value) << PMC_SLPWK_SR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_ASR1 : (PMC Offset: 0x140) (R/ 32) SleepWalking Activity Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 Activity Status            */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 Activity Status            */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 Activity Status            */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 Activity Status            */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 Activity Status            */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 Activity Status            */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 Activity Status            */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 Activity Status            */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 Activity Status            */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 Activity Status            */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 Activity Status            */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 Activity Status            */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 Activity Status            */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 Activity Status            */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 Activity Status            */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 Activity Status            */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 Activity Status            */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 Activity Status            */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 Activity Status            */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 Activity Status            */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 Activity Status            */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 Activity Status            */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 Activity Status            */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 Activity Status            */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 Activity Status            */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x Activity Status            */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ASR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ASR1_OFFSET               (0x140)                                       /**<  (PMC_SLPWK_ASR1) SleepWalking Activity Status Register 1  Offset */
+
+#define PMC_SLPWK_ASR1_PID32_Pos            0                                              /**< (PMC_SLPWK_ASR1) Peripheral 32 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID32_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID32_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 32 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID32                PMC_SLPWK_ASR1_PID32_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID32_Msk instead */
+#define PMC_SLPWK_ASR1_PID33_Pos            1                                              /**< (PMC_SLPWK_ASR1) Peripheral 33 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID33_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID33_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 33 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID33                PMC_SLPWK_ASR1_PID33_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID33_Msk instead */
+#define PMC_SLPWK_ASR1_PID34_Pos            2                                              /**< (PMC_SLPWK_ASR1) Peripheral 34 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID34_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID34_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 34 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID34                PMC_SLPWK_ASR1_PID34_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID34_Msk instead */
+#define PMC_SLPWK_ASR1_PID35_Pos            3                                              /**< (PMC_SLPWK_ASR1) Peripheral 35 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID35_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID35_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 35 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID35                PMC_SLPWK_ASR1_PID35_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID35_Msk instead */
+#define PMC_SLPWK_ASR1_PID37_Pos            5                                              /**< (PMC_SLPWK_ASR1) Peripheral 37 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID37_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID37_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 37 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID37                PMC_SLPWK_ASR1_PID37_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID37_Msk instead */
+#define PMC_SLPWK_ASR1_PID39_Pos            7                                              /**< (PMC_SLPWK_ASR1) Peripheral 39 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID39_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID39_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 39 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID39                PMC_SLPWK_ASR1_PID39_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID39_Msk instead */
+#define PMC_SLPWK_ASR1_PID40_Pos            8                                              /**< (PMC_SLPWK_ASR1) Peripheral 40 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID40_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID40_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 40 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID40                PMC_SLPWK_ASR1_PID40_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID40_Msk instead */
+#define PMC_SLPWK_ASR1_PID41_Pos            9                                              /**< (PMC_SLPWK_ASR1) Peripheral 41 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID41_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID41_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 41 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID41                PMC_SLPWK_ASR1_PID41_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID41_Msk instead */
+#define PMC_SLPWK_ASR1_PID42_Pos            10                                             /**< (PMC_SLPWK_ASR1) Peripheral 42 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID42_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID42_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 42 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID42                PMC_SLPWK_ASR1_PID42_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID42_Msk instead */
+#define PMC_SLPWK_ASR1_PID43_Pos            11                                             /**< (PMC_SLPWK_ASR1) Peripheral 43 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID43_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID43_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 43 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID43                PMC_SLPWK_ASR1_PID43_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID43_Msk instead */
+#define PMC_SLPWK_ASR1_PID44_Pos            12                                             /**< (PMC_SLPWK_ASR1) Peripheral 44 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID44_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID44_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 44 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID44                PMC_SLPWK_ASR1_PID44_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID44_Msk instead */
+#define PMC_SLPWK_ASR1_PID45_Pos            13                                             /**< (PMC_SLPWK_ASR1) Peripheral 45 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID45_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID45_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 45 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID45                PMC_SLPWK_ASR1_PID45_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID45_Msk instead */
+#define PMC_SLPWK_ASR1_PID46_Pos            14                                             /**< (PMC_SLPWK_ASR1) Peripheral 46 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID46_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID46_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 46 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID46                PMC_SLPWK_ASR1_PID46_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID46_Msk instead */
+#define PMC_SLPWK_ASR1_PID47_Pos            15                                             /**< (PMC_SLPWK_ASR1) Peripheral 47 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID47_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID47_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 47 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID47                PMC_SLPWK_ASR1_PID47_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID47_Msk instead */
+#define PMC_SLPWK_ASR1_PID48_Pos            16                                             /**< (PMC_SLPWK_ASR1) Peripheral 48 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID48_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID48_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 48 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID48                PMC_SLPWK_ASR1_PID48_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID48_Msk instead */
+#define PMC_SLPWK_ASR1_PID49_Pos            17                                             /**< (PMC_SLPWK_ASR1) Peripheral 49 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID49_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID49_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 49 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID49                PMC_SLPWK_ASR1_PID49_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID49_Msk instead */
+#define PMC_SLPWK_ASR1_PID50_Pos            18                                             /**< (PMC_SLPWK_ASR1) Peripheral 50 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID50_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID50_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 50 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID50                PMC_SLPWK_ASR1_PID50_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID50_Msk instead */
+#define PMC_SLPWK_ASR1_PID51_Pos            19                                             /**< (PMC_SLPWK_ASR1) Peripheral 51 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID51_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID51_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 51 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID51                PMC_SLPWK_ASR1_PID51_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID51_Msk instead */
+#define PMC_SLPWK_ASR1_PID52_Pos            20                                             /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID52_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID52_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID52                PMC_SLPWK_ASR1_PID52_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID52_Msk instead */
+#define PMC_SLPWK_ASR1_PID53_Pos            21                                             /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID53_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID53_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID53                PMC_SLPWK_ASR1_PID53_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID53_Msk instead */
+#define PMC_SLPWK_ASR1_PID56_Pos            24                                             /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID56_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID56_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID56                PMC_SLPWK_ASR1_PID56_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID56_Msk instead */
+#define PMC_SLPWK_ASR1_PID57_Pos            25                                             /**< (PMC_SLPWK_ASR1) Peripheral 57 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID57_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID57_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 57 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID57                PMC_SLPWK_ASR1_PID57_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID57_Msk instead */
+#define PMC_SLPWK_ASR1_PID58_Pos            26                                             /**< (PMC_SLPWK_ASR1) Peripheral 58 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID58_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID58_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 58 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID58                PMC_SLPWK_ASR1_PID58_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID58_Msk instead */
+#define PMC_SLPWK_ASR1_PID59_Pos            27                                             /**< (PMC_SLPWK_ASR1) Peripheral 59 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID59_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID59_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 59 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID59                PMC_SLPWK_ASR1_PID59_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID59_Msk instead */
+#define PMC_SLPWK_ASR1_PID60_Pos            28                                             /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID60_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID60_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID60                PMC_SLPWK_ASR1_PID60_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID60_Msk instead */
+#define PMC_SLPWK_ASR1_MASK                 _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ASR1) Register MASK  (Use PMC_SLPWK_ASR1_Msk instead)  */
+#define PMC_SLPWK_ASR1_Msk                  _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ASR1) Register Mask  */
+
+#define PMC_SLPWK_ASR1_PID_Pos              0                                              /**< (PMC_SLPWK_ASR1 Position) Peripheral 6x Activity Status */
+#define PMC_SLPWK_ASR1_PID_Msk              (_U_(0x1FFFFFF) << PMC_SLPWK_ASR1_PID_Pos)     /**< (PMC_SLPWK_ASR1 Mask) PID */
+#define PMC_SLPWK_ASR1_PID(value)           (PMC_SLPWK_ASR1_PID_Msk & ((value) << PMC_SLPWK_ASR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_AIPR : (PMC Offset: 0x144) (R/ 32) SleepWalking Activity In Progress Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AIP:1;                     /**< bit:      0  Activity In Progress                     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_AIPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_AIPR_OFFSET               (0x144)                                       /**<  (PMC_SLPWK_AIPR) SleepWalking Activity In Progress Register  Offset */
+
+#define PMC_SLPWK_AIPR_AIP_Pos              0                                              /**< (PMC_SLPWK_AIPR) Activity In Progress Position */
+#define PMC_SLPWK_AIPR_AIP_Msk              (_U_(0x1) << PMC_SLPWK_AIPR_AIP_Pos)           /**< (PMC_SLPWK_AIPR) Activity In Progress Mask */
+#define PMC_SLPWK_AIPR_AIP                  PMC_SLPWK_AIPR_AIP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_AIPR_AIP_Msk instead */
+#define PMC_SLPWK_AIPR_MASK                 _U_(0x01)                                      /**< \deprecated (PMC_SLPWK_AIPR) Register MASK  (Use PMC_SLPWK_AIPR_Msk instead)  */
+#define PMC_SLPWK_AIPR_Msk                  _U_(0x01)                                      /**< (PMC_SLPWK_AIPR) Register Mask  */
+
+
+/* -------- PMC_APLLACR : (PMC Offset: 0x158) (R/W 32) Audio PLL Analog Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCOFLTSEL:4;               /**< bit:   0..3  DCO Filter Selection                     */
+    uint32_t FLTSEL:4;                  /**< bit:   4..7  PLL Filter Selection                     */
+    uint32_t BIAS:2;                    /**< bit:   8..9  Bias Voltage Selection                   */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_APLLACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_APLLACR_OFFSET                  (0x158)                                       /**<  (PMC_APLLACR) Audio PLL Analog Configuration Register  Offset */
+
+#define PMC_APLLACR_DCOFLTSEL_Pos           0                                              /**< (PMC_APLLACR) DCO Filter Selection Position */
+#define PMC_APLLACR_DCOFLTSEL_Msk           (_U_(0xF) << PMC_APLLACR_DCOFLTSEL_Pos)        /**< (PMC_APLLACR) DCO Filter Selection Mask */
+#define PMC_APLLACR_DCOFLTSEL(value)        (PMC_APLLACR_DCOFLTSEL_Msk & ((value) << PMC_APLLACR_DCOFLTSEL_Pos))
+#define PMC_APLLACR_FLTSEL_Pos              4                                              /**< (PMC_APLLACR) PLL Filter Selection Position */
+#define PMC_APLLACR_FLTSEL_Msk              (_U_(0xF) << PMC_APLLACR_FLTSEL_Pos)           /**< (PMC_APLLACR) PLL Filter Selection Mask */
+#define PMC_APLLACR_FLTSEL(value)           (PMC_APLLACR_FLTSEL_Msk & ((value) << PMC_APLLACR_FLTSEL_Pos))
+#define PMC_APLLACR_BIAS_Pos                8                                              /**< (PMC_APLLACR) Bias Voltage Selection Position */
+#define PMC_APLLACR_BIAS_Msk                (_U_(0x3) << PMC_APLLACR_BIAS_Pos)             /**< (PMC_APLLACR) Bias Voltage Selection Mask */
+#define PMC_APLLACR_BIAS(value)             (PMC_APLLACR_BIAS_Msk & ((value) << PMC_APLLACR_BIAS_Pos))
+#define PMC_APLLACR_MASK                    _U_(0x3FF)                                     /**< \deprecated (PMC_APLLACR) Register MASK  (Use PMC_APLLACR_Msk instead)  */
+#define PMC_APLLACR_Msk                     _U_(0x3FF)                                     /**< (PMC_APLLACR) Register Mask  */
+
+
+/* -------- PMC_WMST : (PMC Offset: 0x15c) (R/W 32) Wait Mode Startup Time Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WMST:8;                    /**< bit:   0..7  Wait Mode Startup Time                   */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Write Access Password                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_WMST_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_WMST_OFFSET                     (0x15C)                                       /**<  (PMC_WMST) Wait Mode Startup Time Register  Offset */
+
+#define PMC_WMST_WMST_Pos                   0                                              /**< (PMC_WMST) Wait Mode Startup Time Position */
+#define PMC_WMST_WMST_Msk                   (_U_(0xFF) << PMC_WMST_WMST_Pos)               /**< (PMC_WMST) Wait Mode Startup Time Mask */
+#define PMC_WMST_WMST(value)                (PMC_WMST_WMST_Msk & ((value) << PMC_WMST_WMST_Pos))
+#define PMC_WMST_KEY_Pos                    24                                             /**< (PMC_WMST) Write Access Password Position */
+#define PMC_WMST_KEY_Msk                    (_U_(0xFF) << PMC_WMST_KEY_Pos)                /**< (PMC_WMST) Write Access Password Mask */
+#define PMC_WMST_KEY(value)                 (PMC_WMST_KEY_Msk & ((value) << PMC_WMST_KEY_Pos))
+#define   PMC_WMST_KEY_PASSWD_Val           _U_(0x5A)                                      /**< (PMC_WMST) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define PMC_WMST_KEY_PASSWD                 (PMC_WMST_KEY_PASSWD_Val << PMC_WMST_KEY_Pos)  /**< (PMC_WMST) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define PMC_WMST_MASK                       _U_(0xFF0000FF)                                /**< \deprecated (PMC_WMST) Register MASK  (Use PMC_WMST_Msk instead)  */
+#define PMC_WMST_Msk                        _U_(0xFF0000FF)                                /**< (PMC_WMST) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PMC hardware registers */
+typedef struct {  
+  __O  uint32_t PMC_SCER;       /**< (PMC Offset: 0x00) System Clock Enable Register */
+  __O  uint32_t PMC_SCDR;       /**< (PMC Offset: 0x04) System Clock Disable Register */
+  __I  uint32_t PMC_SCSR;       /**< (PMC Offset: 0x08) System Clock Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t PMC_PCER0;      /**< (PMC Offset: 0x10) Peripheral Clock Enable Register 0 */
+  __O  uint32_t PMC_PCDR0;      /**< (PMC Offset: 0x14) Peripheral Clock Disable Register 0 */
+  __I  uint32_t PMC_PCSR0;      /**< (PMC Offset: 0x18) Peripheral Clock Status Register 0 */
+  __IO uint32_t CKGR_UCKR;      /**< (PMC Offset: 0x1C) UTMI Clock Register */
+  __IO uint32_t CKGR_MOR;       /**< (PMC Offset: 0x20) Main Oscillator Register */
+  __IO uint32_t CKGR_MCFR;      /**< (PMC Offset: 0x24) Main Clock Frequency Register */
+  __IO uint32_t CKGR_PLLAR;     /**< (PMC Offset: 0x28) PLLA Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t PMC_MCKR;       /**< (PMC Offset: 0x30) Master Clock Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO uint32_t PMC_USB;        /**< (PMC Offset: 0x38) USB Clock Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t PMC_PCK[8];     /**< (PMC Offset: 0x40) Programmable Clock Register (chid = 0) 0 */
+  __O  uint32_t PMC_IER;        /**< (PMC Offset: 0x60) Interrupt Enable Register */
+  __O  uint32_t PMC_IDR;        /**< (PMC Offset: 0x64) Interrupt Disable Register */
+  __I  uint32_t PMC_SR;         /**< (PMC Offset: 0x68) Status Register */
+  __I  uint32_t PMC_IMR;        /**< (PMC Offset: 0x6C) Interrupt Mask Register */
+  __IO uint32_t PMC_FSMR;       /**< (PMC Offset: 0x70) Fast Startup Mode Register */
+  __IO uint32_t PMC_FSPR;       /**< (PMC Offset: 0x74) Fast Startup Polarity Register */
+  __O  uint32_t PMC_FOCR;       /**< (PMC Offset: 0x78) Fault Output Clear Register */
+  __I  uint8_t                        Reserved5[104];
+  __IO uint32_t PMC_WPMR;       /**< (PMC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t PMC_WPSR;       /**< (PMC Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  uint32_t PMC_VERSION;    /**< (PMC Offset: 0xFC) Version Register */
+  __O  uint32_t PMC_PCER1;      /**< (PMC Offset: 0x100) Peripheral Clock Enable Register 1 */
+  __O  uint32_t PMC_PCDR1;      /**< (PMC Offset: 0x104) Peripheral Clock Disable Register 1 */
+  __I  uint32_t PMC_PCSR1;      /**< (PMC Offset: 0x108) Peripheral Clock Status Register 1 */
+  __IO uint32_t PMC_PCR;        /**< (PMC Offset: 0x10C) Peripheral Control Register */
+  __IO uint32_t PMC_OCR;        /**< (PMC Offset: 0x110) Oscillator Calibration Register */
+  __O  uint32_t PMC_SLPWK_ER0;  /**< (PMC Offset: 0x114) SleepWalking Enable Register 0 */
+  __O  uint32_t PMC_SLPWK_DR0;  /**< (PMC Offset: 0x118) SleepWalking Disable Register 0 */
+  __I  uint32_t PMC_SLPWK_SR0;  /**< (PMC Offset: 0x11C) SleepWalking Status Register 0 */
+  __I  uint32_t PMC_SLPWK_ASR0; /**< (PMC Offset: 0x120) SleepWalking Activity Status Register 0 */
+  __I  uint8_t                        Reserved7[12];
+  __IO uint32_t PMC_PMMR;       /**< (PMC Offset: 0x130) PLL Maximum Multiplier Value Register */
+  __O  uint32_t PMC_SLPWK_ER1;  /**< (PMC Offset: 0x134) SleepWalking Enable Register 1 */
+  __O  uint32_t PMC_SLPWK_DR1;  /**< (PMC Offset: 0x138) SleepWalking Disable Register 1 */
+  __I  uint32_t PMC_SLPWK_SR1;  /**< (PMC Offset: 0x13C) SleepWalking Status Register 1 */
+  __I  uint32_t PMC_SLPWK_ASR1; /**< (PMC Offset: 0x140) SleepWalking Activity Status Register 1 */
+  __I  uint32_t PMC_SLPWK_AIPR; /**< (PMC Offset: 0x144) SleepWalking Activity In Progress Register */
+  __I  uint8_t                        Reserved8[16];
+  __IO uint32_t PMC_APLLACR;    /**< (PMC Offset: 0x158) Audio PLL Analog Configuration Register */
+  __IO uint32_t PMC_WMST;       /**< (PMC Offset: 0x15C) Wait Mode Startup Time Register */
+} Pmc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PMC hardware registers */
+typedef struct {  
+  __O  PMC_SCER_Type                  PMC_SCER;       /**< Offset: 0x00 ( /W  32) System Clock Enable Register */
+  __O  PMC_SCDR_Type                  PMC_SCDR;       /**< Offset: 0x04 ( /W  32) System Clock Disable Register */
+  __I  PMC_SCSR_Type                  PMC_SCSR;       /**< Offset: 0x08 (R/   32) System Clock Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  PMC_PCER0_Type                 PMC_PCER0;      /**< Offset: 0x10 ( /W  32) Peripheral Clock Enable Register 0 */
+  __O  PMC_PCDR0_Type                 PMC_PCDR0;      /**< Offset: 0x14 ( /W  32) Peripheral Clock Disable Register 0 */
+  __I  PMC_PCSR0_Type                 PMC_PCSR0;      /**< Offset: 0x18 (R/   32) Peripheral Clock Status Register 0 */
+  __IO CKGR_UCKR_Type                 CKGR_UCKR;      /**< Offset: 0x1C (R/W  32) UTMI Clock Register */
+  __IO CKGR_MOR_Type                  CKGR_MOR;       /**< Offset: 0x20 (R/W  32) Main Oscillator Register */
+  __IO CKGR_MCFR_Type                 CKGR_MCFR;      /**< Offset: 0x24 (R/W  32) Main Clock Frequency Register */
+  __IO CKGR_PLLAR_Type                CKGR_PLLAR;     /**< Offset: 0x28 (R/W  32) PLLA Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO PMC_MCKR_Type                  PMC_MCKR;       /**< Offset: 0x30 (R/W  32) Master Clock Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO PMC_USB_Type                   PMC_USB;        /**< Offset: 0x38 (R/W  32) USB Clock Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO PMC_PCK_Type                   PMC_PCK[8];     /**< Offset: 0x40 (R/W  32) Programmable Clock Register (chid = 0) 0 */
+  __O  PMC_IER_Type                   PMC_IER;        /**< Offset: 0x60 ( /W  32) Interrupt Enable Register */
+  __O  PMC_IDR_Type                   PMC_IDR;        /**< Offset: 0x64 ( /W  32) Interrupt Disable Register */
+  __I  PMC_SR_Type                    PMC_SR;         /**< Offset: 0x68 (R/   32) Status Register */
+  __I  PMC_IMR_Type                   PMC_IMR;        /**< Offset: 0x6C (R/   32) Interrupt Mask Register */
+  __IO PMC_FSMR_Type                  PMC_FSMR;       /**< Offset: 0x70 (R/W  32) Fast Startup Mode Register */
+  __IO PMC_FSPR_Type                  PMC_FSPR;       /**< Offset: 0x74 (R/W  32) Fast Startup Polarity Register */
+  __O  PMC_FOCR_Type                  PMC_FOCR;       /**< Offset: 0x78 ( /W  32) Fault Output Clear Register */
+  __I  uint8_t                        Reserved5[104];
+  __IO PMC_WPMR_Type                  PMC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  PMC_WPSR_Type                  PMC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  PMC_VERSION_Type               PMC_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+  __O  PMC_PCER1_Type                 PMC_PCER1;      /**< Offset: 0x100 ( /W  32) Peripheral Clock Enable Register 1 */
+  __O  PMC_PCDR1_Type                 PMC_PCDR1;      /**< Offset: 0x104 ( /W  32) Peripheral Clock Disable Register 1 */
+  __I  PMC_PCSR1_Type                 PMC_PCSR1;      /**< Offset: 0x108 (R/   32) Peripheral Clock Status Register 1 */
+  __IO PMC_PCR_Type                   PMC_PCR;        /**< Offset: 0x10C (R/W  32) Peripheral Control Register */
+  __IO PMC_OCR_Type                   PMC_OCR;        /**< Offset: 0x110 (R/W  32) Oscillator Calibration Register */
+  __O  PMC_SLPWK_ER0_Type             PMC_SLPWK_ER0;  /**< Offset: 0x114 ( /W  32) SleepWalking Enable Register 0 */
+  __O  PMC_SLPWK_DR0_Type             PMC_SLPWK_DR0;  /**< Offset: 0x118 ( /W  32) SleepWalking Disable Register 0 */
+  __I  PMC_SLPWK_SR0_Type             PMC_SLPWK_SR0;  /**< Offset: 0x11C (R/   32) SleepWalking Status Register 0 */
+  __I  PMC_SLPWK_ASR0_Type            PMC_SLPWK_ASR0; /**< Offset: 0x120 (R/   32) SleepWalking Activity Status Register 0 */
+  __I  uint8_t                        Reserved7[12];
+  __IO PMC_PMMR_Type                  PMC_PMMR;       /**< Offset: 0x130 (R/W  32) PLL Maximum Multiplier Value Register */
+  __O  PMC_SLPWK_ER1_Type             PMC_SLPWK_ER1;  /**< Offset: 0x134 ( /W  32) SleepWalking Enable Register 1 */
+  __O  PMC_SLPWK_DR1_Type             PMC_SLPWK_DR1;  /**< Offset: 0x138 ( /W  32) SleepWalking Disable Register 1 */
+  __I  PMC_SLPWK_SR1_Type             PMC_SLPWK_SR1;  /**< Offset: 0x13C (R/   32) SleepWalking Status Register 1 */
+  __I  PMC_SLPWK_ASR1_Type            PMC_SLPWK_ASR1; /**< Offset: 0x140 (R/   32) SleepWalking Activity Status Register 1 */
+  __I  PMC_SLPWK_AIPR_Type            PMC_SLPWK_AIPR; /**< Offset: 0x144 (R/   32) SleepWalking Activity In Progress Register */
+  __I  uint8_t                        Reserved8[16];
+  __IO PMC_APLLACR_Type               PMC_APLLACR;    /**< Offset: 0x158 (R/W  32) Audio PLL Analog Configuration Register */
+  __IO PMC_WMST_Type                  PMC_WMST;       /**< Offset: 0x15C (R/W  32) Wait Mode Startup Time Register */
+} Pmc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Power Management Controller */
+
+#endif /* _SAMV71_PMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/pwm.h
+++ b/asf/sam/include/samv71/component/pwm.h
@@ -1,0 +1,2884 @@
+/**
+ * \file
+ *
+ * \brief Component description for PWM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PWM_COMPONENT_H_
+#define _SAMV71_PWM_COMPONENT_H_
+#define _SAMV71_PWM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Pulse Width Modulation Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PWM */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PWM_6343                       /**< (PWM) Module ID */
+#define REV_PWM X                      /**< (PWM) Module revision */
+
+/* -------- PWM_CMR : (PWM Offset: 0x00) (R/W 32) PWM Channel Mode Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRE:4;                    /**< bit:   0..3  Channel Pre-scaler                       */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CALG:1;                    /**< bit:      8  Channel Alignment                        */
+    uint32_t CPOL:1;                    /**< bit:      9  Channel Polarity                         */
+    uint32_t CES:1;                     /**< bit:     10  Counter Event Selection                  */
+    uint32_t UPDS:1;                    /**< bit:     11  Update Selection                         */
+    uint32_t DPOLI:1;                   /**< bit:     12  Disabled Polarity Inverted               */
+    uint32_t TCTS:1;                    /**< bit:     13  Timer Counter Trigger Selection          */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t DTE:1;                     /**< bit:     16  Dead-Time Generator Enable               */
+    uint32_t DTHI:1;                    /**< bit:     17  Dead-Time PWMHx Output Inverted          */
+    uint32_t DTLI:1;                    /**< bit:     18  Dead-Time PWMLx Output Inverted          */
+    uint32_t PPM:1;                     /**< bit:     19  Push-Pull Mode                           */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMR_OFFSET                      (0x00)                                        /**<  (PWM_CMR) PWM Channel Mode Register (ch_num = 0)  Offset */
+
+#define PWM_CMR_CPRE_Pos                    0                                              /**< (PWM_CMR) Channel Pre-scaler Position */
+#define PWM_CMR_CPRE_Msk                    (_U_(0xF) << PWM_CMR_CPRE_Pos)                 /**< (PWM_CMR) Channel Pre-scaler Mask */
+#define PWM_CMR_CPRE(value)                 (PWM_CMR_CPRE_Msk & ((value) << PWM_CMR_CPRE_Pos))
+#define   PWM_CMR_CPRE_MCK_Val              _U_(0x0)                                       /**< (PWM_CMR) Peripheral clock  */
+#define   PWM_CMR_CPRE_MCK_DIV_2_Val        _U_(0x1)                                       /**< (PWM_CMR) Peripheral clock/2  */
+#define   PWM_CMR_CPRE_MCK_DIV_4_Val        _U_(0x2)                                       /**< (PWM_CMR) Peripheral clock/4  */
+#define   PWM_CMR_CPRE_MCK_DIV_8_Val        _U_(0x3)                                       /**< (PWM_CMR) Peripheral clock/8  */
+#define   PWM_CMR_CPRE_MCK_DIV_16_Val       _U_(0x4)                                       /**< (PWM_CMR) Peripheral clock/16  */
+#define   PWM_CMR_CPRE_MCK_DIV_32_Val       _U_(0x5)                                       /**< (PWM_CMR) Peripheral clock/32  */
+#define   PWM_CMR_CPRE_MCK_DIV_64_Val       _U_(0x6)                                       /**< (PWM_CMR) Peripheral clock/64  */
+#define   PWM_CMR_CPRE_MCK_DIV_128_Val      _U_(0x7)                                       /**< (PWM_CMR) Peripheral clock/128  */
+#define   PWM_CMR_CPRE_MCK_DIV_256_Val      _U_(0x8)                                       /**< (PWM_CMR) Peripheral clock/256  */
+#define   PWM_CMR_CPRE_MCK_DIV_512_Val      _U_(0x9)                                       /**< (PWM_CMR) Peripheral clock/512  */
+#define   PWM_CMR_CPRE_MCK_DIV_1024_Val     _U_(0xA)                                       /**< (PWM_CMR) Peripheral clock/1024  */
+#define   PWM_CMR_CPRE_CLKA_Val             _U_(0xB)                                       /**< (PWM_CMR) Clock A  */
+#define   PWM_CMR_CPRE_CLKB_Val             _U_(0xC)                                       /**< (PWM_CMR) Clock B  */
+#define PWM_CMR_CPRE_MCK                    (PWM_CMR_CPRE_MCK_Val << PWM_CMR_CPRE_Pos)     /**< (PWM_CMR) Peripheral clock Position  */
+#define PWM_CMR_CPRE_MCK_DIV_2              (PWM_CMR_CPRE_MCK_DIV_2_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/2 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_4              (PWM_CMR_CPRE_MCK_DIV_4_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/4 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_8              (PWM_CMR_CPRE_MCK_DIV_8_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/8 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_16             (PWM_CMR_CPRE_MCK_DIV_16_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/16 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_32             (PWM_CMR_CPRE_MCK_DIV_32_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/32 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_64             (PWM_CMR_CPRE_MCK_DIV_64_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/64 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_128            (PWM_CMR_CPRE_MCK_DIV_128_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/128 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_256            (PWM_CMR_CPRE_MCK_DIV_256_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/256 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_512            (PWM_CMR_CPRE_MCK_DIV_512_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/512 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_1024           (PWM_CMR_CPRE_MCK_DIV_1024_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/1024 Position  */
+#define PWM_CMR_CPRE_CLKA                   (PWM_CMR_CPRE_CLKA_Val << PWM_CMR_CPRE_Pos)    /**< (PWM_CMR) Clock A Position  */
+#define PWM_CMR_CPRE_CLKB                   (PWM_CMR_CPRE_CLKB_Val << PWM_CMR_CPRE_Pos)    /**< (PWM_CMR) Clock B Position  */
+#define PWM_CMR_CALG_Pos                    8                                              /**< (PWM_CMR) Channel Alignment Position */
+#define PWM_CMR_CALG_Msk                    (_U_(0x1) << PWM_CMR_CALG_Pos)                 /**< (PWM_CMR) Channel Alignment Mask */
+#define PWM_CMR_CALG                        PWM_CMR_CALG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CALG_Msk instead */
+#define PWM_CMR_CPOL_Pos                    9                                              /**< (PWM_CMR) Channel Polarity Position */
+#define PWM_CMR_CPOL_Msk                    (_U_(0x1) << PWM_CMR_CPOL_Pos)                 /**< (PWM_CMR) Channel Polarity Mask */
+#define PWM_CMR_CPOL                        PWM_CMR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CPOL_Msk instead */
+#define PWM_CMR_CES_Pos                     10                                             /**< (PWM_CMR) Counter Event Selection Position */
+#define PWM_CMR_CES_Msk                     (_U_(0x1) << PWM_CMR_CES_Pos)                  /**< (PWM_CMR) Counter Event Selection Mask */
+#define PWM_CMR_CES                         PWM_CMR_CES_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CES_Msk instead */
+#define PWM_CMR_UPDS_Pos                    11                                             /**< (PWM_CMR) Update Selection Position */
+#define PWM_CMR_UPDS_Msk                    (_U_(0x1) << PWM_CMR_UPDS_Pos)                 /**< (PWM_CMR) Update Selection Mask */
+#define PWM_CMR_UPDS                        PWM_CMR_UPDS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_UPDS_Msk instead */
+#define PWM_CMR_DPOLI_Pos                   12                                             /**< (PWM_CMR) Disabled Polarity Inverted Position */
+#define PWM_CMR_DPOLI_Msk                   (_U_(0x1) << PWM_CMR_DPOLI_Pos)                /**< (PWM_CMR) Disabled Polarity Inverted Mask */
+#define PWM_CMR_DPOLI                       PWM_CMR_DPOLI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DPOLI_Msk instead */
+#define PWM_CMR_TCTS_Pos                    13                                             /**< (PWM_CMR) Timer Counter Trigger Selection Position */
+#define PWM_CMR_TCTS_Msk                    (_U_(0x1) << PWM_CMR_TCTS_Pos)                 /**< (PWM_CMR) Timer Counter Trigger Selection Mask */
+#define PWM_CMR_TCTS                        PWM_CMR_TCTS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_TCTS_Msk instead */
+#define PWM_CMR_DTE_Pos                     16                                             /**< (PWM_CMR) Dead-Time Generator Enable Position */
+#define PWM_CMR_DTE_Msk                     (_U_(0x1) << PWM_CMR_DTE_Pos)                  /**< (PWM_CMR) Dead-Time Generator Enable Mask */
+#define PWM_CMR_DTE                         PWM_CMR_DTE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTE_Msk instead */
+#define PWM_CMR_DTHI_Pos                    17                                             /**< (PWM_CMR) Dead-Time PWMHx Output Inverted Position */
+#define PWM_CMR_DTHI_Msk                    (_U_(0x1) << PWM_CMR_DTHI_Pos)                 /**< (PWM_CMR) Dead-Time PWMHx Output Inverted Mask */
+#define PWM_CMR_DTHI                        PWM_CMR_DTHI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTHI_Msk instead */
+#define PWM_CMR_DTLI_Pos                    18                                             /**< (PWM_CMR) Dead-Time PWMLx Output Inverted Position */
+#define PWM_CMR_DTLI_Msk                    (_U_(0x1) << PWM_CMR_DTLI_Pos)                 /**< (PWM_CMR) Dead-Time PWMLx Output Inverted Mask */
+#define PWM_CMR_DTLI                        PWM_CMR_DTLI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTLI_Msk instead */
+#define PWM_CMR_PPM_Pos                     19                                             /**< (PWM_CMR) Push-Pull Mode Position */
+#define PWM_CMR_PPM_Msk                     (_U_(0x1) << PWM_CMR_PPM_Pos)                  /**< (PWM_CMR) Push-Pull Mode Mask */
+#define PWM_CMR_PPM                         PWM_CMR_PPM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_PPM_Msk instead */
+#define PWM_CMR_MASK                        _U_(0xF3F0F)                                   /**< \deprecated (PWM_CMR) Register MASK  (Use PWM_CMR_Msk instead)  */
+#define PWM_CMR_Msk                         _U_(0xF3F0F)                                   /**< (PWM_CMR) Register Mask  */
+
+
+/* -------- PWM_CDTY : (PWM Offset: 0x04) (R/W 32) PWM Channel Duty Cycle Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CDTY:24;                   /**< bit:  0..23  Channel Duty-Cycle                       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CDTY_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CDTY_OFFSET                     (0x04)                                        /**<  (PWM_CDTY) PWM Channel Duty Cycle Register (ch_num = 0)  Offset */
+
+#define PWM_CDTY_CDTY_Pos                   0                                              /**< (PWM_CDTY) Channel Duty-Cycle Position */
+#define PWM_CDTY_CDTY_Msk                   (_U_(0xFFFFFF) << PWM_CDTY_CDTY_Pos)           /**< (PWM_CDTY) Channel Duty-Cycle Mask */
+#define PWM_CDTY_CDTY(value)                (PWM_CDTY_CDTY_Msk & ((value) << PWM_CDTY_CDTY_Pos))
+#define PWM_CDTY_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CDTY) Register MASK  (Use PWM_CDTY_Msk instead)  */
+#define PWM_CDTY_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CDTY) Register Mask  */
+
+
+/* -------- PWM_CDTYUPD : (PWM Offset: 0x08) (/W 32) PWM Channel Duty Cycle Update Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CDTYUPD:24;                /**< bit:  0..23  Channel Duty-Cycle Update                */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CDTYUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CDTYUPD_OFFSET                  (0x08)                                        /**<  (PWM_CDTYUPD) PWM Channel Duty Cycle Update Register (ch_num = 0)  Offset */
+
+#define PWM_CDTYUPD_CDTYUPD_Pos             0                                              /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Position */
+#define PWM_CDTYUPD_CDTYUPD_Msk             (_U_(0xFFFFFF) << PWM_CDTYUPD_CDTYUPD_Pos)     /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Mask */
+#define PWM_CDTYUPD_CDTYUPD(value)          (PWM_CDTYUPD_CDTYUPD_Msk & ((value) << PWM_CDTYUPD_CDTYUPD_Pos))
+#define PWM_CDTYUPD_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CDTYUPD) Register MASK  (Use PWM_CDTYUPD_Msk instead)  */
+#define PWM_CDTYUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CDTYUPD) Register Mask  */
+
+
+/* -------- PWM_CPRD : (PWM Offset: 0x0c) (R/W 32) PWM Channel Period Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRD:24;                   /**< bit:  0..23  Channel Period                           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CPRD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CPRD_OFFSET                     (0x0C)                                        /**<  (PWM_CPRD) PWM Channel Period Register (ch_num = 0)  Offset */
+
+#define PWM_CPRD_CPRD_Pos                   0                                              /**< (PWM_CPRD) Channel Period Position */
+#define PWM_CPRD_CPRD_Msk                   (_U_(0xFFFFFF) << PWM_CPRD_CPRD_Pos)           /**< (PWM_CPRD) Channel Period Mask */
+#define PWM_CPRD_CPRD(value)                (PWM_CPRD_CPRD_Msk & ((value) << PWM_CPRD_CPRD_Pos))
+#define PWM_CPRD_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CPRD) Register MASK  (Use PWM_CPRD_Msk instead)  */
+#define PWM_CPRD_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CPRD) Register Mask  */
+
+
+/* -------- PWM_CPRDUPD : (PWM Offset: 0x10) (/W 32) PWM Channel Period Update Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRDUPD:24;                /**< bit:  0..23  Channel Period Update                    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CPRDUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CPRDUPD_OFFSET                  (0x10)                                        /**<  (PWM_CPRDUPD) PWM Channel Period Update Register (ch_num = 0)  Offset */
+
+#define PWM_CPRDUPD_CPRDUPD_Pos             0                                              /**< (PWM_CPRDUPD) Channel Period Update Position */
+#define PWM_CPRDUPD_CPRDUPD_Msk             (_U_(0xFFFFFF) << PWM_CPRDUPD_CPRDUPD_Pos)     /**< (PWM_CPRDUPD) Channel Period Update Mask */
+#define PWM_CPRDUPD_CPRDUPD(value)          (PWM_CPRDUPD_CPRDUPD_Msk & ((value) << PWM_CPRDUPD_CPRDUPD_Pos))
+#define PWM_CPRDUPD_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CPRDUPD) Register MASK  (Use PWM_CPRDUPD_Msk instead)  */
+#define PWM_CPRDUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CPRDUPD) Register Mask  */
+
+
+/* -------- PWM_CCNT : (PWM Offset: 0x14) (R/ 32) PWM Channel Counter Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CNT:24;                    /**< bit:  0..23  Channel Counter Register                 */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CCNT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CCNT_OFFSET                     (0x14)                                        /**<  (PWM_CCNT) PWM Channel Counter Register (ch_num = 0)  Offset */
+
+#define PWM_CCNT_CNT_Pos                    0                                              /**< (PWM_CCNT) Channel Counter Register Position */
+#define PWM_CCNT_CNT_Msk                    (_U_(0xFFFFFF) << PWM_CCNT_CNT_Pos)            /**< (PWM_CCNT) Channel Counter Register Mask */
+#define PWM_CCNT_CNT(value)                 (PWM_CCNT_CNT_Msk & ((value) << PWM_CCNT_CNT_Pos))
+#define PWM_CCNT_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CCNT) Register MASK  (Use PWM_CCNT_Msk instead)  */
+#define PWM_CCNT_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CCNT) Register Mask  */
+
+
+/* -------- PWM_DT : (PWM Offset: 0x18) (R/W 32) PWM Channel Dead Time Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTH:16;                    /**< bit:  0..15  Dead-Time Value for PWMHx Output         */
+    uint32_t DTL:16;                    /**< bit: 16..31  Dead-Time Value for PWMLx Output         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DT_OFFSET                       (0x18)                                        /**<  (PWM_DT) PWM Channel Dead Time Register (ch_num = 0)  Offset */
+
+#define PWM_DT_DTH_Pos                      0                                              /**< (PWM_DT) Dead-Time Value for PWMHx Output Position */
+#define PWM_DT_DTH_Msk                      (_U_(0xFFFF) << PWM_DT_DTH_Pos)                /**< (PWM_DT) Dead-Time Value for PWMHx Output Mask */
+#define PWM_DT_DTH(value)                   (PWM_DT_DTH_Msk & ((value) << PWM_DT_DTH_Pos))
+#define PWM_DT_DTL_Pos                      16                                             /**< (PWM_DT) Dead-Time Value for PWMLx Output Position */
+#define PWM_DT_DTL_Msk                      (_U_(0xFFFF) << PWM_DT_DTL_Pos)                /**< (PWM_DT) Dead-Time Value for PWMLx Output Mask */
+#define PWM_DT_DTL(value)                   (PWM_DT_DTL_Msk & ((value) << PWM_DT_DTL_Pos))
+#define PWM_DT_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_DT) Register MASK  (Use PWM_DT_Msk instead)  */
+#define PWM_DT_Msk                          _U_(0xFFFFFFFF)                                /**< (PWM_DT) Register Mask  */
+
+
+/* -------- PWM_DTUPD : (PWM Offset: 0x1c) (/W 32) PWM Channel Dead Time Update Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTHUPD:16;                 /**< bit:  0..15  Dead-Time Value Update for PWMHx Output  */
+    uint32_t DTLUPD:16;                 /**< bit: 16..31  Dead-Time Value Update for PWMLx Output  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DTUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DTUPD_OFFSET                    (0x1C)                                        /**<  (PWM_DTUPD) PWM Channel Dead Time Update Register (ch_num = 0)  Offset */
+
+#define PWM_DTUPD_DTHUPD_Pos                0                                              /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Position */
+#define PWM_DTUPD_DTHUPD_Msk                (_U_(0xFFFF) << PWM_DTUPD_DTHUPD_Pos)          /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Mask */
+#define PWM_DTUPD_DTHUPD(value)             (PWM_DTUPD_DTHUPD_Msk & ((value) << PWM_DTUPD_DTHUPD_Pos))
+#define PWM_DTUPD_DTLUPD_Pos                16                                             /**< (PWM_DTUPD) Dead-Time Value Update for PWMLx Output Position */
+#define PWM_DTUPD_DTLUPD_Msk                (_U_(0xFFFF) << PWM_DTUPD_DTLUPD_Pos)          /**< (PWM_DTUPD) Dead-Time Value Update for PWMLx Output Mask */
+#define PWM_DTUPD_DTLUPD(value)             (PWM_DTUPD_DTLUPD_Msk & ((value) << PWM_DTUPD_DTLUPD_Pos))
+#define PWM_DTUPD_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_DTUPD) Register MASK  (Use PWM_DTUPD_Msk instead)  */
+#define PWM_DTUPD_Msk                       _U_(0xFFFFFFFF)                                /**< (PWM_DTUPD) Register Mask  */
+
+
+/* -------- PWM_CMPV : (PWM Offset: 0x00) (R/W 32) PWM Comparison 0 Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CV:24;                     /**< bit:  0..23  Comparison x Value                       */
+    uint32_t CVM:1;                     /**< bit:     24  Comparison x Value Mode                  */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPV_OFFSET                     (0x00)                                        /**<  (PWM_CMPV) PWM Comparison 0 Value Register  Offset */
+
+#define PWM_CMPV_CV_Pos                     0                                              /**< (PWM_CMPV) Comparison x Value Position */
+#define PWM_CMPV_CV_Msk                     (_U_(0xFFFFFF) << PWM_CMPV_CV_Pos)             /**< (PWM_CMPV) Comparison x Value Mask */
+#define PWM_CMPV_CV(value)                  (PWM_CMPV_CV_Msk & ((value) << PWM_CMPV_CV_Pos))
+#define PWM_CMPV_CVM_Pos                    24                                             /**< (PWM_CMPV) Comparison x Value Mode Position */
+#define PWM_CMPV_CVM_Msk                    (_U_(0x1) << PWM_CMPV_CVM_Pos)                 /**< (PWM_CMPV) Comparison x Value Mode Mask */
+#define PWM_CMPV_CVM                        PWM_CMPV_CVM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPV_CVM_Msk instead */
+#define PWM_CMPV_MASK                       _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_CMPV) Register MASK  (Use PWM_CMPV_Msk instead)  */
+#define PWM_CMPV_Msk                        _U_(0x1FFFFFF)                                 /**< (PWM_CMPV) Register Mask  */
+
+
+/* -------- PWM_CMPVUPD : (PWM Offset: 0x04) (/W 32) PWM Comparison 0 Value Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CVUPD:24;                  /**< bit:  0..23  Comparison x Value Update                */
+    uint32_t CVMUPD:1;                  /**< bit:     24  Comparison x Value Mode Update           */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPVUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPVUPD_OFFSET                  (0x04)                                        /**<  (PWM_CMPVUPD) PWM Comparison 0 Value Update Register  Offset */
+
+#define PWM_CMPVUPD_CVUPD_Pos               0                                              /**< (PWM_CMPVUPD) Comparison x Value Update Position */
+#define PWM_CMPVUPD_CVUPD_Msk               (_U_(0xFFFFFF) << PWM_CMPVUPD_CVUPD_Pos)       /**< (PWM_CMPVUPD) Comparison x Value Update Mask */
+#define PWM_CMPVUPD_CVUPD(value)            (PWM_CMPVUPD_CVUPD_Msk & ((value) << PWM_CMPVUPD_CVUPD_Pos))
+#define PWM_CMPVUPD_CVMUPD_Pos              24                                             /**< (PWM_CMPVUPD) Comparison x Value Mode Update Position */
+#define PWM_CMPVUPD_CVMUPD_Msk              (_U_(0x1) << PWM_CMPVUPD_CVMUPD_Pos)           /**< (PWM_CMPVUPD) Comparison x Value Mode Update Mask */
+#define PWM_CMPVUPD_CVMUPD                  PWM_CMPVUPD_CVMUPD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPVUPD_CVMUPD_Msk instead */
+#define PWM_CMPVUPD_MASK                    _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_CMPVUPD) Register MASK  (Use PWM_CMPVUPD_Msk instead)  */
+#define PWM_CMPVUPD_Msk                     _U_(0x1FFFFFF)                                 /**< (PWM_CMPVUPD) Register Mask  */
+
+
+/* -------- PWM_CMPM : (PWM Offset: 0x08) (R/W 32) PWM Comparison 0 Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CEN:1;                     /**< bit:      0  Comparison x Enable                      */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t CTR:4;                     /**< bit:   4..7  Comparison x Trigger                     */
+    uint32_t CPR:4;                     /**< bit:  8..11  Comparison x Period                      */
+    uint32_t CPRCNT:4;                  /**< bit: 12..15  Comparison x Period Counter              */
+    uint32_t CUPR:4;                    /**< bit: 16..19  Comparison x Update Period               */
+    uint32_t CUPRCNT:4;                 /**< bit: 20..23  Comparison x Update Period Counter       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPM_OFFSET                     (0x08)                                        /**<  (PWM_CMPM) PWM Comparison 0 Mode Register  Offset */
+
+#define PWM_CMPM_CEN_Pos                    0                                              /**< (PWM_CMPM) Comparison x Enable Position */
+#define PWM_CMPM_CEN_Msk                    (_U_(0x1) << PWM_CMPM_CEN_Pos)                 /**< (PWM_CMPM) Comparison x Enable Mask */
+#define PWM_CMPM_CEN                        PWM_CMPM_CEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPM_CEN_Msk instead */
+#define PWM_CMPM_CTR_Pos                    4                                              /**< (PWM_CMPM) Comparison x Trigger Position */
+#define PWM_CMPM_CTR_Msk                    (_U_(0xF) << PWM_CMPM_CTR_Pos)                 /**< (PWM_CMPM) Comparison x Trigger Mask */
+#define PWM_CMPM_CTR(value)                 (PWM_CMPM_CTR_Msk & ((value) << PWM_CMPM_CTR_Pos))
+#define PWM_CMPM_CPR_Pos                    8                                              /**< (PWM_CMPM) Comparison x Period Position */
+#define PWM_CMPM_CPR_Msk                    (_U_(0xF) << PWM_CMPM_CPR_Pos)                 /**< (PWM_CMPM) Comparison x Period Mask */
+#define PWM_CMPM_CPR(value)                 (PWM_CMPM_CPR_Msk & ((value) << PWM_CMPM_CPR_Pos))
+#define PWM_CMPM_CPRCNT_Pos                 12                                             /**< (PWM_CMPM) Comparison x Period Counter Position */
+#define PWM_CMPM_CPRCNT_Msk                 (_U_(0xF) << PWM_CMPM_CPRCNT_Pos)              /**< (PWM_CMPM) Comparison x Period Counter Mask */
+#define PWM_CMPM_CPRCNT(value)              (PWM_CMPM_CPRCNT_Msk & ((value) << PWM_CMPM_CPRCNT_Pos))
+#define PWM_CMPM_CUPR_Pos                   16                                             /**< (PWM_CMPM) Comparison x Update Period Position */
+#define PWM_CMPM_CUPR_Msk                   (_U_(0xF) << PWM_CMPM_CUPR_Pos)                /**< (PWM_CMPM) Comparison x Update Period Mask */
+#define PWM_CMPM_CUPR(value)                (PWM_CMPM_CUPR_Msk & ((value) << PWM_CMPM_CUPR_Pos))
+#define PWM_CMPM_CUPRCNT_Pos                20                                             /**< (PWM_CMPM) Comparison x Update Period Counter Position */
+#define PWM_CMPM_CUPRCNT_Msk                (_U_(0xF) << PWM_CMPM_CUPRCNT_Pos)             /**< (PWM_CMPM) Comparison x Update Period Counter Mask */
+#define PWM_CMPM_CUPRCNT(value)             (PWM_CMPM_CUPRCNT_Msk & ((value) << PWM_CMPM_CUPRCNT_Pos))
+#define PWM_CMPM_MASK                       _U_(0xFFFFF1)                                  /**< \deprecated (PWM_CMPM) Register MASK  (Use PWM_CMPM_Msk instead)  */
+#define PWM_CMPM_Msk                        _U_(0xFFFFF1)                                  /**< (PWM_CMPM) Register Mask  */
+
+
+/* -------- PWM_CMPMUPD : (PWM Offset: 0x0c) (/W 32) PWM Comparison 0 Mode Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CENUPD:1;                  /**< bit:      0  Comparison x Enable Update               */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t CTRUPD:4;                  /**< bit:   4..7  Comparison x Trigger Update              */
+    uint32_t CPRUPD:4;                  /**< bit:  8..11  Comparison x Period Update               */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t CUPRUPD:4;                 /**< bit: 16..19  Comparison x Update Period Update        */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPMUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPMUPD_OFFSET                  (0x0C)                                        /**<  (PWM_CMPMUPD) PWM Comparison 0 Mode Update Register  Offset */
+
+#define PWM_CMPMUPD_CENUPD_Pos              0                                              /**< (PWM_CMPMUPD) Comparison x Enable Update Position */
+#define PWM_CMPMUPD_CENUPD_Msk              (_U_(0x1) << PWM_CMPMUPD_CENUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Enable Update Mask */
+#define PWM_CMPMUPD_CENUPD                  PWM_CMPMUPD_CENUPD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPMUPD_CENUPD_Msk instead */
+#define PWM_CMPMUPD_CTRUPD_Pos              4                                              /**< (PWM_CMPMUPD) Comparison x Trigger Update Position */
+#define PWM_CMPMUPD_CTRUPD_Msk              (_U_(0xF) << PWM_CMPMUPD_CTRUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Trigger Update Mask */
+#define PWM_CMPMUPD_CTRUPD(value)           (PWM_CMPMUPD_CTRUPD_Msk & ((value) << PWM_CMPMUPD_CTRUPD_Pos))
+#define PWM_CMPMUPD_CPRUPD_Pos              8                                              /**< (PWM_CMPMUPD) Comparison x Period Update Position */
+#define PWM_CMPMUPD_CPRUPD_Msk              (_U_(0xF) << PWM_CMPMUPD_CPRUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Period Update Mask */
+#define PWM_CMPMUPD_CPRUPD(value)           (PWM_CMPMUPD_CPRUPD_Msk & ((value) << PWM_CMPMUPD_CPRUPD_Pos))
+#define PWM_CMPMUPD_CUPRUPD_Pos             16                                             /**< (PWM_CMPMUPD) Comparison x Update Period Update Position */
+#define PWM_CMPMUPD_CUPRUPD_Msk             (_U_(0xF) << PWM_CMPMUPD_CUPRUPD_Pos)          /**< (PWM_CMPMUPD) Comparison x Update Period Update Mask */
+#define PWM_CMPMUPD_CUPRUPD(value)          (PWM_CMPMUPD_CUPRUPD_Msk & ((value) << PWM_CMPMUPD_CUPRUPD_Pos))
+#define PWM_CMPMUPD_MASK                    _U_(0xF0FF1)                                   /**< \deprecated (PWM_CMPMUPD) Register MASK  (Use PWM_CMPMUPD_Msk instead)  */
+#define PWM_CMPMUPD_Msk                     _U_(0xF0FF1)                                   /**< (PWM_CMPMUPD) Register Mask  */
+
+
+/* -------- PWM_CLK : (PWM Offset: 0x00) (R/W 32) PWM Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIVA:8;                    /**< bit:   0..7  CLKA Divide Factor                       */
+    uint32_t PREA:4;                    /**< bit:  8..11  CLKA Source Clock Selection              */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DIVB:8;                    /**< bit: 16..23  CLKB Divide Factor                       */
+    uint32_t PREB:4;                    /**< bit: 24..27  CLKB Source Clock Selection              */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CLK_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CLK_OFFSET                      (0x00)                                        /**<  (PWM_CLK) PWM Clock Register  Offset */
+
+#define PWM_CLK_DIVA_Pos                    0                                              /**< (PWM_CLK) CLKA Divide Factor Position */
+#define PWM_CLK_DIVA_Msk                    (_U_(0xFF) << PWM_CLK_DIVA_Pos)                /**< (PWM_CLK) CLKA Divide Factor Mask */
+#define PWM_CLK_DIVA(value)                 (PWM_CLK_DIVA_Msk & ((value) << PWM_CLK_DIVA_Pos))
+#define   PWM_CLK_DIVA_CLKA_POFF_Val        _U_(0x0)                                       /**< (PWM_CLK) CLKA clock is turned off  */
+#define   PWM_CLK_DIVA_PREA_Val             _U_(0x1)                                       /**< (PWM_CLK) CLKA clock is clock selected by PREA  */
+#define PWM_CLK_DIVA_CLKA_POFF              (PWM_CLK_DIVA_CLKA_POFF_Val << PWM_CLK_DIVA_Pos)  /**< (PWM_CLK) CLKA clock is turned off Position  */
+#define PWM_CLK_DIVA_PREA                   (PWM_CLK_DIVA_PREA_Val << PWM_CLK_DIVA_Pos)    /**< (PWM_CLK) CLKA clock is clock selected by PREA Position  */
+#define PWM_CLK_PREA_Pos                    8                                              /**< (PWM_CLK) CLKA Source Clock Selection Position */
+#define PWM_CLK_PREA_Msk                    (_U_(0xF) << PWM_CLK_PREA_Pos)                 /**< (PWM_CLK) CLKA Source Clock Selection Mask */
+#define PWM_CLK_PREA(value)                 (PWM_CLK_PREA_Msk & ((value) << PWM_CLK_PREA_Pos))
+#define   PWM_CLK_PREA_CLK_Val              _U_(0x0)                                       /**< (PWM_CLK) Peripheral clock  */
+#define   PWM_CLK_PREA_CLK_DIV2_Val         _U_(0x1)                                       /**< (PWM_CLK) Peripheral clock/2  */
+#define   PWM_CLK_PREA_CLK_DIV4_Val         _U_(0x2)                                       /**< (PWM_CLK) Peripheral clock/4  */
+#define   PWM_CLK_PREA_CLK_DIV8_Val         _U_(0x3)                                       /**< (PWM_CLK) Peripheral clock/8  */
+#define   PWM_CLK_PREA_CLK_DIV16_Val        _U_(0x4)                                       /**< (PWM_CLK) Peripheral clock/16  */
+#define   PWM_CLK_PREA_CLK_DIV32_Val        _U_(0x5)                                       /**< (PWM_CLK) Peripheral clock/32  */
+#define   PWM_CLK_PREA_CLK_DIV64_Val        _U_(0x6)                                       /**< (PWM_CLK) Peripheral clock/64  */
+#define   PWM_CLK_PREA_CLK_DIV128_Val       _U_(0x7)                                       /**< (PWM_CLK) Peripheral clock/128  */
+#define   PWM_CLK_PREA_CLK_DIV256_Val       _U_(0x8)                                       /**< (PWM_CLK) Peripheral clock/256  */
+#define   PWM_CLK_PREA_CLK_DIV512_Val       _U_(0x9)                                       /**< (PWM_CLK) Peripheral clock/512  */
+#define   PWM_CLK_PREA_CLK_DIV1024_Val      _U_(0xA)                                       /**< (PWM_CLK) Peripheral clock/1024  */
+#define PWM_CLK_PREA_CLK                    (PWM_CLK_PREA_CLK_Val << PWM_CLK_PREA_Pos)     /**< (PWM_CLK) Peripheral clock Position  */
+#define PWM_CLK_PREA_CLK_DIV2               (PWM_CLK_PREA_CLK_DIV2_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/2 Position  */
+#define PWM_CLK_PREA_CLK_DIV4               (PWM_CLK_PREA_CLK_DIV4_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/4 Position  */
+#define PWM_CLK_PREA_CLK_DIV8               (PWM_CLK_PREA_CLK_DIV8_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/8 Position  */
+#define PWM_CLK_PREA_CLK_DIV16              (PWM_CLK_PREA_CLK_DIV16_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/16 Position  */
+#define PWM_CLK_PREA_CLK_DIV32              (PWM_CLK_PREA_CLK_DIV32_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/32 Position  */
+#define PWM_CLK_PREA_CLK_DIV64              (PWM_CLK_PREA_CLK_DIV64_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/64 Position  */
+#define PWM_CLK_PREA_CLK_DIV128             (PWM_CLK_PREA_CLK_DIV128_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/128 Position  */
+#define PWM_CLK_PREA_CLK_DIV256             (PWM_CLK_PREA_CLK_DIV256_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/256 Position  */
+#define PWM_CLK_PREA_CLK_DIV512             (PWM_CLK_PREA_CLK_DIV512_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/512 Position  */
+#define PWM_CLK_PREA_CLK_DIV1024            (PWM_CLK_PREA_CLK_DIV1024_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/1024 Position  */
+#define PWM_CLK_DIVB_Pos                    16                                             /**< (PWM_CLK) CLKB Divide Factor Position */
+#define PWM_CLK_DIVB_Msk                    (_U_(0xFF) << PWM_CLK_DIVB_Pos)                /**< (PWM_CLK) CLKB Divide Factor Mask */
+#define PWM_CLK_DIVB(value)                 (PWM_CLK_DIVB_Msk & ((value) << PWM_CLK_DIVB_Pos))
+#define   PWM_CLK_DIVB_CLKB_POFF_Val        _U_(0x0)                                       /**< (PWM_CLK) CLKB clock is turned off  */
+#define   PWM_CLK_DIVB_PREB_Val             _U_(0x1)                                       /**< (PWM_CLK) CLKB clock is clock selected by PREB  */
+#define PWM_CLK_DIVB_CLKB_POFF              (PWM_CLK_DIVB_CLKB_POFF_Val << PWM_CLK_DIVB_Pos)  /**< (PWM_CLK) CLKB clock is turned off Position  */
+#define PWM_CLK_DIVB_PREB                   (PWM_CLK_DIVB_PREB_Val << PWM_CLK_DIVB_Pos)    /**< (PWM_CLK) CLKB clock is clock selected by PREB Position  */
+#define PWM_CLK_PREB_Pos                    24                                             /**< (PWM_CLK) CLKB Source Clock Selection Position */
+#define PWM_CLK_PREB_Msk                    (_U_(0xF) << PWM_CLK_PREB_Pos)                 /**< (PWM_CLK) CLKB Source Clock Selection Mask */
+#define PWM_CLK_PREB(value)                 (PWM_CLK_PREB_Msk & ((value) << PWM_CLK_PREB_Pos))
+#define   PWM_CLK_PREB_CLK_Val              _U_(0x0)                                       /**< (PWM_CLK) Peripheral clock  */
+#define   PWM_CLK_PREB_CLK_DIV2_Val         _U_(0x1)                                       /**< (PWM_CLK) Peripheral clock/2  */
+#define   PWM_CLK_PREB_CLK_DIV4_Val         _U_(0x2)                                       /**< (PWM_CLK) Peripheral clock/4  */
+#define   PWM_CLK_PREB_CLK_DIV8_Val         _U_(0x3)                                       /**< (PWM_CLK) Peripheral clock/8  */
+#define   PWM_CLK_PREB_CLK_DIV16_Val        _U_(0x4)                                       /**< (PWM_CLK) Peripheral clock/16  */
+#define   PWM_CLK_PREB_CLK_DIV32_Val        _U_(0x5)                                       /**< (PWM_CLK) Peripheral clock/32  */
+#define   PWM_CLK_PREB_CLK_DIV64_Val        _U_(0x6)                                       /**< (PWM_CLK) Peripheral clock/64  */
+#define   PWM_CLK_PREB_CLK_DIV128_Val       _U_(0x7)                                       /**< (PWM_CLK) Peripheral clock/128  */
+#define   PWM_CLK_PREB_CLK_DIV256_Val       _U_(0x8)                                       /**< (PWM_CLK) Peripheral clock/256  */
+#define   PWM_CLK_PREB_CLK_DIV512_Val       _U_(0x9)                                       /**< (PWM_CLK) Peripheral clock/512  */
+#define   PWM_CLK_PREB_CLK_DIV1024_Val      _U_(0xA)                                       /**< (PWM_CLK) Peripheral clock/1024  */
+#define PWM_CLK_PREB_CLK                    (PWM_CLK_PREB_CLK_Val << PWM_CLK_PREB_Pos)     /**< (PWM_CLK) Peripheral clock Position  */
+#define PWM_CLK_PREB_CLK_DIV2               (PWM_CLK_PREB_CLK_DIV2_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/2 Position  */
+#define PWM_CLK_PREB_CLK_DIV4               (PWM_CLK_PREB_CLK_DIV4_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/4 Position  */
+#define PWM_CLK_PREB_CLK_DIV8               (PWM_CLK_PREB_CLK_DIV8_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/8 Position  */
+#define PWM_CLK_PREB_CLK_DIV16              (PWM_CLK_PREB_CLK_DIV16_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/16 Position  */
+#define PWM_CLK_PREB_CLK_DIV32              (PWM_CLK_PREB_CLK_DIV32_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/32 Position  */
+#define PWM_CLK_PREB_CLK_DIV64              (PWM_CLK_PREB_CLK_DIV64_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/64 Position  */
+#define PWM_CLK_PREB_CLK_DIV128             (PWM_CLK_PREB_CLK_DIV128_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/128 Position  */
+#define PWM_CLK_PREB_CLK_DIV256             (PWM_CLK_PREB_CLK_DIV256_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/256 Position  */
+#define PWM_CLK_PREB_CLK_DIV512             (PWM_CLK_PREB_CLK_DIV512_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/512 Position  */
+#define PWM_CLK_PREB_CLK_DIV1024            (PWM_CLK_PREB_CLK_DIV1024_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/1024 Position  */
+#define PWM_CLK_MASK                        _U_(0xFFF0FFF)                                 /**< \deprecated (PWM_CLK) Register MASK  (Use PWM_CLK_Msk instead)  */
+#define PWM_CLK_Msk                         _U_(0xFFF0FFF)                                 /**< (PWM_CLK) Register Mask  */
+
+
+/* -------- PWM_ENA : (PWM Offset: 0x04) (/W 32) PWM Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ENA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ENA_OFFSET                      (0x04)                                        /**<  (PWM_ENA) PWM Enable Register  Offset */
+
+#define PWM_ENA_CHID0_Pos                   0                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID0_Msk                   (_U_(0x1) << PWM_ENA_CHID0_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID0                       PWM_ENA_CHID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID0_Msk instead */
+#define PWM_ENA_CHID1_Pos                   1                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID1_Msk                   (_U_(0x1) << PWM_ENA_CHID1_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID1                       PWM_ENA_CHID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID1_Msk instead */
+#define PWM_ENA_CHID2_Pos                   2                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID2_Msk                   (_U_(0x1) << PWM_ENA_CHID2_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID2                       PWM_ENA_CHID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID2_Msk instead */
+#define PWM_ENA_CHID3_Pos                   3                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID3_Msk                   (_U_(0x1) << PWM_ENA_CHID3_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID3                       PWM_ENA_CHID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID3_Msk instead */
+#define PWM_ENA_MASK                        _U_(0x0F)                                      /**< \deprecated (PWM_ENA) Register MASK  (Use PWM_ENA_Msk instead)  */
+#define PWM_ENA_Msk                         _U_(0x0F)                                      /**< (PWM_ENA) Register Mask  */
+
+#define PWM_ENA_CHID_Pos                    0                                              /**< (PWM_ENA Position) Channel ID */
+#define PWM_ENA_CHID_Msk                    (_U_(0xF) << PWM_ENA_CHID_Pos)                 /**< (PWM_ENA Mask) CHID */
+#define PWM_ENA_CHID(value)                 (PWM_ENA_CHID_Msk & ((value) << PWM_ENA_CHID_Pos))  
+
+/* -------- PWM_DIS : (PWM Offset: 0x08) (/W 32) PWM Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DIS_OFFSET                      (0x08)                                        /**<  (PWM_DIS) PWM Disable Register  Offset */
+
+#define PWM_DIS_CHID0_Pos                   0                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID0_Msk                   (_U_(0x1) << PWM_DIS_CHID0_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID0                       PWM_DIS_CHID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID0_Msk instead */
+#define PWM_DIS_CHID1_Pos                   1                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID1_Msk                   (_U_(0x1) << PWM_DIS_CHID1_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID1                       PWM_DIS_CHID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID1_Msk instead */
+#define PWM_DIS_CHID2_Pos                   2                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID2_Msk                   (_U_(0x1) << PWM_DIS_CHID2_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID2                       PWM_DIS_CHID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID2_Msk instead */
+#define PWM_DIS_CHID3_Pos                   3                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID3_Msk                   (_U_(0x1) << PWM_DIS_CHID3_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID3                       PWM_DIS_CHID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID3_Msk instead */
+#define PWM_DIS_MASK                        _U_(0x0F)                                      /**< \deprecated (PWM_DIS) Register MASK  (Use PWM_DIS_Msk instead)  */
+#define PWM_DIS_Msk                         _U_(0x0F)                                      /**< (PWM_DIS) Register Mask  */
+
+#define PWM_DIS_CHID_Pos                    0                                              /**< (PWM_DIS Position) Channel ID */
+#define PWM_DIS_CHID_Msk                    (_U_(0xF) << PWM_DIS_CHID_Pos)                 /**< (PWM_DIS Mask) CHID */
+#define PWM_DIS_CHID(value)                 (PWM_DIS_CHID_Msk & ((value) << PWM_DIS_CHID_Pos))  
+
+/* -------- PWM_SR : (PWM Offset: 0x0c) (R/ 32) PWM Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SR_OFFSET                       (0x0C)                                        /**<  (PWM_SR) PWM Status Register  Offset */
+
+#define PWM_SR_CHID0_Pos                    0                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID0_Msk                    (_U_(0x1) << PWM_SR_CHID0_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID0                        PWM_SR_CHID0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID0_Msk instead */
+#define PWM_SR_CHID1_Pos                    1                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID1_Msk                    (_U_(0x1) << PWM_SR_CHID1_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID1                        PWM_SR_CHID1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID1_Msk instead */
+#define PWM_SR_CHID2_Pos                    2                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID2_Msk                    (_U_(0x1) << PWM_SR_CHID2_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID2                        PWM_SR_CHID2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID2_Msk instead */
+#define PWM_SR_CHID3_Pos                    3                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID3_Msk                    (_U_(0x1) << PWM_SR_CHID3_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID3                        PWM_SR_CHID3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID3_Msk instead */
+#define PWM_SR_MASK                         _U_(0x0F)                                      /**< \deprecated (PWM_SR) Register MASK  (Use PWM_SR_Msk instead)  */
+#define PWM_SR_Msk                          _U_(0x0F)                                      /**< (PWM_SR) Register Mask  */
+
+#define PWM_SR_CHID_Pos                     0                                              /**< (PWM_SR Position) Channel ID */
+#define PWM_SR_CHID_Msk                     (_U_(0xF) << PWM_SR_CHID_Pos)                  /**< (PWM_SR Mask) CHID */
+#define PWM_SR_CHID(value)                  (PWM_SR_CHID_Msk & ((value) << PWM_SR_CHID_Pos))  
+
+/* -------- PWM_IER1 : (PWM Offset: 0x10) (/W 32) PWM Interrupt Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Enable */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Enable */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Enable */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Enable */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Enable */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Enable */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Enable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IER1_OFFSET                     (0x10)                                        /**<  (PWM_IER1) PWM Interrupt Enable Register 1  Offset */
+
+#define PWM_IER1_CHID0_Pos                  0                                              /**< (PWM_IER1) Counter Event on Channel 0 Interrupt Enable Position */
+#define PWM_IER1_CHID0_Msk                  (_U_(0x1) << PWM_IER1_CHID0_Pos)               /**< (PWM_IER1) Counter Event on Channel 0 Interrupt Enable Mask */
+#define PWM_IER1_CHID0                      PWM_IER1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID0_Msk instead */
+#define PWM_IER1_CHID1_Pos                  1                                              /**< (PWM_IER1) Counter Event on Channel 1 Interrupt Enable Position */
+#define PWM_IER1_CHID1_Msk                  (_U_(0x1) << PWM_IER1_CHID1_Pos)               /**< (PWM_IER1) Counter Event on Channel 1 Interrupt Enable Mask */
+#define PWM_IER1_CHID1                      PWM_IER1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID1_Msk instead */
+#define PWM_IER1_CHID2_Pos                  2                                              /**< (PWM_IER1) Counter Event on Channel 2 Interrupt Enable Position */
+#define PWM_IER1_CHID2_Msk                  (_U_(0x1) << PWM_IER1_CHID2_Pos)               /**< (PWM_IER1) Counter Event on Channel 2 Interrupt Enable Mask */
+#define PWM_IER1_CHID2                      PWM_IER1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID2_Msk instead */
+#define PWM_IER1_CHID3_Pos                  3                                              /**< (PWM_IER1) Counter Event on Channel 3 Interrupt Enable Position */
+#define PWM_IER1_CHID3_Msk                  (_U_(0x1) << PWM_IER1_CHID3_Pos)               /**< (PWM_IER1) Counter Event on Channel 3 Interrupt Enable Mask */
+#define PWM_IER1_CHID3                      PWM_IER1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID3_Msk instead */
+#define PWM_IER1_FCHID0_Pos                 16                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 0 Interrupt Enable Position */
+#define PWM_IER1_FCHID0_Msk                 (_U_(0x1) << PWM_IER1_FCHID0_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 0 Interrupt Enable Mask */
+#define PWM_IER1_FCHID0                     PWM_IER1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID0_Msk instead */
+#define PWM_IER1_FCHID1_Pos                 17                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 1 Interrupt Enable Position */
+#define PWM_IER1_FCHID1_Msk                 (_U_(0x1) << PWM_IER1_FCHID1_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 1 Interrupt Enable Mask */
+#define PWM_IER1_FCHID1                     PWM_IER1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID1_Msk instead */
+#define PWM_IER1_FCHID2_Pos                 18                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 2 Interrupt Enable Position */
+#define PWM_IER1_FCHID2_Msk                 (_U_(0x1) << PWM_IER1_FCHID2_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 2 Interrupt Enable Mask */
+#define PWM_IER1_FCHID2                     PWM_IER1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID2_Msk instead */
+#define PWM_IER1_FCHID3_Pos                 19                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 3 Interrupt Enable Position */
+#define PWM_IER1_FCHID3_Msk                 (_U_(0x1) << PWM_IER1_FCHID3_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 3 Interrupt Enable Mask */
+#define PWM_IER1_FCHID3                     PWM_IER1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID3_Msk instead */
+#define PWM_IER1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IER1) Register MASK  (Use PWM_IER1_Msk instead)  */
+#define PWM_IER1_Msk                        _U_(0xF000F)                                   /**< (PWM_IER1) Register Mask  */
+
+#define PWM_IER1_CHID_Pos                   0                                              /**< (PWM_IER1 Position) Counter Event on Channel x Interrupt Enable */
+#define PWM_IER1_CHID_Msk                   (_U_(0xF) << PWM_IER1_CHID_Pos)                /**< (PWM_IER1 Mask) CHID */
+#define PWM_IER1_CHID(value)                (PWM_IER1_CHID_Msk & ((value) << PWM_IER1_CHID_Pos))  
+#define PWM_IER1_FCHID_Pos                  16                                             /**< (PWM_IER1 Position) Fault Protection Trigger on Channel 3 Interrupt Enable */
+#define PWM_IER1_FCHID_Msk                  (_U_(0xF) << PWM_IER1_FCHID_Pos)               /**< (PWM_IER1 Mask) FCHID */
+#define PWM_IER1_FCHID(value)               (PWM_IER1_FCHID_Msk & ((value) << PWM_IER1_FCHID_Pos))  
+
+/* -------- PWM_IDR1 : (PWM Offset: 0x14) (/W 32) PWM Interrupt Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Disable */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Disable */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Disable */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Disable */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Disable */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Disable */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Disable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IDR1_OFFSET                     (0x14)                                        /**<  (PWM_IDR1) PWM Interrupt Disable Register 1  Offset */
+
+#define PWM_IDR1_CHID0_Pos                  0                                              /**< (PWM_IDR1) Counter Event on Channel 0 Interrupt Disable Position */
+#define PWM_IDR1_CHID0_Msk                  (_U_(0x1) << PWM_IDR1_CHID0_Pos)               /**< (PWM_IDR1) Counter Event on Channel 0 Interrupt Disable Mask */
+#define PWM_IDR1_CHID0                      PWM_IDR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID0_Msk instead */
+#define PWM_IDR1_CHID1_Pos                  1                                              /**< (PWM_IDR1) Counter Event on Channel 1 Interrupt Disable Position */
+#define PWM_IDR1_CHID1_Msk                  (_U_(0x1) << PWM_IDR1_CHID1_Pos)               /**< (PWM_IDR1) Counter Event on Channel 1 Interrupt Disable Mask */
+#define PWM_IDR1_CHID1                      PWM_IDR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID1_Msk instead */
+#define PWM_IDR1_CHID2_Pos                  2                                              /**< (PWM_IDR1) Counter Event on Channel 2 Interrupt Disable Position */
+#define PWM_IDR1_CHID2_Msk                  (_U_(0x1) << PWM_IDR1_CHID2_Pos)               /**< (PWM_IDR1) Counter Event on Channel 2 Interrupt Disable Mask */
+#define PWM_IDR1_CHID2                      PWM_IDR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID2_Msk instead */
+#define PWM_IDR1_CHID3_Pos                  3                                              /**< (PWM_IDR1) Counter Event on Channel 3 Interrupt Disable Position */
+#define PWM_IDR1_CHID3_Msk                  (_U_(0x1) << PWM_IDR1_CHID3_Pos)               /**< (PWM_IDR1) Counter Event on Channel 3 Interrupt Disable Mask */
+#define PWM_IDR1_CHID3                      PWM_IDR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID3_Msk instead */
+#define PWM_IDR1_FCHID0_Pos                 16                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 0 Interrupt Disable Position */
+#define PWM_IDR1_FCHID0_Msk                 (_U_(0x1) << PWM_IDR1_FCHID0_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 0 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID0                     PWM_IDR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID0_Msk instead */
+#define PWM_IDR1_FCHID1_Pos                 17                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 1 Interrupt Disable Position */
+#define PWM_IDR1_FCHID1_Msk                 (_U_(0x1) << PWM_IDR1_FCHID1_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 1 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID1                     PWM_IDR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID1_Msk instead */
+#define PWM_IDR1_FCHID2_Pos                 18                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 2 Interrupt Disable Position */
+#define PWM_IDR1_FCHID2_Msk                 (_U_(0x1) << PWM_IDR1_FCHID2_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 2 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID2                     PWM_IDR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID2_Msk instead */
+#define PWM_IDR1_FCHID3_Pos                 19                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 3 Interrupt Disable Position */
+#define PWM_IDR1_FCHID3_Msk                 (_U_(0x1) << PWM_IDR1_FCHID3_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 3 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID3                     PWM_IDR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID3_Msk instead */
+#define PWM_IDR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IDR1) Register MASK  (Use PWM_IDR1_Msk instead)  */
+#define PWM_IDR1_Msk                        _U_(0xF000F)                                   /**< (PWM_IDR1) Register Mask  */
+
+#define PWM_IDR1_CHID_Pos                   0                                              /**< (PWM_IDR1 Position) Counter Event on Channel x Interrupt Disable */
+#define PWM_IDR1_CHID_Msk                   (_U_(0xF) << PWM_IDR1_CHID_Pos)                /**< (PWM_IDR1 Mask) CHID */
+#define PWM_IDR1_CHID(value)                (PWM_IDR1_CHID_Msk & ((value) << PWM_IDR1_CHID_Pos))  
+#define PWM_IDR1_FCHID_Pos                  16                                             /**< (PWM_IDR1 Position) Fault Protection Trigger on Channel 3 Interrupt Disable */
+#define PWM_IDR1_FCHID_Msk                  (_U_(0xF) << PWM_IDR1_FCHID_Pos)               /**< (PWM_IDR1 Mask) FCHID */
+#define PWM_IDR1_FCHID(value)               (PWM_IDR1_FCHID_Msk & ((value) << PWM_IDR1_FCHID_Pos))  
+
+/* -------- PWM_IMR1 : (PWM Offset: 0x18) (R/ 32) PWM Interrupt Mask Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Mask */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Mask */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Mask */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Mask */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Mask */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Mask */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Mask */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IMR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IMR1_OFFSET                     (0x18)                                        /**<  (PWM_IMR1) PWM Interrupt Mask Register 1  Offset */
+
+#define PWM_IMR1_CHID0_Pos                  0                                              /**< (PWM_IMR1) Counter Event on Channel 0 Interrupt Mask Position */
+#define PWM_IMR1_CHID0_Msk                  (_U_(0x1) << PWM_IMR1_CHID0_Pos)               /**< (PWM_IMR1) Counter Event on Channel 0 Interrupt Mask Mask */
+#define PWM_IMR1_CHID0                      PWM_IMR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID0_Msk instead */
+#define PWM_IMR1_CHID1_Pos                  1                                              /**< (PWM_IMR1) Counter Event on Channel 1 Interrupt Mask Position */
+#define PWM_IMR1_CHID1_Msk                  (_U_(0x1) << PWM_IMR1_CHID1_Pos)               /**< (PWM_IMR1) Counter Event on Channel 1 Interrupt Mask Mask */
+#define PWM_IMR1_CHID1                      PWM_IMR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID1_Msk instead */
+#define PWM_IMR1_CHID2_Pos                  2                                              /**< (PWM_IMR1) Counter Event on Channel 2 Interrupt Mask Position */
+#define PWM_IMR1_CHID2_Msk                  (_U_(0x1) << PWM_IMR1_CHID2_Pos)               /**< (PWM_IMR1) Counter Event on Channel 2 Interrupt Mask Mask */
+#define PWM_IMR1_CHID2                      PWM_IMR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID2_Msk instead */
+#define PWM_IMR1_CHID3_Pos                  3                                              /**< (PWM_IMR1) Counter Event on Channel 3 Interrupt Mask Position */
+#define PWM_IMR1_CHID3_Msk                  (_U_(0x1) << PWM_IMR1_CHID3_Pos)               /**< (PWM_IMR1) Counter Event on Channel 3 Interrupt Mask Mask */
+#define PWM_IMR1_CHID3                      PWM_IMR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID3_Msk instead */
+#define PWM_IMR1_FCHID0_Pos                 16                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 0 Interrupt Mask Position */
+#define PWM_IMR1_FCHID0_Msk                 (_U_(0x1) << PWM_IMR1_FCHID0_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 0 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID0                     PWM_IMR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID0_Msk instead */
+#define PWM_IMR1_FCHID1_Pos                 17                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 1 Interrupt Mask Position */
+#define PWM_IMR1_FCHID1_Msk                 (_U_(0x1) << PWM_IMR1_FCHID1_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 1 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID1                     PWM_IMR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID1_Msk instead */
+#define PWM_IMR1_FCHID2_Pos                 18                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 2 Interrupt Mask Position */
+#define PWM_IMR1_FCHID2_Msk                 (_U_(0x1) << PWM_IMR1_FCHID2_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 2 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID2                     PWM_IMR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID2_Msk instead */
+#define PWM_IMR1_FCHID3_Pos                 19                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 3 Interrupt Mask Position */
+#define PWM_IMR1_FCHID3_Msk                 (_U_(0x1) << PWM_IMR1_FCHID3_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 3 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID3                     PWM_IMR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID3_Msk instead */
+#define PWM_IMR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IMR1) Register MASK  (Use PWM_IMR1_Msk instead)  */
+#define PWM_IMR1_Msk                        _U_(0xF000F)                                   /**< (PWM_IMR1) Register Mask  */
+
+#define PWM_IMR1_CHID_Pos                   0                                              /**< (PWM_IMR1 Position) Counter Event on Channel x Interrupt Mask */
+#define PWM_IMR1_CHID_Msk                   (_U_(0xF) << PWM_IMR1_CHID_Pos)                /**< (PWM_IMR1 Mask) CHID */
+#define PWM_IMR1_CHID(value)                (PWM_IMR1_CHID_Msk & ((value) << PWM_IMR1_CHID_Pos))  
+#define PWM_IMR1_FCHID_Pos                  16                                             /**< (PWM_IMR1 Position) Fault Protection Trigger on Channel 3 Interrupt Mask */
+#define PWM_IMR1_FCHID_Msk                  (_U_(0xF) << PWM_IMR1_FCHID_Pos)               /**< (PWM_IMR1 Mask) FCHID */
+#define PWM_IMR1_FCHID(value)               (PWM_IMR1_FCHID_Msk & ((value) << PWM_IMR1_FCHID_Pos))  
+
+/* -------- PWM_ISR1 : (PWM Offset: 0x1c) (R/ 32) PWM Interrupt Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0               */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1               */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2               */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0    */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1    */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2    */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3    */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3    */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ISR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ISR1_OFFSET                     (0x1C)                                        /**<  (PWM_ISR1) PWM Interrupt Status Register 1  Offset */
+
+#define PWM_ISR1_CHID0_Pos                  0                                              /**< (PWM_ISR1) Counter Event on Channel 0 Position */
+#define PWM_ISR1_CHID0_Msk                  (_U_(0x1) << PWM_ISR1_CHID0_Pos)               /**< (PWM_ISR1) Counter Event on Channel 0 Mask */
+#define PWM_ISR1_CHID0                      PWM_ISR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID0_Msk instead */
+#define PWM_ISR1_CHID1_Pos                  1                                              /**< (PWM_ISR1) Counter Event on Channel 1 Position */
+#define PWM_ISR1_CHID1_Msk                  (_U_(0x1) << PWM_ISR1_CHID1_Pos)               /**< (PWM_ISR1) Counter Event on Channel 1 Mask */
+#define PWM_ISR1_CHID1                      PWM_ISR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID1_Msk instead */
+#define PWM_ISR1_CHID2_Pos                  2                                              /**< (PWM_ISR1) Counter Event on Channel 2 Position */
+#define PWM_ISR1_CHID2_Msk                  (_U_(0x1) << PWM_ISR1_CHID2_Pos)               /**< (PWM_ISR1) Counter Event on Channel 2 Mask */
+#define PWM_ISR1_CHID2                      PWM_ISR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID2_Msk instead */
+#define PWM_ISR1_CHID3_Pos                  3                                              /**< (PWM_ISR1) Counter Event on Channel 3 Position */
+#define PWM_ISR1_CHID3_Msk                  (_U_(0x1) << PWM_ISR1_CHID3_Pos)               /**< (PWM_ISR1) Counter Event on Channel 3 Mask */
+#define PWM_ISR1_CHID3                      PWM_ISR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID3_Msk instead */
+#define PWM_ISR1_FCHID0_Pos                 16                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 0 Position */
+#define PWM_ISR1_FCHID0_Msk                 (_U_(0x1) << PWM_ISR1_FCHID0_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 0 Mask */
+#define PWM_ISR1_FCHID0                     PWM_ISR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID0_Msk instead */
+#define PWM_ISR1_FCHID1_Pos                 17                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 1 Position */
+#define PWM_ISR1_FCHID1_Msk                 (_U_(0x1) << PWM_ISR1_FCHID1_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 1 Mask */
+#define PWM_ISR1_FCHID1                     PWM_ISR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID1_Msk instead */
+#define PWM_ISR1_FCHID2_Pos                 18                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 2 Position */
+#define PWM_ISR1_FCHID2_Msk                 (_U_(0x1) << PWM_ISR1_FCHID2_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 2 Mask */
+#define PWM_ISR1_FCHID2                     PWM_ISR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID2_Msk instead */
+#define PWM_ISR1_FCHID3_Pos                 19                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 3 Position */
+#define PWM_ISR1_FCHID3_Msk                 (_U_(0x1) << PWM_ISR1_FCHID3_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 3 Mask */
+#define PWM_ISR1_FCHID3                     PWM_ISR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID3_Msk instead */
+#define PWM_ISR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_ISR1) Register MASK  (Use PWM_ISR1_Msk instead)  */
+#define PWM_ISR1_Msk                        _U_(0xF000F)                                   /**< (PWM_ISR1) Register Mask  */
+
+#define PWM_ISR1_CHID_Pos                   0                                              /**< (PWM_ISR1 Position) Counter Event on Channel x */
+#define PWM_ISR1_CHID_Msk                   (_U_(0xF) << PWM_ISR1_CHID_Pos)                /**< (PWM_ISR1 Mask) CHID */
+#define PWM_ISR1_CHID(value)                (PWM_ISR1_CHID_Msk & ((value) << PWM_ISR1_CHID_Pos))  
+#define PWM_ISR1_FCHID_Pos                  16                                             /**< (PWM_ISR1 Position) Fault Protection Trigger on Channel 3 */
+#define PWM_ISR1_FCHID_Msk                  (_U_(0xF) << PWM_ISR1_FCHID_Pos)               /**< (PWM_ISR1 Mask) FCHID */
+#define PWM_ISR1_FCHID(value)               (PWM_ISR1_FCHID_Msk & ((value) << PWM_ISR1_FCHID_Pos))  
+
+/* -------- PWM_SCM : (PWM Offset: 0x20) (R/W 32) PWM Sync Channels Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SYNC0:1;                   /**< bit:      0  Synchronous Channel 0                    */
+    uint32_t SYNC1:1;                   /**< bit:      1  Synchronous Channel 1                    */
+    uint32_t SYNC2:1;                   /**< bit:      2  Synchronous Channel 2                    */
+    uint32_t SYNC3:1;                   /**< bit:      3  Synchronous Channel 3                    */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t UPDM:2;                    /**< bit: 16..17  Synchronous Channels Update Mode         */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t PTRM:1;                    /**< bit:     20  DMA Controller Transfer Request Mode     */
+    uint32_t PTRCS:3;                   /**< bit: 21..23  DMA Controller Transfer Request Comparison Selection */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SYNC:4;                    /**< bit:   0..3  Synchronous Channel x                    */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCM_OFFSET                      (0x20)                                        /**<  (PWM_SCM) PWM Sync Channels Mode Register  Offset */
+
+#define PWM_SCM_SYNC0_Pos                   0                                              /**< (PWM_SCM) Synchronous Channel 0 Position */
+#define PWM_SCM_SYNC0_Msk                   (_U_(0x1) << PWM_SCM_SYNC0_Pos)                /**< (PWM_SCM) Synchronous Channel 0 Mask */
+#define PWM_SCM_SYNC0                       PWM_SCM_SYNC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC0_Msk instead */
+#define PWM_SCM_SYNC1_Pos                   1                                              /**< (PWM_SCM) Synchronous Channel 1 Position */
+#define PWM_SCM_SYNC1_Msk                   (_U_(0x1) << PWM_SCM_SYNC1_Pos)                /**< (PWM_SCM) Synchronous Channel 1 Mask */
+#define PWM_SCM_SYNC1                       PWM_SCM_SYNC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC1_Msk instead */
+#define PWM_SCM_SYNC2_Pos                   2                                              /**< (PWM_SCM) Synchronous Channel 2 Position */
+#define PWM_SCM_SYNC2_Msk                   (_U_(0x1) << PWM_SCM_SYNC2_Pos)                /**< (PWM_SCM) Synchronous Channel 2 Mask */
+#define PWM_SCM_SYNC2                       PWM_SCM_SYNC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC2_Msk instead */
+#define PWM_SCM_SYNC3_Pos                   3                                              /**< (PWM_SCM) Synchronous Channel 3 Position */
+#define PWM_SCM_SYNC3_Msk                   (_U_(0x1) << PWM_SCM_SYNC3_Pos)                /**< (PWM_SCM) Synchronous Channel 3 Mask */
+#define PWM_SCM_SYNC3                       PWM_SCM_SYNC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC3_Msk instead */
+#define PWM_SCM_UPDM_Pos                    16                                             /**< (PWM_SCM) Synchronous Channels Update Mode Position */
+#define PWM_SCM_UPDM_Msk                    (_U_(0x3) << PWM_SCM_UPDM_Pos)                 /**< (PWM_SCM) Synchronous Channels Update Mode Mask */
+#define PWM_SCM_UPDM(value)                 (PWM_SCM_UPDM_Msk & ((value) << PWM_SCM_UPDM_Pos))
+#define   PWM_SCM_UPDM_MODE0_Val            _U_(0x0)                                       /**< (PWM_SCM) Manual write of double buffer registers and manual update of synchronous channels  */
+#define   PWM_SCM_UPDM_MODE1_Val            _U_(0x1)                                       /**< (PWM_SCM) Manual write of double buffer registers and automatic update of synchronous channels  */
+#define   PWM_SCM_UPDM_MODE2_Val            _U_(0x2)                                       /**< (PWM_SCM) Automatic write of duty-cycle update registers by the DMA Controller and automatic update of synchronous channels  */
+#define PWM_SCM_UPDM_MODE0                  (PWM_SCM_UPDM_MODE0_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Manual write of double buffer registers and manual update of synchronous channels Position  */
+#define PWM_SCM_UPDM_MODE1                  (PWM_SCM_UPDM_MODE1_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Manual write of double buffer registers and automatic update of synchronous channels Position  */
+#define PWM_SCM_UPDM_MODE2                  (PWM_SCM_UPDM_MODE2_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Automatic write of duty-cycle update registers by the DMA Controller and automatic update of synchronous channels Position  */
+#define PWM_SCM_PTRM_Pos                    20                                             /**< (PWM_SCM) DMA Controller Transfer Request Mode Position */
+#define PWM_SCM_PTRM_Msk                    (_U_(0x1) << PWM_SCM_PTRM_Pos)                 /**< (PWM_SCM) DMA Controller Transfer Request Mode Mask */
+#define PWM_SCM_PTRM                        PWM_SCM_PTRM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_PTRM_Msk instead */
+#define PWM_SCM_PTRCS_Pos                   21                                             /**< (PWM_SCM) DMA Controller Transfer Request Comparison Selection Position */
+#define PWM_SCM_PTRCS_Msk                   (_U_(0x7) << PWM_SCM_PTRCS_Pos)                /**< (PWM_SCM) DMA Controller Transfer Request Comparison Selection Mask */
+#define PWM_SCM_PTRCS(value)                (PWM_SCM_PTRCS_Msk & ((value) << PWM_SCM_PTRCS_Pos))
+#define PWM_SCM_MASK                        _U_(0xF3000F)                                  /**< \deprecated (PWM_SCM) Register MASK  (Use PWM_SCM_Msk instead)  */
+#define PWM_SCM_Msk                         _U_(0xF3000F)                                  /**< (PWM_SCM) Register Mask  */
+
+#define PWM_SCM_SYNC_Pos                    0                                              /**< (PWM_SCM Position) Synchronous Channel x */
+#define PWM_SCM_SYNC_Msk                    (_U_(0xF) << PWM_SCM_SYNC_Pos)                 /**< (PWM_SCM Mask) SYNC */
+#define PWM_SCM_SYNC(value)                 (PWM_SCM_SYNC_Msk & ((value) << PWM_SCM_SYNC_Pos))  
+
+/* -------- PWM_DMAR : (PWM Offset: 0x24) (/W 32) PWM DMA Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DMADUTY:24;                /**< bit:  0..23  Duty-Cycle Holding Register for DMA Access */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DMAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DMAR_OFFSET                     (0x24)                                        /**<  (PWM_DMAR) PWM DMA Register  Offset */
+
+#define PWM_DMAR_DMADUTY_Pos                0                                              /**< (PWM_DMAR) Duty-Cycle Holding Register for DMA Access Position */
+#define PWM_DMAR_DMADUTY_Msk                (_U_(0xFFFFFF) << PWM_DMAR_DMADUTY_Pos)        /**< (PWM_DMAR) Duty-Cycle Holding Register for DMA Access Mask */
+#define PWM_DMAR_DMADUTY(value)             (PWM_DMAR_DMADUTY_Msk & ((value) << PWM_DMAR_DMADUTY_Pos))
+#define PWM_DMAR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_DMAR) Register MASK  (Use PWM_DMAR_Msk instead)  */
+#define PWM_DMAR_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_DMAR) Register Mask  */
+
+
+/* -------- PWM_SCUC : (PWM Offset: 0x28) (R/W 32) PWM Sync Channels Update Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPDULOCK:1;                /**< bit:      0  Synchronous Channels Update Unlock       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUC_OFFSET                     (0x28)                                        /**<  (PWM_SCUC) PWM Sync Channels Update Control Register  Offset */
+
+#define PWM_SCUC_UPDULOCK_Pos               0                                              /**< (PWM_SCUC) Synchronous Channels Update Unlock Position */
+#define PWM_SCUC_UPDULOCK_Msk               (_U_(0x1) << PWM_SCUC_UPDULOCK_Pos)            /**< (PWM_SCUC) Synchronous Channels Update Unlock Mask */
+#define PWM_SCUC_UPDULOCK                   PWM_SCUC_UPDULOCK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCUC_UPDULOCK_Msk instead */
+#define PWM_SCUC_MASK                       _U_(0x01)                                      /**< \deprecated (PWM_SCUC) Register MASK  (Use PWM_SCUC_Msk instead)  */
+#define PWM_SCUC_Msk                        _U_(0x01)                                      /**< (PWM_SCUC) Register Mask  */
+
+
+/* -------- PWM_SCUP : (PWM Offset: 0x2c) (R/W 32) PWM Sync Channels Update Period Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPR:4;                     /**< bit:   0..3  Update Period                            */
+    uint32_t UPRCNT:4;                  /**< bit:   4..7  Update Period Counter                    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUP_OFFSET                     (0x2C)                                        /**<  (PWM_SCUP) PWM Sync Channels Update Period Register  Offset */
+
+#define PWM_SCUP_UPR_Pos                    0                                              /**< (PWM_SCUP) Update Period Position */
+#define PWM_SCUP_UPR_Msk                    (_U_(0xF) << PWM_SCUP_UPR_Pos)                 /**< (PWM_SCUP) Update Period Mask */
+#define PWM_SCUP_UPR(value)                 (PWM_SCUP_UPR_Msk & ((value) << PWM_SCUP_UPR_Pos))
+#define PWM_SCUP_UPRCNT_Pos                 4                                              /**< (PWM_SCUP) Update Period Counter Position */
+#define PWM_SCUP_UPRCNT_Msk                 (_U_(0xF) << PWM_SCUP_UPRCNT_Pos)              /**< (PWM_SCUP) Update Period Counter Mask */
+#define PWM_SCUP_UPRCNT(value)              (PWM_SCUP_UPRCNT_Msk & ((value) << PWM_SCUP_UPRCNT_Pos))
+#define PWM_SCUP_MASK                       _U_(0xFF)                                      /**< \deprecated (PWM_SCUP) Register MASK  (Use PWM_SCUP_Msk instead)  */
+#define PWM_SCUP_Msk                        _U_(0xFF)                                      /**< (PWM_SCUP) Register Mask  */
+
+
+/* -------- PWM_SCUPUPD : (PWM Offset: 0x30) (/W 32) PWM Sync Channels Update Period Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPRUPD:4;                  /**< bit:   0..3  Update Period Update                     */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUPUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUPUPD_OFFSET                  (0x30)                                        /**<  (PWM_SCUPUPD) PWM Sync Channels Update Period Update Register  Offset */
+
+#define PWM_SCUPUPD_UPRUPD_Pos              0                                              /**< (PWM_SCUPUPD) Update Period Update Position */
+#define PWM_SCUPUPD_UPRUPD_Msk              (_U_(0xF) << PWM_SCUPUPD_UPRUPD_Pos)           /**< (PWM_SCUPUPD) Update Period Update Mask */
+#define PWM_SCUPUPD_UPRUPD(value)           (PWM_SCUPUPD_UPRUPD_Msk & ((value) << PWM_SCUPUPD_UPRUPD_Pos))
+#define PWM_SCUPUPD_MASK                    _U_(0x0F)                                      /**< \deprecated (PWM_SCUPUPD) Register MASK  (Use PWM_SCUPUPD_Msk instead)  */
+#define PWM_SCUPUPD_Msk                     _U_(0x0F)                                      /**< (PWM_SCUPUPD) Register Mask  */
+
+
+/* -------- PWM_IER2 : (PWM Offset: 0x34) (/W 32) PWM Interrupt Enable Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Enable */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Enable */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Enable      */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Enable      */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Enable      */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Enable      */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Enable      */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Enable      */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Enable      */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Enable      */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Enable     */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Enable     */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Enable     */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Enable     */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Enable     */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Enable     */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Enable     */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Enable     */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Enable      */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Enable     */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IER2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IER2_OFFSET                     (0x34)                                        /**<  (PWM_IER2) PWM Interrupt Enable Register 2  Offset */
+
+#define PWM_IER2_WRDY_Pos                   0                                              /**< (PWM_IER2) Write Ready for Synchronous Channels Update Interrupt Enable Position */
+#define PWM_IER2_WRDY_Msk                   (_U_(0x1) << PWM_IER2_WRDY_Pos)                /**< (PWM_IER2) Write Ready for Synchronous Channels Update Interrupt Enable Mask */
+#define PWM_IER2_WRDY                       PWM_IER2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_WRDY_Msk instead */
+#define PWM_IER2_UNRE_Pos                   3                                              /**< (PWM_IER2) Synchronous Channels Update Underrun Error Interrupt Enable Position */
+#define PWM_IER2_UNRE_Msk                   (_U_(0x1) << PWM_IER2_UNRE_Pos)                /**< (PWM_IER2) Synchronous Channels Update Underrun Error Interrupt Enable Mask */
+#define PWM_IER2_UNRE                       PWM_IER2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_UNRE_Msk instead */
+#define PWM_IER2_CMPM0_Pos                  8                                              /**< (PWM_IER2) Comparison 0 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM0_Msk                  (_U_(0x1) << PWM_IER2_CMPM0_Pos)               /**< (PWM_IER2) Comparison 0 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM0                      PWM_IER2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM0_Msk instead */
+#define PWM_IER2_CMPM1_Pos                  9                                              /**< (PWM_IER2) Comparison 1 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM1_Msk                  (_U_(0x1) << PWM_IER2_CMPM1_Pos)               /**< (PWM_IER2) Comparison 1 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM1                      PWM_IER2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM1_Msk instead */
+#define PWM_IER2_CMPM2_Pos                  10                                             /**< (PWM_IER2) Comparison 2 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM2_Msk                  (_U_(0x1) << PWM_IER2_CMPM2_Pos)               /**< (PWM_IER2) Comparison 2 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM2                      PWM_IER2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM2_Msk instead */
+#define PWM_IER2_CMPM3_Pos                  11                                             /**< (PWM_IER2) Comparison 3 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM3_Msk                  (_U_(0x1) << PWM_IER2_CMPM3_Pos)               /**< (PWM_IER2) Comparison 3 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM3                      PWM_IER2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM3_Msk instead */
+#define PWM_IER2_CMPM4_Pos                  12                                             /**< (PWM_IER2) Comparison 4 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM4_Msk                  (_U_(0x1) << PWM_IER2_CMPM4_Pos)               /**< (PWM_IER2) Comparison 4 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM4                      PWM_IER2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM4_Msk instead */
+#define PWM_IER2_CMPM5_Pos                  13                                             /**< (PWM_IER2) Comparison 5 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM5_Msk                  (_U_(0x1) << PWM_IER2_CMPM5_Pos)               /**< (PWM_IER2) Comparison 5 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM5                      PWM_IER2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM5_Msk instead */
+#define PWM_IER2_CMPM6_Pos                  14                                             /**< (PWM_IER2) Comparison 6 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM6_Msk                  (_U_(0x1) << PWM_IER2_CMPM6_Pos)               /**< (PWM_IER2) Comparison 6 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM6                      PWM_IER2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM6_Msk instead */
+#define PWM_IER2_CMPM7_Pos                  15                                             /**< (PWM_IER2) Comparison 7 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM7_Msk                  (_U_(0x1) << PWM_IER2_CMPM7_Pos)               /**< (PWM_IER2) Comparison 7 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM7                      PWM_IER2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM7_Msk instead */
+#define PWM_IER2_CMPU0_Pos                  16                                             /**< (PWM_IER2) Comparison 0 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU0_Msk                  (_U_(0x1) << PWM_IER2_CMPU0_Pos)               /**< (PWM_IER2) Comparison 0 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU0                      PWM_IER2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU0_Msk instead */
+#define PWM_IER2_CMPU1_Pos                  17                                             /**< (PWM_IER2) Comparison 1 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU1_Msk                  (_U_(0x1) << PWM_IER2_CMPU1_Pos)               /**< (PWM_IER2) Comparison 1 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU1                      PWM_IER2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU1_Msk instead */
+#define PWM_IER2_CMPU2_Pos                  18                                             /**< (PWM_IER2) Comparison 2 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU2_Msk                  (_U_(0x1) << PWM_IER2_CMPU2_Pos)               /**< (PWM_IER2) Comparison 2 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU2                      PWM_IER2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU2_Msk instead */
+#define PWM_IER2_CMPU3_Pos                  19                                             /**< (PWM_IER2) Comparison 3 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU3_Msk                  (_U_(0x1) << PWM_IER2_CMPU3_Pos)               /**< (PWM_IER2) Comparison 3 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU3                      PWM_IER2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU3_Msk instead */
+#define PWM_IER2_CMPU4_Pos                  20                                             /**< (PWM_IER2) Comparison 4 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU4_Msk                  (_U_(0x1) << PWM_IER2_CMPU4_Pos)               /**< (PWM_IER2) Comparison 4 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU4                      PWM_IER2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU4_Msk instead */
+#define PWM_IER2_CMPU5_Pos                  21                                             /**< (PWM_IER2) Comparison 5 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU5_Msk                  (_U_(0x1) << PWM_IER2_CMPU5_Pos)               /**< (PWM_IER2) Comparison 5 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU5                      PWM_IER2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU5_Msk instead */
+#define PWM_IER2_CMPU6_Pos                  22                                             /**< (PWM_IER2) Comparison 6 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU6_Msk                  (_U_(0x1) << PWM_IER2_CMPU6_Pos)               /**< (PWM_IER2) Comparison 6 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU6                      PWM_IER2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU6_Msk instead */
+#define PWM_IER2_CMPU7_Pos                  23                                             /**< (PWM_IER2) Comparison 7 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU7_Msk                  (_U_(0x1) << PWM_IER2_CMPU7_Pos)               /**< (PWM_IER2) Comparison 7 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU7                      PWM_IER2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU7_Msk instead */
+#define PWM_IER2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IER2) Register MASK  (Use PWM_IER2_Msk instead)  */
+#define PWM_IER2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IER2) Register Mask  */
+
+#define PWM_IER2_CMPM_Pos                   8                                              /**< (PWM_IER2 Position) Comparison x Match Interrupt Enable */
+#define PWM_IER2_CMPM_Msk                   (_U_(0xFF) << PWM_IER2_CMPM_Pos)               /**< (PWM_IER2 Mask) CMPM */
+#define PWM_IER2_CMPM(value)                (PWM_IER2_CMPM_Msk & ((value) << PWM_IER2_CMPM_Pos))  
+#define PWM_IER2_CMPU_Pos                   16                                             /**< (PWM_IER2 Position) Comparison 7 Update Interrupt Enable */
+#define PWM_IER2_CMPU_Msk                   (_U_(0xFF) << PWM_IER2_CMPU_Pos)               /**< (PWM_IER2 Mask) CMPU */
+#define PWM_IER2_CMPU(value)                (PWM_IER2_CMPU_Msk & ((value) << PWM_IER2_CMPU_Pos))  
+
+/* -------- PWM_IDR2 : (PWM Offset: 0x38) (/W 32) PWM Interrupt Disable Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Disable */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Disable */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Disable     */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Disable     */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Disable     */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Disable     */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Disable     */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Disable     */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Disable     */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Disable     */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Disable    */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Disable    */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Disable    */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Disable    */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Disable    */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Disable    */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Disable    */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Disable    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Disable     */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Disable    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IDR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IDR2_OFFSET                     (0x38)                                        /**<  (PWM_IDR2) PWM Interrupt Disable Register 2  Offset */
+
+#define PWM_IDR2_WRDY_Pos                   0                                              /**< (PWM_IDR2) Write Ready for Synchronous Channels Update Interrupt Disable Position */
+#define PWM_IDR2_WRDY_Msk                   (_U_(0x1) << PWM_IDR2_WRDY_Pos)                /**< (PWM_IDR2) Write Ready for Synchronous Channels Update Interrupt Disable Mask */
+#define PWM_IDR2_WRDY                       PWM_IDR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_WRDY_Msk instead */
+#define PWM_IDR2_UNRE_Pos                   3                                              /**< (PWM_IDR2) Synchronous Channels Update Underrun Error Interrupt Disable Position */
+#define PWM_IDR2_UNRE_Msk                   (_U_(0x1) << PWM_IDR2_UNRE_Pos)                /**< (PWM_IDR2) Synchronous Channels Update Underrun Error Interrupt Disable Mask */
+#define PWM_IDR2_UNRE                       PWM_IDR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_UNRE_Msk instead */
+#define PWM_IDR2_CMPM0_Pos                  8                                              /**< (PWM_IDR2) Comparison 0 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM0_Msk                  (_U_(0x1) << PWM_IDR2_CMPM0_Pos)               /**< (PWM_IDR2) Comparison 0 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM0                      PWM_IDR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM0_Msk instead */
+#define PWM_IDR2_CMPM1_Pos                  9                                              /**< (PWM_IDR2) Comparison 1 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM1_Msk                  (_U_(0x1) << PWM_IDR2_CMPM1_Pos)               /**< (PWM_IDR2) Comparison 1 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM1                      PWM_IDR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM1_Msk instead */
+#define PWM_IDR2_CMPM2_Pos                  10                                             /**< (PWM_IDR2) Comparison 2 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM2_Msk                  (_U_(0x1) << PWM_IDR2_CMPM2_Pos)               /**< (PWM_IDR2) Comparison 2 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM2                      PWM_IDR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM2_Msk instead */
+#define PWM_IDR2_CMPM3_Pos                  11                                             /**< (PWM_IDR2) Comparison 3 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM3_Msk                  (_U_(0x1) << PWM_IDR2_CMPM3_Pos)               /**< (PWM_IDR2) Comparison 3 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM3                      PWM_IDR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM3_Msk instead */
+#define PWM_IDR2_CMPM4_Pos                  12                                             /**< (PWM_IDR2) Comparison 4 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM4_Msk                  (_U_(0x1) << PWM_IDR2_CMPM4_Pos)               /**< (PWM_IDR2) Comparison 4 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM4                      PWM_IDR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM4_Msk instead */
+#define PWM_IDR2_CMPM5_Pos                  13                                             /**< (PWM_IDR2) Comparison 5 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM5_Msk                  (_U_(0x1) << PWM_IDR2_CMPM5_Pos)               /**< (PWM_IDR2) Comparison 5 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM5                      PWM_IDR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM5_Msk instead */
+#define PWM_IDR2_CMPM6_Pos                  14                                             /**< (PWM_IDR2) Comparison 6 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM6_Msk                  (_U_(0x1) << PWM_IDR2_CMPM6_Pos)               /**< (PWM_IDR2) Comparison 6 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM6                      PWM_IDR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM6_Msk instead */
+#define PWM_IDR2_CMPM7_Pos                  15                                             /**< (PWM_IDR2) Comparison 7 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM7_Msk                  (_U_(0x1) << PWM_IDR2_CMPM7_Pos)               /**< (PWM_IDR2) Comparison 7 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM7                      PWM_IDR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM7_Msk instead */
+#define PWM_IDR2_CMPU0_Pos                  16                                             /**< (PWM_IDR2) Comparison 0 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU0_Msk                  (_U_(0x1) << PWM_IDR2_CMPU0_Pos)               /**< (PWM_IDR2) Comparison 0 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU0                      PWM_IDR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU0_Msk instead */
+#define PWM_IDR2_CMPU1_Pos                  17                                             /**< (PWM_IDR2) Comparison 1 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU1_Msk                  (_U_(0x1) << PWM_IDR2_CMPU1_Pos)               /**< (PWM_IDR2) Comparison 1 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU1                      PWM_IDR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU1_Msk instead */
+#define PWM_IDR2_CMPU2_Pos                  18                                             /**< (PWM_IDR2) Comparison 2 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU2_Msk                  (_U_(0x1) << PWM_IDR2_CMPU2_Pos)               /**< (PWM_IDR2) Comparison 2 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU2                      PWM_IDR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU2_Msk instead */
+#define PWM_IDR2_CMPU3_Pos                  19                                             /**< (PWM_IDR2) Comparison 3 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU3_Msk                  (_U_(0x1) << PWM_IDR2_CMPU3_Pos)               /**< (PWM_IDR2) Comparison 3 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU3                      PWM_IDR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU3_Msk instead */
+#define PWM_IDR2_CMPU4_Pos                  20                                             /**< (PWM_IDR2) Comparison 4 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU4_Msk                  (_U_(0x1) << PWM_IDR2_CMPU4_Pos)               /**< (PWM_IDR2) Comparison 4 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU4                      PWM_IDR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU4_Msk instead */
+#define PWM_IDR2_CMPU5_Pos                  21                                             /**< (PWM_IDR2) Comparison 5 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU5_Msk                  (_U_(0x1) << PWM_IDR2_CMPU5_Pos)               /**< (PWM_IDR2) Comparison 5 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU5                      PWM_IDR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU5_Msk instead */
+#define PWM_IDR2_CMPU6_Pos                  22                                             /**< (PWM_IDR2) Comparison 6 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU6_Msk                  (_U_(0x1) << PWM_IDR2_CMPU6_Pos)               /**< (PWM_IDR2) Comparison 6 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU6                      PWM_IDR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU6_Msk instead */
+#define PWM_IDR2_CMPU7_Pos                  23                                             /**< (PWM_IDR2) Comparison 7 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU7_Msk                  (_U_(0x1) << PWM_IDR2_CMPU7_Pos)               /**< (PWM_IDR2) Comparison 7 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU7                      PWM_IDR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU7_Msk instead */
+#define PWM_IDR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IDR2) Register MASK  (Use PWM_IDR2_Msk instead)  */
+#define PWM_IDR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IDR2) Register Mask  */
+
+#define PWM_IDR2_CMPM_Pos                   8                                              /**< (PWM_IDR2 Position) Comparison x Match Interrupt Disable */
+#define PWM_IDR2_CMPM_Msk                   (_U_(0xFF) << PWM_IDR2_CMPM_Pos)               /**< (PWM_IDR2 Mask) CMPM */
+#define PWM_IDR2_CMPM(value)                (PWM_IDR2_CMPM_Msk & ((value) << PWM_IDR2_CMPM_Pos))  
+#define PWM_IDR2_CMPU_Pos                   16                                             /**< (PWM_IDR2 Position) Comparison 7 Update Interrupt Disable */
+#define PWM_IDR2_CMPU_Msk                   (_U_(0xFF) << PWM_IDR2_CMPU_Pos)               /**< (PWM_IDR2 Mask) CMPU */
+#define PWM_IDR2_CMPU(value)                (PWM_IDR2_CMPU_Msk & ((value) << PWM_IDR2_CMPU_Pos))  
+
+/* -------- PWM_IMR2 : (PWM Offset: 0x3c) (R/ 32) PWM Interrupt Mask Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Mask */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Mask */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Mask        */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Mask        */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Mask        */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Mask        */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Mask        */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Mask        */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Mask        */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Mask        */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Mask       */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Mask       */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Mask       */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Mask       */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Mask       */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Mask       */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Mask       */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Mask       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Mask        */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Mask       */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IMR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IMR2_OFFSET                     (0x3C)                                        /**<  (PWM_IMR2) PWM Interrupt Mask Register 2  Offset */
+
+#define PWM_IMR2_WRDY_Pos                   0                                              /**< (PWM_IMR2) Write Ready for Synchronous Channels Update Interrupt Mask Position */
+#define PWM_IMR2_WRDY_Msk                   (_U_(0x1) << PWM_IMR2_WRDY_Pos)                /**< (PWM_IMR2) Write Ready for Synchronous Channels Update Interrupt Mask Mask */
+#define PWM_IMR2_WRDY                       PWM_IMR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_WRDY_Msk instead */
+#define PWM_IMR2_UNRE_Pos                   3                                              /**< (PWM_IMR2) Synchronous Channels Update Underrun Error Interrupt Mask Position */
+#define PWM_IMR2_UNRE_Msk                   (_U_(0x1) << PWM_IMR2_UNRE_Pos)                /**< (PWM_IMR2) Synchronous Channels Update Underrun Error Interrupt Mask Mask */
+#define PWM_IMR2_UNRE                       PWM_IMR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_UNRE_Msk instead */
+#define PWM_IMR2_CMPM0_Pos                  8                                              /**< (PWM_IMR2) Comparison 0 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM0_Msk                  (_U_(0x1) << PWM_IMR2_CMPM0_Pos)               /**< (PWM_IMR2) Comparison 0 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM0                      PWM_IMR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM0_Msk instead */
+#define PWM_IMR2_CMPM1_Pos                  9                                              /**< (PWM_IMR2) Comparison 1 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM1_Msk                  (_U_(0x1) << PWM_IMR2_CMPM1_Pos)               /**< (PWM_IMR2) Comparison 1 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM1                      PWM_IMR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM1_Msk instead */
+#define PWM_IMR2_CMPM2_Pos                  10                                             /**< (PWM_IMR2) Comparison 2 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM2_Msk                  (_U_(0x1) << PWM_IMR2_CMPM2_Pos)               /**< (PWM_IMR2) Comparison 2 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM2                      PWM_IMR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM2_Msk instead */
+#define PWM_IMR2_CMPM3_Pos                  11                                             /**< (PWM_IMR2) Comparison 3 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM3_Msk                  (_U_(0x1) << PWM_IMR2_CMPM3_Pos)               /**< (PWM_IMR2) Comparison 3 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM3                      PWM_IMR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM3_Msk instead */
+#define PWM_IMR2_CMPM4_Pos                  12                                             /**< (PWM_IMR2) Comparison 4 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM4_Msk                  (_U_(0x1) << PWM_IMR2_CMPM4_Pos)               /**< (PWM_IMR2) Comparison 4 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM4                      PWM_IMR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM4_Msk instead */
+#define PWM_IMR2_CMPM5_Pos                  13                                             /**< (PWM_IMR2) Comparison 5 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM5_Msk                  (_U_(0x1) << PWM_IMR2_CMPM5_Pos)               /**< (PWM_IMR2) Comparison 5 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM5                      PWM_IMR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM5_Msk instead */
+#define PWM_IMR2_CMPM6_Pos                  14                                             /**< (PWM_IMR2) Comparison 6 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM6_Msk                  (_U_(0x1) << PWM_IMR2_CMPM6_Pos)               /**< (PWM_IMR2) Comparison 6 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM6                      PWM_IMR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM6_Msk instead */
+#define PWM_IMR2_CMPM7_Pos                  15                                             /**< (PWM_IMR2) Comparison 7 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM7_Msk                  (_U_(0x1) << PWM_IMR2_CMPM7_Pos)               /**< (PWM_IMR2) Comparison 7 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM7                      PWM_IMR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM7_Msk instead */
+#define PWM_IMR2_CMPU0_Pos                  16                                             /**< (PWM_IMR2) Comparison 0 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU0_Msk                  (_U_(0x1) << PWM_IMR2_CMPU0_Pos)               /**< (PWM_IMR2) Comparison 0 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU0                      PWM_IMR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU0_Msk instead */
+#define PWM_IMR2_CMPU1_Pos                  17                                             /**< (PWM_IMR2) Comparison 1 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU1_Msk                  (_U_(0x1) << PWM_IMR2_CMPU1_Pos)               /**< (PWM_IMR2) Comparison 1 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU1                      PWM_IMR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU1_Msk instead */
+#define PWM_IMR2_CMPU2_Pos                  18                                             /**< (PWM_IMR2) Comparison 2 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU2_Msk                  (_U_(0x1) << PWM_IMR2_CMPU2_Pos)               /**< (PWM_IMR2) Comparison 2 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU2                      PWM_IMR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU2_Msk instead */
+#define PWM_IMR2_CMPU3_Pos                  19                                             /**< (PWM_IMR2) Comparison 3 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU3_Msk                  (_U_(0x1) << PWM_IMR2_CMPU3_Pos)               /**< (PWM_IMR2) Comparison 3 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU3                      PWM_IMR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU3_Msk instead */
+#define PWM_IMR2_CMPU4_Pos                  20                                             /**< (PWM_IMR2) Comparison 4 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU4_Msk                  (_U_(0x1) << PWM_IMR2_CMPU4_Pos)               /**< (PWM_IMR2) Comparison 4 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU4                      PWM_IMR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU4_Msk instead */
+#define PWM_IMR2_CMPU5_Pos                  21                                             /**< (PWM_IMR2) Comparison 5 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU5_Msk                  (_U_(0x1) << PWM_IMR2_CMPU5_Pos)               /**< (PWM_IMR2) Comparison 5 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU5                      PWM_IMR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU5_Msk instead */
+#define PWM_IMR2_CMPU6_Pos                  22                                             /**< (PWM_IMR2) Comparison 6 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU6_Msk                  (_U_(0x1) << PWM_IMR2_CMPU6_Pos)               /**< (PWM_IMR2) Comparison 6 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU6                      PWM_IMR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU6_Msk instead */
+#define PWM_IMR2_CMPU7_Pos                  23                                             /**< (PWM_IMR2) Comparison 7 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU7_Msk                  (_U_(0x1) << PWM_IMR2_CMPU7_Pos)               /**< (PWM_IMR2) Comparison 7 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU7                      PWM_IMR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU7_Msk instead */
+#define PWM_IMR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IMR2) Register MASK  (Use PWM_IMR2_Msk instead)  */
+#define PWM_IMR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IMR2) Register Mask  */
+
+#define PWM_IMR2_CMPM_Pos                   8                                              /**< (PWM_IMR2 Position) Comparison x Match Interrupt Mask */
+#define PWM_IMR2_CMPM_Msk                   (_U_(0xFF) << PWM_IMR2_CMPM_Pos)               /**< (PWM_IMR2 Mask) CMPM */
+#define PWM_IMR2_CMPM(value)                (PWM_IMR2_CMPM_Msk & ((value) << PWM_IMR2_CMPM_Pos))  
+#define PWM_IMR2_CMPU_Pos                   16                                             /**< (PWM_IMR2 Position) Comparison 7 Update Interrupt Mask */
+#define PWM_IMR2_CMPU_Msk                   (_U_(0xFF) << PWM_IMR2_CMPU_Pos)               /**< (PWM_IMR2 Mask) CMPU */
+#define PWM_IMR2_CMPU(value)                (PWM_IMR2_CMPU_Msk & ((value) << PWM_IMR2_CMPU_Pos))  
+
+/* -------- PWM_ISR2 : (PWM Offset: 0x40) (R/ 32) PWM Interrupt Status Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match                       */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match                       */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match                       */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match                       */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match                       */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match                       */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match                       */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match                       */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update                      */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update                      */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update                      */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update                      */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update                      */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update                      */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update                      */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update                      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match                       */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update                      */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ISR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ISR2_OFFSET                     (0x40)                                        /**<  (PWM_ISR2) PWM Interrupt Status Register 2  Offset */
+
+#define PWM_ISR2_WRDY_Pos                   0                                              /**< (PWM_ISR2) Write Ready for Synchronous Channels Update Position */
+#define PWM_ISR2_WRDY_Msk                   (_U_(0x1) << PWM_ISR2_WRDY_Pos)                /**< (PWM_ISR2) Write Ready for Synchronous Channels Update Mask */
+#define PWM_ISR2_WRDY                       PWM_ISR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_WRDY_Msk instead */
+#define PWM_ISR2_UNRE_Pos                   3                                              /**< (PWM_ISR2) Synchronous Channels Update Underrun Error Position */
+#define PWM_ISR2_UNRE_Msk                   (_U_(0x1) << PWM_ISR2_UNRE_Pos)                /**< (PWM_ISR2) Synchronous Channels Update Underrun Error Mask */
+#define PWM_ISR2_UNRE                       PWM_ISR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_UNRE_Msk instead */
+#define PWM_ISR2_CMPM0_Pos                  8                                              /**< (PWM_ISR2) Comparison 0 Match Position */
+#define PWM_ISR2_CMPM0_Msk                  (_U_(0x1) << PWM_ISR2_CMPM0_Pos)               /**< (PWM_ISR2) Comparison 0 Match Mask */
+#define PWM_ISR2_CMPM0                      PWM_ISR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM0_Msk instead */
+#define PWM_ISR2_CMPM1_Pos                  9                                              /**< (PWM_ISR2) Comparison 1 Match Position */
+#define PWM_ISR2_CMPM1_Msk                  (_U_(0x1) << PWM_ISR2_CMPM1_Pos)               /**< (PWM_ISR2) Comparison 1 Match Mask */
+#define PWM_ISR2_CMPM1                      PWM_ISR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM1_Msk instead */
+#define PWM_ISR2_CMPM2_Pos                  10                                             /**< (PWM_ISR2) Comparison 2 Match Position */
+#define PWM_ISR2_CMPM2_Msk                  (_U_(0x1) << PWM_ISR2_CMPM2_Pos)               /**< (PWM_ISR2) Comparison 2 Match Mask */
+#define PWM_ISR2_CMPM2                      PWM_ISR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM2_Msk instead */
+#define PWM_ISR2_CMPM3_Pos                  11                                             /**< (PWM_ISR2) Comparison 3 Match Position */
+#define PWM_ISR2_CMPM3_Msk                  (_U_(0x1) << PWM_ISR2_CMPM3_Pos)               /**< (PWM_ISR2) Comparison 3 Match Mask */
+#define PWM_ISR2_CMPM3                      PWM_ISR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM3_Msk instead */
+#define PWM_ISR2_CMPM4_Pos                  12                                             /**< (PWM_ISR2) Comparison 4 Match Position */
+#define PWM_ISR2_CMPM4_Msk                  (_U_(0x1) << PWM_ISR2_CMPM4_Pos)               /**< (PWM_ISR2) Comparison 4 Match Mask */
+#define PWM_ISR2_CMPM4                      PWM_ISR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM4_Msk instead */
+#define PWM_ISR2_CMPM5_Pos                  13                                             /**< (PWM_ISR2) Comparison 5 Match Position */
+#define PWM_ISR2_CMPM5_Msk                  (_U_(0x1) << PWM_ISR2_CMPM5_Pos)               /**< (PWM_ISR2) Comparison 5 Match Mask */
+#define PWM_ISR2_CMPM5                      PWM_ISR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM5_Msk instead */
+#define PWM_ISR2_CMPM6_Pos                  14                                             /**< (PWM_ISR2) Comparison 6 Match Position */
+#define PWM_ISR2_CMPM6_Msk                  (_U_(0x1) << PWM_ISR2_CMPM6_Pos)               /**< (PWM_ISR2) Comparison 6 Match Mask */
+#define PWM_ISR2_CMPM6                      PWM_ISR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM6_Msk instead */
+#define PWM_ISR2_CMPM7_Pos                  15                                             /**< (PWM_ISR2) Comparison 7 Match Position */
+#define PWM_ISR2_CMPM7_Msk                  (_U_(0x1) << PWM_ISR2_CMPM7_Pos)               /**< (PWM_ISR2) Comparison 7 Match Mask */
+#define PWM_ISR2_CMPM7                      PWM_ISR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM7_Msk instead */
+#define PWM_ISR2_CMPU0_Pos                  16                                             /**< (PWM_ISR2) Comparison 0 Update Position */
+#define PWM_ISR2_CMPU0_Msk                  (_U_(0x1) << PWM_ISR2_CMPU0_Pos)               /**< (PWM_ISR2) Comparison 0 Update Mask */
+#define PWM_ISR2_CMPU0                      PWM_ISR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU0_Msk instead */
+#define PWM_ISR2_CMPU1_Pos                  17                                             /**< (PWM_ISR2) Comparison 1 Update Position */
+#define PWM_ISR2_CMPU1_Msk                  (_U_(0x1) << PWM_ISR2_CMPU1_Pos)               /**< (PWM_ISR2) Comparison 1 Update Mask */
+#define PWM_ISR2_CMPU1                      PWM_ISR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU1_Msk instead */
+#define PWM_ISR2_CMPU2_Pos                  18                                             /**< (PWM_ISR2) Comparison 2 Update Position */
+#define PWM_ISR2_CMPU2_Msk                  (_U_(0x1) << PWM_ISR2_CMPU2_Pos)               /**< (PWM_ISR2) Comparison 2 Update Mask */
+#define PWM_ISR2_CMPU2                      PWM_ISR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU2_Msk instead */
+#define PWM_ISR2_CMPU3_Pos                  19                                             /**< (PWM_ISR2) Comparison 3 Update Position */
+#define PWM_ISR2_CMPU3_Msk                  (_U_(0x1) << PWM_ISR2_CMPU3_Pos)               /**< (PWM_ISR2) Comparison 3 Update Mask */
+#define PWM_ISR2_CMPU3                      PWM_ISR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU3_Msk instead */
+#define PWM_ISR2_CMPU4_Pos                  20                                             /**< (PWM_ISR2) Comparison 4 Update Position */
+#define PWM_ISR2_CMPU4_Msk                  (_U_(0x1) << PWM_ISR2_CMPU4_Pos)               /**< (PWM_ISR2) Comparison 4 Update Mask */
+#define PWM_ISR2_CMPU4                      PWM_ISR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU4_Msk instead */
+#define PWM_ISR2_CMPU5_Pos                  21                                             /**< (PWM_ISR2) Comparison 5 Update Position */
+#define PWM_ISR2_CMPU5_Msk                  (_U_(0x1) << PWM_ISR2_CMPU5_Pos)               /**< (PWM_ISR2) Comparison 5 Update Mask */
+#define PWM_ISR2_CMPU5                      PWM_ISR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU5_Msk instead */
+#define PWM_ISR2_CMPU6_Pos                  22                                             /**< (PWM_ISR2) Comparison 6 Update Position */
+#define PWM_ISR2_CMPU6_Msk                  (_U_(0x1) << PWM_ISR2_CMPU6_Pos)               /**< (PWM_ISR2) Comparison 6 Update Mask */
+#define PWM_ISR2_CMPU6                      PWM_ISR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU6_Msk instead */
+#define PWM_ISR2_CMPU7_Pos                  23                                             /**< (PWM_ISR2) Comparison 7 Update Position */
+#define PWM_ISR2_CMPU7_Msk                  (_U_(0x1) << PWM_ISR2_CMPU7_Pos)               /**< (PWM_ISR2) Comparison 7 Update Mask */
+#define PWM_ISR2_CMPU7                      PWM_ISR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU7_Msk instead */
+#define PWM_ISR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_ISR2) Register MASK  (Use PWM_ISR2_Msk instead)  */
+#define PWM_ISR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_ISR2) Register Mask  */
+
+#define PWM_ISR2_CMPM_Pos                   8                                              /**< (PWM_ISR2 Position) Comparison x Match */
+#define PWM_ISR2_CMPM_Msk                   (_U_(0xFF) << PWM_ISR2_CMPM_Pos)               /**< (PWM_ISR2 Mask) CMPM */
+#define PWM_ISR2_CMPM(value)                (PWM_ISR2_CMPM_Msk & ((value) << PWM_ISR2_CMPM_Pos))  
+#define PWM_ISR2_CMPU_Pos                   16                                             /**< (PWM_ISR2 Position) Comparison 7 Update */
+#define PWM_ISR2_CMPU_Msk                   (_U_(0xFF) << PWM_ISR2_CMPU_Pos)               /**< (PWM_ISR2 Mask) CMPU */
+#define PWM_ISR2_CMPU(value)                (PWM_ISR2_CMPU_Msk & ((value) << PWM_ISR2_CMPU_Pos))  
+
+/* -------- PWM_OOV : (PWM Offset: 0x44) (R/W 32) PWM Output Override Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OOVH0:1;                   /**< bit:      0  Output Override Value for PWMH output of the channel 0 */
+    uint32_t OOVH1:1;                   /**< bit:      1  Output Override Value for PWMH output of the channel 1 */
+    uint32_t OOVH2:1;                   /**< bit:      2  Output Override Value for PWMH output of the channel 2 */
+    uint32_t OOVH3:1;                   /**< bit:      3  Output Override Value for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OOVL0:1;                   /**< bit:     16  Output Override Value for PWML output of the channel 0 */
+    uint32_t OOVL1:1;                   /**< bit:     17  Output Override Value for PWML output of the channel 1 */
+    uint32_t OOVL2:1;                   /**< bit:     18  Output Override Value for PWML output of the channel 2 */
+    uint32_t OOVL3:1;                   /**< bit:     19  Output Override Value for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OOVH:4;                    /**< bit:   0..3  Output Override Value for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OOVL:4;                    /**< bit: 16..19  Output Override Value for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OOV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OOV_OFFSET                      (0x44)                                        /**<  (PWM_OOV) PWM Output Override Value Register  Offset */
+
+#define PWM_OOV_OOVH0_Pos                   0                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 0 Position */
+#define PWM_OOV_OOVH0_Msk                   (_U_(0x1) << PWM_OOV_OOVH0_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 0 Mask */
+#define PWM_OOV_OOVH0                       PWM_OOV_OOVH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH0_Msk instead */
+#define PWM_OOV_OOVH1_Pos                   1                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 1 Position */
+#define PWM_OOV_OOVH1_Msk                   (_U_(0x1) << PWM_OOV_OOVH1_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 1 Mask */
+#define PWM_OOV_OOVH1                       PWM_OOV_OOVH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH1_Msk instead */
+#define PWM_OOV_OOVH2_Pos                   2                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 2 Position */
+#define PWM_OOV_OOVH2_Msk                   (_U_(0x1) << PWM_OOV_OOVH2_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 2 Mask */
+#define PWM_OOV_OOVH2                       PWM_OOV_OOVH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH2_Msk instead */
+#define PWM_OOV_OOVH3_Pos                   3                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 3 Position */
+#define PWM_OOV_OOVH3_Msk                   (_U_(0x1) << PWM_OOV_OOVH3_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 3 Mask */
+#define PWM_OOV_OOVH3                       PWM_OOV_OOVH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH3_Msk instead */
+#define PWM_OOV_OOVL0_Pos                   16                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 0 Position */
+#define PWM_OOV_OOVL0_Msk                   (_U_(0x1) << PWM_OOV_OOVL0_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 0 Mask */
+#define PWM_OOV_OOVL0                       PWM_OOV_OOVL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL0_Msk instead */
+#define PWM_OOV_OOVL1_Pos                   17                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 1 Position */
+#define PWM_OOV_OOVL1_Msk                   (_U_(0x1) << PWM_OOV_OOVL1_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 1 Mask */
+#define PWM_OOV_OOVL1                       PWM_OOV_OOVL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL1_Msk instead */
+#define PWM_OOV_OOVL2_Pos                   18                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 2 Position */
+#define PWM_OOV_OOVL2_Msk                   (_U_(0x1) << PWM_OOV_OOVL2_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 2 Mask */
+#define PWM_OOV_OOVL2                       PWM_OOV_OOVL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL2_Msk instead */
+#define PWM_OOV_OOVL3_Pos                   19                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 3 Position */
+#define PWM_OOV_OOVL3_Msk                   (_U_(0x1) << PWM_OOV_OOVL3_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 3 Mask */
+#define PWM_OOV_OOVL3                       PWM_OOV_OOVL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL3_Msk instead */
+#define PWM_OOV_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OOV) Register MASK  (Use PWM_OOV_Msk instead)  */
+#define PWM_OOV_Msk                         _U_(0xF000F)                                   /**< (PWM_OOV) Register Mask  */
+
+#define PWM_OOV_OOVH_Pos                    0                                              /**< (PWM_OOV Position) Output Override Value for PWMH output of the channel x */
+#define PWM_OOV_OOVH_Msk                    (_U_(0xF) << PWM_OOV_OOVH_Pos)                 /**< (PWM_OOV Mask) OOVH */
+#define PWM_OOV_OOVH(value)                 (PWM_OOV_OOVH_Msk & ((value) << PWM_OOV_OOVH_Pos))  
+#define PWM_OOV_OOVL_Pos                    16                                             /**< (PWM_OOV Position) Output Override Value for PWML output of the channel 3 */
+#define PWM_OOV_OOVL_Msk                    (_U_(0xF) << PWM_OOV_OOVL_Pos)                 /**< (PWM_OOV Mask) OOVL */
+#define PWM_OOV_OOVL(value)                 (PWM_OOV_OOVL_Msk & ((value) << PWM_OOV_OOVL_Pos))  
+
+/* -------- PWM_OS : (PWM Offset: 0x48) (R/W 32) PWM Output Selection Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSH0:1;                    /**< bit:      0  Output Selection for PWMH output of the channel 0 */
+    uint32_t OSH1:1;                    /**< bit:      1  Output Selection for PWMH output of the channel 1 */
+    uint32_t OSH2:1;                    /**< bit:      2  Output Selection for PWMH output of the channel 2 */
+    uint32_t OSH3:1;                    /**< bit:      3  Output Selection for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSL0:1;                    /**< bit:     16  Output Selection for PWML output of the channel 0 */
+    uint32_t OSL1:1;                    /**< bit:     17  Output Selection for PWML output of the channel 1 */
+    uint32_t OSL2:1;                    /**< bit:     18  Output Selection for PWML output of the channel 2 */
+    uint32_t OSL3:1;                    /**< bit:     19  Output Selection for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSH:4;                     /**< bit:   0..3  Output Selection for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSL:4;                     /**< bit: 16..19  Output Selection for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OS_OFFSET                       (0x48)                                        /**<  (PWM_OS) PWM Output Selection Register  Offset */
+
+#define PWM_OS_OSH0_Pos                     0                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 0 Position */
+#define PWM_OS_OSH0_Msk                     (_U_(0x1) << PWM_OS_OSH0_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 0 Mask */
+#define PWM_OS_OSH0                         PWM_OS_OSH0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH0_Msk instead */
+#define PWM_OS_OSH1_Pos                     1                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 1 Position */
+#define PWM_OS_OSH1_Msk                     (_U_(0x1) << PWM_OS_OSH1_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 1 Mask */
+#define PWM_OS_OSH1                         PWM_OS_OSH1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH1_Msk instead */
+#define PWM_OS_OSH2_Pos                     2                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 2 Position */
+#define PWM_OS_OSH2_Msk                     (_U_(0x1) << PWM_OS_OSH2_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 2 Mask */
+#define PWM_OS_OSH2                         PWM_OS_OSH2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH2_Msk instead */
+#define PWM_OS_OSH3_Pos                     3                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 3 Position */
+#define PWM_OS_OSH3_Msk                     (_U_(0x1) << PWM_OS_OSH3_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 3 Mask */
+#define PWM_OS_OSH3                         PWM_OS_OSH3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH3_Msk instead */
+#define PWM_OS_OSL0_Pos                     16                                             /**< (PWM_OS) Output Selection for PWML output of the channel 0 Position */
+#define PWM_OS_OSL0_Msk                     (_U_(0x1) << PWM_OS_OSL0_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 0 Mask */
+#define PWM_OS_OSL0                         PWM_OS_OSL0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL0_Msk instead */
+#define PWM_OS_OSL1_Pos                     17                                             /**< (PWM_OS) Output Selection for PWML output of the channel 1 Position */
+#define PWM_OS_OSL1_Msk                     (_U_(0x1) << PWM_OS_OSL1_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 1 Mask */
+#define PWM_OS_OSL1                         PWM_OS_OSL1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL1_Msk instead */
+#define PWM_OS_OSL2_Pos                     18                                             /**< (PWM_OS) Output Selection for PWML output of the channel 2 Position */
+#define PWM_OS_OSL2_Msk                     (_U_(0x1) << PWM_OS_OSL2_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 2 Mask */
+#define PWM_OS_OSL2                         PWM_OS_OSL2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL2_Msk instead */
+#define PWM_OS_OSL3_Pos                     19                                             /**< (PWM_OS) Output Selection for PWML output of the channel 3 Position */
+#define PWM_OS_OSL3_Msk                     (_U_(0x1) << PWM_OS_OSL3_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 3 Mask */
+#define PWM_OS_OSL3                         PWM_OS_OSL3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL3_Msk instead */
+#define PWM_OS_MASK                         _U_(0xF000F)                                   /**< \deprecated (PWM_OS) Register MASK  (Use PWM_OS_Msk instead)  */
+#define PWM_OS_Msk                          _U_(0xF000F)                                   /**< (PWM_OS) Register Mask  */
+
+#define PWM_OS_OSH_Pos                      0                                              /**< (PWM_OS Position) Output Selection for PWMH output of the channel x */
+#define PWM_OS_OSH_Msk                      (_U_(0xF) << PWM_OS_OSH_Pos)                   /**< (PWM_OS Mask) OSH */
+#define PWM_OS_OSH(value)                   (PWM_OS_OSH_Msk & ((value) << PWM_OS_OSH_Pos))  
+#define PWM_OS_OSL_Pos                      16                                             /**< (PWM_OS Position) Output Selection for PWML output of the channel 3 */
+#define PWM_OS_OSL_Msk                      (_U_(0xF) << PWM_OS_OSL_Pos)                   /**< (PWM_OS Mask) OSL */
+#define PWM_OS_OSL(value)                   (PWM_OS_OSL_Msk & ((value) << PWM_OS_OSL_Pos))  
+
+/* -------- PWM_OSS : (PWM Offset: 0x4c) (/W 32) PWM Output Selection Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSSH0:1;                   /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
+    uint32_t OSSH1:1;                   /**< bit:      1  Output Selection Set for PWMH output of the channel 1 */
+    uint32_t OSSH2:1;                   /**< bit:      2  Output Selection Set for PWMH output of the channel 2 */
+    uint32_t OSSH3:1;                   /**< bit:      3  Output Selection Set for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSL0:1;                   /**< bit:     16  Output Selection Set for PWML output of the channel 0 */
+    uint32_t OSSL1:1;                   /**< bit:     17  Output Selection Set for PWML output of the channel 1 */
+    uint32_t OSSL2:1;                   /**< bit:     18  Output Selection Set for PWML output of the channel 2 */
+    uint32_t OSSL3:1;                   /**< bit:     19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSSH:4;                    /**< bit:   0..3  Output Selection Set for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSL:4;                    /**< bit: 16..19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSS_OFFSET                      (0x4C)                                        /**<  (PWM_OSS) PWM Output Selection Set Register  Offset */
+
+#define PWM_OSS_OSSH0_Pos                   0                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 0 Position */
+#define PWM_OSS_OSSH0_Msk                   (_U_(0x1) << PWM_OSS_OSSH0_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 0 Mask */
+#define PWM_OSS_OSSH0                       PWM_OSS_OSSH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH0_Msk instead */
+#define PWM_OSS_OSSH1_Pos                   1                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 1 Position */
+#define PWM_OSS_OSSH1_Msk                   (_U_(0x1) << PWM_OSS_OSSH1_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 1 Mask */
+#define PWM_OSS_OSSH1                       PWM_OSS_OSSH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH1_Msk instead */
+#define PWM_OSS_OSSH2_Pos                   2                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 2 Position */
+#define PWM_OSS_OSSH2_Msk                   (_U_(0x1) << PWM_OSS_OSSH2_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 2 Mask */
+#define PWM_OSS_OSSH2                       PWM_OSS_OSSH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH2_Msk instead */
+#define PWM_OSS_OSSH3_Pos                   3                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 3 Position */
+#define PWM_OSS_OSSH3_Msk                   (_U_(0x1) << PWM_OSS_OSSH3_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 3 Mask */
+#define PWM_OSS_OSSH3                       PWM_OSS_OSSH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH3_Msk instead */
+#define PWM_OSS_OSSL0_Pos                   16                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 0 Position */
+#define PWM_OSS_OSSL0_Msk                   (_U_(0x1) << PWM_OSS_OSSL0_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 0 Mask */
+#define PWM_OSS_OSSL0                       PWM_OSS_OSSL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL0_Msk instead */
+#define PWM_OSS_OSSL1_Pos                   17                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 1 Position */
+#define PWM_OSS_OSSL1_Msk                   (_U_(0x1) << PWM_OSS_OSSL1_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 1 Mask */
+#define PWM_OSS_OSSL1                       PWM_OSS_OSSL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL1_Msk instead */
+#define PWM_OSS_OSSL2_Pos                   18                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 2 Position */
+#define PWM_OSS_OSSL2_Msk                   (_U_(0x1) << PWM_OSS_OSSL2_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 2 Mask */
+#define PWM_OSS_OSSL2                       PWM_OSS_OSSL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL2_Msk instead */
+#define PWM_OSS_OSSL3_Pos                   19                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 3 Position */
+#define PWM_OSS_OSSL3_Msk                   (_U_(0x1) << PWM_OSS_OSSL3_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 3 Mask */
+#define PWM_OSS_OSSL3                       PWM_OSS_OSSL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL3_Msk instead */
+#define PWM_OSS_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OSS) Register MASK  (Use PWM_OSS_Msk instead)  */
+#define PWM_OSS_Msk                         _U_(0xF000F)                                   /**< (PWM_OSS) Register Mask  */
+
+#define PWM_OSS_OSSH_Pos                    0                                              /**< (PWM_OSS Position) Output Selection Set for PWMH output of the channel x */
+#define PWM_OSS_OSSH_Msk                    (_U_(0xF) << PWM_OSS_OSSH_Pos)                 /**< (PWM_OSS Mask) OSSH */
+#define PWM_OSS_OSSH(value)                 (PWM_OSS_OSSH_Msk & ((value) << PWM_OSS_OSSH_Pos))  
+#define PWM_OSS_OSSL_Pos                    16                                             /**< (PWM_OSS Position) Output Selection Set for PWML output of the channel 3 */
+#define PWM_OSS_OSSL_Msk                    (_U_(0xF) << PWM_OSS_OSSL_Pos)                 /**< (PWM_OSS Mask) OSSL */
+#define PWM_OSS_OSSL(value)                 (PWM_OSS_OSSL_Msk & ((value) << PWM_OSS_OSSL_Pos))  
+
+/* -------- PWM_OSC : (PWM Offset: 0x50) (/W 32) PWM Output Selection Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSCH0:1;                   /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
+    uint32_t OSCH1:1;                   /**< bit:      1  Output Selection Clear for PWMH output of the channel 1 */
+    uint32_t OSCH2:1;                   /**< bit:      2  Output Selection Clear for PWMH output of the channel 2 */
+    uint32_t OSCH3:1;                   /**< bit:      3  Output Selection Clear for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCL0:1;                   /**< bit:     16  Output Selection Clear for PWML output of the channel 0 */
+    uint32_t OSCL1:1;                   /**< bit:     17  Output Selection Clear for PWML output of the channel 1 */
+    uint32_t OSCL2:1;                   /**< bit:     18  Output Selection Clear for PWML output of the channel 2 */
+    uint32_t OSCL3:1;                   /**< bit:     19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSCH:4;                    /**< bit:   0..3  Output Selection Clear for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCL:4;                    /**< bit: 16..19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSC_OFFSET                      (0x50)                                        /**<  (PWM_OSC) PWM Output Selection Clear Register  Offset */
+
+#define PWM_OSC_OSCH0_Pos                   0                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 0 Position */
+#define PWM_OSC_OSCH0_Msk                   (_U_(0x1) << PWM_OSC_OSCH0_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 0 Mask */
+#define PWM_OSC_OSCH0                       PWM_OSC_OSCH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH0_Msk instead */
+#define PWM_OSC_OSCH1_Pos                   1                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 1 Position */
+#define PWM_OSC_OSCH1_Msk                   (_U_(0x1) << PWM_OSC_OSCH1_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 1 Mask */
+#define PWM_OSC_OSCH1                       PWM_OSC_OSCH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH1_Msk instead */
+#define PWM_OSC_OSCH2_Pos                   2                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 2 Position */
+#define PWM_OSC_OSCH2_Msk                   (_U_(0x1) << PWM_OSC_OSCH2_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 2 Mask */
+#define PWM_OSC_OSCH2                       PWM_OSC_OSCH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH2_Msk instead */
+#define PWM_OSC_OSCH3_Pos                   3                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 3 Position */
+#define PWM_OSC_OSCH3_Msk                   (_U_(0x1) << PWM_OSC_OSCH3_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 3 Mask */
+#define PWM_OSC_OSCH3                       PWM_OSC_OSCH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH3_Msk instead */
+#define PWM_OSC_OSCL0_Pos                   16                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 0 Position */
+#define PWM_OSC_OSCL0_Msk                   (_U_(0x1) << PWM_OSC_OSCL0_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 0 Mask */
+#define PWM_OSC_OSCL0                       PWM_OSC_OSCL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL0_Msk instead */
+#define PWM_OSC_OSCL1_Pos                   17                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 1 Position */
+#define PWM_OSC_OSCL1_Msk                   (_U_(0x1) << PWM_OSC_OSCL1_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 1 Mask */
+#define PWM_OSC_OSCL1                       PWM_OSC_OSCL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL1_Msk instead */
+#define PWM_OSC_OSCL2_Pos                   18                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 2 Position */
+#define PWM_OSC_OSCL2_Msk                   (_U_(0x1) << PWM_OSC_OSCL2_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 2 Mask */
+#define PWM_OSC_OSCL2                       PWM_OSC_OSCL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL2_Msk instead */
+#define PWM_OSC_OSCL3_Pos                   19                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 3 Position */
+#define PWM_OSC_OSCL3_Msk                   (_U_(0x1) << PWM_OSC_OSCL3_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 3 Mask */
+#define PWM_OSC_OSCL3                       PWM_OSC_OSCL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL3_Msk instead */
+#define PWM_OSC_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OSC) Register MASK  (Use PWM_OSC_Msk instead)  */
+#define PWM_OSC_Msk                         _U_(0xF000F)                                   /**< (PWM_OSC) Register Mask  */
+
+#define PWM_OSC_OSCH_Pos                    0                                              /**< (PWM_OSC Position) Output Selection Clear for PWMH output of the channel x */
+#define PWM_OSC_OSCH_Msk                    (_U_(0xF) << PWM_OSC_OSCH_Pos)                 /**< (PWM_OSC Mask) OSCH */
+#define PWM_OSC_OSCH(value)                 (PWM_OSC_OSCH_Msk & ((value) << PWM_OSC_OSCH_Pos))  
+#define PWM_OSC_OSCL_Pos                    16                                             /**< (PWM_OSC Position) Output Selection Clear for PWML output of the channel 3 */
+#define PWM_OSC_OSCL_Msk                    (_U_(0xF) << PWM_OSC_OSCL_Pos)                 /**< (PWM_OSC Mask) OSCL */
+#define PWM_OSC_OSCL(value)                 (PWM_OSC_OSCL_Msk & ((value) << PWM_OSC_OSCL_Pos))  
+
+/* -------- PWM_OSSUPD : (PWM Offset: 0x54) (/W 32) PWM Output Selection Set Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSSUPH0:1;                 /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
+    uint32_t OSSUPH1:1;                 /**< bit:      1  Output Selection Set for PWMH output of the channel 1 */
+    uint32_t OSSUPH2:1;                 /**< bit:      2  Output Selection Set for PWMH output of the channel 2 */
+    uint32_t OSSUPH3:1;                 /**< bit:      3  Output Selection Set for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSUPL0:1;                 /**< bit:     16  Output Selection Set for PWML output of the channel 0 */
+    uint32_t OSSUPL1:1;                 /**< bit:     17  Output Selection Set for PWML output of the channel 1 */
+    uint32_t OSSUPL2:1;                 /**< bit:     18  Output Selection Set for PWML output of the channel 2 */
+    uint32_t OSSUPL3:1;                 /**< bit:     19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSSUPH:4;                  /**< bit:   0..3  Output Selection Set for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSUPL:4;                  /**< bit: 16..19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSSUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSSUPD_OFFSET                   (0x54)                                        /**<  (PWM_OSSUPD) PWM Output Selection Set Update Register  Offset */
+
+#define PWM_OSSUPD_OSSUPH0_Pos              0                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 0 Position */
+#define PWM_OSSUPD_OSSUPH0_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH0_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 0 Mask */
+#define PWM_OSSUPD_OSSUPH0                  PWM_OSSUPD_OSSUPH0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH0_Msk instead */
+#define PWM_OSSUPD_OSSUPH1_Pos              1                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 1 Position */
+#define PWM_OSSUPD_OSSUPH1_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH1_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 1 Mask */
+#define PWM_OSSUPD_OSSUPH1                  PWM_OSSUPD_OSSUPH1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH1_Msk instead */
+#define PWM_OSSUPD_OSSUPH2_Pos              2                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 2 Position */
+#define PWM_OSSUPD_OSSUPH2_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH2_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 2 Mask */
+#define PWM_OSSUPD_OSSUPH2                  PWM_OSSUPD_OSSUPH2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH2_Msk instead */
+#define PWM_OSSUPD_OSSUPH3_Pos              3                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 3 Position */
+#define PWM_OSSUPD_OSSUPH3_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH3_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 3 Mask */
+#define PWM_OSSUPD_OSSUPH3                  PWM_OSSUPD_OSSUPH3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH3_Msk instead */
+#define PWM_OSSUPD_OSSUPL0_Pos              16                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 0 Position */
+#define PWM_OSSUPD_OSSUPL0_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL0_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 0 Mask */
+#define PWM_OSSUPD_OSSUPL0                  PWM_OSSUPD_OSSUPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL0_Msk instead */
+#define PWM_OSSUPD_OSSUPL1_Pos              17                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 1 Position */
+#define PWM_OSSUPD_OSSUPL1_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL1_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 1 Mask */
+#define PWM_OSSUPD_OSSUPL1                  PWM_OSSUPD_OSSUPL1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL1_Msk instead */
+#define PWM_OSSUPD_OSSUPL2_Pos              18                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 2 Position */
+#define PWM_OSSUPD_OSSUPL2_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL2_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 2 Mask */
+#define PWM_OSSUPD_OSSUPL2                  PWM_OSSUPD_OSSUPL2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL2_Msk instead */
+#define PWM_OSSUPD_OSSUPL3_Pos              19                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 3 Position */
+#define PWM_OSSUPD_OSSUPL3_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL3_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 3 Mask */
+#define PWM_OSSUPD_OSSUPL3                  PWM_OSSUPD_OSSUPL3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL3_Msk instead */
+#define PWM_OSSUPD_MASK                     _U_(0xF000F)                                   /**< \deprecated (PWM_OSSUPD) Register MASK  (Use PWM_OSSUPD_Msk instead)  */
+#define PWM_OSSUPD_Msk                      _U_(0xF000F)                                   /**< (PWM_OSSUPD) Register Mask  */
+
+#define PWM_OSSUPD_OSSUPH_Pos               0                                              /**< (PWM_OSSUPD Position) Output Selection Set for PWMH output of the channel x */
+#define PWM_OSSUPD_OSSUPH_Msk               (_U_(0xF) << PWM_OSSUPD_OSSUPH_Pos)            /**< (PWM_OSSUPD Mask) OSSUPH */
+#define PWM_OSSUPD_OSSUPH(value)            (PWM_OSSUPD_OSSUPH_Msk & ((value) << PWM_OSSUPD_OSSUPH_Pos))  
+#define PWM_OSSUPD_OSSUPL_Pos               16                                             /**< (PWM_OSSUPD Position) Output Selection Set for PWML output of the channel 3 */
+#define PWM_OSSUPD_OSSUPL_Msk               (_U_(0xF) << PWM_OSSUPD_OSSUPL_Pos)            /**< (PWM_OSSUPD Mask) OSSUPL */
+#define PWM_OSSUPD_OSSUPL(value)            (PWM_OSSUPD_OSSUPL_Msk & ((value) << PWM_OSSUPD_OSSUPL_Pos))  
+
+/* -------- PWM_OSCUPD : (PWM Offset: 0x58) (/W 32) PWM Output Selection Clear Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSCUPH0:1;                 /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
+    uint32_t OSCUPH1:1;                 /**< bit:      1  Output Selection Clear for PWMH output of the channel 1 */
+    uint32_t OSCUPH2:1;                 /**< bit:      2  Output Selection Clear for PWMH output of the channel 2 */
+    uint32_t OSCUPH3:1;                 /**< bit:      3  Output Selection Clear for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCUPL0:1;                 /**< bit:     16  Output Selection Clear for PWML output of the channel 0 */
+    uint32_t OSCUPL1:1;                 /**< bit:     17  Output Selection Clear for PWML output of the channel 1 */
+    uint32_t OSCUPL2:1;                 /**< bit:     18  Output Selection Clear for PWML output of the channel 2 */
+    uint32_t OSCUPL3:1;                 /**< bit:     19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSCUPH:4;                  /**< bit:   0..3  Output Selection Clear for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCUPL:4;                  /**< bit: 16..19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSCUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSCUPD_OFFSET                   (0x58)                                        /**<  (PWM_OSCUPD) PWM Output Selection Clear Update Register  Offset */
+
+#define PWM_OSCUPD_OSCUPH0_Pos              0                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 0 Position */
+#define PWM_OSCUPD_OSCUPH0_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH0_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 0 Mask */
+#define PWM_OSCUPD_OSCUPH0                  PWM_OSCUPD_OSCUPH0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH0_Msk instead */
+#define PWM_OSCUPD_OSCUPH1_Pos              1                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 1 Position */
+#define PWM_OSCUPD_OSCUPH1_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH1_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 1 Mask */
+#define PWM_OSCUPD_OSCUPH1                  PWM_OSCUPD_OSCUPH1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH1_Msk instead */
+#define PWM_OSCUPD_OSCUPH2_Pos              2                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 2 Position */
+#define PWM_OSCUPD_OSCUPH2_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH2_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 2 Mask */
+#define PWM_OSCUPD_OSCUPH2                  PWM_OSCUPD_OSCUPH2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH2_Msk instead */
+#define PWM_OSCUPD_OSCUPH3_Pos              3                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 3 Position */
+#define PWM_OSCUPD_OSCUPH3_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH3_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 3 Mask */
+#define PWM_OSCUPD_OSCUPH3                  PWM_OSCUPD_OSCUPH3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH3_Msk instead */
+#define PWM_OSCUPD_OSCUPL0_Pos              16                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 0 Position */
+#define PWM_OSCUPD_OSCUPL0_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL0_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 0 Mask */
+#define PWM_OSCUPD_OSCUPL0                  PWM_OSCUPD_OSCUPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL0_Msk instead */
+#define PWM_OSCUPD_OSCUPL1_Pos              17                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 1 Position */
+#define PWM_OSCUPD_OSCUPL1_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL1_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 1 Mask */
+#define PWM_OSCUPD_OSCUPL1                  PWM_OSCUPD_OSCUPL1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL1_Msk instead */
+#define PWM_OSCUPD_OSCUPL2_Pos              18                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 2 Position */
+#define PWM_OSCUPD_OSCUPL2_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL2_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 2 Mask */
+#define PWM_OSCUPD_OSCUPL2                  PWM_OSCUPD_OSCUPL2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL2_Msk instead */
+#define PWM_OSCUPD_OSCUPL3_Pos              19                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 3 Position */
+#define PWM_OSCUPD_OSCUPL3_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL3_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 3 Mask */
+#define PWM_OSCUPD_OSCUPL3                  PWM_OSCUPD_OSCUPL3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL3_Msk instead */
+#define PWM_OSCUPD_MASK                     _U_(0xF000F)                                   /**< \deprecated (PWM_OSCUPD) Register MASK  (Use PWM_OSCUPD_Msk instead)  */
+#define PWM_OSCUPD_Msk                      _U_(0xF000F)                                   /**< (PWM_OSCUPD) Register Mask  */
+
+#define PWM_OSCUPD_OSCUPH_Pos               0                                              /**< (PWM_OSCUPD Position) Output Selection Clear for PWMH output of the channel x */
+#define PWM_OSCUPD_OSCUPH_Msk               (_U_(0xF) << PWM_OSCUPD_OSCUPH_Pos)            /**< (PWM_OSCUPD Mask) OSCUPH */
+#define PWM_OSCUPD_OSCUPH(value)            (PWM_OSCUPD_OSCUPH_Msk & ((value) << PWM_OSCUPD_OSCUPH_Pos))  
+#define PWM_OSCUPD_OSCUPL_Pos               16                                             /**< (PWM_OSCUPD Position) Output Selection Clear for PWML output of the channel 3 */
+#define PWM_OSCUPD_OSCUPL_Msk               (_U_(0xF) << PWM_OSCUPD_OSCUPL_Pos)            /**< (PWM_OSCUPD Mask) OSCUPL */
+#define PWM_OSCUPD_OSCUPL(value)            (PWM_OSCUPD_OSCUPL_Msk & ((value) << PWM_OSCUPD_OSCUPL_Pos))  
+
+/* -------- PWM_FMR : (PWM Offset: 0x5c) (R/W 32) PWM Fault Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPOL:8;                    /**< bit:   0..7  Fault Polarity                           */
+    uint32_t FMOD:8;                    /**< bit:  8..15  Fault Activation Mode                    */
+    uint32_t FFIL:8;                    /**< bit: 16..23  Fault Filtering                          */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FMR_OFFSET                      (0x5C)                                        /**<  (PWM_FMR) PWM Fault Mode Register  Offset */
+
+#define PWM_FMR_FPOL_Pos                    0                                              /**< (PWM_FMR) Fault Polarity Position */
+#define PWM_FMR_FPOL_Msk                    (_U_(0xFF) << PWM_FMR_FPOL_Pos)                /**< (PWM_FMR) Fault Polarity Mask */
+#define PWM_FMR_FPOL(value)                 (PWM_FMR_FPOL_Msk & ((value) << PWM_FMR_FPOL_Pos))
+#define PWM_FMR_FMOD_Pos                    8                                              /**< (PWM_FMR) Fault Activation Mode Position */
+#define PWM_FMR_FMOD_Msk                    (_U_(0xFF) << PWM_FMR_FMOD_Pos)                /**< (PWM_FMR) Fault Activation Mode Mask */
+#define PWM_FMR_FMOD(value)                 (PWM_FMR_FMOD_Msk & ((value) << PWM_FMR_FMOD_Pos))
+#define PWM_FMR_FFIL_Pos                    16                                             /**< (PWM_FMR) Fault Filtering Position */
+#define PWM_FMR_FFIL_Msk                    (_U_(0xFF) << PWM_FMR_FFIL_Pos)                /**< (PWM_FMR) Fault Filtering Mask */
+#define PWM_FMR_FFIL(value)                 (PWM_FMR_FFIL_Msk & ((value) << PWM_FMR_FFIL_Pos))
+#define PWM_FMR_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (PWM_FMR) Register MASK  (Use PWM_FMR_Msk instead)  */
+#define PWM_FMR_Msk                         _U_(0xFFFFFF)                                  /**< (PWM_FMR) Register Mask  */
+
+
+/* -------- PWM_FSR : (PWM Offset: 0x60) (R/ 32) PWM Fault Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FIV:8;                     /**< bit:   0..7  Fault Input Value                        */
+    uint32_t FS:8;                      /**< bit:  8..15  Fault Status                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FSR_OFFSET                      (0x60)                                        /**<  (PWM_FSR) PWM Fault Status Register  Offset */
+
+#define PWM_FSR_FIV_Pos                     0                                              /**< (PWM_FSR) Fault Input Value Position */
+#define PWM_FSR_FIV_Msk                     (_U_(0xFF) << PWM_FSR_FIV_Pos)                 /**< (PWM_FSR) Fault Input Value Mask */
+#define PWM_FSR_FIV(value)                  (PWM_FSR_FIV_Msk & ((value) << PWM_FSR_FIV_Pos))
+#define PWM_FSR_FS_Pos                      8                                              /**< (PWM_FSR) Fault Status Position */
+#define PWM_FSR_FS_Msk                      (_U_(0xFF) << PWM_FSR_FS_Pos)                  /**< (PWM_FSR) Fault Status Mask */
+#define PWM_FSR_FS(value)                   (PWM_FSR_FS_Msk & ((value) << PWM_FSR_FS_Pos))
+#define PWM_FSR_MASK                        _U_(0xFFFF)                                    /**< \deprecated (PWM_FSR) Register MASK  (Use PWM_FSR_Msk instead)  */
+#define PWM_FSR_Msk                         _U_(0xFFFF)                                    /**< (PWM_FSR) Register Mask  */
+
+
+/* -------- PWM_FCR : (PWM Offset: 0x64) (/W 32) PWM Fault Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCLR:8;                    /**< bit:   0..7  Fault Clear                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FCR_OFFSET                      (0x64)                                        /**<  (PWM_FCR) PWM Fault Clear Register  Offset */
+
+#define PWM_FCR_FCLR_Pos                    0                                              /**< (PWM_FCR) Fault Clear Position */
+#define PWM_FCR_FCLR_Msk                    (_U_(0xFF) << PWM_FCR_FCLR_Pos)                /**< (PWM_FCR) Fault Clear Mask */
+#define PWM_FCR_FCLR(value)                 (PWM_FCR_FCLR_Msk & ((value) << PWM_FCR_FCLR_Pos))
+#define PWM_FCR_MASK                        _U_(0xFF)                                      /**< \deprecated (PWM_FCR) Register MASK  (Use PWM_FCR_Msk instead)  */
+#define PWM_FCR_Msk                         _U_(0xFF)                                      /**< (PWM_FCR) Register Mask  */
+
+
+/* -------- PWM_FPV1 : (PWM Offset: 0x68) (R/W 32) PWM Fault Protection Value Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPVH0:1;                   /**< bit:      0  Fault Protection Value for PWMH output on channel 0 */
+    uint32_t FPVH1:1;                   /**< bit:      1  Fault Protection Value for PWMH output on channel 1 */
+    uint32_t FPVH2:1;                   /**< bit:      2  Fault Protection Value for PWMH output on channel 2 */
+    uint32_t FPVH3:1;                   /**< bit:      3  Fault Protection Value for PWMH output on channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPVL0:1;                   /**< bit:     16  Fault Protection Value for PWML output on channel 0 */
+    uint32_t FPVL1:1;                   /**< bit:     17  Fault Protection Value for PWML output on channel 1 */
+    uint32_t FPVL2:1;                   /**< bit:     18  Fault Protection Value for PWML output on channel 2 */
+    uint32_t FPVL3:1;                   /**< bit:     19  Fault Protection Value for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FPVH:4;                    /**< bit:   0..3  Fault Protection Value for PWMH output on channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPVL:4;                    /**< bit: 16..19  Fault Protection Value for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPV1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPV1_OFFSET                     (0x68)                                        /**<  (PWM_FPV1) PWM Fault Protection Value Register 1  Offset */
+
+#define PWM_FPV1_FPVH0_Pos                  0                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 0 Position */
+#define PWM_FPV1_FPVH0_Msk                  (_U_(0x1) << PWM_FPV1_FPVH0_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 0 Mask */
+#define PWM_FPV1_FPVH0                      PWM_FPV1_FPVH0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH0_Msk instead */
+#define PWM_FPV1_FPVH1_Pos                  1                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 1 Position */
+#define PWM_FPV1_FPVH1_Msk                  (_U_(0x1) << PWM_FPV1_FPVH1_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 1 Mask */
+#define PWM_FPV1_FPVH1                      PWM_FPV1_FPVH1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH1_Msk instead */
+#define PWM_FPV1_FPVH2_Pos                  2                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 2 Position */
+#define PWM_FPV1_FPVH2_Msk                  (_U_(0x1) << PWM_FPV1_FPVH2_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 2 Mask */
+#define PWM_FPV1_FPVH2                      PWM_FPV1_FPVH2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH2_Msk instead */
+#define PWM_FPV1_FPVH3_Pos                  3                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 3 Position */
+#define PWM_FPV1_FPVH3_Msk                  (_U_(0x1) << PWM_FPV1_FPVH3_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 3 Mask */
+#define PWM_FPV1_FPVH3                      PWM_FPV1_FPVH3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH3_Msk instead */
+#define PWM_FPV1_FPVL0_Pos                  16                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 0 Position */
+#define PWM_FPV1_FPVL0_Msk                  (_U_(0x1) << PWM_FPV1_FPVL0_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 0 Mask */
+#define PWM_FPV1_FPVL0                      PWM_FPV1_FPVL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL0_Msk instead */
+#define PWM_FPV1_FPVL1_Pos                  17                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 1 Position */
+#define PWM_FPV1_FPVL1_Msk                  (_U_(0x1) << PWM_FPV1_FPVL1_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 1 Mask */
+#define PWM_FPV1_FPVL1                      PWM_FPV1_FPVL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL1_Msk instead */
+#define PWM_FPV1_FPVL2_Pos                  18                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 2 Position */
+#define PWM_FPV1_FPVL2_Msk                  (_U_(0x1) << PWM_FPV1_FPVL2_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 2 Mask */
+#define PWM_FPV1_FPVL2                      PWM_FPV1_FPVL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL2_Msk instead */
+#define PWM_FPV1_FPVL3_Pos                  19                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 3 Position */
+#define PWM_FPV1_FPVL3_Msk                  (_U_(0x1) << PWM_FPV1_FPVL3_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 3 Mask */
+#define PWM_FPV1_FPVL3                      PWM_FPV1_FPVL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL3_Msk instead */
+#define PWM_FPV1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_FPV1) Register MASK  (Use PWM_FPV1_Msk instead)  */
+#define PWM_FPV1_Msk                        _U_(0xF000F)                                   /**< (PWM_FPV1) Register Mask  */
+
+#define PWM_FPV1_FPVH_Pos                   0                                              /**< (PWM_FPV1 Position) Fault Protection Value for PWMH output on channel x */
+#define PWM_FPV1_FPVH_Msk                   (_U_(0xF) << PWM_FPV1_FPVH_Pos)                /**< (PWM_FPV1 Mask) FPVH */
+#define PWM_FPV1_FPVH(value)                (PWM_FPV1_FPVH_Msk & ((value) << PWM_FPV1_FPVH_Pos))  
+#define PWM_FPV1_FPVL_Pos                   16                                             /**< (PWM_FPV1 Position) Fault Protection Value for PWML output on channel 3 */
+#define PWM_FPV1_FPVL_Msk                   (_U_(0xF) << PWM_FPV1_FPVL_Pos)                /**< (PWM_FPV1 Mask) FPVL */
+#define PWM_FPV1_FPVL(value)                (PWM_FPV1_FPVL_Msk & ((value) << PWM_FPV1_FPVL_Pos))  
+
+/* -------- PWM_FPE : (PWM Offset: 0x6c) (R/W 32) PWM Fault Protection Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPE0:8;                    /**< bit:   0..7  Fault Protection Enable for channel 0    */
+    uint32_t FPE1:8;                    /**< bit:  8..15  Fault Protection Enable for channel 1    */
+    uint32_t FPE2:8;                    /**< bit: 16..23  Fault Protection Enable for channel 2    */
+    uint32_t FPE3:8;                    /**< bit: 24..31  Fault Protection Enable for channel 3    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPE_OFFSET                      (0x6C)                                        /**<  (PWM_FPE) PWM Fault Protection Enable Register  Offset */
+
+#define PWM_FPE_FPE0_Pos                    0                                              /**< (PWM_FPE) Fault Protection Enable for channel 0 Position */
+#define PWM_FPE_FPE0_Msk                    (_U_(0xFF) << PWM_FPE_FPE0_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 0 Mask */
+#define PWM_FPE_FPE0(value)                 (PWM_FPE_FPE0_Msk & ((value) << PWM_FPE_FPE0_Pos))
+#define PWM_FPE_FPE1_Pos                    8                                              /**< (PWM_FPE) Fault Protection Enable for channel 1 Position */
+#define PWM_FPE_FPE1_Msk                    (_U_(0xFF) << PWM_FPE_FPE1_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 1 Mask */
+#define PWM_FPE_FPE1(value)                 (PWM_FPE_FPE1_Msk & ((value) << PWM_FPE_FPE1_Pos))
+#define PWM_FPE_FPE2_Pos                    16                                             /**< (PWM_FPE) Fault Protection Enable for channel 2 Position */
+#define PWM_FPE_FPE2_Msk                    (_U_(0xFF) << PWM_FPE_FPE2_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 2 Mask */
+#define PWM_FPE_FPE2(value)                 (PWM_FPE_FPE2_Msk & ((value) << PWM_FPE_FPE2_Pos))
+#define PWM_FPE_FPE3_Pos                    24                                             /**< (PWM_FPE) Fault Protection Enable for channel 3 Position */
+#define PWM_FPE_FPE3_Msk                    (_U_(0xFF) << PWM_FPE_FPE3_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 3 Mask */
+#define PWM_FPE_FPE3(value)                 (PWM_FPE_FPE3_Msk & ((value) << PWM_FPE_FPE3_Pos))
+#define PWM_FPE_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_FPE) Register MASK  (Use PWM_FPE_Msk instead)  */
+#define PWM_FPE_Msk                         _U_(0xFFFFFFFF)                                /**< (PWM_FPE) Register Mask  */
+
+
+/* -------- PWM_ELMR : (PWM Offset: 0x7c) (R/W 32) PWM Event Line 0 Mode Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL0:1;                   /**< bit:      0  Comparison 0 Selection                   */
+    uint32_t CSEL1:1;                   /**< bit:      1  Comparison 1 Selection                   */
+    uint32_t CSEL2:1;                   /**< bit:      2  Comparison 2 Selection                   */
+    uint32_t CSEL3:1;                   /**< bit:      3  Comparison 3 Selection                   */
+    uint32_t CSEL4:1;                   /**< bit:      4  Comparison 4 Selection                   */
+    uint32_t CSEL5:1;                   /**< bit:      5  Comparison 5 Selection                   */
+    uint32_t CSEL6:1;                   /**< bit:      6  Comparison 6 Selection                   */
+    uint32_t CSEL7:1;                   /**< bit:      7  Comparison 7 Selection                   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CSEL:8;                    /**< bit:   0..7  Comparison 7 Selection                   */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ELMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ELMR_OFFSET                     (0x7C)                                        /**<  (PWM_ELMR) PWM Event Line 0 Mode Register 0  Offset */
+
+#define PWM_ELMR_CSEL0_Pos                  0                                              /**< (PWM_ELMR) Comparison 0 Selection Position */
+#define PWM_ELMR_CSEL0_Msk                  (_U_(0x1) << PWM_ELMR_CSEL0_Pos)               /**< (PWM_ELMR) Comparison 0 Selection Mask */
+#define PWM_ELMR_CSEL0                      PWM_ELMR_CSEL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL0_Msk instead */
+#define PWM_ELMR_CSEL1_Pos                  1                                              /**< (PWM_ELMR) Comparison 1 Selection Position */
+#define PWM_ELMR_CSEL1_Msk                  (_U_(0x1) << PWM_ELMR_CSEL1_Pos)               /**< (PWM_ELMR) Comparison 1 Selection Mask */
+#define PWM_ELMR_CSEL1                      PWM_ELMR_CSEL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL1_Msk instead */
+#define PWM_ELMR_CSEL2_Pos                  2                                              /**< (PWM_ELMR) Comparison 2 Selection Position */
+#define PWM_ELMR_CSEL2_Msk                  (_U_(0x1) << PWM_ELMR_CSEL2_Pos)               /**< (PWM_ELMR) Comparison 2 Selection Mask */
+#define PWM_ELMR_CSEL2                      PWM_ELMR_CSEL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL2_Msk instead */
+#define PWM_ELMR_CSEL3_Pos                  3                                              /**< (PWM_ELMR) Comparison 3 Selection Position */
+#define PWM_ELMR_CSEL3_Msk                  (_U_(0x1) << PWM_ELMR_CSEL3_Pos)               /**< (PWM_ELMR) Comparison 3 Selection Mask */
+#define PWM_ELMR_CSEL3                      PWM_ELMR_CSEL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL3_Msk instead */
+#define PWM_ELMR_CSEL4_Pos                  4                                              /**< (PWM_ELMR) Comparison 4 Selection Position */
+#define PWM_ELMR_CSEL4_Msk                  (_U_(0x1) << PWM_ELMR_CSEL4_Pos)               /**< (PWM_ELMR) Comparison 4 Selection Mask */
+#define PWM_ELMR_CSEL4                      PWM_ELMR_CSEL4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL4_Msk instead */
+#define PWM_ELMR_CSEL5_Pos                  5                                              /**< (PWM_ELMR) Comparison 5 Selection Position */
+#define PWM_ELMR_CSEL5_Msk                  (_U_(0x1) << PWM_ELMR_CSEL5_Pos)               /**< (PWM_ELMR) Comparison 5 Selection Mask */
+#define PWM_ELMR_CSEL5                      PWM_ELMR_CSEL5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL5_Msk instead */
+#define PWM_ELMR_CSEL6_Pos                  6                                              /**< (PWM_ELMR) Comparison 6 Selection Position */
+#define PWM_ELMR_CSEL6_Msk                  (_U_(0x1) << PWM_ELMR_CSEL6_Pos)               /**< (PWM_ELMR) Comparison 6 Selection Mask */
+#define PWM_ELMR_CSEL6                      PWM_ELMR_CSEL6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL6_Msk instead */
+#define PWM_ELMR_CSEL7_Pos                  7                                              /**< (PWM_ELMR) Comparison 7 Selection Position */
+#define PWM_ELMR_CSEL7_Msk                  (_U_(0x1) << PWM_ELMR_CSEL7_Pos)               /**< (PWM_ELMR) Comparison 7 Selection Mask */
+#define PWM_ELMR_CSEL7                      PWM_ELMR_CSEL7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL7_Msk instead */
+#define PWM_ELMR_MASK                       _U_(0xFF)                                      /**< \deprecated (PWM_ELMR) Register MASK  (Use PWM_ELMR_Msk instead)  */
+#define PWM_ELMR_Msk                        _U_(0xFF)                                      /**< (PWM_ELMR) Register Mask  */
+
+#define PWM_ELMR_CSEL_Pos                   0                                              /**< (PWM_ELMR Position) Comparison 7 Selection */
+#define PWM_ELMR_CSEL_Msk                   (_U_(0xFF) << PWM_ELMR_CSEL_Pos)               /**< (PWM_ELMR Mask) CSEL */
+#define PWM_ELMR_CSEL(value)                (PWM_ELMR_CSEL_Msk & ((value) << PWM_ELMR_CSEL_Pos))  
+
+/* -------- PWM_SSPR : (PWM Offset: 0xa0) (R/W 32) PWM Spread Spectrum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPRD:24;                   /**< bit:  0..23  Spread Spectrum Limit Value              */
+    uint32_t SPRDM:1;                   /**< bit:     24  Spread Spectrum Counter Mode             */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SSPR_OFFSET                     (0xA0)                                        /**<  (PWM_SSPR) PWM Spread Spectrum Register  Offset */
+
+#define PWM_SSPR_SPRD_Pos                   0                                              /**< (PWM_SSPR) Spread Spectrum Limit Value Position */
+#define PWM_SSPR_SPRD_Msk                   (_U_(0xFFFFFF) << PWM_SSPR_SPRD_Pos)           /**< (PWM_SSPR) Spread Spectrum Limit Value Mask */
+#define PWM_SSPR_SPRD(value)                (PWM_SSPR_SPRD_Msk & ((value) << PWM_SSPR_SPRD_Pos))
+#define PWM_SSPR_SPRDM_Pos                  24                                             /**< (PWM_SSPR) Spread Spectrum Counter Mode Position */
+#define PWM_SSPR_SPRDM_Msk                  (_U_(0x1) << PWM_SSPR_SPRDM_Pos)               /**< (PWM_SSPR) Spread Spectrum Counter Mode Mask */
+#define PWM_SSPR_SPRDM                      PWM_SSPR_SPRDM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SSPR_SPRDM_Msk instead */
+#define PWM_SSPR_MASK                       _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_SSPR) Register MASK  (Use PWM_SSPR_Msk instead)  */
+#define PWM_SSPR_Msk                        _U_(0x1FFFFFF)                                 /**< (PWM_SSPR) Register Mask  */
+
+
+/* -------- PWM_SSPUP : (PWM Offset: 0xa4) (/W 32) PWM Spread Spectrum Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPRDUP:24;                 /**< bit:  0..23  Spread Spectrum Limit Value Update       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SSPUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SSPUP_OFFSET                    (0xA4)                                        /**<  (PWM_SSPUP) PWM Spread Spectrum Update Register  Offset */
+
+#define PWM_SSPUP_SPRDUP_Pos                0                                              /**< (PWM_SSPUP) Spread Spectrum Limit Value Update Position */
+#define PWM_SSPUP_SPRDUP_Msk                (_U_(0xFFFFFF) << PWM_SSPUP_SPRDUP_Pos)        /**< (PWM_SSPUP) Spread Spectrum Limit Value Update Mask */
+#define PWM_SSPUP_SPRDUP(value)             (PWM_SSPUP_SPRDUP_Msk & ((value) << PWM_SSPUP_SPRDUP_Pos))
+#define PWM_SSPUP_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (PWM_SSPUP) Register MASK  (Use PWM_SSPUP_Msk instead)  */
+#define PWM_SSPUP_Msk                       _U_(0xFFFFFF)                                  /**< (PWM_SSPUP) Register Mask  */
+
+
+/* -------- PWM_SMMR : (PWM Offset: 0xb0) (R/W 32) PWM Stepper Motor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GCEN0:1;                   /**< bit:      0  Gray Count ENable                        */
+    uint32_t GCEN1:1;                   /**< bit:      1  Gray Count ENable                        */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t DOWN0:1;                   /**< bit:     16  DOWN Count                               */
+    uint32_t DOWN1:1;                   /**< bit:     17  DOWN Count                               */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t GCEN:2;                    /**< bit:   0..1  Gray Count ENable                        */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t DOWN:2;                    /**< bit: 16..17  DOWN Count                               */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SMMR_OFFSET                     (0xB0)                                        /**<  (PWM_SMMR) PWM Stepper Motor Mode Register  Offset */
+
+#define PWM_SMMR_GCEN0_Pos                  0                                              /**< (PWM_SMMR) Gray Count ENable Position */
+#define PWM_SMMR_GCEN0_Msk                  (_U_(0x1) << PWM_SMMR_GCEN0_Pos)               /**< (PWM_SMMR) Gray Count ENable Mask */
+#define PWM_SMMR_GCEN0                      PWM_SMMR_GCEN0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_GCEN0_Msk instead */
+#define PWM_SMMR_GCEN1_Pos                  1                                              /**< (PWM_SMMR) Gray Count ENable Position */
+#define PWM_SMMR_GCEN1_Msk                  (_U_(0x1) << PWM_SMMR_GCEN1_Pos)               /**< (PWM_SMMR) Gray Count ENable Mask */
+#define PWM_SMMR_GCEN1                      PWM_SMMR_GCEN1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_GCEN1_Msk instead */
+#define PWM_SMMR_DOWN0_Pos                  16                                             /**< (PWM_SMMR) DOWN Count Position */
+#define PWM_SMMR_DOWN0_Msk                  (_U_(0x1) << PWM_SMMR_DOWN0_Pos)               /**< (PWM_SMMR) DOWN Count Mask */
+#define PWM_SMMR_DOWN0                      PWM_SMMR_DOWN0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_DOWN0_Msk instead */
+#define PWM_SMMR_DOWN1_Pos                  17                                             /**< (PWM_SMMR) DOWN Count Position */
+#define PWM_SMMR_DOWN1_Msk                  (_U_(0x1) << PWM_SMMR_DOWN1_Pos)               /**< (PWM_SMMR) DOWN Count Mask */
+#define PWM_SMMR_DOWN1                      PWM_SMMR_DOWN1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_DOWN1_Msk instead */
+#define PWM_SMMR_MASK                       _U_(0x30003)                                   /**< \deprecated (PWM_SMMR) Register MASK  (Use PWM_SMMR_Msk instead)  */
+#define PWM_SMMR_Msk                        _U_(0x30003)                                   /**< (PWM_SMMR) Register Mask  */
+
+#define PWM_SMMR_GCEN_Pos                   0                                              /**< (PWM_SMMR Position) Gray Count ENable */
+#define PWM_SMMR_GCEN_Msk                   (_U_(0x3) << PWM_SMMR_GCEN_Pos)                /**< (PWM_SMMR Mask) GCEN */
+#define PWM_SMMR_GCEN(value)                (PWM_SMMR_GCEN_Msk & ((value) << PWM_SMMR_GCEN_Pos))  
+#define PWM_SMMR_DOWN_Pos                   16                                             /**< (PWM_SMMR Position) DOWN Count */
+#define PWM_SMMR_DOWN_Msk                   (_U_(0x3) << PWM_SMMR_DOWN_Pos)                /**< (PWM_SMMR Mask) DOWN */
+#define PWM_SMMR_DOWN(value)                (PWM_SMMR_DOWN_Msk & ((value) << PWM_SMMR_DOWN_Pos))  
+
+/* -------- PWM_FPV2 : (PWM Offset: 0xc0) (R/W 32) PWM Fault Protection Value 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPZH0:1;                   /**< bit:      0  Fault Protection to Hi-Z for PWMH output on channel 0 */
+    uint32_t FPZH1:1;                   /**< bit:      1  Fault Protection to Hi-Z for PWMH output on channel 1 */
+    uint32_t FPZH2:1;                   /**< bit:      2  Fault Protection to Hi-Z for PWMH output on channel 2 */
+    uint32_t FPZH3:1;                   /**< bit:      3  Fault Protection to Hi-Z for PWMH output on channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPZL0:1;                   /**< bit:     16  Fault Protection to Hi-Z for PWML output on channel 0 */
+    uint32_t FPZL1:1;                   /**< bit:     17  Fault Protection to Hi-Z for PWML output on channel 1 */
+    uint32_t FPZL2:1;                   /**< bit:     18  Fault Protection to Hi-Z for PWML output on channel 2 */
+    uint32_t FPZL3:1;                   /**< bit:     19  Fault Protection to Hi-Z for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FPZH:4;                    /**< bit:   0..3  Fault Protection to Hi-Z for PWMH output on channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPZL:4;                    /**< bit: 16..19  Fault Protection to Hi-Z for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPV2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPV2_OFFSET                     (0xC0)                                        /**<  (PWM_FPV2) PWM Fault Protection Value 2 Register  Offset */
+
+#define PWM_FPV2_FPZH0_Pos                  0                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 0 Position */
+#define PWM_FPV2_FPZH0_Msk                  (_U_(0x1) << PWM_FPV2_FPZH0_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 0 Mask */
+#define PWM_FPV2_FPZH0                      PWM_FPV2_FPZH0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH0_Msk instead */
+#define PWM_FPV2_FPZH1_Pos                  1                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 1 Position */
+#define PWM_FPV2_FPZH1_Msk                  (_U_(0x1) << PWM_FPV2_FPZH1_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 1 Mask */
+#define PWM_FPV2_FPZH1                      PWM_FPV2_FPZH1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH1_Msk instead */
+#define PWM_FPV2_FPZH2_Pos                  2                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 2 Position */
+#define PWM_FPV2_FPZH2_Msk                  (_U_(0x1) << PWM_FPV2_FPZH2_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 2 Mask */
+#define PWM_FPV2_FPZH2                      PWM_FPV2_FPZH2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH2_Msk instead */
+#define PWM_FPV2_FPZH3_Pos                  3                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 3 Position */
+#define PWM_FPV2_FPZH3_Msk                  (_U_(0x1) << PWM_FPV2_FPZH3_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 3 Mask */
+#define PWM_FPV2_FPZH3                      PWM_FPV2_FPZH3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH3_Msk instead */
+#define PWM_FPV2_FPZL0_Pos                  16                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 0 Position */
+#define PWM_FPV2_FPZL0_Msk                  (_U_(0x1) << PWM_FPV2_FPZL0_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 0 Mask */
+#define PWM_FPV2_FPZL0                      PWM_FPV2_FPZL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL0_Msk instead */
+#define PWM_FPV2_FPZL1_Pos                  17                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 1 Position */
+#define PWM_FPV2_FPZL1_Msk                  (_U_(0x1) << PWM_FPV2_FPZL1_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 1 Mask */
+#define PWM_FPV2_FPZL1                      PWM_FPV2_FPZL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL1_Msk instead */
+#define PWM_FPV2_FPZL2_Pos                  18                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 2 Position */
+#define PWM_FPV2_FPZL2_Msk                  (_U_(0x1) << PWM_FPV2_FPZL2_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 2 Mask */
+#define PWM_FPV2_FPZL2                      PWM_FPV2_FPZL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL2_Msk instead */
+#define PWM_FPV2_FPZL3_Pos                  19                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 3 Position */
+#define PWM_FPV2_FPZL3_Msk                  (_U_(0x1) << PWM_FPV2_FPZL3_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 3 Mask */
+#define PWM_FPV2_FPZL3                      PWM_FPV2_FPZL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL3_Msk instead */
+#define PWM_FPV2_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_FPV2) Register MASK  (Use PWM_FPV2_Msk instead)  */
+#define PWM_FPV2_Msk                        _U_(0xF000F)                                   /**< (PWM_FPV2) Register Mask  */
+
+#define PWM_FPV2_FPZH_Pos                   0                                              /**< (PWM_FPV2 Position) Fault Protection to Hi-Z for PWMH output on channel x */
+#define PWM_FPV2_FPZH_Msk                   (_U_(0xF) << PWM_FPV2_FPZH_Pos)                /**< (PWM_FPV2 Mask) FPZH */
+#define PWM_FPV2_FPZH(value)                (PWM_FPV2_FPZH_Msk & ((value) << PWM_FPV2_FPZH_Pos))  
+#define PWM_FPV2_FPZL_Pos                   16                                             /**< (PWM_FPV2 Position) Fault Protection to Hi-Z for PWML output on channel 3 */
+#define PWM_FPV2_FPZL_Msk                   (_U_(0xF) << PWM_FPV2_FPZL_Pos)                /**< (PWM_FPV2 Mask) FPZL */
+#define PWM_FPV2_FPZL(value)                (PWM_FPV2_FPZL_Msk & ((value) << PWM_FPV2_FPZL_Pos))  
+
+/* -------- PWM_WPCR : (PWM Offset: 0xe4) (/W 32) PWM Write Protection Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPCMD:2;                   /**< bit:   0..1  Write Protection Command                 */
+    uint32_t WPRG0:1;                   /**< bit:      2  Write Protection Register Group 0        */
+    uint32_t WPRG1:1;                   /**< bit:      3  Write Protection Register Group 1        */
+    uint32_t WPRG2:1;                   /**< bit:      4  Write Protection Register Group 2        */
+    uint32_t WPRG3:1;                   /**< bit:      5  Write Protection Register Group 3        */
+    uint32_t WPRG4:1;                   /**< bit:      6  Write Protection Register Group 4        */
+    uint32_t WPRG5:1;                   /**< bit:      7  Write Protection Register Group 5        */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t WPRG:6;                    /**< bit:   2..7  Write Protection Register Group x        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_WPCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_WPCR_OFFSET                     (0xE4)                                        /**<  (PWM_WPCR) PWM Write Protection Control Register  Offset */
+
+#define PWM_WPCR_WPCMD_Pos                  0                                              /**< (PWM_WPCR) Write Protection Command Position */
+#define PWM_WPCR_WPCMD_Msk                  (_U_(0x3) << PWM_WPCR_WPCMD_Pos)               /**< (PWM_WPCR) Write Protection Command Mask */
+#define PWM_WPCR_WPCMD(value)               (PWM_WPCR_WPCMD_Msk & ((value) << PWM_WPCR_WPCMD_Pos))
+#define   PWM_WPCR_WPCMD_DISABLE_SW_PROT_Val _U_(0x0)                                       /**< (PWM_WPCR) Disables the software write protection of the register groups of which the bit WPRGx is at '1'.  */
+#define   PWM_WPCR_WPCMD_ENABLE_SW_PROT_Val _U_(0x1)                                       /**< (PWM_WPCR) Enables the software write protection of the register groups of which the bit WPRGx is at '1'.  */
+#define   PWM_WPCR_WPCMD_ENABLE_HW_PROT_Val _U_(0x2)                                       /**< (PWM_WPCR) Enables the hardware write protection of the register groups of which the bit WPRGx is at '1'. Only a hardware reset of the PWM controller can disable the hardware write protection. Moreover, to meet security requirements, the PIO lines associated with the PWM can not be configured through the PIO interface.  */
+#define PWM_WPCR_WPCMD_DISABLE_SW_PROT      (PWM_WPCR_WPCMD_DISABLE_SW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Disables the software write protection of the register groups of which the bit WPRGx is at '1'. Position  */
+#define PWM_WPCR_WPCMD_ENABLE_SW_PROT       (PWM_WPCR_WPCMD_ENABLE_SW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Enables the software write protection of the register groups of which the bit WPRGx is at '1'. Position  */
+#define PWM_WPCR_WPCMD_ENABLE_HW_PROT       (PWM_WPCR_WPCMD_ENABLE_HW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Enables the hardware write protection of the register groups of which the bit WPRGx is at '1'. Only a hardware reset of the PWM controller can disable the hardware write protection. Moreover, to meet security requirements, the PIO lines associated with the PWM can not be configured through the PIO interface. Position  */
+#define PWM_WPCR_WPRG0_Pos                  2                                              /**< (PWM_WPCR) Write Protection Register Group 0 Position */
+#define PWM_WPCR_WPRG0_Msk                  (_U_(0x1) << PWM_WPCR_WPRG0_Pos)               /**< (PWM_WPCR) Write Protection Register Group 0 Mask */
+#define PWM_WPCR_WPRG0                      PWM_WPCR_WPRG0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG0_Msk instead */
+#define PWM_WPCR_WPRG1_Pos                  3                                              /**< (PWM_WPCR) Write Protection Register Group 1 Position */
+#define PWM_WPCR_WPRG1_Msk                  (_U_(0x1) << PWM_WPCR_WPRG1_Pos)               /**< (PWM_WPCR) Write Protection Register Group 1 Mask */
+#define PWM_WPCR_WPRG1                      PWM_WPCR_WPRG1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG1_Msk instead */
+#define PWM_WPCR_WPRG2_Pos                  4                                              /**< (PWM_WPCR) Write Protection Register Group 2 Position */
+#define PWM_WPCR_WPRG2_Msk                  (_U_(0x1) << PWM_WPCR_WPRG2_Pos)               /**< (PWM_WPCR) Write Protection Register Group 2 Mask */
+#define PWM_WPCR_WPRG2                      PWM_WPCR_WPRG2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG2_Msk instead */
+#define PWM_WPCR_WPRG3_Pos                  5                                              /**< (PWM_WPCR) Write Protection Register Group 3 Position */
+#define PWM_WPCR_WPRG3_Msk                  (_U_(0x1) << PWM_WPCR_WPRG3_Pos)               /**< (PWM_WPCR) Write Protection Register Group 3 Mask */
+#define PWM_WPCR_WPRG3                      PWM_WPCR_WPRG3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG3_Msk instead */
+#define PWM_WPCR_WPRG4_Pos                  6                                              /**< (PWM_WPCR) Write Protection Register Group 4 Position */
+#define PWM_WPCR_WPRG4_Msk                  (_U_(0x1) << PWM_WPCR_WPRG4_Pos)               /**< (PWM_WPCR) Write Protection Register Group 4 Mask */
+#define PWM_WPCR_WPRG4                      PWM_WPCR_WPRG4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG4_Msk instead */
+#define PWM_WPCR_WPRG5_Pos                  7                                              /**< (PWM_WPCR) Write Protection Register Group 5 Position */
+#define PWM_WPCR_WPRG5_Msk                  (_U_(0x1) << PWM_WPCR_WPRG5_Pos)               /**< (PWM_WPCR) Write Protection Register Group 5 Mask */
+#define PWM_WPCR_WPRG5                      PWM_WPCR_WPRG5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG5_Msk instead */
+#define PWM_WPCR_WPKEY_Pos                  8                                              /**< (PWM_WPCR) Write Protection Key Position */
+#define PWM_WPCR_WPKEY_Msk                  (_U_(0xFFFFFF) << PWM_WPCR_WPKEY_Pos)          /**< (PWM_WPCR) Write Protection Key Mask */
+#define PWM_WPCR_WPKEY(value)               (PWM_WPCR_WPKEY_Msk & ((value) << PWM_WPCR_WPKEY_Pos))
+#define   PWM_WPCR_WPKEY_PASSWD_Val         _U_(0x50574D)                                  /**< (PWM_WPCR) Writing any other value in this field aborts the write operation of the WPCMD field.Always reads as 0  */
+#define PWM_WPCR_WPKEY_PASSWD               (PWM_WPCR_WPKEY_PASSWD_Val << PWM_WPCR_WPKEY_Pos)  /**< (PWM_WPCR) Writing any other value in this field aborts the write operation of the WPCMD field.Always reads as 0 Position  */
+#define PWM_WPCR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_WPCR) Register MASK  (Use PWM_WPCR_Msk instead)  */
+#define PWM_WPCR_Msk                        _U_(0xFFFFFFFF)                                /**< (PWM_WPCR) Register Mask  */
+
+#define PWM_WPCR_WPRG_Pos                   2                                              /**< (PWM_WPCR Position) Write Protection Register Group x */
+#define PWM_WPCR_WPRG_Msk                   (_U_(0x3F) << PWM_WPCR_WPRG_Pos)               /**< (PWM_WPCR Mask) WPRG */
+#define PWM_WPCR_WPRG(value)                (PWM_WPCR_WPRG_Msk & ((value) << PWM_WPCR_WPRG_Pos))  
+
+/* -------- PWM_WPSR : (PWM Offset: 0xe8) (R/ 32) PWM Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPSWS0:1;                  /**< bit:      0  Write Protect SW Status                  */
+    uint32_t WPSWS1:1;                  /**< bit:      1  Write Protect SW Status                  */
+    uint32_t WPSWS2:1;                  /**< bit:      2  Write Protect SW Status                  */
+    uint32_t WPSWS3:1;                  /**< bit:      3  Write Protect SW Status                  */
+    uint32_t WPSWS4:1;                  /**< bit:      4  Write Protect SW Status                  */
+    uint32_t WPSWS5:1;                  /**< bit:      5  Write Protect SW Status                  */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t WPVS:1;                    /**< bit:      7  Write Protect Violation Status           */
+    uint32_t WPHWS0:1;                  /**< bit:      8  Write Protect HW Status                  */
+    uint32_t WPHWS1:1;                  /**< bit:      9  Write Protect HW Status                  */
+    uint32_t WPHWS2:1;                  /**< bit:     10  Write Protect HW Status                  */
+    uint32_t WPHWS3:1;                  /**< bit:     11  Write Protect HW Status                  */
+    uint32_t WPHWS4:1;                  /**< bit:     12  Write Protect HW Status                  */
+    uint32_t WPHWS5:1;                  /**< bit:     13  Write Protect HW Status                  */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit: 16..31  Write Protect Violation Source           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WPSWS:6;                   /**< bit:   0..5  Write Protect SW Status                  */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t WPHWS:6;                   /**< bit:  8..13  Write Protect HW Status                  */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_WPSR_OFFSET                     (0xE8)                                        /**<  (PWM_WPSR) PWM Write Protection Status Register  Offset */
+
+#define PWM_WPSR_WPSWS0_Pos                 0                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS0_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS0_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS0                     PWM_WPSR_WPSWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS0_Msk instead */
+#define PWM_WPSR_WPSWS1_Pos                 1                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS1_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS1_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS1                     PWM_WPSR_WPSWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS1_Msk instead */
+#define PWM_WPSR_WPSWS2_Pos                 2                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS2_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS2_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS2                     PWM_WPSR_WPSWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS2_Msk instead */
+#define PWM_WPSR_WPSWS3_Pos                 3                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS3_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS3_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS3                     PWM_WPSR_WPSWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS3_Msk instead */
+#define PWM_WPSR_WPSWS4_Pos                 4                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS4_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS4_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS4                     PWM_WPSR_WPSWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS4_Msk instead */
+#define PWM_WPSR_WPSWS5_Pos                 5                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS5_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS5_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS5                     PWM_WPSR_WPSWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS5_Msk instead */
+#define PWM_WPSR_WPVS_Pos                   7                                              /**< (PWM_WPSR) Write Protect Violation Status Position */
+#define PWM_WPSR_WPVS_Msk                   (_U_(0x1) << PWM_WPSR_WPVS_Pos)                /**< (PWM_WPSR) Write Protect Violation Status Mask */
+#define PWM_WPSR_WPVS                       PWM_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPVS_Msk instead */
+#define PWM_WPSR_WPHWS0_Pos                 8                                              /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS0_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS0_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS0                     PWM_WPSR_WPHWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS0_Msk instead */
+#define PWM_WPSR_WPHWS1_Pos                 9                                              /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS1_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS1_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS1                     PWM_WPSR_WPHWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS1_Msk instead */
+#define PWM_WPSR_WPHWS2_Pos                 10                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS2_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS2_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS2                     PWM_WPSR_WPHWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS2_Msk instead */
+#define PWM_WPSR_WPHWS3_Pos                 11                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS3_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS3_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS3                     PWM_WPSR_WPHWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS3_Msk instead */
+#define PWM_WPSR_WPHWS4_Pos                 12                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS4_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS4_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS4                     PWM_WPSR_WPHWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS4_Msk instead */
+#define PWM_WPSR_WPHWS5_Pos                 13                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS5_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS5_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS5                     PWM_WPSR_WPHWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS5_Msk instead */
+#define PWM_WPSR_WPVSRC_Pos                 16                                             /**< (PWM_WPSR) Write Protect Violation Source Position */
+#define PWM_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PWM_WPSR_WPVSRC_Pos)           /**< (PWM_WPSR) Write Protect Violation Source Mask */
+#define PWM_WPSR_WPVSRC(value)              (PWM_WPSR_WPVSRC_Msk & ((value) << PWM_WPSR_WPVSRC_Pos))
+#define PWM_WPSR_MASK                       _U_(0xFFFF3FBF)                                /**< \deprecated (PWM_WPSR) Register MASK  (Use PWM_WPSR_Msk instead)  */
+#define PWM_WPSR_Msk                        _U_(0xFFFF3FBF)                                /**< (PWM_WPSR) Register Mask  */
+
+#define PWM_WPSR_WPSWS_Pos                  0                                              /**< (PWM_WPSR Position) Write Protect SW Status */
+#define PWM_WPSR_WPSWS_Msk                  (_U_(0x3F) << PWM_WPSR_WPSWS_Pos)              /**< (PWM_WPSR Mask) WPSWS */
+#define PWM_WPSR_WPSWS(value)               (PWM_WPSR_WPSWS_Msk & ((value) << PWM_WPSR_WPSWS_Pos))  
+#define PWM_WPSR_WPHWS_Pos                  8                                              /**< (PWM_WPSR Position) Write Protect HW Status */
+#define PWM_WPSR_WPHWS_Msk                  (_U_(0x3F) << PWM_WPSR_WPHWS_Pos)              /**< (PWM_WPSR Mask) WPHWS */
+#define PWM_WPSR_WPHWS(value)               (PWM_WPSR_WPHWS_Msk & ((value) << PWM_WPSR_WPHWS_Pos))  
+
+/* -------- PWM_VERSION : (PWM Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_VERSION_OFFSET                  (0xFC)                                        /**<  (PWM_VERSION) Version Register  Offset */
+
+#define PWM_VERSION_VERSION_Pos             0                                              /**< (PWM_VERSION) Version of the Hardware Module Position */
+#define PWM_VERSION_VERSION_Msk             (_U_(0xFFF) << PWM_VERSION_VERSION_Pos)        /**< (PWM_VERSION) Version of the Hardware Module Mask */
+#define PWM_VERSION_VERSION(value)          (PWM_VERSION_VERSION_Msk & ((value) << PWM_VERSION_VERSION_Pos))
+#define PWM_VERSION_MFN_Pos                 16                                             /**< (PWM_VERSION) Metal Fix Number Position */
+#define PWM_VERSION_MFN_Msk                 (_U_(0x7) << PWM_VERSION_MFN_Pos)              /**< (PWM_VERSION) Metal Fix Number Mask */
+#define PWM_VERSION_MFN(value)              (PWM_VERSION_MFN_Msk & ((value) << PWM_VERSION_MFN_Pos))
+#define PWM_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (PWM_VERSION) Register MASK  (Use PWM_VERSION_Msk instead)  */
+#define PWM_VERSION_Msk                     _U_(0x70FFF)                                   /**< (PWM_VERSION) Register Mask  */
+
+
+/* -------- PWM_CMUPD0 : (PWM Offset: 0x400) (/W 32) PWM Channel Mode Update Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD0_OFFSET                   (0x400)                                       /**<  (PWM_CMUPD0) PWM Channel Mode Update Register (ch_num = 0)  Offset */
+
+#define PWM_CMUPD0_CPOLUP_Pos               9                                              /**< (PWM_CMUPD0) Channel Polarity Update Position */
+#define PWM_CMUPD0_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD0_CPOLUP_Pos)            /**< (PWM_CMUPD0) Channel Polarity Update Mask */
+#define PWM_CMUPD0_CPOLUP                   PWM_CMUPD0_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD0_CPOLUP_Msk instead */
+#define PWM_CMUPD0_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD0) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD0_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD0_CPOLINVUP_Pos)         /**< (PWM_CMUPD0) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD0_CPOLINVUP                PWM_CMUPD0_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD0_CPOLINVUP_Msk instead */
+#define PWM_CMUPD0_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD0) Register MASK  (Use PWM_CMUPD0_Msk instead)  */
+#define PWM_CMUPD0_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD0) Register Mask  */
+
+
+/* -------- PWM_CMUPD1 : (PWM Offset: 0x420) (/W 32) PWM Channel Mode Update Register (ch_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD1_OFFSET                   (0x420)                                       /**<  (PWM_CMUPD1) PWM Channel Mode Update Register (ch_num = 1)  Offset */
+
+#define PWM_CMUPD1_CPOLUP_Pos               9                                              /**< (PWM_CMUPD1) Channel Polarity Update Position */
+#define PWM_CMUPD1_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD1_CPOLUP_Pos)            /**< (PWM_CMUPD1) Channel Polarity Update Mask */
+#define PWM_CMUPD1_CPOLUP                   PWM_CMUPD1_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD1_CPOLUP_Msk instead */
+#define PWM_CMUPD1_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD1) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD1_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD1_CPOLINVUP_Pos)         /**< (PWM_CMUPD1) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD1_CPOLINVUP                PWM_CMUPD1_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD1_CPOLINVUP_Msk instead */
+#define PWM_CMUPD1_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD1) Register MASK  (Use PWM_CMUPD1_Msk instead)  */
+#define PWM_CMUPD1_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD1) Register Mask  */
+
+
+/* -------- PWM_ETRG1 : (PWM Offset: 0x42c) (R/W 32) PWM External Trigger Register (trg_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
+    uint32_t TRGMODE:2;                 /**< bit: 24..25  External Trigger Mode                    */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t TRGEDGE:1;                 /**< bit:     28  Edge Selection                           */
+    uint32_t TRGFILT:1;                 /**< bit:     29  Filtered input                           */
+    uint32_t TRGSRC:1;                  /**< bit:     30  Trigger Source                           */
+    uint32_t RFEN:1;                    /**< bit:     31  Recoverable Fault Enable                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ETRG1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ETRG1_OFFSET                    (0x42C)                                       /**<  (PWM_ETRG1) PWM External Trigger Register (trg_num = 1)  Offset */
+
+#define PWM_ETRG1_MAXCNT_Pos                0                                              /**< (PWM_ETRG1) Maximum Counter value Position */
+#define PWM_ETRG1_MAXCNT_Msk                (_U_(0xFFFFFF) << PWM_ETRG1_MAXCNT_Pos)        /**< (PWM_ETRG1) Maximum Counter value Mask */
+#define PWM_ETRG1_MAXCNT(value)             (PWM_ETRG1_MAXCNT_Msk & ((value) << PWM_ETRG1_MAXCNT_Pos))
+#define PWM_ETRG1_TRGMODE_Pos               24                                             /**< (PWM_ETRG1) External Trigger Mode Position */
+#define PWM_ETRG1_TRGMODE_Msk               (_U_(0x3) << PWM_ETRG1_TRGMODE_Pos)            /**< (PWM_ETRG1) External Trigger Mode Mask */
+#define PWM_ETRG1_TRGMODE(value)            (PWM_ETRG1_TRGMODE_Msk & ((value) << PWM_ETRG1_TRGMODE_Pos))
+#define   PWM_ETRG1_TRGMODE_OFF_Val         _U_(0x0)                                       /**< (PWM_ETRG1) External trigger is not enabled.  */
+#define   PWM_ETRG1_TRGMODE_MODE1_Val       _U_(0x1)                                       /**< (PWM_ETRG1) External PWM Reset Mode  */
+#define   PWM_ETRG1_TRGMODE_MODE2_Val       _U_(0x2)                                       /**< (PWM_ETRG1) External PWM Start Mode  */
+#define   PWM_ETRG1_TRGMODE_MODE3_Val       _U_(0x3)                                       /**< (PWM_ETRG1) Cycle-by-cycle Duty Mode  */
+#define PWM_ETRG1_TRGMODE_OFF               (PWM_ETRG1_TRGMODE_OFF_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External trigger is not enabled. Position  */
+#define PWM_ETRG1_TRGMODE_MODE1             (PWM_ETRG1_TRGMODE_MODE1_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External PWM Reset Mode Position  */
+#define PWM_ETRG1_TRGMODE_MODE2             (PWM_ETRG1_TRGMODE_MODE2_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External PWM Start Mode Position  */
+#define PWM_ETRG1_TRGMODE_MODE3             (PWM_ETRG1_TRGMODE_MODE3_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) Cycle-by-cycle Duty Mode Position  */
+#define PWM_ETRG1_TRGEDGE_Pos               28                                             /**< (PWM_ETRG1) Edge Selection Position */
+#define PWM_ETRG1_TRGEDGE_Msk               (_U_(0x1) << PWM_ETRG1_TRGEDGE_Pos)            /**< (PWM_ETRG1) Edge Selection Mask */
+#define PWM_ETRG1_TRGEDGE                   PWM_ETRG1_TRGEDGE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGEDGE_Msk instead */
+#define   PWM_ETRG1_TRGEDGE_FALLING_ZERO_Val _U_(0x0)                                       /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0  */
+#define   PWM_ETRG1_TRGEDGE_RISING_ONE_Val  _U_(0x1)                                       /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1  */
+#define PWM_ETRG1_TRGEDGE_FALLING_ZERO      (PWM_ETRG1_TRGEDGE_FALLING_ZERO_Val << PWM_ETRG1_TRGEDGE_Pos)  /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0 Position  */
+#define PWM_ETRG1_TRGEDGE_RISING_ONE        (PWM_ETRG1_TRGEDGE_RISING_ONE_Val << PWM_ETRG1_TRGEDGE_Pos)  /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1 Position  */
+#define PWM_ETRG1_TRGFILT_Pos               29                                             /**< (PWM_ETRG1) Filtered input Position */
+#define PWM_ETRG1_TRGFILT_Msk               (_U_(0x1) << PWM_ETRG1_TRGFILT_Pos)            /**< (PWM_ETRG1) Filtered input Mask */
+#define PWM_ETRG1_TRGFILT                   PWM_ETRG1_TRGFILT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGFILT_Msk instead */
+#define PWM_ETRG1_TRGSRC_Pos                30                                             /**< (PWM_ETRG1) Trigger Source Position */
+#define PWM_ETRG1_TRGSRC_Msk                (_U_(0x1) << PWM_ETRG1_TRGSRC_Pos)             /**< (PWM_ETRG1) Trigger Source Mask */
+#define PWM_ETRG1_TRGSRC                    PWM_ETRG1_TRGSRC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGSRC_Msk instead */
+#define PWM_ETRG1_RFEN_Pos                  31                                             /**< (PWM_ETRG1) Recoverable Fault Enable Position */
+#define PWM_ETRG1_RFEN_Msk                  (_U_(0x1) << PWM_ETRG1_RFEN_Pos)               /**< (PWM_ETRG1) Recoverable Fault Enable Mask */
+#define PWM_ETRG1_RFEN                      PWM_ETRG1_RFEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_RFEN_Msk instead */
+#define PWM_ETRG1_MASK                      _U_(0xF3FFFFFF)                                /**< \deprecated (PWM_ETRG1) Register MASK  (Use PWM_ETRG1_Msk instead)  */
+#define PWM_ETRG1_Msk                       _U_(0xF3FFFFFF)                                /**< (PWM_ETRG1) Register Mask  */
+
+
+/* -------- PWM_LEBR1 : (PWM Offset: 0x430) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t PWMLFEN:1;                 /**< bit:     16  PWML Falling Edge Enable                 */
+    uint32_t PWMLREN:1;                 /**< bit:     17  PWML Rising Edge Enable                  */
+    uint32_t PWMHFEN:1;                 /**< bit:     18  PWMH Falling Edge Enable                 */
+    uint32_t PWMHREN:1;                 /**< bit:     19  PWMH Rising Edge Enable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_LEBR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_LEBR1_OFFSET                    (0x430)                                       /**<  (PWM_LEBR1) PWM Leading-Edge Blanking Register (trg_num = 1)  Offset */
+
+#define PWM_LEBR1_LEBDELAY_Pos              0                                              /**< (PWM_LEBR1) Leading-Edge Blanking Delay for TRGINx Position */
+#define PWM_LEBR1_LEBDELAY_Msk              (_U_(0x7F) << PWM_LEBR1_LEBDELAY_Pos)          /**< (PWM_LEBR1) Leading-Edge Blanking Delay for TRGINx Mask */
+#define PWM_LEBR1_LEBDELAY(value)           (PWM_LEBR1_LEBDELAY_Msk & ((value) << PWM_LEBR1_LEBDELAY_Pos))
+#define PWM_LEBR1_PWMLFEN_Pos               16                                             /**< (PWM_LEBR1) PWML Falling Edge Enable Position */
+#define PWM_LEBR1_PWMLFEN_Msk               (_U_(0x1) << PWM_LEBR1_PWMLFEN_Pos)            /**< (PWM_LEBR1) PWML Falling Edge Enable Mask */
+#define PWM_LEBR1_PWMLFEN                   PWM_LEBR1_PWMLFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMLFEN_Msk instead */
+#define PWM_LEBR1_PWMLREN_Pos               17                                             /**< (PWM_LEBR1) PWML Rising Edge Enable Position */
+#define PWM_LEBR1_PWMLREN_Msk               (_U_(0x1) << PWM_LEBR1_PWMLREN_Pos)            /**< (PWM_LEBR1) PWML Rising Edge Enable Mask */
+#define PWM_LEBR1_PWMLREN                   PWM_LEBR1_PWMLREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMLREN_Msk instead */
+#define PWM_LEBR1_PWMHFEN_Pos               18                                             /**< (PWM_LEBR1) PWMH Falling Edge Enable Position */
+#define PWM_LEBR1_PWMHFEN_Msk               (_U_(0x1) << PWM_LEBR1_PWMHFEN_Pos)            /**< (PWM_LEBR1) PWMH Falling Edge Enable Mask */
+#define PWM_LEBR1_PWMHFEN                   PWM_LEBR1_PWMHFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMHFEN_Msk instead */
+#define PWM_LEBR1_PWMHREN_Pos               19                                             /**< (PWM_LEBR1) PWMH Rising Edge Enable Position */
+#define PWM_LEBR1_PWMHREN_Msk               (_U_(0x1) << PWM_LEBR1_PWMHREN_Pos)            /**< (PWM_LEBR1) PWMH Rising Edge Enable Mask */
+#define PWM_LEBR1_PWMHREN                   PWM_LEBR1_PWMHREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMHREN_Msk instead */
+#define PWM_LEBR1_MASK                      _U_(0xF007F)                                   /**< \deprecated (PWM_LEBR1) Register MASK  (Use PWM_LEBR1_Msk instead)  */
+#define PWM_LEBR1_Msk                       _U_(0xF007F)                                   /**< (PWM_LEBR1) Register Mask  */
+
+
+/* -------- PWM_CMUPD2 : (PWM Offset: 0x440) (/W 32) PWM Channel Mode Update Register (ch_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD2_OFFSET                   (0x440)                                       /**<  (PWM_CMUPD2) PWM Channel Mode Update Register (ch_num = 2)  Offset */
+
+#define PWM_CMUPD2_CPOLUP_Pos               9                                              /**< (PWM_CMUPD2) Channel Polarity Update Position */
+#define PWM_CMUPD2_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD2_CPOLUP_Pos)            /**< (PWM_CMUPD2) Channel Polarity Update Mask */
+#define PWM_CMUPD2_CPOLUP                   PWM_CMUPD2_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD2_CPOLUP_Msk instead */
+#define PWM_CMUPD2_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD2) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD2_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD2_CPOLINVUP_Pos)         /**< (PWM_CMUPD2) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD2_CPOLINVUP                PWM_CMUPD2_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD2_CPOLINVUP_Msk instead */
+#define PWM_CMUPD2_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD2) Register MASK  (Use PWM_CMUPD2_Msk instead)  */
+#define PWM_CMUPD2_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD2) Register Mask  */
+
+
+/* -------- PWM_ETRG2 : (PWM Offset: 0x44c) (R/W 32) PWM External Trigger Register (trg_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
+    uint32_t TRGMODE:2;                 /**< bit: 24..25  External Trigger Mode                    */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t TRGEDGE:1;                 /**< bit:     28  Edge Selection                           */
+    uint32_t TRGFILT:1;                 /**< bit:     29  Filtered input                           */
+    uint32_t TRGSRC:1;                  /**< bit:     30  Trigger Source                           */
+    uint32_t RFEN:1;                    /**< bit:     31  Recoverable Fault Enable                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ETRG2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ETRG2_OFFSET                    (0x44C)                                       /**<  (PWM_ETRG2) PWM External Trigger Register (trg_num = 2)  Offset */
+
+#define PWM_ETRG2_MAXCNT_Pos                0                                              /**< (PWM_ETRG2) Maximum Counter value Position */
+#define PWM_ETRG2_MAXCNT_Msk                (_U_(0xFFFFFF) << PWM_ETRG2_MAXCNT_Pos)        /**< (PWM_ETRG2) Maximum Counter value Mask */
+#define PWM_ETRG2_MAXCNT(value)             (PWM_ETRG2_MAXCNT_Msk & ((value) << PWM_ETRG2_MAXCNT_Pos))
+#define PWM_ETRG2_TRGMODE_Pos               24                                             /**< (PWM_ETRG2) External Trigger Mode Position */
+#define PWM_ETRG2_TRGMODE_Msk               (_U_(0x3) << PWM_ETRG2_TRGMODE_Pos)            /**< (PWM_ETRG2) External Trigger Mode Mask */
+#define PWM_ETRG2_TRGMODE(value)            (PWM_ETRG2_TRGMODE_Msk & ((value) << PWM_ETRG2_TRGMODE_Pos))
+#define   PWM_ETRG2_TRGMODE_OFF_Val         _U_(0x0)                                       /**< (PWM_ETRG2) External trigger is not enabled.  */
+#define   PWM_ETRG2_TRGMODE_MODE1_Val       _U_(0x1)                                       /**< (PWM_ETRG2) External PWM Reset Mode  */
+#define   PWM_ETRG2_TRGMODE_MODE2_Val       _U_(0x2)                                       /**< (PWM_ETRG2) External PWM Start Mode  */
+#define   PWM_ETRG2_TRGMODE_MODE3_Val       _U_(0x3)                                       /**< (PWM_ETRG2) Cycle-by-cycle Duty Mode  */
+#define PWM_ETRG2_TRGMODE_OFF               (PWM_ETRG2_TRGMODE_OFF_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External trigger is not enabled. Position  */
+#define PWM_ETRG2_TRGMODE_MODE1             (PWM_ETRG2_TRGMODE_MODE1_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External PWM Reset Mode Position  */
+#define PWM_ETRG2_TRGMODE_MODE2             (PWM_ETRG2_TRGMODE_MODE2_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External PWM Start Mode Position  */
+#define PWM_ETRG2_TRGMODE_MODE3             (PWM_ETRG2_TRGMODE_MODE3_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) Cycle-by-cycle Duty Mode Position  */
+#define PWM_ETRG2_TRGEDGE_Pos               28                                             /**< (PWM_ETRG2) Edge Selection Position */
+#define PWM_ETRG2_TRGEDGE_Msk               (_U_(0x1) << PWM_ETRG2_TRGEDGE_Pos)            /**< (PWM_ETRG2) Edge Selection Mask */
+#define PWM_ETRG2_TRGEDGE                   PWM_ETRG2_TRGEDGE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGEDGE_Msk instead */
+#define   PWM_ETRG2_TRGEDGE_FALLING_ZERO_Val _U_(0x0)                                       /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0  */
+#define   PWM_ETRG2_TRGEDGE_RISING_ONE_Val  _U_(0x1)                                       /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1  */
+#define PWM_ETRG2_TRGEDGE_FALLING_ZERO      (PWM_ETRG2_TRGEDGE_FALLING_ZERO_Val << PWM_ETRG2_TRGEDGE_Pos)  /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0 Position  */
+#define PWM_ETRG2_TRGEDGE_RISING_ONE        (PWM_ETRG2_TRGEDGE_RISING_ONE_Val << PWM_ETRG2_TRGEDGE_Pos)  /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1 Position  */
+#define PWM_ETRG2_TRGFILT_Pos               29                                             /**< (PWM_ETRG2) Filtered input Position */
+#define PWM_ETRG2_TRGFILT_Msk               (_U_(0x1) << PWM_ETRG2_TRGFILT_Pos)            /**< (PWM_ETRG2) Filtered input Mask */
+#define PWM_ETRG2_TRGFILT                   PWM_ETRG2_TRGFILT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGFILT_Msk instead */
+#define PWM_ETRG2_TRGSRC_Pos                30                                             /**< (PWM_ETRG2) Trigger Source Position */
+#define PWM_ETRG2_TRGSRC_Msk                (_U_(0x1) << PWM_ETRG2_TRGSRC_Pos)             /**< (PWM_ETRG2) Trigger Source Mask */
+#define PWM_ETRG2_TRGSRC                    PWM_ETRG2_TRGSRC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGSRC_Msk instead */
+#define PWM_ETRG2_RFEN_Pos                  31                                             /**< (PWM_ETRG2) Recoverable Fault Enable Position */
+#define PWM_ETRG2_RFEN_Msk                  (_U_(0x1) << PWM_ETRG2_RFEN_Pos)               /**< (PWM_ETRG2) Recoverable Fault Enable Mask */
+#define PWM_ETRG2_RFEN                      PWM_ETRG2_RFEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_RFEN_Msk instead */
+#define PWM_ETRG2_MASK                      _U_(0xF3FFFFFF)                                /**< \deprecated (PWM_ETRG2) Register MASK  (Use PWM_ETRG2_Msk instead)  */
+#define PWM_ETRG2_Msk                       _U_(0xF3FFFFFF)                                /**< (PWM_ETRG2) Register Mask  */
+
+
+/* -------- PWM_LEBR2 : (PWM Offset: 0x450) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t PWMLFEN:1;                 /**< bit:     16  PWML Falling Edge Enable                 */
+    uint32_t PWMLREN:1;                 /**< bit:     17  PWML Rising Edge Enable                  */
+    uint32_t PWMHFEN:1;                 /**< bit:     18  PWMH Falling Edge Enable                 */
+    uint32_t PWMHREN:1;                 /**< bit:     19  PWMH Rising Edge Enable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_LEBR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_LEBR2_OFFSET                    (0x450)                                       /**<  (PWM_LEBR2) PWM Leading-Edge Blanking Register (trg_num = 2)  Offset */
+
+#define PWM_LEBR2_LEBDELAY_Pos              0                                              /**< (PWM_LEBR2) Leading-Edge Blanking Delay for TRGINx Position */
+#define PWM_LEBR2_LEBDELAY_Msk              (_U_(0x7F) << PWM_LEBR2_LEBDELAY_Pos)          /**< (PWM_LEBR2) Leading-Edge Blanking Delay for TRGINx Mask */
+#define PWM_LEBR2_LEBDELAY(value)           (PWM_LEBR2_LEBDELAY_Msk & ((value) << PWM_LEBR2_LEBDELAY_Pos))
+#define PWM_LEBR2_PWMLFEN_Pos               16                                             /**< (PWM_LEBR2) PWML Falling Edge Enable Position */
+#define PWM_LEBR2_PWMLFEN_Msk               (_U_(0x1) << PWM_LEBR2_PWMLFEN_Pos)            /**< (PWM_LEBR2) PWML Falling Edge Enable Mask */
+#define PWM_LEBR2_PWMLFEN                   PWM_LEBR2_PWMLFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMLFEN_Msk instead */
+#define PWM_LEBR2_PWMLREN_Pos               17                                             /**< (PWM_LEBR2) PWML Rising Edge Enable Position */
+#define PWM_LEBR2_PWMLREN_Msk               (_U_(0x1) << PWM_LEBR2_PWMLREN_Pos)            /**< (PWM_LEBR2) PWML Rising Edge Enable Mask */
+#define PWM_LEBR2_PWMLREN                   PWM_LEBR2_PWMLREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMLREN_Msk instead */
+#define PWM_LEBR2_PWMHFEN_Pos               18                                             /**< (PWM_LEBR2) PWMH Falling Edge Enable Position */
+#define PWM_LEBR2_PWMHFEN_Msk               (_U_(0x1) << PWM_LEBR2_PWMHFEN_Pos)            /**< (PWM_LEBR2) PWMH Falling Edge Enable Mask */
+#define PWM_LEBR2_PWMHFEN                   PWM_LEBR2_PWMHFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMHFEN_Msk instead */
+#define PWM_LEBR2_PWMHREN_Pos               19                                             /**< (PWM_LEBR2) PWMH Rising Edge Enable Position */
+#define PWM_LEBR2_PWMHREN_Msk               (_U_(0x1) << PWM_LEBR2_PWMHREN_Pos)            /**< (PWM_LEBR2) PWMH Rising Edge Enable Mask */
+#define PWM_LEBR2_PWMHREN                   PWM_LEBR2_PWMHREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMHREN_Msk instead */
+#define PWM_LEBR2_MASK                      _U_(0xF007F)                                   /**< \deprecated (PWM_LEBR2) Register MASK  (Use PWM_LEBR2_Msk instead)  */
+#define PWM_LEBR2_Msk                       _U_(0xF007F)                                   /**< (PWM_LEBR2) Register Mask  */
+
+
+/* -------- PWM_CMUPD3 : (PWM Offset: 0x460) (/W 32) PWM Channel Mode Update Register (ch_num = 3) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD3_OFFSET                   (0x460)                                       /**<  (PWM_CMUPD3) PWM Channel Mode Update Register (ch_num = 3)  Offset */
+
+#define PWM_CMUPD3_CPOLUP_Pos               9                                              /**< (PWM_CMUPD3) Channel Polarity Update Position */
+#define PWM_CMUPD3_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD3_CPOLUP_Pos)            /**< (PWM_CMUPD3) Channel Polarity Update Mask */
+#define PWM_CMUPD3_CPOLUP                   PWM_CMUPD3_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD3_CPOLUP_Msk instead */
+#define PWM_CMUPD3_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD3) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD3_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD3_CPOLINVUP_Pos)         /**< (PWM_CMUPD3) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD3_CPOLINVUP                PWM_CMUPD3_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD3_CPOLINVUP_Msk instead */
+#define PWM_CMUPD3_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD3) Register MASK  (Use PWM_CMUPD3_Msk instead)  */
+#define PWM_CMUPD3_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD3) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PWM_CH_NUM hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CMR;        /**< (PWM_CH_NUM Offset: 0x00) PWM Channel Mode Register (ch_num = 0) */
+  __IO uint32_t PWM_CDTY;       /**< (PWM_CH_NUM Offset: 0x04) PWM Channel Duty Cycle Register (ch_num = 0) */
+  __O  uint32_t PWM_CDTYUPD;    /**< (PWM_CH_NUM Offset: 0x08) PWM Channel Duty Cycle Update Register (ch_num = 0) */
+  __IO uint32_t PWM_CPRD;       /**< (PWM_CH_NUM Offset: 0x0C) PWM Channel Period Register (ch_num = 0) */
+  __O  uint32_t PWM_CPRDUPD;    /**< (PWM_CH_NUM Offset: 0x10) PWM Channel Period Update Register (ch_num = 0) */
+  __I  uint32_t PWM_CCNT;       /**< (PWM_CH_NUM Offset: 0x14) PWM Channel Counter Register (ch_num = 0) */
+  __IO uint32_t PWM_DT;         /**< (PWM_CH_NUM Offset: 0x18) PWM Channel Dead Time Register (ch_num = 0) */
+  __O  uint32_t PWM_DTUPD;      /**< (PWM_CH_NUM Offset: 0x1C) PWM Channel Dead Time Update Register (ch_num = 0) */
+} PwmChNum;
+
+/** \brief PWM_CMP hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CMPV;       /**< (PWM_CMP Offset: 0x00) PWM Comparison 0 Value Register */
+  __O  uint32_t PWM_CMPVUPD;    /**< (PWM_CMP Offset: 0x04) PWM Comparison 0 Value Update Register */
+  __IO uint32_t PWM_CMPM;       /**< (PWM_CMP Offset: 0x08) PWM Comparison 0 Mode Register */
+  __O  uint32_t PWM_CMPMUPD;    /**< (PWM_CMP Offset: 0x0C) PWM Comparison 0 Mode Update Register */
+} PwmCmp;
+
+#define PWMCMP_NUMBER 8
+#define PWMCHNUM_NUMBER 4
+/** \brief PWM hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CLK;        /**< (PWM Offset: 0x00) PWM Clock Register */
+  __O  uint32_t PWM_ENA;        /**< (PWM Offset: 0x04) PWM Enable Register */
+  __O  uint32_t PWM_DIS;        /**< (PWM Offset: 0x08) PWM Disable Register */
+  __I  uint32_t PWM_SR;         /**< (PWM Offset: 0x0C) PWM Status Register */
+  __O  uint32_t PWM_IER1;       /**< (PWM Offset: 0x10) PWM Interrupt Enable Register 1 */
+  __O  uint32_t PWM_IDR1;       /**< (PWM Offset: 0x14) PWM Interrupt Disable Register 1 */
+  __I  uint32_t PWM_IMR1;       /**< (PWM Offset: 0x18) PWM Interrupt Mask Register 1 */
+  __I  uint32_t PWM_ISR1;       /**< (PWM Offset: 0x1C) PWM Interrupt Status Register 1 */
+  __IO uint32_t PWM_SCM;        /**< (PWM Offset: 0x20) PWM Sync Channels Mode Register */
+  __O  uint32_t PWM_DMAR;       /**< (PWM Offset: 0x24) PWM DMA Register */
+  __IO uint32_t PWM_SCUC;       /**< (PWM Offset: 0x28) PWM Sync Channels Update Control Register */
+  __IO uint32_t PWM_SCUP;       /**< (PWM Offset: 0x2C) PWM Sync Channels Update Period Register */
+  __O  uint32_t PWM_SCUPUPD;    /**< (PWM Offset: 0x30) PWM Sync Channels Update Period Update Register */
+  __O  uint32_t PWM_IER2;       /**< (PWM Offset: 0x34) PWM Interrupt Enable Register 2 */
+  __O  uint32_t PWM_IDR2;       /**< (PWM Offset: 0x38) PWM Interrupt Disable Register 2 */
+  __I  uint32_t PWM_IMR2;       /**< (PWM Offset: 0x3C) PWM Interrupt Mask Register 2 */
+  __I  uint32_t PWM_ISR2;       /**< (PWM Offset: 0x40) PWM Interrupt Status Register 2 */
+  __IO uint32_t PWM_OOV;        /**< (PWM Offset: 0x44) PWM Output Override Value Register */
+  __IO uint32_t PWM_OS;         /**< (PWM Offset: 0x48) PWM Output Selection Register */
+  __O  uint32_t PWM_OSS;        /**< (PWM Offset: 0x4C) PWM Output Selection Set Register */
+  __O  uint32_t PWM_OSC;        /**< (PWM Offset: 0x50) PWM Output Selection Clear Register */
+  __O  uint32_t PWM_OSSUPD;     /**< (PWM Offset: 0x54) PWM Output Selection Set Update Register */
+  __O  uint32_t PWM_OSCUPD;     /**< (PWM Offset: 0x58) PWM Output Selection Clear Update Register */
+  __IO uint32_t PWM_FMR;        /**< (PWM Offset: 0x5C) PWM Fault Mode Register */
+  __I  uint32_t PWM_FSR;        /**< (PWM Offset: 0x60) PWM Fault Status Register */
+  __O  uint32_t PWM_FCR;        /**< (PWM Offset: 0x64) PWM Fault Clear Register */
+  __IO uint32_t PWM_FPV1;       /**< (PWM Offset: 0x68) PWM Fault Protection Value Register 1 */
+  __IO uint32_t PWM_FPE;        /**< (PWM Offset: 0x6C) PWM Fault Protection Enable Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO uint32_t PWM_ELMR[2];    /**< (PWM Offset: 0x7C) PWM Event Line 0 Mode Register 0 */
+  __I  uint8_t                        Reserved2[28];
+  __IO uint32_t PWM_SSPR;       /**< (PWM Offset: 0xA0) PWM Spread Spectrum Register */
+  __O  uint32_t PWM_SSPUP;      /**< (PWM Offset: 0xA4) PWM Spread Spectrum Update Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO uint32_t PWM_SMMR;       /**< (PWM Offset: 0xB0) PWM Stepper Motor Mode Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO uint32_t PWM_FPV2;       /**< (PWM Offset: 0xC0) PWM Fault Protection Value 2 Register */
+  __I  uint8_t                        Reserved5[32];
+  __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
+  __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  uint32_t PWM_VERSION;    /**< (PWM Offset: 0xFC) Version Register */
+  __I  uint8_t                        Reserved7[48];
+       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved8[80];
+       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+  __I  uint8_t                        Reserved9[384];
+  __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
+  __I  uint8_t                        Reserved10[28];
+  __O  uint32_t PWM_CMUPD1;     /**< (PWM Offset: 0x420) PWM Channel Mode Update Register (ch_num = 1) */
+  __I  uint8_t                        Reserved11[8];
+  __IO uint32_t PWM_ETRG1;      /**< (PWM Offset: 0x42C) PWM External Trigger Register (trg_num = 1) */
+  __IO uint32_t PWM_LEBR1;      /**< (PWM Offset: 0x430) PWM Leading-Edge Blanking Register (trg_num = 1) */
+  __I  uint8_t                        Reserved12[12];
+  __O  uint32_t PWM_CMUPD2;     /**< (PWM Offset: 0x440) PWM Channel Mode Update Register (ch_num = 2) */
+  __I  uint8_t                        Reserved13[8];
+  __IO uint32_t PWM_ETRG2;      /**< (PWM Offset: 0x44C) PWM External Trigger Register (trg_num = 2) */
+  __IO uint32_t PWM_LEBR2;      /**< (PWM Offset: 0x450) PWM Leading-Edge Blanking Register (trg_num = 2) */
+  __I  uint8_t                        Reserved14[12];
+  __O  uint32_t PWM_CMUPD3;     /**< (PWM Offset: 0x460) PWM Channel Mode Update Register (ch_num = 3) */
+} Pwm;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PWM_CH_NUM hardware registers */
+typedef struct {  
+  __IO PWM_CMR_Type                   PWM_CMR;        /**< Offset: 0x00 (R/W  32) PWM Channel Mode Register (ch_num = 0) */
+  __IO PWM_CDTY_Type                  PWM_CDTY;       /**< Offset: 0x04 (R/W  32) PWM Channel Duty Cycle Register (ch_num = 0) */
+  __O  PWM_CDTYUPD_Type               PWM_CDTYUPD;    /**< Offset: 0x08 ( /W  32) PWM Channel Duty Cycle Update Register (ch_num = 0) */
+  __IO PWM_CPRD_Type                  PWM_CPRD;       /**< Offset: 0x0C (R/W  32) PWM Channel Period Register (ch_num = 0) */
+  __O  PWM_CPRDUPD_Type               PWM_CPRDUPD;    /**< Offset: 0x10 ( /W  32) PWM Channel Period Update Register (ch_num = 0) */
+  __I  PWM_CCNT_Type                  PWM_CCNT;       /**< Offset: 0x14 (R/   32) PWM Channel Counter Register (ch_num = 0) */
+  __IO PWM_DT_Type                    PWM_DT;         /**< Offset: 0x18 (R/W  32) PWM Channel Dead Time Register (ch_num = 0) */
+  __O  PWM_DTUPD_Type                 PWM_DTUPD;      /**< Offset: 0x1C ( /W  32) PWM Channel Dead Time Update Register (ch_num = 0) */
+} PwmChNum;
+
+/** \brief PWM_CMP hardware registers */
+typedef struct {  
+  __IO PWM_CMPV_Type                  PWM_CMPV;       /**< Offset: 0x00 (R/W  32) PWM Comparison 0 Value Register */
+  __O  PWM_CMPVUPD_Type               PWM_CMPVUPD;    /**< Offset: 0x04 ( /W  32) PWM Comparison 0 Value Update Register */
+  __IO PWM_CMPM_Type                  PWM_CMPM;       /**< Offset: 0x08 (R/W  32) PWM Comparison 0 Mode Register */
+  __O  PWM_CMPMUPD_Type               PWM_CMPMUPD;    /**< Offset: 0x0C ( /W  32) PWM Comparison 0 Mode Update Register */
+} PwmCmp;
+
+/** \brief PWM hardware registers */
+typedef struct {  
+  __IO PWM_CLK_Type                   PWM_CLK;        /**< Offset: 0x00 (R/W  32) PWM Clock Register */
+  __O  PWM_ENA_Type                   PWM_ENA;        /**< Offset: 0x04 ( /W  32) PWM Enable Register */
+  __O  PWM_DIS_Type                   PWM_DIS;        /**< Offset: 0x08 ( /W  32) PWM Disable Register */
+  __I  PWM_SR_Type                    PWM_SR;         /**< Offset: 0x0C (R/   32) PWM Status Register */
+  __O  PWM_IER1_Type                  PWM_IER1;       /**< Offset: 0x10 ( /W  32) PWM Interrupt Enable Register 1 */
+  __O  PWM_IDR1_Type                  PWM_IDR1;       /**< Offset: 0x14 ( /W  32) PWM Interrupt Disable Register 1 */
+  __I  PWM_IMR1_Type                  PWM_IMR1;       /**< Offset: 0x18 (R/   32) PWM Interrupt Mask Register 1 */
+  __I  PWM_ISR1_Type                  PWM_ISR1;       /**< Offset: 0x1C (R/   32) PWM Interrupt Status Register 1 */
+  __IO PWM_SCM_Type                   PWM_SCM;        /**< Offset: 0x20 (R/W  32) PWM Sync Channels Mode Register */
+  __O  PWM_DMAR_Type                  PWM_DMAR;       /**< Offset: 0x24 ( /W  32) PWM DMA Register */
+  __IO PWM_SCUC_Type                  PWM_SCUC;       /**< Offset: 0x28 (R/W  32) PWM Sync Channels Update Control Register */
+  __IO PWM_SCUP_Type                  PWM_SCUP;       /**< Offset: 0x2C (R/W  32) PWM Sync Channels Update Period Register */
+  __O  PWM_SCUPUPD_Type               PWM_SCUPUPD;    /**< Offset: 0x30 ( /W  32) PWM Sync Channels Update Period Update Register */
+  __O  PWM_IER2_Type                  PWM_IER2;       /**< Offset: 0x34 ( /W  32) PWM Interrupt Enable Register 2 */
+  __O  PWM_IDR2_Type                  PWM_IDR2;       /**< Offset: 0x38 ( /W  32) PWM Interrupt Disable Register 2 */
+  __I  PWM_IMR2_Type                  PWM_IMR2;       /**< Offset: 0x3C (R/   32) PWM Interrupt Mask Register 2 */
+  __I  PWM_ISR2_Type                  PWM_ISR2;       /**< Offset: 0x40 (R/   32) PWM Interrupt Status Register 2 */
+  __IO PWM_OOV_Type                   PWM_OOV;        /**< Offset: 0x44 (R/W  32) PWM Output Override Value Register */
+  __IO PWM_OS_Type                    PWM_OS;         /**< Offset: 0x48 (R/W  32) PWM Output Selection Register */
+  __O  PWM_OSS_Type                   PWM_OSS;        /**< Offset: 0x4C ( /W  32) PWM Output Selection Set Register */
+  __O  PWM_OSC_Type                   PWM_OSC;        /**< Offset: 0x50 ( /W  32) PWM Output Selection Clear Register */
+  __O  PWM_OSSUPD_Type                PWM_OSSUPD;     /**< Offset: 0x54 ( /W  32) PWM Output Selection Set Update Register */
+  __O  PWM_OSCUPD_Type                PWM_OSCUPD;     /**< Offset: 0x58 ( /W  32) PWM Output Selection Clear Update Register */
+  __IO PWM_FMR_Type                   PWM_FMR;        /**< Offset: 0x5C (R/W  32) PWM Fault Mode Register */
+  __I  PWM_FSR_Type                   PWM_FSR;        /**< Offset: 0x60 (R/   32) PWM Fault Status Register */
+  __O  PWM_FCR_Type                   PWM_FCR;        /**< Offset: 0x64 ( /W  32) PWM Fault Clear Register */
+  __IO PWM_FPV1_Type                  PWM_FPV1;       /**< Offset: 0x68 (R/W  32) PWM Fault Protection Value Register 1 */
+  __IO PWM_FPE_Type                   PWM_FPE;        /**< Offset: 0x6C (R/W  32) PWM Fault Protection Enable Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO PWM_ELMR_Type                  PWM_ELMR[2];    /**< Offset: 0x7C (R/W  32) PWM Event Line 0 Mode Register 0 */
+  __I  uint8_t                        Reserved2[28];
+  __IO PWM_SSPR_Type                  PWM_SSPR;       /**< Offset: 0xA0 (R/W  32) PWM Spread Spectrum Register */
+  __O  PWM_SSPUP_Type                 PWM_SSPUP;      /**< Offset: 0xA4 ( /W  32) PWM Spread Spectrum Update Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO PWM_SMMR_Type                  PWM_SMMR;       /**< Offset: 0xB0 (R/W  32) PWM Stepper Motor Mode Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO PWM_FPV2_Type                  PWM_FPV2;       /**< Offset: 0xC0 (R/W  32) PWM Fault Protection Value 2 Register */
+  __I  uint8_t                        Reserved5[32];
+  __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
+  __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  PWM_VERSION_Type               PWM_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+  __I  uint8_t                        Reserved7[48];
+       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved8[80];
+       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+  __I  uint8_t                        Reserved9[384];
+  __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
+  __I  uint8_t                        Reserved10[28];
+  __O  PWM_CMUPD1_Type                PWM_CMUPD1;     /**< Offset: 0x420 ( /W  32) PWM Channel Mode Update Register (ch_num = 1) */
+  __I  uint8_t                        Reserved11[8];
+  __IO PWM_ETRG1_Type                 PWM_ETRG1;      /**< Offset: 0x42C (R/W  32) PWM External Trigger Register (trg_num = 1) */
+  __IO PWM_LEBR1_Type                 PWM_LEBR1;      /**< Offset: 0x430 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 1) */
+  __I  uint8_t                        Reserved12[12];
+  __O  PWM_CMUPD2_Type                PWM_CMUPD2;     /**< Offset: 0x440 ( /W  32) PWM Channel Mode Update Register (ch_num = 2) */
+  __I  uint8_t                        Reserved13[8];
+  __IO PWM_ETRG2_Type                 PWM_ETRG2;      /**< Offset: 0x44C (R/W  32) PWM External Trigger Register (trg_num = 2) */
+  __IO PWM_LEBR2_Type                 PWM_LEBR2;      /**< Offset: 0x450 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 2) */
+  __I  uint8_t                        Reserved14[12];
+  __O  PWM_CMUPD3_Type                PWM_CMUPD3;     /**< Offset: 0x460 ( /W  32) PWM Channel Mode Update Register (ch_num = 3) */
+} Pwm;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Pulse Width Modulation Controller */
+
+#endif /* _SAMV71_PWM_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/qspi.h
+++ b/asf/sam/include/samv71/component/qspi.h
@@ -1,0 +1,766 @@
+/**
+ * \file
+ *
+ * \brief Component description for QSPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_QSPI_COMPONENT_H_
+#define _SAMV71_QSPI_COMPONENT_H_
+#define _SAMV71_QSPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Quad Serial Peripheral Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR QSPI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define QSPI_11171                      /**< (QSPI) Module ID */
+#define REV_QSPI I                      /**< (QSPI) Module revision */
+
+/* -------- QSPI_CR : (QSPI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QSPIEN:1;                  /**< bit:      0  QSPI Enable                              */
+    uint32_t QSPIDIS:1;                 /**< bit:      1  QSPI Disable                             */
+    uint32_t :5;                        /**< bit:   2..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  QSPI Software Reset                      */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_CR_OFFSET                      (0x00)                                        /**<  (QSPI_CR) Control Register  Offset */
+
+#define QSPI_CR_QSPIEN_Pos                  0                                              /**< (QSPI_CR) QSPI Enable Position */
+#define QSPI_CR_QSPIEN_Msk                  (_U_(0x1) << QSPI_CR_QSPIEN_Pos)               /**< (QSPI_CR) QSPI Enable Mask */
+#define QSPI_CR_QSPIEN                      QSPI_CR_QSPIEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_QSPIEN_Msk instead */
+#define QSPI_CR_QSPIDIS_Pos                 1                                              /**< (QSPI_CR) QSPI Disable Position */
+#define QSPI_CR_QSPIDIS_Msk                 (_U_(0x1) << QSPI_CR_QSPIDIS_Pos)              /**< (QSPI_CR) QSPI Disable Mask */
+#define QSPI_CR_QSPIDIS                     QSPI_CR_QSPIDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_QSPIDIS_Msk instead */
+#define QSPI_CR_SWRST_Pos                   7                                              /**< (QSPI_CR) QSPI Software Reset Position */
+#define QSPI_CR_SWRST_Msk                   (_U_(0x1) << QSPI_CR_SWRST_Pos)                /**< (QSPI_CR) QSPI Software Reset Mask */
+#define QSPI_CR_SWRST                       QSPI_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_SWRST_Msk instead */
+#define QSPI_CR_LASTXFER_Pos                24                                             /**< (QSPI_CR) Last Transfer Position */
+#define QSPI_CR_LASTXFER_Msk                (_U_(0x1) << QSPI_CR_LASTXFER_Pos)             /**< (QSPI_CR) Last Transfer Mask */
+#define QSPI_CR_LASTXFER                    QSPI_CR_LASTXFER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_LASTXFER_Msk instead */
+#define QSPI_CR_MASK                        _U_(0x1000083)                                 /**< \deprecated (QSPI_CR) Register MASK  (Use QSPI_CR_Msk instead)  */
+#define QSPI_CR_Msk                         _U_(0x1000083)                                 /**< (QSPI_CR) Register Mask  */
+
+
+/* -------- QSPI_MR : (QSPI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMM:1;                     /**< bit:      0  Serial Memory Mode                       */
+    uint32_t LLB:1;                     /**< bit:      1  Local Loopback Enable                    */
+    uint32_t WDRBT:1;                   /**< bit:      2  Wait Data Read Before Transfer           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t CSMODE:2;                  /**< bit:   4..5  Chip Select Mode                         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NBBITS:4;                  /**< bit:  8..11  Number Of Bits Per Transfer              */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DLYBCT:8;                  /**< bit: 16..23  Delay Between Consecutive Transfers      */
+    uint32_t DLYCS:8;                   /**< bit: 24..31  Minimum Inactive QCS Delay               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_MR_OFFSET                      (0x04)                                        /**<  (QSPI_MR) Mode Register  Offset */
+
+#define QSPI_MR_SMM_Pos                     0                                              /**< (QSPI_MR) Serial Memory Mode Position */
+#define QSPI_MR_SMM_Msk                     (_U_(0x1) << QSPI_MR_SMM_Pos)                  /**< (QSPI_MR) Serial Memory Mode Mask */
+#define QSPI_MR_SMM                         QSPI_MR_SMM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_SMM_Msk instead */
+#define   QSPI_MR_SMM_SPI_Val               _U_(0x0)                                       /**< (QSPI_MR) The QSPI is in SPI mode.  */
+#define   QSPI_MR_SMM_MEMORY_Val            _U_(0x1)                                       /**< (QSPI_MR) The QSPI is in Serial Memory mode.  */
+#define QSPI_MR_SMM_SPI                     (QSPI_MR_SMM_SPI_Val << QSPI_MR_SMM_Pos)       /**< (QSPI_MR) The QSPI is in SPI mode. Position  */
+#define QSPI_MR_SMM_MEMORY                  (QSPI_MR_SMM_MEMORY_Val << QSPI_MR_SMM_Pos)    /**< (QSPI_MR) The QSPI is in Serial Memory mode. Position  */
+#define QSPI_MR_LLB_Pos                     1                                              /**< (QSPI_MR) Local Loopback Enable Position */
+#define QSPI_MR_LLB_Msk                     (_U_(0x1) << QSPI_MR_LLB_Pos)                  /**< (QSPI_MR) Local Loopback Enable Mask */
+#define QSPI_MR_LLB                         QSPI_MR_LLB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_LLB_Msk instead */
+#define   QSPI_MR_LLB_DISABLED_Val          _U_(0x0)                                       /**< (QSPI_MR) Local loopback path disabled.  */
+#define   QSPI_MR_LLB_ENABLED_Val           _U_(0x1)                                       /**< (QSPI_MR) Local loopback path enabled.  */
+#define QSPI_MR_LLB_DISABLED                (QSPI_MR_LLB_DISABLED_Val << QSPI_MR_LLB_Pos)  /**< (QSPI_MR) Local loopback path disabled. Position  */
+#define QSPI_MR_LLB_ENABLED                 (QSPI_MR_LLB_ENABLED_Val << QSPI_MR_LLB_Pos)   /**< (QSPI_MR) Local loopback path enabled. Position  */
+#define QSPI_MR_WDRBT_Pos                   2                                              /**< (QSPI_MR) Wait Data Read Before Transfer Position */
+#define QSPI_MR_WDRBT_Msk                   (_U_(0x1) << QSPI_MR_WDRBT_Pos)                /**< (QSPI_MR) Wait Data Read Before Transfer Mask */
+#define QSPI_MR_WDRBT                       QSPI_MR_WDRBT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_WDRBT_Msk instead */
+#define   QSPI_MR_WDRBT_DISABLED_Val        _U_(0x0)                                       /**< (QSPI_MR) No effect. In SPI mode, a transfer can be initiated whatever the state of the QSPI_RDR is.  */
+#define   QSPI_MR_WDRBT_ENABLED_Val         _U_(0x1)                                       /**< (QSPI_MR) In SPI mode, a transfer can start only if the QSPI_RDR is empty, i.e., does not contain any unread data. This mode prevents overrun error in reception.  */
+#define QSPI_MR_WDRBT_DISABLED              (QSPI_MR_WDRBT_DISABLED_Val << QSPI_MR_WDRBT_Pos)  /**< (QSPI_MR) No effect. In SPI mode, a transfer can be initiated whatever the state of the QSPI_RDR is. Position  */
+#define QSPI_MR_WDRBT_ENABLED               (QSPI_MR_WDRBT_ENABLED_Val << QSPI_MR_WDRBT_Pos)  /**< (QSPI_MR) In SPI mode, a transfer can start only if the QSPI_RDR is empty, i.e., does not contain any unread data. This mode prevents overrun error in reception. Position  */
+#define QSPI_MR_CSMODE_Pos                  4                                              /**< (QSPI_MR) Chip Select Mode Position */
+#define QSPI_MR_CSMODE_Msk                  (_U_(0x3) << QSPI_MR_CSMODE_Pos)               /**< (QSPI_MR) Chip Select Mode Mask */
+#define QSPI_MR_CSMODE(value)               (QSPI_MR_CSMODE_Msk & ((value) << QSPI_MR_CSMODE_Pos))
+#define   QSPI_MR_CSMODE_NOT_RELOADED_Val   _U_(0x0)                                       /**< (QSPI_MR) The chip select is deasserted if QSPI_TDR.TD has not been reloaded before the end of the current transfer.  */
+#define   QSPI_MR_CSMODE_LASTXFER_Val       _U_(0x1)                                       /**< (QSPI_MR) The chip select is deasserted when the bit LASTXFER is written at 1 and the character written in QSPI_TDR.TD has been transferred.  */
+#define   QSPI_MR_CSMODE_SYSTEMATICALLY_Val _U_(0x2)                                       /**< (QSPI_MR) The chip select is deasserted systematically after each transfer.  */
+#define QSPI_MR_CSMODE_NOT_RELOADED         (QSPI_MR_CSMODE_NOT_RELOADED_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted if QSPI_TDR.TD has not been reloaded before the end of the current transfer. Position  */
+#define QSPI_MR_CSMODE_LASTXFER             (QSPI_MR_CSMODE_LASTXFER_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted when the bit LASTXFER is written at 1 and the character written in QSPI_TDR.TD has been transferred. Position  */
+#define QSPI_MR_CSMODE_SYSTEMATICALLY       (QSPI_MR_CSMODE_SYSTEMATICALLY_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted systematically after each transfer. Position  */
+#define QSPI_MR_NBBITS_Pos                  8                                              /**< (QSPI_MR) Number Of Bits Per Transfer Position */
+#define QSPI_MR_NBBITS_Msk                  (_U_(0xF) << QSPI_MR_NBBITS_Pos)               /**< (QSPI_MR) Number Of Bits Per Transfer Mask */
+#define QSPI_MR_NBBITS(value)               (QSPI_MR_NBBITS_Msk & ((value) << QSPI_MR_NBBITS_Pos))
+#define   QSPI_MR_NBBITS_8_BIT_Val          _U_(0x0)                                       /**< (QSPI_MR) 8 bits for transfer  */
+#define   QSPI_MR_NBBITS_16_BIT_Val         _U_(0x8)                                       /**< (QSPI_MR) 16 bits for transfer  */
+#define QSPI_MR_NBBITS_8_BIT                (QSPI_MR_NBBITS_8_BIT_Val << QSPI_MR_NBBITS_Pos)  /**< (QSPI_MR) 8 bits for transfer Position  */
+#define QSPI_MR_NBBITS_16_BIT               (QSPI_MR_NBBITS_16_BIT_Val << QSPI_MR_NBBITS_Pos)  /**< (QSPI_MR) 16 bits for transfer Position  */
+#define QSPI_MR_DLYBCT_Pos                  16                                             /**< (QSPI_MR) Delay Between Consecutive Transfers Position */
+#define QSPI_MR_DLYBCT_Msk                  (_U_(0xFF) << QSPI_MR_DLYBCT_Pos)              /**< (QSPI_MR) Delay Between Consecutive Transfers Mask */
+#define QSPI_MR_DLYBCT(value)               (QSPI_MR_DLYBCT_Msk & ((value) << QSPI_MR_DLYBCT_Pos))
+#define QSPI_MR_DLYCS_Pos                   24                                             /**< (QSPI_MR) Minimum Inactive QCS Delay Position */
+#define QSPI_MR_DLYCS_Msk                   (_U_(0xFF) << QSPI_MR_DLYCS_Pos)               /**< (QSPI_MR) Minimum Inactive QCS Delay Mask */
+#define QSPI_MR_DLYCS(value)                (QSPI_MR_DLYCS_Msk & ((value) << QSPI_MR_DLYCS_Pos))
+#define QSPI_MR_MASK                        _U_(0xFFFF0F37)                                /**< \deprecated (QSPI_MR) Register MASK  (Use QSPI_MR_Msk instead)  */
+#define QSPI_MR_Msk                         _U_(0xFFFF0F37)                                /**< (QSPI_MR) Register Mask  */
+
+
+/* -------- QSPI_RDR : (QSPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_RDR_OFFSET                     (0x08)                                        /**<  (QSPI_RDR) Receive Data Register  Offset */
+
+#define QSPI_RDR_RD_Pos                     0                                              /**< (QSPI_RDR) Receive Data Position */
+#define QSPI_RDR_RD_Msk                     (_U_(0xFFFF) << QSPI_RDR_RD_Pos)               /**< (QSPI_RDR) Receive Data Mask */
+#define QSPI_RDR_RD(value)                  (QSPI_RDR_RD_Msk & ((value) << QSPI_RDR_RD_Pos))
+#define QSPI_RDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (QSPI_RDR) Register MASK  (Use QSPI_RDR_Msk instead)  */
+#define QSPI_RDR_Msk                        _U_(0xFFFF)                                    /**< (QSPI_RDR) Register Mask  */
+
+
+/* -------- QSPI_TDR : (QSPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_TDR_OFFSET                     (0x0C)                                        /**<  (QSPI_TDR) Transmit Data Register  Offset */
+
+#define QSPI_TDR_TD_Pos                     0                                              /**< (QSPI_TDR) Transmit Data Position */
+#define QSPI_TDR_TD_Msk                     (_U_(0xFFFF) << QSPI_TDR_TD_Pos)               /**< (QSPI_TDR) Transmit Data Mask */
+#define QSPI_TDR_TD(value)                  (QSPI_TDR_TD_Msk & ((value) << QSPI_TDR_TD_Pos))
+#define QSPI_TDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (QSPI_TDR) Register MASK  (Use QSPI_TDR_Msk instead)  */
+#define QSPI_TDR_Msk                        _U_(0xFFFF)                                    /**< (QSPI_TDR) Register Mask  */
+
+
+/* -------- QSPI_SR : (QSPI Offset: 0x10) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty (cleared by writing SPI_TDR) */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty (cleared by writing SPI_TDR) */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Status (cleared on read)   */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise (cleared on read)       */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status                       */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Status (cleared on read) */
+    uint32_t :13;                       /**< bit: 11..23  Reserved */
+    uint32_t QSPIENS:1;                 /**< bit:     24  QSPI Enable Status                       */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SR_OFFSET                      (0x10)                                        /**<  (QSPI_SR) Status Register  Offset */
+
+#define QSPI_SR_RDRF_Pos                    0                                              /**< (QSPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Position */
+#define QSPI_SR_RDRF_Msk                    (_U_(0x1) << QSPI_SR_RDRF_Pos)                 /**< (QSPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Mask */
+#define QSPI_SR_RDRF                        QSPI_SR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_RDRF_Msk instead */
+#define QSPI_SR_TDRE_Pos                    1                                              /**< (QSPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Position */
+#define QSPI_SR_TDRE_Msk                    (_U_(0x1) << QSPI_SR_TDRE_Pos)                 /**< (QSPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Mask */
+#define QSPI_SR_TDRE                        QSPI_SR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_TDRE_Msk instead */
+#define QSPI_SR_TXEMPTY_Pos                 2                                              /**< (QSPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Position */
+#define QSPI_SR_TXEMPTY_Msk                 (_U_(0x1) << QSPI_SR_TXEMPTY_Pos)              /**< (QSPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Mask */
+#define QSPI_SR_TXEMPTY                     QSPI_SR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_TXEMPTY_Msk instead */
+#define QSPI_SR_OVRES_Pos                   3                                              /**< (QSPI_SR) Overrun Error Status (cleared on read) Position */
+#define QSPI_SR_OVRES_Msk                   (_U_(0x1) << QSPI_SR_OVRES_Pos)                /**< (QSPI_SR) Overrun Error Status (cleared on read) Mask */
+#define QSPI_SR_OVRES                       QSPI_SR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_OVRES_Msk instead */
+#define QSPI_SR_CSR_Pos                     8                                              /**< (QSPI_SR) Chip Select Rise (cleared on read) Position */
+#define QSPI_SR_CSR_Msk                     (_U_(0x1) << QSPI_SR_CSR_Pos)                  /**< (QSPI_SR) Chip Select Rise (cleared on read) Mask */
+#define QSPI_SR_CSR                         QSPI_SR_CSR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_CSR_Msk instead */
+#define QSPI_SR_CSS_Pos                     9                                              /**< (QSPI_SR) Chip Select Status Position */
+#define QSPI_SR_CSS_Msk                     (_U_(0x1) << QSPI_SR_CSS_Pos)                  /**< (QSPI_SR) Chip Select Status Mask */
+#define QSPI_SR_CSS                         QSPI_SR_CSS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_CSS_Msk instead */
+#define QSPI_SR_INSTRE_Pos                  10                                             /**< (QSPI_SR) Instruction End Status (cleared on read) Position */
+#define QSPI_SR_INSTRE_Msk                  (_U_(0x1) << QSPI_SR_INSTRE_Pos)               /**< (QSPI_SR) Instruction End Status (cleared on read) Mask */
+#define QSPI_SR_INSTRE                      QSPI_SR_INSTRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_INSTRE_Msk instead */
+#define QSPI_SR_QSPIENS_Pos                 24                                             /**< (QSPI_SR) QSPI Enable Status Position */
+#define QSPI_SR_QSPIENS_Msk                 (_U_(0x1) << QSPI_SR_QSPIENS_Pos)              /**< (QSPI_SR) QSPI Enable Status Mask */
+#define QSPI_SR_QSPIENS                     QSPI_SR_QSPIENS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_QSPIENS_Msk instead */
+#define QSPI_SR_MASK                        _U_(0x100070F)                                 /**< \deprecated (QSPI_SR) Register MASK  (Use QSPI_SR_Msk instead)  */
+#define QSPI_SR_Msk                         _U_(0x100070F)                                 /**< (QSPI_SR) Register Mask  */
+
+
+/* -------- QSPI_IER : (QSPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Enable */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Enable      */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Enable           */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Enable        */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Enable      */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Enable         */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IER_OFFSET                     (0x14)                                        /**<  (QSPI_IER) Interrupt Enable Register  Offset */
+
+#define QSPI_IER_RDRF_Pos                   0                                              /**< (QSPI_IER) Receive Data Register Full Interrupt Enable Position */
+#define QSPI_IER_RDRF_Msk                   (_U_(0x1) << QSPI_IER_RDRF_Pos)                /**< (QSPI_IER) Receive Data Register Full Interrupt Enable Mask */
+#define QSPI_IER_RDRF                       QSPI_IER_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_RDRF_Msk instead */
+#define QSPI_IER_TDRE_Pos                   1                                              /**< (QSPI_IER) Transmit Data Register Empty Interrupt Enable Position */
+#define QSPI_IER_TDRE_Msk                   (_U_(0x1) << QSPI_IER_TDRE_Pos)                /**< (QSPI_IER) Transmit Data Register Empty Interrupt Enable Mask */
+#define QSPI_IER_TDRE                       QSPI_IER_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_TDRE_Msk instead */
+#define QSPI_IER_TXEMPTY_Pos                2                                              /**< (QSPI_IER) Transmission Registers Empty Enable Position */
+#define QSPI_IER_TXEMPTY_Msk                (_U_(0x1) << QSPI_IER_TXEMPTY_Pos)             /**< (QSPI_IER) Transmission Registers Empty Enable Mask */
+#define QSPI_IER_TXEMPTY                    QSPI_IER_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_TXEMPTY_Msk instead */
+#define QSPI_IER_OVRES_Pos                  3                                              /**< (QSPI_IER) Overrun Error Interrupt Enable Position */
+#define QSPI_IER_OVRES_Msk                  (_U_(0x1) << QSPI_IER_OVRES_Pos)               /**< (QSPI_IER) Overrun Error Interrupt Enable Mask */
+#define QSPI_IER_OVRES                      QSPI_IER_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_OVRES_Msk instead */
+#define QSPI_IER_CSR_Pos                    8                                              /**< (QSPI_IER) Chip Select Rise Interrupt Enable Position */
+#define QSPI_IER_CSR_Msk                    (_U_(0x1) << QSPI_IER_CSR_Pos)                 /**< (QSPI_IER) Chip Select Rise Interrupt Enable Mask */
+#define QSPI_IER_CSR                        QSPI_IER_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_CSR_Msk instead */
+#define QSPI_IER_CSS_Pos                    9                                              /**< (QSPI_IER) Chip Select Status Interrupt Enable Position */
+#define QSPI_IER_CSS_Msk                    (_U_(0x1) << QSPI_IER_CSS_Pos)                 /**< (QSPI_IER) Chip Select Status Interrupt Enable Mask */
+#define QSPI_IER_CSS                        QSPI_IER_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_CSS_Msk instead */
+#define QSPI_IER_INSTRE_Pos                 10                                             /**< (QSPI_IER) Instruction End Interrupt Enable Position */
+#define QSPI_IER_INSTRE_Msk                 (_U_(0x1) << QSPI_IER_INSTRE_Pos)              /**< (QSPI_IER) Instruction End Interrupt Enable Mask */
+#define QSPI_IER_INSTRE                     QSPI_IER_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_INSTRE_Msk instead */
+#define QSPI_IER_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IER) Register MASK  (Use QSPI_IER_Msk instead)  */
+#define QSPI_IER_Msk                        _U_(0x70F)                                     /**< (QSPI_IER) Register Mask  */
+
+
+/* -------- QSPI_IDR : (QSPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Disable */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Disable     */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Disable          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Disable       */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Disable     */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Disable        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IDR_OFFSET                     (0x18)                                        /**<  (QSPI_IDR) Interrupt Disable Register  Offset */
+
+#define QSPI_IDR_RDRF_Pos                   0                                              /**< (QSPI_IDR) Receive Data Register Full Interrupt Disable Position */
+#define QSPI_IDR_RDRF_Msk                   (_U_(0x1) << QSPI_IDR_RDRF_Pos)                /**< (QSPI_IDR) Receive Data Register Full Interrupt Disable Mask */
+#define QSPI_IDR_RDRF                       QSPI_IDR_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_RDRF_Msk instead */
+#define QSPI_IDR_TDRE_Pos                   1                                              /**< (QSPI_IDR) Transmit Data Register Empty Interrupt Disable Position */
+#define QSPI_IDR_TDRE_Msk                   (_U_(0x1) << QSPI_IDR_TDRE_Pos)                /**< (QSPI_IDR) Transmit Data Register Empty Interrupt Disable Mask */
+#define QSPI_IDR_TDRE                       QSPI_IDR_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_TDRE_Msk instead */
+#define QSPI_IDR_TXEMPTY_Pos                2                                              /**< (QSPI_IDR) Transmission Registers Empty Disable Position */
+#define QSPI_IDR_TXEMPTY_Msk                (_U_(0x1) << QSPI_IDR_TXEMPTY_Pos)             /**< (QSPI_IDR) Transmission Registers Empty Disable Mask */
+#define QSPI_IDR_TXEMPTY                    QSPI_IDR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_TXEMPTY_Msk instead */
+#define QSPI_IDR_OVRES_Pos                  3                                              /**< (QSPI_IDR) Overrun Error Interrupt Disable Position */
+#define QSPI_IDR_OVRES_Msk                  (_U_(0x1) << QSPI_IDR_OVRES_Pos)               /**< (QSPI_IDR) Overrun Error Interrupt Disable Mask */
+#define QSPI_IDR_OVRES                      QSPI_IDR_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_OVRES_Msk instead */
+#define QSPI_IDR_CSR_Pos                    8                                              /**< (QSPI_IDR) Chip Select Rise Interrupt Disable Position */
+#define QSPI_IDR_CSR_Msk                    (_U_(0x1) << QSPI_IDR_CSR_Pos)                 /**< (QSPI_IDR) Chip Select Rise Interrupt Disable Mask */
+#define QSPI_IDR_CSR                        QSPI_IDR_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_CSR_Msk instead */
+#define QSPI_IDR_CSS_Pos                    9                                              /**< (QSPI_IDR) Chip Select Status Interrupt Disable Position */
+#define QSPI_IDR_CSS_Msk                    (_U_(0x1) << QSPI_IDR_CSS_Pos)                 /**< (QSPI_IDR) Chip Select Status Interrupt Disable Mask */
+#define QSPI_IDR_CSS                        QSPI_IDR_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_CSS_Msk instead */
+#define QSPI_IDR_INSTRE_Pos                 10                                             /**< (QSPI_IDR) Instruction End Interrupt Disable Position */
+#define QSPI_IDR_INSTRE_Msk                 (_U_(0x1) << QSPI_IDR_INSTRE_Pos)              /**< (QSPI_IDR) Instruction End Interrupt Disable Mask */
+#define QSPI_IDR_INSTRE                     QSPI_IDR_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_INSTRE_Msk instead */
+#define QSPI_IDR_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IDR) Register MASK  (Use QSPI_IDR_Msk instead)  */
+#define QSPI_IDR_Msk                        _U_(0x70F)                                     /**< (QSPI_IDR) Register Mask  */
+
+
+/* -------- QSPI_IMR : (QSPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Mask */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Mask        */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Mask             */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Mask          */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Mask        */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Mask           */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IMR_OFFSET                     (0x1C)                                        /**<  (QSPI_IMR) Interrupt Mask Register  Offset */
+
+#define QSPI_IMR_RDRF_Pos                   0                                              /**< (QSPI_IMR) Receive Data Register Full Interrupt Mask Position */
+#define QSPI_IMR_RDRF_Msk                   (_U_(0x1) << QSPI_IMR_RDRF_Pos)                /**< (QSPI_IMR) Receive Data Register Full Interrupt Mask Mask */
+#define QSPI_IMR_RDRF                       QSPI_IMR_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_RDRF_Msk instead */
+#define QSPI_IMR_TDRE_Pos                   1                                              /**< (QSPI_IMR) Transmit Data Register Empty Interrupt Mask Position */
+#define QSPI_IMR_TDRE_Msk                   (_U_(0x1) << QSPI_IMR_TDRE_Pos)                /**< (QSPI_IMR) Transmit Data Register Empty Interrupt Mask Mask */
+#define QSPI_IMR_TDRE                       QSPI_IMR_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_TDRE_Msk instead */
+#define QSPI_IMR_TXEMPTY_Pos                2                                              /**< (QSPI_IMR) Transmission Registers Empty Mask Position */
+#define QSPI_IMR_TXEMPTY_Msk                (_U_(0x1) << QSPI_IMR_TXEMPTY_Pos)             /**< (QSPI_IMR) Transmission Registers Empty Mask Mask */
+#define QSPI_IMR_TXEMPTY                    QSPI_IMR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_TXEMPTY_Msk instead */
+#define QSPI_IMR_OVRES_Pos                  3                                              /**< (QSPI_IMR) Overrun Error Interrupt Mask Position */
+#define QSPI_IMR_OVRES_Msk                  (_U_(0x1) << QSPI_IMR_OVRES_Pos)               /**< (QSPI_IMR) Overrun Error Interrupt Mask Mask */
+#define QSPI_IMR_OVRES                      QSPI_IMR_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_OVRES_Msk instead */
+#define QSPI_IMR_CSR_Pos                    8                                              /**< (QSPI_IMR) Chip Select Rise Interrupt Mask Position */
+#define QSPI_IMR_CSR_Msk                    (_U_(0x1) << QSPI_IMR_CSR_Pos)                 /**< (QSPI_IMR) Chip Select Rise Interrupt Mask Mask */
+#define QSPI_IMR_CSR                        QSPI_IMR_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_CSR_Msk instead */
+#define QSPI_IMR_CSS_Pos                    9                                              /**< (QSPI_IMR) Chip Select Status Interrupt Mask Position */
+#define QSPI_IMR_CSS_Msk                    (_U_(0x1) << QSPI_IMR_CSS_Pos)                 /**< (QSPI_IMR) Chip Select Status Interrupt Mask Mask */
+#define QSPI_IMR_CSS                        QSPI_IMR_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_CSS_Msk instead */
+#define QSPI_IMR_INSTRE_Pos                 10                                             /**< (QSPI_IMR) Instruction End Interrupt Mask Position */
+#define QSPI_IMR_INSTRE_Msk                 (_U_(0x1) << QSPI_IMR_INSTRE_Pos)              /**< (QSPI_IMR) Instruction End Interrupt Mask Mask */
+#define QSPI_IMR_INSTRE                     QSPI_IMR_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_INSTRE_Msk instead */
+#define QSPI_IMR_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IMR) Register MASK  (Use QSPI_IMR_Msk instead)  */
+#define QSPI_IMR_Msk                        _U_(0x70F)                                     /**< (QSPI_IMR) Register Mask  */
+
+
+/* -------- QSPI_SCR : (QSPI Offset: 0x20) (R/W 32) Serial Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
+    uint32_t CPHA:1;                    /**< bit:      1  Clock Phase                              */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t SCBR:8;                    /**< bit:  8..15  Serial Clock Baud Rate                   */
+    uint32_t DLYBS:8;                   /**< bit: 16..23  Delay Before QSCK                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SCR_OFFSET                     (0x20)                                        /**<  (QSPI_SCR) Serial Clock Register  Offset */
+
+#define QSPI_SCR_CPOL_Pos                   0                                              /**< (QSPI_SCR) Clock Polarity Position */
+#define QSPI_SCR_CPOL_Msk                   (_U_(0x1) << QSPI_SCR_CPOL_Pos)                /**< (QSPI_SCR) Clock Polarity Mask */
+#define QSPI_SCR_CPOL                       QSPI_SCR_CPOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SCR_CPOL_Msk instead */
+#define QSPI_SCR_CPHA_Pos                   1                                              /**< (QSPI_SCR) Clock Phase Position */
+#define QSPI_SCR_CPHA_Msk                   (_U_(0x1) << QSPI_SCR_CPHA_Pos)                /**< (QSPI_SCR) Clock Phase Mask */
+#define QSPI_SCR_CPHA                       QSPI_SCR_CPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SCR_CPHA_Msk instead */
+#define QSPI_SCR_SCBR_Pos                   8                                              /**< (QSPI_SCR) Serial Clock Baud Rate Position */
+#define QSPI_SCR_SCBR_Msk                   (_U_(0xFF) << QSPI_SCR_SCBR_Pos)               /**< (QSPI_SCR) Serial Clock Baud Rate Mask */
+#define QSPI_SCR_SCBR(value)                (QSPI_SCR_SCBR_Msk & ((value) << QSPI_SCR_SCBR_Pos))
+#define QSPI_SCR_DLYBS_Pos                  16                                             /**< (QSPI_SCR) Delay Before QSCK Position */
+#define QSPI_SCR_DLYBS_Msk                  (_U_(0xFF) << QSPI_SCR_DLYBS_Pos)              /**< (QSPI_SCR) Delay Before QSCK Mask */
+#define QSPI_SCR_DLYBS(value)               (QSPI_SCR_DLYBS_Msk & ((value) << QSPI_SCR_DLYBS_Pos))
+#define QSPI_SCR_MASK                       _U_(0xFFFF03)                                  /**< \deprecated (QSPI_SCR) Register MASK  (Use QSPI_SCR_Msk instead)  */
+#define QSPI_SCR_Msk                        _U_(0xFFFF03)                                  /**< (QSPI_SCR) Register Mask  */
+
+
+/* -------- QSPI_IAR : (QSPI Offset: 0x30) (R/W 32) Instruction Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Address                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IAR_OFFSET                     (0x30)                                        /**<  (QSPI_IAR) Instruction Address Register  Offset */
+
+#define QSPI_IAR_ADDR_Pos                   0                                              /**< (QSPI_IAR) Address Position */
+#define QSPI_IAR_ADDR_Msk                   (_U_(0xFFFFFFFF) << QSPI_IAR_ADDR_Pos)         /**< (QSPI_IAR) Address Mask */
+#define QSPI_IAR_ADDR(value)                (QSPI_IAR_ADDR_Msk & ((value) << QSPI_IAR_ADDR_Pos))
+#define QSPI_IAR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (QSPI_IAR) Register MASK  (Use QSPI_IAR_Msk instead)  */
+#define QSPI_IAR_Msk                        _U_(0xFFFFFFFF)                                /**< (QSPI_IAR) Register Mask  */
+
+
+/* -------- QSPI_ICR : (QSPI Offset: 0x34) (R/W 32) Instruction Code Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INST:8;                    /**< bit:   0..7  Instruction Code                         */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t OPT:8;                     /**< bit: 16..23  Option Code                              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_ICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_ICR_OFFSET                     (0x34)                                        /**<  (QSPI_ICR) Instruction Code Register  Offset */
+
+#define QSPI_ICR_INST_Pos                   0                                              /**< (QSPI_ICR) Instruction Code Position */
+#define QSPI_ICR_INST_Msk                   (_U_(0xFF) << QSPI_ICR_INST_Pos)               /**< (QSPI_ICR) Instruction Code Mask */
+#define QSPI_ICR_INST(value)                (QSPI_ICR_INST_Msk & ((value) << QSPI_ICR_INST_Pos))
+#define QSPI_ICR_OPT_Pos                    16                                             /**< (QSPI_ICR) Option Code Position */
+#define QSPI_ICR_OPT_Msk                    (_U_(0xFF) << QSPI_ICR_OPT_Pos)                /**< (QSPI_ICR) Option Code Mask */
+#define QSPI_ICR_OPT(value)                 (QSPI_ICR_OPT_Msk & ((value) << QSPI_ICR_OPT_Pos))
+#define QSPI_ICR_MASK                       _U_(0xFF00FF)                                  /**< \deprecated (QSPI_ICR) Register MASK  (Use QSPI_ICR_Msk instead)  */
+#define QSPI_ICR_Msk                        _U_(0xFF00FF)                                  /**< (QSPI_ICR) Register Mask  */
+
+
+/* -------- QSPI_IFR : (QSPI Offset: 0x38) (R/W 32) Instruction Frame Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WIDTH:3;                   /**< bit:   0..2  Width of Instruction Code, Address, Option Code and Data */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t INSTEN:1;                  /**< bit:      4  Instruction Enable                       */
+    uint32_t ADDREN:1;                  /**< bit:      5  Address Enable                           */
+    uint32_t OPTEN:1;                   /**< bit:      6  Option Enable                            */
+    uint32_t DATAEN:1;                  /**< bit:      7  Data Enable                              */
+    uint32_t OPTL:2;                    /**< bit:   8..9  Option Code Length                       */
+    uint32_t ADDRL:1;                   /**< bit:     10  Address Length                           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t TFRTYP:2;                  /**< bit: 12..13  Data Transfer Type                       */
+    uint32_t CRM:1;                     /**< bit:     14  Continuous Read Mode                     */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t NBDUM:5;                   /**< bit: 16..20  Number Of Dummy Cycles                   */
+    uint32_t :11;                       /**< bit: 21..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IFR_OFFSET                     (0x38)                                        /**<  (QSPI_IFR) Instruction Frame Register  Offset */
+
+#define QSPI_IFR_WIDTH_Pos                  0                                              /**< (QSPI_IFR) Width of Instruction Code, Address, Option Code and Data Position */
+#define QSPI_IFR_WIDTH_Msk                  (_U_(0x7) << QSPI_IFR_WIDTH_Pos)               /**< (QSPI_IFR) Width of Instruction Code, Address, Option Code and Data Mask */
+#define QSPI_IFR_WIDTH(value)               (QSPI_IFR_WIDTH_Msk & ((value) << QSPI_IFR_WIDTH_Pos))
+#define   QSPI_IFR_WIDTH_SINGLE_BIT_SPI_Val _U_(0x0)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Single-bit SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_OUTPUT_Val    _U_(0x1)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_OUTPUT_Val    _U_(0x2)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Quad SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_IO_Val        _U_(0x3)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Dual SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_IO_Val        _U_(0x4)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Quad SPI / Data: Quad SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_CMD_Val       _U_(0x5)                                       /**< (QSPI_IFR) Instruction: Dual SPI / Address-Option: Dual SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_CMD_Val       _U_(0x6)                                       /**< (QSPI_IFR) Instruction: Quad SPI / Address-Option: Quad SPI / Data: Quad SPI  */
+#define QSPI_IFR_WIDTH_SINGLE_BIT_SPI       (QSPI_IFR_WIDTH_SINGLE_BIT_SPI_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Single-bit SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_OUTPUT          (QSPI_IFR_WIDTH_DUAL_OUTPUT_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_OUTPUT          (QSPI_IFR_WIDTH_QUAD_OUTPUT_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_IO              (QSPI_IFR_WIDTH_DUAL_IO_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Dual SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_IO              (QSPI_IFR_WIDTH_QUAD_IO_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Quad SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_CMD             (QSPI_IFR_WIDTH_DUAL_CMD_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Dual SPI / Address-Option: Dual SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_CMD             (QSPI_IFR_WIDTH_QUAD_CMD_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Quad SPI / Address-Option: Quad SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_INSTEN_Pos                 4                                              /**< (QSPI_IFR) Instruction Enable Position */
+#define QSPI_IFR_INSTEN_Msk                 (_U_(0x1) << QSPI_IFR_INSTEN_Pos)              /**< (QSPI_IFR) Instruction Enable Mask */
+#define QSPI_IFR_INSTEN                     QSPI_IFR_INSTEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_INSTEN_Msk instead */
+#define QSPI_IFR_ADDREN_Pos                 5                                              /**< (QSPI_IFR) Address Enable Position */
+#define QSPI_IFR_ADDREN_Msk                 (_U_(0x1) << QSPI_IFR_ADDREN_Pos)              /**< (QSPI_IFR) Address Enable Mask */
+#define QSPI_IFR_ADDREN                     QSPI_IFR_ADDREN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_ADDREN_Msk instead */
+#define QSPI_IFR_OPTEN_Pos                  6                                              /**< (QSPI_IFR) Option Enable Position */
+#define QSPI_IFR_OPTEN_Msk                  (_U_(0x1) << QSPI_IFR_OPTEN_Pos)               /**< (QSPI_IFR) Option Enable Mask */
+#define QSPI_IFR_OPTEN                      QSPI_IFR_OPTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_OPTEN_Msk instead */
+#define QSPI_IFR_DATAEN_Pos                 7                                              /**< (QSPI_IFR) Data Enable Position */
+#define QSPI_IFR_DATAEN_Msk                 (_U_(0x1) << QSPI_IFR_DATAEN_Pos)              /**< (QSPI_IFR) Data Enable Mask */
+#define QSPI_IFR_DATAEN                     QSPI_IFR_DATAEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_DATAEN_Msk instead */
+#define QSPI_IFR_OPTL_Pos                   8                                              /**< (QSPI_IFR) Option Code Length Position */
+#define QSPI_IFR_OPTL_Msk                   (_U_(0x3) << QSPI_IFR_OPTL_Pos)                /**< (QSPI_IFR) Option Code Length Mask */
+#define QSPI_IFR_OPTL(value)                (QSPI_IFR_OPTL_Msk & ((value) << QSPI_IFR_OPTL_Pos))
+#define   QSPI_IFR_OPTL_OPTION_1BIT_Val     _U_(0x0)                                       /**< (QSPI_IFR) The option code is 1 bit long.  */
+#define   QSPI_IFR_OPTL_OPTION_2BIT_Val     _U_(0x1)                                       /**< (QSPI_IFR) The option code is 2 bits long.  */
+#define   QSPI_IFR_OPTL_OPTION_4BIT_Val     _U_(0x2)                                       /**< (QSPI_IFR) The option code is 4 bits long.  */
+#define   QSPI_IFR_OPTL_OPTION_8BIT_Val     _U_(0x3)                                       /**< (QSPI_IFR) The option code is 8 bits long.  */
+#define QSPI_IFR_OPTL_OPTION_1BIT           (QSPI_IFR_OPTL_OPTION_1BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 1 bit long. Position  */
+#define QSPI_IFR_OPTL_OPTION_2BIT           (QSPI_IFR_OPTL_OPTION_2BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 2 bits long. Position  */
+#define QSPI_IFR_OPTL_OPTION_4BIT           (QSPI_IFR_OPTL_OPTION_4BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 4 bits long. Position  */
+#define QSPI_IFR_OPTL_OPTION_8BIT           (QSPI_IFR_OPTL_OPTION_8BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 8 bits long. Position  */
+#define QSPI_IFR_ADDRL_Pos                  10                                             /**< (QSPI_IFR) Address Length Position */
+#define QSPI_IFR_ADDRL_Msk                  (_U_(0x1) << QSPI_IFR_ADDRL_Pos)               /**< (QSPI_IFR) Address Length Mask */
+#define QSPI_IFR_ADDRL                      QSPI_IFR_ADDRL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_ADDRL_Msk instead */
+#define   QSPI_IFR_ADDRL_24_BIT_Val         _U_(0x0)                                       /**< (QSPI_IFR) The address is 24 bits long.  */
+#define   QSPI_IFR_ADDRL_32_BIT_Val         _U_(0x1)                                       /**< (QSPI_IFR) The address is 32 bits long.  */
+#define QSPI_IFR_ADDRL_24_BIT               (QSPI_IFR_ADDRL_24_BIT_Val << QSPI_IFR_ADDRL_Pos)  /**< (QSPI_IFR) The address is 24 bits long. Position  */
+#define QSPI_IFR_ADDRL_32_BIT               (QSPI_IFR_ADDRL_32_BIT_Val << QSPI_IFR_ADDRL_Pos)  /**< (QSPI_IFR) The address is 32 bits long. Position  */
+#define QSPI_IFR_TFRTYP_Pos                 12                                             /**< (QSPI_IFR) Data Transfer Type Position */
+#define QSPI_IFR_TFRTYP_Msk                 (_U_(0x3) << QSPI_IFR_TFRTYP_Pos)              /**< (QSPI_IFR) Data Transfer Type Mask */
+#define QSPI_IFR_TFRTYP(value)              (QSPI_IFR_TFRTYP_Msk & ((value) << QSPI_IFR_TFRTYP_Pos))
+#define   QSPI_IFR_TFRTYP_TRSFR_READ_Val    _U_(0x0)                                       /**< (QSPI_IFR) Read transfer from the serial memory.Scrambling is not performed.Read at random location (fetch) in the serial Flash memory is not possible.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY_Val _U_(0x1)                                       /**< (QSPI_IFR) Read data transfer from the serial memory.If enabled, scrambling is performed.Read at random location (fetch) in the serial Flash memory is possible.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_WRITE_Val   _U_(0x2)                                       /**< (QSPI_IFR) Write transfer into the serial memory.Scrambling is not performed.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY_Val _U_(0x3)                                       /**< (QSPI_IFR) Write data transfer into the serial memory.If enabled, scrambling is performed.  */
+#define QSPI_IFR_TFRTYP_TRSFR_READ          (QSPI_IFR_TFRTYP_TRSFR_READ_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Read transfer from the serial memory.Scrambling is not performed.Read at random location (fetch) in the serial Flash memory is not possible. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY   (QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Read data transfer from the serial memory.If enabled, scrambling is performed.Read at random location (fetch) in the serial Flash memory is possible. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_WRITE         (QSPI_IFR_TFRTYP_TRSFR_WRITE_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Write transfer into the serial memory.Scrambling is not performed. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY  (QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Write data transfer into the serial memory.If enabled, scrambling is performed. Position  */
+#define QSPI_IFR_CRM_Pos                    14                                             /**< (QSPI_IFR) Continuous Read Mode Position */
+#define QSPI_IFR_CRM_Msk                    (_U_(0x1) << QSPI_IFR_CRM_Pos)                 /**< (QSPI_IFR) Continuous Read Mode Mask */
+#define QSPI_IFR_CRM                        QSPI_IFR_CRM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_CRM_Msk instead */
+#define   QSPI_IFR_CRM_DISABLED_Val         _U_(0x0)                                       /**< (QSPI_IFR) The Continuous Read mode is disabled.  */
+#define   QSPI_IFR_CRM_ENABLED_Val          _U_(0x1)                                       /**< (QSPI_IFR) The Continuous Read mode is enabled.  */
+#define QSPI_IFR_CRM_DISABLED               (QSPI_IFR_CRM_DISABLED_Val << QSPI_IFR_CRM_Pos)  /**< (QSPI_IFR) The Continuous Read mode is disabled. Position  */
+#define QSPI_IFR_CRM_ENABLED                (QSPI_IFR_CRM_ENABLED_Val << QSPI_IFR_CRM_Pos)  /**< (QSPI_IFR) The Continuous Read mode is enabled. Position  */
+#define QSPI_IFR_NBDUM_Pos                  16                                             /**< (QSPI_IFR) Number Of Dummy Cycles Position */
+#define QSPI_IFR_NBDUM_Msk                  (_U_(0x1F) << QSPI_IFR_NBDUM_Pos)              /**< (QSPI_IFR) Number Of Dummy Cycles Mask */
+#define QSPI_IFR_NBDUM(value)               (QSPI_IFR_NBDUM_Msk & ((value) << QSPI_IFR_NBDUM_Pos))
+#define QSPI_IFR_MASK                       _U_(0x1F77F7)                                  /**< \deprecated (QSPI_IFR) Register MASK  (Use QSPI_IFR_Msk instead)  */
+#define QSPI_IFR_Msk                        _U_(0x1F77F7)                                  /**< (QSPI_IFR) Register Mask  */
+
+
+/* -------- QSPI_SMR : (QSPI Offset: 0x40) (R/W 32) Scrambling Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCREN:1;                   /**< bit:      0  Scrambling/Unscrambling Enable           */
+    uint32_t RVDIS:1;                   /**< bit:      1  Scrambling/Unscrambling Random Value Disable */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SMR_OFFSET                     (0x40)                                        /**<  (QSPI_SMR) Scrambling Mode Register  Offset */
+
+#define QSPI_SMR_SCREN_Pos                  0                                              /**< (QSPI_SMR) Scrambling/Unscrambling Enable Position */
+#define QSPI_SMR_SCREN_Msk                  (_U_(0x1) << QSPI_SMR_SCREN_Pos)               /**< (QSPI_SMR) Scrambling/Unscrambling Enable Mask */
+#define QSPI_SMR_SCREN                      QSPI_SMR_SCREN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SMR_SCREN_Msk instead */
+#define   QSPI_SMR_SCREN_DISABLED_Val       _U_(0x0)                                       /**< (QSPI_SMR) The scrambling/unscrambling is disabled.  */
+#define   QSPI_SMR_SCREN_ENABLED_Val        _U_(0x1)                                       /**< (QSPI_SMR) The scrambling/unscrambling is enabled.  */
+#define QSPI_SMR_SCREN_DISABLED             (QSPI_SMR_SCREN_DISABLED_Val << QSPI_SMR_SCREN_Pos)  /**< (QSPI_SMR) The scrambling/unscrambling is disabled. Position  */
+#define QSPI_SMR_SCREN_ENABLED              (QSPI_SMR_SCREN_ENABLED_Val << QSPI_SMR_SCREN_Pos)  /**< (QSPI_SMR) The scrambling/unscrambling is enabled. Position  */
+#define QSPI_SMR_RVDIS_Pos                  1                                              /**< (QSPI_SMR) Scrambling/Unscrambling Random Value Disable Position */
+#define QSPI_SMR_RVDIS_Msk                  (_U_(0x1) << QSPI_SMR_RVDIS_Pos)               /**< (QSPI_SMR) Scrambling/Unscrambling Random Value Disable Mask */
+#define QSPI_SMR_RVDIS                      QSPI_SMR_RVDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SMR_RVDIS_Msk instead */
+#define QSPI_SMR_MASK                       _U_(0x03)                                      /**< \deprecated (QSPI_SMR) Register MASK  (Use QSPI_SMR_Msk instead)  */
+#define QSPI_SMR_Msk                        _U_(0x03)                                      /**< (QSPI_SMR) Register Mask  */
+
+
+/* -------- QSPI_SKR : (QSPI Offset: 0x44) (/W 32) Scrambling Key Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USRK:32;                   /**< bit:  0..31  User Scrambling Key                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SKR_OFFSET                     (0x44)                                        /**<  (QSPI_SKR) Scrambling Key Register  Offset */
+
+#define QSPI_SKR_USRK_Pos                   0                                              /**< (QSPI_SKR) User Scrambling Key Position */
+#define QSPI_SKR_USRK_Msk                   (_U_(0xFFFFFFFF) << QSPI_SKR_USRK_Pos)         /**< (QSPI_SKR) User Scrambling Key Mask */
+#define QSPI_SKR_USRK(value)                (QSPI_SKR_USRK_Msk & ((value) << QSPI_SKR_USRK_Pos))
+#define QSPI_SKR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (QSPI_SKR) Register MASK  (Use QSPI_SKR_Msk instead)  */
+#define QSPI_SKR_Msk                        _U_(0xFFFFFFFF)                                /**< (QSPI_SKR) Register Mask  */
+
+
+/* -------- QSPI_WPMR : (QSPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_WPMR_OFFSET                    (0xE4)                                        /**<  (QSPI_WPMR) Write Protection Mode Register  Offset */
+
+#define QSPI_WPMR_WPEN_Pos                  0                                              /**< (QSPI_WPMR) Write Protection Enable Position */
+#define QSPI_WPMR_WPEN_Msk                  (_U_(0x1) << QSPI_WPMR_WPEN_Pos)               /**< (QSPI_WPMR) Write Protection Enable Mask */
+#define QSPI_WPMR_WPEN                      QSPI_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_WPMR_WPEN_Msk instead */
+#define QSPI_WPMR_WPKEY_Pos                 8                                              /**< (QSPI_WPMR) Write Protection Key Position */
+#define QSPI_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << QSPI_WPMR_WPKEY_Pos)         /**< (QSPI_WPMR) Write Protection Key Mask */
+#define QSPI_WPMR_WPKEY(value)              (QSPI_WPMR_WPKEY_Msk & ((value) << QSPI_WPMR_WPKEY_Pos))
+#define   QSPI_WPMR_WPKEY_PASSWD_Val        _U_(0x515350)                                  /**< (QSPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define QSPI_WPMR_WPKEY_PASSWD              (QSPI_WPMR_WPKEY_PASSWD_Val << QSPI_WPMR_WPKEY_Pos)  /**< (QSPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define QSPI_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (QSPI_WPMR) Register MASK  (Use QSPI_WPMR_Msk instead)  */
+#define QSPI_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (QSPI_WPMR) Register Mask  */
+
+
+/* -------- QSPI_WPSR : (QSPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_WPSR_OFFSET                    (0xE8)                                        /**<  (QSPI_WPSR) Write Protection Status Register  Offset */
+
+#define QSPI_WPSR_WPVS_Pos                  0                                              /**< (QSPI_WPSR) Write Protection Violation Status Position */
+#define QSPI_WPSR_WPVS_Msk                  (_U_(0x1) << QSPI_WPSR_WPVS_Pos)               /**< (QSPI_WPSR) Write Protection Violation Status Mask */
+#define QSPI_WPSR_WPVS                      QSPI_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_WPSR_WPVS_Msk instead */
+#define QSPI_WPSR_WPVSRC_Pos                8                                              /**< (QSPI_WPSR) Write Protection Violation Source Position */
+#define QSPI_WPSR_WPVSRC_Msk                (_U_(0xFF) << QSPI_WPSR_WPVSRC_Pos)            /**< (QSPI_WPSR) Write Protection Violation Source Mask */
+#define QSPI_WPSR_WPVSRC(value)             (QSPI_WPSR_WPVSRC_Msk & ((value) << QSPI_WPSR_WPVSRC_Pos))
+#define QSPI_WPSR_MASK                      _U_(0xFF01)                                    /**< \deprecated (QSPI_WPSR) Register MASK  (Use QSPI_WPSR_Msk instead)  */
+#define QSPI_WPSR_Msk                       _U_(0xFF01)                                    /**< (QSPI_WPSR) Register Mask  */
+
+
+/* -------- QSPI_VERSION : (QSPI Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_VERSION_OFFSET                 (0xFC)                                        /**<  (QSPI_VERSION) Version Register  Offset */
+
+#define QSPI_VERSION_VERSION_Pos            0                                              /**< (QSPI_VERSION) Hardware Module Version Position */
+#define QSPI_VERSION_VERSION_Msk            (_U_(0xFFF) << QSPI_VERSION_VERSION_Pos)       /**< (QSPI_VERSION) Hardware Module Version Mask */
+#define QSPI_VERSION_VERSION(value)         (QSPI_VERSION_VERSION_Msk & ((value) << QSPI_VERSION_VERSION_Pos))
+#define QSPI_VERSION_MFN_Pos                16                                             /**< (QSPI_VERSION) Metal Fix Number Position */
+#define QSPI_VERSION_MFN_Msk                (_U_(0x7) << QSPI_VERSION_MFN_Pos)             /**< (QSPI_VERSION) Metal Fix Number Mask */
+#define QSPI_VERSION_MFN(value)             (QSPI_VERSION_MFN_Msk & ((value) << QSPI_VERSION_MFN_Pos))
+#define QSPI_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (QSPI_VERSION) Register MASK  (Use QSPI_VERSION_Msk instead)  */
+#define QSPI_VERSION_Msk                    _U_(0x70FFF)                                   /**< (QSPI_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief QSPI hardware registers */
+typedef struct {  
+  __O  uint32_t QSPI_CR;        /**< (QSPI Offset: 0x00) Control Register */
+  __IO uint32_t QSPI_MR;        /**< (QSPI Offset: 0x04) Mode Register */
+  __I  uint32_t QSPI_RDR;       /**< (QSPI Offset: 0x08) Receive Data Register */
+  __O  uint32_t QSPI_TDR;       /**< (QSPI Offset: 0x0C) Transmit Data Register */
+  __I  uint32_t QSPI_SR;        /**< (QSPI Offset: 0x10) Status Register */
+  __O  uint32_t QSPI_IER;       /**< (QSPI Offset: 0x14) Interrupt Enable Register */
+  __O  uint32_t QSPI_IDR;       /**< (QSPI Offset: 0x18) Interrupt Disable Register */
+  __I  uint32_t QSPI_IMR;       /**< (QSPI Offset: 0x1C) Interrupt Mask Register */
+  __IO uint32_t QSPI_SCR;       /**< (QSPI Offset: 0x20) Serial Clock Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO uint32_t QSPI_IAR;       /**< (QSPI Offset: 0x30) Instruction Address Register */
+  __IO uint32_t QSPI_ICR;       /**< (QSPI Offset: 0x34) Instruction Code Register */
+  __IO uint32_t QSPI_IFR;       /**< (QSPI Offset: 0x38) Instruction Frame Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t QSPI_SMR;       /**< (QSPI Offset: 0x40) Scrambling Mode Register */
+  __O  uint32_t QSPI_SKR;       /**< (QSPI Offset: 0x44) Scrambling Key Register */
+  __I  uint8_t                        Reserved3[156];
+  __IO uint32_t QSPI_WPMR;      /**< (QSPI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t QSPI_WPSR;      /**< (QSPI Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  uint32_t QSPI_VERSION;   /**< (QSPI Offset: 0xFC) Version Register */
+} Qspi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief QSPI hardware registers */
+typedef struct {  
+  __O  QSPI_CR_Type                   QSPI_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO QSPI_MR_Type                   QSPI_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  QSPI_RDR_Type                  QSPI_RDR;       /**< Offset: 0x08 (R/   32) Receive Data Register */
+  __O  QSPI_TDR_Type                  QSPI_TDR;       /**< Offset: 0x0C ( /W  32) Transmit Data Register */
+  __I  QSPI_SR_Type                   QSPI_SR;        /**< Offset: 0x10 (R/   32) Status Register */
+  __O  QSPI_IER_Type                  QSPI_IER;       /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
+  __O  QSPI_IDR_Type                  QSPI_IDR;       /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
+  __I  QSPI_IMR_Type                  QSPI_IMR;       /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
+  __IO QSPI_SCR_Type                  QSPI_SCR;       /**< Offset: 0x20 (R/W  32) Serial Clock Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO QSPI_IAR_Type                  QSPI_IAR;       /**< Offset: 0x30 (R/W  32) Instruction Address Register */
+  __IO QSPI_ICR_Type                  QSPI_ICR;       /**< Offset: 0x34 (R/W  32) Instruction Code Register */
+  __IO QSPI_IFR_Type                  QSPI_IFR;       /**< Offset: 0x38 (R/W  32) Instruction Frame Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO QSPI_SMR_Type                  QSPI_SMR;       /**< Offset: 0x40 (R/W  32) Scrambling Mode Register */
+  __O  QSPI_SKR_Type                  QSPI_SKR;       /**< Offset: 0x44 ( /W  32) Scrambling Key Register */
+  __I  uint8_t                        Reserved3[156];
+  __IO QSPI_WPMR_Type                 QSPI_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  QSPI_WPSR_Type                 QSPI_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  QSPI_VERSION_Type              QSPI_VERSION;   /**< Offset: 0xFC (R/   32) Version Register */
+} Qspi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Quad Serial Peripheral Interface */
+
+#endif /* _SAMV71_QSPI_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/rstc.h
+++ b/asf/sam/include/samv71/component/rstc.h
@@ -1,0 +1,189 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RSTC_COMPONENT_H_
+#define _SAMV71_RSTC_COMPONENT_H_
+#define _SAMV71_RSTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Reset Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSTC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RSTC_11009                      /**< (RSTC) Module ID */
+#define REV_RSTC J                      /**< (RSTC) Module revision */
+
+/* -------- RSTC_CR : (RSTC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PROCRST:1;                 /**< bit:      0  Processor Reset                          */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t EXTRST:1;                  /**< bit:      3  External Reset                           */
+    uint32_t :20;                       /**< bit:  4..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  System Reset Key                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_CR_OFFSET                      (0x00)                                        /**<  (RSTC_CR) Control Register  Offset */
+
+#define RSTC_CR_PROCRST_Pos                 0                                              /**< (RSTC_CR) Processor Reset Position */
+#define RSTC_CR_PROCRST_Msk                 (_U_(0x1) << RSTC_CR_PROCRST_Pos)              /**< (RSTC_CR) Processor Reset Mask */
+#define RSTC_CR_PROCRST                     RSTC_CR_PROCRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_CR_PROCRST_Msk instead */
+#define RSTC_CR_EXTRST_Pos                  3                                              /**< (RSTC_CR) External Reset Position */
+#define RSTC_CR_EXTRST_Msk                  (_U_(0x1) << RSTC_CR_EXTRST_Pos)               /**< (RSTC_CR) External Reset Mask */
+#define RSTC_CR_EXTRST                      RSTC_CR_EXTRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_CR_EXTRST_Msk instead */
+#define RSTC_CR_KEY_Pos                     24                                             /**< (RSTC_CR) System Reset Key Position */
+#define RSTC_CR_KEY_Msk                     (_U_(0xFF) << RSTC_CR_KEY_Pos)                 /**< (RSTC_CR) System Reset Key Mask */
+#define RSTC_CR_KEY(value)                  (RSTC_CR_KEY_Msk & ((value) << RSTC_CR_KEY_Pos))
+#define   RSTC_CR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (RSTC_CR) Writing any other value in this field aborts the write operation.  */
+#define RSTC_CR_KEY_PASSWD                  (RSTC_CR_KEY_PASSWD_Val << RSTC_CR_KEY_Pos)    /**< (RSTC_CR) Writing any other value in this field aborts the write operation. Position  */
+#define RSTC_CR_MASK                        _U_(0xFF000009)                                /**< \deprecated (RSTC_CR) Register MASK  (Use RSTC_CR_Msk instead)  */
+#define RSTC_CR_Msk                         _U_(0xFF000009)                                /**< (RSTC_CR) Register Mask  */
+
+
+/* -------- RSTC_SR : (RSTC Offset: 0x04) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URSTS:1;                   /**< bit:      0  User Reset Status                        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t RSTTYP:3;                  /**< bit:  8..10  Reset Type                               */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t NRSTL:1;                   /**< bit:     16  NRST Pin Level                           */
+    uint32_t SRCMP:1;                   /**< bit:     17  Software Reset Command in Progress       */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_SR_OFFSET                      (0x04)                                        /**<  (RSTC_SR) Status Register  Offset */
+
+#define RSTC_SR_URSTS_Pos                   0                                              /**< (RSTC_SR) User Reset Status Position */
+#define RSTC_SR_URSTS_Msk                   (_U_(0x1) << RSTC_SR_URSTS_Pos)                /**< (RSTC_SR) User Reset Status Mask */
+#define RSTC_SR_URSTS                       RSTC_SR_URSTS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_URSTS_Msk instead */
+#define RSTC_SR_RSTTYP_Pos                  8                                              /**< (RSTC_SR) Reset Type Position */
+#define RSTC_SR_RSTTYP_Msk                  (_U_(0x7) << RSTC_SR_RSTTYP_Pos)               /**< (RSTC_SR) Reset Type Mask */
+#define RSTC_SR_RSTTYP(value)               (RSTC_SR_RSTTYP_Msk & ((value) << RSTC_SR_RSTTYP_Pos))
+#define   RSTC_SR_RSTTYP_GENERAL_RST_Val    _U_(0x0)                                       /**< (RSTC_SR) First powerup reset  */
+#define   RSTC_SR_RSTTYP_BACKUP_RST_Val     _U_(0x1)                                       /**< (RSTC_SR) Return from Backup mode  */
+#define   RSTC_SR_RSTTYP_WDT_RST_Val        _U_(0x2)                                       /**< (RSTC_SR) Watchdog fault occurred  */
+#define   RSTC_SR_RSTTYP_SOFT_RST_Val       _U_(0x3)                                       /**< (RSTC_SR) Processor reset required by the software  */
+#define   RSTC_SR_RSTTYP_USER_RST_Val       _U_(0x4)                                       /**< (RSTC_SR) NRST pin detected low  */
+#define RSTC_SR_RSTTYP_GENERAL_RST          (RSTC_SR_RSTTYP_GENERAL_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) First powerup reset Position  */
+#define RSTC_SR_RSTTYP_BACKUP_RST           (RSTC_SR_RSTTYP_BACKUP_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Return from Backup mode Position  */
+#define RSTC_SR_RSTTYP_WDT_RST              (RSTC_SR_RSTTYP_WDT_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Watchdog fault occurred Position  */
+#define RSTC_SR_RSTTYP_SOFT_RST             (RSTC_SR_RSTTYP_SOFT_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Processor reset required by the software Position  */
+#define RSTC_SR_RSTTYP_USER_RST             (RSTC_SR_RSTTYP_USER_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) NRST pin detected low Position  */
+#define RSTC_SR_NRSTL_Pos                   16                                             /**< (RSTC_SR) NRST Pin Level Position */
+#define RSTC_SR_NRSTL_Msk                   (_U_(0x1) << RSTC_SR_NRSTL_Pos)                /**< (RSTC_SR) NRST Pin Level Mask */
+#define RSTC_SR_NRSTL                       RSTC_SR_NRSTL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_NRSTL_Msk instead */
+#define RSTC_SR_SRCMP_Pos                   17                                             /**< (RSTC_SR) Software Reset Command in Progress Position */
+#define RSTC_SR_SRCMP_Msk                   (_U_(0x1) << RSTC_SR_SRCMP_Pos)                /**< (RSTC_SR) Software Reset Command in Progress Mask */
+#define RSTC_SR_SRCMP                       RSTC_SR_SRCMP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_SRCMP_Msk instead */
+#define RSTC_SR_MASK                        _U_(0x30701)                                   /**< \deprecated (RSTC_SR) Register MASK  (Use RSTC_SR_Msk instead)  */
+#define RSTC_SR_Msk                         _U_(0x30701)                                   /**< (RSTC_SR) Register Mask  */
+
+
+/* -------- RSTC_MR : (RSTC Offset: 0x08) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URSTEN:1;                  /**< bit:      0  User Reset Enable                        */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t URSTIEN:1;                 /**< bit:      4  User Reset Interrupt Enable              */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t ERSTL:4;                   /**< bit:  8..11  External Reset Length                    */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Write Access Password                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_MR_OFFSET                      (0x08)                                        /**<  (RSTC_MR) Mode Register  Offset */
+
+#define RSTC_MR_URSTEN_Pos                  0                                              /**< (RSTC_MR) User Reset Enable Position */
+#define RSTC_MR_URSTEN_Msk                  (_U_(0x1) << RSTC_MR_URSTEN_Pos)               /**< (RSTC_MR) User Reset Enable Mask */
+#define RSTC_MR_URSTEN                      RSTC_MR_URSTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_MR_URSTEN_Msk instead */
+#define RSTC_MR_URSTIEN_Pos                 4                                              /**< (RSTC_MR) User Reset Interrupt Enable Position */
+#define RSTC_MR_URSTIEN_Msk                 (_U_(0x1) << RSTC_MR_URSTIEN_Pos)              /**< (RSTC_MR) User Reset Interrupt Enable Mask */
+#define RSTC_MR_URSTIEN                     RSTC_MR_URSTIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_MR_URSTIEN_Msk instead */
+#define RSTC_MR_ERSTL_Pos                   8                                              /**< (RSTC_MR) External Reset Length Position */
+#define RSTC_MR_ERSTL_Msk                   (_U_(0xF) << RSTC_MR_ERSTL_Pos)                /**< (RSTC_MR) External Reset Length Mask */
+#define RSTC_MR_ERSTL(value)                (RSTC_MR_ERSTL_Msk & ((value) << RSTC_MR_ERSTL_Pos))
+#define RSTC_MR_KEY_Pos                     24                                             /**< (RSTC_MR) Write Access Password Position */
+#define RSTC_MR_KEY_Msk                     (_U_(0xFF) << RSTC_MR_KEY_Pos)                 /**< (RSTC_MR) Write Access Password Mask */
+#define RSTC_MR_KEY(value)                  (RSTC_MR_KEY_Msk & ((value) << RSTC_MR_KEY_Pos))
+#define   RSTC_MR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (RSTC_MR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define RSTC_MR_KEY_PASSWD                  (RSTC_MR_KEY_PASSWD_Val << RSTC_MR_KEY_Pos)    /**< (RSTC_MR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define RSTC_MR_MASK                        _U_(0xFF000F11)                                /**< \deprecated (RSTC_MR) Register MASK  (Use RSTC_MR_Msk instead)  */
+#define RSTC_MR_Msk                         _U_(0xFF000F11)                                /**< (RSTC_MR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RSTC hardware registers */
+typedef struct {  
+  __O  uint32_t RSTC_CR;        /**< (RSTC Offset: 0x00) Control Register */
+  __I  uint32_t RSTC_SR;        /**< (RSTC Offset: 0x04) Status Register */
+  __IO uint32_t RSTC_MR;        /**< (RSTC Offset: 0x08) Mode Register */
+} Rstc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RSTC hardware registers */
+typedef struct {  
+  __O  RSTC_CR_Type                   RSTC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __I  RSTC_SR_Type                   RSTC_SR;        /**< Offset: 0x04 (R/   32) Status Register */
+  __IO RSTC_MR_Type                   RSTC_MR;        /**< Offset: 0x08 (R/W  32) Mode Register */
+} Rstc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reset Controller */
+
+#endif /* _SAMV71_RSTC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/rswdt.h
+++ b/asf/sam/include/samv71/component/rswdt.h
@@ -1,0 +1,169 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSWDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RSWDT_COMPONENT_H_
+#define _SAMV71_RSWDT_COMPONENT_H_
+#define _SAMV71_RSWDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Reinforced Safety Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSWDT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RSWDT_11110                      /**< (RSWDT) Module ID */
+#define REV_RSWDT E                      /**< (RSWDT) Module revision */
+
+/* -------- RSWDT_CR : (RSWDT Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
+    uint32_t :23;                       /**< bit:  1..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_CR_OFFSET                     (0x00)                                        /**<  (RSWDT_CR) Control Register  Offset */
+
+#define RSWDT_CR_WDRSTT_Pos                 0                                              /**< (RSWDT_CR) Watchdog Restart Position */
+#define RSWDT_CR_WDRSTT_Msk                 (_U_(0x1) << RSWDT_CR_WDRSTT_Pos)              /**< (RSWDT_CR) Watchdog Restart Mask */
+#define RSWDT_CR_WDRSTT                     RSWDT_CR_WDRSTT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_CR_WDRSTT_Msk instead */
+#define RSWDT_CR_KEY_Pos                    24                                             /**< (RSWDT_CR) Password Position */
+#define RSWDT_CR_KEY_Msk                    (_U_(0xFF) << RSWDT_CR_KEY_Pos)                /**< (RSWDT_CR) Password Mask */
+#define RSWDT_CR_KEY(value)                 (RSWDT_CR_KEY_Msk & ((value) << RSWDT_CR_KEY_Pos))
+#define   RSWDT_CR_KEY_PASSWD_Val           _U_(0xC4)                                      /**< (RSWDT_CR) Writing any other value in this field aborts the write operation.  */
+#define RSWDT_CR_KEY_PASSWD                 (RSWDT_CR_KEY_PASSWD_Val << RSWDT_CR_KEY_Pos)  /**< (RSWDT_CR) Writing any other value in this field aborts the write operation. Position  */
+#define RSWDT_CR_MASK                       _U_(0xFF000001)                                /**< \deprecated (RSWDT_CR) Register MASK  (Use RSWDT_CR_Msk instead)  */
+#define RSWDT_CR_Msk                        _U_(0xFF000001)                                /**< (RSWDT_CR) Register Mask  */
+
+
+/* -------- RSWDT_MR : (RSWDT Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
+    uint32_t WDFIEN:1;                  /**< bit:     12  Watchdog Fault Interrupt Enable          */
+    uint32_t WDRSTEN:1;                 /**< bit:     13  Watchdog Reset Enable                    */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t WDDIS:1;                   /**< bit:     15  Watchdog Disable                         */
+    uint32_t ALLONES:12;                /**< bit: 16..27  Must Always Be Written with 0xFFF        */
+    uint32_t WDDBGHLT:1;                /**< bit:     28  Watchdog Debug Halt                      */
+    uint32_t WDIDLEHLT:1;               /**< bit:     29  Watchdog Idle Halt                       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_MR_OFFSET                     (0x04)                                        /**<  (RSWDT_MR) Mode Register  Offset */
+
+#define RSWDT_MR_WDV_Pos                    0                                              /**< (RSWDT_MR) Watchdog Counter Value Position */
+#define RSWDT_MR_WDV_Msk                    (_U_(0xFFF) << RSWDT_MR_WDV_Pos)               /**< (RSWDT_MR) Watchdog Counter Value Mask */
+#define RSWDT_MR_WDV(value)                 (RSWDT_MR_WDV_Msk & ((value) << RSWDT_MR_WDV_Pos))
+#define RSWDT_MR_WDFIEN_Pos                 12                                             /**< (RSWDT_MR) Watchdog Fault Interrupt Enable Position */
+#define RSWDT_MR_WDFIEN_Msk                 (_U_(0x1) << RSWDT_MR_WDFIEN_Pos)              /**< (RSWDT_MR) Watchdog Fault Interrupt Enable Mask */
+#define RSWDT_MR_WDFIEN                     RSWDT_MR_WDFIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDFIEN_Msk instead */
+#define RSWDT_MR_WDRSTEN_Pos                13                                             /**< (RSWDT_MR) Watchdog Reset Enable Position */
+#define RSWDT_MR_WDRSTEN_Msk                (_U_(0x1) << RSWDT_MR_WDRSTEN_Pos)             /**< (RSWDT_MR) Watchdog Reset Enable Mask */
+#define RSWDT_MR_WDRSTEN                    RSWDT_MR_WDRSTEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDRSTEN_Msk instead */
+#define RSWDT_MR_WDDIS_Pos                  15                                             /**< (RSWDT_MR) Watchdog Disable Position */
+#define RSWDT_MR_WDDIS_Msk                  (_U_(0x1) << RSWDT_MR_WDDIS_Pos)               /**< (RSWDT_MR) Watchdog Disable Mask */
+#define RSWDT_MR_WDDIS                      RSWDT_MR_WDDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDDIS_Msk instead */
+#define RSWDT_MR_ALLONES_Pos                16                                             /**< (RSWDT_MR) Must Always Be Written with 0xFFF Position */
+#define RSWDT_MR_ALLONES_Msk                (_U_(0xFFF) << RSWDT_MR_ALLONES_Pos)           /**< (RSWDT_MR) Must Always Be Written with 0xFFF Mask */
+#define RSWDT_MR_ALLONES(value)             (RSWDT_MR_ALLONES_Msk & ((value) << RSWDT_MR_ALLONES_Pos))
+#define RSWDT_MR_WDDBGHLT_Pos               28                                             /**< (RSWDT_MR) Watchdog Debug Halt Position */
+#define RSWDT_MR_WDDBGHLT_Msk               (_U_(0x1) << RSWDT_MR_WDDBGHLT_Pos)            /**< (RSWDT_MR) Watchdog Debug Halt Mask */
+#define RSWDT_MR_WDDBGHLT                   RSWDT_MR_WDDBGHLT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDDBGHLT_Msk instead */
+#define RSWDT_MR_WDIDLEHLT_Pos              29                                             /**< (RSWDT_MR) Watchdog Idle Halt Position */
+#define RSWDT_MR_WDIDLEHLT_Msk              (_U_(0x1) << RSWDT_MR_WDIDLEHLT_Pos)           /**< (RSWDT_MR) Watchdog Idle Halt Mask */
+#define RSWDT_MR_WDIDLEHLT                  RSWDT_MR_WDIDLEHLT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDIDLEHLT_Msk instead */
+#define RSWDT_MR_MASK                       _U_(0x3FFFBFFF)                                /**< \deprecated (RSWDT_MR) Register MASK  (Use RSWDT_MR_Msk instead)  */
+#define RSWDT_MR_Msk                        _U_(0x3FFFBFFF)                                /**< (RSWDT_MR) Register Mask  */
+
+
+/* -------- RSWDT_SR : (RSWDT Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow                       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_SR_OFFSET                     (0x08)                                        /**<  (RSWDT_SR) Status Register  Offset */
+
+#define RSWDT_SR_WDUNF_Pos                  0                                              /**< (RSWDT_SR) Watchdog Underflow Position */
+#define RSWDT_SR_WDUNF_Msk                  (_U_(0x1) << RSWDT_SR_WDUNF_Pos)               /**< (RSWDT_SR) Watchdog Underflow Mask */
+#define RSWDT_SR_WDUNF                      RSWDT_SR_WDUNF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_SR_WDUNF_Msk instead */
+#define RSWDT_SR_MASK                       _U_(0x01)                                      /**< \deprecated (RSWDT_SR) Register MASK  (Use RSWDT_SR_Msk instead)  */
+#define RSWDT_SR_Msk                        _U_(0x01)                                      /**< (RSWDT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RSWDT hardware registers */
+typedef struct {  
+  __O  uint32_t RSWDT_CR;       /**< (RSWDT Offset: 0x00) Control Register */
+  __IO uint32_t RSWDT_MR;       /**< (RSWDT Offset: 0x04) Mode Register */
+  __I  uint32_t RSWDT_SR;       /**< (RSWDT Offset: 0x08) Status Register */
+} Rswdt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RSWDT hardware registers */
+typedef struct {  
+  __O  RSWDT_CR_Type                  RSWDT_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO RSWDT_MR_Type                  RSWDT_MR;       /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  RSWDT_SR_Type                  RSWDT_SR;       /**< Offset: 0x08 (R/   32) Status Register */
+} Rswdt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reinforced Safety Watchdog Timer */
+
+#endif /* _SAMV71_RSWDT_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/rtc.h
+++ b/asf/sam/include/samv71/component/rtc.h
@@ -1,0 +1,711 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RTC_COMPONENT_H_
+#define _SAMV71_RTC_COMPONENT_H_
+#define _SAMV71_RTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Real-time Clock
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RTC_6056                       /**< (RTC) Module ID */
+#define REV_RTC Y                      /**< (RTC) Module revision */
+
+/* -------- RTC_CR : (RTC Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPDTIM:1;                  /**< bit:      0  Update Request Time Register             */
+    uint32_t UPDCAL:1;                  /**< bit:      1  Update Request Calendar Register         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t TIMEVSEL:2;                /**< bit:   8..9  Time Event Selection                     */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t CALEVSEL:2;                /**< bit: 16..17  Calendar Event Selection                 */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CR_OFFSET                       (0x00)                                        /**<  (RTC_CR) Control Register  Offset */
+
+#define RTC_CR_UPDTIM_Pos                   0                                              /**< (RTC_CR) Update Request Time Register Position */
+#define RTC_CR_UPDTIM_Msk                   (_U_(0x1) << RTC_CR_UPDTIM_Pos)                /**< (RTC_CR) Update Request Time Register Mask */
+#define RTC_CR_UPDTIM                       RTC_CR_UPDTIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CR_UPDTIM_Msk instead */
+#define RTC_CR_UPDCAL_Pos                   1                                              /**< (RTC_CR) Update Request Calendar Register Position */
+#define RTC_CR_UPDCAL_Msk                   (_U_(0x1) << RTC_CR_UPDCAL_Pos)                /**< (RTC_CR) Update Request Calendar Register Mask */
+#define RTC_CR_UPDCAL                       RTC_CR_UPDCAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CR_UPDCAL_Msk instead */
+#define RTC_CR_TIMEVSEL_Pos                 8                                              /**< (RTC_CR) Time Event Selection Position */
+#define RTC_CR_TIMEVSEL_Msk                 (_U_(0x3) << RTC_CR_TIMEVSEL_Pos)              /**< (RTC_CR) Time Event Selection Mask */
+#define RTC_CR_TIMEVSEL(value)              (RTC_CR_TIMEVSEL_Msk & ((value) << RTC_CR_TIMEVSEL_Pos))
+#define   RTC_CR_TIMEVSEL_MINUTE_Val        _U_(0x0)                                       /**< (RTC_CR) Minute change  */
+#define   RTC_CR_TIMEVSEL_HOUR_Val          _U_(0x1)                                       /**< (RTC_CR) Hour change  */
+#define   RTC_CR_TIMEVSEL_MIDNIGHT_Val      _U_(0x2)                                       /**< (RTC_CR) Every day at midnight  */
+#define   RTC_CR_TIMEVSEL_NOON_Val          _U_(0x3)                                       /**< (RTC_CR) Every day at noon  */
+#define RTC_CR_TIMEVSEL_MINUTE              (RTC_CR_TIMEVSEL_MINUTE_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Minute change Position  */
+#define RTC_CR_TIMEVSEL_HOUR                (RTC_CR_TIMEVSEL_HOUR_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Hour change Position  */
+#define RTC_CR_TIMEVSEL_MIDNIGHT            (RTC_CR_TIMEVSEL_MIDNIGHT_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Every day at midnight Position  */
+#define RTC_CR_TIMEVSEL_NOON                (RTC_CR_TIMEVSEL_NOON_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Every day at noon Position  */
+#define RTC_CR_CALEVSEL_Pos                 16                                             /**< (RTC_CR) Calendar Event Selection Position */
+#define RTC_CR_CALEVSEL_Msk                 (_U_(0x3) << RTC_CR_CALEVSEL_Pos)              /**< (RTC_CR) Calendar Event Selection Mask */
+#define RTC_CR_CALEVSEL(value)              (RTC_CR_CALEVSEL_Msk & ((value) << RTC_CR_CALEVSEL_Pos))
+#define   RTC_CR_CALEVSEL_WEEK_Val          _U_(0x0)                                       /**< (RTC_CR) Week change (every Monday at time 00:00:00)  */
+#define   RTC_CR_CALEVSEL_MONTH_Val         _U_(0x1)                                       /**< (RTC_CR) Month change (every 01 of each month at time 00:00:00)  */
+#define   RTC_CR_CALEVSEL_YEAR_Val          _U_(0x2)                                       /**< (RTC_CR) Year change (every January 1 at time 00:00:00)  */
+#define RTC_CR_CALEVSEL_WEEK                (RTC_CR_CALEVSEL_WEEK_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Week change (every Monday at time 00:00:00) Position  */
+#define RTC_CR_CALEVSEL_MONTH               (RTC_CR_CALEVSEL_MONTH_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Month change (every 01 of each month at time 00:00:00) Position  */
+#define RTC_CR_CALEVSEL_YEAR                (RTC_CR_CALEVSEL_YEAR_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Year change (every January 1 at time 00:00:00) Position  */
+#define RTC_CR_MASK                         _U_(0x30303)                                   /**< \deprecated (RTC_CR) Register MASK  (Use RTC_CR_Msk instead)  */
+#define RTC_CR_Msk                          _U_(0x30303)                                   /**< (RTC_CR) Register Mask  */
+
+
+/* -------- RTC_MR : (RTC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HRMOD:1;                   /**< bit:      0  12-/24-hour Mode                         */
+    uint32_t PERSIAN:1;                 /**< bit:      1  PERSIAN Calendar                         */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t NEGPPM:1;                  /**< bit:      4  NEGative PPM Correction                  */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t CORRECTION:7;              /**< bit:  8..14  Slow Clock Correction                    */
+    uint32_t HIGHPPM:1;                 /**< bit:     15  HIGH PPM Correction                      */
+    uint32_t OUT0:3;                    /**< bit: 16..18  RTCOUT0 OutputSource Selection           */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t OUT1:3;                    /**< bit: 20..22  RTCOUT1 Output Source Selection          */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t THIGH:3;                   /**< bit: 24..26  High Duration of the Output Pulse        */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t TPERIOD:2;                 /**< bit: 28..29  Period of the Output Pulse               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MR_OFFSET                       (0x04)                                        /**<  (RTC_MR) Mode Register  Offset */
+
+#define RTC_MR_HRMOD_Pos                    0                                              /**< (RTC_MR) 12-/24-hour Mode Position */
+#define RTC_MR_HRMOD_Msk                    (_U_(0x1) << RTC_MR_HRMOD_Pos)                 /**< (RTC_MR) 12-/24-hour Mode Mask */
+#define RTC_MR_HRMOD                        RTC_MR_HRMOD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_HRMOD_Msk instead */
+#define RTC_MR_PERSIAN_Pos                  1                                              /**< (RTC_MR) PERSIAN Calendar Position */
+#define RTC_MR_PERSIAN_Msk                  (_U_(0x1) << RTC_MR_PERSIAN_Pos)               /**< (RTC_MR) PERSIAN Calendar Mask */
+#define RTC_MR_PERSIAN                      RTC_MR_PERSIAN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_PERSIAN_Msk instead */
+#define RTC_MR_NEGPPM_Pos                   4                                              /**< (RTC_MR) NEGative PPM Correction Position */
+#define RTC_MR_NEGPPM_Msk                   (_U_(0x1) << RTC_MR_NEGPPM_Pos)                /**< (RTC_MR) NEGative PPM Correction Mask */
+#define RTC_MR_NEGPPM                       RTC_MR_NEGPPM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_NEGPPM_Msk instead */
+#define RTC_MR_CORRECTION_Pos               8                                              /**< (RTC_MR) Slow Clock Correction Position */
+#define RTC_MR_CORRECTION_Msk               (_U_(0x7F) << RTC_MR_CORRECTION_Pos)           /**< (RTC_MR) Slow Clock Correction Mask */
+#define RTC_MR_CORRECTION(value)            (RTC_MR_CORRECTION_Msk & ((value) << RTC_MR_CORRECTION_Pos))
+#define RTC_MR_HIGHPPM_Pos                  15                                             /**< (RTC_MR) HIGH PPM Correction Position */
+#define RTC_MR_HIGHPPM_Msk                  (_U_(0x1) << RTC_MR_HIGHPPM_Pos)               /**< (RTC_MR) HIGH PPM Correction Mask */
+#define RTC_MR_HIGHPPM                      RTC_MR_HIGHPPM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_HIGHPPM_Msk instead */
+#define RTC_MR_OUT0_Pos                     16                                             /**< (RTC_MR) RTCOUT0 OutputSource Selection Position */
+#define RTC_MR_OUT0_Msk                     (_U_(0x7) << RTC_MR_OUT0_Pos)                  /**< (RTC_MR) RTCOUT0 OutputSource Selection Mask */
+#define RTC_MR_OUT0(value)                  (RTC_MR_OUT0_Msk & ((value) << RTC_MR_OUT0_Pos))
+#define   RTC_MR_OUT0_NO_WAVE_Val           _U_(0x0)                                       /**< (RTC_MR) No waveform, stuck at '0'  */
+#define   RTC_MR_OUT0_FREQ1HZ_Val           _U_(0x1)                                       /**< (RTC_MR) 1 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ32HZ_Val          _U_(0x2)                                       /**< (RTC_MR) 32 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ64HZ_Val          _U_(0x3)                                       /**< (RTC_MR) 64 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ512HZ_Val         _U_(0x4)                                       /**< (RTC_MR) 512 Hz square wave  */
+#define   RTC_MR_OUT0_ALARM_TOGGLE_Val      _U_(0x5)                                       /**< (RTC_MR) Output toggles when alarm flag rises  */
+#define   RTC_MR_OUT0_ALARM_FLAG_Val        _U_(0x6)                                       /**< (RTC_MR) Output is a copy of the alarm flag  */
+#define   RTC_MR_OUT0_PROG_PULSE_Val        _U_(0x7)                                       /**< (RTC_MR) Duty cycle programmable pulse  */
+#define RTC_MR_OUT0_NO_WAVE                 (RTC_MR_OUT0_NO_WAVE_Val << RTC_MR_OUT0_Pos)   /**< (RTC_MR) No waveform, stuck at '0' Position  */
+#define RTC_MR_OUT0_FREQ1HZ                 (RTC_MR_OUT0_FREQ1HZ_Val << RTC_MR_OUT0_Pos)   /**< (RTC_MR) 1 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ32HZ                (RTC_MR_OUT0_FREQ32HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 32 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ64HZ                (RTC_MR_OUT0_FREQ64HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 64 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ512HZ               (RTC_MR_OUT0_FREQ512HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 512 Hz square wave Position  */
+#define RTC_MR_OUT0_ALARM_TOGGLE            (RTC_MR_OUT0_ALARM_TOGGLE_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Output toggles when alarm flag rises Position  */
+#define RTC_MR_OUT0_ALARM_FLAG              (RTC_MR_OUT0_ALARM_FLAG_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Output is a copy of the alarm flag Position  */
+#define RTC_MR_OUT0_PROG_PULSE              (RTC_MR_OUT0_PROG_PULSE_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Duty cycle programmable pulse Position  */
+#define RTC_MR_OUT1_Pos                     20                                             /**< (RTC_MR) RTCOUT1 Output Source Selection Position */
+#define RTC_MR_OUT1_Msk                     (_U_(0x7) << RTC_MR_OUT1_Pos)                  /**< (RTC_MR) RTCOUT1 Output Source Selection Mask */
+#define RTC_MR_OUT1(value)                  (RTC_MR_OUT1_Msk & ((value) << RTC_MR_OUT1_Pos))
+#define   RTC_MR_OUT1_NO_WAVE_Val           _U_(0x0)                                       /**< (RTC_MR) No waveform, stuck at '0'  */
+#define   RTC_MR_OUT1_FREQ1HZ_Val           _U_(0x1)                                       /**< (RTC_MR) 1 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ32HZ_Val          _U_(0x2)                                       /**< (RTC_MR) 32 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ64HZ_Val          _U_(0x3)                                       /**< (RTC_MR) 64 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ512HZ_Val         _U_(0x4)                                       /**< (RTC_MR) 512 Hz square wave  */
+#define   RTC_MR_OUT1_ALARM_TOGGLE_Val      _U_(0x5)                                       /**< (RTC_MR) Output toggles when alarm flag rises  */
+#define   RTC_MR_OUT1_ALARM_FLAG_Val        _U_(0x6)                                       /**< (RTC_MR) Output is a copy of the alarm flag  */
+#define   RTC_MR_OUT1_PROG_PULSE_Val        _U_(0x7)                                       /**< (RTC_MR) Duty cycle programmable pulse  */
+#define RTC_MR_OUT1_NO_WAVE                 (RTC_MR_OUT1_NO_WAVE_Val << RTC_MR_OUT1_Pos)   /**< (RTC_MR) No waveform, stuck at '0' Position  */
+#define RTC_MR_OUT1_FREQ1HZ                 (RTC_MR_OUT1_FREQ1HZ_Val << RTC_MR_OUT1_Pos)   /**< (RTC_MR) 1 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ32HZ                (RTC_MR_OUT1_FREQ32HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 32 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ64HZ                (RTC_MR_OUT1_FREQ64HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 64 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ512HZ               (RTC_MR_OUT1_FREQ512HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 512 Hz square wave Position  */
+#define RTC_MR_OUT1_ALARM_TOGGLE            (RTC_MR_OUT1_ALARM_TOGGLE_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Output toggles when alarm flag rises Position  */
+#define RTC_MR_OUT1_ALARM_FLAG              (RTC_MR_OUT1_ALARM_FLAG_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Output is a copy of the alarm flag Position  */
+#define RTC_MR_OUT1_PROG_PULSE              (RTC_MR_OUT1_PROG_PULSE_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Duty cycle programmable pulse Position  */
+#define RTC_MR_THIGH_Pos                    24                                             /**< (RTC_MR) High Duration of the Output Pulse Position */
+#define RTC_MR_THIGH_Msk                    (_U_(0x7) << RTC_MR_THIGH_Pos)                 /**< (RTC_MR) High Duration of the Output Pulse Mask */
+#define RTC_MR_THIGH(value)                 (RTC_MR_THIGH_Msk & ((value) << RTC_MR_THIGH_Pos))
+#define   RTC_MR_THIGH_H_31MS_Val           _U_(0x0)                                       /**< (RTC_MR) 31.2 ms  */
+#define   RTC_MR_THIGH_H_16MS_Val           _U_(0x1)                                       /**< (RTC_MR) 15.6 ms  */
+#define   RTC_MR_THIGH_H_4MS_Val            _U_(0x2)                                       /**< (RTC_MR) 3.91 ms  */
+#define   RTC_MR_THIGH_H_976US_Val          _U_(0x3)                                       /**< (RTC_MR) 976 us  */
+#define   RTC_MR_THIGH_H_488US_Val          _U_(0x4)                                       /**< (RTC_MR) 488 us  */
+#define   RTC_MR_THIGH_H_122US_Val          _U_(0x5)                                       /**< (RTC_MR) 122 us  */
+#define   RTC_MR_THIGH_H_30US_Val           _U_(0x6)                                       /**< (RTC_MR) 30.5 us  */
+#define   RTC_MR_THIGH_H_15US_Val           _U_(0x7)                                       /**< (RTC_MR) 15.2 us  */
+#define RTC_MR_THIGH_H_31MS                 (RTC_MR_THIGH_H_31MS_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 31.2 ms Position  */
+#define RTC_MR_THIGH_H_16MS                 (RTC_MR_THIGH_H_16MS_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 15.6 ms Position  */
+#define RTC_MR_THIGH_H_4MS                  (RTC_MR_THIGH_H_4MS_Val << RTC_MR_THIGH_Pos)   /**< (RTC_MR) 3.91 ms Position  */
+#define RTC_MR_THIGH_H_976US                (RTC_MR_THIGH_H_976US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 976 us Position  */
+#define RTC_MR_THIGH_H_488US                (RTC_MR_THIGH_H_488US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 488 us Position  */
+#define RTC_MR_THIGH_H_122US                (RTC_MR_THIGH_H_122US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 122 us Position  */
+#define RTC_MR_THIGH_H_30US                 (RTC_MR_THIGH_H_30US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 30.5 us Position  */
+#define RTC_MR_THIGH_H_15US                 (RTC_MR_THIGH_H_15US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 15.2 us Position  */
+#define RTC_MR_TPERIOD_Pos                  28                                             /**< (RTC_MR) Period of the Output Pulse Position */
+#define RTC_MR_TPERIOD_Msk                  (_U_(0x3) << RTC_MR_TPERIOD_Pos)               /**< (RTC_MR) Period of the Output Pulse Mask */
+#define RTC_MR_TPERIOD(value)               (RTC_MR_TPERIOD_Msk & ((value) << RTC_MR_TPERIOD_Pos))
+#define   RTC_MR_TPERIOD_P_1S_Val           _U_(0x0)                                       /**< (RTC_MR) 1 second  */
+#define   RTC_MR_TPERIOD_P_500MS_Val        _U_(0x1)                                       /**< (RTC_MR) 500 ms  */
+#define   RTC_MR_TPERIOD_P_250MS_Val        _U_(0x2)                                       /**< (RTC_MR) 250 ms  */
+#define   RTC_MR_TPERIOD_P_125MS_Val        _U_(0x3)                                       /**< (RTC_MR) 125 ms  */
+#define RTC_MR_TPERIOD_P_1S                 (RTC_MR_TPERIOD_P_1S_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 1 second Position  */
+#define RTC_MR_TPERIOD_P_500MS              (RTC_MR_TPERIOD_P_500MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 500 ms Position  */
+#define RTC_MR_TPERIOD_P_250MS              (RTC_MR_TPERIOD_P_250MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 250 ms Position  */
+#define RTC_MR_TPERIOD_P_125MS              (RTC_MR_TPERIOD_P_125MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 125 ms Position  */
+#define RTC_MR_MASK                         _U_(0x3777FF13)                                /**< \deprecated (RTC_MR) Register MASK  (Use RTC_MR_Msk instead)  */
+#define RTC_MR_Msk                          _U_(0x3777FF13)                                /**< (RTC_MR) Register Mask  */
+
+
+/* -------- RTC_TIMR : (RTC Offset: 0x08) (R/W 32) Time Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:7;                     /**< bit:   0..6  Current Second                           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MIN:7;                     /**< bit:  8..14  Current Minute                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HOUR:6;                    /**< bit: 16..21  Current Hour                             */
+    uint32_t AMPM:1;                    /**< bit:     22  Ante Meridiem Post Meridiem Indicator    */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TIMR_OFFSET                     (0x08)                                        /**<  (RTC_TIMR) Time Register  Offset */
+
+#define RTC_TIMR_SEC_Pos                    0                                              /**< (RTC_TIMR) Current Second Position */
+#define RTC_TIMR_SEC_Msk                    (_U_(0x7F) << RTC_TIMR_SEC_Pos)                /**< (RTC_TIMR) Current Second Mask */
+#define RTC_TIMR_SEC(value)                 (RTC_TIMR_SEC_Msk & ((value) << RTC_TIMR_SEC_Pos))
+#define RTC_TIMR_MIN_Pos                    8                                              /**< (RTC_TIMR) Current Minute Position */
+#define RTC_TIMR_MIN_Msk                    (_U_(0x7F) << RTC_TIMR_MIN_Pos)                /**< (RTC_TIMR) Current Minute Mask */
+#define RTC_TIMR_MIN(value)                 (RTC_TIMR_MIN_Msk & ((value) << RTC_TIMR_MIN_Pos))
+#define RTC_TIMR_HOUR_Pos                   16                                             /**< (RTC_TIMR) Current Hour Position */
+#define RTC_TIMR_HOUR_Msk                   (_U_(0x3F) << RTC_TIMR_HOUR_Pos)               /**< (RTC_TIMR) Current Hour Mask */
+#define RTC_TIMR_HOUR(value)                (RTC_TIMR_HOUR_Msk & ((value) << RTC_TIMR_HOUR_Pos))
+#define RTC_TIMR_AMPM_Pos                   22                                             /**< (RTC_TIMR) Ante Meridiem Post Meridiem Indicator Position */
+#define RTC_TIMR_AMPM_Msk                   (_U_(0x1) << RTC_TIMR_AMPM_Pos)                /**< (RTC_TIMR) Ante Meridiem Post Meridiem Indicator Mask */
+#define RTC_TIMR_AMPM                       RTC_TIMR_AMPM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMR_AMPM_Msk instead */
+#define RTC_TIMR_MASK                       _U_(0x7F7F7F)                                  /**< \deprecated (RTC_TIMR) Register MASK  (Use RTC_TIMR_Msk instead)  */
+#define RTC_TIMR_Msk                        _U_(0x7F7F7F)                                  /**< (RTC_TIMR) Register Mask  */
+
+
+/* -------- RTC_CALR : (RTC Offset: 0x0c) (R/W 32) Calendar Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CENT:7;                    /**< bit:   0..6  Current Century                          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t YEAR:8;                    /**< bit:  8..15  Current Year                             */
+    uint32_t MONTH:5;                   /**< bit: 16..20  Current Month                            */
+    uint32_t DAY:3;                     /**< bit: 21..23  Current Day in Current Week              */
+    uint32_t DATE:6;                    /**< bit: 24..29  Current Day in Current Month             */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CALR_OFFSET                     (0x0C)                                        /**<  (RTC_CALR) Calendar Register  Offset */
+
+#define RTC_CALR_CENT_Pos                   0                                              /**< (RTC_CALR) Current Century Position */
+#define RTC_CALR_CENT_Msk                   (_U_(0x7F) << RTC_CALR_CENT_Pos)               /**< (RTC_CALR) Current Century Mask */
+#define RTC_CALR_CENT(value)                (RTC_CALR_CENT_Msk & ((value) << RTC_CALR_CENT_Pos))
+#define RTC_CALR_YEAR_Pos                   8                                              /**< (RTC_CALR) Current Year Position */
+#define RTC_CALR_YEAR_Msk                   (_U_(0xFF) << RTC_CALR_YEAR_Pos)               /**< (RTC_CALR) Current Year Mask */
+#define RTC_CALR_YEAR(value)                (RTC_CALR_YEAR_Msk & ((value) << RTC_CALR_YEAR_Pos))
+#define RTC_CALR_MONTH_Pos                  16                                             /**< (RTC_CALR) Current Month Position */
+#define RTC_CALR_MONTH_Msk                  (_U_(0x1F) << RTC_CALR_MONTH_Pos)              /**< (RTC_CALR) Current Month Mask */
+#define RTC_CALR_MONTH(value)               (RTC_CALR_MONTH_Msk & ((value) << RTC_CALR_MONTH_Pos))
+#define RTC_CALR_DAY_Pos                    21                                             /**< (RTC_CALR) Current Day in Current Week Position */
+#define RTC_CALR_DAY_Msk                    (_U_(0x7) << RTC_CALR_DAY_Pos)                 /**< (RTC_CALR) Current Day in Current Week Mask */
+#define RTC_CALR_DAY(value)                 (RTC_CALR_DAY_Msk & ((value) << RTC_CALR_DAY_Pos))
+#define RTC_CALR_DATE_Pos                   24                                             /**< (RTC_CALR) Current Day in Current Month Position */
+#define RTC_CALR_DATE_Msk                   (_U_(0x3F) << RTC_CALR_DATE_Pos)               /**< (RTC_CALR) Current Day in Current Month Mask */
+#define RTC_CALR_DATE(value)                (RTC_CALR_DATE_Msk & ((value) << RTC_CALR_DATE_Pos))
+#define RTC_CALR_MASK                       _U_(0x3FFFFF7F)                                /**< \deprecated (RTC_CALR) Register MASK  (Use RTC_CALR_Msk instead)  */
+#define RTC_CALR_Msk                        _U_(0x3FFFFF7F)                                /**< (RTC_CALR) Register Mask  */
+
+
+/* -------- RTC_TIMALR : (RTC Offset: 0x10) (R/W 32) Time Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:7;                     /**< bit:   0..6  Second Alarm                             */
+    uint32_t SECEN:1;                   /**< bit:      7  Second Alarm Enable                      */
+    uint32_t MIN:7;                     /**< bit:  8..14  Minute Alarm                             */
+    uint32_t MINEN:1;                   /**< bit:     15  Minute Alarm Enable                      */
+    uint32_t HOUR:6;                    /**< bit: 16..21  Hour Alarm                               */
+    uint32_t AMPM:1;                    /**< bit:     22  AM/PM Indicator                          */
+    uint32_t HOUREN:1;                  /**< bit:     23  Hour Alarm Enable                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TIMALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TIMALR_OFFSET                   (0x10)                                        /**<  (RTC_TIMALR) Time Alarm Register  Offset */
+
+#define RTC_TIMALR_SEC_Pos                  0                                              /**< (RTC_TIMALR) Second Alarm Position */
+#define RTC_TIMALR_SEC_Msk                  (_U_(0x7F) << RTC_TIMALR_SEC_Pos)              /**< (RTC_TIMALR) Second Alarm Mask */
+#define RTC_TIMALR_SEC(value)               (RTC_TIMALR_SEC_Msk & ((value) << RTC_TIMALR_SEC_Pos))
+#define RTC_TIMALR_SECEN_Pos                7                                              /**< (RTC_TIMALR) Second Alarm Enable Position */
+#define RTC_TIMALR_SECEN_Msk                (_U_(0x1) << RTC_TIMALR_SECEN_Pos)             /**< (RTC_TIMALR) Second Alarm Enable Mask */
+#define RTC_TIMALR_SECEN                    RTC_TIMALR_SECEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_SECEN_Msk instead */
+#define RTC_TIMALR_MIN_Pos                  8                                              /**< (RTC_TIMALR) Minute Alarm Position */
+#define RTC_TIMALR_MIN_Msk                  (_U_(0x7F) << RTC_TIMALR_MIN_Pos)              /**< (RTC_TIMALR) Minute Alarm Mask */
+#define RTC_TIMALR_MIN(value)               (RTC_TIMALR_MIN_Msk & ((value) << RTC_TIMALR_MIN_Pos))
+#define RTC_TIMALR_MINEN_Pos                15                                             /**< (RTC_TIMALR) Minute Alarm Enable Position */
+#define RTC_TIMALR_MINEN_Msk                (_U_(0x1) << RTC_TIMALR_MINEN_Pos)             /**< (RTC_TIMALR) Minute Alarm Enable Mask */
+#define RTC_TIMALR_MINEN                    RTC_TIMALR_MINEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_MINEN_Msk instead */
+#define RTC_TIMALR_HOUR_Pos                 16                                             /**< (RTC_TIMALR) Hour Alarm Position */
+#define RTC_TIMALR_HOUR_Msk                 (_U_(0x3F) << RTC_TIMALR_HOUR_Pos)             /**< (RTC_TIMALR) Hour Alarm Mask */
+#define RTC_TIMALR_HOUR(value)              (RTC_TIMALR_HOUR_Msk & ((value) << RTC_TIMALR_HOUR_Pos))
+#define RTC_TIMALR_AMPM_Pos                 22                                             /**< (RTC_TIMALR) AM/PM Indicator Position */
+#define RTC_TIMALR_AMPM_Msk                 (_U_(0x1) << RTC_TIMALR_AMPM_Pos)              /**< (RTC_TIMALR) AM/PM Indicator Mask */
+#define RTC_TIMALR_AMPM                     RTC_TIMALR_AMPM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_AMPM_Msk instead */
+#define RTC_TIMALR_HOUREN_Pos               23                                             /**< (RTC_TIMALR) Hour Alarm Enable Position */
+#define RTC_TIMALR_HOUREN_Msk               (_U_(0x1) << RTC_TIMALR_HOUREN_Pos)            /**< (RTC_TIMALR) Hour Alarm Enable Mask */
+#define RTC_TIMALR_HOUREN                   RTC_TIMALR_HOUREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_HOUREN_Msk instead */
+#define RTC_TIMALR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (RTC_TIMALR) Register MASK  (Use RTC_TIMALR_Msk instead)  */
+#define RTC_TIMALR_Msk                      _U_(0xFFFFFF)                                  /**< (RTC_TIMALR) Register Mask  */
+
+
+/* -------- RTC_CALALR : (RTC Offset: 0x14) (R/W 32) Calendar Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t MONTH:5;                   /**< bit: 16..20  Month Alarm                              */
+    uint32_t :2;                        /**< bit: 21..22  Reserved */
+    uint32_t MTHEN:1;                   /**< bit:     23  Month Alarm Enable                       */
+    uint32_t DATE:6;                    /**< bit: 24..29  Date Alarm                               */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t DATEEN:1;                  /**< bit:     31  Date Alarm Enable                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CALALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CALALR_OFFSET                   (0x14)                                        /**<  (RTC_CALALR) Calendar Alarm Register  Offset */
+
+#define RTC_CALALR_MONTH_Pos                16                                             /**< (RTC_CALALR) Month Alarm Position */
+#define RTC_CALALR_MONTH_Msk                (_U_(0x1F) << RTC_CALALR_MONTH_Pos)            /**< (RTC_CALALR) Month Alarm Mask */
+#define RTC_CALALR_MONTH(value)             (RTC_CALALR_MONTH_Msk & ((value) << RTC_CALALR_MONTH_Pos))
+#define RTC_CALALR_MTHEN_Pos                23                                             /**< (RTC_CALALR) Month Alarm Enable Position */
+#define RTC_CALALR_MTHEN_Msk                (_U_(0x1) << RTC_CALALR_MTHEN_Pos)             /**< (RTC_CALALR) Month Alarm Enable Mask */
+#define RTC_CALALR_MTHEN                    RTC_CALALR_MTHEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CALALR_MTHEN_Msk instead */
+#define RTC_CALALR_DATE_Pos                 24                                             /**< (RTC_CALALR) Date Alarm Position */
+#define RTC_CALALR_DATE_Msk                 (_U_(0x3F) << RTC_CALALR_DATE_Pos)             /**< (RTC_CALALR) Date Alarm Mask */
+#define RTC_CALALR_DATE(value)              (RTC_CALALR_DATE_Msk & ((value) << RTC_CALALR_DATE_Pos))
+#define RTC_CALALR_DATEEN_Pos               31                                             /**< (RTC_CALALR) Date Alarm Enable Position */
+#define RTC_CALALR_DATEEN_Msk               (_U_(0x1) << RTC_CALALR_DATEEN_Pos)            /**< (RTC_CALALR) Date Alarm Enable Mask */
+#define RTC_CALALR_DATEEN                   RTC_CALALR_DATEEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CALALR_DATEEN_Msk instead */
+#define RTC_CALALR_MASK                     _U_(0xBF9F0000)                                /**< \deprecated (RTC_CALALR) Register MASK  (Use RTC_CALALR_Msk instead)  */
+#define RTC_CALALR_Msk                      _U_(0xBF9F0000)                                /**< (RTC_CALALR) Register Mask  */
+
+
+/* -------- RTC_SR : (RTC Offset: 0x18) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKUPD:1;                  /**< bit:      0  Acknowledge for Update                   */
+    uint32_t ALARM:1;                   /**< bit:      1  Alarm Flag                               */
+    uint32_t SEC:1;                     /**< bit:      2  Second Event                             */
+    uint32_t TIMEV:1;                   /**< bit:      3  Time Event                               */
+    uint32_t CALEV:1;                   /**< bit:      4  Calendar Event                           */
+    uint32_t TDERR:1;                   /**< bit:      5  Time and/or Date Free Running Error      */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_SR_OFFSET                       (0x18)                                        /**<  (RTC_SR) Status Register  Offset */
+
+#define RTC_SR_ACKUPD_Pos                   0                                              /**< (RTC_SR) Acknowledge for Update Position */
+#define RTC_SR_ACKUPD_Msk                   (_U_(0x1) << RTC_SR_ACKUPD_Pos)                /**< (RTC_SR) Acknowledge for Update Mask */
+#define RTC_SR_ACKUPD                       RTC_SR_ACKUPD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_ACKUPD_Msk instead */
+#define   RTC_SR_ACKUPD_FREERUN_Val         _U_(0x0)                                       /**< (RTC_SR) Time and calendar registers cannot be updated.  */
+#define   RTC_SR_ACKUPD_UPDATE_Val          _U_(0x1)                                       /**< (RTC_SR) Time and calendar registers can be updated.  */
+#define RTC_SR_ACKUPD_FREERUN               (RTC_SR_ACKUPD_FREERUN_Val << RTC_SR_ACKUPD_Pos)  /**< (RTC_SR) Time and calendar registers cannot be updated. Position  */
+#define RTC_SR_ACKUPD_UPDATE                (RTC_SR_ACKUPD_UPDATE_Val << RTC_SR_ACKUPD_Pos)  /**< (RTC_SR) Time and calendar registers can be updated. Position  */
+#define RTC_SR_ALARM_Pos                    1                                              /**< (RTC_SR) Alarm Flag Position */
+#define RTC_SR_ALARM_Msk                    (_U_(0x1) << RTC_SR_ALARM_Pos)                 /**< (RTC_SR) Alarm Flag Mask */
+#define RTC_SR_ALARM                        RTC_SR_ALARM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_ALARM_Msk instead */
+#define   RTC_SR_ALARM_NO_ALARMEVENT_Val    _U_(0x0)                                       /**< (RTC_SR) No alarm matching condition occurred.  */
+#define   RTC_SR_ALARM_ALARMEVENT_Val       _U_(0x1)                                       /**< (RTC_SR) An alarm matching condition has occurred.  */
+#define RTC_SR_ALARM_NO_ALARMEVENT          (RTC_SR_ALARM_NO_ALARMEVENT_Val << RTC_SR_ALARM_Pos)  /**< (RTC_SR) No alarm matching condition occurred. Position  */
+#define RTC_SR_ALARM_ALARMEVENT             (RTC_SR_ALARM_ALARMEVENT_Val << RTC_SR_ALARM_Pos)  /**< (RTC_SR) An alarm matching condition has occurred. Position  */
+#define RTC_SR_SEC_Pos                      2                                              /**< (RTC_SR) Second Event Position */
+#define RTC_SR_SEC_Msk                      (_U_(0x1) << RTC_SR_SEC_Pos)                   /**< (RTC_SR) Second Event Mask */
+#define RTC_SR_SEC                          RTC_SR_SEC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_SEC_Msk instead */
+#define   RTC_SR_SEC_NO_SECEVENT_Val        _U_(0x0)                                       /**< (RTC_SR) No second event has occurred since the last clear.  */
+#define   RTC_SR_SEC_SECEVENT_Val           _U_(0x1)                                       /**< (RTC_SR) At least one second event has occurred since the last clear.  */
+#define RTC_SR_SEC_NO_SECEVENT              (RTC_SR_SEC_NO_SECEVENT_Val << RTC_SR_SEC_Pos)  /**< (RTC_SR) No second event has occurred since the last clear. Position  */
+#define RTC_SR_SEC_SECEVENT                 (RTC_SR_SEC_SECEVENT_Val << RTC_SR_SEC_Pos)    /**< (RTC_SR) At least one second event has occurred since the last clear. Position  */
+#define RTC_SR_TIMEV_Pos                    3                                              /**< (RTC_SR) Time Event Position */
+#define RTC_SR_TIMEV_Msk                    (_U_(0x1) << RTC_SR_TIMEV_Pos)                 /**< (RTC_SR) Time Event Mask */
+#define RTC_SR_TIMEV                        RTC_SR_TIMEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_TIMEV_Msk instead */
+#define   RTC_SR_TIMEV_NO_TIMEVENT_Val      _U_(0x0)                                       /**< (RTC_SR) No time event has occurred since the last clear.  */
+#define   RTC_SR_TIMEV_TIMEVENT_Val         _U_(0x1)                                       /**< (RTC_SR) At least one time event has occurred since the last clear.  */
+#define RTC_SR_TIMEV_NO_TIMEVENT            (RTC_SR_TIMEV_NO_TIMEVENT_Val << RTC_SR_TIMEV_Pos)  /**< (RTC_SR) No time event has occurred since the last clear. Position  */
+#define RTC_SR_TIMEV_TIMEVENT               (RTC_SR_TIMEV_TIMEVENT_Val << RTC_SR_TIMEV_Pos)  /**< (RTC_SR) At least one time event has occurred since the last clear. Position  */
+#define RTC_SR_CALEV_Pos                    4                                              /**< (RTC_SR) Calendar Event Position */
+#define RTC_SR_CALEV_Msk                    (_U_(0x1) << RTC_SR_CALEV_Pos)                 /**< (RTC_SR) Calendar Event Mask */
+#define RTC_SR_CALEV                        RTC_SR_CALEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_CALEV_Msk instead */
+#define   RTC_SR_CALEV_NO_CALEVENT_Val      _U_(0x0)                                       /**< (RTC_SR) No calendar event has occurred since the last clear.  */
+#define   RTC_SR_CALEV_CALEVENT_Val         _U_(0x1)                                       /**< (RTC_SR) At least one calendar event has occurred since the last clear.  */
+#define RTC_SR_CALEV_NO_CALEVENT            (RTC_SR_CALEV_NO_CALEVENT_Val << RTC_SR_CALEV_Pos)  /**< (RTC_SR) No calendar event has occurred since the last clear. Position  */
+#define RTC_SR_CALEV_CALEVENT               (RTC_SR_CALEV_CALEVENT_Val << RTC_SR_CALEV_Pos)  /**< (RTC_SR) At least one calendar event has occurred since the last clear. Position  */
+#define RTC_SR_TDERR_Pos                    5                                              /**< (RTC_SR) Time and/or Date Free Running Error Position */
+#define RTC_SR_TDERR_Msk                    (_U_(0x1) << RTC_SR_TDERR_Pos)                 /**< (RTC_SR) Time and/or Date Free Running Error Mask */
+#define RTC_SR_TDERR                        RTC_SR_TDERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_TDERR_Msk instead */
+#define   RTC_SR_TDERR_CORRECT_Val          _U_(0x0)                                       /**< (RTC_SR) The internal free running counters are carrying valid values since the last read of the Status Register (RTC_SR).  */
+#define   RTC_SR_TDERR_ERR_TIMEDATE_Val     _U_(0x1)                                       /**< (RTC_SR) The internal free running counters have been corrupted (invalid date or time, non-BCD values) since the last read and/or they are still invalid.  */
+#define RTC_SR_TDERR_CORRECT                (RTC_SR_TDERR_CORRECT_Val << RTC_SR_TDERR_Pos)  /**< (RTC_SR) The internal free running counters are carrying valid values since the last read of the Status Register (RTC_SR). Position  */
+#define RTC_SR_TDERR_ERR_TIMEDATE           (RTC_SR_TDERR_ERR_TIMEDATE_Val << RTC_SR_TDERR_Pos)  /**< (RTC_SR) The internal free running counters have been corrupted (invalid date or time, non-BCD values) since the last read and/or they are still invalid. Position  */
+#define RTC_SR_MASK                         _U_(0x3F)                                      /**< \deprecated (RTC_SR) Register MASK  (Use RTC_SR_Msk instead)  */
+#define RTC_SR_Msk                          _U_(0x3F)                                      /**< (RTC_SR) Register Mask  */
+
+
+/* -------- RTC_SCCR : (RTC Offset: 0x1c) (/W 32) Status Clear Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKCLR:1;                  /**< bit:      0  Acknowledge Clear                        */
+    uint32_t ALRCLR:1;                  /**< bit:      1  Alarm Clear                              */
+    uint32_t SECCLR:1;                  /**< bit:      2  Second Clear                             */
+    uint32_t TIMCLR:1;                  /**< bit:      3  Time Clear                               */
+    uint32_t CALCLR:1;                  /**< bit:      4  Calendar Clear                           */
+    uint32_t TDERRCLR:1;                /**< bit:      5  Time and/or Date Free Running Error Clear */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_SCCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_SCCR_OFFSET                     (0x1C)                                        /**<  (RTC_SCCR) Status Clear Command Register  Offset */
+
+#define RTC_SCCR_ACKCLR_Pos                 0                                              /**< (RTC_SCCR) Acknowledge Clear Position */
+#define RTC_SCCR_ACKCLR_Msk                 (_U_(0x1) << RTC_SCCR_ACKCLR_Pos)              /**< (RTC_SCCR) Acknowledge Clear Mask */
+#define RTC_SCCR_ACKCLR                     RTC_SCCR_ACKCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_ACKCLR_Msk instead */
+#define RTC_SCCR_ALRCLR_Pos                 1                                              /**< (RTC_SCCR) Alarm Clear Position */
+#define RTC_SCCR_ALRCLR_Msk                 (_U_(0x1) << RTC_SCCR_ALRCLR_Pos)              /**< (RTC_SCCR) Alarm Clear Mask */
+#define RTC_SCCR_ALRCLR                     RTC_SCCR_ALRCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_ALRCLR_Msk instead */
+#define RTC_SCCR_SECCLR_Pos                 2                                              /**< (RTC_SCCR) Second Clear Position */
+#define RTC_SCCR_SECCLR_Msk                 (_U_(0x1) << RTC_SCCR_SECCLR_Pos)              /**< (RTC_SCCR) Second Clear Mask */
+#define RTC_SCCR_SECCLR                     RTC_SCCR_SECCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_SECCLR_Msk instead */
+#define RTC_SCCR_TIMCLR_Pos                 3                                              /**< (RTC_SCCR) Time Clear Position */
+#define RTC_SCCR_TIMCLR_Msk                 (_U_(0x1) << RTC_SCCR_TIMCLR_Pos)              /**< (RTC_SCCR) Time Clear Mask */
+#define RTC_SCCR_TIMCLR                     RTC_SCCR_TIMCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_TIMCLR_Msk instead */
+#define RTC_SCCR_CALCLR_Pos                 4                                              /**< (RTC_SCCR) Calendar Clear Position */
+#define RTC_SCCR_CALCLR_Msk                 (_U_(0x1) << RTC_SCCR_CALCLR_Pos)              /**< (RTC_SCCR) Calendar Clear Mask */
+#define RTC_SCCR_CALCLR                     RTC_SCCR_CALCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_CALCLR_Msk instead */
+#define RTC_SCCR_TDERRCLR_Pos               5                                              /**< (RTC_SCCR) Time and/or Date Free Running Error Clear Position */
+#define RTC_SCCR_TDERRCLR_Msk               (_U_(0x1) << RTC_SCCR_TDERRCLR_Pos)            /**< (RTC_SCCR) Time and/or Date Free Running Error Clear Mask */
+#define RTC_SCCR_TDERRCLR                   RTC_SCCR_TDERRCLR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_TDERRCLR_Msk instead */
+#define RTC_SCCR_MASK                       _U_(0x3F)                                      /**< \deprecated (RTC_SCCR) Register MASK  (Use RTC_SCCR_Msk instead)  */
+#define RTC_SCCR_Msk                        _U_(0x3F)                                      /**< (RTC_SCCR) Register Mask  */
+
+
+/* -------- RTC_IER : (RTC Offset: 0x20) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKEN:1;                   /**< bit:      0  Acknowledge Update Interrupt Enable      */
+    uint32_t ALREN:1;                   /**< bit:      1  Alarm Interrupt Enable                   */
+    uint32_t SECEN:1;                   /**< bit:      2  Second Event Interrupt Enable            */
+    uint32_t TIMEN:1;                   /**< bit:      3  Time Event Interrupt Enable              */
+    uint32_t CALEN:1;                   /**< bit:      4  Calendar Event Interrupt Enable          */
+    uint32_t TDERREN:1;                 /**< bit:      5  Time and/or Date Error Interrupt Enable  */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IER_OFFSET                      (0x20)                                        /**<  (RTC_IER) Interrupt Enable Register  Offset */
+
+#define RTC_IER_ACKEN_Pos                   0                                              /**< (RTC_IER) Acknowledge Update Interrupt Enable Position */
+#define RTC_IER_ACKEN_Msk                   (_U_(0x1) << RTC_IER_ACKEN_Pos)                /**< (RTC_IER) Acknowledge Update Interrupt Enable Mask */
+#define RTC_IER_ACKEN                       RTC_IER_ACKEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_ACKEN_Msk instead */
+#define RTC_IER_ALREN_Pos                   1                                              /**< (RTC_IER) Alarm Interrupt Enable Position */
+#define RTC_IER_ALREN_Msk                   (_U_(0x1) << RTC_IER_ALREN_Pos)                /**< (RTC_IER) Alarm Interrupt Enable Mask */
+#define RTC_IER_ALREN                       RTC_IER_ALREN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_ALREN_Msk instead */
+#define RTC_IER_SECEN_Pos                   2                                              /**< (RTC_IER) Second Event Interrupt Enable Position */
+#define RTC_IER_SECEN_Msk                   (_U_(0x1) << RTC_IER_SECEN_Pos)                /**< (RTC_IER) Second Event Interrupt Enable Mask */
+#define RTC_IER_SECEN                       RTC_IER_SECEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_SECEN_Msk instead */
+#define RTC_IER_TIMEN_Pos                   3                                              /**< (RTC_IER) Time Event Interrupt Enable Position */
+#define RTC_IER_TIMEN_Msk                   (_U_(0x1) << RTC_IER_TIMEN_Pos)                /**< (RTC_IER) Time Event Interrupt Enable Mask */
+#define RTC_IER_TIMEN                       RTC_IER_TIMEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_TIMEN_Msk instead */
+#define RTC_IER_CALEN_Pos                   4                                              /**< (RTC_IER) Calendar Event Interrupt Enable Position */
+#define RTC_IER_CALEN_Msk                   (_U_(0x1) << RTC_IER_CALEN_Pos)                /**< (RTC_IER) Calendar Event Interrupt Enable Mask */
+#define RTC_IER_CALEN                       RTC_IER_CALEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_CALEN_Msk instead */
+#define RTC_IER_TDERREN_Pos                 5                                              /**< (RTC_IER) Time and/or Date Error Interrupt Enable Position */
+#define RTC_IER_TDERREN_Msk                 (_U_(0x1) << RTC_IER_TDERREN_Pos)              /**< (RTC_IER) Time and/or Date Error Interrupt Enable Mask */
+#define RTC_IER_TDERREN                     RTC_IER_TDERREN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_TDERREN_Msk instead */
+#define RTC_IER_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IER) Register MASK  (Use RTC_IER_Msk instead)  */
+#define RTC_IER_Msk                         _U_(0x3F)                                      /**< (RTC_IER) Register Mask  */
+
+
+/* -------- RTC_IDR : (RTC Offset: 0x24) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKDIS:1;                  /**< bit:      0  Acknowledge Update Interrupt Disable     */
+    uint32_t ALRDIS:1;                  /**< bit:      1  Alarm Interrupt Disable                  */
+    uint32_t SECDIS:1;                  /**< bit:      2  Second Event Interrupt Disable           */
+    uint32_t TIMDIS:1;                  /**< bit:      3  Time Event Interrupt Disable             */
+    uint32_t CALDIS:1;                  /**< bit:      4  Calendar Event Interrupt Disable         */
+    uint32_t TDERRDIS:1;                /**< bit:      5  Time and/or Date Error Interrupt Disable */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IDR_OFFSET                      (0x24)                                        /**<  (RTC_IDR) Interrupt Disable Register  Offset */
+
+#define RTC_IDR_ACKDIS_Pos                  0                                              /**< (RTC_IDR) Acknowledge Update Interrupt Disable Position */
+#define RTC_IDR_ACKDIS_Msk                  (_U_(0x1) << RTC_IDR_ACKDIS_Pos)               /**< (RTC_IDR) Acknowledge Update Interrupt Disable Mask */
+#define RTC_IDR_ACKDIS                      RTC_IDR_ACKDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_ACKDIS_Msk instead */
+#define RTC_IDR_ALRDIS_Pos                  1                                              /**< (RTC_IDR) Alarm Interrupt Disable Position */
+#define RTC_IDR_ALRDIS_Msk                  (_U_(0x1) << RTC_IDR_ALRDIS_Pos)               /**< (RTC_IDR) Alarm Interrupt Disable Mask */
+#define RTC_IDR_ALRDIS                      RTC_IDR_ALRDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_ALRDIS_Msk instead */
+#define RTC_IDR_SECDIS_Pos                  2                                              /**< (RTC_IDR) Second Event Interrupt Disable Position */
+#define RTC_IDR_SECDIS_Msk                  (_U_(0x1) << RTC_IDR_SECDIS_Pos)               /**< (RTC_IDR) Second Event Interrupt Disable Mask */
+#define RTC_IDR_SECDIS                      RTC_IDR_SECDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_SECDIS_Msk instead */
+#define RTC_IDR_TIMDIS_Pos                  3                                              /**< (RTC_IDR) Time Event Interrupt Disable Position */
+#define RTC_IDR_TIMDIS_Msk                  (_U_(0x1) << RTC_IDR_TIMDIS_Pos)               /**< (RTC_IDR) Time Event Interrupt Disable Mask */
+#define RTC_IDR_TIMDIS                      RTC_IDR_TIMDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_TIMDIS_Msk instead */
+#define RTC_IDR_CALDIS_Pos                  4                                              /**< (RTC_IDR) Calendar Event Interrupt Disable Position */
+#define RTC_IDR_CALDIS_Msk                  (_U_(0x1) << RTC_IDR_CALDIS_Pos)               /**< (RTC_IDR) Calendar Event Interrupt Disable Mask */
+#define RTC_IDR_CALDIS                      RTC_IDR_CALDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_CALDIS_Msk instead */
+#define RTC_IDR_TDERRDIS_Pos                5                                              /**< (RTC_IDR) Time and/or Date Error Interrupt Disable Position */
+#define RTC_IDR_TDERRDIS_Msk                (_U_(0x1) << RTC_IDR_TDERRDIS_Pos)             /**< (RTC_IDR) Time and/or Date Error Interrupt Disable Mask */
+#define RTC_IDR_TDERRDIS                    RTC_IDR_TDERRDIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_TDERRDIS_Msk instead */
+#define RTC_IDR_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IDR) Register MASK  (Use RTC_IDR_Msk instead)  */
+#define RTC_IDR_Msk                         _U_(0x3F)                                      /**< (RTC_IDR) Register Mask  */
+
+
+/* -------- RTC_IMR : (RTC Offset: 0x28) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACK:1;                     /**< bit:      0  Acknowledge Update Interrupt Mask        */
+    uint32_t ALR:1;                     /**< bit:      1  Alarm Interrupt Mask                     */
+    uint32_t SEC:1;                     /**< bit:      2  Second Event Interrupt Mask              */
+    uint32_t TIM:1;                     /**< bit:      3  Time Event Interrupt Mask                */
+    uint32_t CAL:1;                     /**< bit:      4  Calendar Event Interrupt Mask            */
+    uint32_t TDERR:1;                   /**< bit:      5  Time and/or Date Error Mask              */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IMR_OFFSET                      (0x28)                                        /**<  (RTC_IMR) Interrupt Mask Register  Offset */
+
+#define RTC_IMR_ACK_Pos                     0                                              /**< (RTC_IMR) Acknowledge Update Interrupt Mask Position */
+#define RTC_IMR_ACK_Msk                     (_U_(0x1) << RTC_IMR_ACK_Pos)                  /**< (RTC_IMR) Acknowledge Update Interrupt Mask Mask */
+#define RTC_IMR_ACK                         RTC_IMR_ACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_ACK_Msk instead */
+#define RTC_IMR_ALR_Pos                     1                                              /**< (RTC_IMR) Alarm Interrupt Mask Position */
+#define RTC_IMR_ALR_Msk                     (_U_(0x1) << RTC_IMR_ALR_Pos)                  /**< (RTC_IMR) Alarm Interrupt Mask Mask */
+#define RTC_IMR_ALR                         RTC_IMR_ALR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_ALR_Msk instead */
+#define RTC_IMR_SEC_Pos                     2                                              /**< (RTC_IMR) Second Event Interrupt Mask Position */
+#define RTC_IMR_SEC_Msk                     (_U_(0x1) << RTC_IMR_SEC_Pos)                  /**< (RTC_IMR) Second Event Interrupt Mask Mask */
+#define RTC_IMR_SEC                         RTC_IMR_SEC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_SEC_Msk instead */
+#define RTC_IMR_TIM_Pos                     3                                              /**< (RTC_IMR) Time Event Interrupt Mask Position */
+#define RTC_IMR_TIM_Msk                     (_U_(0x1) << RTC_IMR_TIM_Pos)                  /**< (RTC_IMR) Time Event Interrupt Mask Mask */
+#define RTC_IMR_TIM                         RTC_IMR_TIM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_TIM_Msk instead */
+#define RTC_IMR_CAL_Pos                     4                                              /**< (RTC_IMR) Calendar Event Interrupt Mask Position */
+#define RTC_IMR_CAL_Msk                     (_U_(0x1) << RTC_IMR_CAL_Pos)                  /**< (RTC_IMR) Calendar Event Interrupt Mask Mask */
+#define RTC_IMR_CAL                         RTC_IMR_CAL_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_CAL_Msk instead */
+#define RTC_IMR_TDERR_Pos                   5                                              /**< (RTC_IMR) Time and/or Date Error Mask Position */
+#define RTC_IMR_TDERR_Msk                   (_U_(0x1) << RTC_IMR_TDERR_Pos)                /**< (RTC_IMR) Time and/or Date Error Mask Mask */
+#define RTC_IMR_TDERR                       RTC_IMR_TDERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_TDERR_Msk instead */
+#define RTC_IMR_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IMR) Register MASK  (Use RTC_IMR_Msk instead)  */
+#define RTC_IMR_Msk                         _U_(0x3F)                                      /**< (RTC_IMR) Register Mask  */
+
+
+/* -------- RTC_VER : (RTC Offset: 0x2c) (R/ 32) Valid Entry Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NVTIM:1;                   /**< bit:      0  Non-valid Time                           */
+    uint32_t NVCAL:1;                   /**< bit:      1  Non-valid Calendar                       */
+    uint32_t NVTIMALR:1;                /**< bit:      2  Non-valid Time Alarm                     */
+    uint32_t NVCALALR:1;                /**< bit:      3  Non-valid Calendar Alarm                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_VER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_VER_OFFSET                      (0x2C)                                        /**<  (RTC_VER) Valid Entry Register  Offset */
+
+#define RTC_VER_NVTIM_Pos                   0                                              /**< (RTC_VER) Non-valid Time Position */
+#define RTC_VER_NVTIM_Msk                   (_U_(0x1) << RTC_VER_NVTIM_Pos)                /**< (RTC_VER) Non-valid Time Mask */
+#define RTC_VER_NVTIM                       RTC_VER_NVTIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVTIM_Msk instead */
+#define RTC_VER_NVCAL_Pos                   1                                              /**< (RTC_VER) Non-valid Calendar Position */
+#define RTC_VER_NVCAL_Msk                   (_U_(0x1) << RTC_VER_NVCAL_Pos)                /**< (RTC_VER) Non-valid Calendar Mask */
+#define RTC_VER_NVCAL                       RTC_VER_NVCAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVCAL_Msk instead */
+#define RTC_VER_NVTIMALR_Pos                2                                              /**< (RTC_VER) Non-valid Time Alarm Position */
+#define RTC_VER_NVTIMALR_Msk                (_U_(0x1) << RTC_VER_NVTIMALR_Pos)             /**< (RTC_VER) Non-valid Time Alarm Mask */
+#define RTC_VER_NVTIMALR                    RTC_VER_NVTIMALR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVTIMALR_Msk instead */
+#define RTC_VER_NVCALALR_Pos                3                                              /**< (RTC_VER) Non-valid Calendar Alarm Position */
+#define RTC_VER_NVCALALR_Msk                (_U_(0x1) << RTC_VER_NVCALALR_Pos)             /**< (RTC_VER) Non-valid Calendar Alarm Mask */
+#define RTC_VER_NVCALALR                    RTC_VER_NVCALALR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVCALALR_Msk instead */
+#define RTC_VER_MASK                        _U_(0x0F)                                      /**< \deprecated (RTC_VER) Register MASK  (Use RTC_VER_Msk instead)  */
+#define RTC_VER_Msk                         _U_(0x0F)                                      /**< (RTC_VER) Register Mask  */
+
+
+/* -------- RTC_VERSION : (RTC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_VERSION_OFFSET                  (0xFC)                                        /**<  (RTC_VERSION) Version Register  Offset */
+
+#define RTC_VERSION_VERSION_Pos             0                                              /**< (RTC_VERSION) Version of the Hardware Module Position */
+#define RTC_VERSION_VERSION_Msk             (_U_(0xFFF) << RTC_VERSION_VERSION_Pos)        /**< (RTC_VERSION) Version of the Hardware Module Mask */
+#define RTC_VERSION_VERSION(value)          (RTC_VERSION_VERSION_Msk & ((value) << RTC_VERSION_VERSION_Pos))
+#define RTC_VERSION_MFN_Pos                 16                                             /**< (RTC_VERSION) Metal Fix Number Position */
+#define RTC_VERSION_MFN_Msk                 (_U_(0x7) << RTC_VERSION_MFN_Pos)              /**< (RTC_VERSION) Metal Fix Number Mask */
+#define RTC_VERSION_MFN(value)              (RTC_VERSION_MFN_Msk & ((value) << RTC_VERSION_MFN_Pos))
+#define RTC_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (RTC_VERSION) Register MASK  (Use RTC_VERSION_Msk instead)  */
+#define RTC_VERSION_Msk                     _U_(0x70FFF)                                   /**< (RTC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RTC hardware registers */
+typedef struct {  
+  __IO uint32_t RTC_CR;         /**< (RTC Offset: 0x00) Control Register */
+  __IO uint32_t RTC_MR;         /**< (RTC Offset: 0x04) Mode Register */
+  __IO uint32_t RTC_TIMR;       /**< (RTC Offset: 0x08) Time Register */
+  __IO uint32_t RTC_CALR;       /**< (RTC Offset: 0x0C) Calendar Register */
+  __IO uint32_t RTC_TIMALR;     /**< (RTC Offset: 0x10) Time Alarm Register */
+  __IO uint32_t RTC_CALALR;     /**< (RTC Offset: 0x14) Calendar Alarm Register */
+  __I  uint32_t RTC_SR;         /**< (RTC Offset: 0x18) Status Register */
+  __O  uint32_t RTC_SCCR;       /**< (RTC Offset: 0x1C) Status Clear Command Register */
+  __O  uint32_t RTC_IER;        /**< (RTC Offset: 0x20) Interrupt Enable Register */
+  __O  uint32_t RTC_IDR;        /**< (RTC Offset: 0x24) Interrupt Disable Register */
+  __I  uint32_t RTC_IMR;        /**< (RTC Offset: 0x28) Interrupt Mask Register */
+  __I  uint32_t RTC_VER;        /**< (RTC Offset: 0x2C) Valid Entry Register */
+  __I  uint8_t                        Reserved1[204];
+  __I  uint32_t RTC_VERSION;    /**< (RTC Offset: 0xFC) Version Register */
+} Rtc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RTC hardware registers */
+typedef struct {  
+  __IO RTC_CR_Type                    RTC_CR;         /**< Offset: 0x00 (R/W  32) Control Register */
+  __IO RTC_MR_Type                    RTC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO RTC_TIMR_Type                  RTC_TIMR;       /**< Offset: 0x08 (R/W  32) Time Register */
+  __IO RTC_CALR_Type                  RTC_CALR;       /**< Offset: 0x0C (R/W  32) Calendar Register */
+  __IO RTC_TIMALR_Type                RTC_TIMALR;     /**< Offset: 0x10 (R/W  32) Time Alarm Register */
+  __IO RTC_CALALR_Type                RTC_CALALR;     /**< Offset: 0x14 (R/W  32) Calendar Alarm Register */
+  __I  RTC_SR_Type                    RTC_SR;         /**< Offset: 0x18 (R/   32) Status Register */
+  __O  RTC_SCCR_Type                  RTC_SCCR;       /**< Offset: 0x1C ( /W  32) Status Clear Command Register */
+  __O  RTC_IER_Type                   RTC_IER;        /**< Offset: 0x20 ( /W  32) Interrupt Enable Register */
+  __O  RTC_IDR_Type                   RTC_IDR;        /**< Offset: 0x24 ( /W  32) Interrupt Disable Register */
+  __I  RTC_IMR_Type                   RTC_IMR;        /**< Offset: 0x28 (R/   32) Interrupt Mask Register */
+  __I  RTC_VER_Type                   RTC_VER;        /**< Offset: 0x2C (R/   32) Valid Entry Register */
+  __I  uint8_t                        Reserved1[204];
+  __I  RTC_VERSION_Type               RTC_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+} Rtc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-time Clock */
+
+#endif /* _SAMV71_RTC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/rtt.h
+++ b/asf/sam/include/samv71/component/rtt.h
@@ -1,0 +1,186 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RTT_COMPONENT_H_
+#define _SAMV71_RTT_COMPONENT_H_
+#define _SAMV71_RTT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Real-time Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RTT_6081                       /**< (RTT) Module ID */
+#define REV_RTT M                      /**< (RTT) Module revision */
+
+/* -------- RTT_MR : (RTT Offset: 0x00) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RTPRES:16;                 /**< bit:  0..15  Real-time Timer Prescaler Value          */
+    uint32_t ALMIEN:1;                  /**< bit:     16  Alarm Interrupt Enable                   */
+    uint32_t RTTINCIEN:1;               /**< bit:     17  Real-time Timer Increment Interrupt Enable */
+    uint32_t RTTRST:1;                  /**< bit:     18  Real-time Timer Restart                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t RTTDIS:1;                  /**< bit:     20  Real-time Timer Disable                  */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t RTC1HZ:1;                  /**< bit:     24  Real-Time Clock 1Hz Clock Selection      */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_MR_OFFSET                       (0x00)                                        /**<  (RTT_MR) Mode Register  Offset */
+
+#define RTT_MR_RTPRES_Pos                   0                                              /**< (RTT_MR) Real-time Timer Prescaler Value Position */
+#define RTT_MR_RTPRES_Msk                   (_U_(0xFFFF) << RTT_MR_RTPRES_Pos)             /**< (RTT_MR) Real-time Timer Prescaler Value Mask */
+#define RTT_MR_RTPRES(value)                (RTT_MR_RTPRES_Msk & ((value) << RTT_MR_RTPRES_Pos))
+#define RTT_MR_ALMIEN_Pos                   16                                             /**< (RTT_MR) Alarm Interrupt Enable Position */
+#define RTT_MR_ALMIEN_Msk                   (_U_(0x1) << RTT_MR_ALMIEN_Pos)                /**< (RTT_MR) Alarm Interrupt Enable Mask */
+#define RTT_MR_ALMIEN                       RTT_MR_ALMIEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_ALMIEN_Msk instead */
+#define RTT_MR_RTTINCIEN_Pos                17                                             /**< (RTT_MR) Real-time Timer Increment Interrupt Enable Position */
+#define RTT_MR_RTTINCIEN_Msk                (_U_(0x1) << RTT_MR_RTTINCIEN_Pos)             /**< (RTT_MR) Real-time Timer Increment Interrupt Enable Mask */
+#define RTT_MR_RTTINCIEN                    RTT_MR_RTTINCIEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTINCIEN_Msk instead */
+#define RTT_MR_RTTRST_Pos                   18                                             /**< (RTT_MR) Real-time Timer Restart Position */
+#define RTT_MR_RTTRST_Msk                   (_U_(0x1) << RTT_MR_RTTRST_Pos)                /**< (RTT_MR) Real-time Timer Restart Mask */
+#define RTT_MR_RTTRST                       RTT_MR_RTTRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTRST_Msk instead */
+#define RTT_MR_RTTDIS_Pos                   20                                             /**< (RTT_MR) Real-time Timer Disable Position */
+#define RTT_MR_RTTDIS_Msk                   (_U_(0x1) << RTT_MR_RTTDIS_Pos)                /**< (RTT_MR) Real-time Timer Disable Mask */
+#define RTT_MR_RTTDIS                       RTT_MR_RTTDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTDIS_Msk instead */
+#define RTT_MR_RTC1HZ_Pos                   24                                             /**< (RTT_MR) Real-Time Clock 1Hz Clock Selection Position */
+#define RTT_MR_RTC1HZ_Msk                   (_U_(0x1) << RTT_MR_RTC1HZ_Pos)                /**< (RTT_MR) Real-Time Clock 1Hz Clock Selection Mask */
+#define RTT_MR_RTC1HZ                       RTT_MR_RTC1HZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTC1HZ_Msk instead */
+#define RTT_MR_MASK                         _U_(0x117FFFF)                                 /**< \deprecated (RTT_MR) Register MASK  (Use RTT_MR_Msk instead)  */
+#define RTT_MR_Msk                          _U_(0x117FFFF)                                 /**< (RTT_MR) Register Mask  */
+
+
+/* -------- RTT_AR : (RTT Offset: 0x04) (R/W 32) Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ALMV:32;                   /**< bit:  0..31  Alarm Value                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_AR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_AR_OFFSET                       (0x04)                                        /**<  (RTT_AR) Alarm Register  Offset */
+
+#define RTT_AR_ALMV_Pos                     0                                              /**< (RTT_AR) Alarm Value Position */
+#define RTT_AR_ALMV_Msk                     (_U_(0xFFFFFFFF) << RTT_AR_ALMV_Pos)           /**< (RTT_AR) Alarm Value Mask */
+#define RTT_AR_ALMV(value)                  (RTT_AR_ALMV_Msk & ((value) << RTT_AR_ALMV_Pos))
+#define RTT_AR_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTT_AR) Register MASK  (Use RTT_AR_Msk instead)  */
+#define RTT_AR_Msk                          _U_(0xFFFFFFFF)                                /**< (RTT_AR) Register Mask  */
+
+
+/* -------- RTT_VR : (RTT Offset: 0x08) (R/ 32) Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CRTV:32;                   /**< bit:  0..31  Current Real-time Value                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_VR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_VR_OFFSET                       (0x08)                                        /**<  (RTT_VR) Value Register  Offset */
+
+#define RTT_VR_CRTV_Pos                     0                                              /**< (RTT_VR) Current Real-time Value Position */
+#define RTT_VR_CRTV_Msk                     (_U_(0xFFFFFFFF) << RTT_VR_CRTV_Pos)           /**< (RTT_VR) Current Real-time Value Mask */
+#define RTT_VR_CRTV(value)                  (RTT_VR_CRTV_Msk & ((value) << RTT_VR_CRTV_Pos))
+#define RTT_VR_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTT_VR) Register MASK  (Use RTT_VR_Msk instead)  */
+#define RTT_VR_Msk                          _U_(0xFFFFFFFF)                                /**< (RTT_VR) Register Mask  */
+
+
+/* -------- RTT_SR : (RTT Offset: 0x0c) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ALMS:1;                    /**< bit:      0  Real-time Alarm Status (cleared on read) */
+    uint32_t RTTINC:1;                  /**< bit:      1  Prescaler Roll-over Status (cleared on read) */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_SR_OFFSET                       (0x0C)                                        /**<  (RTT_SR) Status Register  Offset */
+
+#define RTT_SR_ALMS_Pos                     0                                              /**< (RTT_SR) Real-time Alarm Status (cleared on read) Position */
+#define RTT_SR_ALMS_Msk                     (_U_(0x1) << RTT_SR_ALMS_Pos)                  /**< (RTT_SR) Real-time Alarm Status (cleared on read) Mask */
+#define RTT_SR_ALMS                         RTT_SR_ALMS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_SR_ALMS_Msk instead */
+#define RTT_SR_RTTINC_Pos                   1                                              /**< (RTT_SR) Prescaler Roll-over Status (cleared on read) Position */
+#define RTT_SR_RTTINC_Msk                   (_U_(0x1) << RTT_SR_RTTINC_Pos)                /**< (RTT_SR) Prescaler Roll-over Status (cleared on read) Mask */
+#define RTT_SR_RTTINC                       RTT_SR_RTTINC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_SR_RTTINC_Msk instead */
+#define RTT_SR_MASK                         _U_(0x03)                                      /**< \deprecated (RTT_SR) Register MASK  (Use RTT_SR_Msk instead)  */
+#define RTT_SR_Msk                          _U_(0x03)                                      /**< (RTT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RTT hardware registers */
+typedef struct {  
+  __IO uint32_t RTT_MR;         /**< (RTT Offset: 0x00) Mode Register */
+  __IO uint32_t RTT_AR;         /**< (RTT Offset: 0x04) Alarm Register */
+  __I  uint32_t RTT_VR;         /**< (RTT Offset: 0x08) Value Register */
+  __I  uint32_t RTT_SR;         /**< (RTT Offset: 0x0C) Status Register */
+} Rtt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RTT hardware registers */
+typedef struct {  
+  __IO RTT_MR_Type                    RTT_MR;         /**< Offset: 0x00 (R/W  32) Mode Register */
+  __IO RTT_AR_Type                    RTT_AR;         /**< Offset: 0x04 (R/W  32) Alarm Register */
+  __I  RTT_VR_Type                    RTT_VR;         /**< Offset: 0x08 (R/   32) Value Register */
+  __I  RTT_SR_Type                    RTT_SR;         /**< Offset: 0x0C (R/   32) Status Register */
+} Rtt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-time Timer */
+
+#endif /* _SAMV71_RTT_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/sdramc.h
+++ b/asf/sam/include/samv71/component/sdramc.h
@@ -1,0 +1,531 @@
+/**
+ * \file
+ *
+ * \brief Component description for SDRAMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SDRAMC_COMPONENT_H_
+#define _SAMV71_SDRAMC_COMPONENT_H_
+#define _SAMV71_SDRAMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 SDRAM Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SDRAMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SDRAMC_6100                       /**< (SDRAMC) Module ID */
+#define REV_SDRAMC S                      /**< (SDRAMC) Module revision */
+
+/* -------- SDRAMC_MR : (SDRAMC Offset: 0x00) (R/W 32) SDRAMC Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MODE:3;                    /**< bit:   0..2  SDRAMC Command Mode                      */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_MR_OFFSET                    (0x00)                                        /**<  (SDRAMC_MR) SDRAMC Mode Register  Offset */
+
+#define SDRAMC_MR_MODE_Pos                  0                                              /**< (SDRAMC_MR) SDRAMC Command Mode Position */
+#define SDRAMC_MR_MODE_Msk                  (_U_(0x7) << SDRAMC_MR_MODE_Pos)               /**< (SDRAMC_MR) SDRAMC Command Mode Mask */
+#define SDRAMC_MR_MODE(value)               (SDRAMC_MR_MODE_Msk & ((value) << SDRAMC_MR_MODE_Pos))
+#define   SDRAMC_MR_MODE_NORMAL_Val         _U_(0x0)                                       /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_NOP_Val            _U_(0x1)                                       /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val _U_(0x2)                                       /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_LOAD_MODEREG_Val   _U_(0x3)                                       /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_AUTO_REFRESH_Val   _U_(0x4)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val _U_(0x5)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1.  */
+#define   SDRAMC_MR_MODE_DEEP_POWERDOWN_Val _U_(0x6)                                       /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode.  */
+#define SDRAMC_MR_MODE_NORMAL               (SDRAMC_MR_MODE_NORMAL_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_NOP                  (SDRAMC_MR_MODE_NOP_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_ALLBANKS_PRECHARGE   (SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_LOAD_MODEREG         (SDRAMC_MR_MODE_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_AUTO_REFRESH         (SDRAMC_MR_MODE_AUTO_REFRESH_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_EXT_LOAD_MODEREG     (SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1. Position  */
+#define SDRAMC_MR_MODE_DEEP_POWERDOWN       (SDRAMC_MR_MODE_DEEP_POWERDOWN_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode. Position  */
+#define SDRAMC_MR_MASK                      _U_(0x07)                                      /**< \deprecated (SDRAMC_MR) Register MASK  (Use SDRAMC_MR_Msk instead)  */
+#define SDRAMC_MR_Msk                       _U_(0x07)                                      /**< (SDRAMC_MR) Register Mask  */
+
+
+/* -------- SDRAMC_TR : (SDRAMC Offset: 0x04) (R/W 32) SDRAMC Refresh Timer Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COUNT:12;                  /**< bit:  0..11  SDRAMC Refresh Timer Count               */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_TR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_TR_OFFSET                    (0x04)                                        /**<  (SDRAMC_TR) SDRAMC Refresh Timer Register  Offset */
+
+#define SDRAMC_TR_COUNT_Pos                 0                                              /**< (SDRAMC_TR) SDRAMC Refresh Timer Count Position */
+#define SDRAMC_TR_COUNT_Msk                 (_U_(0xFFF) << SDRAMC_TR_COUNT_Pos)            /**< (SDRAMC_TR) SDRAMC Refresh Timer Count Mask */
+#define SDRAMC_TR_COUNT(value)              (SDRAMC_TR_COUNT_Msk & ((value) << SDRAMC_TR_COUNT_Pos))
+#define SDRAMC_TR_MASK                      _U_(0xFFF)                                     /**< \deprecated (SDRAMC_TR) Register MASK  (Use SDRAMC_TR_Msk instead)  */
+#define SDRAMC_TR_Msk                       _U_(0xFFF)                                     /**< (SDRAMC_TR) Register Mask  */
+
+
+/* -------- SDRAMC_CR : (SDRAMC Offset: 0x08) (R/W 32) SDRAMC Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NC:2;                      /**< bit:   0..1  Number of Column Bits                    */
+    uint32_t NR:2;                      /**< bit:   2..3  Number of Row Bits                       */
+    uint32_t NB:1;                      /**< bit:      4  Number of Banks                          */
+    uint32_t CAS:2;                     /**< bit:   5..6  CAS Latency                              */
+    uint32_t DBW:1;                     /**< bit:      7  Data Bus Width                           */
+    uint32_t TWR:4;                     /**< bit:  8..11  Write Recovery Delay                     */
+    uint32_t TRC_TRFC:4;                /**< bit: 12..15  Row Cycle Delay and Row Refresh Cycle    */
+    uint32_t TRP:4;                     /**< bit: 16..19  Row Precharge Delay                      */
+    uint32_t TRCD:4;                    /**< bit: 20..23  Row to Column Delay                      */
+    uint32_t TRAS:4;                    /**< bit: 24..27  Active to Precharge Delay                */
+    uint32_t TXSR:4;                    /**< bit: 28..31  Exit Self-Refresh to Active Delay        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_CR_OFFSET                    (0x08)                                        /**<  (SDRAMC_CR) SDRAMC Configuration Register  Offset */
+
+#define SDRAMC_CR_NC_Pos                    0                                              /**< (SDRAMC_CR) Number of Column Bits Position */
+#define SDRAMC_CR_NC_Msk                    (_U_(0x3) << SDRAMC_CR_NC_Pos)                 /**< (SDRAMC_CR) Number of Column Bits Mask */
+#define SDRAMC_CR_NC(value)                 (SDRAMC_CR_NC_Msk & ((value) << SDRAMC_CR_NC_Pos))
+#define   SDRAMC_CR_NC_COL8_Val             _U_(0x0)                                       /**< (SDRAMC_CR) 8 column bits  */
+#define   SDRAMC_CR_NC_COL9_Val             _U_(0x1)                                       /**< (SDRAMC_CR) 9 column bits  */
+#define   SDRAMC_CR_NC_COL10_Val            _U_(0x2)                                       /**< (SDRAMC_CR) 10 column bits  */
+#define   SDRAMC_CR_NC_COL11_Val            _U_(0x3)                                       /**< (SDRAMC_CR) 11 column bits  */
+#define SDRAMC_CR_NC_COL8                   (SDRAMC_CR_NC_COL8_Val << SDRAMC_CR_NC_Pos)    /**< (SDRAMC_CR) 8 column bits Position  */
+#define SDRAMC_CR_NC_COL9                   (SDRAMC_CR_NC_COL9_Val << SDRAMC_CR_NC_Pos)    /**< (SDRAMC_CR) 9 column bits Position  */
+#define SDRAMC_CR_NC_COL10                  (SDRAMC_CR_NC_COL10_Val << SDRAMC_CR_NC_Pos)   /**< (SDRAMC_CR) 10 column bits Position  */
+#define SDRAMC_CR_NC_COL11                  (SDRAMC_CR_NC_COL11_Val << SDRAMC_CR_NC_Pos)   /**< (SDRAMC_CR) 11 column bits Position  */
+#define SDRAMC_CR_NR_Pos                    2                                              /**< (SDRAMC_CR) Number of Row Bits Position */
+#define SDRAMC_CR_NR_Msk                    (_U_(0x3) << SDRAMC_CR_NR_Pos)                 /**< (SDRAMC_CR) Number of Row Bits Mask */
+#define SDRAMC_CR_NR(value)                 (SDRAMC_CR_NR_Msk & ((value) << SDRAMC_CR_NR_Pos))
+#define   SDRAMC_CR_NR_ROW11_Val            _U_(0x0)                                       /**< (SDRAMC_CR) 11 row bits  */
+#define   SDRAMC_CR_NR_ROW12_Val            _U_(0x1)                                       /**< (SDRAMC_CR) 12 row bits  */
+#define   SDRAMC_CR_NR_ROW13_Val            _U_(0x2)                                       /**< (SDRAMC_CR) 13 row bits  */
+#define SDRAMC_CR_NR_ROW11                  (SDRAMC_CR_NR_ROW11_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 11 row bits Position  */
+#define SDRAMC_CR_NR_ROW12                  (SDRAMC_CR_NR_ROW12_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 12 row bits Position  */
+#define SDRAMC_CR_NR_ROW13                  (SDRAMC_CR_NR_ROW13_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 13 row bits Position  */
+#define SDRAMC_CR_NB_Pos                    4                                              /**< (SDRAMC_CR) Number of Banks Position */
+#define SDRAMC_CR_NB_Msk                    (_U_(0x1) << SDRAMC_CR_NB_Pos)                 /**< (SDRAMC_CR) Number of Banks Mask */
+#define SDRAMC_CR_NB                        SDRAMC_CR_NB_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CR_NB_Msk instead */
+#define   SDRAMC_CR_NB_BANK2_Val            _U_(0x0)                                       /**< (SDRAMC_CR) 2 banks  */
+#define   SDRAMC_CR_NB_BANK4_Val            _U_(0x1)                                       /**< (SDRAMC_CR) 4 banks  */
+#define SDRAMC_CR_NB_BANK2                  (SDRAMC_CR_NB_BANK2_Val << SDRAMC_CR_NB_Pos)   /**< (SDRAMC_CR) 2 banks Position  */
+#define SDRAMC_CR_NB_BANK4                  (SDRAMC_CR_NB_BANK4_Val << SDRAMC_CR_NB_Pos)   /**< (SDRAMC_CR) 4 banks Position  */
+#define SDRAMC_CR_CAS_Pos                   5                                              /**< (SDRAMC_CR) CAS Latency Position */
+#define SDRAMC_CR_CAS_Msk                   (_U_(0x3) << SDRAMC_CR_CAS_Pos)                /**< (SDRAMC_CR) CAS Latency Mask */
+#define SDRAMC_CR_CAS(value)                (SDRAMC_CR_CAS_Msk & ((value) << SDRAMC_CR_CAS_Pos))
+#define   SDRAMC_CR_CAS_LATENCY1_Val        _U_(0x1)                                       /**< (SDRAMC_CR) 1 cycle latency  */
+#define   SDRAMC_CR_CAS_LATENCY2_Val        _U_(0x2)                                       /**< (SDRAMC_CR) 2 cycle latency  */
+#define   SDRAMC_CR_CAS_LATENCY3_Val        _U_(0x3)                                       /**< (SDRAMC_CR) 3 cycle latency  */
+#define SDRAMC_CR_CAS_LATENCY1              (SDRAMC_CR_CAS_LATENCY1_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 1 cycle latency Position  */
+#define SDRAMC_CR_CAS_LATENCY2              (SDRAMC_CR_CAS_LATENCY2_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 2 cycle latency Position  */
+#define SDRAMC_CR_CAS_LATENCY3              (SDRAMC_CR_CAS_LATENCY3_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 3 cycle latency Position  */
+#define SDRAMC_CR_DBW_Pos                   7                                              /**< (SDRAMC_CR) Data Bus Width Position */
+#define SDRAMC_CR_DBW_Msk                   (_U_(0x1) << SDRAMC_CR_DBW_Pos)                /**< (SDRAMC_CR) Data Bus Width Mask */
+#define SDRAMC_CR_DBW                       SDRAMC_CR_DBW_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CR_DBW_Msk instead */
+#define SDRAMC_CR_TWR_Pos                   8                                              /**< (SDRAMC_CR) Write Recovery Delay Position */
+#define SDRAMC_CR_TWR_Msk                   (_U_(0xF) << SDRAMC_CR_TWR_Pos)                /**< (SDRAMC_CR) Write Recovery Delay Mask */
+#define SDRAMC_CR_TWR(value)                (SDRAMC_CR_TWR_Msk & ((value) << SDRAMC_CR_TWR_Pos))
+#define SDRAMC_CR_TRC_TRFC_Pos              12                                             /**< (SDRAMC_CR) Row Cycle Delay and Row Refresh Cycle Position */
+#define SDRAMC_CR_TRC_TRFC_Msk              (_U_(0xF) << SDRAMC_CR_TRC_TRFC_Pos)           /**< (SDRAMC_CR) Row Cycle Delay and Row Refresh Cycle Mask */
+#define SDRAMC_CR_TRC_TRFC(value)           (SDRAMC_CR_TRC_TRFC_Msk & ((value) << SDRAMC_CR_TRC_TRFC_Pos))
+#define SDRAMC_CR_TRP_Pos                   16                                             /**< (SDRAMC_CR) Row Precharge Delay Position */
+#define SDRAMC_CR_TRP_Msk                   (_U_(0xF) << SDRAMC_CR_TRP_Pos)                /**< (SDRAMC_CR) Row Precharge Delay Mask */
+#define SDRAMC_CR_TRP(value)                (SDRAMC_CR_TRP_Msk & ((value) << SDRAMC_CR_TRP_Pos))
+#define SDRAMC_CR_TRCD_Pos                  20                                             /**< (SDRAMC_CR) Row to Column Delay Position */
+#define SDRAMC_CR_TRCD_Msk                  (_U_(0xF) << SDRAMC_CR_TRCD_Pos)               /**< (SDRAMC_CR) Row to Column Delay Mask */
+#define SDRAMC_CR_TRCD(value)               (SDRAMC_CR_TRCD_Msk & ((value) << SDRAMC_CR_TRCD_Pos))
+#define SDRAMC_CR_TRAS_Pos                  24                                             /**< (SDRAMC_CR) Active to Precharge Delay Position */
+#define SDRAMC_CR_TRAS_Msk                  (_U_(0xF) << SDRAMC_CR_TRAS_Pos)               /**< (SDRAMC_CR) Active to Precharge Delay Mask */
+#define SDRAMC_CR_TRAS(value)               (SDRAMC_CR_TRAS_Msk & ((value) << SDRAMC_CR_TRAS_Pos))
+#define SDRAMC_CR_TXSR_Pos                  28                                             /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Position */
+#define SDRAMC_CR_TXSR_Msk                  (_U_(0xF) << SDRAMC_CR_TXSR_Pos)               /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Mask */
+#define SDRAMC_CR_TXSR(value)               (SDRAMC_CR_TXSR_Msk & ((value) << SDRAMC_CR_TXSR_Pos))
+#define SDRAMC_CR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_CR) Register MASK  (Use SDRAMC_CR_Msk instead)  */
+#define SDRAMC_CR_Msk                       _U_(0xFFFFFFFF)                                /**< (SDRAMC_CR) Register Mask  */
+
+
+/* -------- SDRAMC_LPR : (SDRAMC Offset: 0x10) (R/W 32) SDRAMC Low Power Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LPCB:2;                    /**< bit:   0..1  Low-power Configuration Bits             */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t PASR:3;                    /**< bit:   4..6  Partial Array Self-refresh (only for low-power SDRAM) */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TCSR:2;                    /**< bit:   8..9  Temperature Compensated Self-Refresh (only for low-power SDRAM) */
+    uint32_t DS:2;                      /**< bit: 10..11  Drive Strength (only for low-power SDRAM) */
+    uint32_t TIMEOUT:2;                 /**< bit: 12..13  Time to Define When Low-power Mode Is Enabled */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_LPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_LPR_OFFSET                   (0x10)                                        /**<  (SDRAMC_LPR) SDRAMC Low Power Register  Offset */
+
+#define SDRAMC_LPR_LPCB_Pos                 0                                              /**< (SDRAMC_LPR) Low-power Configuration Bits Position */
+#define SDRAMC_LPR_LPCB_Msk                 (_U_(0x3) << SDRAMC_LPR_LPCB_Pos)              /**< (SDRAMC_LPR) Low-power Configuration Bits Mask */
+#define SDRAMC_LPR_LPCB(value)              (SDRAMC_LPR_LPCB_Msk & ((value) << SDRAMC_LPR_LPCB_Pos))
+#define   SDRAMC_LPR_LPCB_DISABLED_Val      _U_(0x0)                                       /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device.  */
+#define   SDRAMC_LPR_LPCB_SELF_REFRESH_Val  _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_POWER_DOWN_Val    _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val _U_(0x3)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM.  */
+#define SDRAMC_LPR_LPCB_DISABLED            (SDRAMC_LPR_LPCB_DISABLED_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device. Position  */
+#define SDRAMC_LPR_LPCB_SELF_REFRESH        (SDRAMC_LPR_LPCB_SELF_REFRESH_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_POWER_DOWN          (SDRAMC_LPR_LPCB_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_DEEP_POWER_DOWN     (SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM. Position  */
+#define SDRAMC_LPR_PASR_Pos                 4                                              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_PASR_Msk                 (_U_(0x7) << SDRAMC_LPR_PASR_Pos)              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_PASR(value)              (SDRAMC_LPR_PASR_Msk & ((value) << SDRAMC_LPR_PASR_Pos))
+#define SDRAMC_LPR_TCSR_Pos                 8                                              /**< (SDRAMC_LPR) Temperature Compensated Self-Refresh (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_TCSR_Msk                 (_U_(0x3) << SDRAMC_LPR_TCSR_Pos)              /**< (SDRAMC_LPR) Temperature Compensated Self-Refresh (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_TCSR(value)              (SDRAMC_LPR_TCSR_Msk & ((value) << SDRAMC_LPR_TCSR_Pos))
+#define SDRAMC_LPR_DS_Pos                   10                                             /**< (SDRAMC_LPR) Drive Strength (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_DS_Msk                   (_U_(0x3) << SDRAMC_LPR_DS_Pos)                /**< (SDRAMC_LPR) Drive Strength (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_DS(value)                (SDRAMC_LPR_DS_Msk & ((value) << SDRAMC_LPR_DS_Pos))
+#define SDRAMC_LPR_TIMEOUT_Pos              12                                             /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Position */
+#define SDRAMC_LPR_TIMEOUT_Msk              (_U_(0x3) << SDRAMC_LPR_TIMEOUT_Pos)           /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Mask */
+#define SDRAMC_LPR_TIMEOUT(value)           (SDRAMC_LPR_TIMEOUT_Msk & ((value) << SDRAMC_LPR_TIMEOUT_Pos))
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val _U_(0x0)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer.  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER     (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64  (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128 (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer. Position  */
+#define SDRAMC_LPR_MASK                     _U_(0x3F73)                                    /**< \deprecated (SDRAMC_LPR) Register MASK  (Use SDRAMC_LPR_Msk instead)  */
+#define SDRAMC_LPR_Msk                      _U_(0x3F73)                                    /**< (SDRAMC_LPR) Register Mask  */
+
+
+/* -------- SDRAMC_IER : (SDRAMC Offset: 0x14) (/W 32) SDRAMC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Enable           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IER_OFFSET                   (0x14)                                        /**<  (SDRAMC_IER) SDRAMC Interrupt Enable Register  Offset */
+
+#define SDRAMC_IER_RES_Pos                  0                                              /**< (SDRAMC_IER) Refresh Error Interrupt Enable Position */
+#define SDRAMC_IER_RES_Msk                  (_U_(0x1) << SDRAMC_IER_RES_Pos)               /**< (SDRAMC_IER) Refresh Error Interrupt Enable Mask */
+#define SDRAMC_IER_RES                      SDRAMC_IER_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IER_RES_Msk instead */
+#define SDRAMC_IER_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IER) Register MASK  (Use SDRAMC_IER_Msk instead)  */
+#define SDRAMC_IER_Msk                      _U_(0x01)                                      /**< (SDRAMC_IER) Register Mask  */
+
+
+/* -------- SDRAMC_IDR : (SDRAMC Offset: 0x18) (/W 32) SDRAMC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Disable          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IDR_OFFSET                   (0x18)                                        /**<  (SDRAMC_IDR) SDRAMC Interrupt Disable Register  Offset */
+
+#define SDRAMC_IDR_RES_Pos                  0                                              /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Position */
+#define SDRAMC_IDR_RES_Msk                  (_U_(0x1) << SDRAMC_IDR_RES_Pos)               /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Mask */
+#define SDRAMC_IDR_RES                      SDRAMC_IDR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IDR_RES_Msk instead */
+#define SDRAMC_IDR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IDR) Register MASK  (Use SDRAMC_IDR_Msk instead)  */
+#define SDRAMC_IDR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IDR) Register Mask  */
+
+
+/* -------- SDRAMC_IMR : (SDRAMC Offset: 0x1c) (R/ 32) SDRAMC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Mask             */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IMR_OFFSET                   (0x1C)                                        /**<  (SDRAMC_IMR) SDRAMC Interrupt Mask Register  Offset */
+
+#define SDRAMC_IMR_RES_Pos                  0                                              /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Position */
+#define SDRAMC_IMR_RES_Msk                  (_U_(0x1) << SDRAMC_IMR_RES_Pos)               /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Mask */
+#define SDRAMC_IMR_RES                      SDRAMC_IMR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IMR_RES_Msk instead */
+#define SDRAMC_IMR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IMR) Register MASK  (Use SDRAMC_IMR_Msk instead)  */
+#define SDRAMC_IMR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IMR) Register Mask  */
+
+
+/* -------- SDRAMC_ISR : (SDRAMC Offset: 0x20) (R/ 32) SDRAMC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Status (cleared on read)   */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_ISR_OFFSET                   (0x20)                                        /**<  (SDRAMC_ISR) SDRAMC Interrupt Status Register  Offset */
+
+#define SDRAMC_ISR_RES_Pos                  0                                              /**< (SDRAMC_ISR) Refresh Error Status (cleared on read) Position */
+#define SDRAMC_ISR_RES_Msk                  (_U_(0x1) << SDRAMC_ISR_RES_Pos)               /**< (SDRAMC_ISR) Refresh Error Status (cleared on read) Mask */
+#define SDRAMC_ISR_RES                      SDRAMC_ISR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_ISR_RES_Msk instead */
+#define SDRAMC_ISR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_ISR) Register MASK  (Use SDRAMC_ISR_Msk instead)  */
+#define SDRAMC_ISR_Msk                      _U_(0x01)                                      /**< (SDRAMC_ISR) Register Mask  */
+
+
+/* -------- SDRAMC_MDR : (SDRAMC Offset: 0x24) (R/W 32) SDRAMC Memory Device Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MD:2;                      /**< bit:   0..1  Memory Device Type                       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_MDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_MDR_OFFSET                   (0x24)                                        /**<  (SDRAMC_MDR) SDRAMC Memory Device Register  Offset */
+
+#define SDRAMC_MDR_MD_Pos                   0                                              /**< (SDRAMC_MDR) Memory Device Type Position */
+#define SDRAMC_MDR_MD_Msk                   (_U_(0x3) << SDRAMC_MDR_MD_Pos)                /**< (SDRAMC_MDR) Memory Device Type Mask */
+#define SDRAMC_MDR_MD(value)                (SDRAMC_MDR_MD_Msk & ((value) << SDRAMC_MDR_MD_Pos))
+#define   SDRAMC_MDR_MD_SDRAM_Val           _U_(0x0)                                       /**< (SDRAMC_MDR) SDRAM  */
+#define   SDRAMC_MDR_MD_LPSDRAM_Val         _U_(0x1)                                       /**< (SDRAMC_MDR) Low-power SDRAM  */
+#define SDRAMC_MDR_MD_SDRAM                 (SDRAMC_MDR_MD_SDRAM_Val << SDRAMC_MDR_MD_Pos)  /**< (SDRAMC_MDR) SDRAM Position  */
+#define SDRAMC_MDR_MD_LPSDRAM               (SDRAMC_MDR_MD_LPSDRAM_Val << SDRAMC_MDR_MD_Pos)  /**< (SDRAMC_MDR) Low-power SDRAM Position  */
+#define SDRAMC_MDR_MASK                     _U_(0x03)                                      /**< \deprecated (SDRAMC_MDR) Register MASK  (Use SDRAMC_MDR_Msk instead)  */
+#define SDRAMC_MDR_Msk                      _U_(0x03)                                      /**< (SDRAMC_MDR) Register Mask  */
+
+
+/* -------- SDRAMC_CFR1 : (SDRAMC Offset: 0x28) (R/W 32) SDRAMC Configuration Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TMRD:4;                    /**< bit:   0..3  Load Mode Register Command to Active or Refresh Command */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t UNAL:1;                    /**< bit:      8  Support Unaligned Access                 */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_CFR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_CFR1_OFFSET                  (0x28)                                        /**<  (SDRAMC_CFR1) SDRAMC Configuration Register 1  Offset */
+
+#define SDRAMC_CFR1_TMRD_Pos                0                                              /**< (SDRAMC_CFR1) Load Mode Register Command to Active or Refresh Command Position */
+#define SDRAMC_CFR1_TMRD_Msk                (_U_(0xF) << SDRAMC_CFR1_TMRD_Pos)             /**< (SDRAMC_CFR1) Load Mode Register Command to Active or Refresh Command Mask */
+#define SDRAMC_CFR1_TMRD(value)             (SDRAMC_CFR1_TMRD_Msk & ((value) << SDRAMC_CFR1_TMRD_Pos))
+#define SDRAMC_CFR1_UNAL_Pos                8                                              /**< (SDRAMC_CFR1) Support Unaligned Access Position */
+#define SDRAMC_CFR1_UNAL_Msk                (_U_(0x1) << SDRAMC_CFR1_UNAL_Pos)             /**< (SDRAMC_CFR1) Support Unaligned Access Mask */
+#define SDRAMC_CFR1_UNAL                    SDRAMC_CFR1_UNAL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CFR1_UNAL_Msk instead */
+#define   SDRAMC_CFR1_UNAL_UNSUPPORTED_Val  _U_(0x0)                                       /**< (SDRAMC_CFR1) Unaligned access is not supported.  */
+#define   SDRAMC_CFR1_UNAL_SUPPORTED_Val    _U_(0x1)                                       /**< (SDRAMC_CFR1) Unaligned access is supported.  */
+#define SDRAMC_CFR1_UNAL_UNSUPPORTED        (SDRAMC_CFR1_UNAL_UNSUPPORTED_Val << SDRAMC_CFR1_UNAL_Pos)  /**< (SDRAMC_CFR1) Unaligned access is not supported. Position  */
+#define SDRAMC_CFR1_UNAL_SUPPORTED          (SDRAMC_CFR1_UNAL_SUPPORTED_Val << SDRAMC_CFR1_UNAL_Pos)  /**< (SDRAMC_CFR1) Unaligned access is supported. Position  */
+#define SDRAMC_CFR1_MASK                    _U_(0x10F)                                     /**< \deprecated (SDRAMC_CFR1) Register MASK  (Use SDRAMC_CFR1_Msk instead)  */
+#define SDRAMC_CFR1_Msk                     _U_(0x10F)                                     /**< (SDRAMC_CFR1) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS : (SDRAMC Offset: 0x2c) (R/W 32) SDRAMC OCMS Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDR_SE:1;                  /**< bit:      0  SDRAM Memory Controller Scrambling Enable */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_OFFSET                  (0x2C)                                        /**<  (SDRAMC_OCMS) SDRAMC OCMS Register  Offset */
+
+#define SDRAMC_OCMS_SDR_SE_Pos              0                                              /**< (SDRAMC_OCMS) SDRAM Memory Controller Scrambling Enable Position */
+#define SDRAMC_OCMS_SDR_SE_Msk              (_U_(0x1) << SDRAMC_OCMS_SDR_SE_Pos)           /**< (SDRAMC_OCMS) SDRAM Memory Controller Scrambling Enable Mask */
+#define SDRAMC_OCMS_SDR_SE                  SDRAMC_OCMS_SDR_SE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_OCMS_SDR_SE_Msk instead */
+#define SDRAMC_OCMS_MASK                    _U_(0x01)                                      /**< \deprecated (SDRAMC_OCMS) Register MASK  (Use SDRAMC_OCMS_Msk instead)  */
+#define SDRAMC_OCMS_Msk                     _U_(0x01)                                      /**< (SDRAMC_OCMS) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS_KEY1 : (SDRAMC Offset: 0x30) (/W 32) SDRAMC OCMS KEY1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY1:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 1 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_KEY1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_KEY1_OFFSET             (0x30)                                        /**<  (SDRAMC_OCMS_KEY1) SDRAMC OCMS KEY1 Register  Offset */
+
+#define SDRAMC_OCMS_KEY1_KEY1_Pos           0                                              /**< (SDRAMC_OCMS_KEY1) Off-chip Memory Scrambling (OCMS) Key Part 1 Position */
+#define SDRAMC_OCMS_KEY1_KEY1_Msk           (_U_(0xFFFFFFFF) << SDRAMC_OCMS_KEY1_KEY1_Pos)  /**< (SDRAMC_OCMS_KEY1) Off-chip Memory Scrambling (OCMS) Key Part 1 Mask */
+#define SDRAMC_OCMS_KEY1_KEY1(value)        (SDRAMC_OCMS_KEY1_KEY1_Msk & ((value) << SDRAMC_OCMS_KEY1_KEY1_Pos))
+#define SDRAMC_OCMS_KEY1_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_OCMS_KEY1) Register MASK  (Use SDRAMC_OCMS_KEY1_Msk instead)  */
+#define SDRAMC_OCMS_KEY1_Msk                _U_(0xFFFFFFFF)                                /**< (SDRAMC_OCMS_KEY1) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS_KEY2 : (SDRAMC Offset: 0x34) (/W 32) SDRAMC OCMS KEY2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY2:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 2 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_KEY2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_KEY2_OFFSET             (0x34)                                        /**<  (SDRAMC_OCMS_KEY2) SDRAMC OCMS KEY2 Register  Offset */
+
+#define SDRAMC_OCMS_KEY2_KEY2_Pos           0                                              /**< (SDRAMC_OCMS_KEY2) Off-chip Memory Scrambling (OCMS) Key Part 2 Position */
+#define SDRAMC_OCMS_KEY2_KEY2_Msk           (_U_(0xFFFFFFFF) << SDRAMC_OCMS_KEY2_KEY2_Pos)  /**< (SDRAMC_OCMS_KEY2) Off-chip Memory Scrambling (OCMS) Key Part 2 Mask */
+#define SDRAMC_OCMS_KEY2_KEY2(value)        (SDRAMC_OCMS_KEY2_KEY2_Msk & ((value) << SDRAMC_OCMS_KEY2_KEY2_Pos))
+#define SDRAMC_OCMS_KEY2_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_OCMS_KEY2) Register MASK  (Use SDRAMC_OCMS_KEY2_Msk instead)  */
+#define SDRAMC_OCMS_KEY2_Msk                _U_(0xFFFFFFFF)                                /**< (SDRAMC_OCMS_KEY2) Register Mask  */
+
+
+/* -------- SDRAMC_VERSION : (SDRAMC Offset: 0xfc) (R/ 32) SDRAMC Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_VERSION_OFFSET               (0xFC)                                        /**<  (SDRAMC_VERSION) SDRAMC Version Register  Offset */
+
+#define SDRAMC_VERSION_VERSION_Pos          0                                              /**< (SDRAMC_VERSION) Version of the Hardware Module Position */
+#define SDRAMC_VERSION_VERSION_Msk          (_U_(0xFFF) << SDRAMC_VERSION_VERSION_Pos)     /**< (SDRAMC_VERSION) Version of the Hardware Module Mask */
+#define SDRAMC_VERSION_VERSION(value)       (SDRAMC_VERSION_VERSION_Msk & ((value) << SDRAMC_VERSION_VERSION_Pos))
+#define SDRAMC_VERSION_MFN_Pos              16                                             /**< (SDRAMC_VERSION) Metal Fix Number Position */
+#define SDRAMC_VERSION_MFN_Msk              (_U_(0x7) << SDRAMC_VERSION_MFN_Pos)           /**< (SDRAMC_VERSION) Metal Fix Number Mask */
+#define SDRAMC_VERSION_MFN(value)           (SDRAMC_VERSION_MFN_Msk & ((value) << SDRAMC_VERSION_MFN_Pos))
+#define SDRAMC_VERSION_MASK                 _U_(0x70FFF)                                   /**< \deprecated (SDRAMC_VERSION) Register MASK  (Use SDRAMC_VERSION_Msk instead)  */
+#define SDRAMC_VERSION_Msk                  _U_(0x70FFF)                                   /**< (SDRAMC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SDRAMC hardware registers */
+typedef struct {  
+  __IO uint32_t SDRAMC_MR;      /**< (SDRAMC Offset: 0x00) SDRAMC Mode Register */
+  __IO uint32_t SDRAMC_TR;      /**< (SDRAMC Offset: 0x04) SDRAMC Refresh Timer Register */
+  __IO uint32_t SDRAMC_CR;      /**< (SDRAMC Offset: 0x08) SDRAMC Configuration Register */
+  __I  uint8_t                        Reserved1[4];
+  __IO uint32_t SDRAMC_LPR;     /**< (SDRAMC Offset: 0x10) SDRAMC Low Power Register */
+  __O  uint32_t SDRAMC_IER;     /**< (SDRAMC Offset: 0x14) SDRAMC Interrupt Enable Register */
+  __O  uint32_t SDRAMC_IDR;     /**< (SDRAMC Offset: 0x18) SDRAMC Interrupt Disable Register */
+  __I  uint32_t SDRAMC_IMR;     /**< (SDRAMC Offset: 0x1C) SDRAMC Interrupt Mask Register */
+  __I  uint32_t SDRAMC_ISR;     /**< (SDRAMC Offset: 0x20) SDRAMC Interrupt Status Register */
+  __IO uint32_t SDRAMC_MDR;     /**< (SDRAMC Offset: 0x24) SDRAMC Memory Device Register */
+  __IO uint32_t SDRAMC_CFR1;    /**< (SDRAMC Offset: 0x28) SDRAMC Configuration Register 1 */
+  __IO uint32_t SDRAMC_OCMS;    /**< (SDRAMC Offset: 0x2C) SDRAMC OCMS Register */
+  __O  uint32_t SDRAMC_OCMS_KEY1; /**< (SDRAMC Offset: 0x30) SDRAMC OCMS KEY1 Register */
+  __O  uint32_t SDRAMC_OCMS_KEY2; /**< (SDRAMC Offset: 0x34) SDRAMC OCMS KEY2 Register */
+  __I  uint8_t                        Reserved2[196];
+  __I  uint32_t SDRAMC_VERSION; /**< (SDRAMC Offset: 0xFC) SDRAMC Version Register */
+} Sdramc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SDRAMC hardware registers */
+typedef struct {  
+  __IO SDRAMC_MR_Type                 SDRAMC_MR;      /**< Offset: 0x00 (R/W  32) SDRAMC Mode Register */
+  __IO SDRAMC_TR_Type                 SDRAMC_TR;      /**< Offset: 0x04 (R/W  32) SDRAMC Refresh Timer Register */
+  __IO SDRAMC_CR_Type                 SDRAMC_CR;      /**< Offset: 0x08 (R/W  32) SDRAMC Configuration Register */
+  __I  uint8_t                        Reserved1[4];
+  __IO SDRAMC_LPR_Type                SDRAMC_LPR;     /**< Offset: 0x10 (R/W  32) SDRAMC Low Power Register */
+  __O  SDRAMC_IER_Type                SDRAMC_IER;     /**< Offset: 0x14 ( /W  32) SDRAMC Interrupt Enable Register */
+  __O  SDRAMC_IDR_Type                SDRAMC_IDR;     /**< Offset: 0x18 ( /W  32) SDRAMC Interrupt Disable Register */
+  __I  SDRAMC_IMR_Type                SDRAMC_IMR;     /**< Offset: 0x1C (R/   32) SDRAMC Interrupt Mask Register */
+  __I  SDRAMC_ISR_Type                SDRAMC_ISR;     /**< Offset: 0x20 (R/   32) SDRAMC Interrupt Status Register */
+  __IO SDRAMC_MDR_Type                SDRAMC_MDR;     /**< Offset: 0x24 (R/W  32) SDRAMC Memory Device Register */
+  __IO SDRAMC_CFR1_Type               SDRAMC_CFR1;    /**< Offset: 0x28 (R/W  32) SDRAMC Configuration Register 1 */
+  __IO SDRAMC_OCMS_Type               SDRAMC_OCMS;    /**< Offset: 0x2C (R/W  32) SDRAMC OCMS Register */
+  __O  SDRAMC_OCMS_KEY1_Type          SDRAMC_OCMS_KEY1; /**< Offset: 0x30 ( /W  32) SDRAMC OCMS KEY1 Register */
+  __O  SDRAMC_OCMS_KEY2_Type          SDRAMC_OCMS_KEY2; /**< Offset: 0x34 ( /W  32) SDRAMC OCMS KEY2 Register */
+  __I  uint8_t                        Reserved2[196];
+  __I  SDRAMC_VERSION_Type            SDRAMC_VERSION; /**< Offset: 0xFC (R/   32) SDRAMC Version Register */
+} Sdramc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of SDRAM Controller */
+
+#endif /* _SAMV71_SDRAMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/smc.h
+++ b/asf/sam/include/samv71/component/smc.h
@@ -1,0 +1,449 @@
+/**
+ * \file
+ *
+ * \brief Component description for SMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SMC_COMPONENT_H_
+#define _SAMV71_SMC_COMPONENT_H_
+#define _SAMV71_SMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Static Memory Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SMC_6498                       /**< (SMC) Module ID */
+#define REV_SMC J                      /**< (SMC) Module revision */
+
+/* -------- SMC_SETUP : (SMC Offset: 0x00) (R/W 32) SMC Setup Register (CS_number = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_SETUP:6;               /**< bit:   0..5  NWE Setup Length                         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NCS_WR_SETUP:6;            /**< bit:  8..13  NCS Setup Length in WRITE Access         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t NRD_SETUP:6;               /**< bit: 16..21  NRD Setup Length                         */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t NCS_RD_SETUP:6;            /**< bit: 24..29  NCS Setup Length in READ Access          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_SETUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_SETUP_OFFSET                    (0x00)                                        /**<  (SMC_SETUP) SMC Setup Register (CS_number = 0)  Offset */
+
+#define SMC_SETUP_NWE_SETUP_Pos             0                                              /**< (SMC_SETUP) NWE Setup Length Position */
+#define SMC_SETUP_NWE_SETUP_Msk             (_U_(0x3F) << SMC_SETUP_NWE_SETUP_Pos)         /**< (SMC_SETUP) NWE Setup Length Mask */
+#define SMC_SETUP_NWE_SETUP(value)          (SMC_SETUP_NWE_SETUP_Msk & ((value) << SMC_SETUP_NWE_SETUP_Pos))
+#define SMC_SETUP_NCS_WR_SETUP_Pos          8                                              /**< (SMC_SETUP) NCS Setup Length in WRITE Access Position */
+#define SMC_SETUP_NCS_WR_SETUP_Msk          (_U_(0x3F) << SMC_SETUP_NCS_WR_SETUP_Pos)      /**< (SMC_SETUP) NCS Setup Length in WRITE Access Mask */
+#define SMC_SETUP_NCS_WR_SETUP(value)       (SMC_SETUP_NCS_WR_SETUP_Msk & ((value) << SMC_SETUP_NCS_WR_SETUP_Pos))
+#define SMC_SETUP_NRD_SETUP_Pos             16                                             /**< (SMC_SETUP) NRD Setup Length Position */
+#define SMC_SETUP_NRD_SETUP_Msk             (_U_(0x3F) << SMC_SETUP_NRD_SETUP_Pos)         /**< (SMC_SETUP) NRD Setup Length Mask */
+#define SMC_SETUP_NRD_SETUP(value)          (SMC_SETUP_NRD_SETUP_Msk & ((value) << SMC_SETUP_NRD_SETUP_Pos))
+#define SMC_SETUP_NCS_RD_SETUP_Pos          24                                             /**< (SMC_SETUP) NCS Setup Length in READ Access Position */
+#define SMC_SETUP_NCS_RD_SETUP_Msk          (_U_(0x3F) << SMC_SETUP_NCS_RD_SETUP_Pos)      /**< (SMC_SETUP) NCS Setup Length in READ Access Mask */
+#define SMC_SETUP_NCS_RD_SETUP(value)       (SMC_SETUP_NCS_RD_SETUP_Msk & ((value) << SMC_SETUP_NCS_RD_SETUP_Pos))
+#define SMC_SETUP_MASK                      _U_(0x3F3F3F3F)                                /**< \deprecated (SMC_SETUP) Register MASK  (Use SMC_SETUP_Msk instead)  */
+#define SMC_SETUP_Msk                       _U_(0x3F3F3F3F)                                /**< (SMC_SETUP) Register Mask  */
+
+
+/* -------- SMC_PULSE : (SMC Offset: 0x04) (R/W 32) SMC Pulse Register (CS_number = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_PULSE:7;               /**< bit:   0..6  NWE Pulse Length                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t NCS_WR_PULSE:7;            /**< bit:  8..14  NCS Pulse Length in WRITE Access         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t NRD_PULSE:7;               /**< bit: 16..22  NRD Pulse Length                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t NCS_RD_PULSE:7;            /**< bit: 24..30  NCS Pulse Length in READ Access          */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_PULSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_PULSE_OFFSET                    (0x04)                                        /**<  (SMC_PULSE) SMC Pulse Register (CS_number = 0)  Offset */
+
+#define SMC_PULSE_NWE_PULSE_Pos             0                                              /**< (SMC_PULSE) NWE Pulse Length Position */
+#define SMC_PULSE_NWE_PULSE_Msk             (_U_(0x7F) << SMC_PULSE_NWE_PULSE_Pos)         /**< (SMC_PULSE) NWE Pulse Length Mask */
+#define SMC_PULSE_NWE_PULSE(value)          (SMC_PULSE_NWE_PULSE_Msk & ((value) << SMC_PULSE_NWE_PULSE_Pos))
+#define SMC_PULSE_NCS_WR_PULSE_Pos          8                                              /**< (SMC_PULSE) NCS Pulse Length in WRITE Access Position */
+#define SMC_PULSE_NCS_WR_PULSE_Msk          (_U_(0x7F) << SMC_PULSE_NCS_WR_PULSE_Pos)      /**< (SMC_PULSE) NCS Pulse Length in WRITE Access Mask */
+#define SMC_PULSE_NCS_WR_PULSE(value)       (SMC_PULSE_NCS_WR_PULSE_Msk & ((value) << SMC_PULSE_NCS_WR_PULSE_Pos))
+#define SMC_PULSE_NRD_PULSE_Pos             16                                             /**< (SMC_PULSE) NRD Pulse Length Position */
+#define SMC_PULSE_NRD_PULSE_Msk             (_U_(0x7F) << SMC_PULSE_NRD_PULSE_Pos)         /**< (SMC_PULSE) NRD Pulse Length Mask */
+#define SMC_PULSE_NRD_PULSE(value)          (SMC_PULSE_NRD_PULSE_Msk & ((value) << SMC_PULSE_NRD_PULSE_Pos))
+#define SMC_PULSE_NCS_RD_PULSE_Pos          24                                             /**< (SMC_PULSE) NCS Pulse Length in READ Access Position */
+#define SMC_PULSE_NCS_RD_PULSE_Msk          (_U_(0x7F) << SMC_PULSE_NCS_RD_PULSE_Pos)      /**< (SMC_PULSE) NCS Pulse Length in READ Access Mask */
+#define SMC_PULSE_NCS_RD_PULSE(value)       (SMC_PULSE_NCS_RD_PULSE_Msk & ((value) << SMC_PULSE_NCS_RD_PULSE_Pos))
+#define SMC_PULSE_MASK                      _U_(0x7F7F7F7F)                                /**< \deprecated (SMC_PULSE) Register MASK  (Use SMC_PULSE_Msk instead)  */
+#define SMC_PULSE_Msk                       _U_(0x7F7F7F7F)                                /**< (SMC_PULSE) Register Mask  */
+
+
+/* -------- SMC_CYCLE : (SMC Offset: 0x08) (R/W 32) SMC Cycle Register (CS_number = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_CYCLE:9;               /**< bit:   0..8  Total Write Cycle Length                 */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t NRD_CYCLE:9;               /**< bit: 16..24  Total Read Cycle Length                  */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_CYCLE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_CYCLE_OFFSET                    (0x08)                                        /**<  (SMC_CYCLE) SMC Cycle Register (CS_number = 0)  Offset */
+
+#define SMC_CYCLE_NWE_CYCLE_Pos             0                                              /**< (SMC_CYCLE) Total Write Cycle Length Position */
+#define SMC_CYCLE_NWE_CYCLE_Msk             (_U_(0x1FF) << SMC_CYCLE_NWE_CYCLE_Pos)        /**< (SMC_CYCLE) Total Write Cycle Length Mask */
+#define SMC_CYCLE_NWE_CYCLE(value)          (SMC_CYCLE_NWE_CYCLE_Msk & ((value) << SMC_CYCLE_NWE_CYCLE_Pos))
+#define SMC_CYCLE_NRD_CYCLE_Pos             16                                             /**< (SMC_CYCLE) Total Read Cycle Length Position */
+#define SMC_CYCLE_NRD_CYCLE_Msk             (_U_(0x1FF) << SMC_CYCLE_NRD_CYCLE_Pos)        /**< (SMC_CYCLE) Total Read Cycle Length Mask */
+#define SMC_CYCLE_NRD_CYCLE(value)          (SMC_CYCLE_NRD_CYCLE_Msk & ((value) << SMC_CYCLE_NRD_CYCLE_Pos))
+#define SMC_CYCLE_MASK                      _U_(0x1FF01FF)                                 /**< \deprecated (SMC_CYCLE) Register MASK  (Use SMC_CYCLE_Msk instead)  */
+#define SMC_CYCLE_Msk                       _U_(0x1FF01FF)                                 /**< (SMC_CYCLE) Register Mask  */
+
+
+/* -------- SMC_MODE : (SMC Offset: 0x0c) (R/W 32) SMC Mode Register (CS_number = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t READ_MODE:1;               /**< bit:      0  Read Mode                                */
+    uint32_t WRITE_MODE:1;              /**< bit:      1  Write Mode                               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EXNW_MODE:2;               /**< bit:   4..5  NWAIT Mode                               */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t BAT:1;                     /**< bit:      8  Byte Access Type                         */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t DBW:1;                     /**< bit:     12  Data Bus Width                           */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TDF_CYCLES:4;              /**< bit: 16..19  Data Float Time                          */
+    uint32_t TDF_MODE:1;                /**< bit:     20  TDF Optimization                         */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t PMEN:1;                    /**< bit:     24  Page Mode Enabled                        */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t PS:2;                      /**< bit: 28..29  Page Size                                */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_MODE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_MODE_OFFSET                     (0x0C)                                        /**<  (SMC_MODE) SMC Mode Register (CS_number = 0)  Offset */
+
+#define SMC_MODE_READ_MODE_Pos              0                                              /**< (SMC_MODE) Read Mode Position */
+#define SMC_MODE_READ_MODE_Msk              (_U_(0x1) << SMC_MODE_READ_MODE_Pos)           /**< (SMC_MODE) Read Mode Mask */
+#define SMC_MODE_READ_MODE                  SMC_MODE_READ_MODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_READ_MODE_Msk instead */
+#define SMC_MODE_WRITE_MODE_Pos             1                                              /**< (SMC_MODE) Write Mode Position */
+#define SMC_MODE_WRITE_MODE_Msk             (_U_(0x1) << SMC_MODE_WRITE_MODE_Pos)          /**< (SMC_MODE) Write Mode Mask */
+#define SMC_MODE_WRITE_MODE                 SMC_MODE_WRITE_MODE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_WRITE_MODE_Msk instead */
+#define SMC_MODE_EXNW_MODE_Pos              4                                              /**< (SMC_MODE) NWAIT Mode Position */
+#define SMC_MODE_EXNW_MODE_Msk              (_U_(0x3) << SMC_MODE_EXNW_MODE_Pos)           /**< (SMC_MODE) NWAIT Mode Mask */
+#define SMC_MODE_EXNW_MODE(value)           (SMC_MODE_EXNW_MODE_Msk & ((value) << SMC_MODE_EXNW_MODE_Pos))
+#define   SMC_MODE_EXNW_MODE_DISABLED_Val   _U_(0x0)                                       /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select.  */
+#define   SMC_MODE_EXNW_MODE_FROZEN_Val     _U_(0x2)                                       /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped.  */
+#define   SMC_MODE_EXNW_MODE_READY_Val      _U_(0x3)                                       /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high.  */
+#define SMC_MODE_EXNW_MODE_DISABLED         (SMC_MODE_EXNW_MODE_DISABLED_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select. Position  */
+#define SMC_MODE_EXNW_MODE_FROZEN           (SMC_MODE_EXNW_MODE_FROZEN_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped. Position  */
+#define SMC_MODE_EXNW_MODE_READY            (SMC_MODE_EXNW_MODE_READY_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high. Position  */
+#define SMC_MODE_BAT_Pos                    8                                              /**< (SMC_MODE) Byte Access Type Position */
+#define SMC_MODE_BAT_Msk                    (_U_(0x1) << SMC_MODE_BAT_Pos)                 /**< (SMC_MODE) Byte Access Type Mask */
+#define SMC_MODE_BAT                        SMC_MODE_BAT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_BAT_Msk instead */
+#define   SMC_MODE_BAT_BYTE_SELECT_Val      _U_(0x0)                                       /**< (SMC_MODE) Byte select access type:- Write operation is controlled using NCS, NWE, NBS0, NBS1.- Read operation is controlled using NCS, NRD, NBS0, NBS1.  */
+#define   SMC_MODE_BAT_BYTE_WRITE_Val       _U_(0x1)                                       /**< (SMC_MODE) Byte write access type:- Write operation is controlled using NCS, NWR0, NWR1.- Read operation is controlled using NCS and NRD.  */
+#define SMC_MODE_BAT_BYTE_SELECT            (SMC_MODE_BAT_BYTE_SELECT_Val << SMC_MODE_BAT_Pos)  /**< (SMC_MODE) Byte select access type:- Write operation is controlled using NCS, NWE, NBS0, NBS1.- Read operation is controlled using NCS, NRD, NBS0, NBS1. Position  */
+#define SMC_MODE_BAT_BYTE_WRITE             (SMC_MODE_BAT_BYTE_WRITE_Val << SMC_MODE_BAT_Pos)  /**< (SMC_MODE) Byte write access type:- Write operation is controlled using NCS, NWR0, NWR1.- Read operation is controlled using NCS and NRD. Position  */
+#define SMC_MODE_DBW_Pos                    12                                             /**< (SMC_MODE) Data Bus Width Position */
+#define SMC_MODE_DBW_Msk                    (_U_(0x1) << SMC_MODE_DBW_Pos)                 /**< (SMC_MODE) Data Bus Width Mask */
+#define SMC_MODE_DBW                        SMC_MODE_DBW_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_DBW_Msk instead */
+#define   SMC_MODE_DBW_8_BIT_Val            _U_(0x0)                                       /**< (SMC_MODE) 8-bit Data Bus  */
+#define   SMC_MODE_DBW_16_BIT_Val           _U_(0x1)                                       /**< (SMC_MODE) 16-bit Data Bus  */
+#define SMC_MODE_DBW_8_BIT                  (SMC_MODE_DBW_8_BIT_Val << SMC_MODE_DBW_Pos)   /**< (SMC_MODE) 8-bit Data Bus Position  */
+#define SMC_MODE_DBW_16_BIT                 (SMC_MODE_DBW_16_BIT_Val << SMC_MODE_DBW_Pos)  /**< (SMC_MODE) 16-bit Data Bus Position  */
+#define SMC_MODE_TDF_CYCLES_Pos             16                                             /**< (SMC_MODE) Data Float Time Position */
+#define SMC_MODE_TDF_CYCLES_Msk             (_U_(0xF) << SMC_MODE_TDF_CYCLES_Pos)          /**< (SMC_MODE) Data Float Time Mask */
+#define SMC_MODE_TDF_CYCLES(value)          (SMC_MODE_TDF_CYCLES_Msk & ((value) << SMC_MODE_TDF_CYCLES_Pos))
+#define SMC_MODE_TDF_MODE_Pos               20                                             /**< (SMC_MODE) TDF Optimization Position */
+#define SMC_MODE_TDF_MODE_Msk               (_U_(0x1) << SMC_MODE_TDF_MODE_Pos)            /**< (SMC_MODE) TDF Optimization Mask */
+#define SMC_MODE_TDF_MODE                   SMC_MODE_TDF_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_TDF_MODE_Msk instead */
+#define SMC_MODE_PMEN_Pos                   24                                             /**< (SMC_MODE) Page Mode Enabled Position */
+#define SMC_MODE_PMEN_Msk                   (_U_(0x1) << SMC_MODE_PMEN_Pos)                /**< (SMC_MODE) Page Mode Enabled Mask */
+#define SMC_MODE_PMEN                       SMC_MODE_PMEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_PMEN_Msk instead */
+#define SMC_MODE_PS_Pos                     28                                             /**< (SMC_MODE) Page Size Position */
+#define SMC_MODE_PS_Msk                     (_U_(0x3) << SMC_MODE_PS_Pos)                  /**< (SMC_MODE) Page Size Mask */
+#define SMC_MODE_PS(value)                  (SMC_MODE_PS_Msk & ((value) << SMC_MODE_PS_Pos))
+#define   SMC_MODE_PS_4_BYTE_Val            _U_(0x0)                                       /**< (SMC_MODE) 4-byte page  */
+#define   SMC_MODE_PS_8_BYTE_Val            _U_(0x1)                                       /**< (SMC_MODE) 8-byte page  */
+#define   SMC_MODE_PS_16_BYTE_Val           _U_(0x2)                                       /**< (SMC_MODE) 16-byte page  */
+#define   SMC_MODE_PS_32_BYTE_Val           _U_(0x3)                                       /**< (SMC_MODE) 32-byte page  */
+#define SMC_MODE_PS_4_BYTE                  (SMC_MODE_PS_4_BYTE_Val << SMC_MODE_PS_Pos)    /**< (SMC_MODE) 4-byte page Position  */
+#define SMC_MODE_PS_8_BYTE                  (SMC_MODE_PS_8_BYTE_Val << SMC_MODE_PS_Pos)    /**< (SMC_MODE) 8-byte page Position  */
+#define SMC_MODE_PS_16_BYTE                 (SMC_MODE_PS_16_BYTE_Val << SMC_MODE_PS_Pos)   /**< (SMC_MODE) 16-byte page Position  */
+#define SMC_MODE_PS_32_BYTE                 (SMC_MODE_PS_32_BYTE_Val << SMC_MODE_PS_Pos)   /**< (SMC_MODE) 32-byte page Position  */
+#define SMC_MODE_MASK                       _U_(0x311F1133)                                /**< \deprecated (SMC_MODE) Register MASK  (Use SMC_MODE_Msk instead)  */
+#define SMC_MODE_Msk                        _U_(0x311F1133)                                /**< (SMC_MODE) Register Mask  */
+
+
+/* -------- SMC_OCMS : (SMC Offset: 0x80) (R/W 32) SMC Off-Chip Memory Scrambling Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMSE:1;                    /**< bit:      0  Static Memory Controller Scrambling Enable */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t CS0SE:1;                   /**< bit:      8  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS1SE:1;                   /**< bit:      9  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS2SE:1;                   /**< bit:     10  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS3SE:1;                   /**< bit:     11  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_OCMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_OCMS_OFFSET                     (0x80)                                        /**<  (SMC_OCMS) SMC Off-Chip Memory Scrambling Register  Offset */
+
+#define SMC_OCMS_SMSE_Pos                   0                                              /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Position */
+#define SMC_OCMS_SMSE_Msk                   (_U_(0x1) << SMC_OCMS_SMSE_Pos)                /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Mask */
+#define SMC_OCMS_SMSE                       SMC_OCMS_SMSE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_SMSE_Msk instead */
+#define SMC_OCMS_CS0SE_Pos                  8                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS0SE_Msk                  (_U_(0x1) << SMC_OCMS_CS0SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS0SE                      SMC_OCMS_CS0SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS0SE_Msk instead */
+#define SMC_OCMS_CS1SE_Pos                  9                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS1SE_Msk                  (_U_(0x1) << SMC_OCMS_CS1SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS1SE                      SMC_OCMS_CS1SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS1SE_Msk instead */
+#define SMC_OCMS_CS2SE_Pos                  10                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS2SE_Msk                  (_U_(0x1) << SMC_OCMS_CS2SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS2SE                      SMC_OCMS_CS2SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS2SE_Msk instead */
+#define SMC_OCMS_CS3SE_Pos                  11                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS3SE_Msk                  (_U_(0x1) << SMC_OCMS_CS3SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS3SE                      SMC_OCMS_CS3SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS3SE_Msk instead */
+#define SMC_OCMS_MASK                       _U_(0xF01)                                     /**< \deprecated (SMC_OCMS) Register MASK  (Use SMC_OCMS_Msk instead)  */
+#define SMC_OCMS_Msk                        _U_(0xF01)                                     /**< (SMC_OCMS) Register Mask  */
+
+
+/* -------- SMC_KEY1 : (SMC Offset: 0x84) (/W 32) SMC Off-Chip Memory Scrambling KEY1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY1:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 1 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_KEY1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_KEY1_OFFSET                     (0x84)                                        /**<  (SMC_KEY1) SMC Off-Chip Memory Scrambling KEY1 Register  Offset */
+
+#define SMC_KEY1_KEY1_Pos                   0                                              /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Position */
+#define SMC_KEY1_KEY1_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY1_KEY1_Pos)         /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Mask */
+#define SMC_KEY1_KEY1(value)                (SMC_KEY1_KEY1_Msk & ((value) << SMC_KEY1_KEY1_Pos))
+#define SMC_KEY1_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY1) Register MASK  (Use SMC_KEY1_Msk instead)  */
+#define SMC_KEY1_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY1) Register Mask  */
+
+
+/* -------- SMC_KEY2 : (SMC Offset: 0x88) (/W 32) SMC Off-Chip Memory Scrambling KEY2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY2:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 2 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_KEY2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_KEY2_OFFSET                     (0x88)                                        /**<  (SMC_KEY2) SMC Off-Chip Memory Scrambling KEY2 Register  Offset */
+
+#define SMC_KEY2_KEY2_Pos                   0                                              /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Position */
+#define SMC_KEY2_KEY2_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY2_KEY2_Pos)         /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Mask */
+#define SMC_KEY2_KEY2(value)                (SMC_KEY2_KEY2_Msk & ((value) << SMC_KEY2_KEY2_Pos))
+#define SMC_KEY2_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY2) Register MASK  (Use SMC_KEY2_Msk instead)  */
+#define SMC_KEY2_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY2) Register Mask  */
+
+
+/* -------- SMC_WPMR : (SMC Offset: 0xe4) (R/W 32) SMC Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_WPMR_OFFSET                     (0xE4)                                        /**<  (SMC_WPMR) SMC Write Protection Mode Register  Offset */
+
+#define SMC_WPMR_WPEN_Pos                   0                                              /**< (SMC_WPMR) Write Protect Enable Position */
+#define SMC_WPMR_WPEN_Msk                   (_U_(0x1) << SMC_WPMR_WPEN_Pos)                /**< (SMC_WPMR) Write Protect Enable Mask */
+#define SMC_WPMR_WPEN                       SMC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_WPMR_WPEN_Msk instead */
+#define SMC_WPMR_WPKEY_Pos                  8                                              /**< (SMC_WPMR) Write Protection Key Position */
+#define SMC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SMC_WPMR_WPKEY_Pos)          /**< (SMC_WPMR) Write Protection Key Mask */
+#define SMC_WPMR_WPKEY(value)               (SMC_WPMR_WPKEY_Msk & ((value) << SMC_WPMR_WPKEY_Pos))
+#define   SMC_WPMR_WPKEY_PASSWD_Val         _U_(0x534D43)                                  /**< (SMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define SMC_WPMR_WPKEY_PASSWD               (SMC_WPMR_WPKEY_PASSWD_Val << SMC_WPMR_WPKEY_Pos)  /**< (SMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define SMC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SMC_WPMR) Register MASK  (Use SMC_WPMR_Msk instead)  */
+#define SMC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SMC_WPMR) Register Mask  */
+
+
+/* -------- SMC_WPSR : (SMC Offset: 0xe8) (R/ 32) SMC Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_WPSR_OFFSET                     (0xE8)                                        /**<  (SMC_WPSR) SMC Write Protection Status Register  Offset */
+
+#define SMC_WPSR_WPVS_Pos                   0                                              /**< (SMC_WPSR) Write Protection Violation Status Position */
+#define SMC_WPSR_WPVS_Msk                   (_U_(0x1) << SMC_WPSR_WPVS_Pos)                /**< (SMC_WPSR) Write Protection Violation Status Mask */
+#define SMC_WPSR_WPVS                       SMC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_WPSR_WPVS_Msk instead */
+#define SMC_WPSR_WPVSRC_Pos                 8                                              /**< (SMC_WPSR) Write Protection Violation Source Position */
+#define SMC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << SMC_WPSR_WPVSRC_Pos)           /**< (SMC_WPSR) Write Protection Violation Source Mask */
+#define SMC_WPSR_WPVSRC(value)              (SMC_WPSR_WPVSRC_Msk & ((value) << SMC_WPSR_WPVSRC_Pos))
+#define SMC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (SMC_WPSR) Register MASK  (Use SMC_WPSR_Msk instead)  */
+#define SMC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (SMC_WPSR) Register Mask  */
+
+
+/* -------- SMC_VERSION : (SMC Offset: 0xfc) (R/ 32) SMC Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_VERSION_OFFSET                  (0xFC)                                        /**<  (SMC_VERSION) SMC Version Register  Offset */
+
+#define SMC_VERSION_VERSION_Pos             0                                              /**< (SMC_VERSION) Hardware Module Version Position */
+#define SMC_VERSION_VERSION_Msk             (_U_(0xFFF) << SMC_VERSION_VERSION_Pos)        /**< (SMC_VERSION) Hardware Module Version Mask */
+#define SMC_VERSION_VERSION(value)          (SMC_VERSION_VERSION_Msk & ((value) << SMC_VERSION_VERSION_Pos))
+#define SMC_VERSION_MFN_Pos                 16                                             /**< (SMC_VERSION) Metal Fix Number Position */
+#define SMC_VERSION_MFN_Msk                 (_U_(0x7) << SMC_VERSION_MFN_Pos)              /**< (SMC_VERSION) Metal Fix Number Mask */
+#define SMC_VERSION_MFN(value)              (SMC_VERSION_MFN_Msk & ((value) << SMC_VERSION_MFN_Pos))
+#define SMC_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (SMC_VERSION) Register MASK  (Use SMC_VERSION_Msk instead)  */
+#define SMC_VERSION_Msk                     _U_(0x70FFF)                                   /**< (SMC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SMC_CS_NUMBER hardware registers */
+typedef struct {  
+  __IO uint32_t SMC_SETUP;      /**< (SMC_CS_NUMBER Offset: 0x00) SMC Setup Register (CS_number = 0) */
+  __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register (CS_number = 0) */
+  __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register (CS_number = 0) */
+  __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register (CS_number = 0) */
+} SmcCsNumber;
+
+#define SMCCSNUMBER_NUMBER 4
+/** \brief SMC hardware registers */
+typedef struct {  
+       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+  __I  uint8_t                        Reserved1[64];
+  __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
+  __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  uint32_t SMC_KEY2;       /**< (SMC Offset: 0x88) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
+  __IO uint32_t SMC_WPMR;       /**< (SMC Offset: 0xE4) SMC Write Protection Mode Register */
+  __I  uint32_t SMC_WPSR;       /**< (SMC Offset: 0xE8) SMC Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  uint32_t SMC_VERSION;    /**< (SMC Offset: 0xFC) SMC Version Register */
+} Smc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SMC_CS_NUMBER hardware registers */
+typedef struct {  
+  __IO SMC_SETUP_Type                 SMC_SETUP;      /**< Offset: 0x00 (R/W  32) SMC Setup Register (CS_number = 0) */
+  __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register (CS_number = 0) */
+  __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register (CS_number = 0) */
+  __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register (CS_number = 0) */
+} SmcCsNumber;
+
+/** \brief SMC hardware registers */
+typedef struct {  
+       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+  __I  uint8_t                        Reserved1[64];
+  __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
+  __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  SMC_KEY2_Type                  SMC_KEY2;       /**< Offset: 0x88 ( /W  32) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
+  __IO SMC_WPMR_Type                  SMC_WPMR;       /**< Offset: 0xE4 (R/W  32) SMC Write Protection Mode Register */
+  __I  SMC_WPSR_Type                  SMC_WPSR;       /**< Offset: 0xE8 (R/   32) SMC Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  SMC_VERSION_Type               SMC_VERSION;    /**< Offset: 0xFC (R/   32) SMC Version Register */
+} Smc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Static Memory Controller */
+
+#endif /* _SAMV71_SMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/spi.h
+++ b/asf/sam/include/samv71/component/spi.h
@@ -1,0 +1,606 @@
+/**
+ * \file
+ *
+ * \brief Component description for SPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SPI_COMPONENT_H_
+#define _SAMV71_SPI_COMPONENT_H_
+#define _SAMV71_SPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Serial Peripheral Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SPI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SPI_6088                       /**< (SPI) Module ID */
+#define REV_SPI ZK                     /**< (SPI) Module revision */
+
+/* -------- SPI_CR : (SPI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPIEN:1;                   /**< bit:      0  SPI Enable                               */
+    uint32_t SPIDIS:1;                  /**< bit:      1  SPI Disable                              */
+    uint32_t :5;                        /**< bit:   2..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  SPI Software Reset                       */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t REQCLR:1;                  /**< bit:     12  Request to Clear the Comparison Trigger  */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TXFCLR:1;                  /**< bit:     16  Transmit FIFO Clear                      */
+    uint32_t RXFCLR:1;                  /**< bit:     17  Receive FIFO Clear                       */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :5;                        /**< bit: 25..29  Reserved */
+    uint32_t FIFOEN:1;                  /**< bit:     30  FIFO Enable                              */
+    uint32_t FIFODIS:1;                 /**< bit:     31  FIFO Disable                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CR_OFFSET                       (0x00)                                        /**<  (SPI_CR) Control Register  Offset */
+
+#define SPI_CR_SPIEN_Pos                    0                                              /**< (SPI_CR) SPI Enable Position */
+#define SPI_CR_SPIEN_Msk                    (_U_(0x1) << SPI_CR_SPIEN_Pos)                 /**< (SPI_CR) SPI Enable Mask */
+#define SPI_CR_SPIEN                        SPI_CR_SPIEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SPIEN_Msk instead */
+#define SPI_CR_SPIDIS_Pos                   1                                              /**< (SPI_CR) SPI Disable Position */
+#define SPI_CR_SPIDIS_Msk                   (_U_(0x1) << SPI_CR_SPIDIS_Pos)                /**< (SPI_CR) SPI Disable Mask */
+#define SPI_CR_SPIDIS                       SPI_CR_SPIDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SPIDIS_Msk instead */
+#define SPI_CR_SWRST_Pos                    7                                              /**< (SPI_CR) SPI Software Reset Position */
+#define SPI_CR_SWRST_Msk                    (_U_(0x1) << SPI_CR_SWRST_Pos)                 /**< (SPI_CR) SPI Software Reset Mask */
+#define SPI_CR_SWRST                        SPI_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SWRST_Msk instead */
+#define SPI_CR_REQCLR_Pos                   12                                             /**< (SPI_CR) Request to Clear the Comparison Trigger Position */
+#define SPI_CR_REQCLR_Msk                   (_U_(0x1) << SPI_CR_REQCLR_Pos)                /**< (SPI_CR) Request to Clear the Comparison Trigger Mask */
+#define SPI_CR_REQCLR                       SPI_CR_REQCLR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_REQCLR_Msk instead */
+#define SPI_CR_TXFCLR_Pos                   16                                             /**< (SPI_CR) Transmit FIFO Clear Position */
+#define SPI_CR_TXFCLR_Msk                   (_U_(0x1) << SPI_CR_TXFCLR_Pos)                /**< (SPI_CR) Transmit FIFO Clear Mask */
+#define SPI_CR_TXFCLR                       SPI_CR_TXFCLR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_TXFCLR_Msk instead */
+#define SPI_CR_RXFCLR_Pos                   17                                             /**< (SPI_CR) Receive FIFO Clear Position */
+#define SPI_CR_RXFCLR_Msk                   (_U_(0x1) << SPI_CR_RXFCLR_Pos)                /**< (SPI_CR) Receive FIFO Clear Mask */
+#define SPI_CR_RXFCLR                       SPI_CR_RXFCLR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_RXFCLR_Msk instead */
+#define SPI_CR_LASTXFER_Pos                 24                                             /**< (SPI_CR) Last Transfer Position */
+#define SPI_CR_LASTXFER_Msk                 (_U_(0x1) << SPI_CR_LASTXFER_Pos)              /**< (SPI_CR) Last Transfer Mask */
+#define SPI_CR_LASTXFER                     SPI_CR_LASTXFER_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_LASTXFER_Msk instead */
+#define SPI_CR_FIFOEN_Pos                   30                                             /**< (SPI_CR) FIFO Enable Position */
+#define SPI_CR_FIFOEN_Msk                   (_U_(0x1) << SPI_CR_FIFOEN_Pos)                /**< (SPI_CR) FIFO Enable Mask */
+#define SPI_CR_FIFOEN                       SPI_CR_FIFOEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_FIFOEN_Msk instead */
+#define SPI_CR_FIFODIS_Pos                  31                                             /**< (SPI_CR) FIFO Disable Position */
+#define SPI_CR_FIFODIS_Msk                  (_U_(0x1) << SPI_CR_FIFODIS_Pos)               /**< (SPI_CR) FIFO Disable Mask */
+#define SPI_CR_FIFODIS                      SPI_CR_FIFODIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_FIFODIS_Msk instead */
+#define SPI_CR_MASK                         _U_(0xC1031083)                                /**< \deprecated (SPI_CR) Register MASK  (Use SPI_CR_Msk instead)  */
+#define SPI_CR_Msk                          _U_(0xC1031083)                                /**< (SPI_CR) Register Mask  */
+
+
+/* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MSTR:1;                    /**< bit:      0  Master/Slave Mode                        */
+    uint32_t PS:1;                      /**< bit:      1  Peripheral Select                        */
+    uint32_t PCSDEC:1;                  /**< bit:      2  Chip Select Decode                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t MODFDIS:1;                 /**< bit:      4  Mode Fault Detection                     */
+    uint32_t WDRBT:1;                   /**< bit:      5  Wait Data Read Before Transfer           */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t LLB:1;                     /**< bit:      7  Local Loopback Enable                    */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DLYBCS:8;                  /**< bit: 24..31  Delay Between Chip Selects               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_MR_OFFSET                       (0x04)                                        /**<  (SPI_MR) Mode Register  Offset */
+
+#define SPI_MR_MSTR_Pos                     0                                              /**< (SPI_MR) Master/Slave Mode Position */
+#define SPI_MR_MSTR_Msk                     (_U_(0x1) << SPI_MR_MSTR_Pos)                  /**< (SPI_MR) Master/Slave Mode Mask */
+#define SPI_MR_MSTR                         SPI_MR_MSTR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_MSTR_Msk instead */
+#define SPI_MR_PS_Pos                       1                                              /**< (SPI_MR) Peripheral Select Position */
+#define SPI_MR_PS_Msk                       (_U_(0x1) << SPI_MR_PS_Pos)                    /**< (SPI_MR) Peripheral Select Mask */
+#define SPI_MR_PS                           SPI_MR_PS_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_PS_Msk instead */
+#define SPI_MR_PCSDEC_Pos                   2                                              /**< (SPI_MR) Chip Select Decode Position */
+#define SPI_MR_PCSDEC_Msk                   (_U_(0x1) << SPI_MR_PCSDEC_Pos)                /**< (SPI_MR) Chip Select Decode Mask */
+#define SPI_MR_PCSDEC                       SPI_MR_PCSDEC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_PCSDEC_Msk instead */
+#define SPI_MR_MODFDIS_Pos                  4                                              /**< (SPI_MR) Mode Fault Detection Position */
+#define SPI_MR_MODFDIS_Msk                  (_U_(0x1) << SPI_MR_MODFDIS_Pos)               /**< (SPI_MR) Mode Fault Detection Mask */
+#define SPI_MR_MODFDIS                      SPI_MR_MODFDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_MODFDIS_Msk instead */
+#define SPI_MR_WDRBT_Pos                    5                                              /**< (SPI_MR) Wait Data Read Before Transfer Position */
+#define SPI_MR_WDRBT_Msk                    (_U_(0x1) << SPI_MR_WDRBT_Pos)                 /**< (SPI_MR) Wait Data Read Before Transfer Mask */
+#define SPI_MR_WDRBT                        SPI_MR_WDRBT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_WDRBT_Msk instead */
+#define SPI_MR_LLB_Pos                      7                                              /**< (SPI_MR) Local Loopback Enable Position */
+#define SPI_MR_LLB_Msk                      (_U_(0x1) << SPI_MR_LLB_Pos)                   /**< (SPI_MR) Local Loopback Enable Mask */
+#define SPI_MR_LLB                          SPI_MR_LLB_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_LLB_Msk instead */
+#define SPI_MR_PCS_Pos                      16                                             /**< (SPI_MR) Peripheral Chip Select Position */
+#define SPI_MR_PCS_Msk                      (_U_(0xF) << SPI_MR_PCS_Pos)                   /**< (SPI_MR) Peripheral Chip Select Mask */
+#define SPI_MR_PCS(value)                   (SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos))
+#define SPI_MR_DLYBCS_Pos                   24                                             /**< (SPI_MR) Delay Between Chip Selects Position */
+#define SPI_MR_DLYBCS_Msk                   (_U_(0xFF) << SPI_MR_DLYBCS_Pos)               /**< (SPI_MR) Delay Between Chip Selects Mask */
+#define SPI_MR_DLYBCS(value)                (SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos))
+#define SPI_MR_MASK                         _U_(0xFF0F00B7)                                /**< \deprecated (SPI_MR) Register MASK  (Use SPI_MR_Msk instead)  */
+#define SPI_MR_Msk                          _U_(0xFF0F00B7)                                /**< (SPI_MR) Register Mask  */
+
+
+/* -------- SPI_RDR : (SPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_RDR_OFFSET                      (0x08)                                        /**<  (SPI_RDR) Receive Data Register  Offset */
+
+#define SPI_RDR_RD_Pos                      0                                              /**< (SPI_RDR) Receive Data Position */
+#define SPI_RDR_RD_Msk                      (_U_(0xFFFF) << SPI_RDR_RD_Pos)                /**< (SPI_RDR) Receive Data Mask */
+#define SPI_RDR_RD(value)                   (SPI_RDR_RD_Msk & ((value) << SPI_RDR_RD_Pos))
+#define SPI_RDR_PCS_Pos                     16                                             /**< (SPI_RDR) Peripheral Chip Select Position */
+#define SPI_RDR_PCS_Msk                     (_U_(0xF) << SPI_RDR_PCS_Pos)                  /**< (SPI_RDR) Peripheral Chip Select Mask */
+#define SPI_RDR_PCS(value)                  (SPI_RDR_PCS_Msk & ((value) << SPI_RDR_PCS_Pos))
+#define SPI_RDR_MASK                        _U_(0xFFFFF)                                   /**< \deprecated (SPI_RDR) Register MASK  (Use SPI_RDR_Msk instead)  */
+#define SPI_RDR_Msk                         _U_(0xFFFFF)                                   /**< (SPI_RDR) Register Mask  */
+
+
+/* -------- SPI_TDR : (SPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_TDR_OFFSET                      (0x0C)                                        /**<  (SPI_TDR) Transmit Data Register  Offset */
+
+#define SPI_TDR_TD_Pos                      0                                              /**< (SPI_TDR) Transmit Data Position */
+#define SPI_TDR_TD_Msk                      (_U_(0xFFFF) << SPI_TDR_TD_Pos)                /**< (SPI_TDR) Transmit Data Mask */
+#define SPI_TDR_TD(value)                   (SPI_TDR_TD_Msk & ((value) << SPI_TDR_TD_Pos))
+#define SPI_TDR_PCS_Pos                     16                                             /**< (SPI_TDR) Peripheral Chip Select Position */
+#define SPI_TDR_PCS_Msk                     (_U_(0xF) << SPI_TDR_PCS_Pos)                  /**< (SPI_TDR) Peripheral Chip Select Mask */
+#define SPI_TDR_PCS(value)                  (SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos))
+#define SPI_TDR_LASTXFER_Pos                24                                             /**< (SPI_TDR) Last Transfer Position */
+#define SPI_TDR_LASTXFER_Msk                (_U_(0x1) << SPI_TDR_LASTXFER_Pos)             /**< (SPI_TDR) Last Transfer Mask */
+#define SPI_TDR_LASTXFER                    SPI_TDR_LASTXFER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_TDR_LASTXFER_Msk instead */
+#define SPI_TDR_MASK                        _U_(0x10FFFFF)                                 /**< \deprecated (SPI_TDR) Register MASK  (Use SPI_TDR_Msk instead)  */
+#define SPI_TDR_Msk                         _U_(0x10FFFFF)                                 /**< (SPI_TDR) Register Mask  */
+
+
+/* -------- SPI_SR : (SPI Offset: 0x10) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty (cleared by writing SPI_TDR) */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error (cleared on read)       */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Status (cleared on read)   */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising (cleared on read)             */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty (cleared by writing SPI_TDR) */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Status (Slave mode only) (cleared on read) */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t SPIENS:1;                  /**< bit:     16  SPI Enable Status                        */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_SR_OFFSET                       (0x10)                                        /**<  (SPI_SR) Status Register  Offset */
+
+#define SPI_SR_RDRF_Pos                     0                                              /**< (SPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Position */
+#define SPI_SR_RDRF_Msk                     (_U_(0x1) << SPI_SR_RDRF_Pos)                  /**< (SPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Mask */
+#define SPI_SR_RDRF                         SPI_SR_RDRF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_RDRF_Msk instead */
+#define SPI_SR_TDRE_Pos                     1                                              /**< (SPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Position */
+#define SPI_SR_TDRE_Msk                     (_U_(0x1) << SPI_SR_TDRE_Pos)                  /**< (SPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Mask */
+#define SPI_SR_TDRE                         SPI_SR_TDRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_TDRE_Msk instead */
+#define SPI_SR_MODF_Pos                     2                                              /**< (SPI_SR) Mode Fault Error (cleared on read) Position */
+#define SPI_SR_MODF_Msk                     (_U_(0x1) << SPI_SR_MODF_Pos)                  /**< (SPI_SR) Mode Fault Error (cleared on read) Mask */
+#define SPI_SR_MODF                         SPI_SR_MODF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_MODF_Msk instead */
+#define SPI_SR_OVRES_Pos                    3                                              /**< (SPI_SR) Overrun Error Status (cleared on read) Position */
+#define SPI_SR_OVRES_Msk                    (_U_(0x1) << SPI_SR_OVRES_Pos)                 /**< (SPI_SR) Overrun Error Status (cleared on read) Mask */
+#define SPI_SR_OVRES                        SPI_SR_OVRES_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_OVRES_Msk instead */
+#define SPI_SR_NSSR_Pos                     8                                              /**< (SPI_SR) NSS Rising (cleared on read) Position */
+#define SPI_SR_NSSR_Msk                     (_U_(0x1) << SPI_SR_NSSR_Pos)                  /**< (SPI_SR) NSS Rising (cleared on read) Mask */
+#define SPI_SR_NSSR                         SPI_SR_NSSR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_NSSR_Msk instead */
+#define SPI_SR_TXEMPTY_Pos                  9                                              /**< (SPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Position */
+#define SPI_SR_TXEMPTY_Msk                  (_U_(0x1) << SPI_SR_TXEMPTY_Pos)               /**< (SPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Mask */
+#define SPI_SR_TXEMPTY                      SPI_SR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_TXEMPTY_Msk instead */
+#define SPI_SR_UNDES_Pos                    10                                             /**< (SPI_SR) Underrun Error Status (Slave mode only) (cleared on read) Position */
+#define SPI_SR_UNDES_Msk                    (_U_(0x1) << SPI_SR_UNDES_Pos)                 /**< (SPI_SR) Underrun Error Status (Slave mode only) (cleared on read) Mask */
+#define SPI_SR_UNDES                        SPI_SR_UNDES_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_UNDES_Msk instead */
+#define SPI_SR_SPIENS_Pos                   16                                             /**< (SPI_SR) SPI Enable Status Position */
+#define SPI_SR_SPIENS_Msk                   (_U_(0x1) << SPI_SR_SPIENS_Pos)                /**< (SPI_SR) SPI Enable Status Mask */
+#define SPI_SR_SPIENS                       SPI_SR_SPIENS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_SPIENS_Msk instead */
+#define SPI_SR_MASK                         _U_(0x1070F)                                   /**< \deprecated (SPI_SR) Register MASK  (Use SPI_SR_Msk instead)  */
+#define SPI_SR_Msk                          _U_(0x1070F)                                   /**< (SPI_SR) Register Mask  */
+
+
+/* -------- SPI_IER : (SPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Enable */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Enable        */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Enable           */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Enable              */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Enable      */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Enable          */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IER_OFFSET                      (0x14)                                        /**<  (SPI_IER) Interrupt Enable Register  Offset */
+
+#define SPI_IER_RDRF_Pos                    0                                              /**< (SPI_IER) Receive Data Register Full Interrupt Enable Position */
+#define SPI_IER_RDRF_Msk                    (_U_(0x1) << SPI_IER_RDRF_Pos)                 /**< (SPI_IER) Receive Data Register Full Interrupt Enable Mask */
+#define SPI_IER_RDRF                        SPI_IER_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_RDRF_Msk instead */
+#define SPI_IER_TDRE_Pos                    1                                              /**< (SPI_IER) SPI Transmit Data Register Empty Interrupt Enable Position */
+#define SPI_IER_TDRE_Msk                    (_U_(0x1) << SPI_IER_TDRE_Pos)                 /**< (SPI_IER) SPI Transmit Data Register Empty Interrupt Enable Mask */
+#define SPI_IER_TDRE                        SPI_IER_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_TDRE_Msk instead */
+#define SPI_IER_MODF_Pos                    2                                              /**< (SPI_IER) Mode Fault Error Interrupt Enable Position */
+#define SPI_IER_MODF_Msk                    (_U_(0x1) << SPI_IER_MODF_Pos)                 /**< (SPI_IER) Mode Fault Error Interrupt Enable Mask */
+#define SPI_IER_MODF                        SPI_IER_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_MODF_Msk instead */
+#define SPI_IER_OVRES_Pos                   3                                              /**< (SPI_IER) Overrun Error Interrupt Enable Position */
+#define SPI_IER_OVRES_Msk                   (_U_(0x1) << SPI_IER_OVRES_Pos)                /**< (SPI_IER) Overrun Error Interrupt Enable Mask */
+#define SPI_IER_OVRES                       SPI_IER_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_OVRES_Msk instead */
+#define SPI_IER_NSSR_Pos                    8                                              /**< (SPI_IER) NSS Rising Interrupt Enable Position */
+#define SPI_IER_NSSR_Msk                    (_U_(0x1) << SPI_IER_NSSR_Pos)                 /**< (SPI_IER) NSS Rising Interrupt Enable Mask */
+#define SPI_IER_NSSR                        SPI_IER_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_NSSR_Msk instead */
+#define SPI_IER_TXEMPTY_Pos                 9                                              /**< (SPI_IER) Transmission Registers Empty Enable Position */
+#define SPI_IER_TXEMPTY_Msk                 (_U_(0x1) << SPI_IER_TXEMPTY_Pos)              /**< (SPI_IER) Transmission Registers Empty Enable Mask */
+#define SPI_IER_TXEMPTY                     SPI_IER_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_TXEMPTY_Msk instead */
+#define SPI_IER_UNDES_Pos                   10                                             /**< (SPI_IER) Underrun Error Interrupt Enable Position */
+#define SPI_IER_UNDES_Msk                   (_U_(0x1) << SPI_IER_UNDES_Pos)                /**< (SPI_IER) Underrun Error Interrupt Enable Mask */
+#define SPI_IER_UNDES                       SPI_IER_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_UNDES_Msk instead */
+#define SPI_IER_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IER) Register MASK  (Use SPI_IER_Msk instead)  */
+#define SPI_IER_Msk                         _U_(0x70F)                                     /**< (SPI_IER) Register Mask  */
+
+
+/* -------- SPI_IDR : (SPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Disable */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Disable       */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Disable          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Disable             */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Disable     */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Disable         */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IDR_OFFSET                      (0x18)                                        /**<  (SPI_IDR) Interrupt Disable Register  Offset */
+
+#define SPI_IDR_RDRF_Pos                    0                                              /**< (SPI_IDR) Receive Data Register Full Interrupt Disable Position */
+#define SPI_IDR_RDRF_Msk                    (_U_(0x1) << SPI_IDR_RDRF_Pos)                 /**< (SPI_IDR) Receive Data Register Full Interrupt Disable Mask */
+#define SPI_IDR_RDRF                        SPI_IDR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_RDRF_Msk instead */
+#define SPI_IDR_TDRE_Pos                    1                                              /**< (SPI_IDR) SPI Transmit Data Register Empty Interrupt Disable Position */
+#define SPI_IDR_TDRE_Msk                    (_U_(0x1) << SPI_IDR_TDRE_Pos)                 /**< (SPI_IDR) SPI Transmit Data Register Empty Interrupt Disable Mask */
+#define SPI_IDR_TDRE                        SPI_IDR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_TDRE_Msk instead */
+#define SPI_IDR_MODF_Pos                    2                                              /**< (SPI_IDR) Mode Fault Error Interrupt Disable Position */
+#define SPI_IDR_MODF_Msk                    (_U_(0x1) << SPI_IDR_MODF_Pos)                 /**< (SPI_IDR) Mode Fault Error Interrupt Disable Mask */
+#define SPI_IDR_MODF                        SPI_IDR_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_MODF_Msk instead */
+#define SPI_IDR_OVRES_Pos                   3                                              /**< (SPI_IDR) Overrun Error Interrupt Disable Position */
+#define SPI_IDR_OVRES_Msk                   (_U_(0x1) << SPI_IDR_OVRES_Pos)                /**< (SPI_IDR) Overrun Error Interrupt Disable Mask */
+#define SPI_IDR_OVRES                       SPI_IDR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_OVRES_Msk instead */
+#define SPI_IDR_NSSR_Pos                    8                                              /**< (SPI_IDR) NSS Rising Interrupt Disable Position */
+#define SPI_IDR_NSSR_Msk                    (_U_(0x1) << SPI_IDR_NSSR_Pos)                 /**< (SPI_IDR) NSS Rising Interrupt Disable Mask */
+#define SPI_IDR_NSSR                        SPI_IDR_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_NSSR_Msk instead */
+#define SPI_IDR_TXEMPTY_Pos                 9                                              /**< (SPI_IDR) Transmission Registers Empty Disable Position */
+#define SPI_IDR_TXEMPTY_Msk                 (_U_(0x1) << SPI_IDR_TXEMPTY_Pos)              /**< (SPI_IDR) Transmission Registers Empty Disable Mask */
+#define SPI_IDR_TXEMPTY                     SPI_IDR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_TXEMPTY_Msk instead */
+#define SPI_IDR_UNDES_Pos                   10                                             /**< (SPI_IDR) Underrun Error Interrupt Disable Position */
+#define SPI_IDR_UNDES_Msk                   (_U_(0x1) << SPI_IDR_UNDES_Pos)                /**< (SPI_IDR) Underrun Error Interrupt Disable Mask */
+#define SPI_IDR_UNDES                       SPI_IDR_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_UNDES_Msk instead */
+#define SPI_IDR_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IDR) Register MASK  (Use SPI_IDR_Msk instead)  */
+#define SPI_IDR_Msk                         _U_(0x70F)                                     /**< (SPI_IDR) Register Mask  */
+
+
+/* -------- SPI_IMR : (SPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Mask */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Mask          */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Mask             */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Mask                */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Mask        */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Mask            */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IMR_OFFSET                      (0x1C)                                        /**<  (SPI_IMR) Interrupt Mask Register  Offset */
+
+#define SPI_IMR_RDRF_Pos                    0                                              /**< (SPI_IMR) Receive Data Register Full Interrupt Mask Position */
+#define SPI_IMR_RDRF_Msk                    (_U_(0x1) << SPI_IMR_RDRF_Pos)                 /**< (SPI_IMR) Receive Data Register Full Interrupt Mask Mask */
+#define SPI_IMR_RDRF                        SPI_IMR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_RDRF_Msk instead */
+#define SPI_IMR_TDRE_Pos                    1                                              /**< (SPI_IMR) SPI Transmit Data Register Empty Interrupt Mask Position */
+#define SPI_IMR_TDRE_Msk                    (_U_(0x1) << SPI_IMR_TDRE_Pos)                 /**< (SPI_IMR) SPI Transmit Data Register Empty Interrupt Mask Mask */
+#define SPI_IMR_TDRE                        SPI_IMR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_TDRE_Msk instead */
+#define SPI_IMR_MODF_Pos                    2                                              /**< (SPI_IMR) Mode Fault Error Interrupt Mask Position */
+#define SPI_IMR_MODF_Msk                    (_U_(0x1) << SPI_IMR_MODF_Pos)                 /**< (SPI_IMR) Mode Fault Error Interrupt Mask Mask */
+#define SPI_IMR_MODF                        SPI_IMR_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_MODF_Msk instead */
+#define SPI_IMR_OVRES_Pos                   3                                              /**< (SPI_IMR) Overrun Error Interrupt Mask Position */
+#define SPI_IMR_OVRES_Msk                   (_U_(0x1) << SPI_IMR_OVRES_Pos)                /**< (SPI_IMR) Overrun Error Interrupt Mask Mask */
+#define SPI_IMR_OVRES                       SPI_IMR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_OVRES_Msk instead */
+#define SPI_IMR_NSSR_Pos                    8                                              /**< (SPI_IMR) NSS Rising Interrupt Mask Position */
+#define SPI_IMR_NSSR_Msk                    (_U_(0x1) << SPI_IMR_NSSR_Pos)                 /**< (SPI_IMR) NSS Rising Interrupt Mask Mask */
+#define SPI_IMR_NSSR                        SPI_IMR_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_NSSR_Msk instead */
+#define SPI_IMR_TXEMPTY_Pos                 9                                              /**< (SPI_IMR) Transmission Registers Empty Mask Position */
+#define SPI_IMR_TXEMPTY_Msk                 (_U_(0x1) << SPI_IMR_TXEMPTY_Pos)              /**< (SPI_IMR) Transmission Registers Empty Mask Mask */
+#define SPI_IMR_TXEMPTY                     SPI_IMR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_TXEMPTY_Msk instead */
+#define SPI_IMR_UNDES_Pos                   10                                             /**< (SPI_IMR) Underrun Error Interrupt Mask Position */
+#define SPI_IMR_UNDES_Msk                   (_U_(0x1) << SPI_IMR_UNDES_Pos)                /**< (SPI_IMR) Underrun Error Interrupt Mask Mask */
+#define SPI_IMR_UNDES                       SPI_IMR_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_UNDES_Msk instead */
+#define SPI_IMR_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IMR) Register MASK  (Use SPI_IMR_Msk instead)  */
+#define SPI_IMR_Msk                         _U_(0x70F)                                     /**< (SPI_IMR) Register Mask  */
+
+
+/* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register (CS_number = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
+    uint32_t NCPHA:1;                   /**< bit:      1  Clock Phase                              */
+    uint32_t CSNAAT:1;                  /**< bit:      2  Chip Select Not Active After Transfer (Ignored if CSAAT = 1) */
+    uint32_t CSAAT:1;                   /**< bit:      3  Chip Select Active After Transfer        */
+    uint32_t BITS:4;                    /**< bit:   4..7  Bits Per Transfer                        */
+    uint32_t SCBR:8;                    /**< bit:  8..15  Serial Clock Bit Rate                    */
+    uint32_t DLYBS:8;                   /**< bit: 16..23  Delay Before SPCK                        */
+    uint32_t DLYBCT:8;                  /**< bit: 24..31  Delay Between Consecutive Transfers      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_CSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CSR_OFFSET                      (0x30)                                        /**<  (SPI_CSR) Chip Select Register (CS_number = 0) 0  Offset */
+
+#define SPI_CSR_CPOL_Pos                    0                                              /**< (SPI_CSR) Clock Polarity Position */
+#define SPI_CSR_CPOL_Msk                    (_U_(0x1) << SPI_CSR_CPOL_Pos)                 /**< (SPI_CSR) Clock Polarity Mask */
+#define SPI_CSR_CPOL                        SPI_CSR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CPOL_Msk instead */
+#define SPI_CSR_NCPHA_Pos                   1                                              /**< (SPI_CSR) Clock Phase Position */
+#define SPI_CSR_NCPHA_Msk                   (_U_(0x1) << SPI_CSR_NCPHA_Pos)                /**< (SPI_CSR) Clock Phase Mask */
+#define SPI_CSR_NCPHA                       SPI_CSR_NCPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_NCPHA_Msk instead */
+#define SPI_CSR_CSNAAT_Pos                  2                                              /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Position */
+#define SPI_CSR_CSNAAT_Msk                  (_U_(0x1) << SPI_CSR_CSNAAT_Pos)               /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Mask */
+#define SPI_CSR_CSNAAT                      SPI_CSR_CSNAAT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CSNAAT_Msk instead */
+#define SPI_CSR_CSAAT_Pos                   3                                              /**< (SPI_CSR) Chip Select Active After Transfer Position */
+#define SPI_CSR_CSAAT_Msk                   (_U_(0x1) << SPI_CSR_CSAAT_Pos)                /**< (SPI_CSR) Chip Select Active After Transfer Mask */
+#define SPI_CSR_CSAAT                       SPI_CSR_CSAAT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CSAAT_Msk instead */
+#define SPI_CSR_BITS_Pos                    4                                              /**< (SPI_CSR) Bits Per Transfer Position */
+#define SPI_CSR_BITS_Msk                    (_U_(0xF) << SPI_CSR_BITS_Pos)                 /**< (SPI_CSR) Bits Per Transfer Mask */
+#define SPI_CSR_BITS(value)                 (SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos))
+#define   SPI_CSR_BITS_8_BIT_Val            _U_(0x0)                                       /**< (SPI_CSR) 8 bits for transfer  */
+#define   SPI_CSR_BITS_9_BIT_Val            _U_(0x1)                                       /**< (SPI_CSR) 9 bits for transfer  */
+#define   SPI_CSR_BITS_10_BIT_Val           _U_(0x2)                                       /**< (SPI_CSR) 10 bits for transfer  */
+#define   SPI_CSR_BITS_11_BIT_Val           _U_(0x3)                                       /**< (SPI_CSR) 11 bits for transfer  */
+#define   SPI_CSR_BITS_12_BIT_Val           _U_(0x4)                                       /**< (SPI_CSR) 12 bits for transfer  */
+#define   SPI_CSR_BITS_13_BIT_Val           _U_(0x5)                                       /**< (SPI_CSR) 13 bits for transfer  */
+#define   SPI_CSR_BITS_14_BIT_Val           _U_(0x6)                                       /**< (SPI_CSR) 14 bits for transfer  */
+#define   SPI_CSR_BITS_15_BIT_Val           _U_(0x7)                                       /**< (SPI_CSR) 15 bits for transfer  */
+#define   SPI_CSR_BITS_16_BIT_Val           _U_(0x8)                                       /**< (SPI_CSR) 16 bits for transfer  */
+#define SPI_CSR_BITS_8_BIT                  (SPI_CSR_BITS_8_BIT_Val << SPI_CSR_BITS_Pos)   /**< (SPI_CSR) 8 bits for transfer Position  */
+#define SPI_CSR_BITS_9_BIT                  (SPI_CSR_BITS_9_BIT_Val << SPI_CSR_BITS_Pos)   /**< (SPI_CSR) 9 bits for transfer Position  */
+#define SPI_CSR_BITS_10_BIT                 (SPI_CSR_BITS_10_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 10 bits for transfer Position  */
+#define SPI_CSR_BITS_11_BIT                 (SPI_CSR_BITS_11_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 11 bits for transfer Position  */
+#define SPI_CSR_BITS_12_BIT                 (SPI_CSR_BITS_12_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 12 bits for transfer Position  */
+#define SPI_CSR_BITS_13_BIT                 (SPI_CSR_BITS_13_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 13 bits for transfer Position  */
+#define SPI_CSR_BITS_14_BIT                 (SPI_CSR_BITS_14_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 14 bits for transfer Position  */
+#define SPI_CSR_BITS_15_BIT                 (SPI_CSR_BITS_15_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 15 bits for transfer Position  */
+#define SPI_CSR_BITS_16_BIT                 (SPI_CSR_BITS_16_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 16 bits for transfer Position  */
+#define SPI_CSR_SCBR_Pos                    8                                              /**< (SPI_CSR) Serial Clock Bit Rate Position */
+#define SPI_CSR_SCBR_Msk                    (_U_(0xFF) << SPI_CSR_SCBR_Pos)                /**< (SPI_CSR) Serial Clock Bit Rate Mask */
+#define SPI_CSR_SCBR(value)                 (SPI_CSR_SCBR_Msk & ((value) << SPI_CSR_SCBR_Pos))
+#define SPI_CSR_DLYBS_Pos                   16                                             /**< (SPI_CSR) Delay Before SPCK Position */
+#define SPI_CSR_DLYBS_Msk                   (_U_(0xFF) << SPI_CSR_DLYBS_Pos)               /**< (SPI_CSR) Delay Before SPCK Mask */
+#define SPI_CSR_DLYBS(value)                (SPI_CSR_DLYBS_Msk & ((value) << SPI_CSR_DLYBS_Pos))
+#define SPI_CSR_DLYBCT_Pos                  24                                             /**< (SPI_CSR) Delay Between Consecutive Transfers Position */
+#define SPI_CSR_DLYBCT_Msk                  (_U_(0xFF) << SPI_CSR_DLYBCT_Pos)              /**< (SPI_CSR) Delay Between Consecutive Transfers Mask */
+#define SPI_CSR_DLYBCT(value)               (SPI_CSR_DLYBCT_Msk & ((value) << SPI_CSR_DLYBCT_Pos))
+#define SPI_CSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SPI_CSR) Register MASK  (Use SPI_CSR_Msk instead)  */
+#define SPI_CSR_Msk                         _U_(0xFFFFFFFF)                                /**< (SPI_CSR) Register Mask  */
+
+
+/* -------- SPI_WPMR : (SPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPMR_OFFSET                     (0xE4)                                        /**<  (SPI_WPMR) Write Protection Mode Register  Offset */
+
+#define SPI_WPMR_WPEN_Pos                   0                                              /**< (SPI_WPMR) Write Protection Enable Position */
+#define SPI_WPMR_WPEN_Msk                   (_U_(0x1) << SPI_WPMR_WPEN_Pos)                /**< (SPI_WPMR) Write Protection Enable Mask */
+#define SPI_WPMR_WPEN                       SPI_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_WPMR_WPEN_Msk instead */
+#define SPI_WPMR_WPKEY_Pos                  8                                              /**< (SPI_WPMR) Write Protection Key Position */
+#define SPI_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SPI_WPMR_WPKEY_Pos)          /**< (SPI_WPMR) Write Protection Key Mask */
+#define SPI_WPMR_WPKEY(value)               (SPI_WPMR_WPKEY_Msk & ((value) << SPI_WPMR_WPKEY_Pos))
+#define   SPI_WPMR_WPKEY_PASSWD_Val         _U_(0x535049)                                  /**< (SPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define SPI_WPMR_WPKEY_PASSWD               (SPI_WPMR_WPKEY_PASSWD_Val << SPI_WPMR_WPKEY_Pos)  /**< (SPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define SPI_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SPI_WPMR) Register MASK  (Use SPI_WPMR_Msk instead)  */
+#define SPI_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SPI_WPMR) Register Mask  */
+
+
+/* -------- SPI_WPSR : (SPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPSR_OFFSET                     (0xE8)                                        /**<  (SPI_WPSR) Write Protection Status Register  Offset */
+
+#define SPI_WPSR_WPVS_Pos                   0                                              /**< (SPI_WPSR) Write Protection Violation Status Position */
+#define SPI_WPSR_WPVS_Msk                   (_U_(0x1) << SPI_WPSR_WPVS_Pos)                /**< (SPI_WPSR) Write Protection Violation Status Mask */
+#define SPI_WPSR_WPVS                       SPI_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_WPSR_WPVS_Msk instead */
+#define SPI_WPSR_WPVSRC_Pos                 8                                              /**< (SPI_WPSR) Write Protection Violation Source Position */
+#define SPI_WPSR_WPVSRC_Msk                 (_U_(0xFF) << SPI_WPSR_WPVSRC_Pos)             /**< (SPI_WPSR) Write Protection Violation Source Mask */
+#define SPI_WPSR_WPVSRC(value)              (SPI_WPSR_WPVSRC_Msk & ((value) << SPI_WPSR_WPVSRC_Pos))
+#define SPI_WPSR_MASK                       _U_(0xFF01)                                    /**< \deprecated (SPI_WPSR) Register MASK  (Use SPI_WPSR_Msk instead)  */
+#define SPI_WPSR_Msk                        _U_(0xFF01)                                    /**< (SPI_WPSR) Register Mask  */
+
+
+/* -------- SPI_VERSION : (SPI Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_VERSION_OFFSET                  (0xFC)                                        /**<  (SPI_VERSION) Version Register  Offset */
+
+#define SPI_VERSION_VERSION_Pos             0                                              /**< (SPI_VERSION) Version of the Hardware Module Position */
+#define SPI_VERSION_VERSION_Msk             (_U_(0xFFF) << SPI_VERSION_VERSION_Pos)        /**< (SPI_VERSION) Version of the Hardware Module Mask */
+#define SPI_VERSION_VERSION(value)          (SPI_VERSION_VERSION_Msk & ((value) << SPI_VERSION_VERSION_Pos))
+#define SPI_VERSION_MFN_Pos                 16                                             /**< (SPI_VERSION) Metal Fix Number Position */
+#define SPI_VERSION_MFN_Msk                 (_U_(0x7) << SPI_VERSION_MFN_Pos)              /**< (SPI_VERSION) Metal Fix Number Mask */
+#define SPI_VERSION_MFN(value)              (SPI_VERSION_MFN_Msk & ((value) << SPI_VERSION_MFN_Pos))
+#define SPI_VERSION_MASK                    _U_(0x70FFF)                                   /**< \deprecated (SPI_VERSION) Register MASK  (Use SPI_VERSION_Msk instead)  */
+#define SPI_VERSION_Msk                     _U_(0x70FFF)                                   /**< (SPI_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SPI hardware registers */
+typedef struct {  
+  __O  uint32_t SPI_CR;         /**< (SPI Offset: 0x00) Control Register */
+  __IO uint32_t SPI_MR;         /**< (SPI Offset: 0x04) Mode Register */
+  __I  uint32_t SPI_RDR;        /**< (SPI Offset: 0x08) Receive Data Register */
+  __O  uint32_t SPI_TDR;        /**< (SPI Offset: 0x0C) Transmit Data Register */
+  __I  uint32_t SPI_SR;         /**< (SPI Offset: 0x10) Status Register */
+  __O  uint32_t SPI_IER;        /**< (SPI Offset: 0x14) Interrupt Enable Register */
+  __O  uint32_t SPI_IDR;        /**< (SPI Offset: 0x18) Interrupt Disable Register */
+  __I  uint32_t SPI_IMR;        /**< (SPI Offset: 0x1C) Interrupt Mask Register */
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t SPI_CSR[4];     /**< (SPI Offset: 0x30) Chip Select Register (CS_number = 0) 0 */
+  __I  uint8_t                        Reserved2[164];
+  __IO uint32_t SPI_WPMR;       /**< (SPI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t SPI_WPSR;       /**< (SPI Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  uint32_t SPI_VERSION;    /**< (SPI Offset: 0xFC) Version Register */
+} Spi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SPI hardware registers */
+typedef struct {  
+  __O  SPI_CR_Type                    SPI_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO SPI_MR_Type                    SPI_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  SPI_RDR_Type                   SPI_RDR;        /**< Offset: 0x08 (R/   32) Receive Data Register */
+  __O  SPI_TDR_Type                   SPI_TDR;        /**< Offset: 0x0C ( /W  32) Transmit Data Register */
+  __I  SPI_SR_Type                    SPI_SR;         /**< Offset: 0x10 (R/   32) Status Register */
+  __O  SPI_IER_Type                   SPI_IER;        /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
+  __O  SPI_IDR_Type                   SPI_IDR;        /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
+  __I  SPI_IMR_Type                   SPI_IMR;        /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
+  __I  uint8_t                        Reserved1[16];
+  __IO SPI_CSR_Type                   SPI_CSR[4];     /**< Offset: 0x30 (R/W  32) Chip Select Register (CS_number = 0) 0 */
+  __I  uint8_t                        Reserved2[164];
+  __IO SPI_WPMR_Type                  SPI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  SPI_WPSR_Type                  SPI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[16];
+  __I  SPI_VERSION_Type               SPI_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+} Spi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Serial Peripheral Interface */
+
+#endif /* _SAMV71_SPI_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/ssc.h
+++ b/asf/sam/include/samv71/component/ssc.h
@@ -1,0 +1,941 @@
+/**
+ * \file
+ *
+ * \brief Component description for SSC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SSC_COMPONENT_H_
+#define _SAMV71_SSC_COMPONENT_H_
+#define _SAMV71_SSC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Synchronous Serial Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SSC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SSC_6078                       /**< (SSC) Module ID */
+#define REV_SSC O                      /**< (SSC) Module revision */
+
+/* -------- SSC_CR : (SSC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXEN:1;                    /**< bit:      0  Receive Enable                           */
+    uint32_t RXDIS:1;                   /**< bit:      1  Receive Disable                          */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t TXEN:1;                    /**< bit:      8  Transmit Enable                          */
+    uint32_t TXDIS:1;                   /**< bit:      9  Transmit Disable                         */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t SWRST:1;                   /**< bit:     15  Software Reset                           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_CR_OFFSET                       (0x00)                                        /**<  (SSC_CR) Control Register  Offset */
+
+#define SSC_CR_RXEN_Pos                     0                                              /**< (SSC_CR) Receive Enable Position */
+#define SSC_CR_RXEN_Msk                     (_U_(0x1) << SSC_CR_RXEN_Pos)                  /**< (SSC_CR) Receive Enable Mask */
+#define SSC_CR_RXEN                         SSC_CR_RXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_RXEN_Msk instead */
+#define SSC_CR_RXDIS_Pos                    1                                              /**< (SSC_CR) Receive Disable Position */
+#define SSC_CR_RXDIS_Msk                    (_U_(0x1) << SSC_CR_RXDIS_Pos)                 /**< (SSC_CR) Receive Disable Mask */
+#define SSC_CR_RXDIS                        SSC_CR_RXDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_RXDIS_Msk instead */
+#define SSC_CR_TXEN_Pos                     8                                              /**< (SSC_CR) Transmit Enable Position */
+#define SSC_CR_TXEN_Msk                     (_U_(0x1) << SSC_CR_TXEN_Pos)                  /**< (SSC_CR) Transmit Enable Mask */
+#define SSC_CR_TXEN                         SSC_CR_TXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_TXEN_Msk instead */
+#define SSC_CR_TXDIS_Pos                    9                                              /**< (SSC_CR) Transmit Disable Position */
+#define SSC_CR_TXDIS_Msk                    (_U_(0x1) << SSC_CR_TXDIS_Pos)                 /**< (SSC_CR) Transmit Disable Mask */
+#define SSC_CR_TXDIS                        SSC_CR_TXDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_TXDIS_Msk instead */
+#define SSC_CR_SWRST_Pos                    15                                             /**< (SSC_CR) Software Reset Position */
+#define SSC_CR_SWRST_Msk                    (_U_(0x1) << SSC_CR_SWRST_Pos)                 /**< (SSC_CR) Software Reset Mask */
+#define SSC_CR_SWRST                        SSC_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_SWRST_Msk instead */
+#define SSC_CR_MASK                         _U_(0x8303)                                    /**< \deprecated (SSC_CR) Register MASK  (Use SSC_CR_Msk instead)  */
+#define SSC_CR_Msk                          _U_(0x8303)                                    /**< (SSC_CR) Register Mask  */
+
+
+/* -------- SSC_CMR : (SSC Offset: 0x04) (R/W 32) Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIV:12;                    /**< bit:  0..11  Clock Divider                            */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_CMR_OFFSET                      (0x04)                                        /**<  (SSC_CMR) Clock Mode Register  Offset */
+
+#define SSC_CMR_DIV_Pos                     0                                              /**< (SSC_CMR) Clock Divider Position */
+#define SSC_CMR_DIV_Msk                     (_U_(0xFFF) << SSC_CMR_DIV_Pos)                /**< (SSC_CMR) Clock Divider Mask */
+#define SSC_CMR_DIV(value)                  (SSC_CMR_DIV_Msk & ((value) << SSC_CMR_DIV_Pos))
+#define SSC_CMR_MASK                        _U_(0xFFF)                                     /**< \deprecated (SSC_CMR) Register MASK  (Use SSC_CMR_Msk instead)  */
+#define SSC_CMR_Msk                         _U_(0xFFF)                                     /**< (SSC_CMR) Register Mask  */
+
+
+/* -------- SSC_RCMR : (SSC Offset: 0x10) (R/W 32) Receive Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CKS:2;                     /**< bit:   0..1  Receive Clock Selection                  */
+    uint32_t CKO:3;                     /**< bit:   2..4  Receive Clock Output Mode Selection      */
+    uint32_t CKI:1;                     /**< bit:      5  Receive Clock Inversion                  */
+    uint32_t CKG:2;                     /**< bit:   6..7  Receive Clock Gating Selection           */
+    uint32_t START:4;                   /**< bit:  8..11  Receive Start Selection                  */
+    uint32_t STOP:1;                    /**< bit:     12  Receive Stop Selection                   */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t STTDLY:8;                  /**< bit: 16..23  Receive Start Delay                      */
+    uint32_t PERIOD:8;                  /**< bit: 24..31  Receive Period Divider Selection         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RCMR_OFFSET                     (0x10)                                        /**<  (SSC_RCMR) Receive Clock Mode Register  Offset */
+
+#define SSC_RCMR_CKS_Pos                    0                                              /**< (SSC_RCMR) Receive Clock Selection Position */
+#define SSC_RCMR_CKS_Msk                    (_U_(0x3) << SSC_RCMR_CKS_Pos)                 /**< (SSC_RCMR) Receive Clock Selection Mask */
+#define SSC_RCMR_CKS(value)                 (SSC_RCMR_CKS_Msk & ((value) << SSC_RCMR_CKS_Pos))
+#define   SSC_RCMR_CKS_MCK_Val              _U_(0x0)                                       /**< (SSC_RCMR) Divided Clock  */
+#define   SSC_RCMR_CKS_TK_Val               _U_(0x1)                                       /**< (SSC_RCMR) TK Clock signal  */
+#define   SSC_RCMR_CKS_RK_Val               _U_(0x2)                                       /**< (SSC_RCMR) RK pin  */
+#define SSC_RCMR_CKS_MCK                    (SSC_RCMR_CKS_MCK_Val << SSC_RCMR_CKS_Pos)     /**< (SSC_RCMR) Divided Clock Position  */
+#define SSC_RCMR_CKS_TK                     (SSC_RCMR_CKS_TK_Val << SSC_RCMR_CKS_Pos)      /**< (SSC_RCMR) TK Clock signal Position  */
+#define SSC_RCMR_CKS_RK                     (SSC_RCMR_CKS_RK_Val << SSC_RCMR_CKS_Pos)      /**< (SSC_RCMR) RK pin Position  */
+#define SSC_RCMR_CKO_Pos                    2                                              /**< (SSC_RCMR) Receive Clock Output Mode Selection Position */
+#define SSC_RCMR_CKO_Msk                    (_U_(0x7) << SSC_RCMR_CKO_Pos)                 /**< (SSC_RCMR) Receive Clock Output Mode Selection Mask */
+#define SSC_RCMR_CKO(value)                 (SSC_RCMR_CKO_Msk & ((value) << SSC_RCMR_CKO_Pos))
+#define   SSC_RCMR_CKO_NONE_Val             _U_(0x0)                                       /**< (SSC_RCMR) None, RK pin is an input  */
+#define   SSC_RCMR_CKO_CONTINUOUS_Val       _U_(0x1)                                       /**< (SSC_RCMR) Continuous Receive Clock, RK pin is an output  */
+#define   SSC_RCMR_CKO_TRANSFER_Val         _U_(0x2)                                       /**< (SSC_RCMR) Receive Clock only during data transfers, RK pin is an output  */
+#define SSC_RCMR_CKO_NONE                   (SSC_RCMR_CKO_NONE_Val << SSC_RCMR_CKO_Pos)    /**< (SSC_RCMR) None, RK pin is an input Position  */
+#define SSC_RCMR_CKO_CONTINUOUS             (SSC_RCMR_CKO_CONTINUOUS_Val << SSC_RCMR_CKO_Pos)  /**< (SSC_RCMR) Continuous Receive Clock, RK pin is an output Position  */
+#define SSC_RCMR_CKO_TRANSFER               (SSC_RCMR_CKO_TRANSFER_Val << SSC_RCMR_CKO_Pos)  /**< (SSC_RCMR) Receive Clock only during data transfers, RK pin is an output Position  */
+#define SSC_RCMR_CKI_Pos                    5                                              /**< (SSC_RCMR) Receive Clock Inversion Position */
+#define SSC_RCMR_CKI_Msk                    (_U_(0x1) << SSC_RCMR_CKI_Pos)                 /**< (SSC_RCMR) Receive Clock Inversion Mask */
+#define SSC_RCMR_CKI                        SSC_RCMR_CKI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RCMR_CKI_Msk instead */
+#define SSC_RCMR_CKG_Pos                    6                                              /**< (SSC_RCMR) Receive Clock Gating Selection Position */
+#define SSC_RCMR_CKG_Msk                    (_U_(0x3) << SSC_RCMR_CKG_Pos)                 /**< (SSC_RCMR) Receive Clock Gating Selection Mask */
+#define SSC_RCMR_CKG(value)                 (SSC_RCMR_CKG_Msk & ((value) << SSC_RCMR_CKG_Pos))
+#define   SSC_RCMR_CKG_CONTINUOUS_Val       _U_(0x0)                                       /**< (SSC_RCMR) None  */
+#define   SSC_RCMR_CKG_EN_RF_LOW_Val        _U_(0x1)                                       /**< (SSC_RCMR) Receive Clock enabled only if RF Low  */
+#define   SSC_RCMR_CKG_EN_RF_HIGH_Val       _U_(0x2)                                       /**< (SSC_RCMR) Receive Clock enabled only if RF High  */
+#define SSC_RCMR_CKG_CONTINUOUS             (SSC_RCMR_CKG_CONTINUOUS_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) None Position  */
+#define SSC_RCMR_CKG_EN_RF_LOW              (SSC_RCMR_CKG_EN_RF_LOW_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) Receive Clock enabled only if RF Low Position  */
+#define SSC_RCMR_CKG_EN_RF_HIGH             (SSC_RCMR_CKG_EN_RF_HIGH_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) Receive Clock enabled only if RF High Position  */
+#define SSC_RCMR_START_Pos                  8                                              /**< (SSC_RCMR) Receive Start Selection Position */
+#define SSC_RCMR_START_Msk                  (_U_(0xF) << SSC_RCMR_START_Pos)               /**< (SSC_RCMR) Receive Start Selection Mask */
+#define SSC_RCMR_START(value)               (SSC_RCMR_START_Msk & ((value) << SSC_RCMR_START_Pos))
+#define   SSC_RCMR_START_CONTINUOUS_Val     _U_(0x0)                                       /**< (SSC_RCMR) Continuous, as soon as the receiver is enabled, and immediately after the end of transfer of the previous data.  */
+#define   SSC_RCMR_START_TRANSMIT_Val       _U_(0x1)                                       /**< (SSC_RCMR) Transmit start  */
+#define   SSC_RCMR_START_RF_LOW_Val         _U_(0x2)                                       /**< (SSC_RCMR) Detection of a low level on RF signal  */
+#define   SSC_RCMR_START_RF_HIGH_Val        _U_(0x3)                                       /**< (SSC_RCMR) Detection of a high level on RF signal  */
+#define   SSC_RCMR_START_RF_FALLING_Val     _U_(0x4)                                       /**< (SSC_RCMR) Detection of a falling edge on RF signal  */
+#define   SSC_RCMR_START_RF_RISING_Val      _U_(0x5)                                       /**< (SSC_RCMR) Detection of a rising edge on RF signal  */
+#define   SSC_RCMR_START_RF_LEVEL_Val       _U_(0x6)                                       /**< (SSC_RCMR) Detection of any level change on RF signal  */
+#define   SSC_RCMR_START_RF_EDGE_Val        _U_(0x7)                                       /**< (SSC_RCMR) Detection of any edge on RF signal  */
+#define   SSC_RCMR_START_CMP_0_Val          _U_(0x8)                                       /**< (SSC_RCMR) Compare 0  */
+#define SSC_RCMR_START_CONTINUOUS           (SSC_RCMR_START_CONTINUOUS_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Continuous, as soon as the receiver is enabled, and immediately after the end of transfer of the previous data. Position  */
+#define SSC_RCMR_START_TRANSMIT             (SSC_RCMR_START_TRANSMIT_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Transmit start Position  */
+#define SSC_RCMR_START_RF_LOW               (SSC_RCMR_START_RF_LOW_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a low level on RF signal Position  */
+#define SSC_RCMR_START_RF_HIGH              (SSC_RCMR_START_RF_HIGH_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a high level on RF signal Position  */
+#define SSC_RCMR_START_RF_FALLING           (SSC_RCMR_START_RF_FALLING_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a falling edge on RF signal Position  */
+#define SSC_RCMR_START_RF_RISING            (SSC_RCMR_START_RF_RISING_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a rising edge on RF signal Position  */
+#define SSC_RCMR_START_RF_LEVEL             (SSC_RCMR_START_RF_LEVEL_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of any level change on RF signal Position  */
+#define SSC_RCMR_START_RF_EDGE              (SSC_RCMR_START_RF_EDGE_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of any edge on RF signal Position  */
+#define SSC_RCMR_START_CMP_0                (SSC_RCMR_START_CMP_0_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Compare 0 Position  */
+#define SSC_RCMR_STOP_Pos                   12                                             /**< (SSC_RCMR) Receive Stop Selection Position */
+#define SSC_RCMR_STOP_Msk                   (_U_(0x1) << SSC_RCMR_STOP_Pos)                /**< (SSC_RCMR) Receive Stop Selection Mask */
+#define SSC_RCMR_STOP                       SSC_RCMR_STOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RCMR_STOP_Msk instead */
+#define SSC_RCMR_STTDLY_Pos                 16                                             /**< (SSC_RCMR) Receive Start Delay Position */
+#define SSC_RCMR_STTDLY_Msk                 (_U_(0xFF) << SSC_RCMR_STTDLY_Pos)             /**< (SSC_RCMR) Receive Start Delay Mask */
+#define SSC_RCMR_STTDLY(value)              (SSC_RCMR_STTDLY_Msk & ((value) << SSC_RCMR_STTDLY_Pos))
+#define SSC_RCMR_PERIOD_Pos                 24                                             /**< (SSC_RCMR) Receive Period Divider Selection Position */
+#define SSC_RCMR_PERIOD_Msk                 (_U_(0xFF) << SSC_RCMR_PERIOD_Pos)             /**< (SSC_RCMR) Receive Period Divider Selection Mask */
+#define SSC_RCMR_PERIOD(value)              (SSC_RCMR_PERIOD_Msk & ((value) << SSC_RCMR_PERIOD_Pos))
+#define SSC_RCMR_MASK                       _U_(0xFFFF1FFF)                                /**< \deprecated (SSC_RCMR) Register MASK  (Use SSC_RCMR_Msk instead)  */
+#define SSC_RCMR_Msk                        _U_(0xFFFF1FFF)                                /**< (SSC_RCMR) Register Mask  */
+
+
+/* -------- SSC_RFMR : (SSC Offset: 0x14) (R/W 32) Receive Frame Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
+    uint32_t LOOP:1;                    /**< bit:      5  Loop Mode                                */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MSBF:1;                    /**< bit:      7  Most Significant Bit First               */
+    uint32_t DATNB:4;                   /**< bit:  8..11  Data Number per Frame                    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t FSLEN:4;                   /**< bit: 16..19  Receive Frame Sync Length                */
+    uint32_t FSOS:3;                    /**< bit: 20..22  Receive Frame Sync Output Selection      */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t FSEDGE:1;                  /**< bit:     24  Frame Sync Edge Detection                */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t FSLEN_EXT:4;               /**< bit: 28..31  FSLEN Field Extension                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RFMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RFMR_OFFSET                     (0x14)                                        /**<  (SSC_RFMR) Receive Frame Mode Register  Offset */
+
+#define SSC_RFMR_DATLEN_Pos                 0                                              /**< (SSC_RFMR) Data Length Position */
+#define SSC_RFMR_DATLEN_Msk                 (_U_(0x1F) << SSC_RFMR_DATLEN_Pos)             /**< (SSC_RFMR) Data Length Mask */
+#define SSC_RFMR_DATLEN(value)              (SSC_RFMR_DATLEN_Msk & ((value) << SSC_RFMR_DATLEN_Pos))
+#define SSC_RFMR_LOOP_Pos                   5                                              /**< (SSC_RFMR) Loop Mode Position */
+#define SSC_RFMR_LOOP_Msk                   (_U_(0x1) << SSC_RFMR_LOOP_Pos)                /**< (SSC_RFMR) Loop Mode Mask */
+#define SSC_RFMR_LOOP                       SSC_RFMR_LOOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_LOOP_Msk instead */
+#define SSC_RFMR_MSBF_Pos                   7                                              /**< (SSC_RFMR) Most Significant Bit First Position */
+#define SSC_RFMR_MSBF_Msk                   (_U_(0x1) << SSC_RFMR_MSBF_Pos)                /**< (SSC_RFMR) Most Significant Bit First Mask */
+#define SSC_RFMR_MSBF                       SSC_RFMR_MSBF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_MSBF_Msk instead */
+#define SSC_RFMR_DATNB_Pos                  8                                              /**< (SSC_RFMR) Data Number per Frame Position */
+#define SSC_RFMR_DATNB_Msk                  (_U_(0xF) << SSC_RFMR_DATNB_Pos)               /**< (SSC_RFMR) Data Number per Frame Mask */
+#define SSC_RFMR_DATNB(value)               (SSC_RFMR_DATNB_Msk & ((value) << SSC_RFMR_DATNB_Pos))
+#define SSC_RFMR_FSLEN_Pos                  16                                             /**< (SSC_RFMR) Receive Frame Sync Length Position */
+#define SSC_RFMR_FSLEN_Msk                  (_U_(0xF) << SSC_RFMR_FSLEN_Pos)               /**< (SSC_RFMR) Receive Frame Sync Length Mask */
+#define SSC_RFMR_FSLEN(value)               (SSC_RFMR_FSLEN_Msk & ((value) << SSC_RFMR_FSLEN_Pos))
+#define SSC_RFMR_FSOS_Pos                   20                                             /**< (SSC_RFMR) Receive Frame Sync Output Selection Position */
+#define SSC_RFMR_FSOS_Msk                   (_U_(0x7) << SSC_RFMR_FSOS_Pos)                /**< (SSC_RFMR) Receive Frame Sync Output Selection Mask */
+#define SSC_RFMR_FSOS(value)                (SSC_RFMR_FSOS_Msk & ((value) << SSC_RFMR_FSOS_Pos))
+#define   SSC_RFMR_FSOS_NONE_Val            _U_(0x0)                                       /**< (SSC_RFMR) None, RF pin is an input  */
+#define   SSC_RFMR_FSOS_NEGATIVE_Val        _U_(0x1)                                       /**< (SSC_RFMR) Negative Pulse, RF pin is an output  */
+#define   SSC_RFMR_FSOS_POSITIVE_Val        _U_(0x2)                                       /**< (SSC_RFMR) Positive Pulse, RF pin is an output  */
+#define   SSC_RFMR_FSOS_LOW_Val             _U_(0x3)                                       /**< (SSC_RFMR) Driven Low during data transfer, RF pin is an output  */
+#define   SSC_RFMR_FSOS_HIGH_Val            _U_(0x4)                                       /**< (SSC_RFMR) Driven High during data transfer, RF pin is an output  */
+#define   SSC_RFMR_FSOS_TOGGLING_Val        _U_(0x5)                                       /**< (SSC_RFMR) Toggling at each start of data transfer, RF pin is an output  */
+#define SSC_RFMR_FSOS_NONE                  (SSC_RFMR_FSOS_NONE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) None, RF pin is an input Position  */
+#define SSC_RFMR_FSOS_NEGATIVE              (SSC_RFMR_FSOS_NEGATIVE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Negative Pulse, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_POSITIVE              (SSC_RFMR_FSOS_POSITIVE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Positive Pulse, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_LOW                   (SSC_RFMR_FSOS_LOW_Val << SSC_RFMR_FSOS_Pos)   /**< (SSC_RFMR) Driven Low during data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_HIGH                  (SSC_RFMR_FSOS_HIGH_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Driven High during data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_TOGGLING              (SSC_RFMR_FSOS_TOGGLING_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Toggling at each start of data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSEDGE_Pos                 24                                             /**< (SSC_RFMR) Frame Sync Edge Detection Position */
+#define SSC_RFMR_FSEDGE_Msk                 (_U_(0x1) << SSC_RFMR_FSEDGE_Pos)              /**< (SSC_RFMR) Frame Sync Edge Detection Mask */
+#define SSC_RFMR_FSEDGE                     SSC_RFMR_FSEDGE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_FSEDGE_Msk instead */
+#define   SSC_RFMR_FSEDGE_POSITIVE_Val      _U_(0x0)                                       /**< (SSC_RFMR) Positive Edge Detection  */
+#define   SSC_RFMR_FSEDGE_NEGATIVE_Val      _U_(0x1)                                       /**< (SSC_RFMR) Negative Edge Detection  */
+#define SSC_RFMR_FSEDGE_POSITIVE            (SSC_RFMR_FSEDGE_POSITIVE_Val << SSC_RFMR_FSEDGE_Pos)  /**< (SSC_RFMR) Positive Edge Detection Position  */
+#define SSC_RFMR_FSEDGE_NEGATIVE            (SSC_RFMR_FSEDGE_NEGATIVE_Val << SSC_RFMR_FSEDGE_Pos)  /**< (SSC_RFMR) Negative Edge Detection Position  */
+#define SSC_RFMR_FSLEN_EXT_Pos              28                                             /**< (SSC_RFMR) FSLEN Field Extension Position */
+#define SSC_RFMR_FSLEN_EXT_Msk              (_U_(0xF) << SSC_RFMR_FSLEN_EXT_Pos)           /**< (SSC_RFMR) FSLEN Field Extension Mask */
+#define SSC_RFMR_FSLEN_EXT(value)           (SSC_RFMR_FSLEN_EXT_Msk & ((value) << SSC_RFMR_FSLEN_EXT_Pos))
+#define SSC_RFMR_MASK                       _U_(0xF17F0FBF)                                /**< \deprecated (SSC_RFMR) Register MASK  (Use SSC_RFMR_Msk instead)  */
+#define SSC_RFMR_Msk                        _U_(0xF17F0FBF)                                /**< (SSC_RFMR) Register Mask  */
+
+
+/* -------- SSC_TCMR : (SSC Offset: 0x18) (R/W 32) Transmit Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CKS:2;                     /**< bit:   0..1  Transmit Clock Selection                 */
+    uint32_t CKO:3;                     /**< bit:   2..4  Transmit Clock Output Mode Selection     */
+    uint32_t CKI:1;                     /**< bit:      5  Transmit Clock Inversion                 */
+    uint32_t CKG:2;                     /**< bit:   6..7  Transmit Clock Gating Selection          */
+    uint32_t START:4;                   /**< bit:  8..11  Transmit Start Selection                 */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t STTDLY:8;                  /**< bit: 16..23  Transmit Start Delay                     */
+    uint32_t PERIOD:8;                  /**< bit: 24..31  Transmit Period Divider Selection        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TCMR_OFFSET                     (0x18)                                        /**<  (SSC_TCMR) Transmit Clock Mode Register  Offset */
+
+#define SSC_TCMR_CKS_Pos                    0                                              /**< (SSC_TCMR) Transmit Clock Selection Position */
+#define SSC_TCMR_CKS_Msk                    (_U_(0x3) << SSC_TCMR_CKS_Pos)                 /**< (SSC_TCMR) Transmit Clock Selection Mask */
+#define SSC_TCMR_CKS(value)                 (SSC_TCMR_CKS_Msk & ((value) << SSC_TCMR_CKS_Pos))
+#define   SSC_TCMR_CKS_MCK_Val              _U_(0x0)                                       /**< (SSC_TCMR) Divided Clock  */
+#define   SSC_TCMR_CKS_RK_Val               _U_(0x1)                                       /**< (SSC_TCMR) RK Clock signal  */
+#define   SSC_TCMR_CKS_TK_Val               _U_(0x2)                                       /**< (SSC_TCMR) TK pin  */
+#define SSC_TCMR_CKS_MCK                    (SSC_TCMR_CKS_MCK_Val << SSC_TCMR_CKS_Pos)     /**< (SSC_TCMR) Divided Clock Position  */
+#define SSC_TCMR_CKS_RK                     (SSC_TCMR_CKS_RK_Val << SSC_TCMR_CKS_Pos)      /**< (SSC_TCMR) RK Clock signal Position  */
+#define SSC_TCMR_CKS_TK                     (SSC_TCMR_CKS_TK_Val << SSC_TCMR_CKS_Pos)      /**< (SSC_TCMR) TK pin Position  */
+#define SSC_TCMR_CKO_Pos                    2                                              /**< (SSC_TCMR) Transmit Clock Output Mode Selection Position */
+#define SSC_TCMR_CKO_Msk                    (_U_(0x7) << SSC_TCMR_CKO_Pos)                 /**< (SSC_TCMR) Transmit Clock Output Mode Selection Mask */
+#define SSC_TCMR_CKO(value)                 (SSC_TCMR_CKO_Msk & ((value) << SSC_TCMR_CKO_Pos))
+#define   SSC_TCMR_CKO_NONE_Val             _U_(0x0)                                       /**< (SSC_TCMR) None, TK pin is an input  */
+#define   SSC_TCMR_CKO_CONTINUOUS_Val       _U_(0x1)                                       /**< (SSC_TCMR) Continuous Transmit Clock, TK pin is an output  */
+#define   SSC_TCMR_CKO_TRANSFER_Val         _U_(0x2)                                       /**< (SSC_TCMR) Transmit Clock only during data transfers, TK pin is an output  */
+#define SSC_TCMR_CKO_NONE                   (SSC_TCMR_CKO_NONE_Val << SSC_TCMR_CKO_Pos)    /**< (SSC_TCMR) None, TK pin is an input Position  */
+#define SSC_TCMR_CKO_CONTINUOUS             (SSC_TCMR_CKO_CONTINUOUS_Val << SSC_TCMR_CKO_Pos)  /**< (SSC_TCMR) Continuous Transmit Clock, TK pin is an output Position  */
+#define SSC_TCMR_CKO_TRANSFER               (SSC_TCMR_CKO_TRANSFER_Val << SSC_TCMR_CKO_Pos)  /**< (SSC_TCMR) Transmit Clock only during data transfers, TK pin is an output Position  */
+#define SSC_TCMR_CKI_Pos                    5                                              /**< (SSC_TCMR) Transmit Clock Inversion Position */
+#define SSC_TCMR_CKI_Msk                    (_U_(0x1) << SSC_TCMR_CKI_Pos)                 /**< (SSC_TCMR) Transmit Clock Inversion Mask */
+#define SSC_TCMR_CKI                        SSC_TCMR_CKI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TCMR_CKI_Msk instead */
+#define SSC_TCMR_CKG_Pos                    6                                              /**< (SSC_TCMR) Transmit Clock Gating Selection Position */
+#define SSC_TCMR_CKG_Msk                    (_U_(0x3) << SSC_TCMR_CKG_Pos)                 /**< (SSC_TCMR) Transmit Clock Gating Selection Mask */
+#define SSC_TCMR_CKG(value)                 (SSC_TCMR_CKG_Msk & ((value) << SSC_TCMR_CKG_Pos))
+#define   SSC_TCMR_CKG_CONTINUOUS_Val       _U_(0x0)                                       /**< (SSC_TCMR) None  */
+#define   SSC_TCMR_CKG_EN_TF_LOW_Val        _U_(0x1)                                       /**< (SSC_TCMR) Transmit Clock enabled only if TF Low  */
+#define   SSC_TCMR_CKG_EN_TF_HIGH_Val       _U_(0x2)                                       /**< (SSC_TCMR) Transmit Clock enabled only if TF High  */
+#define SSC_TCMR_CKG_CONTINUOUS             (SSC_TCMR_CKG_CONTINUOUS_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) None Position  */
+#define SSC_TCMR_CKG_EN_TF_LOW              (SSC_TCMR_CKG_EN_TF_LOW_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) Transmit Clock enabled only if TF Low Position  */
+#define SSC_TCMR_CKG_EN_TF_HIGH             (SSC_TCMR_CKG_EN_TF_HIGH_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) Transmit Clock enabled only if TF High Position  */
+#define SSC_TCMR_START_Pos                  8                                              /**< (SSC_TCMR) Transmit Start Selection Position */
+#define SSC_TCMR_START_Msk                  (_U_(0xF) << SSC_TCMR_START_Pos)               /**< (SSC_TCMR) Transmit Start Selection Mask */
+#define SSC_TCMR_START(value)               (SSC_TCMR_START_Msk & ((value) << SSC_TCMR_START_Pos))
+#define   SSC_TCMR_START_CONTINUOUS_Val     _U_(0x0)                                       /**< (SSC_TCMR) Continuous, as soon as a word is written in the SSC_THR (if Transmit is enabled), and immediately after the end of transfer of the previous data  */
+#define   SSC_TCMR_START_RECEIVE_Val        _U_(0x1)                                       /**< (SSC_TCMR) Receive start  */
+#define   SSC_TCMR_START_TF_LOW_Val         _U_(0x2)                                       /**< (SSC_TCMR) Detection of a low level on TF signal  */
+#define   SSC_TCMR_START_TF_HIGH_Val        _U_(0x3)                                       /**< (SSC_TCMR) Detection of a high level on TF signal  */
+#define   SSC_TCMR_START_TF_FALLING_Val     _U_(0x4)                                       /**< (SSC_TCMR) Detection of a falling edge on TF signal  */
+#define   SSC_TCMR_START_TF_RISING_Val      _U_(0x5)                                       /**< (SSC_TCMR) Detection of a rising edge on TF signal  */
+#define   SSC_TCMR_START_TF_LEVEL_Val       _U_(0x6)                                       /**< (SSC_TCMR) Detection of any level change on TF signal  */
+#define   SSC_TCMR_START_TF_EDGE_Val        _U_(0x7)                                       /**< (SSC_TCMR) Detection of any edge on TF signal  */
+#define SSC_TCMR_START_CONTINUOUS           (SSC_TCMR_START_CONTINUOUS_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Continuous, as soon as a word is written in the SSC_THR (if Transmit is enabled), and immediately after the end of transfer of the previous data Position  */
+#define SSC_TCMR_START_RECEIVE              (SSC_TCMR_START_RECEIVE_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Receive start Position  */
+#define SSC_TCMR_START_TF_LOW               (SSC_TCMR_START_TF_LOW_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a low level on TF signal Position  */
+#define SSC_TCMR_START_TF_HIGH              (SSC_TCMR_START_TF_HIGH_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a high level on TF signal Position  */
+#define SSC_TCMR_START_TF_FALLING           (SSC_TCMR_START_TF_FALLING_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a falling edge on TF signal Position  */
+#define SSC_TCMR_START_TF_RISING            (SSC_TCMR_START_TF_RISING_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a rising edge on TF signal Position  */
+#define SSC_TCMR_START_TF_LEVEL             (SSC_TCMR_START_TF_LEVEL_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of any level change on TF signal Position  */
+#define SSC_TCMR_START_TF_EDGE              (SSC_TCMR_START_TF_EDGE_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of any edge on TF signal Position  */
+#define SSC_TCMR_STTDLY_Pos                 16                                             /**< (SSC_TCMR) Transmit Start Delay Position */
+#define SSC_TCMR_STTDLY_Msk                 (_U_(0xFF) << SSC_TCMR_STTDLY_Pos)             /**< (SSC_TCMR) Transmit Start Delay Mask */
+#define SSC_TCMR_STTDLY(value)              (SSC_TCMR_STTDLY_Msk & ((value) << SSC_TCMR_STTDLY_Pos))
+#define SSC_TCMR_PERIOD_Pos                 24                                             /**< (SSC_TCMR) Transmit Period Divider Selection Position */
+#define SSC_TCMR_PERIOD_Msk                 (_U_(0xFF) << SSC_TCMR_PERIOD_Pos)             /**< (SSC_TCMR) Transmit Period Divider Selection Mask */
+#define SSC_TCMR_PERIOD(value)              (SSC_TCMR_PERIOD_Msk & ((value) << SSC_TCMR_PERIOD_Pos))
+#define SSC_TCMR_MASK                       _U_(0xFFFF0FFF)                                /**< \deprecated (SSC_TCMR) Register MASK  (Use SSC_TCMR_Msk instead)  */
+#define SSC_TCMR_Msk                        _U_(0xFFFF0FFF)                                /**< (SSC_TCMR) Register Mask  */
+
+
+/* -------- SSC_TFMR : (SSC Offset: 0x1c) (R/W 32) Transmit Frame Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
+    uint32_t DATDEF:1;                  /**< bit:      5  Data Default Value                       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MSBF:1;                    /**< bit:      7  Most Significant Bit First               */
+    uint32_t DATNB:4;                   /**< bit:  8..11  Data Number per Frame                    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t FSLEN:4;                   /**< bit: 16..19  Transmit Frame Sync Length               */
+    uint32_t FSOS:3;                    /**< bit: 20..22  Transmit Frame Sync Output Selection     */
+    uint32_t FSDEN:1;                   /**< bit:     23  Frame Sync Data Enable                   */
+    uint32_t FSEDGE:1;                  /**< bit:     24  Frame Sync Edge Detection                */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t FSLEN_EXT:4;               /**< bit: 28..31  FSLEN Field Extension                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TFMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TFMR_OFFSET                     (0x1C)                                        /**<  (SSC_TFMR) Transmit Frame Mode Register  Offset */
+
+#define SSC_TFMR_DATLEN_Pos                 0                                              /**< (SSC_TFMR) Data Length Position */
+#define SSC_TFMR_DATLEN_Msk                 (_U_(0x1F) << SSC_TFMR_DATLEN_Pos)             /**< (SSC_TFMR) Data Length Mask */
+#define SSC_TFMR_DATLEN(value)              (SSC_TFMR_DATLEN_Msk & ((value) << SSC_TFMR_DATLEN_Pos))
+#define SSC_TFMR_DATDEF_Pos                 5                                              /**< (SSC_TFMR) Data Default Value Position */
+#define SSC_TFMR_DATDEF_Msk                 (_U_(0x1) << SSC_TFMR_DATDEF_Pos)              /**< (SSC_TFMR) Data Default Value Mask */
+#define SSC_TFMR_DATDEF                     SSC_TFMR_DATDEF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_DATDEF_Msk instead */
+#define SSC_TFMR_MSBF_Pos                   7                                              /**< (SSC_TFMR) Most Significant Bit First Position */
+#define SSC_TFMR_MSBF_Msk                   (_U_(0x1) << SSC_TFMR_MSBF_Pos)                /**< (SSC_TFMR) Most Significant Bit First Mask */
+#define SSC_TFMR_MSBF                       SSC_TFMR_MSBF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_MSBF_Msk instead */
+#define SSC_TFMR_DATNB_Pos                  8                                              /**< (SSC_TFMR) Data Number per Frame Position */
+#define SSC_TFMR_DATNB_Msk                  (_U_(0xF) << SSC_TFMR_DATNB_Pos)               /**< (SSC_TFMR) Data Number per Frame Mask */
+#define SSC_TFMR_DATNB(value)               (SSC_TFMR_DATNB_Msk & ((value) << SSC_TFMR_DATNB_Pos))
+#define SSC_TFMR_FSLEN_Pos                  16                                             /**< (SSC_TFMR) Transmit Frame Sync Length Position */
+#define SSC_TFMR_FSLEN_Msk                  (_U_(0xF) << SSC_TFMR_FSLEN_Pos)               /**< (SSC_TFMR) Transmit Frame Sync Length Mask */
+#define SSC_TFMR_FSLEN(value)               (SSC_TFMR_FSLEN_Msk & ((value) << SSC_TFMR_FSLEN_Pos))
+#define SSC_TFMR_FSOS_Pos                   20                                             /**< (SSC_TFMR) Transmit Frame Sync Output Selection Position */
+#define SSC_TFMR_FSOS_Msk                   (_U_(0x7) << SSC_TFMR_FSOS_Pos)                /**< (SSC_TFMR) Transmit Frame Sync Output Selection Mask */
+#define SSC_TFMR_FSOS(value)                (SSC_TFMR_FSOS_Msk & ((value) << SSC_TFMR_FSOS_Pos))
+#define   SSC_TFMR_FSOS_NONE_Val            _U_(0x0)                                       /**< (SSC_TFMR) None, TF pin is an input  */
+#define   SSC_TFMR_FSOS_NEGATIVE_Val        _U_(0x1)                                       /**< (SSC_TFMR) Negative Pulse, TF pin is an output  */
+#define   SSC_TFMR_FSOS_POSITIVE_Val        _U_(0x2)                                       /**< (SSC_TFMR) Positive Pulse, TF pin is an output  */
+#define   SSC_TFMR_FSOS_LOW_Val             _U_(0x3)                                       /**< (SSC_TFMR) Driven Low during data transfer  */
+#define   SSC_TFMR_FSOS_HIGH_Val            _U_(0x4)                                       /**< (SSC_TFMR) Driven High during data transfer  */
+#define   SSC_TFMR_FSOS_TOGGLING_Val        _U_(0x5)                                       /**< (SSC_TFMR) Toggling at each start of data transfer  */
+#define SSC_TFMR_FSOS_NONE                  (SSC_TFMR_FSOS_NONE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) None, TF pin is an input Position  */
+#define SSC_TFMR_FSOS_NEGATIVE              (SSC_TFMR_FSOS_NEGATIVE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Negative Pulse, TF pin is an output Position  */
+#define SSC_TFMR_FSOS_POSITIVE              (SSC_TFMR_FSOS_POSITIVE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Positive Pulse, TF pin is an output Position  */
+#define SSC_TFMR_FSOS_LOW                   (SSC_TFMR_FSOS_LOW_Val << SSC_TFMR_FSOS_Pos)   /**< (SSC_TFMR) Driven Low during data transfer Position  */
+#define SSC_TFMR_FSOS_HIGH                  (SSC_TFMR_FSOS_HIGH_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Driven High during data transfer Position  */
+#define SSC_TFMR_FSOS_TOGGLING              (SSC_TFMR_FSOS_TOGGLING_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Toggling at each start of data transfer Position  */
+#define SSC_TFMR_FSDEN_Pos                  23                                             /**< (SSC_TFMR) Frame Sync Data Enable Position */
+#define SSC_TFMR_FSDEN_Msk                  (_U_(0x1) << SSC_TFMR_FSDEN_Pos)               /**< (SSC_TFMR) Frame Sync Data Enable Mask */
+#define SSC_TFMR_FSDEN                      SSC_TFMR_FSDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_FSDEN_Msk instead */
+#define SSC_TFMR_FSEDGE_Pos                 24                                             /**< (SSC_TFMR) Frame Sync Edge Detection Position */
+#define SSC_TFMR_FSEDGE_Msk                 (_U_(0x1) << SSC_TFMR_FSEDGE_Pos)              /**< (SSC_TFMR) Frame Sync Edge Detection Mask */
+#define SSC_TFMR_FSEDGE                     SSC_TFMR_FSEDGE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_FSEDGE_Msk instead */
+#define   SSC_TFMR_FSEDGE_POSITIVE_Val      _U_(0x0)                                       /**< (SSC_TFMR) Positive Edge Detection  */
+#define   SSC_TFMR_FSEDGE_NEGATIVE_Val      _U_(0x1)                                       /**< (SSC_TFMR) Negative Edge Detection  */
+#define SSC_TFMR_FSEDGE_POSITIVE            (SSC_TFMR_FSEDGE_POSITIVE_Val << SSC_TFMR_FSEDGE_Pos)  /**< (SSC_TFMR) Positive Edge Detection Position  */
+#define SSC_TFMR_FSEDGE_NEGATIVE            (SSC_TFMR_FSEDGE_NEGATIVE_Val << SSC_TFMR_FSEDGE_Pos)  /**< (SSC_TFMR) Negative Edge Detection Position  */
+#define SSC_TFMR_FSLEN_EXT_Pos              28                                             /**< (SSC_TFMR) FSLEN Field Extension Position */
+#define SSC_TFMR_FSLEN_EXT_Msk              (_U_(0xF) << SSC_TFMR_FSLEN_EXT_Pos)           /**< (SSC_TFMR) FSLEN Field Extension Mask */
+#define SSC_TFMR_FSLEN_EXT(value)           (SSC_TFMR_FSLEN_EXT_Msk & ((value) << SSC_TFMR_FSLEN_EXT_Pos))
+#define SSC_TFMR_MASK                       _U_(0xF1FF0FBF)                                /**< \deprecated (SSC_TFMR) Register MASK  (Use SSC_TFMR_Msk instead)  */
+#define SSC_TFMR_Msk                        _U_(0xF1FF0FBF)                                /**< (SSC_TFMR) Register Mask  */
+
+
+/* -------- SSC_RHR : (SSC Offset: 0x20) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDAT:32;                   /**< bit:  0..31  Receive Data                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RHR_OFFSET                      (0x20)                                        /**<  (SSC_RHR) Receive Holding Register  Offset */
+
+#define SSC_RHR_RDAT_Pos                    0                                              /**< (SSC_RHR) Receive Data Position */
+#define SSC_RHR_RDAT_Msk                    (_U_(0xFFFFFFFF) << SSC_RHR_RDAT_Pos)          /**< (SSC_RHR) Receive Data Mask */
+#define SSC_RHR_RDAT(value)                 (SSC_RHR_RDAT_Msk & ((value) << SSC_RHR_RDAT_Pos))
+#define SSC_RHR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SSC_RHR) Register MASK  (Use SSC_RHR_Msk instead)  */
+#define SSC_RHR_Msk                         _U_(0xFFFFFFFF)                                /**< (SSC_RHR) Register Mask  */
+
+
+/* -------- SSC_THR : (SSC Offset: 0x24) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TDAT:32;                   /**< bit:  0..31  Transmit Data                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_THR_OFFSET                      (0x24)                                        /**<  (SSC_THR) Transmit Holding Register  Offset */
+
+#define SSC_THR_TDAT_Pos                    0                                              /**< (SSC_THR) Transmit Data Position */
+#define SSC_THR_TDAT_Msk                    (_U_(0xFFFFFFFF) << SSC_THR_TDAT_Pos)          /**< (SSC_THR) Transmit Data Mask */
+#define SSC_THR_TDAT(value)                 (SSC_THR_TDAT_Msk & ((value) << SSC_THR_TDAT_Pos))
+#define SSC_THR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SSC_THR) Register MASK  (Use SSC_THR_Msk instead)  */
+#define SSC_THR_Msk                         _U_(0xFFFFFFFF)                                /**< (SSC_THR) Register Mask  */
+
+
+/* -------- SSC_RSHR : (SSC Offset: 0x30) (R/ 32) Receive Sync. Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSDAT:16;                  /**< bit:  0..15  Receive Synchronization Data             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RSHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RSHR_OFFSET                     (0x30)                                        /**<  (SSC_RSHR) Receive Sync. Holding Register  Offset */
+
+#define SSC_RSHR_RSDAT_Pos                  0                                              /**< (SSC_RSHR) Receive Synchronization Data Position */
+#define SSC_RSHR_RSDAT_Msk                  (_U_(0xFFFF) << SSC_RSHR_RSDAT_Pos)            /**< (SSC_RSHR) Receive Synchronization Data Mask */
+#define SSC_RSHR_RSDAT(value)               (SSC_RSHR_RSDAT_Msk & ((value) << SSC_RSHR_RSDAT_Pos))
+#define SSC_RSHR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RSHR) Register MASK  (Use SSC_RSHR_Msk instead)  */
+#define SSC_RSHR_Msk                        _U_(0xFFFF)                                    /**< (SSC_RSHR) Register Mask  */
+
+
+/* -------- SSC_TSHR : (SSC Offset: 0x34) (R/W 32) Transmit Sync. Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSDAT:16;                  /**< bit:  0..15  Transmit Synchronization Data            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TSHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TSHR_OFFSET                     (0x34)                                        /**<  (SSC_TSHR) Transmit Sync. Holding Register  Offset */
+
+#define SSC_TSHR_TSDAT_Pos                  0                                              /**< (SSC_TSHR) Transmit Synchronization Data Position */
+#define SSC_TSHR_TSDAT_Msk                  (_U_(0xFFFF) << SSC_TSHR_TSDAT_Pos)            /**< (SSC_TSHR) Transmit Synchronization Data Mask */
+#define SSC_TSHR_TSDAT(value)               (SSC_TSHR_TSDAT_Msk & ((value) << SSC_TSHR_TSDAT_Pos))
+#define SSC_TSHR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_TSHR) Register MASK  (Use SSC_TSHR_Msk instead)  */
+#define SSC_TSHR_Msk                        _U_(0xFFFF)                                    /**< (SSC_TSHR) Register Mask  */
+
+
+/* -------- SSC_RC0R : (SSC Offset: 0x38) (R/W 32) Receive Compare 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CP0:16;                    /**< bit:  0..15  Receive Compare Data 0                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RC0R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RC0R_OFFSET                     (0x38)                                        /**<  (SSC_RC0R) Receive Compare 0 Register  Offset */
+
+#define SSC_RC0R_CP0_Pos                    0                                              /**< (SSC_RC0R) Receive Compare Data 0 Position */
+#define SSC_RC0R_CP0_Msk                    (_U_(0xFFFF) << SSC_RC0R_CP0_Pos)              /**< (SSC_RC0R) Receive Compare Data 0 Mask */
+#define SSC_RC0R_CP0(value)                 (SSC_RC0R_CP0_Msk & ((value) << SSC_RC0R_CP0_Pos))
+#define SSC_RC0R_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RC0R) Register MASK  (Use SSC_RC0R_Msk instead)  */
+#define SSC_RC0R_Msk                        _U_(0xFFFF)                                    /**< (SSC_RC0R) Register Mask  */
+
+
+/* -------- SSC_RC1R : (SSC Offset: 0x3c) (R/W 32) Receive Compare 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CP1:16;                    /**< bit:  0..15  Receive Compare Data 1                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RC1R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RC1R_OFFSET                     (0x3C)                                        /**<  (SSC_RC1R) Receive Compare 1 Register  Offset */
+
+#define SSC_RC1R_CP1_Pos                    0                                              /**< (SSC_RC1R) Receive Compare Data 1 Position */
+#define SSC_RC1R_CP1_Msk                    (_U_(0xFFFF) << SSC_RC1R_CP1_Pos)              /**< (SSC_RC1R) Receive Compare Data 1 Mask */
+#define SSC_RC1R_CP1(value)                 (SSC_RC1R_CP1_Msk & ((value) << SSC_RC1R_CP1_Pos))
+#define SSC_RC1R_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RC1R) Register MASK  (Use SSC_RC1R_Msk instead)  */
+#define SSC_RC1R_Msk                        _U_(0xFFFF)                                    /**< (SSC_RC1R) Register Mask  */
+
+
+/* -------- SSC_SR : (SSC Offset: 0x40) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready                           */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty                           */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready                            */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun                          */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0                                */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1                                */
+    uint32_t TXSYN:1;                   /**< bit:     10  Transmit Sync                            */
+    uint32_t RXSYN:1;                   /**< bit:     11  Receive Sync                             */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t TXEN:1;                    /**< bit:     16  Transmit Enable                          */
+    uint32_t RXEN:1;                    /**< bit:     17  Receive Enable                           */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x                                */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_SR_OFFSET                       (0x40)                                        /**<  (SSC_SR) Status Register  Offset */
+
+#define SSC_SR_TXRDY_Pos                    0                                              /**< (SSC_SR) Transmit Ready Position */
+#define SSC_SR_TXRDY_Msk                    (_U_(0x1) << SSC_SR_TXRDY_Pos)                 /**< (SSC_SR) Transmit Ready Mask */
+#define SSC_SR_TXRDY                        SSC_SR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXRDY_Msk instead */
+#define SSC_SR_TXEMPTY_Pos                  1                                              /**< (SSC_SR) Transmit Empty Position */
+#define SSC_SR_TXEMPTY_Msk                  (_U_(0x1) << SSC_SR_TXEMPTY_Pos)               /**< (SSC_SR) Transmit Empty Mask */
+#define SSC_SR_TXEMPTY                      SSC_SR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXEMPTY_Msk instead */
+#define SSC_SR_RXRDY_Pos                    4                                              /**< (SSC_SR) Receive Ready Position */
+#define SSC_SR_RXRDY_Msk                    (_U_(0x1) << SSC_SR_RXRDY_Pos)                 /**< (SSC_SR) Receive Ready Mask */
+#define SSC_SR_RXRDY                        SSC_SR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXRDY_Msk instead */
+#define SSC_SR_OVRUN_Pos                    5                                              /**< (SSC_SR) Receive Overrun Position */
+#define SSC_SR_OVRUN_Msk                    (_U_(0x1) << SSC_SR_OVRUN_Pos)                 /**< (SSC_SR) Receive Overrun Mask */
+#define SSC_SR_OVRUN                        SSC_SR_OVRUN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_OVRUN_Msk instead */
+#define SSC_SR_CP0_Pos                      8                                              /**< (SSC_SR) Compare 0 Position */
+#define SSC_SR_CP0_Msk                      (_U_(0x1) << SSC_SR_CP0_Pos)                   /**< (SSC_SR) Compare 0 Mask */
+#define SSC_SR_CP0                          SSC_SR_CP0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_CP0_Msk instead */
+#define SSC_SR_CP1_Pos                      9                                              /**< (SSC_SR) Compare 1 Position */
+#define SSC_SR_CP1_Msk                      (_U_(0x1) << SSC_SR_CP1_Pos)                   /**< (SSC_SR) Compare 1 Mask */
+#define SSC_SR_CP1                          SSC_SR_CP1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_CP1_Msk instead */
+#define SSC_SR_TXSYN_Pos                    10                                             /**< (SSC_SR) Transmit Sync Position */
+#define SSC_SR_TXSYN_Msk                    (_U_(0x1) << SSC_SR_TXSYN_Pos)                 /**< (SSC_SR) Transmit Sync Mask */
+#define SSC_SR_TXSYN                        SSC_SR_TXSYN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXSYN_Msk instead */
+#define SSC_SR_RXSYN_Pos                    11                                             /**< (SSC_SR) Receive Sync Position */
+#define SSC_SR_RXSYN_Msk                    (_U_(0x1) << SSC_SR_RXSYN_Pos)                 /**< (SSC_SR) Receive Sync Mask */
+#define SSC_SR_RXSYN                        SSC_SR_RXSYN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXSYN_Msk instead */
+#define SSC_SR_TXEN_Pos                     16                                             /**< (SSC_SR) Transmit Enable Position */
+#define SSC_SR_TXEN_Msk                     (_U_(0x1) << SSC_SR_TXEN_Pos)                  /**< (SSC_SR) Transmit Enable Mask */
+#define SSC_SR_TXEN                         SSC_SR_TXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXEN_Msk instead */
+#define SSC_SR_RXEN_Pos                     17                                             /**< (SSC_SR) Receive Enable Position */
+#define SSC_SR_RXEN_Msk                     (_U_(0x1) << SSC_SR_RXEN_Pos)                  /**< (SSC_SR) Receive Enable Mask */
+#define SSC_SR_RXEN                         SSC_SR_RXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXEN_Msk instead */
+#define SSC_SR_MASK                         _U_(0x30F33)                                   /**< \deprecated (SSC_SR) Register MASK  (Use SSC_SR_Msk instead)  */
+#define SSC_SR_Msk                          _U_(0x30F33)                                   /**< (SSC_SR) Register Mask  */
+
+#define SSC_SR_CP_Pos                       8                                              /**< (SSC_SR Position) Compare x */
+#define SSC_SR_CP_Msk                       (_U_(0x3) << SSC_SR_CP_Pos)                    /**< (SSC_SR Mask) CP */
+#define SSC_SR_CP(value)                    (SSC_SR_CP_Msk & ((value) << SSC_SR_CP_Pos))   
+
+/* -------- SSC_IER : (SSC Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Enable          */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Enable          */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Enable           */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Enable         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Enable                 */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Enable                 */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IER_OFFSET                      (0x44)                                        /**<  (SSC_IER) Interrupt Enable Register  Offset */
+
+#define SSC_IER_TXRDY_Pos                   0                                              /**< (SSC_IER) Transmit Ready Interrupt Enable Position */
+#define SSC_IER_TXRDY_Msk                   (_U_(0x1) << SSC_IER_TXRDY_Pos)                /**< (SSC_IER) Transmit Ready Interrupt Enable Mask */
+#define SSC_IER_TXRDY                       SSC_IER_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXRDY_Msk instead */
+#define SSC_IER_TXEMPTY_Pos                 1                                              /**< (SSC_IER) Transmit Empty Interrupt Enable Position */
+#define SSC_IER_TXEMPTY_Msk                 (_U_(0x1) << SSC_IER_TXEMPTY_Pos)              /**< (SSC_IER) Transmit Empty Interrupt Enable Mask */
+#define SSC_IER_TXEMPTY                     SSC_IER_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXEMPTY_Msk instead */
+#define SSC_IER_RXRDY_Pos                   4                                              /**< (SSC_IER) Receive Ready Interrupt Enable Position */
+#define SSC_IER_RXRDY_Msk                   (_U_(0x1) << SSC_IER_RXRDY_Pos)                /**< (SSC_IER) Receive Ready Interrupt Enable Mask */
+#define SSC_IER_RXRDY                       SSC_IER_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_RXRDY_Msk instead */
+#define SSC_IER_OVRUN_Pos                   5                                              /**< (SSC_IER) Receive Overrun Interrupt Enable Position */
+#define SSC_IER_OVRUN_Msk                   (_U_(0x1) << SSC_IER_OVRUN_Pos)                /**< (SSC_IER) Receive Overrun Interrupt Enable Mask */
+#define SSC_IER_OVRUN                       SSC_IER_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_OVRUN_Msk instead */
+#define SSC_IER_CP0_Pos                     8                                              /**< (SSC_IER) Compare 0 Interrupt Enable Position */
+#define SSC_IER_CP0_Msk                     (_U_(0x1) << SSC_IER_CP0_Pos)                  /**< (SSC_IER) Compare 0 Interrupt Enable Mask */
+#define SSC_IER_CP0                         SSC_IER_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_CP0_Msk instead */
+#define SSC_IER_CP1_Pos                     9                                              /**< (SSC_IER) Compare 1 Interrupt Enable Position */
+#define SSC_IER_CP1_Msk                     (_U_(0x1) << SSC_IER_CP1_Pos)                  /**< (SSC_IER) Compare 1 Interrupt Enable Mask */
+#define SSC_IER_CP1                         SSC_IER_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_CP1_Msk instead */
+#define SSC_IER_TXSYN_Pos                   10                                             /**< (SSC_IER) Tx Sync Interrupt Enable Position */
+#define SSC_IER_TXSYN_Msk                   (_U_(0x1) << SSC_IER_TXSYN_Pos)                /**< (SSC_IER) Tx Sync Interrupt Enable Mask */
+#define SSC_IER_TXSYN                       SSC_IER_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXSYN_Msk instead */
+#define SSC_IER_RXSYN_Pos                   11                                             /**< (SSC_IER) Rx Sync Interrupt Enable Position */
+#define SSC_IER_RXSYN_Msk                   (_U_(0x1) << SSC_IER_RXSYN_Pos)                /**< (SSC_IER) Rx Sync Interrupt Enable Mask */
+#define SSC_IER_RXSYN                       SSC_IER_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_RXSYN_Msk instead */
+#define SSC_IER_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IER) Register MASK  (Use SSC_IER_Msk instead)  */
+#define SSC_IER_Msk                         _U_(0xF33)                                     /**< (SSC_IER) Register Mask  */
+
+#define SSC_IER_CP_Pos                      8                                              /**< (SSC_IER Position) Compare x Interrupt Enable */
+#define SSC_IER_CP_Msk                      (_U_(0x3) << SSC_IER_CP_Pos)                   /**< (SSC_IER Mask) CP */
+#define SSC_IER_CP(value)                   (SSC_IER_CP_Msk & ((value) << SSC_IER_CP_Pos))  
+
+/* -------- SSC_IDR : (SSC Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Disable         */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Disable         */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Disable          */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Disable        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Disable              */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Disable              */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Enable                 */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Enable                 */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Disable              */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IDR_OFFSET                      (0x48)                                        /**<  (SSC_IDR) Interrupt Disable Register  Offset */
+
+#define SSC_IDR_TXRDY_Pos                   0                                              /**< (SSC_IDR) Transmit Ready Interrupt Disable Position */
+#define SSC_IDR_TXRDY_Msk                   (_U_(0x1) << SSC_IDR_TXRDY_Pos)                /**< (SSC_IDR) Transmit Ready Interrupt Disable Mask */
+#define SSC_IDR_TXRDY                       SSC_IDR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXRDY_Msk instead */
+#define SSC_IDR_TXEMPTY_Pos                 1                                              /**< (SSC_IDR) Transmit Empty Interrupt Disable Position */
+#define SSC_IDR_TXEMPTY_Msk                 (_U_(0x1) << SSC_IDR_TXEMPTY_Pos)              /**< (SSC_IDR) Transmit Empty Interrupt Disable Mask */
+#define SSC_IDR_TXEMPTY                     SSC_IDR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXEMPTY_Msk instead */
+#define SSC_IDR_RXRDY_Pos                   4                                              /**< (SSC_IDR) Receive Ready Interrupt Disable Position */
+#define SSC_IDR_RXRDY_Msk                   (_U_(0x1) << SSC_IDR_RXRDY_Pos)                /**< (SSC_IDR) Receive Ready Interrupt Disable Mask */
+#define SSC_IDR_RXRDY                       SSC_IDR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_RXRDY_Msk instead */
+#define SSC_IDR_OVRUN_Pos                   5                                              /**< (SSC_IDR) Receive Overrun Interrupt Disable Position */
+#define SSC_IDR_OVRUN_Msk                   (_U_(0x1) << SSC_IDR_OVRUN_Pos)                /**< (SSC_IDR) Receive Overrun Interrupt Disable Mask */
+#define SSC_IDR_OVRUN                       SSC_IDR_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_OVRUN_Msk instead */
+#define SSC_IDR_CP0_Pos                     8                                              /**< (SSC_IDR) Compare 0 Interrupt Disable Position */
+#define SSC_IDR_CP0_Msk                     (_U_(0x1) << SSC_IDR_CP0_Pos)                  /**< (SSC_IDR) Compare 0 Interrupt Disable Mask */
+#define SSC_IDR_CP0                         SSC_IDR_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_CP0_Msk instead */
+#define SSC_IDR_CP1_Pos                     9                                              /**< (SSC_IDR) Compare 1 Interrupt Disable Position */
+#define SSC_IDR_CP1_Msk                     (_U_(0x1) << SSC_IDR_CP1_Pos)                  /**< (SSC_IDR) Compare 1 Interrupt Disable Mask */
+#define SSC_IDR_CP1                         SSC_IDR_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_CP1_Msk instead */
+#define SSC_IDR_TXSYN_Pos                   10                                             /**< (SSC_IDR) Tx Sync Interrupt Enable Position */
+#define SSC_IDR_TXSYN_Msk                   (_U_(0x1) << SSC_IDR_TXSYN_Pos)                /**< (SSC_IDR) Tx Sync Interrupt Enable Mask */
+#define SSC_IDR_TXSYN                       SSC_IDR_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXSYN_Msk instead */
+#define SSC_IDR_RXSYN_Pos                   11                                             /**< (SSC_IDR) Rx Sync Interrupt Enable Position */
+#define SSC_IDR_RXSYN_Msk                   (_U_(0x1) << SSC_IDR_RXSYN_Pos)                /**< (SSC_IDR) Rx Sync Interrupt Enable Mask */
+#define SSC_IDR_RXSYN                       SSC_IDR_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_RXSYN_Msk instead */
+#define SSC_IDR_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IDR) Register MASK  (Use SSC_IDR_Msk instead)  */
+#define SSC_IDR_Msk                         _U_(0xF33)                                     /**< (SSC_IDR) Register Mask  */
+
+#define SSC_IDR_CP_Pos                      8                                              /**< (SSC_IDR Position) Compare x Interrupt Disable */
+#define SSC_IDR_CP_Msk                      (_U_(0x3) << SSC_IDR_CP_Pos)                   /**< (SSC_IDR Mask) CP */
+#define SSC_IDR_CP(value)                   (SSC_IDR_CP_Msk & ((value) << SSC_IDR_CP_Pos))  
+
+/* -------- SSC_IMR : (SSC Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Mask            */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Mask            */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Mask             */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Mask           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Mask                 */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Mask                 */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Mask                   */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Mask                   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Mask                 */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IMR_OFFSET                      (0x4C)                                        /**<  (SSC_IMR) Interrupt Mask Register  Offset */
+
+#define SSC_IMR_TXRDY_Pos                   0                                              /**< (SSC_IMR) Transmit Ready Interrupt Mask Position */
+#define SSC_IMR_TXRDY_Msk                   (_U_(0x1) << SSC_IMR_TXRDY_Pos)                /**< (SSC_IMR) Transmit Ready Interrupt Mask Mask */
+#define SSC_IMR_TXRDY                       SSC_IMR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXRDY_Msk instead */
+#define SSC_IMR_TXEMPTY_Pos                 1                                              /**< (SSC_IMR) Transmit Empty Interrupt Mask Position */
+#define SSC_IMR_TXEMPTY_Msk                 (_U_(0x1) << SSC_IMR_TXEMPTY_Pos)              /**< (SSC_IMR) Transmit Empty Interrupt Mask Mask */
+#define SSC_IMR_TXEMPTY                     SSC_IMR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXEMPTY_Msk instead */
+#define SSC_IMR_RXRDY_Pos                   4                                              /**< (SSC_IMR) Receive Ready Interrupt Mask Position */
+#define SSC_IMR_RXRDY_Msk                   (_U_(0x1) << SSC_IMR_RXRDY_Pos)                /**< (SSC_IMR) Receive Ready Interrupt Mask Mask */
+#define SSC_IMR_RXRDY                       SSC_IMR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_RXRDY_Msk instead */
+#define SSC_IMR_OVRUN_Pos                   5                                              /**< (SSC_IMR) Receive Overrun Interrupt Mask Position */
+#define SSC_IMR_OVRUN_Msk                   (_U_(0x1) << SSC_IMR_OVRUN_Pos)                /**< (SSC_IMR) Receive Overrun Interrupt Mask Mask */
+#define SSC_IMR_OVRUN                       SSC_IMR_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_OVRUN_Msk instead */
+#define SSC_IMR_CP0_Pos                     8                                              /**< (SSC_IMR) Compare 0 Interrupt Mask Position */
+#define SSC_IMR_CP0_Msk                     (_U_(0x1) << SSC_IMR_CP0_Pos)                  /**< (SSC_IMR) Compare 0 Interrupt Mask Mask */
+#define SSC_IMR_CP0                         SSC_IMR_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_CP0_Msk instead */
+#define SSC_IMR_CP1_Pos                     9                                              /**< (SSC_IMR) Compare 1 Interrupt Mask Position */
+#define SSC_IMR_CP1_Msk                     (_U_(0x1) << SSC_IMR_CP1_Pos)                  /**< (SSC_IMR) Compare 1 Interrupt Mask Mask */
+#define SSC_IMR_CP1                         SSC_IMR_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_CP1_Msk instead */
+#define SSC_IMR_TXSYN_Pos                   10                                             /**< (SSC_IMR) Tx Sync Interrupt Mask Position */
+#define SSC_IMR_TXSYN_Msk                   (_U_(0x1) << SSC_IMR_TXSYN_Pos)                /**< (SSC_IMR) Tx Sync Interrupt Mask Mask */
+#define SSC_IMR_TXSYN                       SSC_IMR_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXSYN_Msk instead */
+#define SSC_IMR_RXSYN_Pos                   11                                             /**< (SSC_IMR) Rx Sync Interrupt Mask Position */
+#define SSC_IMR_RXSYN_Msk                   (_U_(0x1) << SSC_IMR_RXSYN_Pos)                /**< (SSC_IMR) Rx Sync Interrupt Mask Mask */
+#define SSC_IMR_RXSYN                       SSC_IMR_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_RXSYN_Msk instead */
+#define SSC_IMR_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IMR) Register MASK  (Use SSC_IMR_Msk instead)  */
+#define SSC_IMR_Msk                         _U_(0xF33)                                     /**< (SSC_IMR) Register Mask  */
+
+#define SSC_IMR_CP_Pos                      8                                              /**< (SSC_IMR Position) Compare x Interrupt Mask */
+#define SSC_IMR_CP_Msk                      (_U_(0x3) << SSC_IMR_CP_Pos)                   /**< (SSC_IMR Mask) CP */
+#define SSC_IMR_CP(value)                   (SSC_IMR_CP_Msk & ((value) << SSC_IMR_CP_Pos))  
+
+/* -------- SSC_WPMR : (SSC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_WPMR_OFFSET                     (0xE4)                                        /**<  (SSC_WPMR) Write Protection Mode Register  Offset */
+
+#define SSC_WPMR_WPEN_Pos                   0                                              /**< (SSC_WPMR) Write Protection Enable Position */
+#define SSC_WPMR_WPEN_Msk                   (_U_(0x1) << SSC_WPMR_WPEN_Pos)                /**< (SSC_WPMR) Write Protection Enable Mask */
+#define SSC_WPMR_WPEN                       SSC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_WPMR_WPEN_Msk instead */
+#define SSC_WPMR_WPKEY_Pos                  8                                              /**< (SSC_WPMR) Write Protection Key Position */
+#define SSC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SSC_WPMR_WPKEY_Pos)          /**< (SSC_WPMR) Write Protection Key Mask */
+#define SSC_WPMR_WPKEY(value)               (SSC_WPMR_WPKEY_Msk & ((value) << SSC_WPMR_WPKEY_Pos))
+#define   SSC_WPMR_WPKEY_PASSWD_Val         _U_(0x535343)                                  /**< (SSC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define SSC_WPMR_WPKEY_PASSWD               (SSC_WPMR_WPKEY_PASSWD_Val << SSC_WPMR_WPKEY_Pos)  /**< (SSC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define SSC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SSC_WPMR) Register MASK  (Use SSC_WPMR_Msk instead)  */
+#define SSC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SSC_WPMR) Register Mask  */
+
+
+/* -------- SSC_WPSR : (SSC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protect Violation Source           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_WPSR_OFFSET                     (0xE8)                                        /**<  (SSC_WPSR) Write Protection Status Register  Offset */
+
+#define SSC_WPSR_WPVS_Pos                   0                                              /**< (SSC_WPSR) Write Protection Violation Status Position */
+#define SSC_WPSR_WPVS_Msk                   (_U_(0x1) << SSC_WPSR_WPVS_Pos)                /**< (SSC_WPSR) Write Protection Violation Status Mask */
+#define SSC_WPSR_WPVS                       SSC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_WPSR_WPVS_Msk instead */
+#define SSC_WPSR_WPVSRC_Pos                 8                                              /**< (SSC_WPSR) Write Protect Violation Source Position */
+#define SSC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << SSC_WPSR_WPVSRC_Pos)           /**< (SSC_WPSR) Write Protect Violation Source Mask */
+#define SSC_WPSR_WPVSRC(value)              (SSC_WPSR_WPVSRC_Msk & ((value) << SSC_WPSR_WPVSRC_Pos))
+#define SSC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (SSC_WPSR) Register MASK  (Use SSC_WPSR_Msk instead)  */
+#define SSC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (SSC_WPSR) Register Mask  */
+
+
+/* -------- SSC_VERSION : (SSC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:16;                /**< bit:  0..15  Version of the Hardware Module           */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_VERSION_OFFSET                  (0xFC)                                        /**<  (SSC_VERSION) Version Register  Offset */
+
+#define SSC_VERSION_VERSION_Pos             0                                              /**< (SSC_VERSION) Version of the Hardware Module Position */
+#define SSC_VERSION_VERSION_Msk             (_U_(0xFFFF) << SSC_VERSION_VERSION_Pos)       /**< (SSC_VERSION) Version of the Hardware Module Mask */
+#define SSC_VERSION_VERSION(value)          (SSC_VERSION_VERSION_Msk & ((value) << SSC_VERSION_VERSION_Pos))
+#define SSC_VERSION_MFN_Pos                 16                                             /**< (SSC_VERSION) Metal Fix Number Position */
+#define SSC_VERSION_MFN_Msk                 (_U_(0x7) << SSC_VERSION_MFN_Pos)              /**< (SSC_VERSION) Metal Fix Number Mask */
+#define SSC_VERSION_MFN(value)              (SSC_VERSION_MFN_Msk & ((value) << SSC_VERSION_MFN_Pos))
+#define SSC_VERSION_MASK                    _U_(0x7FFFF)                                   /**< \deprecated (SSC_VERSION) Register MASK  (Use SSC_VERSION_Msk instead)  */
+#define SSC_VERSION_Msk                     _U_(0x7FFFF)                                   /**< (SSC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SSC hardware registers */
+typedef struct {  
+  __O  uint32_t SSC_CR;         /**< (SSC Offset: 0x00) Control Register */
+  __IO uint32_t SSC_CMR;        /**< (SSC Offset: 0x04) Clock Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t SSC_RCMR;       /**< (SSC Offset: 0x10) Receive Clock Mode Register */
+  __IO uint32_t SSC_RFMR;       /**< (SSC Offset: 0x14) Receive Frame Mode Register */
+  __IO uint32_t SSC_TCMR;       /**< (SSC Offset: 0x18) Transmit Clock Mode Register */
+  __IO uint32_t SSC_TFMR;       /**< (SSC Offset: 0x1C) Transmit Frame Mode Register */
+  __I  uint32_t SSC_RHR;        /**< (SSC Offset: 0x20) Receive Holding Register */
+  __O  uint32_t SSC_THR;        /**< (SSC Offset: 0x24) Transmit Holding Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  uint32_t SSC_RSHR;       /**< (SSC Offset: 0x30) Receive Sync. Holding Register */
+  __IO uint32_t SSC_TSHR;       /**< (SSC Offset: 0x34) Transmit Sync. Holding Register */
+  __IO uint32_t SSC_RC0R;       /**< (SSC Offset: 0x38) Receive Compare 0 Register */
+  __IO uint32_t SSC_RC1R;       /**< (SSC Offset: 0x3C) Receive Compare 1 Register */
+  __I  uint32_t SSC_SR;         /**< (SSC Offset: 0x40) Status Register */
+  __O  uint32_t SSC_IER;        /**< (SSC Offset: 0x44) Interrupt Enable Register */
+  __O  uint32_t SSC_IDR;        /**< (SSC Offset: 0x48) Interrupt Disable Register */
+  __I  uint32_t SSC_IMR;        /**< (SSC Offset: 0x4C) Interrupt Mask Register */
+  __I  uint8_t                        Reserved3[148];
+  __IO uint32_t SSC_WPMR;       /**< (SSC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t SSC_WPSR;       /**< (SSC Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  uint32_t SSC_VERSION;    /**< (SSC Offset: 0xFC) Version Register */
+} Ssc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SSC hardware registers */
+typedef struct {  
+  __O  SSC_CR_Type                    SSC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO SSC_CMR_Type                   SSC_CMR;        /**< Offset: 0x04 (R/W  32) Clock Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO SSC_RCMR_Type                  SSC_RCMR;       /**< Offset: 0x10 (R/W  32) Receive Clock Mode Register */
+  __IO SSC_RFMR_Type                  SSC_RFMR;       /**< Offset: 0x14 (R/W  32) Receive Frame Mode Register */
+  __IO SSC_TCMR_Type                  SSC_TCMR;       /**< Offset: 0x18 (R/W  32) Transmit Clock Mode Register */
+  __IO SSC_TFMR_Type                  SSC_TFMR;       /**< Offset: 0x1C (R/W  32) Transmit Frame Mode Register */
+  __I  SSC_RHR_Type                   SSC_RHR;        /**< Offset: 0x20 (R/   32) Receive Holding Register */
+  __O  SSC_THR_Type                   SSC_THR;        /**< Offset: 0x24 ( /W  32) Transmit Holding Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  SSC_RSHR_Type                  SSC_RSHR;       /**< Offset: 0x30 (R/   32) Receive Sync. Holding Register */
+  __IO SSC_TSHR_Type                  SSC_TSHR;       /**< Offset: 0x34 (R/W  32) Transmit Sync. Holding Register */
+  __IO SSC_RC0R_Type                  SSC_RC0R;       /**< Offset: 0x38 (R/W  32) Receive Compare 0 Register */
+  __IO SSC_RC1R_Type                  SSC_RC1R;       /**< Offset: 0x3C (R/W  32) Receive Compare 1 Register */
+  __I  SSC_SR_Type                    SSC_SR;         /**< Offset: 0x40 (R/   32) Status Register */
+  __O  SSC_IER_Type                   SSC_IER;        /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
+  __O  SSC_IDR_Type                   SSC_IDR;        /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
+  __I  SSC_IMR_Type                   SSC_IMR;        /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
+  __I  uint8_t                        Reserved3[148];
+  __IO SSC_WPMR_Type                  SSC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  SSC_WPSR_Type                  SSC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  SSC_VERSION_Type               SSC_VERSION;    /**< Offset: 0xFC (R/   32) Version Register */
+} Ssc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Synchronous Serial Controller */
+
+#endif /* _SAMV71_SSC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/supc.h
+++ b/asf/sam/include/samv71/component/supc.h
@@ -1,0 +1,854 @@
+/**
+ * \file
+ *
+ * \brief Component description for SUPC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SUPC_COMPONENT_H_
+#define _SAMV71_SUPC_COMPONENT_H_
+#define _SAMV71_SUPC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Supply Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SUPC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SUPC_6452                       /**< (SUPC) Module ID */
+#define REV_SUPC ZB                     /**< (SUPC) Module revision */
+
+/* -------- SUPC_CR : (SUPC Offset: 0x00) (/W 32) Supply Controller Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t VROFF:1;                   /**< bit:      2  Voltage Regulator Off                    */
+    uint32_t XTALSEL:1;                 /**< bit:      3  Crystal Oscillator Select                */
+    uint32_t :20;                       /**< bit:  4..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_CR_OFFSET                      (0x00)                                        /**<  (SUPC_CR) Supply Controller Control Register  Offset */
+
+#define SUPC_CR_VROFF_Pos                   2                                              /**< (SUPC_CR) Voltage Regulator Off Position */
+#define SUPC_CR_VROFF_Msk                   (_U_(0x1) << SUPC_CR_VROFF_Pos)                /**< (SUPC_CR) Voltage Regulator Off Mask */
+#define SUPC_CR_VROFF                       SUPC_CR_VROFF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_CR_VROFF_Msk instead */
+#define   SUPC_CR_VROFF_NO_EFFECT_Val       _U_(0x0)                                       /**< (SUPC_CR) No effect.  */
+#define   SUPC_CR_VROFF_STOP_VREG_Val       _U_(0x1)                                       /**< (SUPC_CR) If KEY is correct, VROFF asserts the vddcore_nreset and stops the voltage regulator.  */
+#define SUPC_CR_VROFF_NO_EFFECT             (SUPC_CR_VROFF_NO_EFFECT_Val << SUPC_CR_VROFF_Pos)  /**< (SUPC_CR) No effect. Position  */
+#define SUPC_CR_VROFF_STOP_VREG             (SUPC_CR_VROFF_STOP_VREG_Val << SUPC_CR_VROFF_Pos)  /**< (SUPC_CR) If KEY is correct, VROFF asserts the vddcore_nreset and stops the voltage regulator. Position  */
+#define SUPC_CR_XTALSEL_Pos                 3                                              /**< (SUPC_CR) Crystal Oscillator Select Position */
+#define SUPC_CR_XTALSEL_Msk                 (_U_(0x1) << SUPC_CR_XTALSEL_Pos)              /**< (SUPC_CR) Crystal Oscillator Select Mask */
+#define SUPC_CR_XTALSEL                     SUPC_CR_XTALSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_CR_XTALSEL_Msk instead */
+#define   SUPC_CR_XTALSEL_NO_EFFECT_Val     _U_(0x0)                                       /**< (SUPC_CR) No effect.  */
+#define   SUPC_CR_XTALSEL_CRYSTAL_SEL_Val   _U_(0x1)                                       /**< (SUPC_CR) If KEY is correct, XTALSEL switches the slow clock on the crystal oscillator output.  */
+#define SUPC_CR_XTALSEL_NO_EFFECT           (SUPC_CR_XTALSEL_NO_EFFECT_Val << SUPC_CR_XTALSEL_Pos)  /**< (SUPC_CR) No effect. Position  */
+#define SUPC_CR_XTALSEL_CRYSTAL_SEL         (SUPC_CR_XTALSEL_CRYSTAL_SEL_Val << SUPC_CR_XTALSEL_Pos)  /**< (SUPC_CR) If KEY is correct, XTALSEL switches the slow clock on the crystal oscillator output. Position  */
+#define SUPC_CR_KEY_Pos                     24                                             /**< (SUPC_CR) Password Position */
+#define SUPC_CR_KEY_Msk                     (_U_(0xFF) << SUPC_CR_KEY_Pos)                 /**< (SUPC_CR) Password Mask */
+#define SUPC_CR_KEY(value)                  (SUPC_CR_KEY_Msk & ((value) << SUPC_CR_KEY_Pos))
+#define   SUPC_CR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (SUPC_CR) Writing any other value in this field aborts the write operation.  */
+#define SUPC_CR_KEY_PASSWD                  (SUPC_CR_KEY_PASSWD_Val << SUPC_CR_KEY_Pos)    /**< (SUPC_CR) Writing any other value in this field aborts the write operation. Position  */
+#define SUPC_CR_MASK                        _U_(0xFF00000C)                                /**< \deprecated (SUPC_CR) Register MASK  (Use SUPC_CR_Msk instead)  */
+#define SUPC_CR_Msk                         _U_(0xFF00000C)                                /**< (SUPC_CR) Register Mask  */
+
+
+/* -------- SUPC_SMMR : (SUPC Offset: 0x04) (R/W 32) Supply Controller Supply Monitor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMTH:4;                    /**< bit:   0..3  Supply Monitor Threshold                 */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t SMSMPL:3;                  /**< bit:  8..10  Supply Monitor Sampling Period           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t SMRSTEN:1;                 /**< bit:     12  Supply Monitor Reset Enable              */
+    uint32_t SMIEN:1;                   /**< bit:     13  Supply Monitor Interrupt Enable          */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_SMMR_OFFSET                    (0x04)                                        /**<  (SUPC_SMMR) Supply Controller Supply Monitor Mode Register  Offset */
+
+#define SUPC_SMMR_SMTH_Pos                  0                                              /**< (SUPC_SMMR) Supply Monitor Threshold Position */
+#define SUPC_SMMR_SMTH_Msk                  (_U_(0xF) << SUPC_SMMR_SMTH_Pos)               /**< (SUPC_SMMR) Supply Monitor Threshold Mask */
+#define SUPC_SMMR_SMTH(value)               (SUPC_SMMR_SMTH_Msk & ((value) << SUPC_SMMR_SMTH_Pos))
+#define SUPC_SMMR_SMSMPL_Pos                8                                              /**< (SUPC_SMMR) Supply Monitor Sampling Period Position */
+#define SUPC_SMMR_SMSMPL_Msk                (_U_(0x7) << SUPC_SMMR_SMSMPL_Pos)             /**< (SUPC_SMMR) Supply Monitor Sampling Period Mask */
+#define SUPC_SMMR_SMSMPL(value)             (SUPC_SMMR_SMSMPL_Msk & ((value) << SUPC_SMMR_SMSMPL_Pos))
+#define   SUPC_SMMR_SMSMPL_SMD_Val          _U_(0x0)                                       /**< (SUPC_SMMR) Supply Monitor disabled  */
+#define   SUPC_SMMR_SMSMPL_CSM_Val          _U_(0x1)                                       /**< (SUPC_SMMR) Continuous Supply Monitor  */
+#define   SUPC_SMMR_SMSMPL_32SLCK_Val       _U_(0x2)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 32 SLCK periods  */
+#define   SUPC_SMMR_SMSMPL_256SLCK_Val      _U_(0x3)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 256 SLCK periods  */
+#define   SUPC_SMMR_SMSMPL_2048SLCK_Val     _U_(0x4)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 2,048 SLCK periods  */
+#define SUPC_SMMR_SMSMPL_SMD                (SUPC_SMMR_SMSMPL_SMD_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor disabled Position  */
+#define SUPC_SMMR_SMSMPL_CSM                (SUPC_SMMR_SMSMPL_CSM_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Continuous Supply Monitor Position  */
+#define SUPC_SMMR_SMSMPL_32SLCK             (SUPC_SMMR_SMSMPL_32SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 32 SLCK periods Position  */
+#define SUPC_SMMR_SMSMPL_256SLCK            (SUPC_SMMR_SMSMPL_256SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 256 SLCK periods Position  */
+#define SUPC_SMMR_SMSMPL_2048SLCK           (SUPC_SMMR_SMSMPL_2048SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 2,048 SLCK periods Position  */
+#define SUPC_SMMR_SMRSTEN_Pos               12                                             /**< (SUPC_SMMR) Supply Monitor Reset Enable Position */
+#define SUPC_SMMR_SMRSTEN_Msk               (_U_(0x1) << SUPC_SMMR_SMRSTEN_Pos)            /**< (SUPC_SMMR) Supply Monitor Reset Enable Mask */
+#define SUPC_SMMR_SMRSTEN                   SUPC_SMMR_SMRSTEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SMMR_SMRSTEN_Msk instead */
+#define   SUPC_SMMR_SMRSTEN_NOT_ENABLE_Val  _U_(0x0)                                       /**< (SUPC_SMMR) The core reset signal vddcore_nreset is not affected when a supply monitor detection occurs.  */
+#define   SUPC_SMMR_SMRSTEN_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_SMMR) The core reset signal, vddcore_nreset is asserted when a supply monitor detection occurs.  */
+#define SUPC_SMMR_SMRSTEN_NOT_ENABLE        (SUPC_SMMR_SMRSTEN_NOT_ENABLE_Val << SUPC_SMMR_SMRSTEN_Pos)  /**< (SUPC_SMMR) The core reset signal vddcore_nreset is not affected when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMRSTEN_ENABLE            (SUPC_SMMR_SMRSTEN_ENABLE_Val << SUPC_SMMR_SMRSTEN_Pos)  /**< (SUPC_SMMR) The core reset signal, vddcore_nreset is asserted when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMIEN_Pos                 13                                             /**< (SUPC_SMMR) Supply Monitor Interrupt Enable Position */
+#define SUPC_SMMR_SMIEN_Msk                 (_U_(0x1) << SUPC_SMMR_SMIEN_Pos)              /**< (SUPC_SMMR) Supply Monitor Interrupt Enable Mask */
+#define SUPC_SMMR_SMIEN                     SUPC_SMMR_SMIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SMMR_SMIEN_Msk instead */
+#define   SUPC_SMMR_SMIEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_SMMR) The SUPC interrupt signal is not affected when a supply monitor detection occurs.  */
+#define   SUPC_SMMR_SMIEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_SMMR) The SUPC interrupt signal is asserted when a supply monitor detection occurs.  */
+#define SUPC_SMMR_SMIEN_NOT_ENABLE          (SUPC_SMMR_SMIEN_NOT_ENABLE_Val << SUPC_SMMR_SMIEN_Pos)  /**< (SUPC_SMMR) The SUPC interrupt signal is not affected when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMIEN_ENABLE              (SUPC_SMMR_SMIEN_ENABLE_Val << SUPC_SMMR_SMIEN_Pos)  /**< (SUPC_SMMR) The SUPC interrupt signal is asserted when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_MASK                      _U_(0x370F)                                    /**< \deprecated (SUPC_SMMR) Register MASK  (Use SUPC_SMMR_Msk instead)  */
+#define SUPC_SMMR_Msk                       _U_(0x370F)                                    /**< (SUPC_SMMR) Register Mask  */
+
+
+/* -------- SUPC_MR : (SUPC Offset: 0x08) (R/W 32) Supply Controller Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t BODRSTEN:1;                /**< bit:     12  Brownout Detector Reset Enable           */
+    uint32_t BODDIS:1;                  /**< bit:     13  Brownout Detector Disable                */
+    uint32_t ONREG:1;                   /**< bit:     14  Voltage Regulator Enable                 */
+    uint32_t :2;                        /**< bit: 15..16  Reserved */
+    uint32_t BKUPRETON:1;               /**< bit:     17  SRAM On In Backup Mode                   */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t OSCBYPASS:1;               /**< bit:     20  Oscillator Bypass                        */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password Key                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_MR_OFFSET                      (0x08)                                        /**<  (SUPC_MR) Supply Controller Mode Register  Offset */
+
+#define SUPC_MR_BODRSTEN_Pos                12                                             /**< (SUPC_MR) Brownout Detector Reset Enable Position */
+#define SUPC_MR_BODRSTEN_Msk                (_U_(0x1) << SUPC_MR_BODRSTEN_Pos)             /**< (SUPC_MR) Brownout Detector Reset Enable Mask */
+#define SUPC_MR_BODRSTEN                    SUPC_MR_BODRSTEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BODRSTEN_Msk instead */
+#define   SUPC_MR_BODRSTEN_NOT_ENABLE_Val   _U_(0x0)                                       /**< (SUPC_MR) The core reset signal vddcore_nreset is not affected when a brownout detection occurs.  */
+#define   SUPC_MR_BODRSTEN_ENABLE_Val       _U_(0x1)                                       /**< (SUPC_MR) The core reset signal, vddcore_nreset is asserted when a brownout detection occurs.  */
+#define SUPC_MR_BODRSTEN_NOT_ENABLE         (SUPC_MR_BODRSTEN_NOT_ENABLE_Val << SUPC_MR_BODRSTEN_Pos)  /**< (SUPC_MR) The core reset signal vddcore_nreset is not affected when a brownout detection occurs. Position  */
+#define SUPC_MR_BODRSTEN_ENABLE             (SUPC_MR_BODRSTEN_ENABLE_Val << SUPC_MR_BODRSTEN_Pos)  /**< (SUPC_MR) The core reset signal, vddcore_nreset is asserted when a brownout detection occurs. Position  */
+#define SUPC_MR_BODDIS_Pos                  13                                             /**< (SUPC_MR) Brownout Detector Disable Position */
+#define SUPC_MR_BODDIS_Msk                  (_U_(0x1) << SUPC_MR_BODDIS_Pos)               /**< (SUPC_MR) Brownout Detector Disable Mask */
+#define SUPC_MR_BODDIS                      SUPC_MR_BODDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BODDIS_Msk instead */
+#define   SUPC_MR_BODDIS_ENABLE_Val         _U_(0x0)                                       /**< (SUPC_MR) The core brownout detector is enabled.  */
+#define   SUPC_MR_BODDIS_DISABLE_Val        _U_(0x1)                                       /**< (SUPC_MR) The core brownout detector is disabled.  */
+#define SUPC_MR_BODDIS_ENABLE               (SUPC_MR_BODDIS_ENABLE_Val << SUPC_MR_BODDIS_Pos)  /**< (SUPC_MR) The core brownout detector is enabled. Position  */
+#define SUPC_MR_BODDIS_DISABLE              (SUPC_MR_BODDIS_DISABLE_Val << SUPC_MR_BODDIS_Pos)  /**< (SUPC_MR) The core brownout detector is disabled. Position  */
+#define SUPC_MR_ONREG_Pos                   14                                             /**< (SUPC_MR) Voltage Regulator Enable Position */
+#define SUPC_MR_ONREG_Msk                   (_U_(0x1) << SUPC_MR_ONREG_Pos)                /**< (SUPC_MR) Voltage Regulator Enable Mask */
+#define SUPC_MR_ONREG                       SUPC_MR_ONREG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_ONREG_Msk instead */
+#define   SUPC_MR_ONREG_ONREG_UNUSED_Val    _U_(0x0)                                       /**< (SUPC_MR) Internal voltage regulator is not used (external power supply is used).  */
+#define   SUPC_MR_ONREG_ONREG_USED_Val      _U_(0x1)                                       /**< (SUPC_MR) Internal voltage regulator is used.  */
+#define SUPC_MR_ONREG_ONREG_UNUSED          (SUPC_MR_ONREG_ONREG_UNUSED_Val << SUPC_MR_ONREG_Pos)  /**< (SUPC_MR) Internal voltage regulator is not used (external power supply is used). Position  */
+#define SUPC_MR_ONREG_ONREG_USED            (SUPC_MR_ONREG_ONREG_USED_Val << SUPC_MR_ONREG_Pos)  /**< (SUPC_MR) Internal voltage regulator is used. Position  */
+#define SUPC_MR_BKUPRETON_Pos               17                                             /**< (SUPC_MR) SRAM On In Backup Mode Position */
+#define SUPC_MR_BKUPRETON_Msk               (_U_(0x1) << SUPC_MR_BKUPRETON_Pos)            /**< (SUPC_MR) SRAM On In Backup Mode Mask */
+#define SUPC_MR_BKUPRETON                   SUPC_MR_BKUPRETON_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BKUPRETON_Msk instead */
+#define SUPC_MR_OSCBYPASS_Pos               20                                             /**< (SUPC_MR) Oscillator Bypass Position */
+#define SUPC_MR_OSCBYPASS_Msk               (_U_(0x1) << SUPC_MR_OSCBYPASS_Pos)            /**< (SUPC_MR) Oscillator Bypass Mask */
+#define SUPC_MR_OSCBYPASS                   SUPC_MR_OSCBYPASS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_OSCBYPASS_Msk instead */
+#define   SUPC_MR_OSCBYPASS_NO_EFFECT_Val   _U_(0x0)                                       /**< (SUPC_MR) No effect. Clock selection depends on the value of XTALSEL (SUPC_CR).  */
+#define   SUPC_MR_OSCBYPASS_BYPASS_Val      _U_(0x1)                                       /**< (SUPC_MR) The 32 kHz crystal oscillator is bypassed if XTALSEL (SUPC_CR) is set. OSCBYPASS must be set prior to setting XTALSEL.  */
+#define SUPC_MR_OSCBYPASS_NO_EFFECT         (SUPC_MR_OSCBYPASS_NO_EFFECT_Val << SUPC_MR_OSCBYPASS_Pos)  /**< (SUPC_MR) No effect. Clock selection depends on the value of XTALSEL (SUPC_CR). Position  */
+#define SUPC_MR_OSCBYPASS_BYPASS            (SUPC_MR_OSCBYPASS_BYPASS_Val << SUPC_MR_OSCBYPASS_Pos)  /**< (SUPC_MR) The 32 kHz crystal oscillator is bypassed if XTALSEL (SUPC_CR) is set. OSCBYPASS must be set prior to setting XTALSEL. Position  */
+#define SUPC_MR_KEY_Pos                     24                                             /**< (SUPC_MR) Password Key Position */
+#define SUPC_MR_KEY_Msk                     (_U_(0xFF) << SUPC_MR_KEY_Pos)                 /**< (SUPC_MR) Password Key Mask */
+#define SUPC_MR_KEY(value)                  (SUPC_MR_KEY_Msk & ((value) << SUPC_MR_KEY_Pos))
+#define   SUPC_MR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (SUPC_MR) Writing any other value in this field aborts the write operation.  */
+#define SUPC_MR_KEY_PASSWD                  (SUPC_MR_KEY_PASSWD_Val << SUPC_MR_KEY_Pos)    /**< (SUPC_MR) Writing any other value in this field aborts the write operation. Position  */
+#define SUPC_MR_MASK                        _U_(0xFF127000)                                /**< \deprecated (SUPC_MR) Register MASK  (Use SUPC_MR_Msk instead)  */
+#define SUPC_MR_Msk                         _U_(0xFF127000)                                /**< (SUPC_MR) Register Mask  */
+
+
+/* -------- SUPC_WUMR : (SUPC Offset: 0x0c) (R/W 32) Supply Controller Wakeup Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      1  Supply Monitor Wakeup Enable             */
+    uint32_t RTTEN:1;                   /**< bit:      2  Real-time Timer Wakeup Enable            */
+    uint32_t RTCEN:1;                   /**< bit:      3  Real-time Clock Wakeup Enable            */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t LPDBCEN0:1;                /**< bit:      5  Low-power Debouncer Enable WKUP0         */
+    uint32_t LPDBCEN1:1;                /**< bit:      6  Low-power Debouncer Enable WKUP1         */
+    uint32_t LPDBCCLR:1;                /**< bit:      7  Low-power Debouncer Clear                */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t WKUPDBC:3;                 /**< bit: 12..14  Wakeup Inputs Debouncer Period           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t LPDBC:3;                   /**< bit: 16..18  Low-power Debouncer Period               */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t LPDBCEN:2;                 /**< bit:   5..6  Low-power Debouncer Enable WKUPx         */
+    uint32_t :25;                       /**< bit:  7..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_WUMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_WUMR_OFFSET                    (0x0C)                                        /**<  (SUPC_WUMR) Supply Controller Wakeup Mode Register  Offset */
+
+#define SUPC_WUMR_SMEN_Pos                  1                                              /**< (SUPC_WUMR) Supply Monitor Wakeup Enable Position */
+#define SUPC_WUMR_SMEN_Msk                  (_U_(0x1) << SUPC_WUMR_SMEN_Pos)               /**< (SUPC_WUMR) Supply Monitor Wakeup Enable Mask */
+#define SUPC_WUMR_SMEN                      SUPC_WUMR_SMEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_SMEN_Msk instead */
+#define   SUPC_WUMR_SMEN_NOT_ENABLE_Val     _U_(0x0)                                       /**< (SUPC_WUMR) The supply monitor detection has no wakeup effect.  */
+#define   SUPC_WUMR_SMEN_ENABLE_Val         _U_(0x1)                                       /**< (SUPC_WUMR) The supply monitor detection forces the wakeup of the core power supply.  */
+#define SUPC_WUMR_SMEN_NOT_ENABLE           (SUPC_WUMR_SMEN_NOT_ENABLE_Val << SUPC_WUMR_SMEN_Pos)  /**< (SUPC_WUMR) The supply monitor detection has no wakeup effect. Position  */
+#define SUPC_WUMR_SMEN_ENABLE               (SUPC_WUMR_SMEN_ENABLE_Val << SUPC_WUMR_SMEN_Pos)  /**< (SUPC_WUMR) The supply monitor detection forces the wakeup of the core power supply. Position  */
+#define SUPC_WUMR_RTTEN_Pos                 2                                              /**< (SUPC_WUMR) Real-time Timer Wakeup Enable Position */
+#define SUPC_WUMR_RTTEN_Msk                 (_U_(0x1) << SUPC_WUMR_RTTEN_Pos)              /**< (SUPC_WUMR) Real-time Timer Wakeup Enable Mask */
+#define SUPC_WUMR_RTTEN                     SUPC_WUMR_RTTEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_RTTEN_Msk instead */
+#define   SUPC_WUMR_RTTEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_WUMR) The RTT alarm signal has no wakeup effect.  */
+#define   SUPC_WUMR_RTTEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_WUMR) The RTT alarm signal forces the wakeup of the core power supply.  */
+#define SUPC_WUMR_RTTEN_NOT_ENABLE          (SUPC_WUMR_RTTEN_NOT_ENABLE_Val << SUPC_WUMR_RTTEN_Pos)  /**< (SUPC_WUMR) The RTT alarm signal has no wakeup effect. Position  */
+#define SUPC_WUMR_RTTEN_ENABLE              (SUPC_WUMR_RTTEN_ENABLE_Val << SUPC_WUMR_RTTEN_Pos)  /**< (SUPC_WUMR) The RTT alarm signal forces the wakeup of the core power supply. Position  */
+#define SUPC_WUMR_RTCEN_Pos                 3                                              /**< (SUPC_WUMR) Real-time Clock Wakeup Enable Position */
+#define SUPC_WUMR_RTCEN_Msk                 (_U_(0x1) << SUPC_WUMR_RTCEN_Pos)              /**< (SUPC_WUMR) Real-time Clock Wakeup Enable Mask */
+#define SUPC_WUMR_RTCEN                     SUPC_WUMR_RTCEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_RTCEN_Msk instead */
+#define   SUPC_WUMR_RTCEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_WUMR) The RTC alarm signal has no wakeup effect.  */
+#define   SUPC_WUMR_RTCEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_WUMR) The RTC alarm signal forces the wakeup of the core power supply.  */
+#define SUPC_WUMR_RTCEN_NOT_ENABLE          (SUPC_WUMR_RTCEN_NOT_ENABLE_Val << SUPC_WUMR_RTCEN_Pos)  /**< (SUPC_WUMR) The RTC alarm signal has no wakeup effect. Position  */
+#define SUPC_WUMR_RTCEN_ENABLE              (SUPC_WUMR_RTCEN_ENABLE_Val << SUPC_WUMR_RTCEN_Pos)  /**< (SUPC_WUMR) The RTC alarm signal forces the wakeup of the core power supply. Position  */
+#define SUPC_WUMR_LPDBCEN0_Pos              5                                              /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP0 Position */
+#define SUPC_WUMR_LPDBCEN0_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCEN0_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP0 Mask */
+#define SUPC_WUMR_LPDBCEN0                  SUPC_WUMR_LPDBCEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCEN0_Msk instead */
+#define   SUPC_WUMR_LPDBCEN0_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) The WKUP0 input pin is not connected to the low-power debouncer.  */
+#define   SUPC_WUMR_LPDBCEN0_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) The WKUP0 input pin is connected to the low-power debouncer and forces a system wakeup.  */
+#define SUPC_WUMR_LPDBCEN0_NOT_ENABLE       (SUPC_WUMR_LPDBCEN0_NOT_ENABLE_Val << SUPC_WUMR_LPDBCEN0_Pos)  /**< (SUPC_WUMR) The WKUP0 input pin is not connected to the low-power debouncer. Position  */
+#define SUPC_WUMR_LPDBCEN0_ENABLE           (SUPC_WUMR_LPDBCEN0_ENABLE_Val << SUPC_WUMR_LPDBCEN0_Pos)  /**< (SUPC_WUMR) The WKUP0 input pin is connected to the low-power debouncer and forces a system wakeup. Position  */
+#define SUPC_WUMR_LPDBCEN1_Pos              6                                              /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP1 Position */
+#define SUPC_WUMR_LPDBCEN1_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCEN1_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP1 Mask */
+#define SUPC_WUMR_LPDBCEN1                  SUPC_WUMR_LPDBCEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCEN1_Msk instead */
+#define   SUPC_WUMR_LPDBCEN1_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) The WKUP1 input pin is not connected to the low-power debouncer.  */
+#define   SUPC_WUMR_LPDBCEN1_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) The WKUP1 input pin is connected to the low-power debouncer and forces a system wakeup.  */
+#define SUPC_WUMR_LPDBCEN1_NOT_ENABLE       (SUPC_WUMR_LPDBCEN1_NOT_ENABLE_Val << SUPC_WUMR_LPDBCEN1_Pos)  /**< (SUPC_WUMR) The WKUP1 input pin is not connected to the low-power debouncer. Position  */
+#define SUPC_WUMR_LPDBCEN1_ENABLE           (SUPC_WUMR_LPDBCEN1_ENABLE_Val << SUPC_WUMR_LPDBCEN1_Pos)  /**< (SUPC_WUMR) The WKUP1 input pin is connected to the low-power debouncer and forces a system wakeup. Position  */
+#define SUPC_WUMR_LPDBCCLR_Pos              7                                              /**< (SUPC_WUMR) Low-power Debouncer Clear Position */
+#define SUPC_WUMR_LPDBCCLR_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCCLR_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Clear Mask */
+#define SUPC_WUMR_LPDBCCLR                  SUPC_WUMR_LPDBCCLR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCCLR_Msk instead */
+#define   SUPC_WUMR_LPDBCCLR_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) A low-power debounce event does not create an immediate clear on the first half of GPBR registers.  */
+#define   SUPC_WUMR_LPDBCCLR_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) A low-power debounce event on WKUP0 or WKUP1 generates an immediate clear on the first half of GPBR registers.  */
+#define SUPC_WUMR_LPDBCCLR_NOT_ENABLE       (SUPC_WUMR_LPDBCCLR_NOT_ENABLE_Val << SUPC_WUMR_LPDBCCLR_Pos)  /**< (SUPC_WUMR) A low-power debounce event does not create an immediate clear on the first half of GPBR registers. Position  */
+#define SUPC_WUMR_LPDBCCLR_ENABLE           (SUPC_WUMR_LPDBCCLR_ENABLE_Val << SUPC_WUMR_LPDBCCLR_Pos)  /**< (SUPC_WUMR) A low-power debounce event on WKUP0 or WKUP1 generates an immediate clear on the first half of GPBR registers. Position  */
+#define SUPC_WUMR_WKUPDBC_Pos               12                                             /**< (SUPC_WUMR) Wakeup Inputs Debouncer Period Position */
+#define SUPC_WUMR_WKUPDBC_Msk               (_U_(0x7) << SUPC_WUMR_WKUPDBC_Pos)            /**< (SUPC_WUMR) Wakeup Inputs Debouncer Period Mask */
+#define SUPC_WUMR_WKUPDBC(value)            (SUPC_WUMR_WKUPDBC_Msk & ((value) << SUPC_WUMR_WKUPDBC_Pos))
+#define   SUPC_WUMR_WKUPDBC_IMMEDIATE_Val   _U_(0x0)                                       /**< (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge.  */
+#define   SUPC_WUMR_WKUPDBC_3_SLCK_Val      _U_(0x1)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 3 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_32_SLCK_Val     _U_(0x2)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_512_SLCK_Val    _U_(0x3)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 512 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_4096_SLCK_Val   _U_(0x4)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 4,096 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_32768_SLCK_Val  _U_(0x5)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32,768 SLCK periods  */
+#define SUPC_WUMR_WKUPDBC_IMMEDIATE         (SUPC_WUMR_WKUPDBC_IMMEDIATE_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge. Position  */
+#define SUPC_WUMR_WKUPDBC_3_SLCK            (SUPC_WUMR_WKUPDBC_3_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 3 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_32_SLCK           (SUPC_WUMR_WKUPDBC_32_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_512_SLCK          (SUPC_WUMR_WKUPDBC_512_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 512 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_4096_SLCK         (SUPC_WUMR_WKUPDBC_4096_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 4,096 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_32768_SLCK        (SUPC_WUMR_WKUPDBC_32768_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32,768 SLCK periods Position  */
+#define SUPC_WUMR_LPDBC_Pos                 16                                             /**< (SUPC_WUMR) Low-power Debouncer Period Position */
+#define SUPC_WUMR_LPDBC_Msk                 (_U_(0x7) << SUPC_WUMR_LPDBC_Pos)              /**< (SUPC_WUMR) Low-power Debouncer Period Mask */
+#define SUPC_WUMR_LPDBC(value)              (SUPC_WUMR_LPDBC_Msk & ((value) << SUPC_WUMR_LPDBC_Pos))
+#define   SUPC_WUMR_LPDBC_DISABLE_Val       _U_(0x0)                                       /**< (SUPC_WUMR) Disables the low-power debouncers.  */
+#define   SUPC_WUMR_LPDBC_2_RTCOUT_Val      _U_(0x1)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 2 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_3_RTCOUT_Val      _U_(0x2)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 3 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_4_RTCOUT_Val      _U_(0x3)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 4 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_5_RTCOUT_Val      _U_(0x4)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 5 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_6_RTCOUT_Val      _U_(0x5)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 6 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_7_RTCOUT_Val      _U_(0x6)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 7 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_8_RTCOUT_Val      _U_(0x7)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 8 RTCOUTx clock periods  */
+#define SUPC_WUMR_LPDBC_DISABLE             (SUPC_WUMR_LPDBC_DISABLE_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) Disables the low-power debouncers. Position  */
+#define SUPC_WUMR_LPDBC_2_RTCOUT            (SUPC_WUMR_LPDBC_2_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 2 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_3_RTCOUT            (SUPC_WUMR_LPDBC_3_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 3 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_4_RTCOUT            (SUPC_WUMR_LPDBC_4_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 4 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_5_RTCOUT            (SUPC_WUMR_LPDBC_5_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 5 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_6_RTCOUT            (SUPC_WUMR_LPDBC_6_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 6 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_7_RTCOUT            (SUPC_WUMR_LPDBC_7_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 7 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_8_RTCOUT            (SUPC_WUMR_LPDBC_8_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 8 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_MASK                      _U_(0x770EE)                                   /**< \deprecated (SUPC_WUMR) Register MASK  (Use SUPC_WUMR_Msk instead)  */
+#define SUPC_WUMR_Msk                       _U_(0x770EE)                                   /**< (SUPC_WUMR) Register Mask  */
+
+#define SUPC_WUMR_LPDBCEN_Pos               5                                              /**< (SUPC_WUMR Position) Low-power Debouncer Enable WKUPx */
+#define SUPC_WUMR_LPDBCEN_Msk               (_U_(0x3) << SUPC_WUMR_LPDBCEN_Pos)            /**< (SUPC_WUMR Mask) LPDBCEN */
+#define SUPC_WUMR_LPDBCEN(value)            (SUPC_WUMR_LPDBCEN_Msk & ((value) << SUPC_WUMR_LPDBCEN_Pos))  
+
+/* -------- SUPC_WUIR : (SUPC Offset: 0x10) (R/W 32) Supply Controller Wakeup Inputs Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WKUPEN0:1;                 /**< bit:      0  Wakeup Input Enable 0 to 0               */
+    uint32_t WKUPEN1:1;                 /**< bit:      1  Wakeup Input Enable 0 to 1               */
+    uint32_t WKUPEN2:1;                 /**< bit:      2  Wakeup Input Enable 0 to 2               */
+    uint32_t WKUPEN3:1;                 /**< bit:      3  Wakeup Input Enable 0 to 3               */
+    uint32_t WKUPEN4:1;                 /**< bit:      4  Wakeup Input Enable 0 to 4               */
+    uint32_t WKUPEN5:1;                 /**< bit:      5  Wakeup Input Enable 0 to 5               */
+    uint32_t WKUPEN6:1;                 /**< bit:      6  Wakeup Input Enable 0 to 6               */
+    uint32_t WKUPEN7:1;                 /**< bit:      7  Wakeup Input Enable 0 to 7               */
+    uint32_t WKUPEN8:1;                 /**< bit:      8  Wakeup Input Enable 0 to 8               */
+    uint32_t WKUPEN9:1;                 /**< bit:      9  Wakeup Input Enable 0 to 9               */
+    uint32_t WKUPEN10:1;                /**< bit:     10  Wakeup Input Enable 0 to 10              */
+    uint32_t WKUPEN11:1;                /**< bit:     11  Wakeup Input Enable 0 to 11              */
+    uint32_t WKUPEN12:1;                /**< bit:     12  Wakeup Input Enable 0 to 12              */
+    uint32_t WKUPEN13:1;                /**< bit:     13  Wakeup Input Enable 0 to 13              */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WKUPT0:1;                  /**< bit:     16  Wakeup Input Type 0 to 0                 */
+    uint32_t WKUPT1:1;                  /**< bit:     17  Wakeup Input Type 0 to 1                 */
+    uint32_t WKUPT2:1;                  /**< bit:     18  Wakeup Input Type 0 to 2                 */
+    uint32_t WKUPT3:1;                  /**< bit:     19  Wakeup Input Type 0 to 3                 */
+    uint32_t WKUPT4:1;                  /**< bit:     20  Wakeup Input Type 0 to 4                 */
+    uint32_t WKUPT5:1;                  /**< bit:     21  Wakeup Input Type 0 to 5                 */
+    uint32_t WKUPT6:1;                  /**< bit:     22  Wakeup Input Type 0 to 6                 */
+    uint32_t WKUPT7:1;                  /**< bit:     23  Wakeup Input Type 0 to 7                 */
+    uint32_t WKUPT8:1;                  /**< bit:     24  Wakeup Input Type 0 to 8                 */
+    uint32_t WKUPT9:1;                  /**< bit:     25  Wakeup Input Type 0 to 9                 */
+    uint32_t WKUPT10:1;                 /**< bit:     26  Wakeup Input Type 0 to 10                */
+    uint32_t WKUPT11:1;                 /**< bit:     27  Wakeup Input Type 0 to 11                */
+    uint32_t WKUPT12:1;                 /**< bit:     28  Wakeup Input Type 0 to 12                */
+    uint32_t WKUPT13:1;                 /**< bit:     29  Wakeup Input Type 0 to 13                */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WKUPEN:14;                 /**< bit:  0..13  Wakeup Input Enable x to x               */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WKUPT:14;                  /**< bit: 16..29  Wakeup Input Type x to x3                */
+    uint32_t :2;                        /**< bit: 30..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_WUIR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_WUIR_OFFSET                    (0x10)                                        /**<  (SUPC_WUIR) Supply Controller Wakeup Inputs Register  Offset */
+
+#define SUPC_WUIR_WKUPEN0_Pos               0                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 0 Position */
+#define SUPC_WUIR_WKUPEN0_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN0_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 0 Mask */
+#define SUPC_WUIR_WKUPEN0                   SUPC_WUIR_WKUPEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN0_Msk instead */
+#define   SUPC_WUIR_WKUPEN0_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN0_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN0_DISABLE           (SUPC_WUIR_WKUPEN0_DISABLE_Val << SUPC_WUIR_WKUPEN0_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN0_ENABLE            (SUPC_WUIR_WKUPEN0_ENABLE_Val << SUPC_WUIR_WKUPEN0_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN1_Pos               1                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 1 Position */
+#define SUPC_WUIR_WKUPEN1_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN1_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 1 Mask */
+#define SUPC_WUIR_WKUPEN1                   SUPC_WUIR_WKUPEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN1_Msk instead */
+#define   SUPC_WUIR_WKUPEN1_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN1_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN1_DISABLE           (SUPC_WUIR_WKUPEN1_DISABLE_Val << SUPC_WUIR_WKUPEN1_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN1_ENABLE            (SUPC_WUIR_WKUPEN1_ENABLE_Val << SUPC_WUIR_WKUPEN1_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN2_Pos               2                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 2 Position */
+#define SUPC_WUIR_WKUPEN2_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN2_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 2 Mask */
+#define SUPC_WUIR_WKUPEN2                   SUPC_WUIR_WKUPEN2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN2_Msk instead */
+#define   SUPC_WUIR_WKUPEN2_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN2_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN2_DISABLE           (SUPC_WUIR_WKUPEN2_DISABLE_Val << SUPC_WUIR_WKUPEN2_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN2_ENABLE            (SUPC_WUIR_WKUPEN2_ENABLE_Val << SUPC_WUIR_WKUPEN2_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN3_Pos               3                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 3 Position */
+#define SUPC_WUIR_WKUPEN3_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN3_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 3 Mask */
+#define SUPC_WUIR_WKUPEN3                   SUPC_WUIR_WKUPEN3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN3_Msk instead */
+#define   SUPC_WUIR_WKUPEN3_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN3_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN3_DISABLE           (SUPC_WUIR_WKUPEN3_DISABLE_Val << SUPC_WUIR_WKUPEN3_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN3_ENABLE            (SUPC_WUIR_WKUPEN3_ENABLE_Val << SUPC_WUIR_WKUPEN3_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN4_Pos               4                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 4 Position */
+#define SUPC_WUIR_WKUPEN4_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN4_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 4 Mask */
+#define SUPC_WUIR_WKUPEN4                   SUPC_WUIR_WKUPEN4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN4_Msk instead */
+#define   SUPC_WUIR_WKUPEN4_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN4_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN4_DISABLE           (SUPC_WUIR_WKUPEN4_DISABLE_Val << SUPC_WUIR_WKUPEN4_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN4_ENABLE            (SUPC_WUIR_WKUPEN4_ENABLE_Val << SUPC_WUIR_WKUPEN4_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN5_Pos               5                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 5 Position */
+#define SUPC_WUIR_WKUPEN5_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN5_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 5 Mask */
+#define SUPC_WUIR_WKUPEN5                   SUPC_WUIR_WKUPEN5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN5_Msk instead */
+#define   SUPC_WUIR_WKUPEN5_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN5_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN5_DISABLE           (SUPC_WUIR_WKUPEN5_DISABLE_Val << SUPC_WUIR_WKUPEN5_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN5_ENABLE            (SUPC_WUIR_WKUPEN5_ENABLE_Val << SUPC_WUIR_WKUPEN5_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN6_Pos               6                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 6 Position */
+#define SUPC_WUIR_WKUPEN6_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN6_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 6 Mask */
+#define SUPC_WUIR_WKUPEN6                   SUPC_WUIR_WKUPEN6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN6_Msk instead */
+#define   SUPC_WUIR_WKUPEN6_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN6_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN6_DISABLE           (SUPC_WUIR_WKUPEN6_DISABLE_Val << SUPC_WUIR_WKUPEN6_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN6_ENABLE            (SUPC_WUIR_WKUPEN6_ENABLE_Val << SUPC_WUIR_WKUPEN6_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN7_Pos               7                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 7 Position */
+#define SUPC_WUIR_WKUPEN7_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN7_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 7 Mask */
+#define SUPC_WUIR_WKUPEN7                   SUPC_WUIR_WKUPEN7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN7_Msk instead */
+#define   SUPC_WUIR_WKUPEN7_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN7_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN7_DISABLE           (SUPC_WUIR_WKUPEN7_DISABLE_Val << SUPC_WUIR_WKUPEN7_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN7_ENABLE            (SUPC_WUIR_WKUPEN7_ENABLE_Val << SUPC_WUIR_WKUPEN7_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN8_Pos               8                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 8 Position */
+#define SUPC_WUIR_WKUPEN8_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN8_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 8 Mask */
+#define SUPC_WUIR_WKUPEN8                   SUPC_WUIR_WKUPEN8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN8_Msk instead */
+#define   SUPC_WUIR_WKUPEN8_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN8_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN8_DISABLE           (SUPC_WUIR_WKUPEN8_DISABLE_Val << SUPC_WUIR_WKUPEN8_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN8_ENABLE            (SUPC_WUIR_WKUPEN8_ENABLE_Val << SUPC_WUIR_WKUPEN8_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN9_Pos               9                                              /**< (SUPC_WUIR) Wakeup Input Enable 0 to 9 Position */
+#define SUPC_WUIR_WKUPEN9_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN9_Pos)            /**< (SUPC_WUIR) Wakeup Input Enable 0 to 9 Mask */
+#define SUPC_WUIR_WKUPEN9                   SUPC_WUIR_WKUPEN9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN9_Msk instead */
+#define   SUPC_WUIR_WKUPEN9_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN9_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN9_DISABLE           (SUPC_WUIR_WKUPEN9_DISABLE_Val << SUPC_WUIR_WKUPEN9_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN9_ENABLE            (SUPC_WUIR_WKUPEN9_ENABLE_Val << SUPC_WUIR_WKUPEN9_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN10_Pos              10                                             /**< (SUPC_WUIR) Wakeup Input Enable 0 to 10 Position */
+#define SUPC_WUIR_WKUPEN10_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN10_Pos)           /**< (SUPC_WUIR) Wakeup Input Enable 0 to 10 Mask */
+#define SUPC_WUIR_WKUPEN10                  SUPC_WUIR_WKUPEN10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN10_Msk instead */
+#define   SUPC_WUIR_WKUPEN10_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN10_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN10_DISABLE          (SUPC_WUIR_WKUPEN10_DISABLE_Val << SUPC_WUIR_WKUPEN10_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN10_ENABLE           (SUPC_WUIR_WKUPEN10_ENABLE_Val << SUPC_WUIR_WKUPEN10_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN11_Pos              11                                             /**< (SUPC_WUIR) Wakeup Input Enable 0 to 11 Position */
+#define SUPC_WUIR_WKUPEN11_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN11_Pos)           /**< (SUPC_WUIR) Wakeup Input Enable 0 to 11 Mask */
+#define SUPC_WUIR_WKUPEN11                  SUPC_WUIR_WKUPEN11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN11_Msk instead */
+#define   SUPC_WUIR_WKUPEN11_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN11_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN11_DISABLE          (SUPC_WUIR_WKUPEN11_DISABLE_Val << SUPC_WUIR_WKUPEN11_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN11_ENABLE           (SUPC_WUIR_WKUPEN11_ENABLE_Val << SUPC_WUIR_WKUPEN11_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN12_Pos              12                                             /**< (SUPC_WUIR) Wakeup Input Enable 0 to 12 Position */
+#define SUPC_WUIR_WKUPEN12_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN12_Pos)           /**< (SUPC_WUIR) Wakeup Input Enable 0 to 12 Mask */
+#define SUPC_WUIR_WKUPEN12                  SUPC_WUIR_WKUPEN12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN12_Msk instead */
+#define   SUPC_WUIR_WKUPEN12_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN12_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN12_DISABLE          (SUPC_WUIR_WKUPEN12_DISABLE_Val << SUPC_WUIR_WKUPEN12_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN12_ENABLE           (SUPC_WUIR_WKUPEN12_ENABLE_Val << SUPC_WUIR_WKUPEN12_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN13_Pos              13                                             /**< (SUPC_WUIR) Wakeup Input Enable 0 to 13 Position */
+#define SUPC_WUIR_WKUPEN13_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN13_Pos)           /**< (SUPC_WUIR) Wakeup Input Enable 0 to 13 Mask */
+#define SUPC_WUIR_WKUPEN13                  SUPC_WUIR_WKUPEN13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN13_Msk instead */
+#define   SUPC_WUIR_WKUPEN13_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect.  */
+#define   SUPC_WUIR_WKUPEN13_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPEN13_DISABLE          (SUPC_WUIR_WKUPEN13_DISABLE_Val << SUPC_WUIR_WKUPEN13_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input has no wakeup effect. Position  */
+#define SUPC_WUIR_WKUPEN13_ENABLE           (SUPC_WUIR_WKUPEN13_ENABLE_Val << SUPC_WUIR_WKUPEN13_Pos)  /**< (SUPC_WUIR) The corresponding wakeup input is enabled for a wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT0_Pos                16                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 0 Position */
+#define SUPC_WUIR_WKUPT0_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT0_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 0 Mask */
+#define SUPC_WUIR_WKUPT0                    SUPC_WUIR_WKUPT0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT0_Msk instead */
+#define   SUPC_WUIR_WKUPT0_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT0_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT0_LOW                (SUPC_WUIR_WKUPT0_LOW_Val << SUPC_WUIR_WKUPT0_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT0_HIGH               (SUPC_WUIR_WKUPT0_HIGH_Val << SUPC_WUIR_WKUPT0_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT1_Pos                17                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 1 Position */
+#define SUPC_WUIR_WKUPT1_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT1_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 1 Mask */
+#define SUPC_WUIR_WKUPT1                    SUPC_WUIR_WKUPT1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT1_Msk instead */
+#define   SUPC_WUIR_WKUPT1_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT1_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT1_LOW                (SUPC_WUIR_WKUPT1_LOW_Val << SUPC_WUIR_WKUPT1_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT1_HIGH               (SUPC_WUIR_WKUPT1_HIGH_Val << SUPC_WUIR_WKUPT1_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT2_Pos                18                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 2 Position */
+#define SUPC_WUIR_WKUPT2_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT2_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 2 Mask */
+#define SUPC_WUIR_WKUPT2                    SUPC_WUIR_WKUPT2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT2_Msk instead */
+#define   SUPC_WUIR_WKUPT2_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT2_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT2_LOW                (SUPC_WUIR_WKUPT2_LOW_Val << SUPC_WUIR_WKUPT2_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT2_HIGH               (SUPC_WUIR_WKUPT2_HIGH_Val << SUPC_WUIR_WKUPT2_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT3_Pos                19                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 3 Position */
+#define SUPC_WUIR_WKUPT3_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT3_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 3 Mask */
+#define SUPC_WUIR_WKUPT3                    SUPC_WUIR_WKUPT3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT3_Msk instead */
+#define   SUPC_WUIR_WKUPT3_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT3_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT3_LOW                (SUPC_WUIR_WKUPT3_LOW_Val << SUPC_WUIR_WKUPT3_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT3_HIGH               (SUPC_WUIR_WKUPT3_HIGH_Val << SUPC_WUIR_WKUPT3_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT4_Pos                20                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 4 Position */
+#define SUPC_WUIR_WKUPT4_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT4_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 4 Mask */
+#define SUPC_WUIR_WKUPT4                    SUPC_WUIR_WKUPT4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT4_Msk instead */
+#define   SUPC_WUIR_WKUPT4_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT4_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT4_LOW                (SUPC_WUIR_WKUPT4_LOW_Val << SUPC_WUIR_WKUPT4_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT4_HIGH               (SUPC_WUIR_WKUPT4_HIGH_Val << SUPC_WUIR_WKUPT4_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT5_Pos                21                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 5 Position */
+#define SUPC_WUIR_WKUPT5_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT5_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 5 Mask */
+#define SUPC_WUIR_WKUPT5                    SUPC_WUIR_WKUPT5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT5_Msk instead */
+#define   SUPC_WUIR_WKUPT5_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT5_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT5_LOW                (SUPC_WUIR_WKUPT5_LOW_Val << SUPC_WUIR_WKUPT5_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT5_HIGH               (SUPC_WUIR_WKUPT5_HIGH_Val << SUPC_WUIR_WKUPT5_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT6_Pos                22                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 6 Position */
+#define SUPC_WUIR_WKUPT6_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT6_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 6 Mask */
+#define SUPC_WUIR_WKUPT6                    SUPC_WUIR_WKUPT6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT6_Msk instead */
+#define   SUPC_WUIR_WKUPT6_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT6_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT6_LOW                (SUPC_WUIR_WKUPT6_LOW_Val << SUPC_WUIR_WKUPT6_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT6_HIGH               (SUPC_WUIR_WKUPT6_HIGH_Val << SUPC_WUIR_WKUPT6_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT7_Pos                23                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 7 Position */
+#define SUPC_WUIR_WKUPT7_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT7_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 7 Mask */
+#define SUPC_WUIR_WKUPT7                    SUPC_WUIR_WKUPT7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT7_Msk instead */
+#define   SUPC_WUIR_WKUPT7_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT7_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT7_LOW                (SUPC_WUIR_WKUPT7_LOW_Val << SUPC_WUIR_WKUPT7_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT7_HIGH               (SUPC_WUIR_WKUPT7_HIGH_Val << SUPC_WUIR_WKUPT7_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT8_Pos                24                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 8 Position */
+#define SUPC_WUIR_WKUPT8_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT8_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 8 Mask */
+#define SUPC_WUIR_WKUPT8                    SUPC_WUIR_WKUPT8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT8_Msk instead */
+#define   SUPC_WUIR_WKUPT8_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT8_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT8_LOW                (SUPC_WUIR_WKUPT8_LOW_Val << SUPC_WUIR_WKUPT8_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT8_HIGH               (SUPC_WUIR_WKUPT8_HIGH_Val << SUPC_WUIR_WKUPT8_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT9_Pos                25                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 9 Position */
+#define SUPC_WUIR_WKUPT9_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT9_Pos)             /**< (SUPC_WUIR) Wakeup Input Type 0 to 9 Mask */
+#define SUPC_WUIR_WKUPT9                    SUPC_WUIR_WKUPT9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT9_Msk instead */
+#define   SUPC_WUIR_WKUPT9_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT9_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT9_LOW                (SUPC_WUIR_WKUPT9_LOW_Val << SUPC_WUIR_WKUPT9_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT9_HIGH               (SUPC_WUIR_WKUPT9_HIGH_Val << SUPC_WUIR_WKUPT9_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT10_Pos               26                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 10 Position */
+#define SUPC_WUIR_WKUPT10_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT10_Pos)            /**< (SUPC_WUIR) Wakeup Input Type 0 to 10 Mask */
+#define SUPC_WUIR_WKUPT10                   SUPC_WUIR_WKUPT10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT10_Msk instead */
+#define   SUPC_WUIR_WKUPT10_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT10_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT10_LOW               (SUPC_WUIR_WKUPT10_LOW_Val << SUPC_WUIR_WKUPT10_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT10_HIGH              (SUPC_WUIR_WKUPT10_HIGH_Val << SUPC_WUIR_WKUPT10_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT11_Pos               27                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 11 Position */
+#define SUPC_WUIR_WKUPT11_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT11_Pos)            /**< (SUPC_WUIR) Wakeup Input Type 0 to 11 Mask */
+#define SUPC_WUIR_WKUPT11                   SUPC_WUIR_WKUPT11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT11_Msk instead */
+#define   SUPC_WUIR_WKUPT11_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT11_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT11_LOW               (SUPC_WUIR_WKUPT11_LOW_Val << SUPC_WUIR_WKUPT11_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT11_HIGH              (SUPC_WUIR_WKUPT11_HIGH_Val << SUPC_WUIR_WKUPT11_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT12_Pos               28                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 12 Position */
+#define SUPC_WUIR_WKUPT12_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT12_Pos)            /**< (SUPC_WUIR) Wakeup Input Type 0 to 12 Mask */
+#define SUPC_WUIR_WKUPT12                   SUPC_WUIR_WKUPT12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT12_Msk instead */
+#define   SUPC_WUIR_WKUPT12_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT12_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT12_LOW               (SUPC_WUIR_WKUPT12_LOW_Val << SUPC_WUIR_WKUPT12_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT12_HIGH              (SUPC_WUIR_WKUPT12_HIGH_Val << SUPC_WUIR_WKUPT12_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT13_Pos               29                                             /**< (SUPC_WUIR) Wakeup Input Type 0 to 13 Position */
+#define SUPC_WUIR_WKUPT13_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT13_Pos)            /**< (SUPC_WUIR) Wakeup Input Type 0 to 13 Mask */
+#define SUPC_WUIR_WKUPT13                   SUPC_WUIR_WKUPT13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT13_Msk instead */
+#define   SUPC_WUIR_WKUPT13_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply.  */
+#define   SUPC_WUIR_WKUPT13_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply.  */
+#define SUPC_WUIR_WKUPT13_LOW               (SUPC_WUIR_WKUPT13_LOW_Val << SUPC_WUIR_WKUPT13_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT13_HIGH              (SUPC_WUIR_WKUPT13_HIGH_Val << SUPC_WUIR_WKUPT13_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wakeup input forces the wakeup of the core power supply. Position  */
+#define SUPC_WUIR_MASK                      _U_(0x3FFF3FFF)                                /**< \deprecated (SUPC_WUIR) Register MASK  (Use SUPC_WUIR_Msk instead)  */
+#define SUPC_WUIR_Msk                       _U_(0x3FFF3FFF)                                /**< (SUPC_WUIR) Register Mask  */
+
+#define SUPC_WUIR_WKUPEN_Pos                0                                              /**< (SUPC_WUIR Position) Wakeup Input Enable x to x */
+#define SUPC_WUIR_WKUPEN_Msk                (_U_(0x3FFF) << SUPC_WUIR_WKUPEN_Pos)          /**< (SUPC_WUIR Mask) WKUPEN */
+#define SUPC_WUIR_WKUPEN(value)             (SUPC_WUIR_WKUPEN_Msk & ((value) << SUPC_WUIR_WKUPEN_Pos))  
+#define SUPC_WUIR_WKUPT_Pos                 16                                             /**< (SUPC_WUIR Position) Wakeup Input Type x to x3 */
+#define SUPC_WUIR_WKUPT_Msk                 (_U_(0x3FFF) << SUPC_WUIR_WKUPT_Pos)           /**< (SUPC_WUIR Mask) WKUPT */
+#define SUPC_WUIR_WKUPT(value)              (SUPC_WUIR_WKUPT_Msk & ((value) << SUPC_WUIR_WKUPT_Pos))  
+
+/* -------- SUPC_SR : (SUPC Offset: 0x14) (R/ 32) Supply Controller Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t WKUPS:1;                   /**< bit:      1  WKUP Wakeup Status (cleared on read)     */
+    uint32_t SMWS:1;                    /**< bit:      2  Supply Monitor Detection Wakeup Status (cleared on read) */
+    uint32_t BODRSTS:1;                 /**< bit:      3  Brownout Detector Reset Status (cleared on read) */
+    uint32_t SMRSTS:1;                  /**< bit:      4  Supply Monitor Reset Status (cleared on read) */
+    uint32_t SMS:1;                     /**< bit:      5  Supply Monitor Status (cleared on read)  */
+    uint32_t SMOS:1;                    /**< bit:      6  Supply Monitor Output Status             */
+    uint32_t OSCSEL:1;                  /**< bit:      7  32-kHz Oscillator Selection Status       */
+    uint32_t :5;                        /**< bit:  8..12  Reserved */
+    uint32_t LPDBCS0:1;                 /**< bit:     13  Low-power Debouncer Wakeup Status on WKUP0 (cleared on read) */
+    uint32_t LPDBCS1:1;                 /**< bit:     14  Low-power Debouncer Wakeup Status on WKUP1 (cleared on read) */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t WKUPIS0:1;                 /**< bit:     16  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS1:1;                 /**< bit:     17  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS2:1;                 /**< bit:     18  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS3:1;                 /**< bit:     19  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS4:1;                 /**< bit:     20  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS5:1;                 /**< bit:     21  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS6:1;                 /**< bit:     22  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS7:1;                 /**< bit:     23  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS8:1;                 /**< bit:     24  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS9:1;                 /**< bit:     25  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS10:1;                /**< bit:     26  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS11:1;                /**< bit:     27  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS12:1;                /**< bit:     28  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS13:1;                /**< bit:     29  WKUPx Input Status (cleared on read)     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LPDBCS:2;                  /**< bit: 13..14  Low-power Debouncer Wakeup Status on WKUPx (cleared on read) */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t WKUPIS:14;                 /**< bit: 16..29  WKUPx Input Status (cleared on read)     */
+    uint32_t :2;                        /**< bit: 30..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_SR_OFFSET                      (0x14)                                        /**<  (SUPC_SR) Supply Controller Status Register  Offset */
+
+#define SUPC_SR_WKUPS_Pos                   1                                              /**< (SUPC_SR) WKUP Wakeup Status (cleared on read) Position */
+#define SUPC_SR_WKUPS_Msk                   (_U_(0x1) << SUPC_SR_WKUPS_Pos)                /**< (SUPC_SR) WKUP Wakeup Status (cleared on read) Mask */
+#define SUPC_SR_WKUPS                       SUPC_SR_WKUPS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPS_Msk instead */
+#define   SUPC_SR_WKUPS_NO_Val              _U_(0x0)                                       /**< (SUPC_SR) No wakeup due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_WKUPS_PRESENT_Val         _U_(0x1)                                       /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPS_NO                    (SUPC_SR_WKUPS_NO_Val << SUPC_SR_WKUPS_Pos)    /**< (SUPC_SR) No wakeup due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPS_PRESENT               (SUPC_SR_WKUPS_PRESENT_Val << SUPC_SR_WKUPS_Pos)  /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMWS_Pos                    2                                              /**< (SUPC_SR) Supply Monitor Detection Wakeup Status (cleared on read) Position */
+#define SUPC_SR_SMWS_Msk                    (_U_(0x1) << SUPC_SR_SMWS_Pos)                 /**< (SUPC_SR) Supply Monitor Detection Wakeup Status (cleared on read) Mask */
+#define SUPC_SR_SMWS                        SUPC_SR_SMWS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMWS_Msk instead */
+#define   SUPC_SR_SMWS_NO_Val               _U_(0x0)                                       /**< (SUPC_SR) No wakeup due to a supply monitor detection has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_SMWS_PRESENT_Val          _U_(0x1)                                       /**< (SUPC_SR) At least one wakeup due to a supply monitor detection has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_SMWS_NO                     (SUPC_SR_SMWS_NO_Val << SUPC_SR_SMWS_Pos)      /**< (SUPC_SR) No wakeup due to a supply monitor detection has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMWS_PRESENT                (SUPC_SR_SMWS_PRESENT_Val << SUPC_SR_SMWS_Pos)  /**< (SUPC_SR) At least one wakeup due to a supply monitor detection has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_BODRSTS_Pos                 3                                              /**< (SUPC_SR) Brownout Detector Reset Status (cleared on read) Position */
+#define SUPC_SR_BODRSTS_Msk                 (_U_(0x1) << SUPC_SR_BODRSTS_Pos)              /**< (SUPC_SR) Brownout Detector Reset Status (cleared on read) Mask */
+#define SUPC_SR_BODRSTS                     SUPC_SR_BODRSTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_BODRSTS_Msk instead */
+#define   SUPC_SR_BODRSTS_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No core brownout rising edge event has been detected since the last read of the SUPC_SR.  */
+#define   SUPC_SR_BODRSTS_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one brownout output rising edge event has been detected since the last read of the SUPC_SR.  */
+#define SUPC_SR_BODRSTS_NO                  (SUPC_SR_BODRSTS_NO_Val << SUPC_SR_BODRSTS_Pos)  /**< (SUPC_SR) No core brownout rising edge event has been detected since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_BODRSTS_PRESENT             (SUPC_SR_BODRSTS_PRESENT_Val << SUPC_SR_BODRSTS_Pos)  /**< (SUPC_SR) At least one brownout output rising edge event has been detected since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMRSTS_Pos                  4                                              /**< (SUPC_SR) Supply Monitor Reset Status (cleared on read) Position */
+#define SUPC_SR_SMRSTS_Msk                  (_U_(0x1) << SUPC_SR_SMRSTS_Pos)               /**< (SUPC_SR) Supply Monitor Reset Status (cleared on read) Mask */
+#define SUPC_SR_SMRSTS                      SUPC_SR_SMRSTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMRSTS_Msk instead */
+#define   SUPC_SR_SMRSTS_NO_Val             _U_(0x0)                                       /**< (SUPC_SR) No supply monitor detection has generated a core reset since the last read of the SUPC_SR.  */
+#define   SUPC_SR_SMRSTS_PRESENT_Val        _U_(0x1)                                       /**< (SUPC_SR) At least one supply monitor detection has generated a core reset since the last read of the SUPC_SR.  */
+#define SUPC_SR_SMRSTS_NO                   (SUPC_SR_SMRSTS_NO_Val << SUPC_SR_SMRSTS_Pos)  /**< (SUPC_SR) No supply monitor detection has generated a core reset since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMRSTS_PRESENT              (SUPC_SR_SMRSTS_PRESENT_Val << SUPC_SR_SMRSTS_Pos)  /**< (SUPC_SR) At least one supply monitor detection has generated a core reset since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMS_Pos                     5                                              /**< (SUPC_SR) Supply Monitor Status (cleared on read) Position */
+#define SUPC_SR_SMS_Msk                     (_U_(0x1) << SUPC_SR_SMS_Pos)                  /**< (SUPC_SR) Supply Monitor Status (cleared on read) Mask */
+#define SUPC_SR_SMS                         SUPC_SR_SMS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMS_Msk instead */
+#define   SUPC_SR_SMS_NO_Val                _U_(0x0)                                       /**< (SUPC_SR) No supply monitor detection since the last read of SUPC_SR.  */
+#define   SUPC_SR_SMS_PRESENT_Val           _U_(0x1)                                       /**< (SUPC_SR) At least one supply monitor detection since the last read of SUPC_SR.  */
+#define SUPC_SR_SMS_NO                      (SUPC_SR_SMS_NO_Val << SUPC_SR_SMS_Pos)        /**< (SUPC_SR) No supply monitor detection since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMS_PRESENT                 (SUPC_SR_SMS_PRESENT_Val << SUPC_SR_SMS_Pos)   /**< (SUPC_SR) At least one supply monitor detection since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMOS_Pos                    6                                              /**< (SUPC_SR) Supply Monitor Output Status Position */
+#define SUPC_SR_SMOS_Msk                    (_U_(0x1) << SUPC_SR_SMOS_Pos)                 /**< (SUPC_SR) Supply Monitor Output Status Mask */
+#define SUPC_SR_SMOS                        SUPC_SR_SMOS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMOS_Msk instead */
+#define   SUPC_SR_SMOS_HIGH_Val             _U_(0x0)                                       /**< (SUPC_SR) The supply monitor detected VDDIO higher than its threshold at its last measurement.  */
+#define   SUPC_SR_SMOS_LOW_Val              _U_(0x1)                                       /**< (SUPC_SR) The supply monitor detected VDDIO lower than its threshold at its last measurement.  */
+#define SUPC_SR_SMOS_HIGH                   (SUPC_SR_SMOS_HIGH_Val << SUPC_SR_SMOS_Pos)    /**< (SUPC_SR) The supply monitor detected VDDIO higher than its threshold at its last measurement. Position  */
+#define SUPC_SR_SMOS_LOW                    (SUPC_SR_SMOS_LOW_Val << SUPC_SR_SMOS_Pos)     /**< (SUPC_SR) The supply monitor detected VDDIO lower than its threshold at its last measurement. Position  */
+#define SUPC_SR_OSCSEL_Pos                  7                                              /**< (SUPC_SR) 32-kHz Oscillator Selection Status Position */
+#define SUPC_SR_OSCSEL_Msk                  (_U_(0x1) << SUPC_SR_OSCSEL_Pos)               /**< (SUPC_SR) 32-kHz Oscillator Selection Status Mask */
+#define SUPC_SR_OSCSEL                      SUPC_SR_OSCSEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_OSCSEL_Msk instead */
+#define   SUPC_SR_OSCSEL_RC_Val             _U_(0x0)                                       /**< (SUPC_SR) The slow clock, SLCK, is generated by the embedded 32 kHz RC oscillator.  */
+#define   SUPC_SR_OSCSEL_CRYST_Val          _U_(0x1)                                       /**< (SUPC_SR) The slow clock, SLCK, is generated by the 32 kHz crystal oscillator.  */
+#define SUPC_SR_OSCSEL_RC                   (SUPC_SR_OSCSEL_RC_Val << SUPC_SR_OSCSEL_Pos)  /**< (SUPC_SR) The slow clock, SLCK, is generated by the embedded 32 kHz RC oscillator. Position  */
+#define SUPC_SR_OSCSEL_CRYST                (SUPC_SR_OSCSEL_CRYST_Val << SUPC_SR_OSCSEL_Pos)  /**< (SUPC_SR) The slow clock, SLCK, is generated by the 32 kHz crystal oscillator. Position  */
+#define SUPC_SR_LPDBCS0_Pos                 13                                             /**< (SUPC_SR) Low-power Debouncer Wakeup Status on WKUP0 (cleared on read) Position */
+#define SUPC_SR_LPDBCS0_Msk                 (_U_(0x1) << SUPC_SR_LPDBCS0_Pos)              /**< (SUPC_SR) Low-power Debouncer Wakeup Status on WKUP0 (cleared on read) Mask */
+#define SUPC_SR_LPDBCS0                     SUPC_SR_LPDBCS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_LPDBCS0_Msk instead */
+#define   SUPC_SR_LPDBCS0_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No wakeup due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_LPDBCS0_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_LPDBCS0_NO                  (SUPC_SR_LPDBCS0_NO_Val << SUPC_SR_LPDBCS0_Pos)  /**< (SUPC_SR) No wakeup due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS0_PRESENT             (SUPC_SR_LPDBCS0_PRESENT_Val << SUPC_SR_LPDBCS0_Pos)  /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS1_Pos                 14                                             /**< (SUPC_SR) Low-power Debouncer Wakeup Status on WKUP1 (cleared on read) Position */
+#define SUPC_SR_LPDBCS1_Msk                 (_U_(0x1) << SUPC_SR_LPDBCS1_Pos)              /**< (SUPC_SR) Low-power Debouncer Wakeup Status on WKUP1 (cleared on read) Mask */
+#define SUPC_SR_LPDBCS1                     SUPC_SR_LPDBCS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_LPDBCS1_Msk instead */
+#define   SUPC_SR_LPDBCS1_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No wakeup due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_LPDBCS1_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_LPDBCS1_NO                  (SUPC_SR_LPDBCS1_NO_Val << SUPC_SR_LPDBCS1_Pos)  /**< (SUPC_SR) No wakeup due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS1_PRESENT             (SUPC_SR_LPDBCS1_PRESENT_Val << SUPC_SR_LPDBCS1_Pos)  /**< (SUPC_SR) At least one wakeup due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS0_Pos                 16                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS0_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS0_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS0                     SUPC_SR_WKUPIS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS0_Msk instead */
+#define   SUPC_SR_WKUPIS0_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS0_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS0_DIS                 (SUPC_SR_WKUPIS0_DIS_Val << SUPC_SR_WKUPIS0_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS0_EN                  (SUPC_SR_WKUPIS0_EN_Val << SUPC_SR_WKUPIS0_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS1_Pos                 17                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS1_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS1_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS1                     SUPC_SR_WKUPIS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS1_Msk instead */
+#define   SUPC_SR_WKUPIS1_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS1_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS1_DIS                 (SUPC_SR_WKUPIS1_DIS_Val << SUPC_SR_WKUPIS1_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS1_EN                  (SUPC_SR_WKUPIS1_EN_Val << SUPC_SR_WKUPIS1_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS2_Pos                 18                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS2_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS2_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS2                     SUPC_SR_WKUPIS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS2_Msk instead */
+#define   SUPC_SR_WKUPIS2_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS2_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS2_DIS                 (SUPC_SR_WKUPIS2_DIS_Val << SUPC_SR_WKUPIS2_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS2_EN                  (SUPC_SR_WKUPIS2_EN_Val << SUPC_SR_WKUPIS2_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS3_Pos                 19                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS3_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS3_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS3                     SUPC_SR_WKUPIS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS3_Msk instead */
+#define   SUPC_SR_WKUPIS3_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS3_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS3_DIS                 (SUPC_SR_WKUPIS3_DIS_Val << SUPC_SR_WKUPIS3_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS3_EN                  (SUPC_SR_WKUPIS3_EN_Val << SUPC_SR_WKUPIS3_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS4_Pos                 20                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS4_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS4_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS4                     SUPC_SR_WKUPIS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS4_Msk instead */
+#define   SUPC_SR_WKUPIS4_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS4_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS4_DIS                 (SUPC_SR_WKUPIS4_DIS_Val << SUPC_SR_WKUPIS4_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS4_EN                  (SUPC_SR_WKUPIS4_EN_Val << SUPC_SR_WKUPIS4_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS5_Pos                 21                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS5_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS5_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS5                     SUPC_SR_WKUPIS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS5_Msk instead */
+#define   SUPC_SR_WKUPIS5_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS5_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS5_DIS                 (SUPC_SR_WKUPIS5_DIS_Val << SUPC_SR_WKUPIS5_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS5_EN                  (SUPC_SR_WKUPIS5_EN_Val << SUPC_SR_WKUPIS5_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS6_Pos                 22                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS6_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS6_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS6                     SUPC_SR_WKUPIS6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS6_Msk instead */
+#define   SUPC_SR_WKUPIS6_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS6_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS6_DIS                 (SUPC_SR_WKUPIS6_DIS_Val << SUPC_SR_WKUPIS6_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS6_EN                  (SUPC_SR_WKUPIS6_EN_Val << SUPC_SR_WKUPIS6_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS7_Pos                 23                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS7_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS7_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS7                     SUPC_SR_WKUPIS7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS7_Msk instead */
+#define   SUPC_SR_WKUPIS7_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS7_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS7_DIS                 (SUPC_SR_WKUPIS7_DIS_Val << SUPC_SR_WKUPIS7_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS7_EN                  (SUPC_SR_WKUPIS7_EN_Val << SUPC_SR_WKUPIS7_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS8_Pos                 24                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS8_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS8_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS8                     SUPC_SR_WKUPIS8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS8_Msk instead */
+#define   SUPC_SR_WKUPIS8_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS8_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS8_DIS                 (SUPC_SR_WKUPIS8_DIS_Val << SUPC_SR_WKUPIS8_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS8_EN                  (SUPC_SR_WKUPIS8_EN_Val << SUPC_SR_WKUPIS8_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS9_Pos                 25                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS9_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS9_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS9                     SUPC_SR_WKUPIS9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS9_Msk instead */
+#define   SUPC_SR_WKUPIS9_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS9_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS9_DIS                 (SUPC_SR_WKUPIS9_DIS_Val << SUPC_SR_WKUPIS9_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS9_EN                  (SUPC_SR_WKUPIS9_EN_Val << SUPC_SR_WKUPIS9_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS10_Pos                26                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS10_Msk                (_U_(0x1) << SUPC_SR_WKUPIS10_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS10                    SUPC_SR_WKUPIS10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS10_Msk instead */
+#define   SUPC_SR_WKUPIS10_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS10_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS10_DIS                (SUPC_SR_WKUPIS10_DIS_Val << SUPC_SR_WKUPIS10_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS10_EN                 (SUPC_SR_WKUPIS10_EN_Val << SUPC_SR_WKUPIS10_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS11_Pos                27                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS11_Msk                (_U_(0x1) << SUPC_SR_WKUPIS11_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS11                    SUPC_SR_WKUPIS11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS11_Msk instead */
+#define   SUPC_SR_WKUPIS11_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS11_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS11_DIS                (SUPC_SR_WKUPIS11_DIS_Val << SUPC_SR_WKUPIS11_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS11_EN                 (SUPC_SR_WKUPIS11_EN_Val << SUPC_SR_WKUPIS11_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS12_Pos                28                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS12_Msk                (_U_(0x1) << SUPC_SR_WKUPIS12_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS12                    SUPC_SR_WKUPIS12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS12_Msk instead */
+#define   SUPC_SR_WKUPIS12_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS12_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS12_DIS                (SUPC_SR_WKUPIS12_DIS_Val << SUPC_SR_WKUPIS12_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS12_EN                 (SUPC_SR_WKUPIS12_EN_Val << SUPC_SR_WKUPIS12_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS13_Pos                29                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS13_Msk                (_U_(0x1) << SUPC_SR_WKUPIS13_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS13                    SUPC_SR_WKUPIS13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS13_Msk instead */
+#define   SUPC_SR_WKUPIS13_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event.  */
+#define   SUPC_SR_WKUPIS13_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS13_DIS                (SUPC_SR_WKUPIS13_DIS_Val << SUPC_SR_WKUPIS13_Pos)  /**< (SUPC_SR) The corresponding wakeup input is disabled, or was inactive at the time the debouncer triggered a wakeup event. Position  */
+#define SUPC_SR_WKUPIS13_EN                 (SUPC_SR_WKUPIS13_EN_Val << SUPC_SR_WKUPIS13_Pos)  /**< (SUPC_SR) The corresponding wakeup input was active at the time the debouncer triggered a wakeup event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_MASK                        _U_(0x3FFF60FE)                                /**< \deprecated (SUPC_SR) Register MASK  (Use SUPC_SR_Msk instead)  */
+#define SUPC_SR_Msk                         _U_(0x3FFF60FE)                                /**< (SUPC_SR) Register Mask  */
+
+#define SUPC_SR_LPDBCS_Pos                  13                                             /**< (SUPC_SR Position) Low-power Debouncer Wakeup Status on WKUPx (cleared on read) */
+#define SUPC_SR_LPDBCS_Msk                  (_U_(0x3) << SUPC_SR_LPDBCS_Pos)               /**< (SUPC_SR Mask) LPDBCS */
+#define SUPC_SR_LPDBCS(value)               (SUPC_SR_LPDBCS_Msk & ((value) << SUPC_SR_LPDBCS_Pos))  
+#define SUPC_SR_WKUPIS_Pos                  16                                             /**< (SUPC_SR Position) WKUPx Input Status (cleared on read) */
+#define SUPC_SR_WKUPIS_Msk                  (_U_(0x3FFF) << SUPC_SR_WKUPIS_Pos)            /**< (SUPC_SR Mask) WKUPIS */
+#define SUPC_SR_WKUPIS(value)               (SUPC_SR_WKUPIS_Msk & ((value) << SUPC_SR_WKUPIS_Pos))  
+
+/* -------- SYSC_VERSION : (SUPC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SYSC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSC_VERSION_OFFSET                 (0xFC)                                        /**<  (SYSC_VERSION) Version Register  Offset */
+
+#define SYSC_VERSION_VERSION_Pos            0                                              /**< (SYSC_VERSION) Version of the Hardware Module Position */
+#define SYSC_VERSION_VERSION_Msk            (_U_(0xFFF) << SYSC_VERSION_VERSION_Pos)       /**< (SYSC_VERSION) Version of the Hardware Module Mask */
+#define SYSC_VERSION_VERSION(value)         (SYSC_VERSION_VERSION_Msk & ((value) << SYSC_VERSION_VERSION_Pos))
+#define SYSC_VERSION_MFN_Pos                16                                             /**< (SYSC_VERSION) Metal Fix Number Position */
+#define SYSC_VERSION_MFN_Msk                (_U_(0x7) << SYSC_VERSION_MFN_Pos)             /**< (SYSC_VERSION) Metal Fix Number Mask */
+#define SYSC_VERSION_MFN(value)             (SYSC_VERSION_MFN_Msk & ((value) << SYSC_VERSION_MFN_Pos))
+#define SYSC_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (SYSC_VERSION) Register MASK  (Use SYSC_VERSION_Msk instead)  */
+#define SYSC_VERSION_Msk                    _U_(0x70FFF)                                   /**< (SYSC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SUPC hardware registers */
+typedef struct {  
+  __O  uint32_t SUPC_CR;        /**< (SUPC Offset: 0x00) Supply Controller Control Register */
+  __IO uint32_t SUPC_SMMR;      /**< (SUPC Offset: 0x04) Supply Controller Supply Monitor Mode Register */
+  __IO uint32_t SUPC_MR;        /**< (SUPC Offset: 0x08) Supply Controller Mode Register */
+  __IO uint32_t SUPC_WUMR;      /**< (SUPC Offset: 0x0C) Supply Controller Wakeup Mode Register */
+  __IO uint32_t SUPC_WUIR;      /**< (SUPC Offset: 0x10) Supply Controller Wakeup Inputs Register */
+  __I  uint32_t SUPC_SR;        /**< (SUPC Offset: 0x14) Supply Controller Status Register */
+  __I  uint8_t                        Reserved1[228];
+  __I  uint32_t SYSC_VERSION;   /**< (SUPC Offset: 0xFC) Version Register */
+} Supc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SUPC hardware registers */
+typedef struct {  
+  __O  SUPC_CR_Type                   SUPC_CR;        /**< Offset: 0x00 ( /W  32) Supply Controller Control Register */
+  __IO SUPC_SMMR_Type                 SUPC_SMMR;      /**< Offset: 0x04 (R/W  32) Supply Controller Supply Monitor Mode Register */
+  __IO SUPC_MR_Type                   SUPC_MR;        /**< Offset: 0x08 (R/W  32) Supply Controller Mode Register */
+  __IO SUPC_WUMR_Type                 SUPC_WUMR;      /**< Offset: 0x0C (R/W  32) Supply Controller Wakeup Mode Register */
+  __IO SUPC_WUIR_Type                 SUPC_WUIR;      /**< Offset: 0x10 (R/W  32) Supply Controller Wakeup Inputs Register */
+  __I  SUPC_SR_Type                   SUPC_SR;        /**< Offset: 0x14 (R/   32) Supply Controller Status Register */
+  __I  uint8_t                        Reserved1[228];
+  __I  SYSC_VERSION_Type              SYSC_VERSION;   /**< Offset: 0xFC (R/   32) Version Register */
+} Supc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Supply Controller */
+
+#endif /* _SAMV71_SUPC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/tc.h
+++ b/asf/sam/include/samv71/component/tc.h
@@ -1,0 +1,995 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TC_COMPONENT_H_
+#define _SAMV71_TC_COMPONENT_H_
+#define _SAMV71_TC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Timer Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TC_6082                       /**< (TC) Module ID */
+#define REV_TC ZI                     /**< (TC) Module revision */
+
+/* -------- TC_CCR : (TC Offset: 0x00) (/W 32) Channel Control Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLKEN:1;                   /**< bit:      0  Counter Clock Enable Command             */
+    uint32_t CLKDIS:1;                  /**< bit:      1  Counter Clock Disable Command            */
+    uint32_t SWTRG:1;                   /**< bit:      2  Software Trigger Command                 */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CCR_OFFSET                       (0x00)                                        /**<  (TC_CCR) Channel Control Register (channel = 0)  Offset */
+
+#define TC_CCR_CLKEN_Pos                    0                                              /**< (TC_CCR) Counter Clock Enable Command Position */
+#define TC_CCR_CLKEN_Msk                    (_U_(0x1) << TC_CCR_CLKEN_Pos)                 /**< (TC_CCR) Counter Clock Enable Command Mask */
+#define TC_CCR_CLKEN                        TC_CCR_CLKEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_CLKEN_Msk instead */
+#define TC_CCR_CLKDIS_Pos                   1                                              /**< (TC_CCR) Counter Clock Disable Command Position */
+#define TC_CCR_CLKDIS_Msk                   (_U_(0x1) << TC_CCR_CLKDIS_Pos)                /**< (TC_CCR) Counter Clock Disable Command Mask */
+#define TC_CCR_CLKDIS                       TC_CCR_CLKDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_CLKDIS_Msk instead */
+#define TC_CCR_SWTRG_Pos                    2                                              /**< (TC_CCR) Software Trigger Command Position */
+#define TC_CCR_SWTRG_Msk                    (_U_(0x1) << TC_CCR_SWTRG_Pos)                 /**< (TC_CCR) Software Trigger Command Mask */
+#define TC_CCR_SWTRG                        TC_CCR_SWTRG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_SWTRG_Msk instead */
+#define TC_CCR_MASK                         _U_(0x07)                                      /**< \deprecated (TC_CCR) Register MASK  (Use TC_CCR_Msk instead)  */
+#define TC_CCR_Msk                          _U_(0x07)                                      /**< (TC_CCR) Register Mask  */
+
+
+/* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) Channel Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCCLKS:3;                  /**< bit:   0..2  Clock Selection                          */
+    uint32_t CLKI:1;                    /**< bit:      3  Clock Invert                             */
+    uint32_t BURST:2;                   /**< bit:   4..5  Burst Signal Selection                   */
+    uint32_t LDBSTOP:1;                 /**< bit:      6  Counter Clock Stopped with RB Loading    */
+    uint32_t LDBDIS:1;                  /**< bit:      7  Counter Clock Disable with RB Loading    */
+    uint32_t ETRGEDG:2;                 /**< bit:   8..9  External Trigger Edge Selection          */
+    uint32_t ABETRG:1;                  /**< bit:     10  TIOAx or TIOBx External Trigger Selection */
+    uint32_t :3;                        /**< bit: 11..13  Reserved */
+    uint32_t CPCTRG:1;                  /**< bit:     14  RC Compare Trigger Enable                */
+    uint32_t WAVE:1;                    /**< bit:     15  Waveform Mode                            */
+    uint32_t LDRA:2;                    /**< bit: 16..17  RA Loading Edge Selection                */
+    uint32_t LDRB:2;                    /**< bit: 18..19  RB Loading Edge Selection                */
+    uint32_t SBSMPLR:3;                 /**< bit: 20..22  Loading Edge Subsampling Ratio           */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CMR_OFFSET                       (0x04)                                        /**<  (TC_CMR) Channel Mode Register (channel = 0)  Offset */
+
+#define TC_CMR_TCCLKS_Pos                   0                                              /**< (TC_CMR) Clock Selection Position */
+#define TC_CMR_TCCLKS_Msk                   (_U_(0x7) << TC_CMR_TCCLKS_Pos)                /**< (TC_CMR) Clock Selection Mask */
+#define TC_CMR_TCCLKS(value)                (TC_CMR_TCCLKS_Msk & ((value) << TC_CMR_TCCLKS_Pos))
+#define   TC_CMR_TCCLKS_TIMER_CLOCK1_Val    _U_(0x0)                                       /**< (TC_CMR) Clock selected: internal PCK6 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK2_Val    _U_(0x1)                                       /**< (TC_CMR) Clock selected: internal MCK/8 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK3_Val    _U_(0x2)                                       /**< (TC_CMR) Clock selected: internal MCK/32 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK4_Val    _U_(0x3)                                       /**< (TC_CMR) Clock selected: internal MCK/128 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK5_Val    _U_(0x4)                                       /**< (TC_CMR) Clock selected: internal SLCK clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_XC0_Val             _U_(0x5)                                       /**< (TC_CMR) Clock selected: XC0  */
+#define   TC_CMR_TCCLKS_XC1_Val             _U_(0x6)                                       /**< (TC_CMR) Clock selected: XC1  */
+#define   TC_CMR_TCCLKS_XC2_Val             _U_(0x7)                                       /**< (TC_CMR) Clock selected: XC2  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK1          (TC_CMR_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal PCK6 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK2          (TC_CMR_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/8 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK3          (TC_CMR_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/32 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK4          (TC_CMR_TCCLKS_TIMER_CLOCK4_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/128 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK5          (TC_CMR_TCCLKS_TIMER_CLOCK5_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal SLCK clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_XC0                   (TC_CMR_TCCLKS_XC0_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC0 Position  */
+#define TC_CMR_TCCLKS_XC1                   (TC_CMR_TCCLKS_XC1_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC1 Position  */
+#define TC_CMR_TCCLKS_XC2                   (TC_CMR_TCCLKS_XC2_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC2 Position  */
+#define TC_CMR_CLKI_Pos                     3                                              /**< (TC_CMR) Clock Invert Position */
+#define TC_CMR_CLKI_Msk                     (_U_(0x1) << TC_CMR_CLKI_Pos)                  /**< (TC_CMR) Clock Invert Mask */
+#define TC_CMR_CLKI                         TC_CMR_CLKI_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CLKI_Msk instead */
+#define TC_CMR_BURST_Pos                    4                                              /**< (TC_CMR) Burst Signal Selection Position */
+#define TC_CMR_BURST_Msk                    (_U_(0x3) << TC_CMR_BURST_Pos)                 /**< (TC_CMR) Burst Signal Selection Mask */
+#define TC_CMR_BURST(value)                 (TC_CMR_BURST_Msk & ((value) << TC_CMR_BURST_Pos))
+#define   TC_CMR_BURST_NONE_Val             _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
+#define   TC_CMR_BURST_XC0_Val              _U_(0x1)                                       /**< (TC_CMR) XC0 is ANDed with the selected clock.  */
+#define   TC_CMR_BURST_XC1_Val              _U_(0x2)                                       /**< (TC_CMR) XC1 is ANDed with the selected clock.  */
+#define   TC_CMR_BURST_XC2_Val              _U_(0x3)                                       /**< (TC_CMR) XC2 is ANDed with the selected clock.  */
+#define TC_CMR_BURST_NONE                   (TC_CMR_BURST_NONE_Val << TC_CMR_BURST_Pos)    /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_BURST_XC0                    (TC_CMR_BURST_XC0_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC0 is ANDed with the selected clock. Position  */
+#define TC_CMR_BURST_XC1                    (TC_CMR_BURST_XC1_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC1 is ANDed with the selected clock. Position  */
+#define TC_CMR_BURST_XC2                    (TC_CMR_BURST_XC2_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC2 is ANDed with the selected clock. Position  */
+#define TC_CMR_LDBSTOP_Pos                  6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_LDBSTOP_Msk                  (_U_(0x1) << TC_CMR_LDBSTOP_Pos)               /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_LDBSTOP                      TC_CMR_LDBSTOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBSTOP_Msk instead */
+#define TC_CMR_LDBDIS_Pos                   7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_LDBDIS_Msk                   (_U_(0x1) << TC_CMR_LDBDIS_Pos)                /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_LDBDIS                       TC_CMR_LDBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBDIS_Msk instead */
+#define TC_CMR_ETRGEDG_Pos                  8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_ETRGEDG_Msk                  (_U_(0x3) << TC_CMR_ETRGEDG_Pos)               /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_ETRGEDG(value)               (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
+#define   TC_CMR_ETRGEDG_NONE_Val           _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
+#define   TC_CMR_ETRGEDG_RISING_Val         _U_(0x1)                                       /**< (TC_CMR) Rising edge  */
+#define   TC_CMR_ETRGEDG_FALLING_Val        _U_(0x2)                                       /**< (TC_CMR) Falling edge  */
+#define   TC_CMR_ETRGEDG_EDGE_Val           _U_(0x3)                                       /**< (TC_CMR) Each edge  */
+#define TC_CMR_ETRGEDG_NONE                 (TC_CMR_ETRGEDG_NONE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_ETRGEDG_RISING               (TC_CMR_ETRGEDG_RISING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_ETRGEDG_FALLING              (TC_CMR_ETRGEDG_FALLING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_ETRGEDG_EDGE                 (TC_CMR_ETRGEDG_EDGE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
+#define TC_CMR_ABETRG_Pos                   10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_ABETRG_Msk                   (_U_(0x1) << TC_CMR_ABETRG_Pos)                /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_ABETRG                       TC_CMR_ABETRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_ABETRG_Msk instead */
+#define TC_CMR_CPCTRG_Pos                   14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CPCTRG_Msk                   (_U_(0x1) << TC_CMR_CPCTRG_Pos)                /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CPCTRG                       TC_CMR_CPCTRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CPCTRG_Msk instead */
+#define TC_CMR_WAVE_Pos                     15                                             /**< (TC_CMR) Waveform Mode Position */
+#define TC_CMR_WAVE_Msk                     (_U_(0x1) << TC_CMR_WAVE_Pos)                  /**< (TC_CMR) Waveform Mode Mask */
+#define TC_CMR_WAVE                         TC_CMR_WAVE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVE_Msk instead */
+#define TC_CMR_LDRA_Pos                     16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_LDRA_Msk                     (_U_(0x3) << TC_CMR_LDRA_Pos)                  /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_LDRA(value)                  (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
+#define   TC_CMR_LDRA_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRA_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRA_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRA_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRA_NONE                    (TC_CMR_LDRA_NONE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRA_RISING                  (TC_CMR_LDRA_RISING_Val << TC_CMR_LDRA_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRA_FALLING                 (TC_CMR_LDRA_FALLING_Val << TC_CMR_LDRA_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRA_EDGE                    (TC_CMR_LDRA_EDGE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_LDRB_Pos                     18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_LDRB_Msk                     (_U_(0x3) << TC_CMR_LDRB_Pos)                  /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_LDRB(value)                  (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
+#define   TC_CMR_LDRB_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRB_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRB_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRB_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRB_NONE                    (TC_CMR_LDRB_NONE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRB_RISING                  (TC_CMR_LDRB_RISING_Val << TC_CMR_LDRB_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRB_FALLING                 (TC_CMR_LDRB_FALLING_Val << TC_CMR_LDRB_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRB_EDGE                    (TC_CMR_LDRB_EDGE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_SBSMPLR_Pos                  20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_SBSMPLR_Msk                  (_U_(0x7) << TC_CMR_SBSMPLR_Pos)               /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_SBSMPLR(value)               (TC_CMR_SBSMPLR_Msk & ((value) << TC_CMR_SBSMPLR_Pos))
+#define   TC_CMR_SBSMPLR_ONE_Val            _U_(0x0)                                       /**< (TC_CMR) Load a Capture Register each selected edge  */
+#define   TC_CMR_SBSMPLR_HALF_Val           _U_(0x1)                                       /**< (TC_CMR) Load a Capture Register every 2 selected edges  */
+#define   TC_CMR_SBSMPLR_FOURTH_Val         _U_(0x2)                                       /**< (TC_CMR) Load a Capture Register every 4 selected edges  */
+#define   TC_CMR_SBSMPLR_EIGHTH_Val         _U_(0x3)                                       /**< (TC_CMR) Load a Capture Register every 8 selected edges  */
+#define   TC_CMR_SBSMPLR_SIXTEENTH_Val      _U_(0x4)                                       /**< (TC_CMR) Load a Capture Register every 16 selected edges  */
+#define TC_CMR_SBSMPLR_ONE                  (TC_CMR_SBSMPLR_ONE_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
+#define TC_CMR_SBSMPLR_HALF                 (TC_CMR_SBSMPLR_HALF_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
+#define TC_CMR_SBSMPLR_FOURTH               (TC_CMR_SBSMPLR_FOURTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
+#define TC_CMR_SBSMPLR_EIGHTH               (TC_CMR_SBSMPLR_EIGHTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
+#define TC_CMR_SBSMPLR_SIXTEENTH            (TC_CMR_SBSMPLR_SIXTEENTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
+#define TC_CMR_MASK                         _U_(0x7FC7FF)                                  /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
+#define TC_CMR_Msk                          _U_(0x7FC7FF)                                  /**< (TC_CMR) Register Mask  */
+
+
+/* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) Stepper Motor Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GCEN:1;                    /**< bit:      0  Gray Count Enable                        */
+    uint32_t DOWN:1;                    /**< bit:      1  Down Count                               */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SMMR_OFFSET                      (0x08)                                        /**<  (TC_SMMR) Stepper Motor Mode Register (channel = 0)  Offset */
+
+#define TC_SMMR_GCEN_Pos                    0                                              /**< (TC_SMMR) Gray Count Enable Position */
+#define TC_SMMR_GCEN_Msk                    (_U_(0x1) << TC_SMMR_GCEN_Pos)                 /**< (TC_SMMR) Gray Count Enable Mask */
+#define TC_SMMR_GCEN                        TC_SMMR_GCEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SMMR_GCEN_Msk instead */
+#define TC_SMMR_DOWN_Pos                    1                                              /**< (TC_SMMR) Down Count Position */
+#define TC_SMMR_DOWN_Msk                    (_U_(0x1) << TC_SMMR_DOWN_Pos)                 /**< (TC_SMMR) Down Count Mask */
+#define TC_SMMR_DOWN                        TC_SMMR_DOWN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SMMR_DOWN_Msk instead */
+#define TC_SMMR_MASK                        _U_(0x03)                                      /**< \deprecated (TC_SMMR) Register MASK  (Use TC_SMMR_Msk instead)  */
+#define TC_SMMR_Msk                         _U_(0x03)                                      /**< (TC_SMMR) Register Mask  */
+
+
+/* -------- TC_RAB : (TC Offset: 0x0c) (R/ 32) Register AB (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RAB:32;                    /**< bit:  0..31  Register A or Register B                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RAB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RAB_OFFSET                       (0x0C)                                        /**<  (TC_RAB) Register AB (channel = 0)  Offset */
+
+#define TC_RAB_RAB_Pos                      0                                              /**< (TC_RAB) Register A or Register B Position */
+#define TC_RAB_RAB_Msk                      (_U_(0xFFFFFFFF) << TC_RAB_RAB_Pos)            /**< (TC_RAB) Register A or Register B Mask */
+#define TC_RAB_RAB(value)                   (TC_RAB_RAB_Msk & ((value) << TC_RAB_RAB_Pos))
+#define TC_RAB_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RAB) Register MASK  (Use TC_RAB_Msk instead)  */
+#define TC_RAB_Msk                          _U_(0xFFFFFFFF)                                /**< (TC_RAB) Register Mask  */
+
+
+/* -------- TC_CV : (TC Offset: 0x10) (R/ 32) Counter Value (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CV:32;                     /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CV_OFFSET                        (0x10)                                        /**<  (TC_CV) Counter Value (channel = 0)  Offset */
+
+#define TC_CV_CV_Pos                        0                                              /**< (TC_CV) Counter Value Position */
+#define TC_CV_CV_Msk                        (_U_(0xFFFFFFFF) << TC_CV_CV_Pos)              /**< (TC_CV) Counter Value Mask */
+#define TC_CV_CV(value)                     (TC_CV_CV_Msk & ((value) << TC_CV_CV_Pos))   
+#define TC_CV_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_CV) Register MASK  (Use TC_CV_Msk instead)  */
+#define TC_CV_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_CV) Register Mask  */
+
+
+/* -------- TC_RA : (TC Offset: 0x14) (R/W 32) Register A (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RA:32;                     /**< bit:  0..31  Register A                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RA_OFFSET                        (0x14)                                        /**<  (TC_RA) Register A (channel = 0)  Offset */
+
+#define TC_RA_RA_Pos                        0                                              /**< (TC_RA) Register A Position */
+#define TC_RA_RA_Msk                        (_U_(0xFFFFFFFF) << TC_RA_RA_Pos)              /**< (TC_RA) Register A Mask */
+#define TC_RA_RA(value)                     (TC_RA_RA_Msk & ((value) << TC_RA_RA_Pos))   
+#define TC_RA_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RA) Register MASK  (Use TC_RA_Msk instead)  */
+#define TC_RA_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RA) Register Mask  */
+
+
+/* -------- TC_RB : (TC Offset: 0x18) (R/W 32) Register B (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RB:32;                     /**< bit:  0..31  Register B                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RB_OFFSET                        (0x18)                                        /**<  (TC_RB) Register B (channel = 0)  Offset */
+
+#define TC_RB_RB_Pos                        0                                              /**< (TC_RB) Register B Position */
+#define TC_RB_RB_Msk                        (_U_(0xFFFFFFFF) << TC_RB_RB_Pos)              /**< (TC_RB) Register B Mask */
+#define TC_RB_RB(value)                     (TC_RB_RB_Msk & ((value) << TC_RB_RB_Pos))   
+#define TC_RB_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RB) Register MASK  (Use TC_RB_Msk instead)  */
+#define TC_RB_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RB) Register Mask  */
+
+
+/* -------- TC_RC : (TC Offset: 0x1c) (R/W 32) Register C (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RC:32;                     /**< bit:  0..31  Register C                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RC_OFFSET                        (0x1C)                                        /**<  (TC_RC) Register C (channel = 0)  Offset */
+
+#define TC_RC_RC_Pos                        0                                              /**< (TC_RC) Register C Position */
+#define TC_RC_RC_Msk                        (_U_(0xFFFFFFFF) << TC_RC_RC_Pos)              /**< (TC_RC) Register C Mask */
+#define TC_RC_RC(value)                     (TC_RC_RC_Msk & ((value) << TC_RC_RC_Pos))   
+#define TC_RC_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RC) Register MASK  (Use TC_RC_Msk instead)  */
+#define TC_RC_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RC) Register Mask  */
+
+
+/* -------- TC_SR : (TC Offset: 0x20) (R/ 32) Status Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow Status (cleared on read) */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun Status (cleared on read)    */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare Status (cleared on read)      */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare Status (cleared on read)      */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare Status (cleared on read)      */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading Status (cleared on read)      */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading Status (cleared on read)      */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger Status (cleared on read) */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t CLKSTA:1;                  /**< bit:     16  Clock Enabling Status                    */
+    uint32_t MTIOA:1;                   /**< bit:     17  TIOAx Mirror                             */
+    uint32_t MTIOB:1;                   /**< bit:     18  TIOBx Mirror                             */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SR_OFFSET                        (0x20)                                        /**<  (TC_SR) Status Register (channel = 0)  Offset */
+
+#define TC_SR_COVFS_Pos                     0                                              /**< (TC_SR) Counter Overflow Status (cleared on read) Position */
+#define TC_SR_COVFS_Msk                     (_U_(0x1) << TC_SR_COVFS_Pos)                  /**< (TC_SR) Counter Overflow Status (cleared on read) Mask */
+#define TC_SR_COVFS                         TC_SR_COVFS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_COVFS_Msk instead */
+#define TC_SR_LOVRS_Pos                     1                                              /**< (TC_SR) Load Overrun Status (cleared on read) Position */
+#define TC_SR_LOVRS_Msk                     (_U_(0x1) << TC_SR_LOVRS_Pos)                  /**< (TC_SR) Load Overrun Status (cleared on read) Mask */
+#define TC_SR_LOVRS                         TC_SR_LOVRS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LOVRS_Msk instead */
+#define TC_SR_CPAS_Pos                      2                                              /**< (TC_SR) RA Compare Status (cleared on read) Position */
+#define TC_SR_CPAS_Msk                      (_U_(0x1) << TC_SR_CPAS_Pos)                   /**< (TC_SR) RA Compare Status (cleared on read) Mask */
+#define TC_SR_CPAS                          TC_SR_CPAS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPAS_Msk instead */
+#define TC_SR_CPBS_Pos                      3                                              /**< (TC_SR) RB Compare Status (cleared on read) Position */
+#define TC_SR_CPBS_Msk                      (_U_(0x1) << TC_SR_CPBS_Pos)                   /**< (TC_SR) RB Compare Status (cleared on read) Mask */
+#define TC_SR_CPBS                          TC_SR_CPBS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPBS_Msk instead */
+#define TC_SR_CPCS_Pos                      4                                              /**< (TC_SR) RC Compare Status (cleared on read) Position */
+#define TC_SR_CPCS_Msk                      (_U_(0x1) << TC_SR_CPCS_Pos)                   /**< (TC_SR) RC Compare Status (cleared on read) Mask */
+#define TC_SR_CPCS                          TC_SR_CPCS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPCS_Msk instead */
+#define TC_SR_LDRAS_Pos                     5                                              /**< (TC_SR) RA Loading Status (cleared on read) Position */
+#define TC_SR_LDRAS_Msk                     (_U_(0x1) << TC_SR_LDRAS_Pos)                  /**< (TC_SR) RA Loading Status (cleared on read) Mask */
+#define TC_SR_LDRAS                         TC_SR_LDRAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LDRAS_Msk instead */
+#define TC_SR_LDRBS_Pos                     6                                              /**< (TC_SR) RB Loading Status (cleared on read) Position */
+#define TC_SR_LDRBS_Msk                     (_U_(0x1) << TC_SR_LDRBS_Pos)                  /**< (TC_SR) RB Loading Status (cleared on read) Mask */
+#define TC_SR_LDRBS                         TC_SR_LDRBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LDRBS_Msk instead */
+#define TC_SR_ETRGS_Pos                     7                                              /**< (TC_SR) External Trigger Status (cleared on read) Position */
+#define TC_SR_ETRGS_Msk                     (_U_(0x1) << TC_SR_ETRGS_Pos)                  /**< (TC_SR) External Trigger Status (cleared on read) Mask */
+#define TC_SR_ETRGS                         TC_SR_ETRGS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_ETRGS_Msk instead */
+#define TC_SR_CLKSTA_Pos                    16                                             /**< (TC_SR) Clock Enabling Status Position */
+#define TC_SR_CLKSTA_Msk                    (_U_(0x1) << TC_SR_CLKSTA_Pos)                 /**< (TC_SR) Clock Enabling Status Mask */
+#define TC_SR_CLKSTA                        TC_SR_CLKSTA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CLKSTA_Msk instead */
+#define TC_SR_MTIOA_Pos                     17                                             /**< (TC_SR) TIOAx Mirror Position */
+#define TC_SR_MTIOA_Msk                     (_U_(0x1) << TC_SR_MTIOA_Pos)                  /**< (TC_SR) TIOAx Mirror Mask */
+#define TC_SR_MTIOA                         TC_SR_MTIOA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_MTIOA_Msk instead */
+#define TC_SR_MTIOB_Pos                     18                                             /**< (TC_SR) TIOBx Mirror Position */
+#define TC_SR_MTIOB_Msk                     (_U_(0x1) << TC_SR_MTIOB_Pos)                  /**< (TC_SR) TIOBx Mirror Mask */
+#define TC_SR_MTIOB                         TC_SR_MTIOB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_MTIOB_Msk instead */
+#define TC_SR_MASK                          _U_(0x700FF)                                   /**< \deprecated (TC_SR) Register MASK  (Use TC_SR_Msk instead)  */
+#define TC_SR_Msk                           _U_(0x700FF)                                   /**< (TC_SR) Register Mask  */
+
+
+/* -------- TC_IER : (TC Offset: 0x24) (/W 32) Interrupt Enable Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IER_OFFSET                       (0x24)                                        /**<  (TC_IER) Interrupt Enable Register (channel = 0)  Offset */
+
+#define TC_IER_COVFS_Pos                    0                                              /**< (TC_IER) Counter Overflow Position */
+#define TC_IER_COVFS_Msk                    (_U_(0x1) << TC_IER_COVFS_Pos)                 /**< (TC_IER) Counter Overflow Mask */
+#define TC_IER_COVFS                        TC_IER_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_COVFS_Msk instead */
+#define TC_IER_LOVRS_Pos                    1                                              /**< (TC_IER) Load Overrun Position */
+#define TC_IER_LOVRS_Msk                    (_U_(0x1) << TC_IER_LOVRS_Pos)                 /**< (TC_IER) Load Overrun Mask */
+#define TC_IER_LOVRS                        TC_IER_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LOVRS_Msk instead */
+#define TC_IER_CPAS_Pos                     2                                              /**< (TC_IER) RA Compare Position */
+#define TC_IER_CPAS_Msk                     (_U_(0x1) << TC_IER_CPAS_Pos)                  /**< (TC_IER) RA Compare Mask */
+#define TC_IER_CPAS                         TC_IER_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPAS_Msk instead */
+#define TC_IER_CPBS_Pos                     3                                              /**< (TC_IER) RB Compare Position */
+#define TC_IER_CPBS_Msk                     (_U_(0x1) << TC_IER_CPBS_Pos)                  /**< (TC_IER) RB Compare Mask */
+#define TC_IER_CPBS                         TC_IER_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPBS_Msk instead */
+#define TC_IER_CPCS_Pos                     4                                              /**< (TC_IER) RC Compare Position */
+#define TC_IER_CPCS_Msk                     (_U_(0x1) << TC_IER_CPCS_Pos)                  /**< (TC_IER) RC Compare Mask */
+#define TC_IER_CPCS                         TC_IER_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPCS_Msk instead */
+#define TC_IER_LDRAS_Pos                    5                                              /**< (TC_IER) RA Loading Position */
+#define TC_IER_LDRAS_Msk                    (_U_(0x1) << TC_IER_LDRAS_Pos)                 /**< (TC_IER) RA Loading Mask */
+#define TC_IER_LDRAS                        TC_IER_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LDRAS_Msk instead */
+#define TC_IER_LDRBS_Pos                    6                                              /**< (TC_IER) RB Loading Position */
+#define TC_IER_LDRBS_Msk                    (_U_(0x1) << TC_IER_LDRBS_Pos)                 /**< (TC_IER) RB Loading Mask */
+#define TC_IER_LDRBS                        TC_IER_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LDRBS_Msk instead */
+#define TC_IER_ETRGS_Pos                    7                                              /**< (TC_IER) External Trigger Position */
+#define TC_IER_ETRGS_Msk                    (_U_(0x1) << TC_IER_ETRGS_Pos)                 /**< (TC_IER) External Trigger Mask */
+#define TC_IER_ETRGS                        TC_IER_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_ETRGS_Msk instead */
+#define TC_IER_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IER) Register MASK  (Use TC_IER_Msk instead)  */
+#define TC_IER_Msk                          _U_(0xFF)                                      /**< (TC_IER) Register Mask  */
+
+
+/* -------- TC_IDR : (TC Offset: 0x28) (/W 32) Interrupt Disable Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IDR_OFFSET                       (0x28)                                        /**<  (TC_IDR) Interrupt Disable Register (channel = 0)  Offset */
+
+#define TC_IDR_COVFS_Pos                    0                                              /**< (TC_IDR) Counter Overflow Position */
+#define TC_IDR_COVFS_Msk                    (_U_(0x1) << TC_IDR_COVFS_Pos)                 /**< (TC_IDR) Counter Overflow Mask */
+#define TC_IDR_COVFS                        TC_IDR_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_COVFS_Msk instead */
+#define TC_IDR_LOVRS_Pos                    1                                              /**< (TC_IDR) Load Overrun Position */
+#define TC_IDR_LOVRS_Msk                    (_U_(0x1) << TC_IDR_LOVRS_Pos)                 /**< (TC_IDR) Load Overrun Mask */
+#define TC_IDR_LOVRS                        TC_IDR_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LOVRS_Msk instead */
+#define TC_IDR_CPAS_Pos                     2                                              /**< (TC_IDR) RA Compare Position */
+#define TC_IDR_CPAS_Msk                     (_U_(0x1) << TC_IDR_CPAS_Pos)                  /**< (TC_IDR) RA Compare Mask */
+#define TC_IDR_CPAS                         TC_IDR_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPAS_Msk instead */
+#define TC_IDR_CPBS_Pos                     3                                              /**< (TC_IDR) RB Compare Position */
+#define TC_IDR_CPBS_Msk                     (_U_(0x1) << TC_IDR_CPBS_Pos)                  /**< (TC_IDR) RB Compare Mask */
+#define TC_IDR_CPBS                         TC_IDR_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPBS_Msk instead */
+#define TC_IDR_CPCS_Pos                     4                                              /**< (TC_IDR) RC Compare Position */
+#define TC_IDR_CPCS_Msk                     (_U_(0x1) << TC_IDR_CPCS_Pos)                  /**< (TC_IDR) RC Compare Mask */
+#define TC_IDR_CPCS                         TC_IDR_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPCS_Msk instead */
+#define TC_IDR_LDRAS_Pos                    5                                              /**< (TC_IDR) RA Loading Position */
+#define TC_IDR_LDRAS_Msk                    (_U_(0x1) << TC_IDR_LDRAS_Pos)                 /**< (TC_IDR) RA Loading Mask */
+#define TC_IDR_LDRAS                        TC_IDR_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LDRAS_Msk instead */
+#define TC_IDR_LDRBS_Pos                    6                                              /**< (TC_IDR) RB Loading Position */
+#define TC_IDR_LDRBS_Msk                    (_U_(0x1) << TC_IDR_LDRBS_Pos)                 /**< (TC_IDR) RB Loading Mask */
+#define TC_IDR_LDRBS                        TC_IDR_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LDRBS_Msk instead */
+#define TC_IDR_ETRGS_Pos                    7                                              /**< (TC_IDR) External Trigger Position */
+#define TC_IDR_ETRGS_Msk                    (_U_(0x1) << TC_IDR_ETRGS_Pos)                 /**< (TC_IDR) External Trigger Mask */
+#define TC_IDR_ETRGS                        TC_IDR_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_ETRGS_Msk instead */
+#define TC_IDR_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IDR) Register MASK  (Use TC_IDR_Msk instead)  */
+#define TC_IDR_Msk                          _U_(0xFF)                                      /**< (TC_IDR) Register Mask  */
+
+
+/* -------- TC_IMR : (TC Offset: 0x2c) (R/ 32) Interrupt Mask Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IMR_OFFSET                       (0x2C)                                        /**<  (TC_IMR) Interrupt Mask Register (channel = 0)  Offset */
+
+#define TC_IMR_COVFS_Pos                    0                                              /**< (TC_IMR) Counter Overflow Position */
+#define TC_IMR_COVFS_Msk                    (_U_(0x1) << TC_IMR_COVFS_Pos)                 /**< (TC_IMR) Counter Overflow Mask */
+#define TC_IMR_COVFS                        TC_IMR_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_COVFS_Msk instead */
+#define TC_IMR_LOVRS_Pos                    1                                              /**< (TC_IMR) Load Overrun Position */
+#define TC_IMR_LOVRS_Msk                    (_U_(0x1) << TC_IMR_LOVRS_Pos)                 /**< (TC_IMR) Load Overrun Mask */
+#define TC_IMR_LOVRS                        TC_IMR_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LOVRS_Msk instead */
+#define TC_IMR_CPAS_Pos                     2                                              /**< (TC_IMR) RA Compare Position */
+#define TC_IMR_CPAS_Msk                     (_U_(0x1) << TC_IMR_CPAS_Pos)                  /**< (TC_IMR) RA Compare Mask */
+#define TC_IMR_CPAS                         TC_IMR_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPAS_Msk instead */
+#define TC_IMR_CPBS_Pos                     3                                              /**< (TC_IMR) RB Compare Position */
+#define TC_IMR_CPBS_Msk                     (_U_(0x1) << TC_IMR_CPBS_Pos)                  /**< (TC_IMR) RB Compare Mask */
+#define TC_IMR_CPBS                         TC_IMR_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPBS_Msk instead */
+#define TC_IMR_CPCS_Pos                     4                                              /**< (TC_IMR) RC Compare Position */
+#define TC_IMR_CPCS_Msk                     (_U_(0x1) << TC_IMR_CPCS_Pos)                  /**< (TC_IMR) RC Compare Mask */
+#define TC_IMR_CPCS                         TC_IMR_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPCS_Msk instead */
+#define TC_IMR_LDRAS_Pos                    5                                              /**< (TC_IMR) RA Loading Position */
+#define TC_IMR_LDRAS_Msk                    (_U_(0x1) << TC_IMR_LDRAS_Pos)                 /**< (TC_IMR) RA Loading Mask */
+#define TC_IMR_LDRAS                        TC_IMR_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LDRAS_Msk instead */
+#define TC_IMR_LDRBS_Pos                    6                                              /**< (TC_IMR) RB Loading Position */
+#define TC_IMR_LDRBS_Msk                    (_U_(0x1) << TC_IMR_LDRBS_Pos)                 /**< (TC_IMR) RB Loading Mask */
+#define TC_IMR_LDRBS                        TC_IMR_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LDRBS_Msk instead */
+#define TC_IMR_ETRGS_Pos                    7                                              /**< (TC_IMR) External Trigger Position */
+#define TC_IMR_ETRGS_Msk                    (_U_(0x1) << TC_IMR_ETRGS_Pos)                 /**< (TC_IMR) External Trigger Mask */
+#define TC_IMR_ETRGS                        TC_IMR_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_ETRGS_Msk instead */
+#define TC_IMR_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IMR) Register MASK  (Use TC_IMR_Msk instead)  */
+#define TC_IMR_Msk                          _U_(0xFF)                                      /**< (TC_IMR) Register Mask  */
+
+
+/* -------- TC_EMR : (TC Offset: 0x30) (R/W 32) Extended Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRIGSRCA:2;                /**< bit:   0..1  Trigger Source for Input A               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t TRIGSRCB:2;                /**< bit:   4..5  Trigger Source for Input B               */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NODIVCLK:1;                /**< bit:      8  No Divided Clock                         */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_EMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EMR_OFFSET                       (0x30)                                        /**<  (TC_EMR) Extended Mode Register (channel = 0)  Offset */
+
+#define TC_EMR_TRIGSRCA_Pos                 0                                              /**< (TC_EMR) Trigger Source for Input A Position */
+#define TC_EMR_TRIGSRCA_Msk                 (_U_(0x3) << TC_EMR_TRIGSRCA_Pos)              /**< (TC_EMR) Trigger Source for Input A Mask */
+#define TC_EMR_TRIGSRCA(value)              (TC_EMR_TRIGSRCA_Msk & ((value) << TC_EMR_TRIGSRCA_Pos))
+#define   TC_EMR_TRIGSRCA_EXTERNAL_TIOAx_Val _U_(0x0)                                       /**< (TC_EMR) The trigger/capture input A is driven by external pin TIOAx  */
+#define   TC_EMR_TRIGSRCA_PWMx_Val          _U_(0x1)                                       /**< (TC_EMR) The trigger/capture input A is driven internally by PWMx  */
+#define TC_EMR_TRIGSRCA_EXTERNAL_TIOAx      (TC_EMR_TRIGSRCA_EXTERNAL_TIOAx_Val << TC_EMR_TRIGSRCA_Pos)  /**< (TC_EMR) The trigger/capture input A is driven by external pin TIOAx Position  */
+#define TC_EMR_TRIGSRCA_PWMx                (TC_EMR_TRIGSRCA_PWMx_Val << TC_EMR_TRIGSRCA_Pos)  /**< (TC_EMR) The trigger/capture input A is driven internally by PWMx Position  */
+#define TC_EMR_TRIGSRCB_Pos                 4                                              /**< (TC_EMR) Trigger Source for Input B Position */
+#define TC_EMR_TRIGSRCB_Msk                 (_U_(0x3) << TC_EMR_TRIGSRCB_Pos)              /**< (TC_EMR) Trigger Source for Input B Mask */
+#define TC_EMR_TRIGSRCB(value)              (TC_EMR_TRIGSRCB_Msk & ((value) << TC_EMR_TRIGSRCB_Pos))
+#define   TC_EMR_TRIGSRCB_EXTERNAL_TIOBx_Val _U_(0x0)                                       /**< (TC_EMR) The trigger/capture input B is driven by external pin TIOBx  */
+#define   TC_EMR_TRIGSRCB_PWMx_Val          _U_(0x1)                                       /**< (TC_EMR) For TC0 to TC10: The trigger/capture input B is driven internally by the comparator output (see Figure 7-16) of the PWMx.For TC11: The trigger/capture input B is driven internally by the GTSUCOMP signal of the Ethernet MAC (GMAC).  */
+#define TC_EMR_TRIGSRCB_EXTERNAL_TIOBx      (TC_EMR_TRIGSRCB_EXTERNAL_TIOBx_Val << TC_EMR_TRIGSRCB_Pos)  /**< (TC_EMR) The trigger/capture input B is driven by external pin TIOBx Position  */
+#define TC_EMR_TRIGSRCB_PWMx                (TC_EMR_TRIGSRCB_PWMx_Val << TC_EMR_TRIGSRCB_Pos)  /**< (TC_EMR) For TC0 to TC10: The trigger/capture input B is driven internally by the comparator output (see Figure 7-16) of the PWMx.For TC11: The trigger/capture input B is driven internally by the GTSUCOMP signal of the Ethernet MAC (GMAC). Position  */
+#define TC_EMR_NODIVCLK_Pos                 8                                              /**< (TC_EMR) No Divided Clock Position */
+#define TC_EMR_NODIVCLK_Msk                 (_U_(0x1) << TC_EMR_NODIVCLK_Pos)              /**< (TC_EMR) No Divided Clock Mask */
+#define TC_EMR_NODIVCLK                     TC_EMR_NODIVCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EMR_NODIVCLK_Msk instead */
+#define TC_EMR_MASK                         _U_(0x133)                                     /**< \deprecated (TC_EMR) Register MASK  (Use TC_EMR_Msk instead)  */
+#define TC_EMR_Msk                          _U_(0x133)                                     /**< (TC_EMR) Register Mask  */
+
+
+/* -------- TC_BCR : (TC Offset: 0xc0) (/W 32) Block Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SYNC:1;                    /**< bit:      0  Synchro Command                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_BCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BCR_OFFSET                       (0xC0)                                        /**<  (TC_BCR) Block Control Register  Offset */
+
+#define TC_BCR_SYNC_Pos                     0                                              /**< (TC_BCR) Synchro Command Position */
+#define TC_BCR_SYNC_Msk                     (_U_(0x1) << TC_BCR_SYNC_Pos)                  /**< (TC_BCR) Synchro Command Mask */
+#define TC_BCR_SYNC                         TC_BCR_SYNC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BCR_SYNC_Msk instead */
+#define TC_BCR_MASK                         _U_(0x01)                                      /**< \deprecated (TC_BCR) Register MASK  (Use TC_BCR_Msk instead)  */
+#define TC_BCR_Msk                          _U_(0x01)                                      /**< (TC_BCR) Register Mask  */
+
+
+/* -------- TC_BMR : (TC Offset: 0xc4) (R/W 32) Block Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TC0XC0S:2;                 /**< bit:   0..1  External Clock Signal 0 Selection        */
+    uint32_t TC1XC1S:2;                 /**< bit:   2..3  External Clock Signal 1 Selection        */
+    uint32_t TC2XC2S:2;                 /**< bit:   4..5  External Clock Signal 2 Selection        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t QDEN:1;                    /**< bit:      8  Quadrature Decoder Enabled               */
+    uint32_t POSEN:1;                   /**< bit:      9  Position Enabled                         */
+    uint32_t SPEEDEN:1;                 /**< bit:     10  Speed Enabled                            */
+    uint32_t QDTRANS:1;                 /**< bit:     11  Quadrature Decoding Transparent          */
+    uint32_t EDGPHA:1;                  /**< bit:     12  Edge on PHA Count Mode                   */
+    uint32_t INVA:1;                    /**< bit:     13  Inverted PHA                             */
+    uint32_t INVB:1;                    /**< bit:     14  Inverted PHB                             */
+    uint32_t INVIDX:1;                  /**< bit:     15  Inverted Index                           */
+    uint32_t SWAP:1;                    /**< bit:     16  Swap PHA and PHB                         */
+    uint32_t IDXPHB:1;                  /**< bit:     17  Index Pin is PHB Pin                     */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t MAXFILT:6;                 /**< bit: 20..25  Maximum Filter                           */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_BMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BMR_OFFSET                       (0xC4)                                        /**<  (TC_BMR) Block Mode Register  Offset */
+
+#define TC_BMR_TC0XC0S_Pos                  0                                              /**< (TC_BMR) External Clock Signal 0 Selection Position */
+#define TC_BMR_TC0XC0S_Msk                  (_U_(0x3) << TC_BMR_TC0XC0S_Pos)               /**< (TC_BMR) External Clock Signal 0 Selection Mask */
+#define TC_BMR_TC0XC0S(value)               (TC_BMR_TC0XC0S_Msk & ((value) << TC_BMR_TC0XC0S_Pos))
+#define   TC_BMR_TC0XC0S_TCLK0_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC0: TCLK0  */
+#define   TC_BMR_TC0XC0S_TIOA1_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC0: TIOA1  */
+#define   TC_BMR_TC0XC0S_TIOA2_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC0: TIOA2  */
+#define TC_BMR_TC0XC0S_TCLK0                (TC_BMR_TC0XC0S_TCLK0_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TCLK0 Position  */
+#define TC_BMR_TC0XC0S_TIOA1                (TC_BMR_TC0XC0S_TIOA1_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TIOA1 Position  */
+#define TC_BMR_TC0XC0S_TIOA2                (TC_BMR_TC0XC0S_TIOA2_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TIOA2 Position  */
+#define TC_BMR_TC1XC1S_Pos                  2                                              /**< (TC_BMR) External Clock Signal 1 Selection Position */
+#define TC_BMR_TC1XC1S_Msk                  (_U_(0x3) << TC_BMR_TC1XC1S_Pos)               /**< (TC_BMR) External Clock Signal 1 Selection Mask */
+#define TC_BMR_TC1XC1S(value)               (TC_BMR_TC1XC1S_Msk & ((value) << TC_BMR_TC1XC1S_Pos))
+#define   TC_BMR_TC1XC1S_TCLK1_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC1: TCLK1  */
+#define   TC_BMR_TC1XC1S_TIOA0_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC1: TIOA0  */
+#define   TC_BMR_TC1XC1S_TIOA2_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC1: TIOA2  */
+#define TC_BMR_TC1XC1S_TCLK1                (TC_BMR_TC1XC1S_TCLK1_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TCLK1 Position  */
+#define TC_BMR_TC1XC1S_TIOA0                (TC_BMR_TC1XC1S_TIOA0_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TIOA0 Position  */
+#define TC_BMR_TC1XC1S_TIOA2                (TC_BMR_TC1XC1S_TIOA2_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TIOA2 Position  */
+#define TC_BMR_TC2XC2S_Pos                  4                                              /**< (TC_BMR) External Clock Signal 2 Selection Position */
+#define TC_BMR_TC2XC2S_Msk                  (_U_(0x3) << TC_BMR_TC2XC2S_Pos)               /**< (TC_BMR) External Clock Signal 2 Selection Mask */
+#define TC_BMR_TC2XC2S(value)               (TC_BMR_TC2XC2S_Msk & ((value) << TC_BMR_TC2XC2S_Pos))
+#define   TC_BMR_TC2XC2S_TCLK2_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC2: TCLK2  */
+#define   TC_BMR_TC2XC2S_TIOA0_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC2: TIOA0  */
+#define   TC_BMR_TC2XC2S_TIOA1_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC2: TIOA1  */
+#define TC_BMR_TC2XC2S_TCLK2                (TC_BMR_TC2XC2S_TCLK2_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TCLK2 Position  */
+#define TC_BMR_TC2XC2S_TIOA0                (TC_BMR_TC2XC2S_TIOA0_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TIOA0 Position  */
+#define TC_BMR_TC2XC2S_TIOA1                (TC_BMR_TC2XC2S_TIOA1_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TIOA1 Position  */
+#define TC_BMR_QDEN_Pos                     8                                              /**< (TC_BMR) Quadrature Decoder Enabled Position */
+#define TC_BMR_QDEN_Msk                     (_U_(0x1) << TC_BMR_QDEN_Pos)                  /**< (TC_BMR) Quadrature Decoder Enabled Mask */
+#define TC_BMR_QDEN                         TC_BMR_QDEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_QDEN_Msk instead */
+#define TC_BMR_POSEN_Pos                    9                                              /**< (TC_BMR) Position Enabled Position */
+#define TC_BMR_POSEN_Msk                    (_U_(0x1) << TC_BMR_POSEN_Pos)                 /**< (TC_BMR) Position Enabled Mask */
+#define TC_BMR_POSEN                        TC_BMR_POSEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_POSEN_Msk instead */
+#define TC_BMR_SPEEDEN_Pos                  10                                             /**< (TC_BMR) Speed Enabled Position */
+#define TC_BMR_SPEEDEN_Msk                  (_U_(0x1) << TC_BMR_SPEEDEN_Pos)               /**< (TC_BMR) Speed Enabled Mask */
+#define TC_BMR_SPEEDEN                      TC_BMR_SPEEDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_SPEEDEN_Msk instead */
+#define TC_BMR_QDTRANS_Pos                  11                                             /**< (TC_BMR) Quadrature Decoding Transparent Position */
+#define TC_BMR_QDTRANS_Msk                  (_U_(0x1) << TC_BMR_QDTRANS_Pos)               /**< (TC_BMR) Quadrature Decoding Transparent Mask */
+#define TC_BMR_QDTRANS                      TC_BMR_QDTRANS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_QDTRANS_Msk instead */
+#define TC_BMR_EDGPHA_Pos                   12                                             /**< (TC_BMR) Edge on PHA Count Mode Position */
+#define TC_BMR_EDGPHA_Msk                   (_U_(0x1) << TC_BMR_EDGPHA_Pos)                /**< (TC_BMR) Edge on PHA Count Mode Mask */
+#define TC_BMR_EDGPHA                       TC_BMR_EDGPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_EDGPHA_Msk instead */
+#define TC_BMR_INVA_Pos                     13                                             /**< (TC_BMR) Inverted PHA Position */
+#define TC_BMR_INVA_Msk                     (_U_(0x1) << TC_BMR_INVA_Pos)                  /**< (TC_BMR) Inverted PHA Mask */
+#define TC_BMR_INVA                         TC_BMR_INVA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVA_Msk instead */
+#define TC_BMR_INVB_Pos                     14                                             /**< (TC_BMR) Inverted PHB Position */
+#define TC_BMR_INVB_Msk                     (_U_(0x1) << TC_BMR_INVB_Pos)                  /**< (TC_BMR) Inverted PHB Mask */
+#define TC_BMR_INVB                         TC_BMR_INVB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVB_Msk instead */
+#define TC_BMR_INVIDX_Pos                   15                                             /**< (TC_BMR) Inverted Index Position */
+#define TC_BMR_INVIDX_Msk                   (_U_(0x1) << TC_BMR_INVIDX_Pos)                /**< (TC_BMR) Inverted Index Mask */
+#define TC_BMR_INVIDX                       TC_BMR_INVIDX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVIDX_Msk instead */
+#define TC_BMR_SWAP_Pos                     16                                             /**< (TC_BMR) Swap PHA and PHB Position */
+#define TC_BMR_SWAP_Msk                     (_U_(0x1) << TC_BMR_SWAP_Pos)                  /**< (TC_BMR) Swap PHA and PHB Mask */
+#define TC_BMR_SWAP                         TC_BMR_SWAP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_SWAP_Msk instead */
+#define TC_BMR_IDXPHB_Pos                   17                                             /**< (TC_BMR) Index Pin is PHB Pin Position */
+#define TC_BMR_IDXPHB_Msk                   (_U_(0x1) << TC_BMR_IDXPHB_Pos)                /**< (TC_BMR) Index Pin is PHB Pin Mask */
+#define TC_BMR_IDXPHB                       TC_BMR_IDXPHB_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_IDXPHB_Msk instead */
+#define TC_BMR_MAXFILT_Pos                  20                                             /**< (TC_BMR) Maximum Filter Position */
+#define TC_BMR_MAXFILT_Msk                  (_U_(0x3F) << TC_BMR_MAXFILT_Pos)              /**< (TC_BMR) Maximum Filter Mask */
+#define TC_BMR_MAXFILT(value)               (TC_BMR_MAXFILT_Msk & ((value) << TC_BMR_MAXFILT_Pos))
+#define TC_BMR_MASK                         _U_(0x3F3FF3F)                                 /**< \deprecated (TC_BMR) Register MASK  (Use TC_BMR_Msk instead)  */
+#define TC_BMR_Msk                          _U_(0x3F3FF3F)                                 /**< (TC_BMR) Register Mask  */
+
+
+/* -------- TC_QIER : (TC Offset: 0xc8) (/W 32) QDEC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIER_OFFSET                      (0xC8)                                        /**<  (TC_QIER) QDEC Interrupt Enable Register  Offset */
+
+#define TC_QIER_IDX_Pos                     0                                              /**< (TC_QIER) Index Position */
+#define TC_QIER_IDX_Msk                     (_U_(0x1) << TC_QIER_IDX_Pos)                  /**< (TC_QIER) Index Mask */
+#define TC_QIER_IDX                         TC_QIER_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_IDX_Msk instead */
+#define TC_QIER_DIRCHG_Pos                  1                                              /**< (TC_QIER) Direction Change Position */
+#define TC_QIER_DIRCHG_Msk                  (_U_(0x1) << TC_QIER_DIRCHG_Pos)               /**< (TC_QIER) Direction Change Mask */
+#define TC_QIER_DIRCHG                      TC_QIER_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_DIRCHG_Msk instead */
+#define TC_QIER_QERR_Pos                    2                                              /**< (TC_QIER) Quadrature Error Position */
+#define TC_QIER_QERR_Msk                    (_U_(0x1) << TC_QIER_QERR_Pos)                 /**< (TC_QIER) Quadrature Error Mask */
+#define TC_QIER_QERR                        TC_QIER_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_QERR_Msk instead */
+#define TC_QIER_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIER) Register MASK  (Use TC_QIER_Msk instead)  */
+#define TC_QIER_Msk                         _U_(0x07)                                      /**< (TC_QIER) Register Mask  */
+
+
+/* -------- TC_QIDR : (TC Offset: 0xcc) (/W 32) QDEC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIDR_OFFSET                      (0xCC)                                        /**<  (TC_QIDR) QDEC Interrupt Disable Register  Offset */
+
+#define TC_QIDR_IDX_Pos                     0                                              /**< (TC_QIDR) Index Position */
+#define TC_QIDR_IDX_Msk                     (_U_(0x1) << TC_QIDR_IDX_Pos)                  /**< (TC_QIDR) Index Mask */
+#define TC_QIDR_IDX                         TC_QIDR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_IDX_Msk instead */
+#define TC_QIDR_DIRCHG_Pos                  1                                              /**< (TC_QIDR) Direction Change Position */
+#define TC_QIDR_DIRCHG_Msk                  (_U_(0x1) << TC_QIDR_DIRCHG_Pos)               /**< (TC_QIDR) Direction Change Mask */
+#define TC_QIDR_DIRCHG                      TC_QIDR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_DIRCHG_Msk instead */
+#define TC_QIDR_QERR_Pos                    2                                              /**< (TC_QIDR) Quadrature Error Position */
+#define TC_QIDR_QERR_Msk                    (_U_(0x1) << TC_QIDR_QERR_Pos)                 /**< (TC_QIDR) Quadrature Error Mask */
+#define TC_QIDR_QERR                        TC_QIDR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_QERR_Msk instead */
+#define TC_QIDR_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIDR) Register MASK  (Use TC_QIDR_Msk instead)  */
+#define TC_QIDR_Msk                         _U_(0x07)                                      /**< (TC_QIDR) Register Mask  */
+
+
+/* -------- TC_QIMR : (TC Offset: 0xd0) (R/ 32) QDEC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIMR_OFFSET                      (0xD0)                                        /**<  (TC_QIMR) QDEC Interrupt Mask Register  Offset */
+
+#define TC_QIMR_IDX_Pos                     0                                              /**< (TC_QIMR) Index Position */
+#define TC_QIMR_IDX_Msk                     (_U_(0x1) << TC_QIMR_IDX_Pos)                  /**< (TC_QIMR) Index Mask */
+#define TC_QIMR_IDX                         TC_QIMR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_IDX_Msk instead */
+#define TC_QIMR_DIRCHG_Pos                  1                                              /**< (TC_QIMR) Direction Change Position */
+#define TC_QIMR_DIRCHG_Msk                  (_U_(0x1) << TC_QIMR_DIRCHG_Pos)               /**< (TC_QIMR) Direction Change Mask */
+#define TC_QIMR_DIRCHG                      TC_QIMR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_DIRCHG_Msk instead */
+#define TC_QIMR_QERR_Pos                    2                                              /**< (TC_QIMR) Quadrature Error Position */
+#define TC_QIMR_QERR_Msk                    (_U_(0x1) << TC_QIMR_QERR_Pos)                 /**< (TC_QIMR) Quadrature Error Mask */
+#define TC_QIMR_QERR                        TC_QIMR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_QERR_Msk instead */
+#define TC_QIMR_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIMR) Register MASK  (Use TC_QIMR_Msk instead)  */
+#define TC_QIMR_Msk                         _U_(0x07)                                      /**< (TC_QIMR) Register Mask  */
+
+
+/* -------- TC_QISR : (TC Offset: 0xd4) (R/ 32) QDEC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t DIR:1;                     /**< bit:      8  Direction                                */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QISR_OFFSET                      (0xD4)                                        /**<  (TC_QISR) QDEC Interrupt Status Register  Offset */
+
+#define TC_QISR_IDX_Pos                     0                                              /**< (TC_QISR) Index Position */
+#define TC_QISR_IDX_Msk                     (_U_(0x1) << TC_QISR_IDX_Pos)                  /**< (TC_QISR) Index Mask */
+#define TC_QISR_IDX                         TC_QISR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_IDX_Msk instead */
+#define TC_QISR_DIRCHG_Pos                  1                                              /**< (TC_QISR) Direction Change Position */
+#define TC_QISR_DIRCHG_Msk                  (_U_(0x1) << TC_QISR_DIRCHG_Pos)               /**< (TC_QISR) Direction Change Mask */
+#define TC_QISR_DIRCHG                      TC_QISR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_DIRCHG_Msk instead */
+#define TC_QISR_QERR_Pos                    2                                              /**< (TC_QISR) Quadrature Error Position */
+#define TC_QISR_QERR_Msk                    (_U_(0x1) << TC_QISR_QERR_Pos)                 /**< (TC_QISR) Quadrature Error Mask */
+#define TC_QISR_QERR                        TC_QISR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_QERR_Msk instead */
+#define TC_QISR_DIR_Pos                     8                                              /**< (TC_QISR) Direction Position */
+#define TC_QISR_DIR_Msk                     (_U_(0x1) << TC_QISR_DIR_Pos)                  /**< (TC_QISR) Direction Mask */
+#define TC_QISR_DIR                         TC_QISR_DIR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_DIR_Msk instead */
+#define TC_QISR_MASK                        _U_(0x107)                                     /**< \deprecated (TC_QISR) Register MASK  (Use TC_QISR_Msk instead)  */
+#define TC_QISR_Msk                         _U_(0x107)                                     /**< (TC_QISR) Register Mask  */
+
+
+/* -------- TC_FMR : (TC Offset: 0xd8) (R/W 32) Fault Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENCF0:1;                   /**< bit:      0  Enable Compare Fault Channel 0           */
+    uint32_t ENCF1:1;                   /**< bit:      1  Enable Compare Fault Channel 1           */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ENCF:2;                    /**< bit:   0..1  Enable Compare Fault Channel x           */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_FMR_OFFSET                       (0xD8)                                        /**<  (TC_FMR) Fault Mode Register  Offset */
+
+#define TC_FMR_ENCF0_Pos                    0                                              /**< (TC_FMR) Enable Compare Fault Channel 0 Position */
+#define TC_FMR_ENCF0_Msk                    (_U_(0x1) << TC_FMR_ENCF0_Pos)                 /**< (TC_FMR) Enable Compare Fault Channel 0 Mask */
+#define TC_FMR_ENCF0                        TC_FMR_ENCF0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_FMR_ENCF0_Msk instead */
+#define TC_FMR_ENCF1_Pos                    1                                              /**< (TC_FMR) Enable Compare Fault Channel 1 Position */
+#define TC_FMR_ENCF1_Msk                    (_U_(0x1) << TC_FMR_ENCF1_Pos)                 /**< (TC_FMR) Enable Compare Fault Channel 1 Mask */
+#define TC_FMR_ENCF1                        TC_FMR_ENCF1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_FMR_ENCF1_Msk instead */
+#define TC_FMR_MASK                         _U_(0x03)                                      /**< \deprecated (TC_FMR) Register MASK  (Use TC_FMR_Msk instead)  */
+#define TC_FMR_Msk                          _U_(0x03)                                      /**< (TC_FMR) Register Mask  */
+
+#define TC_FMR_ENCF_Pos                     0                                              /**< (TC_FMR Position) Enable Compare Fault Channel x */
+#define TC_FMR_ENCF_Msk                     (_U_(0x3) << TC_FMR_ENCF_Pos)                  /**< (TC_FMR Mask) ENCF */
+#define TC_FMR_ENCF(value)                  (TC_FMR_ENCF_Msk & ((value) << TC_FMR_ENCF_Pos))  
+
+/* -------- TC_WPMR : (TC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WPMR_OFFSET                      (0xE4)                                        /**<  (TC_WPMR) Write Protection Mode Register  Offset */
+
+#define TC_WPMR_WPEN_Pos                    0                                              /**< (TC_WPMR) Write Protection Enable Position */
+#define TC_WPMR_WPEN_Msk                    (_U_(0x1) << TC_WPMR_WPEN_Pos)                 /**< (TC_WPMR) Write Protection Enable Mask */
+#define TC_WPMR_WPEN                        TC_WPMR_WPEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_WPMR_WPEN_Msk instead */
+#define TC_WPMR_WPKEY_Pos                   8                                              /**< (TC_WPMR) Write Protection Key Position */
+#define TC_WPMR_WPKEY_Msk                   (_U_(0xFFFFFF) << TC_WPMR_WPKEY_Pos)           /**< (TC_WPMR) Write Protection Key Mask */
+#define TC_WPMR_WPKEY(value)                (TC_WPMR_WPKEY_Msk & ((value) << TC_WPMR_WPKEY_Pos))
+#define   TC_WPMR_WPKEY_PASSWD_Val          _U_(0x54494D)                                  /**< (TC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define TC_WPMR_WPKEY_PASSWD                (TC_WPMR_WPKEY_PASSWD_Val << TC_WPMR_WPKEY_Pos)  /**< (TC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define TC_WPMR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (TC_WPMR) Register MASK  (Use TC_WPMR_Msk instead)  */
+#define TC_WPMR_Msk                         _U_(0xFFFFFF01)                                /**< (TC_WPMR) Register Mask  */
+
+
+/* -------- TC_VER : (TC Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_VER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_VER_OFFSET                       (0xFC)                                        /**<  (TC_VER) Version Register  Offset */
+
+#define TC_VER_VERSION_Pos                  0                                              /**< (TC_VER) Version of the Hardware Module Position */
+#define TC_VER_VERSION_Msk                  (_U_(0xFFF) << TC_VER_VERSION_Pos)             /**< (TC_VER) Version of the Hardware Module Mask */
+#define TC_VER_VERSION(value)               (TC_VER_VERSION_Msk & ((value) << TC_VER_VERSION_Pos))
+#define TC_VER_MFN_Pos                      16                                             /**< (TC_VER) Metal Fix Number Position */
+#define TC_VER_MFN_Msk                      (_U_(0x7) << TC_VER_MFN_Pos)                   /**< (TC_VER) Metal Fix Number Mask */
+#define TC_VER_MFN(value)                   (TC_VER_MFN_Msk & ((value) << TC_VER_MFN_Pos))
+#define TC_VER_MASK                         _U_(0x70FFF)                                   /**< \deprecated (TC_VER) Register MASK  (Use TC_VER_Msk instead)  */
+#define TC_VER_Msk                          _U_(0x70FFF)                                   /**< (TC_VER) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TC_CHANNEL hardware registers */
+typedef struct {  
+  __O  uint32_t TC_CCR;         /**< (TC_CHANNEL Offset: 0x00) Channel Control Register (channel = 0) */
+  __IO uint32_t TC_CMR;         /**< (TC_CHANNEL Offset: 0x04) Channel Mode Register (channel = 0) */
+  __IO uint32_t TC_SMMR;        /**< (TC_CHANNEL Offset: 0x08) Stepper Motor Mode Register (channel = 0) */
+  __I  uint32_t TC_RAB;         /**< (TC_CHANNEL Offset: 0x0C) Register AB (channel = 0) */
+  __I  uint32_t TC_CV;          /**< (TC_CHANNEL Offset: 0x10) Counter Value (channel = 0) */
+  __IO uint32_t TC_RA;          /**< (TC_CHANNEL Offset: 0x14) Register A (channel = 0) */
+  __IO uint32_t TC_RB;          /**< (TC_CHANNEL Offset: 0x18) Register B (channel = 0) */
+  __IO uint32_t TC_RC;          /**< (TC_CHANNEL Offset: 0x1C) Register C (channel = 0) */
+  __I  uint32_t TC_SR;          /**< (TC_CHANNEL Offset: 0x20) Status Register (channel = 0) */
+  __O  uint32_t TC_IER;         /**< (TC_CHANNEL Offset: 0x24) Interrupt Enable Register (channel = 0) */
+  __O  uint32_t TC_IDR;         /**< (TC_CHANNEL Offset: 0x28) Interrupt Disable Register (channel = 0) */
+  __I  uint32_t TC_IMR;         /**< (TC_CHANNEL Offset: 0x2C) Interrupt Mask Register (channel = 0) */
+  __IO uint32_t TC_EMR;         /**< (TC_CHANNEL Offset: 0x30) Extended Mode Register (channel = 0) */
+  __I  uint8_t                        Reserved1[12];
+} TcChannel;
+
+#define TCCHANNEL_NUMBER 3
+/** \brief TC hardware registers */
+typedef struct {  
+       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+  __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
+  __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
+  __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
+  __O  uint32_t TC_QIDR;        /**< (TC Offset: 0xCC) QDEC Interrupt Disable Register */
+  __I  uint32_t TC_QIMR;        /**< (TC Offset: 0xD0) QDEC Interrupt Mask Register */
+  __I  uint32_t TC_QISR;        /**< (TC Offset: 0xD4) QDEC Interrupt Status Register */
+  __IO uint32_t TC_FMR;         /**< (TC Offset: 0xD8) Fault Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t TC_WPMR;        /**< (TC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint8_t                        Reserved2[20];
+  __I  uint32_t TC_VER;         /**< (TC Offset: 0xFC) Version Register */
+} Tc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TC_CHANNEL hardware registers */
+typedef struct {  
+  __O  TC_CCR_Type                    TC_CCR;         /**< Offset: 0x00 ( /W  32) Channel Control Register (channel = 0) */
+  __IO TC_CMR_Type                    TC_CMR;         /**< Offset: 0x04 (R/W  32) Channel Mode Register (channel = 0) */
+  __IO TC_SMMR_Type                   TC_SMMR;        /**< Offset: 0x08 (R/W  32) Stepper Motor Mode Register (channel = 0) */
+  __I  TC_RAB_Type                    TC_RAB;         /**< Offset: 0x0C (R/   32) Register AB (channel = 0) */
+  __I  TC_CV_Type                     TC_CV;          /**< Offset: 0x10 (R/   32) Counter Value (channel = 0) */
+  __IO TC_RA_Type                     TC_RA;          /**< Offset: 0x14 (R/W  32) Register A (channel = 0) */
+  __IO TC_RB_Type                     TC_RB;          /**< Offset: 0x18 (R/W  32) Register B (channel = 0) */
+  __IO TC_RC_Type                     TC_RC;          /**< Offset: 0x1C (R/W  32) Register C (channel = 0) */
+  __I  TC_SR_Type                     TC_SR;          /**< Offset: 0x20 (R/   32) Status Register (channel = 0) */
+  __O  TC_IER_Type                    TC_IER;         /**< Offset: 0x24 ( /W  32) Interrupt Enable Register (channel = 0) */
+  __O  TC_IDR_Type                    TC_IDR;         /**< Offset: 0x28 ( /W  32) Interrupt Disable Register (channel = 0) */
+  __I  TC_IMR_Type                    TC_IMR;         /**< Offset: 0x2C (R/   32) Interrupt Mask Register (channel = 0) */
+  __IO TC_EMR_Type                    TC_EMR;         /**< Offset: 0x30 (R/W  32) Extended Mode Register (channel = 0) */
+  __I  uint8_t                        Reserved1[12];
+} TcChannel;
+
+/** \brief TC hardware registers */
+typedef struct {  
+       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
+  __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
+  __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
+  __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */
+  __O  TC_QIDR_Type                   TC_QIDR;        /**< Offset: 0xCC ( /W  32) QDEC Interrupt Disable Register */
+  __I  TC_QIMR_Type                   TC_QIMR;        /**< Offset: 0xD0 (R/   32) QDEC Interrupt Mask Register */
+  __I  TC_QISR_Type                   TC_QISR;        /**< Offset: 0xD4 (R/   32) QDEC Interrupt Status Register */
+  __IO TC_FMR_Type                    TC_FMR;         /**< Offset: 0xD8 (R/W  32) Fault Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO TC_WPMR_Type                   TC_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  uint8_t                        Reserved2[20];
+  __I  TC_VER_Type                    TC_VER;         /**< Offset: 0xFC (R/   32) Version Register */
+} Tc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Timer Counter */
+
+#endif /* _SAMV71_TC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/trng.h
+++ b/asf/sam/include/samv71/component/trng.h
@@ -1,0 +1,250 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TRNG_COMPONENT_H_
+#define _SAMV71_TRNG_COMPONENT_H_
+#define _SAMV71_TRNG_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 True Random Number Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TRNG_6334                       /**< (TRNG) Module ID */
+#define REV_TRNG G                      /**< (TRNG) Module revision */
+
+/* -------- TRNG_CR : (TRNG Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  Enables the TRNG to Provide Random Values */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t KEY:24;                    /**< bit:  8..31  Security Key                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CR_OFFSET                      (0x00)                                        /**<  (TRNG_CR) Control Register  Offset */
+
+#define TRNG_CR_ENABLE_Pos                  0                                              /**< (TRNG_CR) Enables the TRNG to Provide Random Values Position */
+#define TRNG_CR_ENABLE_Msk                  (_U_(0x1) << TRNG_CR_ENABLE_Pos)               /**< (TRNG_CR) Enables the TRNG to Provide Random Values Mask */
+#define TRNG_CR_ENABLE                      TRNG_CR_ENABLE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CR_ENABLE_Msk instead */
+#define TRNG_CR_KEY_Pos                     8                                              /**< (TRNG_CR) Security Key Position */
+#define TRNG_CR_KEY_Msk                     (_U_(0xFFFFFF) << TRNG_CR_KEY_Pos)             /**< (TRNG_CR) Security Key Mask */
+#define TRNG_CR_KEY(value)                  (TRNG_CR_KEY_Msk & ((value) << TRNG_CR_KEY_Pos))
+#define   TRNG_CR_KEY_PASSWD_Val            _U_(0x524E47)                                  /**< (TRNG_CR) Writing any other value in this field aborts the write operation.  */
+#define TRNG_CR_KEY_PASSWD                  (TRNG_CR_KEY_PASSWD_Val << TRNG_CR_KEY_Pos)    /**< (TRNG_CR) Writing any other value in this field aborts the write operation. Position  */
+#define TRNG_CR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (TRNG_CR) Register MASK  (Use TRNG_CR_Msk instead)  */
+#define TRNG_CR_Msk                         _U_(0xFFFFFF01)                                /**< (TRNG_CR) Register Mask  */
+
+
+/* -------- TRNG_IER : (TRNG Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IER_OFFSET                     (0x10)                                        /**<  (TRNG_IER) Interrupt Enable Register  Offset */
+
+#define TRNG_IER_DATRDY_Pos                 0                                              /**< (TRNG_IER) Data Ready Interrupt Enable Position */
+#define TRNG_IER_DATRDY_Msk                 (_U_(0x1) << TRNG_IER_DATRDY_Pos)              /**< (TRNG_IER) Data Ready Interrupt Enable Mask */
+#define TRNG_IER_DATRDY                     TRNG_IER_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IER_DATRDY_Msk instead */
+#define TRNG_IER_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IER) Register MASK  (Use TRNG_IER_Msk instead)  */
+#define TRNG_IER_Msk                        _U_(0x01)                                      /**< (TRNG_IER) Register Mask  */
+
+
+/* -------- TRNG_IDR : (TRNG Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IDR_OFFSET                     (0x14)                                        /**<  (TRNG_IDR) Interrupt Disable Register  Offset */
+
+#define TRNG_IDR_DATRDY_Pos                 0                                              /**< (TRNG_IDR) Data Ready Interrupt Disable Position */
+#define TRNG_IDR_DATRDY_Msk                 (_U_(0x1) << TRNG_IDR_DATRDY_Pos)              /**< (TRNG_IDR) Data Ready Interrupt Disable Mask */
+#define TRNG_IDR_DATRDY                     TRNG_IDR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IDR_DATRDY_Msk instead */
+#define TRNG_IDR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IDR) Register MASK  (Use TRNG_IDR_Msk instead)  */
+#define TRNG_IDR_Msk                        _U_(0x01)                                      /**< (TRNG_IDR) Register Mask  */
+
+
+/* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IMR_OFFSET                     (0x18)                                        /**<  (TRNG_IMR) Interrupt Mask Register  Offset */
+
+#define TRNG_IMR_DATRDY_Pos                 0                                              /**< (TRNG_IMR) Data Ready Interrupt Mask Position */
+#define TRNG_IMR_DATRDY_Msk                 (_U_(0x1) << TRNG_IMR_DATRDY_Pos)              /**< (TRNG_IMR) Data Ready Interrupt Mask Mask */
+#define TRNG_IMR_DATRDY                     TRNG_IMR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IMR_DATRDY_Msk instead */
+#define TRNG_IMR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IMR) Register MASK  (Use TRNG_IMR_Msk instead)  */
+#define TRNG_IMR_Msk                        _U_(0x01)                                      /**< (TRNG_IMR) Register Mask  */
+
+
+/* -------- TRNG_ISR : (TRNG Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready                               */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ISR_OFFSET                     (0x1C)                                        /**<  (TRNG_ISR) Interrupt Status Register  Offset */
+
+#define TRNG_ISR_DATRDY_Pos                 0                                              /**< (TRNG_ISR) Data Ready Position */
+#define TRNG_ISR_DATRDY_Msk                 (_U_(0x1) << TRNG_ISR_DATRDY_Pos)              /**< (TRNG_ISR) Data Ready Mask */
+#define TRNG_ISR_DATRDY                     TRNG_ISR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_ISR_DATRDY_Msk instead */
+#define TRNG_ISR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_ISR) Register MASK  (Use TRNG_ISR_Msk instead)  */
+#define TRNG_ISR_Msk                        _U_(0x01)                                      /**< (TRNG_ISR) Register Mask  */
+
+
+/* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/ 32) Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_ODATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ODATA_OFFSET                   (0x50)                                        /**<  (TRNG_ODATA) Output Data Register  Offset */
+
+#define TRNG_ODATA_ODATA_Pos                0                                              /**< (TRNG_ODATA) Output Data Position */
+#define TRNG_ODATA_ODATA_Msk                (_U_(0xFFFFFFFF) << TRNG_ODATA_ODATA_Pos)      /**< (TRNG_ODATA) Output Data Mask */
+#define TRNG_ODATA_ODATA(value)             (TRNG_ODATA_ODATA_Msk & ((value) << TRNG_ODATA_ODATA_Pos))
+#define TRNG_ODATA_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (TRNG_ODATA) Register MASK  (Use TRNG_ODATA_Msk instead)  */
+#define TRNG_ODATA_Msk                      _U_(0xFFFFFFFF)                                /**< (TRNG_ODATA) Register Mask  */
+
+
+/* -------- TRNG_VERSION : (TRNG Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_VERSION_OFFSET                 (0xFC)                                        /**<  (TRNG_VERSION) Version Register  Offset */
+
+#define TRNG_VERSION_VERSION_Pos            0                                              /**< (TRNG_VERSION) Version of the Hardware Module Position */
+#define TRNG_VERSION_VERSION_Msk            (_U_(0xFFF) << TRNG_VERSION_VERSION_Pos)       /**< (TRNG_VERSION) Version of the Hardware Module Mask */
+#define TRNG_VERSION_VERSION(value)         (TRNG_VERSION_VERSION_Msk & ((value) << TRNG_VERSION_VERSION_Pos))
+#define TRNG_VERSION_MFN_Pos                16                                             /**< (TRNG_VERSION) Metal Fix Number Position */
+#define TRNG_VERSION_MFN_Msk                (_U_(0x7) << TRNG_VERSION_MFN_Pos)             /**< (TRNG_VERSION) Metal Fix Number Mask */
+#define TRNG_VERSION_MFN(value)             (TRNG_VERSION_MFN_Msk & ((value) << TRNG_VERSION_MFN_Pos))
+#define TRNG_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (TRNG_VERSION) Register MASK  (Use TRNG_VERSION_Msk instead)  */
+#define TRNG_VERSION_Msk                    _U_(0x70FFF)                                   /**< (TRNG_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TRNG hardware registers */
+typedef struct {  
+  __O  uint32_t TRNG_CR;        /**< (TRNG Offset: 0x00) Control Register */
+  __I  uint8_t                        Reserved1[12];
+  __O  uint32_t TRNG_IER;       /**< (TRNG Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t TRNG_IDR;       /**< (TRNG Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t TRNG_IMR;       /**< (TRNG Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t TRNG_ISR;       /**< (TRNG Offset: 0x1C) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[48];
+  __I  uint32_t TRNG_ODATA;     /**< (TRNG Offset: 0x50) Output Data Register */
+  __I  uint8_t                        Reserved3[168];
+  __I  uint32_t TRNG_VERSION;   /**< (TRNG Offset: 0xFC) Version Register */
+} Trng;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TRNG hardware registers */
+typedef struct {  
+  __O  TRNG_CR_Type                   TRNG_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __I  uint8_t                        Reserved1[12];
+  __O  TRNG_IER_Type                  TRNG_IER;       /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  TRNG_IDR_Type                  TRNG_IDR;       /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  TRNG_IMR_Type                  TRNG_IMR;       /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  TRNG_ISR_Type                  TRNG_ISR;       /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[48];
+  __I  TRNG_ODATA_Type                TRNG_ODATA;     /**< Offset: 0x50 (R/   32) Output Data Register */
+  __I  uint8_t                        Reserved3[168];
+  __I  TRNG_VERSION_Type              TRNG_VERSION;   /**< Offset: 0xFC (R/   32) Version Register */
+} Trng;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of True Random Number Generator */
+
+#endif /* _SAMV71_TRNG_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/twihs.h
+++ b/asf/sam/include/samv71/component/twihs.h
@@ -1,0 +1,998 @@
+/**
+ * \file
+ *
+ * \brief Component description for TWIHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TWIHS_COMPONENT_H_
+#define _SAMV71_TWIHS_COMPONENT_H_
+#define _SAMV71_TWIHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Two-wire Interface High Speed
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TWIHS */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TWIHS_11210                      /**< (TWIHS) Module ID */
+#define REV_TWIHS X                      /**< (TWIHS) Module revision */
+
+/* -------- TWIHS_CR : (TWIHS Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t START:1;                   /**< bit:      0  Send a START Condition                   */
+    uint32_t STOP:1;                    /**< bit:      1  Send a STOP Condition                    */
+    uint32_t MSEN:1;                    /**< bit:      2  TWIHS Master Mode Enabled                */
+    uint32_t MSDIS:1;                   /**< bit:      3  TWIHS Master Mode Disabled               */
+    uint32_t SVEN:1;                    /**< bit:      4  TWIHS Slave Mode Enabled                 */
+    uint32_t SVDIS:1;                   /**< bit:      5  TWIHS Slave Mode Disabled                */
+    uint32_t QUICK:1;                   /**< bit:      6  SMBus Quick Command                      */
+    uint32_t SWRST:1;                   /**< bit:      7  Software Reset                           */
+    uint32_t HSEN:1;                    /**< bit:      8  TWIHS High-Speed Mode Enabled            */
+    uint32_t HSDIS:1;                   /**< bit:      9  TWIHS High-Speed Mode Disabled           */
+    uint32_t SMBEN:1;                   /**< bit:     10  SMBus Mode Enabled                       */
+    uint32_t SMBDIS:1;                  /**< bit:     11  SMBus Mode Disabled                      */
+    uint32_t PECEN:1;                   /**< bit:     12  Packet Error Checking Enable             */
+    uint32_t PECDIS:1;                  /**< bit:     13  Packet Error Checking Disable            */
+    uint32_t PECRQ:1;                   /**< bit:     14  PEC Request                              */
+    uint32_t CLEAR:1;                   /**< bit:     15  Bus CLEAR Command                        */
+    uint32_t ACMEN:1;                   /**< bit:     16  Alternative Command Mode Enable          */
+    uint32_t ACMDIS:1;                  /**< bit:     17  Alternative Command Mode Disable         */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t THRCLR:1;                  /**< bit:     24  Transmit Holding Register Clear          */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t LOCKCLR:1;                 /**< bit:     26  Lock Clear                               */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t FIFOEN:1;                  /**< bit:     28  FIFO Enable                              */
+    uint32_t FIFODIS:1;                 /**< bit:     29  FIFO Disable                             */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_CR_OFFSET                     (0x00)                                        /**<  (TWIHS_CR) Control Register  Offset */
+
+#define TWIHS_CR_START_Pos                  0                                              /**< (TWIHS_CR) Send a START Condition Position */
+#define TWIHS_CR_START_Msk                  (_U_(0x1) << TWIHS_CR_START_Pos)               /**< (TWIHS_CR) Send a START Condition Mask */
+#define TWIHS_CR_START                      TWIHS_CR_START_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_START_Msk instead */
+#define TWIHS_CR_STOP_Pos                   1                                              /**< (TWIHS_CR) Send a STOP Condition Position */
+#define TWIHS_CR_STOP_Msk                   (_U_(0x1) << TWIHS_CR_STOP_Pos)                /**< (TWIHS_CR) Send a STOP Condition Mask */
+#define TWIHS_CR_STOP                       TWIHS_CR_STOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_STOP_Msk instead */
+#define TWIHS_CR_MSEN_Pos                   2                                              /**< (TWIHS_CR) TWIHS Master Mode Enabled Position */
+#define TWIHS_CR_MSEN_Msk                   (_U_(0x1) << TWIHS_CR_MSEN_Pos)                /**< (TWIHS_CR) TWIHS Master Mode Enabled Mask */
+#define TWIHS_CR_MSEN                       TWIHS_CR_MSEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_MSEN_Msk instead */
+#define TWIHS_CR_MSDIS_Pos                  3                                              /**< (TWIHS_CR) TWIHS Master Mode Disabled Position */
+#define TWIHS_CR_MSDIS_Msk                  (_U_(0x1) << TWIHS_CR_MSDIS_Pos)               /**< (TWIHS_CR) TWIHS Master Mode Disabled Mask */
+#define TWIHS_CR_MSDIS                      TWIHS_CR_MSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_MSDIS_Msk instead */
+#define TWIHS_CR_SVEN_Pos                   4                                              /**< (TWIHS_CR) TWIHS Slave Mode Enabled Position */
+#define TWIHS_CR_SVEN_Msk                   (_U_(0x1) << TWIHS_CR_SVEN_Pos)                /**< (TWIHS_CR) TWIHS Slave Mode Enabled Mask */
+#define TWIHS_CR_SVEN                       TWIHS_CR_SVEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SVEN_Msk instead */
+#define TWIHS_CR_SVDIS_Pos                  5                                              /**< (TWIHS_CR) TWIHS Slave Mode Disabled Position */
+#define TWIHS_CR_SVDIS_Msk                  (_U_(0x1) << TWIHS_CR_SVDIS_Pos)               /**< (TWIHS_CR) TWIHS Slave Mode Disabled Mask */
+#define TWIHS_CR_SVDIS                      TWIHS_CR_SVDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SVDIS_Msk instead */
+#define TWIHS_CR_QUICK_Pos                  6                                              /**< (TWIHS_CR) SMBus Quick Command Position */
+#define TWIHS_CR_QUICK_Msk                  (_U_(0x1) << TWIHS_CR_QUICK_Pos)               /**< (TWIHS_CR) SMBus Quick Command Mask */
+#define TWIHS_CR_QUICK                      TWIHS_CR_QUICK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_QUICK_Msk instead */
+#define TWIHS_CR_SWRST_Pos                  7                                              /**< (TWIHS_CR) Software Reset Position */
+#define TWIHS_CR_SWRST_Msk                  (_U_(0x1) << TWIHS_CR_SWRST_Pos)               /**< (TWIHS_CR) Software Reset Mask */
+#define TWIHS_CR_SWRST                      TWIHS_CR_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SWRST_Msk instead */
+#define TWIHS_CR_HSEN_Pos                   8                                              /**< (TWIHS_CR) TWIHS High-Speed Mode Enabled Position */
+#define TWIHS_CR_HSEN_Msk                   (_U_(0x1) << TWIHS_CR_HSEN_Pos)                /**< (TWIHS_CR) TWIHS High-Speed Mode Enabled Mask */
+#define TWIHS_CR_HSEN                       TWIHS_CR_HSEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_HSEN_Msk instead */
+#define TWIHS_CR_HSDIS_Pos                  9                                              /**< (TWIHS_CR) TWIHS High-Speed Mode Disabled Position */
+#define TWIHS_CR_HSDIS_Msk                  (_U_(0x1) << TWIHS_CR_HSDIS_Pos)               /**< (TWIHS_CR) TWIHS High-Speed Mode Disabled Mask */
+#define TWIHS_CR_HSDIS                      TWIHS_CR_HSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_HSDIS_Msk instead */
+#define TWIHS_CR_SMBEN_Pos                  10                                             /**< (TWIHS_CR) SMBus Mode Enabled Position */
+#define TWIHS_CR_SMBEN_Msk                  (_U_(0x1) << TWIHS_CR_SMBEN_Pos)               /**< (TWIHS_CR) SMBus Mode Enabled Mask */
+#define TWIHS_CR_SMBEN                      TWIHS_CR_SMBEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SMBEN_Msk instead */
+#define TWIHS_CR_SMBDIS_Pos                 11                                             /**< (TWIHS_CR) SMBus Mode Disabled Position */
+#define TWIHS_CR_SMBDIS_Msk                 (_U_(0x1) << TWIHS_CR_SMBDIS_Pos)              /**< (TWIHS_CR) SMBus Mode Disabled Mask */
+#define TWIHS_CR_SMBDIS                     TWIHS_CR_SMBDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SMBDIS_Msk instead */
+#define TWIHS_CR_PECEN_Pos                  12                                             /**< (TWIHS_CR) Packet Error Checking Enable Position */
+#define TWIHS_CR_PECEN_Msk                  (_U_(0x1) << TWIHS_CR_PECEN_Pos)               /**< (TWIHS_CR) Packet Error Checking Enable Mask */
+#define TWIHS_CR_PECEN                      TWIHS_CR_PECEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECEN_Msk instead */
+#define TWIHS_CR_PECDIS_Pos                 13                                             /**< (TWIHS_CR) Packet Error Checking Disable Position */
+#define TWIHS_CR_PECDIS_Msk                 (_U_(0x1) << TWIHS_CR_PECDIS_Pos)              /**< (TWIHS_CR) Packet Error Checking Disable Mask */
+#define TWIHS_CR_PECDIS                     TWIHS_CR_PECDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECDIS_Msk instead */
+#define TWIHS_CR_PECRQ_Pos                  14                                             /**< (TWIHS_CR) PEC Request Position */
+#define TWIHS_CR_PECRQ_Msk                  (_U_(0x1) << TWIHS_CR_PECRQ_Pos)               /**< (TWIHS_CR) PEC Request Mask */
+#define TWIHS_CR_PECRQ                      TWIHS_CR_PECRQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECRQ_Msk instead */
+#define TWIHS_CR_CLEAR_Pos                  15                                             /**< (TWIHS_CR) Bus CLEAR Command Position */
+#define TWIHS_CR_CLEAR_Msk                  (_U_(0x1) << TWIHS_CR_CLEAR_Pos)               /**< (TWIHS_CR) Bus CLEAR Command Mask */
+#define TWIHS_CR_CLEAR                      TWIHS_CR_CLEAR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_CLEAR_Msk instead */
+#define TWIHS_CR_ACMEN_Pos                  16                                             /**< (TWIHS_CR) Alternative Command Mode Enable Position */
+#define TWIHS_CR_ACMEN_Msk                  (_U_(0x1) << TWIHS_CR_ACMEN_Pos)               /**< (TWIHS_CR) Alternative Command Mode Enable Mask */
+#define TWIHS_CR_ACMEN                      TWIHS_CR_ACMEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_ACMEN_Msk instead */
+#define TWIHS_CR_ACMDIS_Pos                 17                                             /**< (TWIHS_CR) Alternative Command Mode Disable Position */
+#define TWIHS_CR_ACMDIS_Msk                 (_U_(0x1) << TWIHS_CR_ACMDIS_Pos)              /**< (TWIHS_CR) Alternative Command Mode Disable Mask */
+#define TWIHS_CR_ACMDIS                     TWIHS_CR_ACMDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_ACMDIS_Msk instead */
+#define TWIHS_CR_THRCLR_Pos                 24                                             /**< (TWIHS_CR) Transmit Holding Register Clear Position */
+#define TWIHS_CR_THRCLR_Msk                 (_U_(0x1) << TWIHS_CR_THRCLR_Pos)              /**< (TWIHS_CR) Transmit Holding Register Clear Mask */
+#define TWIHS_CR_THRCLR                     TWIHS_CR_THRCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_THRCLR_Msk instead */
+#define TWIHS_CR_LOCKCLR_Pos                26                                             /**< (TWIHS_CR) Lock Clear Position */
+#define TWIHS_CR_LOCKCLR_Msk                (_U_(0x1) << TWIHS_CR_LOCKCLR_Pos)             /**< (TWIHS_CR) Lock Clear Mask */
+#define TWIHS_CR_LOCKCLR                    TWIHS_CR_LOCKCLR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_LOCKCLR_Msk instead */
+#define TWIHS_CR_FIFOEN_Pos                 28                                             /**< (TWIHS_CR) FIFO Enable Position */
+#define TWIHS_CR_FIFOEN_Msk                 (_U_(0x1) << TWIHS_CR_FIFOEN_Pos)              /**< (TWIHS_CR) FIFO Enable Mask */
+#define TWIHS_CR_FIFOEN                     TWIHS_CR_FIFOEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_FIFOEN_Msk instead */
+#define TWIHS_CR_FIFODIS_Pos                29                                             /**< (TWIHS_CR) FIFO Disable Position */
+#define TWIHS_CR_FIFODIS_Msk                (_U_(0x1) << TWIHS_CR_FIFODIS_Pos)             /**< (TWIHS_CR) FIFO Disable Mask */
+#define TWIHS_CR_FIFODIS                    TWIHS_CR_FIFODIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_FIFODIS_Msk instead */
+#define TWIHS_CR_MASK                       _U_(0x3503FFFF)                                /**< \deprecated (TWIHS_CR) Register MASK  (Use TWIHS_CR_Msk instead)  */
+#define TWIHS_CR_Msk                        _U_(0x3503FFFF)                                /**< (TWIHS_CR) Register Mask  */
+
+
+/* -------- TWIHS_MMR : (TWIHS Offset: 0x04) (R/W 32) Master Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t IADRSZ:2;                  /**< bit:   8..9  Internal Device Address Size             */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t MREAD:1;                   /**< bit:     12  Master Read Direction                    */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t DADR:7;                    /**< bit: 16..22  Device Address                           */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_MMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_MMR_OFFSET                    (0x04)                                        /**<  (TWIHS_MMR) Master Mode Register  Offset */
+
+#define TWIHS_MMR_IADRSZ_Pos                8                                              /**< (TWIHS_MMR) Internal Device Address Size Position */
+#define TWIHS_MMR_IADRSZ_Msk                (_U_(0x3) << TWIHS_MMR_IADRSZ_Pos)             /**< (TWIHS_MMR) Internal Device Address Size Mask */
+#define TWIHS_MMR_IADRSZ(value)             (TWIHS_MMR_IADRSZ_Msk & ((value) << TWIHS_MMR_IADRSZ_Pos))
+#define   TWIHS_MMR_IADRSZ_NONE_Val         _U_(0x0)                                       /**< (TWIHS_MMR) No internal device address  */
+#define   TWIHS_MMR_IADRSZ_1_BYTE_Val       _U_(0x1)                                       /**< (TWIHS_MMR) One-byte internal device address  */
+#define   TWIHS_MMR_IADRSZ_2_BYTE_Val       _U_(0x2)                                       /**< (TWIHS_MMR) Two-byte internal device address  */
+#define   TWIHS_MMR_IADRSZ_3_BYTE_Val       _U_(0x3)                                       /**< (TWIHS_MMR) Three-byte internal device address  */
+#define TWIHS_MMR_IADRSZ_NONE               (TWIHS_MMR_IADRSZ_NONE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) No internal device address Position  */
+#define TWIHS_MMR_IADRSZ_1_BYTE             (TWIHS_MMR_IADRSZ_1_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) One-byte internal device address Position  */
+#define TWIHS_MMR_IADRSZ_2_BYTE             (TWIHS_MMR_IADRSZ_2_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) Two-byte internal device address Position  */
+#define TWIHS_MMR_IADRSZ_3_BYTE             (TWIHS_MMR_IADRSZ_3_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) Three-byte internal device address Position  */
+#define TWIHS_MMR_MREAD_Pos                 12                                             /**< (TWIHS_MMR) Master Read Direction Position */
+#define TWIHS_MMR_MREAD_Msk                 (_U_(0x1) << TWIHS_MMR_MREAD_Pos)              /**< (TWIHS_MMR) Master Read Direction Mask */
+#define TWIHS_MMR_MREAD                     TWIHS_MMR_MREAD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_MMR_MREAD_Msk instead */
+#define TWIHS_MMR_DADR_Pos                  16                                             /**< (TWIHS_MMR) Device Address Position */
+#define TWIHS_MMR_DADR_Msk                  (_U_(0x7F) << TWIHS_MMR_DADR_Pos)              /**< (TWIHS_MMR) Device Address Mask */
+#define TWIHS_MMR_DADR(value)               (TWIHS_MMR_DADR_Msk & ((value) << TWIHS_MMR_DADR_Pos))
+#define TWIHS_MMR_MASK                      _U_(0x7F1300)                                  /**< \deprecated (TWIHS_MMR) Register MASK  (Use TWIHS_MMR_Msk instead)  */
+#define TWIHS_MMR_Msk                       _U_(0x7F1300)                                  /**< (TWIHS_MMR) Register Mask  */
+
+
+/* -------- TWIHS_SMR : (TWIHS Offset: 0x08) (R/W 32) Slave Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NACKEN:1;                  /**< bit:      0  Slave Receiver Data Phase NACK enable    */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t SMDA:1;                    /**< bit:      2  SMBus Default Address                    */
+    uint32_t SMHH:1;                    /**< bit:      3  SMBus Host Header                        */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t SCLWSDIS:1;                /**< bit:      6  Clock Wait State Disable                 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MASK:7;                    /**< bit:  8..14  Slave Address Mask                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SADR:7;                    /**< bit: 16..22  Slave Address                            */
+    uint32_t :5;                        /**< bit: 23..27  Reserved */
+    uint32_t SADR1EN:1;                 /**< bit:     28  Slave Address 1 Enable                   */
+    uint32_t SADR2EN:1;                 /**< bit:     29  Slave Address 2 Enable                   */
+    uint32_t SADR3EN:1;                 /**< bit:     30  Slave Address 3 Enable                   */
+    uint32_t DATAMEN:1;                 /**< bit:     31  Data Matching Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SMR_OFFSET                    (0x08)                                        /**<  (TWIHS_SMR) Slave Mode Register  Offset */
+
+#define TWIHS_SMR_NACKEN_Pos                0                                              /**< (TWIHS_SMR) Slave Receiver Data Phase NACK enable Position */
+#define TWIHS_SMR_NACKEN_Msk                (_U_(0x1) << TWIHS_SMR_NACKEN_Pos)             /**< (TWIHS_SMR) Slave Receiver Data Phase NACK enable Mask */
+#define TWIHS_SMR_NACKEN                    TWIHS_SMR_NACKEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_NACKEN_Msk instead */
+#define TWIHS_SMR_SMDA_Pos                  2                                              /**< (TWIHS_SMR) SMBus Default Address Position */
+#define TWIHS_SMR_SMDA_Msk                  (_U_(0x1) << TWIHS_SMR_SMDA_Pos)               /**< (TWIHS_SMR) SMBus Default Address Mask */
+#define TWIHS_SMR_SMDA                      TWIHS_SMR_SMDA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SMDA_Msk instead */
+#define TWIHS_SMR_SMHH_Pos                  3                                              /**< (TWIHS_SMR) SMBus Host Header Position */
+#define TWIHS_SMR_SMHH_Msk                  (_U_(0x1) << TWIHS_SMR_SMHH_Pos)               /**< (TWIHS_SMR) SMBus Host Header Mask */
+#define TWIHS_SMR_SMHH                      TWIHS_SMR_SMHH_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SMHH_Msk instead */
+#define TWIHS_SMR_SCLWSDIS_Pos              6                                              /**< (TWIHS_SMR) Clock Wait State Disable Position */
+#define TWIHS_SMR_SCLWSDIS_Msk              (_U_(0x1) << TWIHS_SMR_SCLWSDIS_Pos)           /**< (TWIHS_SMR) Clock Wait State Disable Mask */
+#define TWIHS_SMR_SCLWSDIS                  TWIHS_SMR_SCLWSDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SCLWSDIS_Msk instead */
+#define TWIHS_SMR_MASK_Pos                  8                                              /**< (TWIHS_SMR) Slave Address Mask Position */
+#define TWIHS_SMR_MASK_Msk                  (_U_(0x7F) << TWIHS_SMR_MASK_Pos)              /**< (TWIHS_SMR) Slave Address Mask Mask */
+#define TWIHS_SMR_MASK(value)               (TWIHS_SMR_MASK_Msk & ((value) << TWIHS_SMR_MASK_Pos))
+#define TWIHS_SMR_SADR_Pos                  16                                             /**< (TWIHS_SMR) Slave Address Position */
+#define TWIHS_SMR_SADR_Msk                  (_U_(0x7F) << TWIHS_SMR_SADR_Pos)              /**< (TWIHS_SMR) Slave Address Mask */
+#define TWIHS_SMR_SADR(value)               (TWIHS_SMR_SADR_Msk & ((value) << TWIHS_SMR_SADR_Pos))
+#define TWIHS_SMR_SADR1EN_Pos               28                                             /**< (TWIHS_SMR) Slave Address 1 Enable Position */
+#define TWIHS_SMR_SADR1EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR1EN_Pos)            /**< (TWIHS_SMR) Slave Address 1 Enable Mask */
+#define TWIHS_SMR_SADR1EN                   TWIHS_SMR_SADR1EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR1EN_Msk instead */
+#define TWIHS_SMR_SADR2EN_Pos               29                                             /**< (TWIHS_SMR) Slave Address 2 Enable Position */
+#define TWIHS_SMR_SADR2EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR2EN_Pos)            /**< (TWIHS_SMR) Slave Address 2 Enable Mask */
+#define TWIHS_SMR_SADR2EN                   TWIHS_SMR_SADR2EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR2EN_Msk instead */
+#define TWIHS_SMR_SADR3EN_Pos               30                                             /**< (TWIHS_SMR) Slave Address 3 Enable Position */
+#define TWIHS_SMR_SADR3EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR3EN_Pos)            /**< (TWIHS_SMR) Slave Address 3 Enable Mask */
+#define TWIHS_SMR_SADR3EN                   TWIHS_SMR_SADR3EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR3EN_Msk instead */
+#define TWIHS_SMR_DATAMEN_Pos               31                                             /**< (TWIHS_SMR) Data Matching Enable Position */
+#define TWIHS_SMR_DATAMEN_Msk               (_U_(0x1) << TWIHS_SMR_DATAMEN_Pos)            /**< (TWIHS_SMR) Data Matching Enable Mask */
+#define TWIHS_SMR_DATAMEN                   TWIHS_SMR_DATAMEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_DATAMEN_Msk instead */
+#define TWIHS_SMR_Msk                       _U_(0xF07F7F4D)                                /**< (TWIHS_SMR) Register Mask  */
+
+
+/* -------- TWIHS_IADR : (TWIHS Offset: 0x0c) (R/W 32) Internal Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IADR:24;                   /**< bit:  0..23  Internal Address                         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IADR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IADR_OFFSET                   (0x0C)                                        /**<  (TWIHS_IADR) Internal Address Register  Offset */
+
+#define TWIHS_IADR_IADR_Pos                 0                                              /**< (TWIHS_IADR) Internal Address Position */
+#define TWIHS_IADR_IADR_Msk                 (_U_(0xFFFFFF) << TWIHS_IADR_IADR_Pos)         /**< (TWIHS_IADR) Internal Address Mask */
+#define TWIHS_IADR_IADR(value)              (TWIHS_IADR_IADR_Msk & ((value) << TWIHS_IADR_IADR_Pos))
+#define TWIHS_IADR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (TWIHS_IADR) Register MASK  (Use TWIHS_IADR_Msk instead)  */
+#define TWIHS_IADR_Msk                      _U_(0xFFFFFF)                                  /**< (TWIHS_IADR) Register Mask  */
+
+
+/* -------- TWIHS_CWGR : (TWIHS Offset: 0x10) (R/W 32) Clock Waveform Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLDIV:8;                   /**< bit:   0..7  Clock Low Divider                        */
+    uint32_t CHDIV:8;                   /**< bit:  8..15  Clock High Divider                       */
+    uint32_t CKDIV:3;                   /**< bit: 16..18  Clock Divider                            */
+    uint32_t :5;                        /**< bit: 19..23  Reserved */
+    uint32_t HOLD:6;                    /**< bit: 24..29  TWD Hold Time Versus TWCK Falling        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_CWGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_CWGR_OFFSET                   (0x10)                                        /**<  (TWIHS_CWGR) Clock Waveform Generator Register  Offset */
+
+#define TWIHS_CWGR_CLDIV_Pos                0                                              /**< (TWIHS_CWGR) Clock Low Divider Position */
+#define TWIHS_CWGR_CLDIV_Msk                (_U_(0xFF) << TWIHS_CWGR_CLDIV_Pos)            /**< (TWIHS_CWGR) Clock Low Divider Mask */
+#define TWIHS_CWGR_CLDIV(value)             (TWIHS_CWGR_CLDIV_Msk & ((value) << TWIHS_CWGR_CLDIV_Pos))
+#define TWIHS_CWGR_CHDIV_Pos                8                                              /**< (TWIHS_CWGR) Clock High Divider Position */
+#define TWIHS_CWGR_CHDIV_Msk                (_U_(0xFF) << TWIHS_CWGR_CHDIV_Pos)            /**< (TWIHS_CWGR) Clock High Divider Mask */
+#define TWIHS_CWGR_CHDIV(value)             (TWIHS_CWGR_CHDIV_Msk & ((value) << TWIHS_CWGR_CHDIV_Pos))
+#define TWIHS_CWGR_CKDIV_Pos                16                                             /**< (TWIHS_CWGR) Clock Divider Position */
+#define TWIHS_CWGR_CKDIV_Msk                (_U_(0x7) << TWIHS_CWGR_CKDIV_Pos)             /**< (TWIHS_CWGR) Clock Divider Mask */
+#define TWIHS_CWGR_CKDIV(value)             (TWIHS_CWGR_CKDIV_Msk & ((value) << TWIHS_CWGR_CKDIV_Pos))
+#define TWIHS_CWGR_HOLD_Pos                 24                                             /**< (TWIHS_CWGR) TWD Hold Time Versus TWCK Falling Position */
+#define TWIHS_CWGR_HOLD_Msk                 (_U_(0x3F) << TWIHS_CWGR_HOLD_Pos)             /**< (TWIHS_CWGR) TWD Hold Time Versus TWCK Falling Mask */
+#define TWIHS_CWGR_HOLD(value)              (TWIHS_CWGR_HOLD_Msk & ((value) << TWIHS_CWGR_HOLD_Pos))
+#define TWIHS_CWGR_MASK                     _U_(0x3F07FFFF)                                /**< \deprecated (TWIHS_CWGR) Register MASK  (Use TWIHS_CWGR_Msk instead)  */
+#define TWIHS_CWGR_Msk                      _U_(0x3F07FFFF)                                /**< (TWIHS_CWGR) Register Mask  */
+
+
+/* -------- TWIHS_SR : (TWIHS Offset: 0x20) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed (cleared by writing TWIHS_THR) */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready (cleared by reading TWIHS_RHR) */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready (cleared by writing TWIHS_THR) */
+    uint32_t SVREAD:1;                  /**< bit:      3  Slave Read                               */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access                             */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access (cleared on read)    */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error (cleared on read)          */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error (cleared on read)         */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledged (cleared on read)       */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost (cleared on read)       */
+    uint32_t SCLWS:1;                   /**< bit:     10  Clock Wait State                         */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access (cleared on read)    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge (cleared on read) */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error (cleared on read)          */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error (cleared on read)              */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match (cleared on read) */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match (cleared on read) */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t SCL:1;                     /**< bit:     24  SCL Line Value                           */
+    uint32_t SDA:1;                     /**< bit:     25  SDA Line Value                           */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SR_OFFSET                     (0x20)                                        /**<  (TWIHS_SR) Status Register  Offset */
+
+#define TWIHS_SR_TXCOMP_Pos                 0                                              /**< (TWIHS_SR) Transmission Completed (cleared by writing TWIHS_THR) Position */
+#define TWIHS_SR_TXCOMP_Msk                 (_U_(0x1) << TWIHS_SR_TXCOMP_Pos)              /**< (TWIHS_SR) Transmission Completed (cleared by writing TWIHS_THR) Mask */
+#define TWIHS_SR_TXCOMP                     TWIHS_SR_TXCOMP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TXCOMP_Msk instead */
+#define TWIHS_SR_RXRDY_Pos                  1                                              /**< (TWIHS_SR) Receive Holding Register Ready (cleared by reading TWIHS_RHR) Position */
+#define TWIHS_SR_RXRDY_Msk                  (_U_(0x1) << TWIHS_SR_RXRDY_Pos)               /**< (TWIHS_SR) Receive Holding Register Ready (cleared by reading TWIHS_RHR) Mask */
+#define TWIHS_SR_RXRDY                      TWIHS_SR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_RXRDY_Msk instead */
+#define TWIHS_SR_TXRDY_Pos                  2                                              /**< (TWIHS_SR) Transmit Holding Register Ready (cleared by writing TWIHS_THR) Position */
+#define TWIHS_SR_TXRDY_Msk                  (_U_(0x1) << TWIHS_SR_TXRDY_Pos)               /**< (TWIHS_SR) Transmit Holding Register Ready (cleared by writing TWIHS_THR) Mask */
+#define TWIHS_SR_TXRDY                      TWIHS_SR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TXRDY_Msk instead */
+#define TWIHS_SR_SVREAD_Pos                 3                                              /**< (TWIHS_SR) Slave Read Position */
+#define TWIHS_SR_SVREAD_Msk                 (_U_(0x1) << TWIHS_SR_SVREAD_Pos)              /**< (TWIHS_SR) Slave Read Mask */
+#define TWIHS_SR_SVREAD                     TWIHS_SR_SVREAD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SVREAD_Msk instead */
+#define TWIHS_SR_SVACC_Pos                  4                                              /**< (TWIHS_SR) Slave Access Position */
+#define TWIHS_SR_SVACC_Msk                  (_U_(0x1) << TWIHS_SR_SVACC_Pos)               /**< (TWIHS_SR) Slave Access Mask */
+#define TWIHS_SR_SVACC                      TWIHS_SR_SVACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SVACC_Msk instead */
+#define TWIHS_SR_GACC_Pos                   5                                              /**< (TWIHS_SR) General Call Access (cleared on read) Position */
+#define TWIHS_SR_GACC_Msk                   (_U_(0x1) << TWIHS_SR_GACC_Pos)                /**< (TWIHS_SR) General Call Access (cleared on read) Mask */
+#define TWIHS_SR_GACC                       TWIHS_SR_GACC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_GACC_Msk instead */
+#define TWIHS_SR_OVRE_Pos                   6                                              /**< (TWIHS_SR) Overrun Error (cleared on read) Position */
+#define TWIHS_SR_OVRE_Msk                   (_U_(0x1) << TWIHS_SR_OVRE_Pos)                /**< (TWIHS_SR) Overrun Error (cleared on read) Mask */
+#define TWIHS_SR_OVRE                       TWIHS_SR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_OVRE_Msk instead */
+#define TWIHS_SR_UNRE_Pos                   7                                              /**< (TWIHS_SR) Underrun Error (cleared on read) Position */
+#define TWIHS_SR_UNRE_Msk                   (_U_(0x1) << TWIHS_SR_UNRE_Pos)                /**< (TWIHS_SR) Underrun Error (cleared on read) Mask */
+#define TWIHS_SR_UNRE                       TWIHS_SR_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_UNRE_Msk instead */
+#define TWIHS_SR_NACK_Pos                   8                                              /**< (TWIHS_SR) Not Acknowledged (cleared on read) Position */
+#define TWIHS_SR_NACK_Msk                   (_U_(0x1) << TWIHS_SR_NACK_Pos)                /**< (TWIHS_SR) Not Acknowledged (cleared on read) Mask */
+#define TWIHS_SR_NACK                       TWIHS_SR_NACK_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_NACK_Msk instead */
+#define TWIHS_SR_ARBLST_Pos                 9                                              /**< (TWIHS_SR) Arbitration Lost (cleared on read) Position */
+#define TWIHS_SR_ARBLST_Msk                 (_U_(0x1) << TWIHS_SR_ARBLST_Pos)              /**< (TWIHS_SR) Arbitration Lost (cleared on read) Mask */
+#define TWIHS_SR_ARBLST                     TWIHS_SR_ARBLST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_ARBLST_Msk instead */
+#define TWIHS_SR_SCLWS_Pos                  10                                             /**< (TWIHS_SR) Clock Wait State Position */
+#define TWIHS_SR_SCLWS_Msk                  (_U_(0x1) << TWIHS_SR_SCLWS_Pos)               /**< (TWIHS_SR) Clock Wait State Mask */
+#define TWIHS_SR_SCLWS                      TWIHS_SR_SCLWS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SCLWS_Msk instead */
+#define TWIHS_SR_EOSACC_Pos                 11                                             /**< (TWIHS_SR) End Of Slave Access (cleared on read) Position */
+#define TWIHS_SR_EOSACC_Msk                 (_U_(0x1) << TWIHS_SR_EOSACC_Pos)              /**< (TWIHS_SR) End Of Slave Access (cleared on read) Mask */
+#define TWIHS_SR_EOSACC                     TWIHS_SR_EOSACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_EOSACC_Msk instead */
+#define TWIHS_SR_MCACK_Pos                  16                                             /**< (TWIHS_SR) Master Code Acknowledge (cleared on read) Position */
+#define TWIHS_SR_MCACK_Msk                  (_U_(0x1) << TWIHS_SR_MCACK_Pos)               /**< (TWIHS_SR) Master Code Acknowledge (cleared on read) Mask */
+#define TWIHS_SR_MCACK                      TWIHS_SR_MCACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_MCACK_Msk instead */
+#define TWIHS_SR_TOUT_Pos                   18                                             /**< (TWIHS_SR) Timeout Error (cleared on read) Position */
+#define TWIHS_SR_TOUT_Msk                   (_U_(0x1) << TWIHS_SR_TOUT_Pos)                /**< (TWIHS_SR) Timeout Error (cleared on read) Mask */
+#define TWIHS_SR_TOUT                       TWIHS_SR_TOUT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TOUT_Msk instead */
+#define TWIHS_SR_PECERR_Pos                 19                                             /**< (TWIHS_SR) PEC Error (cleared on read) Position */
+#define TWIHS_SR_PECERR_Msk                 (_U_(0x1) << TWIHS_SR_PECERR_Pos)              /**< (TWIHS_SR) PEC Error (cleared on read) Mask */
+#define TWIHS_SR_PECERR                     TWIHS_SR_PECERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_PECERR_Msk instead */
+#define TWIHS_SR_SMBDAM_Pos                 20                                             /**< (TWIHS_SR) SMBus Default Address Match (cleared on read) Position */
+#define TWIHS_SR_SMBDAM_Msk                 (_U_(0x1) << TWIHS_SR_SMBDAM_Pos)              /**< (TWIHS_SR) SMBus Default Address Match (cleared on read) Mask */
+#define TWIHS_SR_SMBDAM                     TWIHS_SR_SMBDAM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SMBDAM_Msk instead */
+#define TWIHS_SR_SMBHHM_Pos                 21                                             /**< (TWIHS_SR) SMBus Host Header Address Match (cleared on read) Position */
+#define TWIHS_SR_SMBHHM_Msk                 (_U_(0x1) << TWIHS_SR_SMBHHM_Pos)              /**< (TWIHS_SR) SMBus Host Header Address Match (cleared on read) Mask */
+#define TWIHS_SR_SMBHHM                     TWIHS_SR_SMBHHM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SMBHHM_Msk instead */
+#define TWIHS_SR_SCL_Pos                    24                                             /**< (TWIHS_SR) SCL Line Value Position */
+#define TWIHS_SR_SCL_Msk                    (_U_(0x1) << TWIHS_SR_SCL_Pos)                 /**< (TWIHS_SR) SCL Line Value Mask */
+#define TWIHS_SR_SCL                        TWIHS_SR_SCL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SCL_Msk instead */
+#define TWIHS_SR_SDA_Pos                    25                                             /**< (TWIHS_SR) SDA Line Value Position */
+#define TWIHS_SR_SDA_Msk                    (_U_(0x1) << TWIHS_SR_SDA_Pos)                 /**< (TWIHS_SR) SDA Line Value Mask */
+#define TWIHS_SR_SDA                        TWIHS_SR_SDA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SDA_Msk instead */
+#define TWIHS_SR_MASK                       _U_(0x33D0FFF)                                 /**< \deprecated (TWIHS_SR) Register MASK  (Use TWIHS_SR_Msk instead)  */
+#define TWIHS_SR_Msk                        _U_(0x33D0FFF)                                 /**< (TWIHS_SR) Register Mask  */
+
+
+/* -------- TWIHS_IER : (TWIHS Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Enable  */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Enable */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Enable */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Enable            */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Enable     */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Enable           */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Enable          */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Enable         */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Enable        */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Enable        */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Enable     */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Enable */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Enable           */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Enable               */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Enable */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Enable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IER_OFFSET                    (0x24)                                        /**<  (TWIHS_IER) Interrupt Enable Register  Offset */
+
+#define TWIHS_IER_TXCOMP_Pos                0                                              /**< (TWIHS_IER) Transmission Completed Interrupt Enable Position */
+#define TWIHS_IER_TXCOMP_Msk                (_U_(0x1) << TWIHS_IER_TXCOMP_Pos)             /**< (TWIHS_IER) Transmission Completed Interrupt Enable Mask */
+#define TWIHS_IER_TXCOMP                    TWIHS_IER_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TXCOMP_Msk instead */
+#define TWIHS_IER_RXRDY_Pos                 1                                              /**< (TWIHS_IER) Receive Holding Register Ready Interrupt Enable Position */
+#define TWIHS_IER_RXRDY_Msk                 (_U_(0x1) << TWIHS_IER_RXRDY_Pos)              /**< (TWIHS_IER) Receive Holding Register Ready Interrupt Enable Mask */
+#define TWIHS_IER_RXRDY                     TWIHS_IER_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_RXRDY_Msk instead */
+#define TWIHS_IER_TXRDY_Pos                 2                                              /**< (TWIHS_IER) Transmit Holding Register Ready Interrupt Enable Position */
+#define TWIHS_IER_TXRDY_Msk                 (_U_(0x1) << TWIHS_IER_TXRDY_Pos)              /**< (TWIHS_IER) Transmit Holding Register Ready Interrupt Enable Mask */
+#define TWIHS_IER_TXRDY                     TWIHS_IER_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TXRDY_Msk instead */
+#define TWIHS_IER_SVACC_Pos                 4                                              /**< (TWIHS_IER) Slave Access Interrupt Enable Position */
+#define TWIHS_IER_SVACC_Msk                 (_U_(0x1) << TWIHS_IER_SVACC_Pos)              /**< (TWIHS_IER) Slave Access Interrupt Enable Mask */
+#define TWIHS_IER_SVACC                     TWIHS_IER_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SVACC_Msk instead */
+#define TWIHS_IER_GACC_Pos                  5                                              /**< (TWIHS_IER) General Call Access Interrupt Enable Position */
+#define TWIHS_IER_GACC_Msk                  (_U_(0x1) << TWIHS_IER_GACC_Pos)               /**< (TWIHS_IER) General Call Access Interrupt Enable Mask */
+#define TWIHS_IER_GACC                      TWIHS_IER_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_GACC_Msk instead */
+#define TWIHS_IER_OVRE_Pos                  6                                              /**< (TWIHS_IER) Overrun Error Interrupt Enable Position */
+#define TWIHS_IER_OVRE_Msk                  (_U_(0x1) << TWIHS_IER_OVRE_Pos)               /**< (TWIHS_IER) Overrun Error Interrupt Enable Mask */
+#define TWIHS_IER_OVRE                      TWIHS_IER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_OVRE_Msk instead */
+#define TWIHS_IER_UNRE_Pos                  7                                              /**< (TWIHS_IER) Underrun Error Interrupt Enable Position */
+#define TWIHS_IER_UNRE_Msk                  (_U_(0x1) << TWIHS_IER_UNRE_Pos)               /**< (TWIHS_IER) Underrun Error Interrupt Enable Mask */
+#define TWIHS_IER_UNRE                      TWIHS_IER_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_UNRE_Msk instead */
+#define TWIHS_IER_NACK_Pos                  8                                              /**< (TWIHS_IER) Not Acknowledge Interrupt Enable Position */
+#define TWIHS_IER_NACK_Msk                  (_U_(0x1) << TWIHS_IER_NACK_Pos)               /**< (TWIHS_IER) Not Acknowledge Interrupt Enable Mask */
+#define TWIHS_IER_NACK                      TWIHS_IER_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_NACK_Msk instead */
+#define TWIHS_IER_ARBLST_Pos                9                                              /**< (TWIHS_IER) Arbitration Lost Interrupt Enable Position */
+#define TWIHS_IER_ARBLST_Msk                (_U_(0x1) << TWIHS_IER_ARBLST_Pos)             /**< (TWIHS_IER) Arbitration Lost Interrupt Enable Mask */
+#define TWIHS_IER_ARBLST                    TWIHS_IER_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_ARBLST_Msk instead */
+#define TWIHS_IER_SCL_WS_Pos                10                                             /**< (TWIHS_IER) Clock Wait State Interrupt Enable Position */
+#define TWIHS_IER_SCL_WS_Msk                (_U_(0x1) << TWIHS_IER_SCL_WS_Pos)             /**< (TWIHS_IER) Clock Wait State Interrupt Enable Mask */
+#define TWIHS_IER_SCL_WS                    TWIHS_IER_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SCL_WS_Msk instead */
+#define TWIHS_IER_EOSACC_Pos                11                                             /**< (TWIHS_IER) End Of Slave Access Interrupt Enable Position */
+#define TWIHS_IER_EOSACC_Msk                (_U_(0x1) << TWIHS_IER_EOSACC_Pos)             /**< (TWIHS_IER) End Of Slave Access Interrupt Enable Mask */
+#define TWIHS_IER_EOSACC                    TWIHS_IER_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_EOSACC_Msk instead */
+#define TWIHS_IER_MCACK_Pos                 16                                             /**< (TWIHS_IER) Master Code Acknowledge Interrupt Enable Position */
+#define TWIHS_IER_MCACK_Msk                 (_U_(0x1) << TWIHS_IER_MCACK_Pos)              /**< (TWIHS_IER) Master Code Acknowledge Interrupt Enable Mask */
+#define TWIHS_IER_MCACK                     TWIHS_IER_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_MCACK_Msk instead */
+#define TWIHS_IER_TOUT_Pos                  18                                             /**< (TWIHS_IER) Timeout Error Interrupt Enable Position */
+#define TWIHS_IER_TOUT_Msk                  (_U_(0x1) << TWIHS_IER_TOUT_Pos)               /**< (TWIHS_IER) Timeout Error Interrupt Enable Mask */
+#define TWIHS_IER_TOUT                      TWIHS_IER_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TOUT_Msk instead */
+#define TWIHS_IER_PECERR_Pos                19                                             /**< (TWIHS_IER) PEC Error Interrupt Enable Position */
+#define TWIHS_IER_PECERR_Msk                (_U_(0x1) << TWIHS_IER_PECERR_Pos)             /**< (TWIHS_IER) PEC Error Interrupt Enable Mask */
+#define TWIHS_IER_PECERR                    TWIHS_IER_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_PECERR_Msk instead */
+#define TWIHS_IER_SMBDAM_Pos                20                                             /**< (TWIHS_IER) SMBus Default Address Match Interrupt Enable Position */
+#define TWIHS_IER_SMBDAM_Msk                (_U_(0x1) << TWIHS_IER_SMBDAM_Pos)             /**< (TWIHS_IER) SMBus Default Address Match Interrupt Enable Mask */
+#define TWIHS_IER_SMBDAM                    TWIHS_IER_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SMBDAM_Msk instead */
+#define TWIHS_IER_SMBHHM_Pos                21                                             /**< (TWIHS_IER) SMBus Host Header Address Match Interrupt Enable Position */
+#define TWIHS_IER_SMBHHM_Msk                (_U_(0x1) << TWIHS_IER_SMBHHM_Pos)             /**< (TWIHS_IER) SMBus Host Header Address Match Interrupt Enable Mask */
+#define TWIHS_IER_SMBHHM                    TWIHS_IER_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SMBHHM_Msk instead */
+#define TWIHS_IER_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IER) Register MASK  (Use TWIHS_IER_Msk instead)  */
+#define TWIHS_IER_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IER) Register Mask  */
+
+
+/* -------- TWIHS_IDR : (TWIHS Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Disable */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Disable */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Disable */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Disable           */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Disable    */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Disable          */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Disable         */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Disable        */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Disable       */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Disable       */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Disable    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Disable */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Disable          */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Disable              */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Disable */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Disable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IDR_OFFSET                    (0x28)                                        /**<  (TWIHS_IDR) Interrupt Disable Register  Offset */
+
+#define TWIHS_IDR_TXCOMP_Pos                0                                              /**< (TWIHS_IDR) Transmission Completed Interrupt Disable Position */
+#define TWIHS_IDR_TXCOMP_Msk                (_U_(0x1) << TWIHS_IDR_TXCOMP_Pos)             /**< (TWIHS_IDR) Transmission Completed Interrupt Disable Mask */
+#define TWIHS_IDR_TXCOMP                    TWIHS_IDR_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TXCOMP_Msk instead */
+#define TWIHS_IDR_RXRDY_Pos                 1                                              /**< (TWIHS_IDR) Receive Holding Register Ready Interrupt Disable Position */
+#define TWIHS_IDR_RXRDY_Msk                 (_U_(0x1) << TWIHS_IDR_RXRDY_Pos)              /**< (TWIHS_IDR) Receive Holding Register Ready Interrupt Disable Mask */
+#define TWIHS_IDR_RXRDY                     TWIHS_IDR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_RXRDY_Msk instead */
+#define TWIHS_IDR_TXRDY_Pos                 2                                              /**< (TWIHS_IDR) Transmit Holding Register Ready Interrupt Disable Position */
+#define TWIHS_IDR_TXRDY_Msk                 (_U_(0x1) << TWIHS_IDR_TXRDY_Pos)              /**< (TWIHS_IDR) Transmit Holding Register Ready Interrupt Disable Mask */
+#define TWIHS_IDR_TXRDY                     TWIHS_IDR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TXRDY_Msk instead */
+#define TWIHS_IDR_SVACC_Pos                 4                                              /**< (TWIHS_IDR) Slave Access Interrupt Disable Position */
+#define TWIHS_IDR_SVACC_Msk                 (_U_(0x1) << TWIHS_IDR_SVACC_Pos)              /**< (TWIHS_IDR) Slave Access Interrupt Disable Mask */
+#define TWIHS_IDR_SVACC                     TWIHS_IDR_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SVACC_Msk instead */
+#define TWIHS_IDR_GACC_Pos                  5                                              /**< (TWIHS_IDR) General Call Access Interrupt Disable Position */
+#define TWIHS_IDR_GACC_Msk                  (_U_(0x1) << TWIHS_IDR_GACC_Pos)               /**< (TWIHS_IDR) General Call Access Interrupt Disable Mask */
+#define TWIHS_IDR_GACC                      TWIHS_IDR_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_GACC_Msk instead */
+#define TWIHS_IDR_OVRE_Pos                  6                                              /**< (TWIHS_IDR) Overrun Error Interrupt Disable Position */
+#define TWIHS_IDR_OVRE_Msk                  (_U_(0x1) << TWIHS_IDR_OVRE_Pos)               /**< (TWIHS_IDR) Overrun Error Interrupt Disable Mask */
+#define TWIHS_IDR_OVRE                      TWIHS_IDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_OVRE_Msk instead */
+#define TWIHS_IDR_UNRE_Pos                  7                                              /**< (TWIHS_IDR) Underrun Error Interrupt Disable Position */
+#define TWIHS_IDR_UNRE_Msk                  (_U_(0x1) << TWIHS_IDR_UNRE_Pos)               /**< (TWIHS_IDR) Underrun Error Interrupt Disable Mask */
+#define TWIHS_IDR_UNRE                      TWIHS_IDR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_UNRE_Msk instead */
+#define TWIHS_IDR_NACK_Pos                  8                                              /**< (TWIHS_IDR) Not Acknowledge Interrupt Disable Position */
+#define TWIHS_IDR_NACK_Msk                  (_U_(0x1) << TWIHS_IDR_NACK_Pos)               /**< (TWIHS_IDR) Not Acknowledge Interrupt Disable Mask */
+#define TWIHS_IDR_NACK                      TWIHS_IDR_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_NACK_Msk instead */
+#define TWIHS_IDR_ARBLST_Pos                9                                              /**< (TWIHS_IDR) Arbitration Lost Interrupt Disable Position */
+#define TWIHS_IDR_ARBLST_Msk                (_U_(0x1) << TWIHS_IDR_ARBLST_Pos)             /**< (TWIHS_IDR) Arbitration Lost Interrupt Disable Mask */
+#define TWIHS_IDR_ARBLST                    TWIHS_IDR_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_ARBLST_Msk instead */
+#define TWIHS_IDR_SCL_WS_Pos                10                                             /**< (TWIHS_IDR) Clock Wait State Interrupt Disable Position */
+#define TWIHS_IDR_SCL_WS_Msk                (_U_(0x1) << TWIHS_IDR_SCL_WS_Pos)             /**< (TWIHS_IDR) Clock Wait State Interrupt Disable Mask */
+#define TWIHS_IDR_SCL_WS                    TWIHS_IDR_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SCL_WS_Msk instead */
+#define TWIHS_IDR_EOSACC_Pos                11                                             /**< (TWIHS_IDR) End Of Slave Access Interrupt Disable Position */
+#define TWIHS_IDR_EOSACC_Msk                (_U_(0x1) << TWIHS_IDR_EOSACC_Pos)             /**< (TWIHS_IDR) End Of Slave Access Interrupt Disable Mask */
+#define TWIHS_IDR_EOSACC                    TWIHS_IDR_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_EOSACC_Msk instead */
+#define TWIHS_IDR_MCACK_Pos                 16                                             /**< (TWIHS_IDR) Master Code Acknowledge Interrupt Disable Position */
+#define TWIHS_IDR_MCACK_Msk                 (_U_(0x1) << TWIHS_IDR_MCACK_Pos)              /**< (TWIHS_IDR) Master Code Acknowledge Interrupt Disable Mask */
+#define TWIHS_IDR_MCACK                     TWIHS_IDR_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_MCACK_Msk instead */
+#define TWIHS_IDR_TOUT_Pos                  18                                             /**< (TWIHS_IDR) Timeout Error Interrupt Disable Position */
+#define TWIHS_IDR_TOUT_Msk                  (_U_(0x1) << TWIHS_IDR_TOUT_Pos)               /**< (TWIHS_IDR) Timeout Error Interrupt Disable Mask */
+#define TWIHS_IDR_TOUT                      TWIHS_IDR_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TOUT_Msk instead */
+#define TWIHS_IDR_PECERR_Pos                19                                             /**< (TWIHS_IDR) PEC Error Interrupt Disable Position */
+#define TWIHS_IDR_PECERR_Msk                (_U_(0x1) << TWIHS_IDR_PECERR_Pos)             /**< (TWIHS_IDR) PEC Error Interrupt Disable Mask */
+#define TWIHS_IDR_PECERR                    TWIHS_IDR_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_PECERR_Msk instead */
+#define TWIHS_IDR_SMBDAM_Pos                20                                             /**< (TWIHS_IDR) SMBus Default Address Match Interrupt Disable Position */
+#define TWIHS_IDR_SMBDAM_Msk                (_U_(0x1) << TWIHS_IDR_SMBDAM_Pos)             /**< (TWIHS_IDR) SMBus Default Address Match Interrupt Disable Mask */
+#define TWIHS_IDR_SMBDAM                    TWIHS_IDR_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SMBDAM_Msk instead */
+#define TWIHS_IDR_SMBHHM_Pos                21                                             /**< (TWIHS_IDR) SMBus Host Header Address Match Interrupt Disable Position */
+#define TWIHS_IDR_SMBHHM_Msk                (_U_(0x1) << TWIHS_IDR_SMBHHM_Pos)             /**< (TWIHS_IDR) SMBus Host Header Address Match Interrupt Disable Mask */
+#define TWIHS_IDR_SMBHHM                    TWIHS_IDR_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SMBHHM_Msk instead */
+#define TWIHS_IDR_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IDR) Register MASK  (Use TWIHS_IDR_Msk instead)  */
+#define TWIHS_IDR_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IDR) Register Mask  */
+
+
+/* -------- TWIHS_IMR : (TWIHS Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Mask    */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Mask */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Mask */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Mask              */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Mask       */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Mask             */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Mask            */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Mask           */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Mask          */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Mask          */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Mask       */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Mask   */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Mask             */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Mask                 */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Mask */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Mask */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IMR_OFFSET                    (0x2C)                                        /**<  (TWIHS_IMR) Interrupt Mask Register  Offset */
+
+#define TWIHS_IMR_TXCOMP_Pos                0                                              /**< (TWIHS_IMR) Transmission Completed Interrupt Mask Position */
+#define TWIHS_IMR_TXCOMP_Msk                (_U_(0x1) << TWIHS_IMR_TXCOMP_Pos)             /**< (TWIHS_IMR) Transmission Completed Interrupt Mask Mask */
+#define TWIHS_IMR_TXCOMP                    TWIHS_IMR_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TXCOMP_Msk instead */
+#define TWIHS_IMR_RXRDY_Pos                 1                                              /**< (TWIHS_IMR) Receive Holding Register Ready Interrupt Mask Position */
+#define TWIHS_IMR_RXRDY_Msk                 (_U_(0x1) << TWIHS_IMR_RXRDY_Pos)              /**< (TWIHS_IMR) Receive Holding Register Ready Interrupt Mask Mask */
+#define TWIHS_IMR_RXRDY                     TWIHS_IMR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_RXRDY_Msk instead */
+#define TWIHS_IMR_TXRDY_Pos                 2                                              /**< (TWIHS_IMR) Transmit Holding Register Ready Interrupt Mask Position */
+#define TWIHS_IMR_TXRDY_Msk                 (_U_(0x1) << TWIHS_IMR_TXRDY_Pos)              /**< (TWIHS_IMR) Transmit Holding Register Ready Interrupt Mask Mask */
+#define TWIHS_IMR_TXRDY                     TWIHS_IMR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TXRDY_Msk instead */
+#define TWIHS_IMR_SVACC_Pos                 4                                              /**< (TWIHS_IMR) Slave Access Interrupt Mask Position */
+#define TWIHS_IMR_SVACC_Msk                 (_U_(0x1) << TWIHS_IMR_SVACC_Pos)              /**< (TWIHS_IMR) Slave Access Interrupt Mask Mask */
+#define TWIHS_IMR_SVACC                     TWIHS_IMR_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SVACC_Msk instead */
+#define TWIHS_IMR_GACC_Pos                  5                                              /**< (TWIHS_IMR) General Call Access Interrupt Mask Position */
+#define TWIHS_IMR_GACC_Msk                  (_U_(0x1) << TWIHS_IMR_GACC_Pos)               /**< (TWIHS_IMR) General Call Access Interrupt Mask Mask */
+#define TWIHS_IMR_GACC                      TWIHS_IMR_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_GACC_Msk instead */
+#define TWIHS_IMR_OVRE_Pos                  6                                              /**< (TWIHS_IMR) Overrun Error Interrupt Mask Position */
+#define TWIHS_IMR_OVRE_Msk                  (_U_(0x1) << TWIHS_IMR_OVRE_Pos)               /**< (TWIHS_IMR) Overrun Error Interrupt Mask Mask */
+#define TWIHS_IMR_OVRE                      TWIHS_IMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_OVRE_Msk instead */
+#define TWIHS_IMR_UNRE_Pos                  7                                              /**< (TWIHS_IMR) Underrun Error Interrupt Mask Position */
+#define TWIHS_IMR_UNRE_Msk                  (_U_(0x1) << TWIHS_IMR_UNRE_Pos)               /**< (TWIHS_IMR) Underrun Error Interrupt Mask Mask */
+#define TWIHS_IMR_UNRE                      TWIHS_IMR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_UNRE_Msk instead */
+#define TWIHS_IMR_NACK_Pos                  8                                              /**< (TWIHS_IMR) Not Acknowledge Interrupt Mask Position */
+#define TWIHS_IMR_NACK_Msk                  (_U_(0x1) << TWIHS_IMR_NACK_Pos)               /**< (TWIHS_IMR) Not Acknowledge Interrupt Mask Mask */
+#define TWIHS_IMR_NACK                      TWIHS_IMR_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_NACK_Msk instead */
+#define TWIHS_IMR_ARBLST_Pos                9                                              /**< (TWIHS_IMR) Arbitration Lost Interrupt Mask Position */
+#define TWIHS_IMR_ARBLST_Msk                (_U_(0x1) << TWIHS_IMR_ARBLST_Pos)             /**< (TWIHS_IMR) Arbitration Lost Interrupt Mask Mask */
+#define TWIHS_IMR_ARBLST                    TWIHS_IMR_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_ARBLST_Msk instead */
+#define TWIHS_IMR_SCL_WS_Pos                10                                             /**< (TWIHS_IMR) Clock Wait State Interrupt Mask Position */
+#define TWIHS_IMR_SCL_WS_Msk                (_U_(0x1) << TWIHS_IMR_SCL_WS_Pos)             /**< (TWIHS_IMR) Clock Wait State Interrupt Mask Mask */
+#define TWIHS_IMR_SCL_WS                    TWIHS_IMR_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SCL_WS_Msk instead */
+#define TWIHS_IMR_EOSACC_Pos                11                                             /**< (TWIHS_IMR) End Of Slave Access Interrupt Mask Position */
+#define TWIHS_IMR_EOSACC_Msk                (_U_(0x1) << TWIHS_IMR_EOSACC_Pos)             /**< (TWIHS_IMR) End Of Slave Access Interrupt Mask Mask */
+#define TWIHS_IMR_EOSACC                    TWIHS_IMR_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_EOSACC_Msk instead */
+#define TWIHS_IMR_MCACK_Pos                 16                                             /**< (TWIHS_IMR) Master Code Acknowledge Interrupt Mask Position */
+#define TWIHS_IMR_MCACK_Msk                 (_U_(0x1) << TWIHS_IMR_MCACK_Pos)              /**< (TWIHS_IMR) Master Code Acknowledge Interrupt Mask Mask */
+#define TWIHS_IMR_MCACK                     TWIHS_IMR_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_MCACK_Msk instead */
+#define TWIHS_IMR_TOUT_Pos                  18                                             /**< (TWIHS_IMR) Timeout Error Interrupt Mask Position */
+#define TWIHS_IMR_TOUT_Msk                  (_U_(0x1) << TWIHS_IMR_TOUT_Pos)               /**< (TWIHS_IMR) Timeout Error Interrupt Mask Mask */
+#define TWIHS_IMR_TOUT                      TWIHS_IMR_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TOUT_Msk instead */
+#define TWIHS_IMR_PECERR_Pos                19                                             /**< (TWIHS_IMR) PEC Error Interrupt Mask Position */
+#define TWIHS_IMR_PECERR_Msk                (_U_(0x1) << TWIHS_IMR_PECERR_Pos)             /**< (TWIHS_IMR) PEC Error Interrupt Mask Mask */
+#define TWIHS_IMR_PECERR                    TWIHS_IMR_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_PECERR_Msk instead */
+#define TWIHS_IMR_SMBDAM_Pos                20                                             /**< (TWIHS_IMR) SMBus Default Address Match Interrupt Mask Position */
+#define TWIHS_IMR_SMBDAM_Msk                (_U_(0x1) << TWIHS_IMR_SMBDAM_Pos)             /**< (TWIHS_IMR) SMBus Default Address Match Interrupt Mask Mask */
+#define TWIHS_IMR_SMBDAM                    TWIHS_IMR_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SMBDAM_Msk instead */
+#define TWIHS_IMR_SMBHHM_Pos                21                                             /**< (TWIHS_IMR) SMBus Host Header Address Match Interrupt Mask Position */
+#define TWIHS_IMR_SMBHHM_Msk                (_U_(0x1) << TWIHS_IMR_SMBHHM_Pos)             /**< (TWIHS_IMR) SMBus Host Header Address Match Interrupt Mask Mask */
+#define TWIHS_IMR_SMBHHM                    TWIHS_IMR_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SMBHHM_Msk instead */
+#define TWIHS_IMR_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IMR) Register MASK  (Use TWIHS_IMR_Msk instead)  */
+#define TWIHS_IMR_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IMR) Register Mask  */
+
+
+/* -------- TWIHS_RHR : (TWIHS Offset: 0x30) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXDATA:8;                  /**< bit:   0..7  Master or Slave Receive Holding Data     */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_RHR_OFFSET                    (0x30)                                        /**<  (TWIHS_RHR) Receive Holding Register  Offset */
+
+#define TWIHS_RHR_RXDATA_Pos                0                                              /**< (TWIHS_RHR) Master or Slave Receive Holding Data Position */
+#define TWIHS_RHR_RXDATA_Msk                (_U_(0xFF) << TWIHS_RHR_RXDATA_Pos)            /**< (TWIHS_RHR) Master or Slave Receive Holding Data Mask */
+#define TWIHS_RHR_RXDATA(value)             (TWIHS_RHR_RXDATA_Msk & ((value) << TWIHS_RHR_RXDATA_Pos))
+#define TWIHS_RHR_MASK                      _U_(0xFF)                                      /**< \deprecated (TWIHS_RHR) Register MASK  (Use TWIHS_RHR_Msk instead)  */
+#define TWIHS_RHR_Msk                       _U_(0xFF)                                      /**< (TWIHS_RHR) Register Mask  */
+
+
+/* -------- TWIHS_THR : (TWIHS Offset: 0x34) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXDATA:8;                  /**< bit:   0..7  Master or Slave Transmit Holding Data    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_THR_OFFSET                    (0x34)                                        /**<  (TWIHS_THR) Transmit Holding Register  Offset */
+
+#define TWIHS_THR_TXDATA_Pos                0                                              /**< (TWIHS_THR) Master or Slave Transmit Holding Data Position */
+#define TWIHS_THR_TXDATA_Msk                (_U_(0xFF) << TWIHS_THR_TXDATA_Pos)            /**< (TWIHS_THR) Master or Slave Transmit Holding Data Mask */
+#define TWIHS_THR_TXDATA(value)             (TWIHS_THR_TXDATA_Msk & ((value) << TWIHS_THR_TXDATA_Pos))
+#define TWIHS_THR_MASK                      _U_(0xFF)                                      /**< \deprecated (TWIHS_THR) Register MASK  (Use TWIHS_THR_Msk instead)  */
+#define TWIHS_THR_Msk                       _U_(0xFF)                                      /**< (TWIHS_THR) Register Mask  */
+
+
+/* -------- TWIHS_SMBTR : (TWIHS Offset: 0x38) (R/W 32) SMBus Timing Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PRESC:4;                   /**< bit:   0..3  SMBus Clock Prescaler                    */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t TLOWS:8;                   /**< bit:  8..15  Slave Clock Stretch Maximum Cycles       */
+    uint32_t TLOWM:8;                   /**< bit: 16..23  Master Clock Stretch Maximum Cycles      */
+    uint32_t THMAX:8;                   /**< bit: 24..31  Clock High Maximum Cycles                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SMBTR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SMBTR_OFFSET                  (0x38)                                        /**<  (TWIHS_SMBTR) SMBus Timing Register  Offset */
+
+#define TWIHS_SMBTR_PRESC_Pos               0                                              /**< (TWIHS_SMBTR) SMBus Clock Prescaler Position */
+#define TWIHS_SMBTR_PRESC_Msk               (_U_(0xF) << TWIHS_SMBTR_PRESC_Pos)            /**< (TWIHS_SMBTR) SMBus Clock Prescaler Mask */
+#define TWIHS_SMBTR_PRESC(value)            (TWIHS_SMBTR_PRESC_Msk & ((value) << TWIHS_SMBTR_PRESC_Pos))
+#define TWIHS_SMBTR_TLOWS_Pos               8                                              /**< (TWIHS_SMBTR) Slave Clock Stretch Maximum Cycles Position */
+#define TWIHS_SMBTR_TLOWS_Msk               (_U_(0xFF) << TWIHS_SMBTR_TLOWS_Pos)           /**< (TWIHS_SMBTR) Slave Clock Stretch Maximum Cycles Mask */
+#define TWIHS_SMBTR_TLOWS(value)            (TWIHS_SMBTR_TLOWS_Msk & ((value) << TWIHS_SMBTR_TLOWS_Pos))
+#define TWIHS_SMBTR_TLOWM_Pos               16                                             /**< (TWIHS_SMBTR) Master Clock Stretch Maximum Cycles Position */
+#define TWIHS_SMBTR_TLOWM_Msk               (_U_(0xFF) << TWIHS_SMBTR_TLOWM_Pos)           /**< (TWIHS_SMBTR) Master Clock Stretch Maximum Cycles Mask */
+#define TWIHS_SMBTR_TLOWM(value)            (TWIHS_SMBTR_TLOWM_Msk & ((value) << TWIHS_SMBTR_TLOWM_Pos))
+#define TWIHS_SMBTR_THMAX_Pos               24                                             /**< (TWIHS_SMBTR) Clock High Maximum Cycles Position */
+#define TWIHS_SMBTR_THMAX_Msk               (_U_(0xFF) << TWIHS_SMBTR_THMAX_Pos)           /**< (TWIHS_SMBTR) Clock High Maximum Cycles Mask */
+#define TWIHS_SMBTR_THMAX(value)            (TWIHS_SMBTR_THMAX_Msk & ((value) << TWIHS_SMBTR_THMAX_Pos))
+#define TWIHS_SMBTR_MASK                    _U_(0xFFFFFF0F)                                /**< \deprecated (TWIHS_SMBTR) Register MASK  (Use TWIHS_SMBTR_Msk instead)  */
+#define TWIHS_SMBTR_Msk                     _U_(0xFFFFFF0F)                                /**< (TWIHS_SMBTR) Register Mask  */
+
+
+/* -------- TWIHS_FILTR : (TWIHS Offset: 0x44) (R/W 32) Filter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FILT:1;                    /**< bit:      0  RX Digital Filter                        */
+    uint32_t PADFEN:1;                  /**< bit:      1  PAD Filter Enable                        */
+    uint32_t PADFCFG:1;                 /**< bit:      2  PAD Filter Config                        */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t THRES:3;                   /**< bit:  8..10  Digital Filter Threshold                 */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_FILTR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_FILTR_OFFSET                  (0x44)                                        /**<  (TWIHS_FILTR) Filter Register  Offset */
+
+#define TWIHS_FILTR_FILT_Pos                0                                              /**< (TWIHS_FILTR) RX Digital Filter Position */
+#define TWIHS_FILTR_FILT_Msk                (_U_(0x1) << TWIHS_FILTR_FILT_Pos)             /**< (TWIHS_FILTR) RX Digital Filter Mask */
+#define TWIHS_FILTR_FILT                    TWIHS_FILTR_FILT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_FILT_Msk instead */
+#define TWIHS_FILTR_PADFEN_Pos              1                                              /**< (TWIHS_FILTR) PAD Filter Enable Position */
+#define TWIHS_FILTR_PADFEN_Msk              (_U_(0x1) << TWIHS_FILTR_PADFEN_Pos)           /**< (TWIHS_FILTR) PAD Filter Enable Mask */
+#define TWIHS_FILTR_PADFEN                  TWIHS_FILTR_PADFEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_PADFEN_Msk instead */
+#define TWIHS_FILTR_PADFCFG_Pos             2                                              /**< (TWIHS_FILTR) PAD Filter Config Position */
+#define TWIHS_FILTR_PADFCFG_Msk             (_U_(0x1) << TWIHS_FILTR_PADFCFG_Pos)          /**< (TWIHS_FILTR) PAD Filter Config Mask */
+#define TWIHS_FILTR_PADFCFG                 TWIHS_FILTR_PADFCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_PADFCFG_Msk instead */
+#define TWIHS_FILTR_THRES_Pos               8                                              /**< (TWIHS_FILTR) Digital Filter Threshold Position */
+#define TWIHS_FILTR_THRES_Msk               (_U_(0x7) << TWIHS_FILTR_THRES_Pos)            /**< (TWIHS_FILTR) Digital Filter Threshold Mask */
+#define TWIHS_FILTR_THRES(value)            (TWIHS_FILTR_THRES_Msk & ((value) << TWIHS_FILTR_THRES_Pos))
+#define TWIHS_FILTR_MASK                    _U_(0x707)                                     /**< \deprecated (TWIHS_FILTR) Register MASK  (Use TWIHS_FILTR_Msk instead)  */
+#define TWIHS_FILTR_Msk                     _U_(0x707)                                     /**< (TWIHS_FILTR) Register Mask  */
+
+
+/* -------- TWIHS_SWMR : (TWIHS Offset: 0x4c) (R/W 32) SleepWalking Matching Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SADR1:7;                   /**< bit:   0..6  Slave Address 1                          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t SADR2:7;                   /**< bit:  8..14  Slave Address 2                          */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SADR3:7;                   /**< bit: 16..22  Slave Address 3                          */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t DATAM:8;                   /**< bit: 24..31  Data Match                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SWMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SWMR_OFFSET                   (0x4C)                                        /**<  (TWIHS_SWMR) SleepWalking Matching Register  Offset */
+
+#define TWIHS_SWMR_SADR1_Pos                0                                              /**< (TWIHS_SWMR) Slave Address 1 Position */
+#define TWIHS_SWMR_SADR1_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR1_Pos)            /**< (TWIHS_SWMR) Slave Address 1 Mask */
+#define TWIHS_SWMR_SADR1(value)             (TWIHS_SWMR_SADR1_Msk & ((value) << TWIHS_SWMR_SADR1_Pos))
+#define TWIHS_SWMR_SADR2_Pos                8                                              /**< (TWIHS_SWMR) Slave Address 2 Position */
+#define TWIHS_SWMR_SADR2_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR2_Pos)            /**< (TWIHS_SWMR) Slave Address 2 Mask */
+#define TWIHS_SWMR_SADR2(value)             (TWIHS_SWMR_SADR2_Msk & ((value) << TWIHS_SWMR_SADR2_Pos))
+#define TWIHS_SWMR_SADR3_Pos                16                                             /**< (TWIHS_SWMR) Slave Address 3 Position */
+#define TWIHS_SWMR_SADR3_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR3_Pos)            /**< (TWIHS_SWMR) Slave Address 3 Mask */
+#define TWIHS_SWMR_SADR3(value)             (TWIHS_SWMR_SADR3_Msk & ((value) << TWIHS_SWMR_SADR3_Pos))
+#define TWIHS_SWMR_DATAM_Pos                24                                             /**< (TWIHS_SWMR) Data Match Position */
+#define TWIHS_SWMR_DATAM_Msk                (_U_(0xFF) << TWIHS_SWMR_DATAM_Pos)            /**< (TWIHS_SWMR) Data Match Mask */
+#define TWIHS_SWMR_DATAM(value)             (TWIHS_SWMR_DATAM_Msk & ((value) << TWIHS_SWMR_DATAM_Pos))
+#define TWIHS_SWMR_MASK                     _U_(0xFF7F7F7F)                                /**< \deprecated (TWIHS_SWMR) Register MASK  (Use TWIHS_SWMR_Msk instead)  */
+#define TWIHS_SWMR_Msk                      _U_(0xFF7F7F7F)                                /**< (TWIHS_SWMR) Register Mask  */
+
+
+/* -------- TWIHS_DR : (TWIHS Offset: 0xd0) (R/ 32) Debug Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWEN:1;                    /**< bit:      0  SleepWalking Enable                      */
+    uint32_t CLKRQ:1;                   /**< bit:      1  Clock Request                            */
+    uint32_t SWMATCH:1;                 /**< bit:      2  SleepWalking Match                       */
+    uint32_t TRP:1;                     /**< bit:      3  Transfer Pending                         */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_DR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_DR_OFFSET                     (0xD0)                                        /**<  (TWIHS_DR) Debug Register  Offset */
+
+#define TWIHS_DR_SWEN_Pos                   0                                              /**< (TWIHS_DR) SleepWalking Enable Position */
+#define TWIHS_DR_SWEN_Msk                   (_U_(0x1) << TWIHS_DR_SWEN_Pos)                /**< (TWIHS_DR) SleepWalking Enable Mask */
+#define TWIHS_DR_SWEN                       TWIHS_DR_SWEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_DR_SWEN_Msk instead */
+#define TWIHS_DR_CLKRQ_Pos                  1                                              /**< (TWIHS_DR) Clock Request Position */
+#define TWIHS_DR_CLKRQ_Msk                  (_U_(0x1) << TWIHS_DR_CLKRQ_Pos)               /**< (TWIHS_DR) Clock Request Mask */
+#define TWIHS_DR_CLKRQ                      TWIHS_DR_CLKRQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_DR_CLKRQ_Msk instead */
+#define TWIHS_DR_SWMATCH_Pos                2                                              /**< (TWIHS_DR) SleepWalking Match Position */
+#define TWIHS_DR_SWMATCH_Msk                (_U_(0x1) << TWIHS_DR_SWMATCH_Pos)             /**< (TWIHS_DR) SleepWalking Match Mask */
+#define TWIHS_DR_SWMATCH                    TWIHS_DR_SWMATCH_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_DR_SWMATCH_Msk instead */
+#define TWIHS_DR_TRP_Pos                    3                                              /**< (TWIHS_DR) Transfer Pending Position */
+#define TWIHS_DR_TRP_Msk                    (_U_(0x1) << TWIHS_DR_TRP_Pos)                 /**< (TWIHS_DR) Transfer Pending Mask */
+#define TWIHS_DR_TRP                        TWIHS_DR_TRP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_DR_TRP_Msk instead */
+#define TWIHS_DR_MASK                       _U_(0x0F)                                      /**< \deprecated (TWIHS_DR) Register MASK  (Use TWIHS_DR_Msk instead)  */
+#define TWIHS_DR_Msk                        _U_(0x0F)                                      /**< (TWIHS_DR) Register Mask  */
+
+
+/* -------- TWIHS_WPMR : (TWIHS Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_WPMR_OFFSET                   (0xE4)                                        /**<  (TWIHS_WPMR) Write Protection Mode Register  Offset */
+
+#define TWIHS_WPMR_WPEN_Pos                 0                                              /**< (TWIHS_WPMR) Write Protection Enable Position */
+#define TWIHS_WPMR_WPEN_Msk                 (_U_(0x1) << TWIHS_WPMR_WPEN_Pos)              /**< (TWIHS_WPMR) Write Protection Enable Mask */
+#define TWIHS_WPMR_WPEN                     TWIHS_WPMR_WPEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_WPMR_WPEN_Msk instead */
+#define TWIHS_WPMR_WPKEY_Pos                8                                              /**< (TWIHS_WPMR) Write Protection Key Position */
+#define TWIHS_WPMR_WPKEY_Msk                (_U_(0xFFFFFF) << TWIHS_WPMR_WPKEY_Pos)        /**< (TWIHS_WPMR) Write Protection Key Mask */
+#define TWIHS_WPMR_WPKEY(value)             (TWIHS_WPMR_WPKEY_Msk & ((value) << TWIHS_WPMR_WPKEY_Pos))
+#define   TWIHS_WPMR_WPKEY_PASSWD_Val       _U_(0x545749)                                  /**< (TWIHS_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0  */
+#define TWIHS_WPMR_WPKEY_PASSWD             (TWIHS_WPMR_WPKEY_PASSWD_Val << TWIHS_WPMR_WPKEY_Pos)  /**< (TWIHS_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0 Position  */
+#define TWIHS_WPMR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (TWIHS_WPMR) Register MASK  (Use TWIHS_WPMR_Msk instead)  */
+#define TWIHS_WPMR_Msk                      _U_(0xFFFFFF01)                                /**< (TWIHS_WPMR) Register Mask  */
+
+
+/* -------- TWIHS_WPSR : (TWIHS Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:24;                 /**< bit:  8..31  Write Protection Violation Source        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_WPSR_OFFSET                   (0xE8)                                        /**<  (TWIHS_WPSR) Write Protection Status Register  Offset */
+
+#define TWIHS_WPSR_WPVS_Pos                 0                                              /**< (TWIHS_WPSR) Write Protection Violation Status Position */
+#define TWIHS_WPSR_WPVS_Msk                 (_U_(0x1) << TWIHS_WPSR_WPVS_Pos)              /**< (TWIHS_WPSR) Write Protection Violation Status Mask */
+#define TWIHS_WPSR_WPVS                     TWIHS_WPSR_WPVS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_WPSR_WPVS_Msk instead */
+#define TWIHS_WPSR_WPVSRC_Pos               8                                              /**< (TWIHS_WPSR) Write Protection Violation Source Position */
+#define TWIHS_WPSR_WPVSRC_Msk               (_U_(0xFFFFFF) << TWIHS_WPSR_WPVSRC_Pos)       /**< (TWIHS_WPSR) Write Protection Violation Source Mask */
+#define TWIHS_WPSR_WPVSRC(value)            (TWIHS_WPSR_WPVSRC_Msk & ((value) << TWIHS_WPSR_WPVSRC_Pos))
+#define TWIHS_WPSR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (TWIHS_WPSR) Register MASK  (Use TWIHS_WPSR_Msk instead)  */
+#define TWIHS_WPSR_Msk                      _U_(0xFFFFFF01)                                /**< (TWIHS_WPSR) Register Mask  */
+
+
+/* -------- TWIHS_VER : (TWIHS Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_VER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_VER_OFFSET                    (0xFC)                                        /**<  (TWIHS_VER) Version Register  Offset */
+
+#define TWIHS_VER_VERSION_Pos               0                                              /**< (TWIHS_VER) Version of the Hardware Module Position */
+#define TWIHS_VER_VERSION_Msk               (_U_(0xFFF) << TWIHS_VER_VERSION_Pos)          /**< (TWIHS_VER) Version of the Hardware Module Mask */
+#define TWIHS_VER_VERSION(value)            (TWIHS_VER_VERSION_Msk & ((value) << TWIHS_VER_VERSION_Pos))
+#define TWIHS_VER_MFN_Pos                   16                                             /**< (TWIHS_VER) Metal Fix Number Position */
+#define TWIHS_VER_MFN_Msk                   (_U_(0x7) << TWIHS_VER_MFN_Pos)                /**< (TWIHS_VER) Metal Fix Number Mask */
+#define TWIHS_VER_MFN(value)                (TWIHS_VER_MFN_Msk & ((value) << TWIHS_VER_MFN_Pos))
+#define TWIHS_VER_MASK                      _U_(0x70FFF)                                   /**< \deprecated (TWIHS_VER) Register MASK  (Use TWIHS_VER_Msk instead)  */
+#define TWIHS_VER_Msk                       _U_(0x70FFF)                                   /**< (TWIHS_VER) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TWIHS hardware registers */
+typedef struct {  
+  __O  uint32_t TWIHS_CR;       /**< (TWIHS Offset: 0x00) Control Register */
+  __IO uint32_t TWIHS_MMR;      /**< (TWIHS Offset: 0x04) Master Mode Register */
+  __IO uint32_t TWIHS_SMR;      /**< (TWIHS Offset: 0x08) Slave Mode Register */
+  __IO uint32_t TWIHS_IADR;     /**< (TWIHS Offset: 0x0C) Internal Address Register */
+  __IO uint32_t TWIHS_CWGR;     /**< (TWIHS Offset: 0x10) Clock Waveform Generator Register */
+  __I  uint8_t                        Reserved1[12];
+  __I  uint32_t TWIHS_SR;       /**< (TWIHS Offset: 0x20) Status Register */
+  __O  uint32_t TWIHS_IER;      /**< (TWIHS Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t TWIHS_IDR;      /**< (TWIHS Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t TWIHS_IMR;      /**< (TWIHS Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t TWIHS_RHR;      /**< (TWIHS Offset: 0x30) Receive Holding Register */
+  __O  uint32_t TWIHS_THR;      /**< (TWIHS Offset: 0x34) Transmit Holding Register */
+  __IO uint32_t TWIHS_SMBTR;    /**< (TWIHS Offset: 0x38) SMBus Timing Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO uint32_t TWIHS_FILTR;    /**< (TWIHS Offset: 0x44) Filter Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO uint32_t TWIHS_SWMR;     /**< (TWIHS Offset: 0x4C) SleepWalking Matching Register */
+  __I  uint8_t                        Reserved4[128];
+  __I  uint32_t TWIHS_DR;       /**< (TWIHS Offset: 0xD0) Debug Register */
+  __I  uint8_t                        Reserved5[16];
+  __IO uint32_t TWIHS_WPMR;     /**< (TWIHS Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t TWIHS_WPSR;     /**< (TWIHS Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  uint32_t TWIHS_VER;      /**< (TWIHS Offset: 0xFC) Version Register */
+} Twihs;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TWIHS hardware registers */
+typedef struct {  
+  __O  TWIHS_CR_Type                  TWIHS_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO TWIHS_MMR_Type                 TWIHS_MMR;      /**< Offset: 0x04 (R/W  32) Master Mode Register */
+  __IO TWIHS_SMR_Type                 TWIHS_SMR;      /**< Offset: 0x08 (R/W  32) Slave Mode Register */
+  __IO TWIHS_IADR_Type                TWIHS_IADR;     /**< Offset: 0x0C (R/W  32) Internal Address Register */
+  __IO TWIHS_CWGR_Type                TWIHS_CWGR;     /**< Offset: 0x10 (R/W  32) Clock Waveform Generator Register */
+  __I  uint8_t                        Reserved1[12];
+  __I  TWIHS_SR_Type                  TWIHS_SR;       /**< Offset: 0x20 (R/   32) Status Register */
+  __O  TWIHS_IER_Type                 TWIHS_IER;      /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  TWIHS_IDR_Type                 TWIHS_IDR;      /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  TWIHS_IMR_Type                 TWIHS_IMR;      /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  TWIHS_RHR_Type                 TWIHS_RHR;      /**< Offset: 0x30 (R/   32) Receive Holding Register */
+  __O  TWIHS_THR_Type                 TWIHS_THR;      /**< Offset: 0x34 ( /W  32) Transmit Holding Register */
+  __IO TWIHS_SMBTR_Type               TWIHS_SMBTR;    /**< Offset: 0x38 (R/W  32) SMBus Timing Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO TWIHS_FILTR_Type               TWIHS_FILTR;    /**< Offset: 0x44 (R/W  32) Filter Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO TWIHS_SWMR_Type                TWIHS_SWMR;     /**< Offset: 0x4C (R/W  32) SleepWalking Matching Register */
+  __I  uint8_t                        Reserved4[128];
+  __I  TWIHS_DR_Type                  TWIHS_DR;       /**< Offset: 0xD0 (R/   32) Debug Register */
+  __I  uint8_t                        Reserved5[16];
+  __IO TWIHS_WPMR_Type                TWIHS_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  TWIHS_WPSR_Type                TWIHS_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[16];
+  __I  TWIHS_VER_Type                 TWIHS_VER;      /**< Offset: 0xFC (R/   32) Version Register */
+} Twihs;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Two-wire Interface High Speed */
+
+#endif /* _SAMV71_TWIHS_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/uart.h
+++ b/asf/sam/include/samv71/component/uart.h
@@ -1,0 +1,585 @@
+/**
+ * \file
+ *
+ * \brief Component description for UART
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART_COMPONENT_H_
+#define _SAMV71_UART_COMPONENT_H_
+#define _SAMV71_UART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Universal Asynchronous Receiver Transmitter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR UART */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define UART_6418                       /**< (UART) Module ID */
+#define REV_UART P                      /**< (UART) Module revision */
+
+/* -------- UART_CR : (UART Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RSTRX:1;                   /**< bit:      2  Reset Receiver                           */
+    uint32_t RSTTX:1;                   /**< bit:      3  Reset Transmitter                        */
+    uint32_t RXEN:1;                    /**< bit:      4  Receiver Enable                          */
+    uint32_t RXDIS:1;                   /**< bit:      5  Receiver Disable                         */
+    uint32_t TXEN:1;                    /**< bit:      6  Transmitter Enable                       */
+    uint32_t TXDIS:1;                   /**< bit:      7  Transmitter Disable                      */
+    uint32_t RSTSTA:1;                  /**< bit:      8  Reset Status                             */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t REQCLR:1;                  /**< bit:     12  Request Clear                            */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t DBGE:1;                    /**< bit:     15  Debug Enable                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_CR_OFFSET                      (0x00)                                        /**<  (UART_CR) Control Register  Offset */
+
+#define UART_CR_RSTRX_Pos                   2                                              /**< (UART_CR) Reset Receiver Position */
+#define UART_CR_RSTRX_Msk                   (_U_(0x1) << UART_CR_RSTRX_Pos)                /**< (UART_CR) Reset Receiver Mask */
+#define UART_CR_RSTRX                       UART_CR_RSTRX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTRX_Msk instead */
+#define UART_CR_RSTTX_Pos                   3                                              /**< (UART_CR) Reset Transmitter Position */
+#define UART_CR_RSTTX_Msk                   (_U_(0x1) << UART_CR_RSTTX_Pos)                /**< (UART_CR) Reset Transmitter Mask */
+#define UART_CR_RSTTX                       UART_CR_RSTTX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTTX_Msk instead */
+#define UART_CR_RXEN_Pos                    4                                              /**< (UART_CR) Receiver Enable Position */
+#define UART_CR_RXEN_Msk                    (_U_(0x1) << UART_CR_RXEN_Pos)                 /**< (UART_CR) Receiver Enable Mask */
+#define UART_CR_RXEN                        UART_CR_RXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RXEN_Msk instead */
+#define UART_CR_RXDIS_Pos                   5                                              /**< (UART_CR) Receiver Disable Position */
+#define UART_CR_RXDIS_Msk                   (_U_(0x1) << UART_CR_RXDIS_Pos)                /**< (UART_CR) Receiver Disable Mask */
+#define UART_CR_RXDIS                       UART_CR_RXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RXDIS_Msk instead */
+#define UART_CR_TXEN_Pos                    6                                              /**< (UART_CR) Transmitter Enable Position */
+#define UART_CR_TXEN_Msk                    (_U_(0x1) << UART_CR_TXEN_Pos)                 /**< (UART_CR) Transmitter Enable Mask */
+#define UART_CR_TXEN                        UART_CR_TXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_TXEN_Msk instead */
+#define UART_CR_TXDIS_Pos                   7                                              /**< (UART_CR) Transmitter Disable Position */
+#define UART_CR_TXDIS_Msk                   (_U_(0x1) << UART_CR_TXDIS_Pos)                /**< (UART_CR) Transmitter Disable Mask */
+#define UART_CR_TXDIS                       UART_CR_TXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_TXDIS_Msk instead */
+#define UART_CR_RSTSTA_Pos                  8                                              /**< (UART_CR) Reset Status Position */
+#define UART_CR_RSTSTA_Msk                  (_U_(0x1) << UART_CR_RSTSTA_Pos)               /**< (UART_CR) Reset Status Mask */
+#define UART_CR_RSTSTA                      UART_CR_RSTSTA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTSTA_Msk instead */
+#define UART_CR_REQCLR_Pos                  12                                             /**< (UART_CR) Request Clear Position */
+#define UART_CR_REQCLR_Msk                  (_U_(0x1) << UART_CR_REQCLR_Pos)               /**< (UART_CR) Request Clear Mask */
+#define UART_CR_REQCLR                      UART_CR_REQCLR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_REQCLR_Msk instead */
+#define UART_CR_DBGE_Pos                    15                                             /**< (UART_CR) Debug Enable Position */
+#define UART_CR_DBGE_Msk                    (_U_(0x1) << UART_CR_DBGE_Pos)                 /**< (UART_CR) Debug Enable Mask */
+#define UART_CR_DBGE                        UART_CR_DBGE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_DBGE_Msk instead */
+#define UART_CR_MASK                        _U_(0x91FC)                                    /**< \deprecated (UART_CR) Register MASK  (Use UART_CR_Msk instead)  */
+#define UART_CR_Msk                         _U_(0x91FC)                                    /**< (UART_CR) Register Mask  */
+
+
+/* -------- UART_MR : (UART Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t FILTER:1;                  /**< bit:      4  Receiver Digital Filter                  */
+    uint32_t :4;                        /**< bit:   5..8  Reserved */
+    uint32_t PAR:3;                     /**< bit:  9..11  Parity Type                              */
+    uint32_t BRSRCCK:1;                 /**< bit:     12  Baud Rate Source Clock                   */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CHMODE:2;                  /**< bit: 14..15  Channel Mode                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_MR_OFFSET                      (0x04)                                        /**<  (UART_MR) Mode Register  Offset */
+
+#define UART_MR_FILTER_Pos                  4                                              /**< (UART_MR) Receiver Digital Filter Position */
+#define UART_MR_FILTER_Msk                  (_U_(0x1) << UART_MR_FILTER_Pos)               /**< (UART_MR) Receiver Digital Filter Mask */
+#define UART_MR_FILTER                      UART_MR_FILTER_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_MR_FILTER_Msk instead */
+#define   UART_MR_FILTER_DISABLED_Val       _U_(0x0)                                       /**< (UART_MR) UART does not filter the receive line.  */
+#define   UART_MR_FILTER_ENABLED_Val        _U_(0x1)                                       /**< (UART_MR) UART filters the receive line using a three-sample filter (16x-bit clock) (2 over 3 majority).  */
+#define UART_MR_FILTER_DISABLED             (UART_MR_FILTER_DISABLED_Val << UART_MR_FILTER_Pos)  /**< (UART_MR) UART does not filter the receive line. Position  */
+#define UART_MR_FILTER_ENABLED              (UART_MR_FILTER_ENABLED_Val << UART_MR_FILTER_Pos)  /**< (UART_MR) UART filters the receive line using a three-sample filter (16x-bit clock) (2 over 3 majority). Position  */
+#define UART_MR_PAR_Pos                     9                                              /**< (UART_MR) Parity Type Position */
+#define UART_MR_PAR_Msk                     (_U_(0x7) << UART_MR_PAR_Pos)                  /**< (UART_MR) Parity Type Mask */
+#define UART_MR_PAR(value)                  (UART_MR_PAR_Msk & ((value) << UART_MR_PAR_Pos))
+#define   UART_MR_PAR_EVEN_Val              _U_(0x0)                                       /**< (UART_MR) Even Parity  */
+#define   UART_MR_PAR_ODD_Val               _U_(0x1)                                       /**< (UART_MR) Odd Parity  */
+#define   UART_MR_PAR_SPACE_Val             _U_(0x2)                                       /**< (UART_MR) Space: parity forced to 0  */
+#define   UART_MR_PAR_MARK_Val              _U_(0x3)                                       /**< (UART_MR) Mark: parity forced to 1  */
+#define   UART_MR_PAR_NO_Val                _U_(0x4)                                       /**< (UART_MR) No parity  */
+#define UART_MR_PAR_EVEN                    (UART_MR_PAR_EVEN_Val << UART_MR_PAR_Pos)      /**< (UART_MR) Even Parity Position  */
+#define UART_MR_PAR_ODD                     (UART_MR_PAR_ODD_Val << UART_MR_PAR_Pos)       /**< (UART_MR) Odd Parity Position  */
+#define UART_MR_PAR_SPACE                   (UART_MR_PAR_SPACE_Val << UART_MR_PAR_Pos)     /**< (UART_MR) Space: parity forced to 0 Position  */
+#define UART_MR_PAR_MARK                    (UART_MR_PAR_MARK_Val << UART_MR_PAR_Pos)      /**< (UART_MR) Mark: parity forced to 1 Position  */
+#define UART_MR_PAR_NO                      (UART_MR_PAR_NO_Val << UART_MR_PAR_Pos)        /**< (UART_MR) No parity Position  */
+#define UART_MR_BRSRCCK_Pos                 12                                             /**< (UART_MR) Baud Rate Source Clock Position */
+#define UART_MR_BRSRCCK_Msk                 (_U_(0x1) << UART_MR_BRSRCCK_Pos)              /**< (UART_MR) Baud Rate Source Clock Mask */
+#define UART_MR_BRSRCCK                     UART_MR_BRSRCCK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_MR_BRSRCCK_Msk instead */
+#define   UART_MR_BRSRCCK_PERIPH_CLK_Val    _U_(0x0)                                       /**< (UART_MR) The baud rate is driven by the peripheral clock  */
+#define   UART_MR_BRSRCCK_PMC_PCK_Val       _U_(0x1)                                       /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)).  */
+#define UART_MR_BRSRCCK_PERIPH_CLK          (UART_MR_BRSRCCK_PERIPH_CLK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by the peripheral clock Position  */
+#define UART_MR_BRSRCCK_PMC_PCK             (UART_MR_BRSRCCK_PMC_PCK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)). Position  */
+#define UART_MR_CHMODE_Pos                  14                                             /**< (UART_MR) Channel Mode Position */
+#define UART_MR_CHMODE_Msk                  (_U_(0x3) << UART_MR_CHMODE_Pos)               /**< (UART_MR) Channel Mode Mask */
+#define UART_MR_CHMODE(value)               (UART_MR_CHMODE_Msk & ((value) << UART_MR_CHMODE_Pos))
+#define   UART_MR_CHMODE_NORMAL_Val         _U_(0x0)                                       /**< (UART_MR) Normal mode  */
+#define   UART_MR_CHMODE_AUTOMATIC_Val      _U_(0x1)                                       /**< (UART_MR) Automatic echo  */
+#define   UART_MR_CHMODE_LOCAL_LOOPBACK_Val _U_(0x2)                                       /**< (UART_MR) Local loopback  */
+#define   UART_MR_CHMODE_REMOTE_LOOPBACK_Val _U_(0x3)                                       /**< (UART_MR) Remote loopback  */
+#define UART_MR_CHMODE_NORMAL               (UART_MR_CHMODE_NORMAL_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Normal mode Position  */
+#define UART_MR_CHMODE_AUTOMATIC            (UART_MR_CHMODE_AUTOMATIC_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Automatic echo Position  */
+#define UART_MR_CHMODE_LOCAL_LOOPBACK       (UART_MR_CHMODE_LOCAL_LOOPBACK_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Local loopback Position  */
+#define UART_MR_CHMODE_REMOTE_LOOPBACK      (UART_MR_CHMODE_REMOTE_LOOPBACK_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Remote loopback Position  */
+#define UART_MR_MASK                        _U_(0xDE10)                                    /**< \deprecated (UART_MR) Register MASK  (Use UART_MR_Msk instead)  */
+#define UART_MR_Msk                         _U_(0xDE10)                                    /**< (UART_MR) Register Mask  */
+
+
+/* -------- UART_IER : (UART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Enable RXRDY Interrupt                   */
+    uint32_t TXRDY:1;                   /**< bit:      1  Enable TXRDY Interrupt                   */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Enable Overrun Error Interrupt           */
+    uint32_t FRAME:1;                   /**< bit:      6  Enable Framing Error Interrupt           */
+    uint32_t PARE:1;                    /**< bit:      7  Enable Parity Error Interrupt            */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Enable TXEMPTY Interrupt                 */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Enable Comparison Interrupt              */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IER_OFFSET                     (0x08)                                        /**<  (UART_IER) Interrupt Enable Register  Offset */
+
+#define UART_IER_RXRDY_Pos                  0                                              /**< (UART_IER) Enable RXRDY Interrupt Position */
+#define UART_IER_RXRDY_Msk                  (_U_(0x1) << UART_IER_RXRDY_Pos)               /**< (UART_IER) Enable RXRDY Interrupt Mask */
+#define UART_IER_RXRDY                      UART_IER_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_RXRDY_Msk instead */
+#define UART_IER_TXRDY_Pos                  1                                              /**< (UART_IER) Enable TXRDY Interrupt Position */
+#define UART_IER_TXRDY_Msk                  (_U_(0x1) << UART_IER_TXRDY_Pos)               /**< (UART_IER) Enable TXRDY Interrupt Mask */
+#define UART_IER_TXRDY                      UART_IER_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_TXRDY_Msk instead */
+#define UART_IER_OVRE_Pos                   5                                              /**< (UART_IER) Enable Overrun Error Interrupt Position */
+#define UART_IER_OVRE_Msk                   (_U_(0x1) << UART_IER_OVRE_Pos)                /**< (UART_IER) Enable Overrun Error Interrupt Mask */
+#define UART_IER_OVRE                       UART_IER_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_OVRE_Msk instead */
+#define UART_IER_FRAME_Pos                  6                                              /**< (UART_IER) Enable Framing Error Interrupt Position */
+#define UART_IER_FRAME_Msk                  (_U_(0x1) << UART_IER_FRAME_Pos)               /**< (UART_IER) Enable Framing Error Interrupt Mask */
+#define UART_IER_FRAME                      UART_IER_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_FRAME_Msk instead */
+#define UART_IER_PARE_Pos                   7                                              /**< (UART_IER) Enable Parity Error Interrupt Position */
+#define UART_IER_PARE_Msk                   (_U_(0x1) << UART_IER_PARE_Pos)                /**< (UART_IER) Enable Parity Error Interrupt Mask */
+#define UART_IER_PARE                       UART_IER_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_PARE_Msk instead */
+#define UART_IER_TXEMPTY_Pos                9                                              /**< (UART_IER) Enable TXEMPTY Interrupt Position */
+#define UART_IER_TXEMPTY_Msk                (_U_(0x1) << UART_IER_TXEMPTY_Pos)             /**< (UART_IER) Enable TXEMPTY Interrupt Mask */
+#define UART_IER_TXEMPTY                    UART_IER_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_TXEMPTY_Msk instead */
+#define UART_IER_CMP_Pos                    15                                             /**< (UART_IER) Enable Comparison Interrupt Position */
+#define UART_IER_CMP_Msk                    (_U_(0x1) << UART_IER_CMP_Pos)                 /**< (UART_IER) Enable Comparison Interrupt Mask */
+#define UART_IER_CMP                        UART_IER_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_CMP_Msk instead */
+#define UART_IER_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IER) Register MASK  (Use UART_IER_Msk instead)  */
+#define UART_IER_Msk                        _U_(0x82E3)                                    /**< (UART_IER) Register Mask  */
+
+
+/* -------- UART_IDR : (UART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Disable RXRDY Interrupt                  */
+    uint32_t TXRDY:1;                   /**< bit:      1  Disable TXRDY Interrupt                  */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Disable Overrun Error Interrupt          */
+    uint32_t FRAME:1;                   /**< bit:      6  Disable Framing Error Interrupt          */
+    uint32_t PARE:1;                    /**< bit:      7  Disable Parity Error Interrupt           */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Disable TXEMPTY Interrupt                */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Disable Comparison Interrupt             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IDR_OFFSET                     (0x0C)                                        /**<  (UART_IDR) Interrupt Disable Register  Offset */
+
+#define UART_IDR_RXRDY_Pos                  0                                              /**< (UART_IDR) Disable RXRDY Interrupt Position */
+#define UART_IDR_RXRDY_Msk                  (_U_(0x1) << UART_IDR_RXRDY_Pos)               /**< (UART_IDR) Disable RXRDY Interrupt Mask */
+#define UART_IDR_RXRDY                      UART_IDR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_RXRDY_Msk instead */
+#define UART_IDR_TXRDY_Pos                  1                                              /**< (UART_IDR) Disable TXRDY Interrupt Position */
+#define UART_IDR_TXRDY_Msk                  (_U_(0x1) << UART_IDR_TXRDY_Pos)               /**< (UART_IDR) Disable TXRDY Interrupt Mask */
+#define UART_IDR_TXRDY                      UART_IDR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_TXRDY_Msk instead */
+#define UART_IDR_OVRE_Pos                   5                                              /**< (UART_IDR) Disable Overrun Error Interrupt Position */
+#define UART_IDR_OVRE_Msk                   (_U_(0x1) << UART_IDR_OVRE_Pos)                /**< (UART_IDR) Disable Overrun Error Interrupt Mask */
+#define UART_IDR_OVRE                       UART_IDR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_OVRE_Msk instead */
+#define UART_IDR_FRAME_Pos                  6                                              /**< (UART_IDR) Disable Framing Error Interrupt Position */
+#define UART_IDR_FRAME_Msk                  (_U_(0x1) << UART_IDR_FRAME_Pos)               /**< (UART_IDR) Disable Framing Error Interrupt Mask */
+#define UART_IDR_FRAME                      UART_IDR_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_FRAME_Msk instead */
+#define UART_IDR_PARE_Pos                   7                                              /**< (UART_IDR) Disable Parity Error Interrupt Position */
+#define UART_IDR_PARE_Msk                   (_U_(0x1) << UART_IDR_PARE_Pos)                /**< (UART_IDR) Disable Parity Error Interrupt Mask */
+#define UART_IDR_PARE                       UART_IDR_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_PARE_Msk instead */
+#define UART_IDR_TXEMPTY_Pos                9                                              /**< (UART_IDR) Disable TXEMPTY Interrupt Position */
+#define UART_IDR_TXEMPTY_Msk                (_U_(0x1) << UART_IDR_TXEMPTY_Pos)             /**< (UART_IDR) Disable TXEMPTY Interrupt Mask */
+#define UART_IDR_TXEMPTY                    UART_IDR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_TXEMPTY_Msk instead */
+#define UART_IDR_CMP_Pos                    15                                             /**< (UART_IDR) Disable Comparison Interrupt Position */
+#define UART_IDR_CMP_Msk                    (_U_(0x1) << UART_IDR_CMP_Pos)                 /**< (UART_IDR) Disable Comparison Interrupt Mask */
+#define UART_IDR_CMP                        UART_IDR_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_CMP_Msk instead */
+#define UART_IDR_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IDR) Register MASK  (Use UART_IDR_Msk instead)  */
+#define UART_IDR_Msk                        _U_(0x82E3)                                    /**< (UART_IDR) Register Mask  */
+
+
+/* -------- UART_IMR : (UART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Mask RXRDY Interrupt                     */
+    uint32_t TXRDY:1;                   /**< bit:      1  Disable TXRDY Interrupt                  */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Mask Overrun Error Interrupt             */
+    uint32_t FRAME:1;                   /**< bit:      6  Mask Framing Error Interrupt             */
+    uint32_t PARE:1;                    /**< bit:      7  Mask Parity Error Interrupt              */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Mask TXEMPTY Interrupt                   */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Mask Comparison Interrupt                */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IMR_OFFSET                     (0x10)                                        /**<  (UART_IMR) Interrupt Mask Register  Offset */
+
+#define UART_IMR_RXRDY_Pos                  0                                              /**< (UART_IMR) Mask RXRDY Interrupt Position */
+#define UART_IMR_RXRDY_Msk                  (_U_(0x1) << UART_IMR_RXRDY_Pos)               /**< (UART_IMR) Mask RXRDY Interrupt Mask */
+#define UART_IMR_RXRDY                      UART_IMR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_RXRDY_Msk instead */
+#define UART_IMR_TXRDY_Pos                  1                                              /**< (UART_IMR) Disable TXRDY Interrupt Position */
+#define UART_IMR_TXRDY_Msk                  (_U_(0x1) << UART_IMR_TXRDY_Pos)               /**< (UART_IMR) Disable TXRDY Interrupt Mask */
+#define UART_IMR_TXRDY                      UART_IMR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_TXRDY_Msk instead */
+#define UART_IMR_OVRE_Pos                   5                                              /**< (UART_IMR) Mask Overrun Error Interrupt Position */
+#define UART_IMR_OVRE_Msk                   (_U_(0x1) << UART_IMR_OVRE_Pos)                /**< (UART_IMR) Mask Overrun Error Interrupt Mask */
+#define UART_IMR_OVRE                       UART_IMR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_OVRE_Msk instead */
+#define UART_IMR_FRAME_Pos                  6                                              /**< (UART_IMR) Mask Framing Error Interrupt Position */
+#define UART_IMR_FRAME_Msk                  (_U_(0x1) << UART_IMR_FRAME_Pos)               /**< (UART_IMR) Mask Framing Error Interrupt Mask */
+#define UART_IMR_FRAME                      UART_IMR_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_FRAME_Msk instead */
+#define UART_IMR_PARE_Pos                   7                                              /**< (UART_IMR) Mask Parity Error Interrupt Position */
+#define UART_IMR_PARE_Msk                   (_U_(0x1) << UART_IMR_PARE_Pos)                /**< (UART_IMR) Mask Parity Error Interrupt Mask */
+#define UART_IMR_PARE                       UART_IMR_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_PARE_Msk instead */
+#define UART_IMR_TXEMPTY_Pos                9                                              /**< (UART_IMR) Mask TXEMPTY Interrupt Position */
+#define UART_IMR_TXEMPTY_Msk                (_U_(0x1) << UART_IMR_TXEMPTY_Pos)             /**< (UART_IMR) Mask TXEMPTY Interrupt Mask */
+#define UART_IMR_TXEMPTY                    UART_IMR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_TXEMPTY_Msk instead */
+#define UART_IMR_CMP_Pos                    15                                             /**< (UART_IMR) Mask Comparison Interrupt Position */
+#define UART_IMR_CMP_Msk                    (_U_(0x1) << UART_IMR_CMP_Pos)                 /**< (UART_IMR) Mask Comparison Interrupt Mask */
+#define UART_IMR_CMP                        UART_IMR_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_CMP_Msk instead */
+#define UART_IMR_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IMR) Register MASK  (Use UART_IMR_Msk instead)  */
+#define UART_IMR_Msk                        _U_(0x82E3)                                    /**< (UART_IMR) Register Mask  */
+
+
+/* -------- UART_SR : (UART Offset: 0x14) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready                           */
+    uint32_t TXRDY:1;                   /**< bit:      1  Transmitter Ready                        */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error                            */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error                            */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error                             */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmitter Empty                        */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Comparison Match                         */
+    uint32_t :5;                        /**< bit: 16..20  Reserved */
+    uint32_t SWES:1;                    /**< bit:     21  SleepWalking Enable Status               */
+    uint32_t CLKREQ:1;                  /**< bit:     22  Clock Request                            */
+    uint32_t WKUPREQ:1;                 /**< bit:     23  Wake-Up Request                          */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_SR_OFFSET                      (0x14)                                        /**<  (UART_SR) Status Register  Offset */
+
+#define UART_SR_RXRDY_Pos                   0                                              /**< (UART_SR) Receiver Ready Position */
+#define UART_SR_RXRDY_Msk                   (_U_(0x1) << UART_SR_RXRDY_Pos)                /**< (UART_SR) Receiver Ready Mask */
+#define UART_SR_RXRDY                       UART_SR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_RXRDY_Msk instead */
+#define UART_SR_TXRDY_Pos                   1                                              /**< (UART_SR) Transmitter Ready Position */
+#define UART_SR_TXRDY_Msk                   (_U_(0x1) << UART_SR_TXRDY_Pos)                /**< (UART_SR) Transmitter Ready Mask */
+#define UART_SR_TXRDY                       UART_SR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_TXRDY_Msk instead */
+#define UART_SR_OVRE_Pos                    5                                              /**< (UART_SR) Overrun Error Position */
+#define UART_SR_OVRE_Msk                    (_U_(0x1) << UART_SR_OVRE_Pos)                 /**< (UART_SR) Overrun Error Mask */
+#define UART_SR_OVRE                        UART_SR_OVRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_OVRE_Msk instead */
+#define UART_SR_FRAME_Pos                   6                                              /**< (UART_SR) Framing Error Position */
+#define UART_SR_FRAME_Msk                   (_U_(0x1) << UART_SR_FRAME_Pos)                /**< (UART_SR) Framing Error Mask */
+#define UART_SR_FRAME                       UART_SR_FRAME_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_FRAME_Msk instead */
+#define UART_SR_PARE_Pos                    7                                              /**< (UART_SR) Parity Error Position */
+#define UART_SR_PARE_Msk                    (_U_(0x1) << UART_SR_PARE_Pos)                 /**< (UART_SR) Parity Error Mask */
+#define UART_SR_PARE                        UART_SR_PARE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_PARE_Msk instead */
+#define UART_SR_TXEMPTY_Pos                 9                                              /**< (UART_SR) Transmitter Empty Position */
+#define UART_SR_TXEMPTY_Msk                 (_U_(0x1) << UART_SR_TXEMPTY_Pos)              /**< (UART_SR) Transmitter Empty Mask */
+#define UART_SR_TXEMPTY                     UART_SR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_TXEMPTY_Msk instead */
+#define UART_SR_CMP_Pos                     15                                             /**< (UART_SR) Comparison Match Position */
+#define UART_SR_CMP_Msk                     (_U_(0x1) << UART_SR_CMP_Pos)                  /**< (UART_SR) Comparison Match Mask */
+#define UART_SR_CMP                         UART_SR_CMP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_CMP_Msk instead */
+#define UART_SR_SWES_Pos                    21                                             /**< (UART_SR) SleepWalking Enable Status Position */
+#define UART_SR_SWES_Msk                    (_U_(0x1) << UART_SR_SWES_Pos)                 /**< (UART_SR) SleepWalking Enable Status Mask */
+#define UART_SR_SWES                        UART_SR_SWES_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_SWES_Msk instead */
+#define UART_SR_CLKREQ_Pos                  22                                             /**< (UART_SR) Clock Request Position */
+#define UART_SR_CLKREQ_Msk                  (_U_(0x1) << UART_SR_CLKREQ_Pos)               /**< (UART_SR) Clock Request Mask */
+#define UART_SR_CLKREQ                      UART_SR_CLKREQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_CLKREQ_Msk instead */
+#define UART_SR_WKUPREQ_Pos                 23                                             /**< (UART_SR) Wake-Up Request Position */
+#define UART_SR_WKUPREQ_Msk                 (_U_(0x1) << UART_SR_WKUPREQ_Pos)              /**< (UART_SR) Wake-Up Request Mask */
+#define UART_SR_WKUPREQ                     UART_SR_WKUPREQ_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_WKUPREQ_Msk instead */
+#define UART_SR_MASK                        _U_(0xE082E3)                                  /**< \deprecated (UART_SR) Register MASK  (Use UART_SR_Msk instead)  */
+#define UART_SR_Msk                         _U_(0xE082E3)                                  /**< (UART_SR) Register Mask  */
+
+
+/* -------- UART_RHR : (UART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXCHR:8;                   /**< bit:   0..7  Received Character                       */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_RHR_OFFSET                     (0x18)                                        /**<  (UART_RHR) Receive Holding Register  Offset */
+
+#define UART_RHR_RXCHR_Pos                  0                                              /**< (UART_RHR) Received Character Position */
+#define UART_RHR_RXCHR_Msk                  (_U_(0xFF) << UART_RHR_RXCHR_Pos)              /**< (UART_RHR) Received Character Mask */
+#define UART_RHR_RXCHR(value)               (UART_RHR_RXCHR_Msk & ((value) << UART_RHR_RXCHR_Pos))
+#define UART_RHR_MASK                       _U_(0xFF)                                      /**< \deprecated (UART_RHR) Register MASK  (Use UART_RHR_Msk instead)  */
+#define UART_RHR_Msk                        _U_(0xFF)                                      /**< (UART_RHR) Register Mask  */
+
+
+/* -------- UART_THR : (UART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCHR:8;                   /**< bit:   0..7  Character to be Transmitted              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_THR_OFFSET                     (0x1C)                                        /**<  (UART_THR) Transmit Holding Register  Offset */
+
+#define UART_THR_TXCHR_Pos                  0                                              /**< (UART_THR) Character to be Transmitted Position */
+#define UART_THR_TXCHR_Msk                  (_U_(0xFF) << UART_THR_TXCHR_Pos)              /**< (UART_THR) Character to be Transmitted Mask */
+#define UART_THR_TXCHR(value)               (UART_THR_TXCHR_Msk & ((value) << UART_THR_TXCHR_Pos))
+#define UART_THR_MASK                       _U_(0xFF)                                      /**< \deprecated (UART_THR) Register MASK  (Use UART_THR_Msk instead)  */
+#define UART_THR_Msk                        _U_(0xFF)                                      /**< (UART_THR) Register Mask  */
+
+
+/* -------- UART_BRGR : (UART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CD:16;                     /**< bit:  0..15  Clock Divisor                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_BRGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_BRGR_OFFSET                    (0x20)                                        /**<  (UART_BRGR) Baud Rate Generator Register  Offset */
+
+#define UART_BRGR_CD_Pos                    0                                              /**< (UART_BRGR) Clock Divisor Position */
+#define UART_BRGR_CD_Msk                    (_U_(0xFFFF) << UART_BRGR_CD_Pos)              /**< (UART_BRGR) Clock Divisor Mask */
+#define UART_BRGR_CD(value)                 (UART_BRGR_CD_Msk & ((value) << UART_BRGR_CD_Pos))
+#define UART_BRGR_MASK                      _U_(0xFFFF)                                    /**< \deprecated (UART_BRGR) Register MASK  (Use UART_BRGR_Msk instead)  */
+#define UART_BRGR_Msk                       _U_(0xFFFF)                                    /**< (UART_BRGR) Register Mask  */
+
+
+/* -------- UART_CMPR : (UART Offset: 0x24) (R/W 32) Comparison Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VAL1:8;                    /**< bit:   0..7  First Comparison Value for Received Character */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t CMPMODE:1;                 /**< bit:     12  Comparison Mode                          */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CMPPAR:1;                  /**< bit:     14  Compare Parity                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t VAL2:8;                    /**< bit: 16..23  Second Comparison Value for Received Character */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_CMPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_CMPR_OFFSET                    (0x24)                                        /**<  (UART_CMPR) Comparison Register  Offset */
+
+#define UART_CMPR_VAL1_Pos                  0                                              /**< (UART_CMPR) First Comparison Value for Received Character Position */
+#define UART_CMPR_VAL1_Msk                  (_U_(0xFF) << UART_CMPR_VAL1_Pos)              /**< (UART_CMPR) First Comparison Value for Received Character Mask */
+#define UART_CMPR_VAL1(value)               (UART_CMPR_VAL1_Msk & ((value) << UART_CMPR_VAL1_Pos))
+#define UART_CMPR_CMPMODE_Pos               12                                             /**< (UART_CMPR) Comparison Mode Position */
+#define UART_CMPR_CMPMODE_Msk               (_U_(0x1) << UART_CMPR_CMPMODE_Pos)            /**< (UART_CMPR) Comparison Mode Mask */
+#define UART_CMPR_CMPMODE                   UART_CMPR_CMPMODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CMPR_CMPMODE_Msk instead */
+#define   UART_CMPR_CMPMODE_FLAG_ONLY_Val   _U_(0x0)                                       /**< (UART_CMPR) Any character is received and comparison function drives CMP flag.  */
+#define   UART_CMPR_CMPMODE_START_CONDITION_Val _U_(0x1)                                       /**< (UART_CMPR) Comparison condition must be met to start reception.  */
+#define UART_CMPR_CMPMODE_FLAG_ONLY         (UART_CMPR_CMPMODE_FLAG_ONLY_Val << UART_CMPR_CMPMODE_Pos)  /**< (UART_CMPR) Any character is received and comparison function drives CMP flag. Position  */
+#define UART_CMPR_CMPMODE_START_CONDITION   (UART_CMPR_CMPMODE_START_CONDITION_Val << UART_CMPR_CMPMODE_Pos)  /**< (UART_CMPR) Comparison condition must be met to start reception. Position  */
+#define UART_CMPR_CMPPAR_Pos                14                                             /**< (UART_CMPR) Compare Parity Position */
+#define UART_CMPR_CMPPAR_Msk                (_U_(0x1) << UART_CMPR_CMPPAR_Pos)             /**< (UART_CMPR) Compare Parity Mask */
+#define UART_CMPR_CMPPAR                    UART_CMPR_CMPPAR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CMPR_CMPPAR_Msk instead */
+#define UART_CMPR_VAL2_Pos                  16                                             /**< (UART_CMPR) Second Comparison Value for Received Character Position */
+#define UART_CMPR_VAL2_Msk                  (_U_(0xFF) << UART_CMPR_VAL2_Pos)              /**< (UART_CMPR) Second Comparison Value for Received Character Mask */
+#define UART_CMPR_VAL2(value)               (UART_CMPR_VAL2_Msk & ((value) << UART_CMPR_VAL2_Pos))
+#define UART_CMPR_MASK                      _U_(0xFF50FF)                                  /**< \deprecated (UART_CMPR) Register MASK  (Use UART_CMPR_Msk instead)  */
+#define UART_CMPR_Msk                       _U_(0xFF50FF)                                  /**< (UART_CMPR) Register Mask  */
+
+
+/* -------- UART_WPMR : (UART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_WPMR_OFFSET                    (0xE4)                                        /**<  (UART_WPMR) Write Protection Mode Register  Offset */
+
+#define UART_WPMR_WPEN_Pos                  0                                              /**< (UART_WPMR) Write Protection Enable Position */
+#define UART_WPMR_WPEN_Msk                  (_U_(0x1) << UART_WPMR_WPEN_Pos)               /**< (UART_WPMR) Write Protection Enable Mask */
+#define UART_WPMR_WPEN                      UART_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_WPMR_WPEN_Msk instead */
+#define UART_WPMR_WPKEY_Pos                 8                                              /**< (UART_WPMR) Write Protection Key Position */
+#define UART_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << UART_WPMR_WPKEY_Pos)         /**< (UART_WPMR) Write Protection Key Mask */
+#define UART_WPMR_WPKEY(value)              (UART_WPMR_WPKEY_Msk & ((value) << UART_WPMR_WPKEY_Pos))
+#define   UART_WPMR_WPKEY_PASSWD_Val        _U_(0x554152)                                  /**< (UART_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define UART_WPMR_WPKEY_PASSWD              (UART_WPMR_WPKEY_PASSWD_Val << UART_WPMR_WPKEY_Pos)  /**< (UART_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define UART_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (UART_WPMR) Register MASK  (Use UART_WPMR_Msk instead)  */
+#define UART_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (UART_WPMR) Register Mask  */
+
+
+/* -------- UART_VERSION : (UART Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_VERSION_OFFSET                 (0xFC)                                        /**<  (UART_VERSION) Version Register  Offset */
+
+#define UART_VERSION_VERSION_Pos            0                                              /**< (UART_VERSION) Hardware Module Version Position */
+#define UART_VERSION_VERSION_Msk            (_U_(0xFFF) << UART_VERSION_VERSION_Pos)       /**< (UART_VERSION) Hardware Module Version Mask */
+#define UART_VERSION_VERSION(value)         (UART_VERSION_VERSION_Msk & ((value) << UART_VERSION_VERSION_Pos))
+#define UART_VERSION_MFN_Pos                16                                             /**< (UART_VERSION) Metal Fix Number Position */
+#define UART_VERSION_MFN_Msk                (_U_(0x7) << UART_VERSION_MFN_Pos)             /**< (UART_VERSION) Metal Fix Number Mask */
+#define UART_VERSION_MFN(value)             (UART_VERSION_MFN_Msk & ((value) << UART_VERSION_MFN_Pos))
+#define UART_VERSION_MASK                   _U_(0x70FFF)                                   /**< \deprecated (UART_VERSION) Register MASK  (Use UART_VERSION_Msk instead)  */
+#define UART_VERSION_Msk                    _U_(0x70FFF)                                   /**< (UART_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief UART hardware registers */
+typedef struct {  
+  __O  uint32_t UART_CR;        /**< (UART Offset: 0x00) Control Register */
+  __IO uint32_t UART_MR;        /**< (UART Offset: 0x04) Mode Register */
+  __O  uint32_t UART_IER;       /**< (UART Offset: 0x08) Interrupt Enable Register */
+  __O  uint32_t UART_IDR;       /**< (UART Offset: 0x0C) Interrupt Disable Register */
+  __I  uint32_t UART_IMR;       /**< (UART Offset: 0x10) Interrupt Mask Register */
+  __I  uint32_t UART_SR;        /**< (UART Offset: 0x14) Status Register */
+  __I  uint32_t UART_RHR;       /**< (UART Offset: 0x18) Receive Holding Register */
+  __O  uint32_t UART_THR;       /**< (UART Offset: 0x1C) Transmit Holding Register */
+  __IO uint32_t UART_BRGR;      /**< (UART Offset: 0x20) Baud Rate Generator Register */
+  __IO uint32_t UART_CMPR;      /**< (UART Offset: 0x24) Comparison Register */
+  __I  uint8_t                        Reserved1[188];
+  __IO uint32_t UART_WPMR;      /**< (UART Offset: 0xE4) Write Protection Mode Register */
+  __I  uint8_t                        Reserved2[20];
+  __I  uint32_t UART_VERSION;   /**< (UART Offset: 0xFC) Version Register */
+} Uart;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief UART hardware registers */
+typedef struct {  
+  __O  UART_CR_Type                   UART_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO UART_MR_Type                   UART_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __O  UART_IER_Type                  UART_IER;       /**< Offset: 0x08 ( /W  32) Interrupt Enable Register */
+  __O  UART_IDR_Type                  UART_IDR;       /**< Offset: 0x0C ( /W  32) Interrupt Disable Register */
+  __I  UART_IMR_Type                  UART_IMR;       /**< Offset: 0x10 (R/   32) Interrupt Mask Register */
+  __I  UART_SR_Type                   UART_SR;        /**< Offset: 0x14 (R/   32) Status Register */
+  __I  UART_RHR_Type                  UART_RHR;       /**< Offset: 0x18 (R/   32) Receive Holding Register */
+  __O  UART_THR_Type                  UART_THR;       /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
+  __IO UART_BRGR_Type                 UART_BRGR;      /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
+  __IO UART_CMPR_Type                 UART_CMPR;      /**< Offset: 0x24 (R/W  32) Comparison Register */
+  __I  uint8_t                        Reserved1[188];
+  __IO UART_WPMR_Type                 UART_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  uint8_t                        Reserved2[20];
+  __I  UART_VERSION_Type              UART_VERSION;   /**< Offset: 0xFC (R/   32) Version Register */
+} Uart;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Universal Asynchronous Receiver Transmitter */
+
+#endif /* _SAMV71_UART_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/usart.h
+++ b/asf/sam/include/samv71/component/usart.h
@@ -1,0 +1,1486 @@
+/**
+ * \file
+ *
+ * \brief Component description for USART
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USART_COMPONENT_H_
+#define _SAMV71_USART_COMPONENT_H_
+#define _SAMV71_USART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Universal Synchronous Asynchronous Receiver Transmitter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USART */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define USART_6089                       /**< (USART) Module ID */
+#define REV_USART ZU                     /**< (USART) Module revision */
+
+/* -------- US_CR : (USART Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RSTRX:1;                   /**< bit:      2  Reset Receiver                           */
+    uint32_t RSTTX:1;                   /**< bit:      3  Reset Transmitter                        */
+    uint32_t RXEN:1;                    /**< bit:      4  Receiver Enable                          */
+    uint32_t RXDIS:1;                   /**< bit:      5  Receiver Disable                         */
+    uint32_t TXEN:1;                    /**< bit:      6  Transmitter Enable                       */
+    uint32_t TXDIS:1;                   /**< bit:      7  Transmitter Disable                      */
+    uint32_t RSTSTA:1;                  /**< bit:      8  Reset Status Bits                        */
+    uint32_t STTBRK:1;                  /**< bit:      9  Start Break                              */
+    uint32_t STPBRK:1;                  /**< bit:     10  Stop Break                               */
+    uint32_t STTTO:1;                   /**< bit:     11  Clear TIMEOUT Flag and Start Timeout After Next Character Received */
+    uint32_t SENDA:1;                   /**< bit:     12  Send Address                             */
+    uint32_t RSTIT:1;                   /**< bit:     13  Reset Iterations                         */
+    uint32_t RSTNACK:1;                 /**< bit:     14  Reset Non Acknowledge                    */
+    uint32_t RETTO:1;                   /**< bit:     15  Start Timeout Immediately                */
+    uint32_t DTREN:1;                   /**< bit:     16  Data Terminal Ready Enable               */
+    uint32_t DTRDIS:1;                  /**< bit:     17  Data Terminal Ready Disable              */
+    uint32_t RTSEN:1;                   /**< bit:     18  Request to Send Pin Control              */
+    uint32_t RTSDIS:1;                  /**< bit:     19  Request to Send Pin Control              */
+    uint32_t LINABT:1;                  /**< bit:     20  Abort LIN Transmission                   */
+    uint32_t LINWKUP:1;                 /**< bit:     21  Send LIN Wakeup Signal                   */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CR_OFFSET                        (0x00)                                        /**<  (US_CR) Control Register  Offset */
+
+#define US_CR_RSTRX_Pos                     2                                              /**< (US_CR) Reset Receiver Position */
+#define US_CR_RSTRX_Msk                     (_U_(0x1) << US_CR_RSTRX_Pos)                  /**< (US_CR) Reset Receiver Mask */
+#define US_CR_RSTRX                         US_CR_RSTRX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTRX_Msk instead */
+#define US_CR_RSTTX_Pos                     3                                              /**< (US_CR) Reset Transmitter Position */
+#define US_CR_RSTTX_Msk                     (_U_(0x1) << US_CR_RSTTX_Pos)                  /**< (US_CR) Reset Transmitter Mask */
+#define US_CR_RSTTX                         US_CR_RSTTX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTTX_Msk instead */
+#define US_CR_RXEN_Pos                      4                                              /**< (US_CR) Receiver Enable Position */
+#define US_CR_RXEN_Msk                      (_U_(0x1) << US_CR_RXEN_Pos)                   /**< (US_CR) Receiver Enable Mask */
+#define US_CR_RXEN                          US_CR_RXEN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RXEN_Msk instead */
+#define US_CR_RXDIS_Pos                     5                                              /**< (US_CR) Receiver Disable Position */
+#define US_CR_RXDIS_Msk                     (_U_(0x1) << US_CR_RXDIS_Pos)                  /**< (US_CR) Receiver Disable Mask */
+#define US_CR_RXDIS                         US_CR_RXDIS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RXDIS_Msk instead */
+#define US_CR_TXEN_Pos                      6                                              /**< (US_CR) Transmitter Enable Position */
+#define US_CR_TXEN_Msk                      (_U_(0x1) << US_CR_TXEN_Pos)                   /**< (US_CR) Transmitter Enable Mask */
+#define US_CR_TXEN                          US_CR_TXEN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_TXEN_Msk instead */
+#define US_CR_TXDIS_Pos                     7                                              /**< (US_CR) Transmitter Disable Position */
+#define US_CR_TXDIS_Msk                     (_U_(0x1) << US_CR_TXDIS_Pos)                  /**< (US_CR) Transmitter Disable Mask */
+#define US_CR_TXDIS                         US_CR_TXDIS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_TXDIS_Msk instead */
+#define US_CR_RSTSTA_Pos                    8                                              /**< (US_CR) Reset Status Bits Position */
+#define US_CR_RSTSTA_Msk                    (_U_(0x1) << US_CR_RSTSTA_Pos)                 /**< (US_CR) Reset Status Bits Mask */
+#define US_CR_RSTSTA                        US_CR_RSTSTA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTSTA_Msk instead */
+#define US_CR_STTBRK_Pos                    9                                              /**< (US_CR) Start Break Position */
+#define US_CR_STTBRK_Msk                    (_U_(0x1) << US_CR_STTBRK_Pos)                 /**< (US_CR) Start Break Mask */
+#define US_CR_STTBRK                        US_CR_STTBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTBRK_Msk instead */
+#define US_CR_STPBRK_Pos                    10                                             /**< (US_CR) Stop Break Position */
+#define US_CR_STPBRK_Msk                    (_U_(0x1) << US_CR_STPBRK_Pos)                 /**< (US_CR) Stop Break Mask */
+#define US_CR_STPBRK                        US_CR_STPBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STPBRK_Msk instead */
+#define US_CR_STTTO_Pos                     11                                             /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Position */
+#define US_CR_STTTO_Msk                     (_U_(0x1) << US_CR_STTTO_Pos)                  /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Mask */
+#define US_CR_STTTO                         US_CR_STTTO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTTO_Msk instead */
+#define US_CR_SENDA_Pos                     12                                             /**< (US_CR) Send Address Position */
+#define US_CR_SENDA_Msk                     (_U_(0x1) << US_CR_SENDA_Pos)                  /**< (US_CR) Send Address Mask */
+#define US_CR_SENDA                         US_CR_SENDA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SENDA_Msk instead */
+#define US_CR_RSTIT_Pos                     13                                             /**< (US_CR) Reset Iterations Position */
+#define US_CR_RSTIT_Msk                     (_U_(0x1) << US_CR_RSTIT_Pos)                  /**< (US_CR) Reset Iterations Mask */
+#define US_CR_RSTIT                         US_CR_RSTIT_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTIT_Msk instead */
+#define US_CR_RSTNACK_Pos                   14                                             /**< (US_CR) Reset Non Acknowledge Position */
+#define US_CR_RSTNACK_Msk                   (_U_(0x1) << US_CR_RSTNACK_Pos)                /**< (US_CR) Reset Non Acknowledge Mask */
+#define US_CR_RSTNACK                       US_CR_RSTNACK_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTNACK_Msk instead */
+#define US_CR_RETTO_Pos                     15                                             /**< (US_CR) Start Timeout Immediately Position */
+#define US_CR_RETTO_Msk                     (_U_(0x1) << US_CR_RETTO_Pos)                  /**< (US_CR) Start Timeout Immediately Mask */
+#define US_CR_RETTO                         US_CR_RETTO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RETTO_Msk instead */
+#define US_CR_DTREN_Pos                     16                                             /**< (US_CR) Data Terminal Ready Enable Position */
+#define US_CR_DTREN_Msk                     (_U_(0x1) << US_CR_DTREN_Pos)                  /**< (US_CR) Data Terminal Ready Enable Mask */
+#define US_CR_DTREN                         US_CR_DTREN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTREN_Msk instead */
+#define US_CR_DTRDIS_Pos                    17                                             /**< (US_CR) Data Terminal Ready Disable Position */
+#define US_CR_DTRDIS_Msk                    (_U_(0x1) << US_CR_DTRDIS_Pos)                 /**< (US_CR) Data Terminal Ready Disable Mask */
+#define US_CR_DTRDIS                        US_CR_DTRDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTRDIS_Msk instead */
+#define US_CR_RTSEN_Pos                     18                                             /**< (US_CR) Request to Send Pin Control Position */
+#define US_CR_RTSEN_Msk                     (_U_(0x1) << US_CR_RTSEN_Pos)                  /**< (US_CR) Request to Send Pin Control Mask */
+#define US_CR_RTSEN                         US_CR_RTSEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSEN_Msk instead */
+#define US_CR_RTSDIS_Pos                    19                                             /**< (US_CR) Request to Send Pin Control Position */
+#define US_CR_RTSDIS_Msk                    (_U_(0x1) << US_CR_RTSDIS_Pos)                 /**< (US_CR) Request to Send Pin Control Mask */
+#define US_CR_RTSDIS                        US_CR_RTSDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSDIS_Msk instead */
+#define US_CR_LINABT_Pos                    20                                             /**< (US_CR) Abort LIN Transmission Position */
+#define US_CR_LINABT_Msk                    (_U_(0x1) << US_CR_LINABT_Pos)                 /**< (US_CR) Abort LIN Transmission Mask */
+#define US_CR_LINABT                        US_CR_LINABT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINABT_Msk instead */
+#define US_CR_LINWKUP_Pos                   21                                             /**< (US_CR) Send LIN Wakeup Signal Position */
+#define US_CR_LINWKUP_Msk                   (_U_(0x1) << US_CR_LINWKUP_Pos)                /**< (US_CR) Send LIN Wakeup Signal Mask */
+#define US_CR_LINWKUP                       US_CR_LINWKUP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINWKUP_Msk instead */
+#define US_CR_MASK                          _U_(0x3FFFFC)                                  /**< \deprecated (US_CR) Register MASK  (Use US_CR_Msk instead)  */
+#define US_CR_Msk                           _U_(0x3FFFFC)                                  /**< (US_CR) Register Mask  */
+
+
+/* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USART_MODE:4;              /**< bit:   0..3  USART Mode of Operation                  */
+    uint32_t USCLKS:2;                  /**< bit:   4..5  Clock Selection                          */
+    uint32_t CHRL:2;                    /**< bit:   6..7  Character Length                         */
+    uint32_t SYNC:1;                    /**< bit:      8  Synchronous Mode Select                  */
+    uint32_t PAR:3;                     /**< bit:  9..11  Parity Type                              */
+    uint32_t NBSTOP:2;                  /**< bit: 12..13  Number of Stop Bits                      */
+    uint32_t CHMODE:2;                  /**< bit: 14..15  Channel Mode                             */
+    uint32_t MSBF:1;                    /**< bit:     16  Bit Order                                */
+    uint32_t MODE9:1;                   /**< bit:     17  9-bit Character Length                   */
+    uint32_t CLKO:1;                    /**< bit:     18  Clock Output Select                      */
+    uint32_t OVER:1;                    /**< bit:     19  Oversampling Mode                        */
+    uint32_t INACK:1;                   /**< bit:     20  Inhibit Non Acknowledge                  */
+    uint32_t DSNACK:1;                  /**< bit:     21  Disable Successive NACK                  */
+    uint32_t VAR_SYNC:1;                /**< bit:     22  Variable Synchronization of Command/Data Sync Start Frame Delimiter */
+    uint32_t INVDATA:1;                 /**< bit:     23  Inverted Data                            */
+    uint32_t MAX_ITERATION:3;           /**< bit: 24..26  Maximum Number of Automatic Iteration    */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t FILTER:1;                  /**< bit:     28  Receive Line Filter                      */
+    uint32_t MAN:1;                     /**< bit:     29  Manchester Encoder/Decoder Enable        */
+    uint32_t MODSYNC:1;                 /**< bit:     30  Manchester Synchronization Mode          */
+    uint32_t ONEBIT:1;                  /**< bit:     31  Start Frame Delimiter Selector           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :17;                       /**< bit:  0..16  Reserved */
+    uint32_t MODE:1;                    /**< bit:     17  9-bit Character Length                   */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} US_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MR_OFFSET                        (0x04)                                        /**<  (US_MR) Mode Register  Offset */
+
+#define US_MR_USART_MODE_Pos                0                                              /**< (US_MR) USART Mode of Operation Position */
+#define US_MR_USART_MODE_Msk                (_U_(0xF) << US_MR_USART_MODE_Pos)             /**< (US_MR) USART Mode of Operation Mask */
+#define US_MR_USART_MODE(value)             (US_MR_USART_MODE_Msk & ((value) << US_MR_USART_MODE_Pos))
+#define   US_MR_USART_MODE_NORMAL_Val       _U_(0x0)                                       /**< (US_MR) Normal mode  */
+#define   US_MR_USART_MODE_RS485_Val        _U_(0x1)                                       /**< (US_MR) RS485  */
+#define   US_MR_USART_MODE_HW_HANDSHAKING_Val _U_(0x2)                                       /**< (US_MR) Hardware Handshaking  */
+#define   US_MR_USART_MODE_MODEM_Val        _U_(0x3)                                       /**< (US_MR) Modem  */
+#define   US_MR_USART_MODE_IS07816_T_0_Val  _U_(0x4)                                       /**< (US_MR) IS07816 Protocol: T = 0  */
+#define   US_MR_USART_MODE_IS07816_T_1_Val  _U_(0x6)                                       /**< (US_MR) IS07816 Protocol: T = 1  */
+#define   US_MR_USART_MODE_IRDA_Val         _U_(0x8)                                       /**< (US_MR) IrDA  */
+#define   US_MR_USART_MODE_LON_Val          _U_(0x9)                                       /**< (US_MR) LON  */
+#define   US_MR_USART_MODE_SPI_MASTER_Val   _U_(0xE)                                       /**< (US_MR) SPI master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2)  */
+#define   US_MR_USART_MODE_SPI_SLAVE_Val    _U_(0xF)                                       /**< (US_MR) SPI Slave mode  */
+#define US_MR_USART_MODE_NORMAL             (US_MR_USART_MODE_NORMAL_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_USART_MODE_RS485              (US_MR_USART_MODE_RS485_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) RS485 Position  */
+#define US_MR_USART_MODE_HW_HANDSHAKING     (US_MR_USART_MODE_HW_HANDSHAKING_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Hardware Handshaking Position  */
+#define US_MR_USART_MODE_MODEM              (US_MR_USART_MODE_MODEM_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Modem Position  */
+#define US_MR_USART_MODE_IS07816_T_0        (US_MR_USART_MODE_IS07816_T_0_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 0 Position  */
+#define US_MR_USART_MODE_IS07816_T_1        (US_MR_USART_MODE_IS07816_T_1_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 1 Position  */
+#define US_MR_USART_MODE_IRDA               (US_MR_USART_MODE_IRDA_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IrDA Position  */
+#define US_MR_USART_MODE_LON                (US_MR_USART_MODE_LON_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LON Position  */
+#define US_MR_USART_MODE_SPI_MASTER         (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2) Position  */
+#define US_MR_USART_MODE_SPI_SLAVE          (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Slave mode Position  */
+#define US_MR_USCLKS_Pos                    4                                              /**< (US_MR) Clock Selection Position */
+#define US_MR_USCLKS_Msk                    (_U_(0x3) << US_MR_USCLKS_Pos)                 /**< (US_MR) Clock Selection Mask */
+#define US_MR_USCLKS(value)                 (US_MR_USCLKS_Msk & ((value) << US_MR_USCLKS_Pos))
+#define   US_MR_USCLKS_MCK_Val              _U_(0x0)                                       /**< (US_MR) Peripheral clock is selected  */
+#define   US_MR_USCLKS_DIV_Val              _U_(0x1)                                       /**< (US_MR) Peripheral clock divided (DIV=DIV=8) is selected  */
+#define   US_MR_USCLKS_PCK_Val              _U_(0x2)                                       /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1.  */
+#define   US_MR_USCLKS_SCK_Val              _U_(0x3)                                       /**< (US_MR) Serial clock (SCK) is selected  */
+#define US_MR_USCLKS_MCK                    (US_MR_USCLKS_MCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock is selected Position  */
+#define US_MR_USCLKS_DIV                    (US_MR_USCLKS_DIV_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock divided (DIV=DIV=8) is selected Position  */
+#define US_MR_USCLKS_PCK                    (US_MR_USCLKS_PCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1. Position  */
+#define US_MR_USCLKS_SCK                    (US_MR_USCLKS_SCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Serial clock (SCK) is selected Position  */
+#define US_MR_CHRL_Pos                      6                                              /**< (US_MR) Character Length Position */
+#define US_MR_CHRL_Msk                      (_U_(0x3) << US_MR_CHRL_Pos)                   /**< (US_MR) Character Length Mask */
+#define US_MR_CHRL(value)                   (US_MR_CHRL_Msk & ((value) << US_MR_CHRL_Pos))
+#define   US_MR_CHRL_5_BIT_Val              _U_(0x0)                                       /**< (US_MR) Character length is 5 bits  */
+#define   US_MR_CHRL_6_BIT_Val              _U_(0x1)                                       /**< (US_MR) Character length is 6 bits  */
+#define   US_MR_CHRL_7_BIT_Val              _U_(0x2)                                       /**< (US_MR) Character length is 7 bits  */
+#define   US_MR_CHRL_8_BIT_Val              _U_(0x3)                                       /**< (US_MR) Character length is 8 bits  */
+#define US_MR_CHRL_5_BIT                    (US_MR_CHRL_5_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 5 bits Position  */
+#define US_MR_CHRL_6_BIT                    (US_MR_CHRL_6_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 6 bits Position  */
+#define US_MR_CHRL_7_BIT                    (US_MR_CHRL_7_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 7 bits Position  */
+#define US_MR_CHRL_8_BIT                    (US_MR_CHRL_8_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 8 bits Position  */
+#define US_MR_SYNC_Pos                      8                                              /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_SYNC_Msk                      (_U_(0x1) << US_MR_SYNC_Pos)                   /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_SYNC                          US_MR_SYNC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SYNC_Msk instead */
+#define US_MR_PAR_Pos                       9                                              /**< (US_MR) Parity Type Position */
+#define US_MR_PAR_Msk                       (_U_(0x7) << US_MR_PAR_Pos)                    /**< (US_MR) Parity Type Mask */
+#define US_MR_PAR(value)                    (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos)) 
+#define   US_MR_PAR_EVEN_Val                _U_(0x0)                                       /**< (US_MR) Even parity  */
+#define   US_MR_PAR_ODD_Val                 _U_(0x1)                                       /**< (US_MR) Odd parity  */
+#define   US_MR_PAR_SPACE_Val               _U_(0x2)                                       /**< (US_MR) Parity forced to 0 (Space)  */
+#define   US_MR_PAR_MARK_Val                _U_(0x3)                                       /**< (US_MR) Parity forced to 1 (Mark)  */
+#define   US_MR_PAR_NO_Val                  _U_(0x4)                                       /**< (US_MR) No parity  */
+#define   US_MR_PAR_MULTIDROP_Val           _U_(0x6)                                       /**< (US_MR) Multidrop mode  */
+#define US_MR_PAR_EVEN                      (US_MR_PAR_EVEN_Val << US_MR_PAR_Pos)          /**< (US_MR) Even parity Position  */
+#define US_MR_PAR_ODD                       (US_MR_PAR_ODD_Val << US_MR_PAR_Pos)           /**< (US_MR) Odd parity Position  */
+#define US_MR_PAR_SPACE                     (US_MR_PAR_SPACE_Val << US_MR_PAR_Pos)         /**< (US_MR) Parity forced to 0 (Space) Position  */
+#define US_MR_PAR_MARK                      (US_MR_PAR_MARK_Val << US_MR_PAR_Pos)          /**< (US_MR) Parity forced to 1 (Mark) Position  */
+#define US_MR_PAR_NO                        (US_MR_PAR_NO_Val << US_MR_PAR_Pos)            /**< (US_MR) No parity Position  */
+#define US_MR_PAR_MULTIDROP                 (US_MR_PAR_MULTIDROP_Val << US_MR_PAR_Pos)     /**< (US_MR) Multidrop mode Position  */
+#define US_MR_NBSTOP_Pos                    12                                             /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_NBSTOP_Msk                    (_U_(0x3) << US_MR_NBSTOP_Pos)                 /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_NBSTOP(value)                 (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
+#define   US_MR_NBSTOP_1_BIT_Val            _U_(0x0)                                       /**< (US_MR) 1 stop bit  */
+#define   US_MR_NBSTOP_1_5_BIT_Val          _U_(0x1)                                       /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
+#define   US_MR_NBSTOP_2_BIT_Val            _U_(0x2)                                       /**< (US_MR) 2 stop bits  */
+#define US_MR_NBSTOP_1_BIT                  (US_MR_NBSTOP_1_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 1 stop bit Position  */
+#define US_MR_NBSTOP_1_5_BIT                (US_MR_NBSTOP_1_5_BIT_Val << US_MR_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
+#define US_MR_NBSTOP_2_BIT                  (US_MR_NBSTOP_2_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 2 stop bits Position  */
+#define US_MR_CHMODE_Pos                    14                                             /**< (US_MR) Channel Mode Position */
+#define US_MR_CHMODE_Msk                    (_U_(0x3) << US_MR_CHMODE_Pos)                 /**< (US_MR) Channel Mode Mask */
+#define US_MR_CHMODE(value)                 (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
+#define   US_MR_CHMODE_NORMAL_Val           _U_(0x0)                                       /**< (US_MR) Normal mode  */
+#define   US_MR_CHMODE_AUTOMATIC_Val        _U_(0x1)                                       /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin.  */
+#define   US_MR_CHMODE_LOCAL_LOOPBACK_Val   _U_(0x2)                                       /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input.  */
+#define   US_MR_CHMODE_REMOTE_LOOPBACK_Val  _U_(0x3)                                       /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin.  */
+#define US_MR_CHMODE_NORMAL                 (US_MR_CHMODE_NORMAL_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_CHMODE_AUTOMATIC              (US_MR_CHMODE_AUTOMATIC_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
+#define US_MR_CHMODE_LOCAL_LOOPBACK         (US_MR_CHMODE_LOCAL_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
+#define US_MR_CHMODE_REMOTE_LOOPBACK        (US_MR_CHMODE_REMOTE_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
+#define US_MR_MSBF_Pos                      16                                             /**< (US_MR) Bit Order Position */
+#define US_MR_MSBF_Msk                      (_U_(0x1) << US_MR_MSBF_Pos)                   /**< (US_MR) Bit Order Mask */
+#define US_MR_MSBF                          US_MR_MSBF_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MSBF_Msk instead */
+#define US_MR_MODE9_Pos                     17                                             /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_MODE9_Msk                     (_U_(0x1) << US_MR_MODE9_Pos)                  /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_MODE9                         US_MR_MODE9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODE9_Msk instead */
+#define US_MR_CLKO_Pos                      18                                             /**< (US_MR) Clock Output Select Position */
+#define US_MR_CLKO_Msk                      (_U_(0x1) << US_MR_CLKO_Pos)                   /**< (US_MR) Clock Output Select Mask */
+#define US_MR_CLKO                          US_MR_CLKO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_CLKO_Msk instead */
+#define US_MR_OVER_Pos                      19                                             /**< (US_MR) Oversampling Mode Position */
+#define US_MR_OVER_Msk                      (_U_(0x1) << US_MR_OVER_Pos)                   /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_OVER                          US_MR_OVER_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_OVER_Msk instead */
+#define US_MR_INACK_Pos                     20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_INACK_Msk                     (_U_(0x1) << US_MR_INACK_Pos)                  /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_INACK                         US_MR_INACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INACK_Msk instead */
+#define US_MR_DSNACK_Pos                    21                                             /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_DSNACK_Msk                    (_U_(0x1) << US_MR_DSNACK_Pos)                 /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_DSNACK                        US_MR_DSNACK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_DSNACK_Msk instead */
+#define US_MR_VAR_SYNC_Pos                  22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_VAR_SYNC_Msk                  (_U_(0x1) << US_MR_VAR_SYNC_Pos)               /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_VAR_SYNC                      US_MR_VAR_SYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_VAR_SYNC_Msk instead */
+#define US_MR_INVDATA_Pos                   23                                             /**< (US_MR) Inverted Data Position */
+#define US_MR_INVDATA_Msk                   (_U_(0x1) << US_MR_INVDATA_Pos)                /**< (US_MR) Inverted Data Mask */
+#define US_MR_INVDATA                       US_MR_INVDATA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INVDATA_Msk instead */
+#define US_MR_MAX_ITERATION_Pos             24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_MAX_ITERATION_Msk             (_U_(0x7) << US_MR_MAX_ITERATION_Pos)          /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_MAX_ITERATION(value)          (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
+#define US_MR_FILTER_Pos                    28                                             /**< (US_MR) Receive Line Filter Position */
+#define US_MR_FILTER_Msk                    (_U_(0x1) << US_MR_FILTER_Pos)                 /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_FILTER                        US_MR_FILTER_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_FILTER_Msk instead */
+#define US_MR_MAN_Pos                       29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_MAN_Msk                       (_U_(0x1) << US_MR_MAN_Pos)                    /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_MAN                           US_MR_MAN_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MAN_Msk instead */
+#define US_MR_MODSYNC_Pos                   30                                             /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_MODSYNC_Msk                   (_U_(0x1) << US_MR_MODSYNC_Pos)                /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_MODSYNC                       US_MR_MODSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODSYNC_Msk instead */
+#define US_MR_ONEBIT_Pos                    31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_ONEBIT_Msk                    (_U_(0x1) << US_MR_ONEBIT_Pos)                 /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_ONEBIT                        US_MR_ONEBIT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_ONEBIT_Msk instead */
+#define US_MR_MASK                          _U_(0xF7FFFFFF)                                /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
+#define US_MR_Msk                           _U_(0xF7FFFFFF)                                /**< (US_MR) Register Mask  */
+
+#define US_MR_MODE_Pos                      17                                             /**< (US_MR Position) 9-bit Character Length */
+#define US_MR_MODE_Msk                      (_U_(0x1) << US_MR_MODE_Pos)                   /**< (US_MR Mask) MODE */
+#define US_MR_MODE(value)                   (US_MR_MODE_Msk & ((value) << US_MR_MODE_Pos))  
+
+/* -------- US_IER : (USART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Enable                   */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Enable                   */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Enable          */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Enable           */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Enable            */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Enable                 */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Enable                 */
+    uint32_t ITER:1;                    /**< bit:     10  Max number of Repetitions Reached Interrupt Enable */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Enable         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Enable       */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Enable       */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Enable */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Enable */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Enable        */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IER_OFFSET                       (0x08)                                        /**<  (US_IER) Interrupt Enable Register  Offset */
+
+#define US_IER_RXRDY_Pos                    0                                              /**< (US_IER) RXRDY Interrupt Enable Position */
+#define US_IER_RXRDY_Msk                    (_U_(0x1) << US_IER_RXRDY_Pos)                 /**< (US_IER) RXRDY Interrupt Enable Mask */
+#define US_IER_RXRDY                        US_IER_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXRDY_Msk instead */
+#define US_IER_TXRDY_Pos                    1                                              /**< (US_IER) TXRDY Interrupt Enable Position */
+#define US_IER_TXRDY_Msk                    (_U_(0x1) << US_IER_TXRDY_Pos)                 /**< (US_IER) TXRDY Interrupt Enable Mask */
+#define US_IER_TXRDY                        US_IER_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXRDY_Msk instead */
+#define US_IER_RXBRK_Pos                    2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_RXBRK_Msk                    (_U_(0x1) << US_IER_RXBRK_Pos)                 /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_RXBRK                        US_IER_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXBRK_Msk instead */
+#define US_IER_OVRE_Pos                     5                                              /**< (US_IER) Overrun Error Interrupt Enable Position */
+#define US_IER_OVRE_Msk                     (_U_(0x1) << US_IER_OVRE_Pos)                  /**< (US_IER) Overrun Error Interrupt Enable Mask */
+#define US_IER_OVRE                         US_IER_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_OVRE_Msk instead */
+#define US_IER_FRAME_Pos                    6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_FRAME_Msk                    (_U_(0x1) << US_IER_FRAME_Pos)                 /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_FRAME                        US_IER_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_FRAME_Msk instead */
+#define US_IER_PARE_Pos                     7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_PARE_Msk                     (_U_(0x1) << US_IER_PARE_Pos)                  /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_PARE                         US_IER_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_PARE_Msk instead */
+#define US_IER_TIMEOUT_Pos                  8                                              /**< (US_IER) Timeout Interrupt Enable Position */
+#define US_IER_TIMEOUT_Msk                  (_U_(0x1) << US_IER_TIMEOUT_Pos)               /**< (US_IER) Timeout Interrupt Enable Mask */
+#define US_IER_TIMEOUT                      US_IER_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TIMEOUT_Msk instead */
+#define US_IER_TXEMPTY_Pos                  9                                              /**< (US_IER) TXEMPTY Interrupt Enable Position */
+#define US_IER_TXEMPTY_Msk                  (_U_(0x1) << US_IER_TXEMPTY_Pos)               /**< (US_IER) TXEMPTY Interrupt Enable Mask */
+#define US_IER_TXEMPTY                      US_IER_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXEMPTY_Msk instead */
+#define US_IER_ITER_Pos                     10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_ITER_Msk                     (_U_(0x1) << US_IER_ITER_Pos)                  /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_ITER                         US_IER_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_ITER_Msk instead */
+#define US_IER_NACK_Pos                     13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_NACK_Msk                     (_U_(0x1) << US_IER_NACK_Pos)                  /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_NACK                         US_IER_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_NACK_Msk instead */
+#define US_IER_RIIC_Pos                     16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_RIIC_Msk                     (_U_(0x1) << US_IER_RIIC_Pos)                  /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_RIIC                         US_IER_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RIIC_Msk instead */
+#define US_IER_DSRIC_Pos                    17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_DSRIC_Msk                    (_U_(0x1) << US_IER_DSRIC_Pos)                 /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_DSRIC                        US_IER_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DSRIC_Msk instead */
+#define US_IER_DCDIC_Pos                    18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_DCDIC_Msk                    (_U_(0x1) << US_IER_DCDIC_Pos)                 /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_DCDIC                        US_IER_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DCDIC_Msk instead */
+#define US_IER_CTSIC_Pos                    19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_CTSIC_Msk                    (_U_(0x1) << US_IER_CTSIC_Pos)                 /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_CTSIC                        US_IER_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_CTSIC_Msk instead */
+#define US_IER_MANE_Pos                     24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_MANE_Msk                     (_U_(0x1) << US_IER_MANE_Pos)                  /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_MANE                         US_IER_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_MANE_Msk instead */
+#define US_IER_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
+#define US_IER_Msk                          _U_(0x10F27E7)                                 /**< (US_IER) Register Mask  */
+
+
+/* -------- US_IDR : (USART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Disable                  */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Disable                  */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Disable         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Disable          */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Disable           */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Disable                */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Disable                */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Disable */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Disable        */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Disable      */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Disable      */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Disable */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Disable       */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDR_OFFSET                       (0x0C)                                        /**<  (US_IDR) Interrupt Disable Register  Offset */
+
+#define US_IDR_RXRDY_Pos                    0                                              /**< (US_IDR) RXRDY Interrupt Disable Position */
+#define US_IDR_RXRDY_Msk                    (_U_(0x1) << US_IDR_RXRDY_Pos)                 /**< (US_IDR) RXRDY Interrupt Disable Mask */
+#define US_IDR_RXRDY                        US_IDR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXRDY_Msk instead */
+#define US_IDR_TXRDY_Pos                    1                                              /**< (US_IDR) TXRDY Interrupt Disable Position */
+#define US_IDR_TXRDY_Msk                    (_U_(0x1) << US_IDR_TXRDY_Pos)                 /**< (US_IDR) TXRDY Interrupt Disable Mask */
+#define US_IDR_TXRDY                        US_IDR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXRDY_Msk instead */
+#define US_IDR_RXBRK_Pos                    2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_RXBRK_Msk                    (_U_(0x1) << US_IDR_RXBRK_Pos)                 /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_RXBRK                        US_IDR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXBRK_Msk instead */
+#define US_IDR_OVRE_Pos                     5                                              /**< (US_IDR) Overrun Error Interrupt Enable Position */
+#define US_IDR_OVRE_Msk                     (_U_(0x1) << US_IDR_OVRE_Pos)                  /**< (US_IDR) Overrun Error Interrupt Enable Mask */
+#define US_IDR_OVRE                         US_IDR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_OVRE_Msk instead */
+#define US_IDR_FRAME_Pos                    6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_FRAME_Msk                    (_U_(0x1) << US_IDR_FRAME_Pos)                 /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_FRAME                        US_IDR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_FRAME_Msk instead */
+#define US_IDR_PARE_Pos                     7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_PARE_Msk                     (_U_(0x1) << US_IDR_PARE_Pos)                  /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_PARE                         US_IDR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_PARE_Msk instead */
+#define US_IDR_TIMEOUT_Pos                  8                                              /**< (US_IDR) Timeout Interrupt Disable Position */
+#define US_IDR_TIMEOUT_Msk                  (_U_(0x1) << US_IDR_TIMEOUT_Pos)               /**< (US_IDR) Timeout Interrupt Disable Mask */
+#define US_IDR_TIMEOUT                      US_IDR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TIMEOUT_Msk instead */
+#define US_IDR_TXEMPTY_Pos                  9                                              /**< (US_IDR) TXEMPTY Interrupt Disable Position */
+#define US_IDR_TXEMPTY_Msk                  (_U_(0x1) << US_IDR_TXEMPTY_Pos)               /**< (US_IDR) TXEMPTY Interrupt Disable Mask */
+#define US_IDR_TXEMPTY                      US_IDR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXEMPTY_Msk instead */
+#define US_IDR_ITER_Pos                     10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_ITER_Msk                     (_U_(0x1) << US_IDR_ITER_Pos)                  /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_ITER                         US_IDR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_ITER_Msk instead */
+#define US_IDR_NACK_Pos                     13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_NACK_Msk                     (_U_(0x1) << US_IDR_NACK_Pos)                  /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_NACK                         US_IDR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_NACK_Msk instead */
+#define US_IDR_RIIC_Pos                     16                                             /**< (US_IDR) Ring Indicator Input Change Disable Position */
+#define US_IDR_RIIC_Msk                     (_U_(0x1) << US_IDR_RIIC_Pos)                  /**< (US_IDR) Ring Indicator Input Change Disable Mask */
+#define US_IDR_RIIC                         US_IDR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RIIC_Msk instead */
+#define US_IDR_DSRIC_Pos                    17                                             /**< (US_IDR) Data Set Ready Input Change Disable Position */
+#define US_IDR_DSRIC_Msk                    (_U_(0x1) << US_IDR_DSRIC_Pos)                 /**< (US_IDR) Data Set Ready Input Change Disable Mask */
+#define US_IDR_DSRIC                        US_IDR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DSRIC_Msk instead */
+#define US_IDR_DCDIC_Pos                    18                                             /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Position */
+#define US_IDR_DCDIC_Msk                    (_U_(0x1) << US_IDR_DCDIC_Pos)                 /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Mask */
+#define US_IDR_DCDIC                        US_IDR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DCDIC_Msk instead */
+#define US_IDR_CTSIC_Pos                    19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_CTSIC_Msk                    (_U_(0x1) << US_IDR_CTSIC_Pos)                 /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_CTSIC                        US_IDR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_CTSIC_Msk instead */
+#define US_IDR_MANE_Pos                     24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_MANE_Msk                     (_U_(0x1) << US_IDR_MANE_Pos)                  /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_MANE                         US_IDR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_MANE_Msk instead */
+#define US_IDR_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
+#define US_IDR_Msk                          _U_(0x10F27E7)                                 /**< (US_IDR) Register Mask  */
+
+
+/* -------- US_IMR : (USART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Mask                     */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Mask                     */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Mask            */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Mask             */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Mask             */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Mask              */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Mask                   */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Mask                   */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Mask */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Mask           */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Mask         */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Mask         */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Mask */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Mask          */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IMR_OFFSET                       (0x10)                                        /**<  (US_IMR) Interrupt Mask Register  Offset */
+
+#define US_IMR_RXRDY_Pos                    0                                              /**< (US_IMR) RXRDY Interrupt Mask Position */
+#define US_IMR_RXRDY_Msk                    (_U_(0x1) << US_IMR_RXRDY_Pos)                 /**< (US_IMR) RXRDY Interrupt Mask Mask */
+#define US_IMR_RXRDY                        US_IMR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RXRDY_Msk instead */
+#define US_IMR_TXRDY_Pos                    1                                              /**< (US_IMR) TXRDY Interrupt Mask Position */
+#define US_IMR_TXRDY_Msk                    (_U_(0x1) << US_IMR_TXRDY_Pos)                 /**< (US_IMR) TXRDY Interrupt Mask Mask */
+#define US_IMR_TXRDY                        US_IMR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXRDY_Msk instead */
+#define US_IMR_RXBRK_Pos                    2                                              /**< (US_IMR) Receiver Break Interrupt Mask Position */
+#define US_IMR_RXBRK_Msk                    (_U_(0x1) << US_IMR_RXBRK_Pos)                 /**< (US_IMR) Receiver Break Interrupt Mask Mask */
+#define US_IMR_RXBRK                        US_IMR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RXBRK_Msk instead */
+#define US_IMR_OVRE_Pos                     5                                              /**< (US_IMR) Overrun Error Interrupt Mask Position */
+#define US_IMR_OVRE_Msk                     (_U_(0x1) << US_IMR_OVRE_Pos)                  /**< (US_IMR) Overrun Error Interrupt Mask Mask */
+#define US_IMR_OVRE                         US_IMR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_OVRE_Msk instead */
+#define US_IMR_FRAME_Pos                    6                                              /**< (US_IMR) Framing Error Interrupt Mask Position */
+#define US_IMR_FRAME_Msk                    (_U_(0x1) << US_IMR_FRAME_Pos)                 /**< (US_IMR) Framing Error Interrupt Mask Mask */
+#define US_IMR_FRAME                        US_IMR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_FRAME_Msk instead */
+#define US_IMR_PARE_Pos                     7                                              /**< (US_IMR) Parity Error Interrupt Mask Position */
+#define US_IMR_PARE_Msk                     (_U_(0x1) << US_IMR_PARE_Pos)                  /**< (US_IMR) Parity Error Interrupt Mask Mask */
+#define US_IMR_PARE                         US_IMR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_PARE_Msk instead */
+#define US_IMR_TIMEOUT_Pos                  8                                              /**< (US_IMR) Timeout Interrupt Mask Position */
+#define US_IMR_TIMEOUT_Msk                  (_U_(0x1) << US_IMR_TIMEOUT_Pos)               /**< (US_IMR) Timeout Interrupt Mask Mask */
+#define US_IMR_TIMEOUT                      US_IMR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TIMEOUT_Msk instead */
+#define US_IMR_TXEMPTY_Pos                  9                                              /**< (US_IMR) TXEMPTY Interrupt Mask Position */
+#define US_IMR_TXEMPTY_Msk                  (_U_(0x1) << US_IMR_TXEMPTY_Pos)               /**< (US_IMR) TXEMPTY Interrupt Mask Mask */
+#define US_IMR_TXEMPTY                      US_IMR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXEMPTY_Msk instead */
+#define US_IMR_ITER_Pos                     10                                             /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Position */
+#define US_IMR_ITER_Msk                     (_U_(0x1) << US_IMR_ITER_Pos)                  /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Mask */
+#define US_IMR_ITER                         US_IMR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_ITER_Msk instead */
+#define US_IMR_NACK_Pos                     13                                             /**< (US_IMR) Non Acknowledge Interrupt Mask Position */
+#define US_IMR_NACK_Msk                     (_U_(0x1) << US_IMR_NACK_Pos)                  /**< (US_IMR) Non Acknowledge Interrupt Mask Mask */
+#define US_IMR_NACK                         US_IMR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_NACK_Msk instead */
+#define US_IMR_RIIC_Pos                     16                                             /**< (US_IMR) Ring Indicator Input Change Mask Position */
+#define US_IMR_RIIC_Msk                     (_U_(0x1) << US_IMR_RIIC_Pos)                  /**< (US_IMR) Ring Indicator Input Change Mask Mask */
+#define US_IMR_RIIC                         US_IMR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RIIC_Msk instead */
+#define US_IMR_DSRIC_Pos                    17                                             /**< (US_IMR) Data Set Ready Input Change Mask Position */
+#define US_IMR_DSRIC_Msk                    (_U_(0x1) << US_IMR_DSRIC_Pos)                 /**< (US_IMR) Data Set Ready Input Change Mask Mask */
+#define US_IMR_DSRIC                        US_IMR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_DSRIC_Msk instead */
+#define US_IMR_DCDIC_Pos                    18                                             /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Position */
+#define US_IMR_DCDIC_Msk                    (_U_(0x1) << US_IMR_DCDIC_Pos)                 /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Mask */
+#define US_IMR_DCDIC                        US_IMR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_DCDIC_Msk instead */
+#define US_IMR_CTSIC_Pos                    19                                             /**< (US_IMR) Clear to Send Input Change Interrupt Mask Position */
+#define US_IMR_CTSIC_Msk                    (_U_(0x1) << US_IMR_CTSIC_Pos)                 /**< (US_IMR) Clear to Send Input Change Interrupt Mask Mask */
+#define US_IMR_CTSIC                        US_IMR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_CTSIC_Msk instead */
+#define US_IMR_MANE_Pos                     24                                             /**< (US_IMR) Manchester Error Interrupt Mask Position */
+#define US_IMR_MANE_Msk                     (_U_(0x1) << US_IMR_MANE_Pos)                  /**< (US_IMR) Manchester Error Interrupt Mask Mask */
+#define US_IMR_MANE                         US_IMR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_MANE_Msk instead */
+#define US_IMR_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IMR) Register MASK  (Use US_IMR_Msk instead)  */
+#define US_IMR_Msk                          _U_(0x10F27E7)                                 /**< (US_IMR) Register Mask  */
+
+
+/* -------- US_CSR : (USART Offset: 0x14) (R/ 32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready (cleared by reading US_RHR) */
+    uint32_t TXRDY:1;                   /**< bit:      1  Transmitter Ready (cleared by writing US_THR) */
+    uint32_t RXBRK:1;                   /**< bit:      2  Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmitter Empty (cleared by writing US_THR) */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Flag (cleared on read) */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Flag (cleared on read) */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Flag (cleared on read) */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Flag (cleared on read) */
+    uint32_t RI:1;                      /**< bit:     20  Image of RI Input                        */
+    uint32_t DSR:1;                     /**< bit:     21  Image of DSR Input                       */
+    uint32_t DCD:1;                     /**< bit:     22  Image of DCD Input                       */
+    uint32_t CTS:1;                     /**< bit:     23  Image of CTS Input                       */
+    uint32_t MANERR:1;                  /**< bit:     24  Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_CSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CSR_OFFSET                       (0x14)                                        /**<  (US_CSR) Channel Status Register  Offset */
+
+#define US_CSR_RXRDY_Pos                    0                                              /**< (US_CSR) Receiver Ready (cleared by reading US_RHR) Position */
+#define US_CSR_RXRDY_Msk                    (_U_(0x1) << US_CSR_RXRDY_Pos)                 /**< (US_CSR) Receiver Ready (cleared by reading US_RHR) Mask */
+#define US_CSR_RXRDY                        US_CSR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXRDY_Msk instead */
+#define US_CSR_TXRDY_Pos                    1                                              /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Position */
+#define US_CSR_TXRDY_Msk                    (_U_(0x1) << US_CSR_TXRDY_Pos)                 /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Mask */
+#define US_CSR_TXRDY                        US_CSR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXRDY_Msk instead */
+#define US_CSR_RXBRK_Pos                    2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_RXBRK_Msk                    (_U_(0x1) << US_CSR_RXBRK_Pos)                 /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_RXBRK                        US_CSR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXBRK_Msk instead */
+#define US_CSR_OVRE_Pos                     5                                              /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_OVRE_Msk                     (_U_(0x1) << US_CSR_OVRE_Pos)                  /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_OVRE                         US_CSR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_OVRE_Msk instead */
+#define US_CSR_FRAME_Pos                    6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_FRAME_Msk                    (_U_(0x1) << US_CSR_FRAME_Pos)                 /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_FRAME                        US_CSR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_FRAME_Msk instead */
+#define US_CSR_PARE_Pos                     7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_PARE_Msk                     (_U_(0x1) << US_CSR_PARE_Pos)                  /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_PARE                         US_CSR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_PARE_Msk instead */
+#define US_CSR_TIMEOUT_Pos                  8                                              /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_TIMEOUT_Msk                  (_U_(0x1) << US_CSR_TIMEOUT_Pos)               /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_TIMEOUT                      US_CSR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TIMEOUT_Msk instead */
+#define US_CSR_TXEMPTY_Pos                  9                                              /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Position */
+#define US_CSR_TXEMPTY_Msk                  (_U_(0x1) << US_CSR_TXEMPTY_Pos)               /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Mask */
+#define US_CSR_TXEMPTY                      US_CSR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXEMPTY_Msk instead */
+#define US_CSR_ITER_Pos                     10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_ITER_Msk                     (_U_(0x1) << US_CSR_ITER_Pos)                  /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_ITER                         US_CSR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_ITER_Msk instead */
+#define US_CSR_NACK_Pos                     13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_NACK_Msk                     (_U_(0x1) << US_CSR_NACK_Pos)                  /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_NACK                         US_CSR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_NACK_Msk instead */
+#define US_CSR_RIIC_Pos                     16                                             /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Position */
+#define US_CSR_RIIC_Msk                     (_U_(0x1) << US_CSR_RIIC_Pos)                  /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Mask */
+#define US_CSR_RIIC                         US_CSR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RIIC_Msk instead */
+#define US_CSR_DSRIC_Pos                    17                                             /**< (US_CSR) Data Set Ready Input Change Flag (cleared on read) Position */
+#define US_CSR_DSRIC_Msk                    (_U_(0x1) << US_CSR_DSRIC_Pos)                 /**< (US_CSR) Data Set Ready Input Change Flag (cleared on read) Mask */
+#define US_CSR_DSRIC                        US_CSR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSRIC_Msk instead */
+#define US_CSR_DCDIC_Pos                    18                                             /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Position */
+#define US_CSR_DCDIC_Msk                    (_U_(0x1) << US_CSR_DCDIC_Pos)                 /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Mask */
+#define US_CSR_DCDIC                        US_CSR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCDIC_Msk instead */
+#define US_CSR_CTSIC_Pos                    19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_CTSIC_Msk                    (_U_(0x1) << US_CSR_CTSIC_Pos)                 /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_CTSIC                        US_CSR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTSIC_Msk instead */
+#define US_CSR_RI_Pos                       20                                             /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_RI_Msk                       (_U_(0x1) << US_CSR_RI_Pos)                    /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_RI                           US_CSR_RI_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RI_Msk instead */
+#define US_CSR_DSR_Pos                      21                                             /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_DSR_Msk                      (_U_(0x1) << US_CSR_DSR_Pos)                   /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_DSR                          US_CSR_DSR_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSR_Msk instead */
+#define US_CSR_DCD_Pos                      22                                             /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_DCD_Msk                      (_U_(0x1) << US_CSR_DCD_Pos)                   /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_DCD                          US_CSR_DCD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCD_Msk instead */
+#define US_CSR_CTS_Pos                      23                                             /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_CTS_Msk                      (_U_(0x1) << US_CSR_CTS_Pos)                   /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_CTS                          US_CSR_CTS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTS_Msk instead */
+#define US_CSR_MANERR_Pos                   24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_MANERR_Msk                   (_U_(0x1) << US_CSR_MANERR_Pos)                /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_MANERR                       US_CSR_MANERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_MANERR_Msk instead */
+#define US_CSR_MASK                         _U_(0x1FF27E7)                                 /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
+#define US_CSR_Msk                          _U_(0x1FF27E7)                                 /**< (US_CSR) Register Mask  */
+
+
+/* -------- US_RHR : (USART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXCHR:9;                   /**< bit:   0..8  Received Character                       */
+    uint32_t :6;                        /**< bit:  9..14  Reserved */
+    uint32_t RXSYNH:1;                  /**< bit:     15  Received Sync                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RHR_OFFSET                       (0x18)                                        /**<  (US_RHR) Receive Holding Register  Offset */
+
+#define US_RHR_RXCHR_Pos                    0                                              /**< (US_RHR) Received Character Position */
+#define US_RHR_RXCHR_Msk                    (_U_(0x1FF) << US_RHR_RXCHR_Pos)               /**< (US_RHR) Received Character Mask */
+#define US_RHR_RXCHR(value)                 (US_RHR_RXCHR_Msk & ((value) << US_RHR_RXCHR_Pos))
+#define US_RHR_RXSYNH_Pos                   15                                             /**< (US_RHR) Received Sync Position */
+#define US_RHR_RXSYNH_Msk                   (_U_(0x1) << US_RHR_RXSYNH_Pos)                /**< (US_RHR) Received Sync Mask */
+#define US_RHR_RXSYNH                       US_RHR_RXSYNH_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_RHR_RXSYNH_Msk instead */
+#define US_RHR_MASK                         _U_(0x81FF)                                    /**< \deprecated (US_RHR) Register MASK  (Use US_RHR_Msk instead)  */
+#define US_RHR_Msk                          _U_(0x81FF)                                    /**< (US_RHR) Register Mask  */
+
+
+/* -------- US_THR : (USART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCHR:9;                   /**< bit:   0..8  Character to be Transmitted              */
+    uint32_t :6;                        /**< bit:  9..14  Reserved */
+    uint32_t TXSYNH:1;                  /**< bit:     15  Sync Field to be Transmitted             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_THR_OFFSET                       (0x1C)                                        /**<  (US_THR) Transmit Holding Register  Offset */
+
+#define US_THR_TXCHR_Pos                    0                                              /**< (US_THR) Character to be Transmitted Position */
+#define US_THR_TXCHR_Msk                    (_U_(0x1FF) << US_THR_TXCHR_Pos)               /**< (US_THR) Character to be Transmitted Mask */
+#define US_THR_TXCHR(value)                 (US_THR_TXCHR_Msk & ((value) << US_THR_TXCHR_Pos))
+#define US_THR_TXSYNH_Pos                   15                                             /**< (US_THR) Sync Field to be Transmitted Position */
+#define US_THR_TXSYNH_Msk                   (_U_(0x1) << US_THR_TXSYNH_Pos)                /**< (US_THR) Sync Field to be Transmitted Mask */
+#define US_THR_TXSYNH                       US_THR_TXSYNH_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_THR_TXSYNH_Msk instead */
+#define US_THR_MASK                         _U_(0x81FF)                                    /**< \deprecated (US_THR) Register MASK  (Use US_THR_Msk instead)  */
+#define US_THR_Msk                          _U_(0x81FF)                                    /**< (US_THR) Register Mask  */
+
+
+/* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CD:16;                     /**< bit:  0..15  Clock Divider                            */
+    uint32_t FP:3;                      /**< bit: 16..18  Fractional Part                          */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_BRGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_BRGR_OFFSET                      (0x20)                                        /**<  (US_BRGR) Baud Rate Generator Register  Offset */
+
+#define US_BRGR_CD_Pos                      0                                              /**< (US_BRGR) Clock Divider Position */
+#define US_BRGR_CD_Msk                      (_U_(0xFFFF) << US_BRGR_CD_Pos)                /**< (US_BRGR) Clock Divider Mask */
+#define US_BRGR_CD(value)                   (US_BRGR_CD_Msk & ((value) << US_BRGR_CD_Pos))
+#define US_BRGR_FP_Pos                      16                                             /**< (US_BRGR) Fractional Part Position */
+#define US_BRGR_FP_Msk                      (_U_(0x7) << US_BRGR_FP_Pos)                   /**< (US_BRGR) Fractional Part Mask */
+#define US_BRGR_FP(value)                   (US_BRGR_FP_Msk & ((value) << US_BRGR_FP_Pos))
+#define US_BRGR_MASK                        _U_(0x7FFFF)                                   /**< \deprecated (US_BRGR) Register MASK  (Use US_BRGR_Msk instead)  */
+#define US_BRGR_Msk                         _U_(0x7FFFF)                                   /**< (US_BRGR) Register Mask  */
+
+
+/* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TO:17;                     /**< bit:  0..16  Timeout Value                            */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_RTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RTOR_OFFSET                      (0x24)                                        /**<  (US_RTOR) Receiver Timeout Register  Offset */
+
+#define US_RTOR_TO_Pos                      0                                              /**< (US_RTOR) Timeout Value Position */
+#define US_RTOR_TO_Msk                      (_U_(0x1FFFF) << US_RTOR_TO_Pos)               /**< (US_RTOR) Timeout Value Mask */
+#define US_RTOR_TO(value)                   (US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos))
+#define US_RTOR_MASK                        _U_(0x1FFFF)                                   /**< \deprecated (US_RTOR) Register MASK  (Use US_RTOR_Msk instead)  */
+#define US_RTOR_Msk                         _U_(0x1FFFF)                                   /**< (US_RTOR) Register Mask  */
+
+
+/* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TG:8;                      /**< bit:   0..7  Timeguard Value                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_TTGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_TTGR_OFFSET                      (0x28)                                        /**<  (US_TTGR) Transmitter Timeguard Register  Offset */
+
+#define US_TTGR_TG_Pos                      0                                              /**< (US_TTGR) Timeguard Value Position */
+#define US_TTGR_TG_Msk                      (_U_(0xFF) << US_TTGR_TG_Pos)                  /**< (US_TTGR) Timeguard Value Mask */
+#define US_TTGR_TG(value)                   (US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos))
+#define US_TTGR_MASK                        _U_(0xFF)                                      /**< \deprecated (US_TTGR) Register MASK  (Use US_TTGR_Msk instead)  */
+#define US_TTGR_Msk                         _U_(0xFF)                                      /**< (US_TTGR) Register Mask  */
+
+
+/* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FI_DI_RATIO:16;            /**< bit:  0..15  FI Over DI Ratio Value                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_FIDI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_FIDI_OFFSET                      (0x40)                                        /**<  (US_FIDI) FI DI Ratio Register  Offset */
+
+#define US_FIDI_FI_DI_RATIO_Pos             0                                              /**< (US_FIDI) FI Over DI Ratio Value Position */
+#define US_FIDI_FI_DI_RATIO_Msk             (_U_(0xFFFF) << US_FIDI_FI_DI_RATIO_Pos)       /**< (US_FIDI) FI Over DI Ratio Value Mask */
+#define US_FIDI_FI_DI_RATIO(value)          (US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos))
+#define US_FIDI_MASK                        _U_(0xFFFF)                                    /**< \deprecated (US_FIDI) Register MASK  (Use US_FIDI_Msk instead)  */
+#define US_FIDI_Msk                         _U_(0xFFFF)                                    /**< (US_FIDI) Register Mask  */
+
+
+/* -------- US_NER : (USART Offset: 0x44) (R/ 32) Number of Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NB_ERRORS:8;               /**< bit:   0..7  Number of Errors                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_NER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_NER_OFFSET                       (0x44)                                        /**<  (US_NER) Number of Errors Register  Offset */
+
+#define US_NER_NB_ERRORS_Pos                0                                              /**< (US_NER) Number of Errors Position */
+#define US_NER_NB_ERRORS_Msk                (_U_(0xFF) << US_NER_NB_ERRORS_Pos)            /**< (US_NER) Number of Errors Mask */
+#define US_NER_NB_ERRORS(value)             (US_NER_NB_ERRORS_Msk & ((value) << US_NER_NB_ERRORS_Pos))
+#define US_NER_MASK                         _U_(0xFF)                                      /**< \deprecated (US_NER) Register MASK  (Use US_NER_Msk instead)  */
+#define US_NER_Msk                          _U_(0xFF)                                      /**< (US_NER) Register Mask  */
+
+
+/* -------- US_IF : (USART Offset: 0x4c) (R/W 32) IrDA Filter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IRDA_FILTER:8;             /**< bit:   0..7  IrDA Filter                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IF_OFFSET                        (0x4C)                                        /**<  (US_IF) IrDA Filter Register  Offset */
+
+#define US_IF_IRDA_FILTER_Pos               0                                              /**< (US_IF) IrDA Filter Position */
+#define US_IF_IRDA_FILTER_Msk               (_U_(0xFF) << US_IF_IRDA_FILTER_Pos)           /**< (US_IF) IrDA Filter Mask */
+#define US_IF_IRDA_FILTER(value)            (US_IF_IRDA_FILTER_Msk & ((value) << US_IF_IRDA_FILTER_Pos))
+#define US_IF_MASK                          _U_(0xFF)                                      /**< \deprecated (US_IF) Register MASK  (Use US_IF_Msk instead)  */
+#define US_IF_Msk                           _U_(0xFF)                                      /**< (US_IF) Register Mask  */
+
+
+/* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TX_PL:4;                   /**< bit:   0..3  Transmitter Preamble Length              */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t TX_PP:2;                   /**< bit:   8..9  Transmitter Preamble Pattern             */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t TX_MPOL:1;                 /**< bit:     12  Transmitter Manchester Polarity          */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t RX_PL:4;                   /**< bit: 16..19  Receiver Preamble Length                 */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t RX_PP:2;                   /**< bit: 24..25  Receiver Preamble Pattern detected       */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t RX_MPOL:1;                 /**< bit:     28  Receiver Manchester Polarity             */
+    uint32_t ONE:1;                     /**< bit:     29  Must Be Set to 1                         */
+    uint32_t DRIFT:1;                   /**< bit:     30  Drift Compensation                       */
+    uint32_t RXIDLEV:1;                 /**< bit:     31                                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_MAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MAN_OFFSET                       (0x50)                                        /**<  (US_MAN) Manchester Configuration Register  Offset */
+
+#define US_MAN_TX_PL_Pos                    0                                              /**< (US_MAN) Transmitter Preamble Length Position */
+#define US_MAN_TX_PL_Msk                    (_U_(0xF) << US_MAN_TX_PL_Pos)                 /**< (US_MAN) Transmitter Preamble Length Mask */
+#define US_MAN_TX_PL(value)                 (US_MAN_TX_PL_Msk & ((value) << US_MAN_TX_PL_Pos))
+#define US_MAN_TX_PP_Pos                    8                                              /**< (US_MAN) Transmitter Preamble Pattern Position */
+#define US_MAN_TX_PP_Msk                    (_U_(0x3) << US_MAN_TX_PP_Pos)                 /**< (US_MAN) Transmitter Preamble Pattern Mask */
+#define US_MAN_TX_PP(value)                 (US_MAN_TX_PP_Msk & ((value) << US_MAN_TX_PP_Pos))
+#define   US_MAN_TX_PP_ALL_ONE_Val          _U_(0x0)                                       /**< (US_MAN) The preamble is composed of '1's  */
+#define   US_MAN_TX_PP_ALL_ZERO_Val         _U_(0x1)                                       /**< (US_MAN) The preamble is composed of '0's  */
+#define   US_MAN_TX_PP_ZERO_ONE_Val         _U_(0x2)                                       /**< (US_MAN) The preamble is composed of '01's  */
+#define   US_MAN_TX_PP_ONE_ZERO_Val         _U_(0x3)                                       /**< (US_MAN) The preamble is composed of '10's  */
+#define US_MAN_TX_PP_ALL_ONE                (US_MAN_TX_PP_ALL_ONE_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '1's Position  */
+#define US_MAN_TX_PP_ALL_ZERO               (US_MAN_TX_PP_ALL_ZERO_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '0's Position  */
+#define US_MAN_TX_PP_ZERO_ONE               (US_MAN_TX_PP_ZERO_ONE_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '01's Position  */
+#define US_MAN_TX_PP_ONE_ZERO               (US_MAN_TX_PP_ONE_ZERO_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '10's Position  */
+#define US_MAN_TX_MPOL_Pos                  12                                             /**< (US_MAN) Transmitter Manchester Polarity Position */
+#define US_MAN_TX_MPOL_Msk                  (_U_(0x1) << US_MAN_TX_MPOL_Pos)               /**< (US_MAN) Transmitter Manchester Polarity Mask */
+#define US_MAN_TX_MPOL                      US_MAN_TX_MPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_TX_MPOL_Msk instead */
+#define US_MAN_RX_PL_Pos                    16                                             /**< (US_MAN) Receiver Preamble Length Position */
+#define US_MAN_RX_PL_Msk                    (_U_(0xF) << US_MAN_RX_PL_Pos)                 /**< (US_MAN) Receiver Preamble Length Mask */
+#define US_MAN_RX_PL(value)                 (US_MAN_RX_PL_Msk & ((value) << US_MAN_RX_PL_Pos))
+#define US_MAN_RX_PP_Pos                    24                                             /**< (US_MAN) Receiver Preamble Pattern detected Position */
+#define US_MAN_RX_PP_Msk                    (_U_(0x3) << US_MAN_RX_PP_Pos)                 /**< (US_MAN) Receiver Preamble Pattern detected Mask */
+#define US_MAN_RX_PP(value)                 (US_MAN_RX_PP_Msk & ((value) << US_MAN_RX_PP_Pos))
+#define   US_MAN_RX_PP_ALL_ONE_Val          _U_(0x0)                                       /**< (US_MAN) The preamble is composed of '1's  */
+#define   US_MAN_RX_PP_ALL_ZERO_Val         _U_(0x1)                                       /**< (US_MAN) The preamble is composed of '0's  */
+#define   US_MAN_RX_PP_ZERO_ONE_Val         _U_(0x2)                                       /**< (US_MAN) The preamble is composed of '01's  */
+#define   US_MAN_RX_PP_ONE_ZERO_Val         _U_(0x3)                                       /**< (US_MAN) The preamble is composed of '10's  */
+#define US_MAN_RX_PP_ALL_ONE                (US_MAN_RX_PP_ALL_ONE_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '1's Position  */
+#define US_MAN_RX_PP_ALL_ZERO               (US_MAN_RX_PP_ALL_ZERO_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '0's Position  */
+#define US_MAN_RX_PP_ZERO_ONE               (US_MAN_RX_PP_ZERO_ONE_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '01's Position  */
+#define US_MAN_RX_PP_ONE_ZERO               (US_MAN_RX_PP_ONE_ZERO_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '10's Position  */
+#define US_MAN_RX_MPOL_Pos                  28                                             /**< (US_MAN) Receiver Manchester Polarity Position */
+#define US_MAN_RX_MPOL_Msk                  (_U_(0x1) << US_MAN_RX_MPOL_Pos)               /**< (US_MAN) Receiver Manchester Polarity Mask */
+#define US_MAN_RX_MPOL                      US_MAN_RX_MPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_RX_MPOL_Msk instead */
+#define US_MAN_ONE_Pos                      29                                             /**< (US_MAN) Must Be Set to 1 Position */
+#define US_MAN_ONE_Msk                      (_U_(0x1) << US_MAN_ONE_Pos)                   /**< (US_MAN) Must Be Set to 1 Mask */
+#define US_MAN_ONE                          US_MAN_ONE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_ONE_Msk instead */
+#define US_MAN_DRIFT_Pos                    30                                             /**< (US_MAN) Drift Compensation Position */
+#define US_MAN_DRIFT_Msk                    (_U_(0x1) << US_MAN_DRIFT_Pos)                 /**< (US_MAN) Drift Compensation Mask */
+#define US_MAN_DRIFT                        US_MAN_DRIFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_DRIFT_Msk instead */
+#define US_MAN_RXIDLEV_Pos                  31                                             /**< (US_MAN)  Position */
+#define US_MAN_RXIDLEV_Msk                  (_U_(0x1) << US_MAN_RXIDLEV_Pos)               /**< (US_MAN)  Mask */
+#define US_MAN_RXIDLEV                      US_MAN_RXIDLEV_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_RXIDLEV_Msk instead */
+#define US_MAN_MASK                         _U_(0xF30F130F)                                /**< \deprecated (US_MAN) Register MASK  (Use US_MAN_Msk instead)  */
+#define US_MAN_Msk                          _U_(0xF30F130F)                                /**< (US_MAN) Register Mask  */
+
+
+/* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NACT:2;                    /**< bit:   0..1  LIN Node Action                          */
+    uint32_t PARDIS:1;                  /**< bit:      2  Parity Disable                           */
+    uint32_t CHKDIS:1;                  /**< bit:      3  Checksum Disable                         */
+    uint32_t CHKTYP:1;                  /**< bit:      4  Checksum Type                            */
+    uint32_t DLM:1;                     /**< bit:      5  Data Length Mode                         */
+    uint32_t FSDIS:1;                   /**< bit:      6  Frame Slot Mode Disable                  */
+    uint32_t WKUPTYP:1;                 /**< bit:      7  Wakeup Signal Type                       */
+    uint32_t DLC:8;                     /**< bit:  8..15  Data Length Control                      */
+    uint32_t PDCM:1;                    /**< bit:     16  DMAC Mode                                */
+    uint32_t SYNCDIS:1;                 /**< bit:     17  Synchronization Disable                  */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINMR_OFFSET                     (0x54)                                        /**<  (US_LINMR) LIN Mode Register  Offset */
+
+#define US_LINMR_NACT_Pos                   0                                              /**< (US_LINMR) LIN Node Action Position */
+#define US_LINMR_NACT_Msk                   (_U_(0x3) << US_LINMR_NACT_Pos)                /**< (US_LINMR) LIN Node Action Mask */
+#define US_LINMR_NACT(value)                (US_LINMR_NACT_Msk & ((value) << US_LINMR_NACT_Pos))
+#define   US_LINMR_NACT_PUBLISH_Val         _U_(0x0)                                       /**< (US_LINMR) The USART transmits the response.  */
+#define   US_LINMR_NACT_SUBSCRIBE_Val       _U_(0x1)                                       /**< (US_LINMR) The USART receives the response.  */
+#define   US_LINMR_NACT_IGNORE_Val          _U_(0x2)                                       /**< (US_LINMR) The USART does not transmit and does not receive the response.  */
+#define US_LINMR_NACT_PUBLISH               (US_LINMR_NACT_PUBLISH_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART transmits the response. Position  */
+#define US_LINMR_NACT_SUBSCRIBE             (US_LINMR_NACT_SUBSCRIBE_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART receives the response. Position  */
+#define US_LINMR_NACT_IGNORE                (US_LINMR_NACT_IGNORE_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART does not transmit and does not receive the response. Position  */
+#define US_LINMR_PARDIS_Pos                 2                                              /**< (US_LINMR) Parity Disable Position */
+#define US_LINMR_PARDIS_Msk                 (_U_(0x1) << US_LINMR_PARDIS_Pos)              /**< (US_LINMR) Parity Disable Mask */
+#define US_LINMR_PARDIS                     US_LINMR_PARDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_PARDIS_Msk instead */
+#define US_LINMR_CHKDIS_Pos                 3                                              /**< (US_LINMR) Checksum Disable Position */
+#define US_LINMR_CHKDIS_Msk                 (_U_(0x1) << US_LINMR_CHKDIS_Pos)              /**< (US_LINMR) Checksum Disable Mask */
+#define US_LINMR_CHKDIS                     US_LINMR_CHKDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_CHKDIS_Msk instead */
+#define US_LINMR_CHKTYP_Pos                 4                                              /**< (US_LINMR) Checksum Type Position */
+#define US_LINMR_CHKTYP_Msk                 (_U_(0x1) << US_LINMR_CHKTYP_Pos)              /**< (US_LINMR) Checksum Type Mask */
+#define US_LINMR_CHKTYP                     US_LINMR_CHKTYP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_CHKTYP_Msk instead */
+#define US_LINMR_DLM_Pos                    5                                              /**< (US_LINMR) Data Length Mode Position */
+#define US_LINMR_DLM_Msk                    (_U_(0x1) << US_LINMR_DLM_Pos)                 /**< (US_LINMR) Data Length Mode Mask */
+#define US_LINMR_DLM                        US_LINMR_DLM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_DLM_Msk instead */
+#define US_LINMR_FSDIS_Pos                  6                                              /**< (US_LINMR) Frame Slot Mode Disable Position */
+#define US_LINMR_FSDIS_Msk                  (_U_(0x1) << US_LINMR_FSDIS_Pos)               /**< (US_LINMR) Frame Slot Mode Disable Mask */
+#define US_LINMR_FSDIS                      US_LINMR_FSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_FSDIS_Msk instead */
+#define US_LINMR_WKUPTYP_Pos                7                                              /**< (US_LINMR) Wakeup Signal Type Position */
+#define US_LINMR_WKUPTYP_Msk                (_U_(0x1) << US_LINMR_WKUPTYP_Pos)             /**< (US_LINMR) Wakeup Signal Type Mask */
+#define US_LINMR_WKUPTYP                    US_LINMR_WKUPTYP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_WKUPTYP_Msk instead */
+#define US_LINMR_DLC_Pos                    8                                              /**< (US_LINMR) Data Length Control Position */
+#define US_LINMR_DLC_Msk                    (_U_(0xFF) << US_LINMR_DLC_Pos)                /**< (US_LINMR) Data Length Control Mask */
+#define US_LINMR_DLC(value)                 (US_LINMR_DLC_Msk & ((value) << US_LINMR_DLC_Pos))
+#define US_LINMR_PDCM_Pos                   16                                             /**< (US_LINMR) DMAC Mode Position */
+#define US_LINMR_PDCM_Msk                   (_U_(0x1) << US_LINMR_PDCM_Pos)                /**< (US_LINMR) DMAC Mode Mask */
+#define US_LINMR_PDCM                       US_LINMR_PDCM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_PDCM_Msk instead */
+#define US_LINMR_SYNCDIS_Pos                17                                             /**< (US_LINMR) Synchronization Disable Position */
+#define US_LINMR_SYNCDIS_Msk                (_U_(0x1) << US_LINMR_SYNCDIS_Pos)             /**< (US_LINMR) Synchronization Disable Mask */
+#define US_LINMR_SYNCDIS                    US_LINMR_SYNCDIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_SYNCDIS_Msk instead */
+#define US_LINMR_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (US_LINMR) Register MASK  (Use US_LINMR_Msk instead)  */
+#define US_LINMR_Msk                        _U_(0x3FFFF)                                   /**< (US_LINMR) Register Mask  */
+
+
+/* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDCHR:8;                   /**< bit:   0..7  Identifier Character                     */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINIR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINIR_OFFSET                     (0x58)                                        /**<  (US_LINIR) LIN Identifier Register  Offset */
+
+#define US_LINIR_IDCHR_Pos                  0                                              /**< (US_LINIR) Identifier Character Position */
+#define US_LINIR_IDCHR_Msk                  (_U_(0xFF) << US_LINIR_IDCHR_Pos)              /**< (US_LINIR) Identifier Character Mask */
+#define US_LINIR_IDCHR(value)               (US_LINIR_IDCHR_Msk & ((value) << US_LINIR_IDCHR_Pos))
+#define US_LINIR_MASK                       _U_(0xFF)                                      /**< \deprecated (US_LINIR) Register MASK  (Use US_LINIR_Msk instead)  */
+#define US_LINIR_Msk                        _U_(0xFF)                                      /**< (US_LINIR) Register Mask  */
+
+
+/* -------- US_LINBRR : (USART Offset: 0x5c) (R/ 32) LIN Baud Rate Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LINCD:16;                  /**< bit:  0..15  Clock Divider after Synchronization      */
+    uint32_t LINFP:3;                   /**< bit: 16..18  Fractional Part after Synchronization    */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINBRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINBRR_OFFSET                    (0x5C)                                        /**<  (US_LINBRR) LIN Baud Rate Register  Offset */
+
+#define US_LINBRR_LINCD_Pos                 0                                              /**< (US_LINBRR) Clock Divider after Synchronization Position */
+#define US_LINBRR_LINCD_Msk                 (_U_(0xFFFF) << US_LINBRR_LINCD_Pos)           /**< (US_LINBRR) Clock Divider after Synchronization Mask */
+#define US_LINBRR_LINCD(value)              (US_LINBRR_LINCD_Msk & ((value) << US_LINBRR_LINCD_Pos))
+#define US_LINBRR_LINFP_Pos                 16                                             /**< (US_LINBRR) Fractional Part after Synchronization Position */
+#define US_LINBRR_LINFP_Msk                 (_U_(0x7) << US_LINBRR_LINFP_Pos)              /**< (US_LINBRR) Fractional Part after Synchronization Mask */
+#define US_LINBRR_LINFP(value)              (US_LINBRR_LINFP_Msk & ((value) << US_LINBRR_LINFP_Pos))
+#define US_LINBRR_MASK                      _U_(0x7FFFF)                                   /**< \deprecated (US_LINBRR) Register MASK  (Use US_LINBRR_Msk instead)  */
+#define US_LINBRR_Msk                       _U_(0x7FFFF)                                   /**< (US_LINBRR) Register Mask  */
+
+
+/* -------- US_LONMR : (USART Offset: 0x60) (R/W 32) LON Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COMMT:1;                   /**< bit:      0  LON comm_type Parameter Value            */
+    uint32_t COLDET:1;                  /**< bit:      1  LON Collision Detection Feature          */
+    uint32_t TCOL:1;                    /**< bit:      2  Terminate Frame upon Collision Notification */
+    uint32_t CDTAIL:1;                  /**< bit:      3  LON Collision Detection on Frame Tail    */
+    uint32_t DMAM:1;                    /**< bit:      4  LON DMA Mode                             */
+    uint32_t LCDS:1;                    /**< bit:      5  LON Collision Detection Source           */
+    uint32_t :10;                       /**< bit:  6..15  Reserved */
+    uint32_t EOFS:8;                    /**< bit: 16..23  End of Frame Condition Size              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONMR_OFFSET                     (0x60)                                        /**<  (US_LONMR) LON Mode Register  Offset */
+
+#define US_LONMR_COMMT_Pos                  0                                              /**< (US_LONMR) LON comm_type Parameter Value Position */
+#define US_LONMR_COMMT_Msk                  (_U_(0x1) << US_LONMR_COMMT_Pos)               /**< (US_LONMR) LON comm_type Parameter Value Mask */
+#define US_LONMR_COMMT                      US_LONMR_COMMT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_COMMT_Msk instead */
+#define US_LONMR_COLDET_Pos                 1                                              /**< (US_LONMR) LON Collision Detection Feature Position */
+#define US_LONMR_COLDET_Msk                 (_U_(0x1) << US_LONMR_COLDET_Pos)              /**< (US_LONMR) LON Collision Detection Feature Mask */
+#define US_LONMR_COLDET                     US_LONMR_COLDET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_COLDET_Msk instead */
+#define US_LONMR_TCOL_Pos                   2                                              /**< (US_LONMR) Terminate Frame upon Collision Notification Position */
+#define US_LONMR_TCOL_Msk                   (_U_(0x1) << US_LONMR_TCOL_Pos)                /**< (US_LONMR) Terminate Frame upon Collision Notification Mask */
+#define US_LONMR_TCOL                       US_LONMR_TCOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_TCOL_Msk instead */
+#define US_LONMR_CDTAIL_Pos                 3                                              /**< (US_LONMR) LON Collision Detection on Frame Tail Position */
+#define US_LONMR_CDTAIL_Msk                 (_U_(0x1) << US_LONMR_CDTAIL_Pos)              /**< (US_LONMR) LON Collision Detection on Frame Tail Mask */
+#define US_LONMR_CDTAIL                     US_LONMR_CDTAIL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_CDTAIL_Msk instead */
+#define US_LONMR_DMAM_Pos                   4                                              /**< (US_LONMR) LON DMA Mode Position */
+#define US_LONMR_DMAM_Msk                   (_U_(0x1) << US_LONMR_DMAM_Pos)                /**< (US_LONMR) LON DMA Mode Mask */
+#define US_LONMR_DMAM                       US_LONMR_DMAM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_DMAM_Msk instead */
+#define US_LONMR_LCDS_Pos                   5                                              /**< (US_LONMR) LON Collision Detection Source Position */
+#define US_LONMR_LCDS_Msk                   (_U_(0x1) << US_LONMR_LCDS_Pos)                /**< (US_LONMR) LON Collision Detection Source Mask */
+#define US_LONMR_LCDS                       US_LONMR_LCDS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_LCDS_Msk instead */
+#define US_LONMR_EOFS_Pos                   16                                             /**< (US_LONMR) End of Frame Condition Size Position */
+#define US_LONMR_EOFS_Msk                   (_U_(0xFF) << US_LONMR_EOFS_Pos)               /**< (US_LONMR) End of Frame Condition Size Mask */
+#define US_LONMR_EOFS(value)                (US_LONMR_EOFS_Msk & ((value) << US_LONMR_EOFS_Pos))
+#define US_LONMR_MASK                       _U_(0xFF003F)                                  /**< \deprecated (US_LONMR) Register MASK  (Use US_LONMR_Msk instead)  */
+#define US_LONMR_Msk                        _U_(0xFF003F)                                  /**< (US_LONMR) Register Mask  */
+
+
+/* -------- US_LONPR : (USART Offset: 0x64) (R/W 32) LON Preamble Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONPL:14;                  /**< bit:  0..13  LON Preamble Length                      */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONPR_OFFSET                     (0x64)                                        /**<  (US_LONPR) LON Preamble Register  Offset */
+
+#define US_LONPR_LONPL_Pos                  0                                              /**< (US_LONPR) LON Preamble Length Position */
+#define US_LONPR_LONPL_Msk                  (_U_(0x3FFF) << US_LONPR_LONPL_Pos)            /**< (US_LONPR) LON Preamble Length Mask */
+#define US_LONPR_LONPL(value)               (US_LONPR_LONPL_Msk & ((value) << US_LONPR_LONPL_Pos))
+#define US_LONPR_MASK                       _U_(0x3FFF)                                    /**< \deprecated (US_LONPR) Register MASK  (Use US_LONPR_Msk instead)  */
+#define US_LONPR_Msk                        _U_(0x3FFF)                                    /**< (US_LONPR) Register Mask  */
+
+
+/* -------- US_LONDL : (USART Offset: 0x68) (R/W 32) LON Data Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONDL:8;                   /**< bit:   0..7  LON Data Length                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONDL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONDL_OFFSET                     (0x68)                                        /**<  (US_LONDL) LON Data Length Register  Offset */
+
+#define US_LONDL_LONDL_Pos                  0                                              /**< (US_LONDL) LON Data Length Position */
+#define US_LONDL_LONDL_Msk                  (_U_(0xFF) << US_LONDL_LONDL_Pos)              /**< (US_LONDL) LON Data Length Mask */
+#define US_LONDL_LONDL(value)               (US_LONDL_LONDL_Msk & ((value) << US_LONDL_LONDL_Pos))
+#define US_LONDL_MASK                       _U_(0xFF)                                      /**< \deprecated (US_LONDL) Register MASK  (Use US_LONDL_Msk instead)  */
+#define US_LONDL_Msk                        _U_(0xFF)                                      /**< (US_LONDL) Register Mask  */
+
+
+/* -------- US_LONL2HDR : (USART Offset: 0x6c) (R/W 32) LON L2HDR Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BLI:6;                     /**< bit:   0..5  LON Backlog Increment                    */
+    uint32_t ALTP:1;                    /**< bit:      6  LON Alternate Path Bit                   */
+    uint32_t PB:1;                      /**< bit:      7  LON Priority Bit                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONL2HDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONL2HDR_OFFSET                  (0x6C)                                        /**<  (US_LONL2HDR) LON L2HDR Register  Offset */
+
+#define US_LONL2HDR_BLI_Pos                 0                                              /**< (US_LONL2HDR) LON Backlog Increment Position */
+#define US_LONL2HDR_BLI_Msk                 (_U_(0x3F) << US_LONL2HDR_BLI_Pos)             /**< (US_LONL2HDR) LON Backlog Increment Mask */
+#define US_LONL2HDR_BLI(value)              (US_LONL2HDR_BLI_Msk & ((value) << US_LONL2HDR_BLI_Pos))
+#define US_LONL2HDR_ALTP_Pos                6                                              /**< (US_LONL2HDR) LON Alternate Path Bit Position */
+#define US_LONL2HDR_ALTP_Msk                (_U_(0x1) << US_LONL2HDR_ALTP_Pos)             /**< (US_LONL2HDR) LON Alternate Path Bit Mask */
+#define US_LONL2HDR_ALTP                    US_LONL2HDR_ALTP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONL2HDR_ALTP_Msk instead */
+#define US_LONL2HDR_PB_Pos                  7                                              /**< (US_LONL2HDR) LON Priority Bit Position */
+#define US_LONL2HDR_PB_Msk                  (_U_(0x1) << US_LONL2HDR_PB_Pos)               /**< (US_LONL2HDR) LON Priority Bit Mask */
+#define US_LONL2HDR_PB                      US_LONL2HDR_PB_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONL2HDR_PB_Msk instead */
+#define US_LONL2HDR_MASK                    _U_(0xFF)                                      /**< \deprecated (US_LONL2HDR) Register MASK  (Use US_LONL2HDR_Msk instead)  */
+#define US_LONL2HDR_Msk                     _U_(0xFF)                                      /**< (US_LONL2HDR) Register Mask  */
+
+
+/* -------- US_LONBL : (USART Offset: 0x70) (R/ 32) LON Backlog Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONBL:6;                   /**< bit:   0..5  LON Node Backlog Value                   */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONBL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONBL_OFFSET                     (0x70)                                        /**<  (US_LONBL) LON Backlog Register  Offset */
+
+#define US_LONBL_LONBL_Pos                  0                                              /**< (US_LONBL) LON Node Backlog Value Position */
+#define US_LONBL_LONBL_Msk                  (_U_(0x3F) << US_LONBL_LONBL_Pos)              /**< (US_LONBL) LON Node Backlog Value Mask */
+#define US_LONBL_LONBL(value)               (US_LONBL_LONBL_Msk & ((value) << US_LONBL_LONBL_Pos))
+#define US_LONBL_MASK                       _U_(0x3F)                                      /**< \deprecated (US_LONBL) Register MASK  (Use US_LONBL_Msk instead)  */
+#define US_LONBL_Msk                        _U_(0x3F)                                      /**< (US_LONBL) Register Mask  */
+
+
+/* -------- US_LONB1TX : (USART Offset: 0x74) (R/W 32) LON Beta1 Tx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BETA1TX:24;                /**< bit:  0..23  LON Beta1 Length after Transmission      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONB1TX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONB1TX_OFFSET                   (0x74)                                        /**<  (US_LONB1TX) LON Beta1 Tx Register  Offset */
+
+#define US_LONB1TX_BETA1TX_Pos              0                                              /**< (US_LONB1TX) LON Beta1 Length after Transmission Position */
+#define US_LONB1TX_BETA1TX_Msk              (_U_(0xFFFFFF) << US_LONB1TX_BETA1TX_Pos)      /**< (US_LONB1TX) LON Beta1 Length after Transmission Mask */
+#define US_LONB1TX_BETA1TX(value)           (US_LONB1TX_BETA1TX_Msk & ((value) << US_LONB1TX_BETA1TX_Pos))
+#define US_LONB1TX_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (US_LONB1TX) Register MASK  (Use US_LONB1TX_Msk instead)  */
+#define US_LONB1TX_Msk                      _U_(0xFFFFFF)                                  /**< (US_LONB1TX) Register Mask  */
+
+
+/* -------- US_LONB1RX : (USART Offset: 0x78) (R/W 32) LON Beta1 Rx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BETA1RX:24;                /**< bit:  0..23  LON Beta1 Length after Reception         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONB1RX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONB1RX_OFFSET                   (0x78)                                        /**<  (US_LONB1RX) LON Beta1 Rx Register  Offset */
+
+#define US_LONB1RX_BETA1RX_Pos              0                                              /**< (US_LONB1RX) LON Beta1 Length after Reception Position */
+#define US_LONB1RX_BETA1RX_Msk              (_U_(0xFFFFFF) << US_LONB1RX_BETA1RX_Pos)      /**< (US_LONB1RX) LON Beta1 Length after Reception Mask */
+#define US_LONB1RX_BETA1RX(value)           (US_LONB1RX_BETA1RX_Msk & ((value) << US_LONB1RX_BETA1RX_Pos))
+#define US_LONB1RX_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (US_LONB1RX) Register MASK  (Use US_LONB1RX_Msk instead)  */
+#define US_LONB1RX_Msk                      _U_(0xFFFFFF)                                  /**< (US_LONB1RX) Register Mask  */
+
+
+/* -------- US_LONPRIO : (USART Offset: 0x7c) (R/W 32) LON Priority Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PSNB:7;                    /**< bit:   0..6  LON Priority Slot Number                 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t NPS:7;                     /**< bit:  8..14  LON Node Priority Slot                   */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONPRIO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONPRIO_OFFSET                   (0x7C)                                        /**<  (US_LONPRIO) LON Priority Register  Offset */
+
+#define US_LONPRIO_PSNB_Pos                 0                                              /**< (US_LONPRIO) LON Priority Slot Number Position */
+#define US_LONPRIO_PSNB_Msk                 (_U_(0x7F) << US_LONPRIO_PSNB_Pos)             /**< (US_LONPRIO) LON Priority Slot Number Mask */
+#define US_LONPRIO_PSNB(value)              (US_LONPRIO_PSNB_Msk & ((value) << US_LONPRIO_PSNB_Pos))
+#define US_LONPRIO_NPS_Pos                  8                                              /**< (US_LONPRIO) LON Node Priority Slot Position */
+#define US_LONPRIO_NPS_Msk                  (_U_(0x7F) << US_LONPRIO_NPS_Pos)              /**< (US_LONPRIO) LON Node Priority Slot Mask */
+#define US_LONPRIO_NPS(value)               (US_LONPRIO_NPS_Msk & ((value) << US_LONPRIO_NPS_Pos))
+#define US_LONPRIO_MASK                     _U_(0x7F7F)                                    /**< \deprecated (US_LONPRIO) Register MASK  (Use US_LONPRIO_Msk instead)  */
+#define US_LONPRIO_Msk                      _U_(0x7F7F)                                    /**< (US_LONPRIO) Register Mask  */
+
+
+/* -------- US_IDTTX : (USART Offset: 0x80) (R/W 32) LON IDT Tx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDTTX:24;                  /**< bit:  0..23  LON Indeterminate Time after Transmission (comm_type = 1 mode only) */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDTTX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDTTX_OFFSET                     (0x80)                                        /**<  (US_IDTTX) LON IDT Tx Register  Offset */
+
+#define US_IDTTX_IDTTX_Pos                  0                                              /**< (US_IDTTX) LON Indeterminate Time after Transmission (comm_type = 1 mode only) Position */
+#define US_IDTTX_IDTTX_Msk                  (_U_(0xFFFFFF) << US_IDTTX_IDTTX_Pos)          /**< (US_IDTTX) LON Indeterminate Time after Transmission (comm_type = 1 mode only) Mask */
+#define US_IDTTX_IDTTX(value)               (US_IDTTX_IDTTX_Msk & ((value) << US_IDTTX_IDTTX_Pos))
+#define US_IDTTX_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (US_IDTTX) Register MASK  (Use US_IDTTX_Msk instead)  */
+#define US_IDTTX_Msk                        _U_(0xFFFFFF)                                  /**< (US_IDTTX) Register Mask  */
+
+
+/* -------- US_IDTRX : (USART Offset: 0x84) (R/W 32) LON IDT Rx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDTRX:24;                  /**< bit:  0..23  LON Indeterminate Time after Reception (comm_type = 1 mode only) */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDTRX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDTRX_OFFSET                     (0x84)                                        /**<  (US_IDTRX) LON IDT Rx Register  Offset */
+
+#define US_IDTRX_IDTRX_Pos                  0                                              /**< (US_IDTRX) LON Indeterminate Time after Reception (comm_type = 1 mode only) Position */
+#define US_IDTRX_IDTRX_Msk                  (_U_(0xFFFFFF) << US_IDTRX_IDTRX_Pos)          /**< (US_IDTRX) LON Indeterminate Time after Reception (comm_type = 1 mode only) Mask */
+#define US_IDTRX_IDTRX(value)               (US_IDTRX_IDTRX_Msk & ((value) << US_IDTRX_IDTRX_Pos))
+#define US_IDTRX_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (US_IDTRX) Register MASK  (Use US_IDTRX_Msk instead)  */
+#define US_IDTRX_Msk                        _U_(0xFFFFFF)                                  /**< (US_IDTRX) Register Mask  */
+
+
+/* -------- US_ICDIFF : (USART Offset: 0x88) (R/W 32) IC DIFF Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ICDIFF:4;                  /**< bit:   0..3  IC Differentiator Number                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_ICDIFF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_ICDIFF_OFFSET                    (0x88)                                        /**<  (US_ICDIFF) IC DIFF Register  Offset */
+
+#define US_ICDIFF_ICDIFF_Pos                0                                              /**< (US_ICDIFF) IC Differentiator Number Position */
+#define US_ICDIFF_ICDIFF_Msk                (_U_(0xF) << US_ICDIFF_ICDIFF_Pos)             /**< (US_ICDIFF) IC Differentiator Number Mask */
+#define US_ICDIFF_ICDIFF(value)             (US_ICDIFF_ICDIFF_Msk & ((value) << US_ICDIFF_ICDIFF_Pos))
+#define US_ICDIFF_MASK                      _U_(0x0F)                                      /**< \deprecated (US_ICDIFF) Register MASK  (Use US_ICDIFF_Msk instead)  */
+#define US_ICDIFF_Msk                       _U_(0x0F)                                      /**< (US_ICDIFF) Register Mask  */
+
+
+/* -------- US_WPMR : (USART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPMR_OFFSET                      (0xE4)                                        /**<  (US_WPMR) Write Protection Mode Register  Offset */
+
+#define US_WPMR_WPEN_Pos                    0                                              /**< (US_WPMR) Write Protection Enable Position */
+#define US_WPMR_WPEN_Msk                    (_U_(0x1) << US_WPMR_WPEN_Pos)                 /**< (US_WPMR) Write Protection Enable Mask */
+#define US_WPMR_WPEN                        US_WPMR_WPEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_WPMR_WPEN_Msk instead */
+#define US_WPMR_WPKEY_Pos                   8                                              /**< (US_WPMR) Write Protection Key Position */
+#define US_WPMR_WPKEY_Msk                   (_U_(0xFFFFFF) << US_WPMR_WPKEY_Pos)           /**< (US_WPMR) Write Protection Key Mask */
+#define US_WPMR_WPKEY(value)                (US_WPMR_WPKEY_Msk & ((value) << US_WPMR_WPKEY_Pos))
+#define   US_WPMR_WPKEY_PASSWD_Val          _U_(0x555341)                                  /**< (US_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define US_WPMR_WPKEY_PASSWD                (US_WPMR_WPKEY_PASSWD_Val << US_WPMR_WPKEY_Pos)  /**< (US_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define US_WPMR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (US_WPMR) Register MASK  (Use US_WPMR_Msk instead)  */
+#define US_WPMR_Msk                         _U_(0xFFFFFF01)                                /**< (US_WPMR) Register Mask  */
+
+
+/* -------- US_WPSR : (USART Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPSR_OFFSET                      (0xE8)                                        /**<  (US_WPSR) Write Protection Status Register  Offset */
+
+#define US_WPSR_WPVS_Pos                    0                                              /**< (US_WPSR) Write Protection Violation Status Position */
+#define US_WPSR_WPVS_Msk                    (_U_(0x1) << US_WPSR_WPVS_Pos)                 /**< (US_WPSR) Write Protection Violation Status Mask */
+#define US_WPSR_WPVS                        US_WPSR_WPVS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_WPSR_WPVS_Msk instead */
+#define US_WPSR_WPVSRC_Pos                  8                                              /**< (US_WPSR) Write Protection Violation Source Position */
+#define US_WPSR_WPVSRC_Msk                  (_U_(0xFFFF) << US_WPSR_WPVSRC_Pos)            /**< (US_WPSR) Write Protection Violation Source Mask */
+#define US_WPSR_WPVSRC(value)               (US_WPSR_WPVSRC_Msk & ((value) << US_WPSR_WPVSRC_Pos))
+#define US_WPSR_MASK                        _U_(0xFFFF01)                                  /**< \deprecated (US_WPSR) Register MASK  (Use US_WPSR_Msk instead)  */
+#define US_WPSR_Msk                         _U_(0xFFFF01)                                  /**< (US_WPSR) Register Mask  */
+
+
+/* -------- US_VERSION : (USART Offset: 0xfc) (R/ 32) Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Hardware Module Version                  */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_VERSION_OFFSET                   (0xFC)                                        /**<  (US_VERSION) Version Register  Offset */
+
+#define US_VERSION_VERSION_Pos              0                                              /**< (US_VERSION) Hardware Module Version Position */
+#define US_VERSION_VERSION_Msk              (_U_(0xFFF) << US_VERSION_VERSION_Pos)         /**< (US_VERSION) Hardware Module Version Mask */
+#define US_VERSION_VERSION(value)           (US_VERSION_VERSION_Msk & ((value) << US_VERSION_VERSION_Pos))
+#define US_VERSION_MFN_Pos                  16                                             /**< (US_VERSION) Metal Fix Number Position */
+#define US_VERSION_MFN_Msk                  (_U_(0x7) << US_VERSION_MFN_Pos)               /**< (US_VERSION) Metal Fix Number Mask */
+#define US_VERSION_MFN(value)               (US_VERSION_MFN_Msk & ((value) << US_VERSION_MFN_Pos))
+#define US_VERSION_MASK                     _U_(0x70FFF)                                   /**< \deprecated (US_VERSION) Register MASK  (Use US_VERSION_Msk instead)  */
+#define US_VERSION_Msk                      _U_(0x70FFF)                                   /**< (US_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief USART hardware registers */
+typedef struct {  
+  __O  uint32_t US_CR;          /**< (USART Offset: 0x00) Control Register */
+  __IO uint32_t US_MR;          /**< (USART Offset: 0x04) Mode Register */
+  __O  uint32_t US_IER;         /**< (USART Offset: 0x08) Interrupt Enable Register */
+  __O  uint32_t US_IDR;         /**< (USART Offset: 0x0C) Interrupt Disable Register */
+  __I  uint32_t US_IMR;         /**< (USART Offset: 0x10) Interrupt Mask Register */
+  __I  uint32_t US_CSR;         /**< (USART Offset: 0x14) Channel Status Register */
+  __I  uint32_t US_RHR;         /**< (USART Offset: 0x18) Receive Holding Register */
+  __O  uint32_t US_THR;         /**< (USART Offset: 0x1C) Transmit Holding Register */
+  __IO uint32_t US_BRGR;        /**< (USART Offset: 0x20) Baud Rate Generator Register */
+  __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Timeout Register */
+  __IO uint32_t US_TTGR;        /**< (USART Offset: 0x28) Transmitter Timeguard Register */
+  __I  uint8_t                        Reserved1[20];
+  __IO uint32_t US_FIDI;        /**< (USART Offset: 0x40) FI DI Ratio Register */
+  __I  uint32_t US_NER;         /**< (USART Offset: 0x44) Number of Errors Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t US_IF;          /**< (USART Offset: 0x4C) IrDA Filter Register */
+  __IO uint32_t US_MAN;         /**< (USART Offset: 0x50) Manchester Configuration Register */
+  __IO uint32_t US_LINMR;       /**< (USART Offset: 0x54) LIN Mode Register */
+  __IO uint32_t US_LINIR;       /**< (USART Offset: 0x58) LIN Identifier Register */
+  __I  uint32_t US_LINBRR;      /**< (USART Offset: 0x5C) LIN Baud Rate Register */
+  __IO uint32_t US_LONMR;       /**< (USART Offset: 0x60) LON Mode Register */
+  __IO uint32_t US_LONPR;       /**< (USART Offset: 0x64) LON Preamble Register */
+  __IO uint32_t US_LONDL;       /**< (USART Offset: 0x68) LON Data Length Register */
+  __IO uint32_t US_LONL2HDR;    /**< (USART Offset: 0x6C) LON L2HDR Register */
+  __I  uint32_t US_LONBL;       /**< (USART Offset: 0x70) LON Backlog Register */
+  __IO uint32_t US_LONB1TX;     /**< (USART Offset: 0x74) LON Beta1 Tx Register */
+  __IO uint32_t US_LONB1RX;     /**< (USART Offset: 0x78) LON Beta1 Rx Register */
+  __IO uint32_t US_LONPRIO;     /**< (USART Offset: 0x7C) LON Priority Register */
+  __IO uint32_t US_IDTTX;       /**< (USART Offset: 0x80) LON IDT Tx Register */
+  __IO uint32_t US_IDTRX;       /**< (USART Offset: 0x84) LON IDT Rx Register */
+  __IO uint32_t US_ICDIFF;      /**< (USART Offset: 0x88) IC DIFF Register */
+  __I  uint8_t                        Reserved3[88];
+  __IO uint32_t US_WPMR;        /**< (USART Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t US_WPSR;        /**< (USART Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  uint32_t US_VERSION;     /**< (USART Offset: 0xFC) Version Register */
+} Usart;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief USART hardware registers */
+typedef struct {  
+  __O  US_CR_Type                     US_CR;          /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO US_MR_Type                     US_MR;          /**< Offset: 0x04 (R/W  32) Mode Register */
+  __O  US_IER_Type                    US_IER;         /**< Offset: 0x08 ( /W  32) Interrupt Enable Register */
+  __O  US_IDR_Type                    US_IDR;         /**< Offset: 0x0C ( /W  32) Interrupt Disable Register */
+  __I  US_IMR_Type                    US_IMR;         /**< Offset: 0x10 (R/   32) Interrupt Mask Register */
+  __I  US_CSR_Type                    US_CSR;         /**< Offset: 0x14 (R/   32) Channel Status Register */
+  __I  US_RHR_Type                    US_RHR;         /**< Offset: 0x18 (R/   32) Receive Holding Register */
+  __O  US_THR_Type                    US_THR;         /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
+  __IO US_BRGR_Type                   US_BRGR;        /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
+  __IO US_RTOR_Type                   US_RTOR;        /**< Offset: 0x24 (R/W  32) Receiver Timeout Register */
+  __IO US_TTGR_Type                   US_TTGR;        /**< Offset: 0x28 (R/W  32) Transmitter Timeguard Register */
+  __I  uint8_t                        Reserved1[20];
+  __IO US_FIDI_Type                   US_FIDI;        /**< Offset: 0x40 (R/W  32) FI DI Ratio Register */
+  __I  US_NER_Type                    US_NER;         /**< Offset: 0x44 (R/   32) Number of Errors Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO US_IF_Type                     US_IF;          /**< Offset: 0x4C (R/W  32) IrDA Filter Register */
+  __IO US_MAN_Type                    US_MAN;         /**< Offset: 0x50 (R/W  32) Manchester Configuration Register */
+  __IO US_LINMR_Type                  US_LINMR;       /**< Offset: 0x54 (R/W  32) LIN Mode Register */
+  __IO US_LINIR_Type                  US_LINIR;       /**< Offset: 0x58 (R/W  32) LIN Identifier Register */
+  __I  US_LINBRR_Type                 US_LINBRR;      /**< Offset: 0x5C (R/   32) LIN Baud Rate Register */
+  __IO US_LONMR_Type                  US_LONMR;       /**< Offset: 0x60 (R/W  32) LON Mode Register */
+  __IO US_LONPR_Type                  US_LONPR;       /**< Offset: 0x64 (R/W  32) LON Preamble Register */
+  __IO US_LONDL_Type                  US_LONDL;       /**< Offset: 0x68 (R/W  32) LON Data Length Register */
+  __IO US_LONL2HDR_Type               US_LONL2HDR;    /**< Offset: 0x6C (R/W  32) LON L2HDR Register */
+  __I  US_LONBL_Type                  US_LONBL;       /**< Offset: 0x70 (R/   32) LON Backlog Register */
+  __IO US_LONB1TX_Type                US_LONB1TX;     /**< Offset: 0x74 (R/W  32) LON Beta1 Tx Register */
+  __IO US_LONB1RX_Type                US_LONB1RX;     /**< Offset: 0x78 (R/W  32) LON Beta1 Rx Register */
+  __IO US_LONPRIO_Type                US_LONPRIO;     /**< Offset: 0x7C (R/W  32) LON Priority Register */
+  __IO US_IDTTX_Type                  US_IDTTX;       /**< Offset: 0x80 (R/W  32) LON IDT Tx Register */
+  __IO US_IDTRX_Type                  US_IDTRX;       /**< Offset: 0x84 (R/W  32) LON IDT Rx Register */
+  __IO US_ICDIFF_Type                 US_ICDIFF;      /**< Offset: 0x88 (R/W  32) IC DIFF Register */
+  __I  uint8_t                        Reserved3[88];
+  __IO US_WPMR_Type                   US_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  US_WPSR_Type                   US_WPSR;        /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved4[16];
+  __I  US_VERSION_Type                US_VERSION;     /**< Offset: 0xFC (R/   32) Version Register */
+} Usart;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Universal Synchronous Asynchronous Receiver Transmitter */
+
+#endif /* _SAMV71_USART_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/usbhs.h
+++ b/asf/sam/include/samv71/component/usbhs.h
@@ -1,0 +1,3709 @@
+/**
+ * \file
+ *
+ * \brief Component description for USBHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USBHS_COMPONENT_H_
+#define _SAMV71_USBHS_COMPONENT_H_
+#define _SAMV71_USBHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 USB High-Speed Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USBHS */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define USBHS_11292                      /**< (USBHS) Module ID */
+#define REV_USBHS E                      /**< (USBHS) Module revision */
+
+/* -------- USBHS_DEVDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Device DMA Channel Next Descriptor Address Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMANXTDSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_DEVDMANXTDSC) Device DMA Channel Next Descriptor Address Register (n = 1)  Offset */
+
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Position */
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Mask */
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD(value) (USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Msk & ((value) << USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos))
+#define USBHS_DEVDMANXTDSC_MASK             _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_DEVDMANXTDSC) Register MASK  (Use USBHS_DEVDMANXTDSC_Msk instead)  */
+#define USBHS_DEVDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMANXTDSC) Register Mask  */
+
+
+/* -------- USBHS_DEVDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Device DMA Channel Address Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMAADDRESS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_DEVDMAADDRESS) Device DMA Channel Address Register (n = 1)  Offset */
+
+#define USBHS_DEVDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_DEVDMAADDRESS) Buffer Address Position */
+#define USBHS_DEVDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_DEVDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_DEVDMAADDRESS) Buffer Address Mask */
+#define USBHS_DEVDMAADDRESS_BUFF_ADD(value) (USBHS_DEVDMAADDRESS_BUFF_ADD_Msk & ((value) << USBHS_DEVDMAADDRESS_BUFF_ADD_Pos))
+#define USBHS_DEVDMAADDRESS_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_DEVDMAADDRESS) Register MASK  (Use USBHS_DEVDMAADDRESS_Msk instead)  */
+#define USBHS_DEVDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMAADDRESS) Register Mask  */
+
+
+/* -------- USBHS_DEVDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Device DMA Channel Control Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
+    uint32_t LDNXT_DSC:1;               /**< bit:      1  Load Next Channel Transfer Descriptor Enable Command */
+    uint32_t END_TR_EN:1;               /**< bit:      2  End of Transfer Enable Control (OUT transfers only) */
+    uint32_t END_B_EN:1;                /**< bit:      3  End of Buffer Enable Control             */
+    uint32_t END_TR_IT:1;               /**< bit:      4  End of Transfer Interrupt Enable         */
+    uint32_t END_BUFFIT:1;              /**< bit:      5  End of Buffer Interrupt Enable           */
+    uint32_t DESC_LD_IT:1;              /**< bit:      6  Descriptor Loaded Interrupt Enable       */
+    uint32_t BURST_LCK:1;               /**< bit:      7  Burst Lock Enable                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t BUFF_LENGTH:16;            /**< bit: 16..31  Buffer Byte Length (Write-only)          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMACONTROL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_DEVDMACONTROL) Device DMA Channel Control Register (n = 1)  Offset */
+
+#define USBHS_DEVDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_DEVDMACONTROL) Channel Enable Command Position */
+#define USBHS_DEVDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_DEVDMACONTROL) Channel Enable Command Mask */
+#define USBHS_DEVDMACONTROL_CHANN_ENB       USBHS_DEVDMACONTROL_CHANN_ENB_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_CHANN_ENB_Msk instead */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC_Pos   1                                              /**< (USBHS_DEVDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Position */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_LDNXT_DSC_Pos)  /**< (USBHS_DEVDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Mask */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC       USBHS_DEVDMACONTROL_LDNXT_DSC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_LDNXT_DSC_Msk instead */
+#define USBHS_DEVDMACONTROL_END_TR_EN_Pos   2                                              /**< (USBHS_DEVDMACONTROL) End of Transfer Enable Control (OUT transfers only) Position */
+#define USBHS_DEVDMACONTROL_END_TR_EN_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_END_TR_EN_Pos)  /**< (USBHS_DEVDMACONTROL) End of Transfer Enable Control (OUT transfers only) Mask */
+#define USBHS_DEVDMACONTROL_END_TR_EN       USBHS_DEVDMACONTROL_END_TR_EN_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_TR_EN_Msk instead */
+#define USBHS_DEVDMACONTROL_END_B_EN_Pos    3                                              /**< (USBHS_DEVDMACONTROL) End of Buffer Enable Control Position */
+#define USBHS_DEVDMACONTROL_END_B_EN_Msk    (_U_(0x1) << USBHS_DEVDMACONTROL_END_B_EN_Pos)  /**< (USBHS_DEVDMACONTROL) End of Buffer Enable Control Mask */
+#define USBHS_DEVDMACONTROL_END_B_EN        USBHS_DEVDMACONTROL_END_B_EN_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_B_EN_Msk instead */
+#define USBHS_DEVDMACONTROL_END_TR_IT_Pos   4                                              /**< (USBHS_DEVDMACONTROL) End of Transfer Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_END_TR_IT_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_END_TR_IT_Pos)  /**< (USBHS_DEVDMACONTROL) End of Transfer Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_END_TR_IT       USBHS_DEVDMACONTROL_END_TR_IT_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_TR_IT_Msk instead */
+#define USBHS_DEVDMACONTROL_END_BUFFIT_Pos  5                                              /**< (USBHS_DEVDMACONTROL) End of Buffer Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_END_BUFFIT_Msk  (_U_(0x1) << USBHS_DEVDMACONTROL_END_BUFFIT_Pos)  /**< (USBHS_DEVDMACONTROL) End of Buffer Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_END_BUFFIT      USBHS_DEVDMACONTROL_END_BUFFIT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_BUFFIT_Msk instead */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT_Pos  6                                              /**< (USBHS_DEVDMACONTROL) Descriptor Loaded Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT_Msk  (_U_(0x1) << USBHS_DEVDMACONTROL_DESC_LD_IT_Pos)  /**< (USBHS_DEVDMACONTROL) Descriptor Loaded Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT      USBHS_DEVDMACONTROL_DESC_LD_IT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_DESC_LD_IT_Msk instead */
+#define USBHS_DEVDMACONTROL_BURST_LCK_Pos   7                                              /**< (USBHS_DEVDMACONTROL) Burst Lock Enable Position */
+#define USBHS_DEVDMACONTROL_BURST_LCK_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_BURST_LCK_Pos)  /**< (USBHS_DEVDMACONTROL) Burst Lock Enable Mask */
+#define USBHS_DEVDMACONTROL_BURST_LCK       USBHS_DEVDMACONTROL_BURST_LCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_BURST_LCK_Msk instead */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos 16                                             /**< (USBHS_DEVDMACONTROL) Buffer Byte Length (Write-only) Position */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH_Msk (_U_(0xFFFF) << USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos)  /**< (USBHS_DEVDMACONTROL) Buffer Byte Length (Write-only) Mask */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH(value) (USBHS_DEVDMACONTROL_BUFF_LENGTH_Msk & ((value) << USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos))
+#define USBHS_DEVDMACONTROL_MASK            _U_(0xFFFF00FF)                                /**< \deprecated (USBHS_DEVDMACONTROL) Register MASK  (Use USBHS_DEVDMACONTROL_Msk instead)  */
+#define USBHS_DEVDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_DEVDMACONTROL) Register Mask  */
+
+
+/* -------- USBHS_DEVDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Device DMA Channel Status Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
+    uint32_t CHANN_ACT:1;               /**< bit:      1  Channel Active Status                    */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t END_TR_ST:1;               /**< bit:      4  End of Channel Transfer Status           */
+    uint32_t END_BF_ST:1;               /**< bit:      5  End of Channel Buffer Status             */
+    uint32_t DESC_LDST:1;               /**< bit:      6  Descriptor Loaded Status                 */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t BUFF_COUNT:16;             /**< bit: 16..31  Buffer Byte Count                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMASTATUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_DEVDMASTATUS) Device DMA Channel Status Register (n = 1)  Offset */
+
+#define USBHS_DEVDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_DEVDMASTATUS) Channel Enable Status Position */
+#define USBHS_DEVDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_DEVDMASTATUS) Channel Enable Status Mask */
+#define USBHS_DEVDMASTATUS_CHANN_ENB        USBHS_DEVDMASTATUS_CHANN_ENB_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_CHANN_ENB_Msk instead */
+#define USBHS_DEVDMASTATUS_CHANN_ACT_Pos    1                                              /**< (USBHS_DEVDMASTATUS) Channel Active Status Position */
+#define USBHS_DEVDMASTATUS_CHANN_ACT_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_CHANN_ACT_Pos)  /**< (USBHS_DEVDMASTATUS) Channel Active Status Mask */
+#define USBHS_DEVDMASTATUS_CHANN_ACT        USBHS_DEVDMASTATUS_CHANN_ACT_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_CHANN_ACT_Msk instead */
+#define USBHS_DEVDMASTATUS_END_TR_ST_Pos    4                                              /**< (USBHS_DEVDMASTATUS) End of Channel Transfer Status Position */
+#define USBHS_DEVDMASTATUS_END_TR_ST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_END_TR_ST_Pos)  /**< (USBHS_DEVDMASTATUS) End of Channel Transfer Status Mask */
+#define USBHS_DEVDMASTATUS_END_TR_ST        USBHS_DEVDMASTATUS_END_TR_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_END_TR_ST_Msk instead */
+#define USBHS_DEVDMASTATUS_END_BF_ST_Pos    5                                              /**< (USBHS_DEVDMASTATUS) End of Channel Buffer Status Position */
+#define USBHS_DEVDMASTATUS_END_BF_ST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_END_BF_ST_Pos)  /**< (USBHS_DEVDMASTATUS) End of Channel Buffer Status Mask */
+#define USBHS_DEVDMASTATUS_END_BF_ST        USBHS_DEVDMASTATUS_END_BF_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_END_BF_ST_Msk instead */
+#define USBHS_DEVDMASTATUS_DESC_LDST_Pos    6                                              /**< (USBHS_DEVDMASTATUS) Descriptor Loaded Status Position */
+#define USBHS_DEVDMASTATUS_DESC_LDST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_DESC_LDST_Pos)  /**< (USBHS_DEVDMASTATUS) Descriptor Loaded Status Mask */
+#define USBHS_DEVDMASTATUS_DESC_LDST        USBHS_DEVDMASTATUS_DESC_LDST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_DESC_LDST_Msk instead */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT_Pos   16                                             /**< (USBHS_DEVDMASTATUS) Buffer Byte Count Position */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT_Msk   (_U_(0xFFFF) << USBHS_DEVDMASTATUS_BUFF_COUNT_Pos)  /**< (USBHS_DEVDMASTATUS) Buffer Byte Count Mask */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT(value) (USBHS_DEVDMASTATUS_BUFF_COUNT_Msk & ((value) << USBHS_DEVDMASTATUS_BUFF_COUNT_Pos))
+#define USBHS_DEVDMASTATUS_MASK             _U_(0xFFFF0073)                                /**< \deprecated (USBHS_DEVDMASTATUS) Register MASK  (Use USBHS_DEVDMASTATUS_Msk instead)  */
+#define USBHS_DEVDMASTATUS_Msk              _U_(0xFFFF0073)                                /**< (USBHS_DEVDMASTATUS) Register Mask  */
+
+
+/* -------- USBHS_HSTDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Host DMA Channel Next Descriptor Address Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMANXTDSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_HSTDMANXTDSC) Host DMA Channel Next Descriptor Address Register (n = 1)  Offset */
+
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Position */
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Mask */
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD(value) (USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Msk & ((value) << USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos))
+#define USBHS_HSTDMANXTDSC_MASK             _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_HSTDMANXTDSC) Register MASK  (Use USBHS_HSTDMANXTDSC_Msk instead)  */
+#define USBHS_HSTDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMANXTDSC) Register Mask  */
+
+
+/* -------- USBHS_HSTDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Host DMA Channel Address Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMAADDRESS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_HSTDMAADDRESS) Host DMA Channel Address Register (n = 1)  Offset */
+
+#define USBHS_HSTDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_HSTDMAADDRESS) Buffer Address Position */
+#define USBHS_HSTDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_HSTDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_HSTDMAADDRESS) Buffer Address Mask */
+#define USBHS_HSTDMAADDRESS_BUFF_ADD(value) (USBHS_HSTDMAADDRESS_BUFF_ADD_Msk & ((value) << USBHS_HSTDMAADDRESS_BUFF_ADD_Pos))
+#define USBHS_HSTDMAADDRESS_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_HSTDMAADDRESS) Register MASK  (Use USBHS_HSTDMAADDRESS_Msk instead)  */
+#define USBHS_HSTDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMAADDRESS) Register Mask  */
+
+
+/* -------- USBHS_HSTDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Host DMA Channel Control Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
+    uint32_t LDNXT_DSC:1;               /**< bit:      1  Load Next Channel Transfer Descriptor Enable Command */
+    uint32_t END_TR_EN:1;               /**< bit:      2  End of Transfer Enable Control (OUT transfers only) */
+    uint32_t END_B_EN:1;                /**< bit:      3  End of Buffer Enable Control             */
+    uint32_t END_TR_IT:1;               /**< bit:      4  End of Transfer Interrupt Enable         */
+    uint32_t END_BUFFIT:1;              /**< bit:      5  End of Buffer Interrupt Enable           */
+    uint32_t DESC_LD_IT:1;              /**< bit:      6  Descriptor Loaded Interrupt Enable       */
+    uint32_t BURST_LCK:1;               /**< bit:      7  Burst Lock Enable                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t BUFF_LENGTH:16;            /**< bit: 16..31  Buffer Byte Length (Write-only)          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMACONTROL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_HSTDMACONTROL) Host DMA Channel Control Register (n = 1)  Offset */
+
+#define USBHS_HSTDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_HSTDMACONTROL) Channel Enable Command Position */
+#define USBHS_HSTDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_HSTDMACONTROL) Channel Enable Command Mask */
+#define USBHS_HSTDMACONTROL_CHANN_ENB       USBHS_HSTDMACONTROL_CHANN_ENB_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_CHANN_ENB_Msk instead */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC_Pos   1                                              /**< (USBHS_HSTDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Position */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_LDNXT_DSC_Pos)  /**< (USBHS_HSTDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Mask */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC       USBHS_HSTDMACONTROL_LDNXT_DSC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_LDNXT_DSC_Msk instead */
+#define USBHS_HSTDMACONTROL_END_TR_EN_Pos   2                                              /**< (USBHS_HSTDMACONTROL) End of Transfer Enable Control (OUT transfers only) Position */
+#define USBHS_HSTDMACONTROL_END_TR_EN_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_END_TR_EN_Pos)  /**< (USBHS_HSTDMACONTROL) End of Transfer Enable Control (OUT transfers only) Mask */
+#define USBHS_HSTDMACONTROL_END_TR_EN       USBHS_HSTDMACONTROL_END_TR_EN_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_TR_EN_Msk instead */
+#define USBHS_HSTDMACONTROL_END_B_EN_Pos    3                                              /**< (USBHS_HSTDMACONTROL) End of Buffer Enable Control Position */
+#define USBHS_HSTDMACONTROL_END_B_EN_Msk    (_U_(0x1) << USBHS_HSTDMACONTROL_END_B_EN_Pos)  /**< (USBHS_HSTDMACONTROL) End of Buffer Enable Control Mask */
+#define USBHS_HSTDMACONTROL_END_B_EN        USBHS_HSTDMACONTROL_END_B_EN_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_B_EN_Msk instead */
+#define USBHS_HSTDMACONTROL_END_TR_IT_Pos   4                                              /**< (USBHS_HSTDMACONTROL) End of Transfer Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_END_TR_IT_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_END_TR_IT_Pos)  /**< (USBHS_HSTDMACONTROL) End of Transfer Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_END_TR_IT       USBHS_HSTDMACONTROL_END_TR_IT_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_TR_IT_Msk instead */
+#define USBHS_HSTDMACONTROL_END_BUFFIT_Pos  5                                              /**< (USBHS_HSTDMACONTROL) End of Buffer Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_END_BUFFIT_Msk  (_U_(0x1) << USBHS_HSTDMACONTROL_END_BUFFIT_Pos)  /**< (USBHS_HSTDMACONTROL) End of Buffer Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_END_BUFFIT      USBHS_HSTDMACONTROL_END_BUFFIT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_BUFFIT_Msk instead */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT_Pos  6                                              /**< (USBHS_HSTDMACONTROL) Descriptor Loaded Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT_Msk  (_U_(0x1) << USBHS_HSTDMACONTROL_DESC_LD_IT_Pos)  /**< (USBHS_HSTDMACONTROL) Descriptor Loaded Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT      USBHS_HSTDMACONTROL_DESC_LD_IT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_DESC_LD_IT_Msk instead */
+#define USBHS_HSTDMACONTROL_BURST_LCK_Pos   7                                              /**< (USBHS_HSTDMACONTROL) Burst Lock Enable Position */
+#define USBHS_HSTDMACONTROL_BURST_LCK_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_BURST_LCK_Pos)  /**< (USBHS_HSTDMACONTROL) Burst Lock Enable Mask */
+#define USBHS_HSTDMACONTROL_BURST_LCK       USBHS_HSTDMACONTROL_BURST_LCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_BURST_LCK_Msk instead */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos 16                                             /**< (USBHS_HSTDMACONTROL) Buffer Byte Length (Write-only) Position */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH_Msk (_U_(0xFFFF) << USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos)  /**< (USBHS_HSTDMACONTROL) Buffer Byte Length (Write-only) Mask */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH(value) (USBHS_HSTDMACONTROL_BUFF_LENGTH_Msk & ((value) << USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos))
+#define USBHS_HSTDMACONTROL_MASK            _U_(0xFFFF00FF)                                /**< \deprecated (USBHS_HSTDMACONTROL) Register MASK  (Use USBHS_HSTDMACONTROL_Msk instead)  */
+#define USBHS_HSTDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_HSTDMACONTROL) Register Mask  */
+
+
+/* -------- USBHS_HSTDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Host DMA Channel Status Register (n = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
+    uint32_t CHANN_ACT:1;               /**< bit:      1  Channel Active Status                    */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t END_TR_ST:1;               /**< bit:      4  End of Channel Transfer Status           */
+    uint32_t END_BF_ST:1;               /**< bit:      5  End of Channel Buffer Status             */
+    uint32_t DESC_LDST:1;               /**< bit:      6  Descriptor Loaded Status                 */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t BUFF_COUNT:16;             /**< bit: 16..31  Buffer Byte Count                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMASTATUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_HSTDMASTATUS) Host DMA Channel Status Register (n = 1)  Offset */
+
+#define USBHS_HSTDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_HSTDMASTATUS) Channel Enable Status Position */
+#define USBHS_HSTDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_HSTDMASTATUS) Channel Enable Status Mask */
+#define USBHS_HSTDMASTATUS_CHANN_ENB        USBHS_HSTDMASTATUS_CHANN_ENB_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_CHANN_ENB_Msk instead */
+#define USBHS_HSTDMASTATUS_CHANN_ACT_Pos    1                                              /**< (USBHS_HSTDMASTATUS) Channel Active Status Position */
+#define USBHS_HSTDMASTATUS_CHANN_ACT_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_CHANN_ACT_Pos)  /**< (USBHS_HSTDMASTATUS) Channel Active Status Mask */
+#define USBHS_HSTDMASTATUS_CHANN_ACT        USBHS_HSTDMASTATUS_CHANN_ACT_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_CHANN_ACT_Msk instead */
+#define USBHS_HSTDMASTATUS_END_TR_ST_Pos    4                                              /**< (USBHS_HSTDMASTATUS) End of Channel Transfer Status Position */
+#define USBHS_HSTDMASTATUS_END_TR_ST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_END_TR_ST_Pos)  /**< (USBHS_HSTDMASTATUS) End of Channel Transfer Status Mask */
+#define USBHS_HSTDMASTATUS_END_TR_ST        USBHS_HSTDMASTATUS_END_TR_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_END_TR_ST_Msk instead */
+#define USBHS_HSTDMASTATUS_END_BF_ST_Pos    5                                              /**< (USBHS_HSTDMASTATUS) End of Channel Buffer Status Position */
+#define USBHS_HSTDMASTATUS_END_BF_ST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_END_BF_ST_Pos)  /**< (USBHS_HSTDMASTATUS) End of Channel Buffer Status Mask */
+#define USBHS_HSTDMASTATUS_END_BF_ST        USBHS_HSTDMASTATUS_END_BF_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_END_BF_ST_Msk instead */
+#define USBHS_HSTDMASTATUS_DESC_LDST_Pos    6                                              /**< (USBHS_HSTDMASTATUS) Descriptor Loaded Status Position */
+#define USBHS_HSTDMASTATUS_DESC_LDST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_DESC_LDST_Pos)  /**< (USBHS_HSTDMASTATUS) Descriptor Loaded Status Mask */
+#define USBHS_HSTDMASTATUS_DESC_LDST        USBHS_HSTDMASTATUS_DESC_LDST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_DESC_LDST_Msk instead */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT_Pos   16                                             /**< (USBHS_HSTDMASTATUS) Buffer Byte Count Position */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT_Msk   (_U_(0xFFFF) << USBHS_HSTDMASTATUS_BUFF_COUNT_Pos)  /**< (USBHS_HSTDMASTATUS) Buffer Byte Count Mask */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT(value) (USBHS_HSTDMASTATUS_BUFF_COUNT_Msk & ((value) << USBHS_HSTDMASTATUS_BUFF_COUNT_Pos))
+#define USBHS_HSTDMASTATUS_MASK             _U_(0xFFFF0073)                                /**< \deprecated (USBHS_HSTDMASTATUS) Register MASK  (Use USBHS_HSTDMASTATUS_Msk instead)  */
+#define USBHS_HSTDMASTATUS_Msk              _U_(0xFFFF0073)                                /**< (USBHS_HSTDMASTATUS) Register Mask  */
+
+
+/* -------- USBHS_DEVCTRL : (USBHS Offset: 0x00) (R/W 32) Device General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UADD:7;                    /**< bit:   0..6  USB Address                              */
+    uint32_t ADDEN:1;                   /**< bit:      7  Address Enable                           */
+    uint32_t DETACH:1;                  /**< bit:      8  Detach                                   */
+    uint32_t RMWKUP:1;                  /**< bit:      9  Remote Wake-Up                           */
+    uint32_t SPDCONF:2;                 /**< bit: 10..11  Mode Configuration                       */
+    uint32_t LS:1;                      /**< bit:     12  Low-Speed Mode Force                     */
+    uint32_t TSTJ:1;                    /**< bit:     13  Test mode J                              */
+    uint32_t TSTK:1;                    /**< bit:     14  Test mode K                              */
+    uint32_t TSTPCKT:1;                 /**< bit:     15  Test packet mode                         */
+    uint32_t OPMODE2:1;                 /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t OPMODE:1;                  /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVCTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVCTRL_OFFSET                (0x00)                                        /**<  (USBHS_DEVCTRL) Device General Control Register  Offset */
+
+#define USBHS_DEVCTRL_UADD_Pos              0                                              /**< (USBHS_DEVCTRL) USB Address Position */
+#define USBHS_DEVCTRL_UADD_Msk              (_U_(0x7F) << USBHS_DEVCTRL_UADD_Pos)          /**< (USBHS_DEVCTRL) USB Address Mask */
+#define USBHS_DEVCTRL_UADD(value)           (USBHS_DEVCTRL_UADD_Msk & ((value) << USBHS_DEVCTRL_UADD_Pos))
+#define USBHS_DEVCTRL_ADDEN_Pos             7                                              /**< (USBHS_DEVCTRL) Address Enable Position */
+#define USBHS_DEVCTRL_ADDEN_Msk             (_U_(0x1) << USBHS_DEVCTRL_ADDEN_Pos)          /**< (USBHS_DEVCTRL) Address Enable Mask */
+#define USBHS_DEVCTRL_ADDEN                 USBHS_DEVCTRL_ADDEN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_ADDEN_Msk instead */
+#define USBHS_DEVCTRL_DETACH_Pos            8                                              /**< (USBHS_DEVCTRL) Detach Position */
+#define USBHS_DEVCTRL_DETACH_Msk            (_U_(0x1) << USBHS_DEVCTRL_DETACH_Pos)         /**< (USBHS_DEVCTRL) Detach Mask */
+#define USBHS_DEVCTRL_DETACH                USBHS_DEVCTRL_DETACH_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_DETACH_Msk instead */
+#define USBHS_DEVCTRL_RMWKUP_Pos            9                                              /**< (USBHS_DEVCTRL) Remote Wake-Up Position */
+#define USBHS_DEVCTRL_RMWKUP_Msk            (_U_(0x1) << USBHS_DEVCTRL_RMWKUP_Pos)         /**< (USBHS_DEVCTRL) Remote Wake-Up Mask */
+#define USBHS_DEVCTRL_RMWKUP                USBHS_DEVCTRL_RMWKUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_RMWKUP_Msk instead */
+#define USBHS_DEVCTRL_SPDCONF_Pos           10                                             /**< (USBHS_DEVCTRL) Mode Configuration Position */
+#define USBHS_DEVCTRL_SPDCONF_Msk           (_U_(0x3) << USBHS_DEVCTRL_SPDCONF_Pos)        /**< (USBHS_DEVCTRL) Mode Configuration Mask */
+#define USBHS_DEVCTRL_SPDCONF(value)        (USBHS_DEVCTRL_SPDCONF_Msk & ((value) << USBHS_DEVCTRL_SPDCONF_Pos))
+#define   USBHS_DEVCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable.  */
+#define   USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_DEVCTRL) Forced high speed.  */
+#define   USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability.  */
+#define USBHS_DEVCTRL_SPDCONF_NORMAL        (USBHS_DEVCTRL_SPDCONF_NORMAL_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable. Position  */
+#define USBHS_DEVCTRL_SPDCONF_LOW_POWER     (USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_HIGH_SPEED    (USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) Forced high speed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_FORCED_FS     (USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability. Position  */
+#define USBHS_DEVCTRL_LS_Pos                12                                             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Position */
+#define USBHS_DEVCTRL_LS_Msk                (_U_(0x1) << USBHS_DEVCTRL_LS_Pos)             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Mask */
+#define USBHS_DEVCTRL_LS                    USBHS_DEVCTRL_LS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_LS_Msk instead */
+#define USBHS_DEVCTRL_TSTJ_Pos              13                                             /**< (USBHS_DEVCTRL) Test mode J Position */
+#define USBHS_DEVCTRL_TSTJ_Msk              (_U_(0x1) << USBHS_DEVCTRL_TSTJ_Pos)           /**< (USBHS_DEVCTRL) Test mode J Mask */
+#define USBHS_DEVCTRL_TSTJ                  USBHS_DEVCTRL_TSTJ_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTJ_Msk instead */
+#define USBHS_DEVCTRL_TSTK_Pos              14                                             /**< (USBHS_DEVCTRL) Test mode K Position */
+#define USBHS_DEVCTRL_TSTK_Msk              (_U_(0x1) << USBHS_DEVCTRL_TSTK_Pos)           /**< (USBHS_DEVCTRL) Test mode K Mask */
+#define USBHS_DEVCTRL_TSTK                  USBHS_DEVCTRL_TSTK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTK_Msk instead */
+#define USBHS_DEVCTRL_TSTPCKT_Pos           15                                             /**< (USBHS_DEVCTRL) Test packet mode Position */
+#define USBHS_DEVCTRL_TSTPCKT_Msk           (_U_(0x1) << USBHS_DEVCTRL_TSTPCKT_Pos)        /**< (USBHS_DEVCTRL) Test packet mode Mask */
+#define USBHS_DEVCTRL_TSTPCKT               USBHS_DEVCTRL_TSTPCKT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTPCKT_Msk instead */
+#define USBHS_DEVCTRL_OPMODE2_Pos           16                                             /**< (USBHS_DEVCTRL) Specific Operational mode Position */
+#define USBHS_DEVCTRL_OPMODE2_Msk           (_U_(0x1) << USBHS_DEVCTRL_OPMODE2_Pos)        /**< (USBHS_DEVCTRL) Specific Operational mode Mask */
+#define USBHS_DEVCTRL_OPMODE2               USBHS_DEVCTRL_OPMODE2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_OPMODE2_Msk instead */
+#define USBHS_DEVCTRL_MASK                  _U_(0x1FFFF)                                   /**< \deprecated (USBHS_DEVCTRL) Register MASK  (Use USBHS_DEVCTRL_Msk instead)  */
+#define USBHS_DEVCTRL_Msk                   _U_(0x1FFFF)                                   /**< (USBHS_DEVCTRL) Register Mask  */
+
+#define USBHS_DEVCTRL_OPMODE_Pos            16                                             /**< (USBHS_DEVCTRL Position) Specific Operational mode */
+#define USBHS_DEVCTRL_OPMODE_Msk            (_U_(0x1) << USBHS_DEVCTRL_OPMODE_Pos)         /**< (USBHS_DEVCTRL Mask) OPMODE */
+#define USBHS_DEVCTRL_OPMODE(value)         (USBHS_DEVCTRL_OPMODE_Msk & ((value) << USBHS_DEVCTRL_OPMODE_Pos))  
+
+/* -------- USBHS_DEVISR : (USBHS Offset: 0x04) (R/ 32) Device Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSP:1;                    /**< bit:      0  Suspend Interrupt                        */
+    uint32_t MSOF:1;                    /**< bit:      1  Micro Start of Frame Interrupt           */
+    uint32_t SOF:1;                     /**< bit:      2  Start of Frame Interrupt                 */
+    uint32_t EORST:1;                   /**< bit:      3  End of Reset Interrupt                   */
+    uint32_t WAKEUP:1;                  /**< bit:      4  Wake-Up Interrupt                        */
+    uint32_t EORSM:1;                   /**< bit:      5  End of Resume Interrupt                  */
+    uint32_t UPRSM:1;                   /**< bit:      6  Upstream Resume Interrupt                */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt                     */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt                     */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt                     */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt                     */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt                     */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt                     */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt                     */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt                     */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt                     */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt                     */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt                  */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt                  */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt                  */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt                  */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt                  */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt                  */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt                     */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVISR_OFFSET                 (0x04)                                        /**<  (USBHS_DEVISR) Device Global Interrupt Status Register  Offset */
+
+#define USBHS_DEVISR_SUSP_Pos               0                                              /**< (USBHS_DEVISR) Suspend Interrupt Position */
+#define USBHS_DEVISR_SUSP_Msk               (_U_(0x1) << USBHS_DEVISR_SUSP_Pos)            /**< (USBHS_DEVISR) Suspend Interrupt Mask */
+#define USBHS_DEVISR_SUSP                   USBHS_DEVISR_SUSP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_SUSP_Msk instead */
+#define USBHS_DEVISR_MSOF_Pos               1                                              /**< (USBHS_DEVISR) Micro Start of Frame Interrupt Position */
+#define USBHS_DEVISR_MSOF_Msk               (_U_(0x1) << USBHS_DEVISR_MSOF_Pos)            /**< (USBHS_DEVISR) Micro Start of Frame Interrupt Mask */
+#define USBHS_DEVISR_MSOF                   USBHS_DEVISR_MSOF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_MSOF_Msk instead */
+#define USBHS_DEVISR_SOF_Pos                2                                              /**< (USBHS_DEVISR) Start of Frame Interrupt Position */
+#define USBHS_DEVISR_SOF_Msk                (_U_(0x1) << USBHS_DEVISR_SOF_Pos)             /**< (USBHS_DEVISR) Start of Frame Interrupt Mask */
+#define USBHS_DEVISR_SOF                    USBHS_DEVISR_SOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_SOF_Msk instead */
+#define USBHS_DEVISR_EORST_Pos              3                                              /**< (USBHS_DEVISR) End of Reset Interrupt Position */
+#define USBHS_DEVISR_EORST_Msk              (_U_(0x1) << USBHS_DEVISR_EORST_Pos)           /**< (USBHS_DEVISR) End of Reset Interrupt Mask */
+#define USBHS_DEVISR_EORST                  USBHS_DEVISR_EORST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_EORST_Msk instead */
+#define USBHS_DEVISR_WAKEUP_Pos             4                                              /**< (USBHS_DEVISR) Wake-Up Interrupt Position */
+#define USBHS_DEVISR_WAKEUP_Msk             (_U_(0x1) << USBHS_DEVISR_WAKEUP_Pos)          /**< (USBHS_DEVISR) Wake-Up Interrupt Mask */
+#define USBHS_DEVISR_WAKEUP                 USBHS_DEVISR_WAKEUP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_WAKEUP_Msk instead */
+#define USBHS_DEVISR_EORSM_Pos              5                                              /**< (USBHS_DEVISR) End of Resume Interrupt Position */
+#define USBHS_DEVISR_EORSM_Msk              (_U_(0x1) << USBHS_DEVISR_EORSM_Pos)           /**< (USBHS_DEVISR) End of Resume Interrupt Mask */
+#define USBHS_DEVISR_EORSM                  USBHS_DEVISR_EORSM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_EORSM_Msk instead */
+#define USBHS_DEVISR_UPRSM_Pos              6                                              /**< (USBHS_DEVISR) Upstream Resume Interrupt Position */
+#define USBHS_DEVISR_UPRSM_Msk              (_U_(0x1) << USBHS_DEVISR_UPRSM_Pos)           /**< (USBHS_DEVISR) Upstream Resume Interrupt Mask */
+#define USBHS_DEVISR_UPRSM                  USBHS_DEVISR_UPRSM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_UPRSM_Msk instead */
+#define USBHS_DEVISR_PEP_0_Pos              12                                             /**< (USBHS_DEVISR) Endpoint 0 Interrupt Position */
+#define USBHS_DEVISR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_0_Pos)           /**< (USBHS_DEVISR) Endpoint 0 Interrupt Mask */
+#define USBHS_DEVISR_PEP_0                  USBHS_DEVISR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_0_Msk instead */
+#define USBHS_DEVISR_PEP_1_Pos              13                                             /**< (USBHS_DEVISR) Endpoint 1 Interrupt Position */
+#define USBHS_DEVISR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_1_Pos)           /**< (USBHS_DEVISR) Endpoint 1 Interrupt Mask */
+#define USBHS_DEVISR_PEP_1                  USBHS_DEVISR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_1_Msk instead */
+#define USBHS_DEVISR_PEP_2_Pos              14                                             /**< (USBHS_DEVISR) Endpoint 2 Interrupt Position */
+#define USBHS_DEVISR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_2_Pos)           /**< (USBHS_DEVISR) Endpoint 2 Interrupt Mask */
+#define USBHS_DEVISR_PEP_2                  USBHS_DEVISR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_2_Msk instead */
+#define USBHS_DEVISR_PEP_3_Pos              15                                             /**< (USBHS_DEVISR) Endpoint 3 Interrupt Position */
+#define USBHS_DEVISR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_3_Pos)           /**< (USBHS_DEVISR) Endpoint 3 Interrupt Mask */
+#define USBHS_DEVISR_PEP_3                  USBHS_DEVISR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_3_Msk instead */
+#define USBHS_DEVISR_PEP_4_Pos              16                                             /**< (USBHS_DEVISR) Endpoint 4 Interrupt Position */
+#define USBHS_DEVISR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_4_Pos)           /**< (USBHS_DEVISR) Endpoint 4 Interrupt Mask */
+#define USBHS_DEVISR_PEP_4                  USBHS_DEVISR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_4_Msk instead */
+#define USBHS_DEVISR_PEP_5_Pos              17                                             /**< (USBHS_DEVISR) Endpoint 5 Interrupt Position */
+#define USBHS_DEVISR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_5_Pos)           /**< (USBHS_DEVISR) Endpoint 5 Interrupt Mask */
+#define USBHS_DEVISR_PEP_5                  USBHS_DEVISR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_5_Msk instead */
+#define USBHS_DEVISR_PEP_6_Pos              18                                             /**< (USBHS_DEVISR) Endpoint 6 Interrupt Position */
+#define USBHS_DEVISR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_6_Pos)           /**< (USBHS_DEVISR) Endpoint 6 Interrupt Mask */
+#define USBHS_DEVISR_PEP_6                  USBHS_DEVISR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_6_Msk instead */
+#define USBHS_DEVISR_PEP_7_Pos              19                                             /**< (USBHS_DEVISR) Endpoint 7 Interrupt Position */
+#define USBHS_DEVISR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_7_Pos)           /**< (USBHS_DEVISR) Endpoint 7 Interrupt Mask */
+#define USBHS_DEVISR_PEP_7                  USBHS_DEVISR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_7_Msk instead */
+#define USBHS_DEVISR_PEP_8_Pos              20                                             /**< (USBHS_DEVISR) Endpoint 8 Interrupt Position */
+#define USBHS_DEVISR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_8_Pos)           /**< (USBHS_DEVISR) Endpoint 8 Interrupt Mask */
+#define USBHS_DEVISR_PEP_8                  USBHS_DEVISR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_8_Msk instead */
+#define USBHS_DEVISR_PEP_9_Pos              21                                             /**< (USBHS_DEVISR) Endpoint 9 Interrupt Position */
+#define USBHS_DEVISR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_9_Pos)           /**< (USBHS_DEVISR) Endpoint 9 Interrupt Mask */
+#define USBHS_DEVISR_PEP_9                  USBHS_DEVISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_9_Msk instead */
+#define USBHS_DEVISR_DMA_1_Pos              25                                             /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Position */
+#define USBHS_DEVISR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_1_Pos)           /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Mask */
+#define USBHS_DEVISR_DMA_1                  USBHS_DEVISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_1_Msk instead */
+#define USBHS_DEVISR_DMA_2_Pos              26                                             /**< (USBHS_DEVISR) DMA Channel 2 Interrupt Position */
+#define USBHS_DEVISR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_2_Pos)           /**< (USBHS_DEVISR) DMA Channel 2 Interrupt Mask */
+#define USBHS_DEVISR_DMA_2                  USBHS_DEVISR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_2_Msk instead */
+#define USBHS_DEVISR_DMA_3_Pos              27                                             /**< (USBHS_DEVISR) DMA Channel 3 Interrupt Position */
+#define USBHS_DEVISR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_3_Pos)           /**< (USBHS_DEVISR) DMA Channel 3 Interrupt Mask */
+#define USBHS_DEVISR_DMA_3                  USBHS_DEVISR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_3_Msk instead */
+#define USBHS_DEVISR_DMA_4_Pos              28                                             /**< (USBHS_DEVISR) DMA Channel 4 Interrupt Position */
+#define USBHS_DEVISR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_4_Pos)           /**< (USBHS_DEVISR) DMA Channel 4 Interrupt Mask */
+#define USBHS_DEVISR_DMA_4                  USBHS_DEVISR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_4_Msk instead */
+#define USBHS_DEVISR_DMA_5_Pos              29                                             /**< (USBHS_DEVISR) DMA Channel 5 Interrupt Position */
+#define USBHS_DEVISR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_5_Pos)           /**< (USBHS_DEVISR) DMA Channel 5 Interrupt Mask */
+#define USBHS_DEVISR_DMA_5                  USBHS_DEVISR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_5_Msk instead */
+#define USBHS_DEVISR_DMA_6_Pos              30                                             /**< (USBHS_DEVISR) DMA Channel 6 Interrupt Position */
+#define USBHS_DEVISR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_6_Pos)           /**< (USBHS_DEVISR) DMA Channel 6 Interrupt Mask */
+#define USBHS_DEVISR_DMA_6                  USBHS_DEVISR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_6_Msk instead */
+#define USBHS_DEVISR_DMA_7_Pos              31                                             /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Position */
+#define USBHS_DEVISR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_7_Pos)           /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Mask */
+#define USBHS_DEVISR_DMA_7                  USBHS_DEVISR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_7_Msk instead */
+#define USBHS_DEVISR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVISR) Register MASK  (Use USBHS_DEVISR_Msk instead)  */
+#define USBHS_DEVISR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVISR) Register Mask  */
+
+#define USBHS_DEVISR_PEP__Pos               12                                             /**< (USBHS_DEVISR Position) Endpoint x Interrupt */
+#define USBHS_DEVISR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVISR_PEP__Pos)          /**< (USBHS_DEVISR Mask) PEP_ */
+#define USBHS_DEVISR_PEP_(value)            (USBHS_DEVISR_PEP__Msk & ((value) << USBHS_DEVISR_PEP__Pos))  
+#define USBHS_DEVISR_DMA__Pos               25                                             /**< (USBHS_DEVISR Position) DMA Channel 7 Interrupt */
+#define USBHS_DEVISR_DMA__Msk               (_U_(0x7F) << USBHS_DEVISR_DMA__Pos)           /**< (USBHS_DEVISR Mask) DMA_ */
+#define USBHS_DEVISR_DMA_(value)            (USBHS_DEVISR_DMA__Msk & ((value) << USBHS_DEVISR_DMA__Pos))  
+
+/* -------- USBHS_DEVICR : (USBHS Offset: 0x08) (/W 32) Device Global Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPC:1;                   /**< bit:      0  Suspend Interrupt Clear                  */
+    uint32_t MSOFC:1;                   /**< bit:      1  Micro Start of Frame Interrupt Clear     */
+    uint32_t SOFC:1;                    /**< bit:      2  Start of Frame Interrupt Clear           */
+    uint32_t EORSTC:1;                  /**< bit:      3  End of Reset Interrupt Clear             */
+    uint32_t WAKEUPC:1;                 /**< bit:      4  Wake-Up Interrupt Clear                  */
+    uint32_t EORSMC:1;                  /**< bit:      5  End of Resume Interrupt Clear            */
+    uint32_t UPRSMC:1;                  /**< bit:      6  Upstream Resume Interrupt Clear          */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVICR_OFFSET                 (0x08)                                        /**<  (USBHS_DEVICR) Device Global Interrupt Clear Register  Offset */
+
+#define USBHS_DEVICR_SUSPC_Pos              0                                              /**< (USBHS_DEVICR) Suspend Interrupt Clear Position */
+#define USBHS_DEVICR_SUSPC_Msk              (_U_(0x1) << USBHS_DEVICR_SUSPC_Pos)           /**< (USBHS_DEVICR) Suspend Interrupt Clear Mask */
+#define USBHS_DEVICR_SUSPC                  USBHS_DEVICR_SUSPC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_SUSPC_Msk instead */
+#define USBHS_DEVICR_MSOFC_Pos              1                                              /**< (USBHS_DEVICR) Micro Start of Frame Interrupt Clear Position */
+#define USBHS_DEVICR_MSOFC_Msk              (_U_(0x1) << USBHS_DEVICR_MSOFC_Pos)           /**< (USBHS_DEVICR) Micro Start of Frame Interrupt Clear Mask */
+#define USBHS_DEVICR_MSOFC                  USBHS_DEVICR_MSOFC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_MSOFC_Msk instead */
+#define USBHS_DEVICR_SOFC_Pos               2                                              /**< (USBHS_DEVICR) Start of Frame Interrupt Clear Position */
+#define USBHS_DEVICR_SOFC_Msk               (_U_(0x1) << USBHS_DEVICR_SOFC_Pos)            /**< (USBHS_DEVICR) Start of Frame Interrupt Clear Mask */
+#define USBHS_DEVICR_SOFC                   USBHS_DEVICR_SOFC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_SOFC_Msk instead */
+#define USBHS_DEVICR_EORSTC_Pos             3                                              /**< (USBHS_DEVICR) End of Reset Interrupt Clear Position */
+#define USBHS_DEVICR_EORSTC_Msk             (_U_(0x1) << USBHS_DEVICR_EORSTC_Pos)          /**< (USBHS_DEVICR) End of Reset Interrupt Clear Mask */
+#define USBHS_DEVICR_EORSTC                 USBHS_DEVICR_EORSTC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_EORSTC_Msk instead */
+#define USBHS_DEVICR_WAKEUPC_Pos            4                                              /**< (USBHS_DEVICR) Wake-Up Interrupt Clear Position */
+#define USBHS_DEVICR_WAKEUPC_Msk            (_U_(0x1) << USBHS_DEVICR_WAKEUPC_Pos)         /**< (USBHS_DEVICR) Wake-Up Interrupt Clear Mask */
+#define USBHS_DEVICR_WAKEUPC                USBHS_DEVICR_WAKEUPC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_WAKEUPC_Msk instead */
+#define USBHS_DEVICR_EORSMC_Pos             5                                              /**< (USBHS_DEVICR) End of Resume Interrupt Clear Position */
+#define USBHS_DEVICR_EORSMC_Msk             (_U_(0x1) << USBHS_DEVICR_EORSMC_Pos)          /**< (USBHS_DEVICR) End of Resume Interrupt Clear Mask */
+#define USBHS_DEVICR_EORSMC                 USBHS_DEVICR_EORSMC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_EORSMC_Msk instead */
+#define USBHS_DEVICR_UPRSMC_Pos             6                                              /**< (USBHS_DEVICR) Upstream Resume Interrupt Clear Position */
+#define USBHS_DEVICR_UPRSMC_Msk             (_U_(0x1) << USBHS_DEVICR_UPRSMC_Pos)          /**< (USBHS_DEVICR) Upstream Resume Interrupt Clear Mask */
+#define USBHS_DEVICR_UPRSMC                 USBHS_DEVICR_UPRSMC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_UPRSMC_Msk instead */
+#define USBHS_DEVICR_MASK                   _U_(0x7F)                                      /**< \deprecated (USBHS_DEVICR) Register MASK  (Use USBHS_DEVICR_Msk instead)  */
+#define USBHS_DEVICR_Msk                    _U_(0x7F)                                      /**< (USBHS_DEVICR) Register Mask  */
+
+
+/* -------- USBHS_DEVIFR : (USBHS Offset: 0x0c) (/W 32) Device Global Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPS:1;                   /**< bit:      0  Suspend Interrupt Set                    */
+    uint32_t MSOFS:1;                   /**< bit:      1  Micro Start of Frame Interrupt Set       */
+    uint32_t SOFS:1;                    /**< bit:      2  Start of Frame Interrupt Set             */
+    uint32_t EORSTS:1;                  /**< bit:      3  End of Reset Interrupt Set               */
+    uint32_t WAKEUPS:1;                 /**< bit:      4  Wake-Up Interrupt Set                    */
+    uint32_t EORSMS:1;                  /**< bit:      5  End of Resume Interrupt Set              */
+    uint32_t UPRSMS:1;                  /**< bit:      6  Upstream Resume Interrupt Set            */
+    uint32_t :18;                       /**< bit:  7..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Set              */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Set              */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Set              */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Set              */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Set              */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Set              */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Set              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :25;                       /**< bit:  0..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Set              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIFR_OFFSET                 (0x0C)                                        /**<  (USBHS_DEVIFR) Device Global Interrupt Set Register  Offset */
+
+#define USBHS_DEVIFR_SUSPS_Pos              0                                              /**< (USBHS_DEVIFR) Suspend Interrupt Set Position */
+#define USBHS_DEVIFR_SUSPS_Msk              (_U_(0x1) << USBHS_DEVIFR_SUSPS_Pos)           /**< (USBHS_DEVIFR) Suspend Interrupt Set Mask */
+#define USBHS_DEVIFR_SUSPS                  USBHS_DEVIFR_SUSPS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_SUSPS_Msk instead */
+#define USBHS_DEVIFR_MSOFS_Pos              1                                              /**< (USBHS_DEVIFR) Micro Start of Frame Interrupt Set Position */
+#define USBHS_DEVIFR_MSOFS_Msk              (_U_(0x1) << USBHS_DEVIFR_MSOFS_Pos)           /**< (USBHS_DEVIFR) Micro Start of Frame Interrupt Set Mask */
+#define USBHS_DEVIFR_MSOFS                  USBHS_DEVIFR_MSOFS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_MSOFS_Msk instead */
+#define USBHS_DEVIFR_SOFS_Pos               2                                              /**< (USBHS_DEVIFR) Start of Frame Interrupt Set Position */
+#define USBHS_DEVIFR_SOFS_Msk               (_U_(0x1) << USBHS_DEVIFR_SOFS_Pos)            /**< (USBHS_DEVIFR) Start of Frame Interrupt Set Mask */
+#define USBHS_DEVIFR_SOFS                   USBHS_DEVIFR_SOFS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_SOFS_Msk instead */
+#define USBHS_DEVIFR_EORSTS_Pos             3                                              /**< (USBHS_DEVIFR) End of Reset Interrupt Set Position */
+#define USBHS_DEVIFR_EORSTS_Msk             (_U_(0x1) << USBHS_DEVIFR_EORSTS_Pos)          /**< (USBHS_DEVIFR) End of Reset Interrupt Set Mask */
+#define USBHS_DEVIFR_EORSTS                 USBHS_DEVIFR_EORSTS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_EORSTS_Msk instead */
+#define USBHS_DEVIFR_WAKEUPS_Pos            4                                              /**< (USBHS_DEVIFR) Wake-Up Interrupt Set Position */
+#define USBHS_DEVIFR_WAKEUPS_Msk            (_U_(0x1) << USBHS_DEVIFR_WAKEUPS_Pos)         /**< (USBHS_DEVIFR) Wake-Up Interrupt Set Mask */
+#define USBHS_DEVIFR_WAKEUPS                USBHS_DEVIFR_WAKEUPS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_WAKEUPS_Msk instead */
+#define USBHS_DEVIFR_EORSMS_Pos             5                                              /**< (USBHS_DEVIFR) End of Resume Interrupt Set Position */
+#define USBHS_DEVIFR_EORSMS_Msk             (_U_(0x1) << USBHS_DEVIFR_EORSMS_Pos)          /**< (USBHS_DEVIFR) End of Resume Interrupt Set Mask */
+#define USBHS_DEVIFR_EORSMS                 USBHS_DEVIFR_EORSMS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_EORSMS_Msk instead */
+#define USBHS_DEVIFR_UPRSMS_Pos             6                                              /**< (USBHS_DEVIFR) Upstream Resume Interrupt Set Position */
+#define USBHS_DEVIFR_UPRSMS_Msk             (_U_(0x1) << USBHS_DEVIFR_UPRSMS_Pos)          /**< (USBHS_DEVIFR) Upstream Resume Interrupt Set Mask */
+#define USBHS_DEVIFR_UPRSMS                 USBHS_DEVIFR_UPRSMS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_UPRSMS_Msk instead */
+#define USBHS_DEVIFR_DMA_1_Pos              25                                             /**< (USBHS_DEVIFR) DMA Channel 1 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_1_Pos)           /**< (USBHS_DEVIFR) DMA Channel 1 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_1                  USBHS_DEVIFR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_1_Msk instead */
+#define USBHS_DEVIFR_DMA_2_Pos              26                                             /**< (USBHS_DEVIFR) DMA Channel 2 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_2_Pos)           /**< (USBHS_DEVIFR) DMA Channel 2 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_2                  USBHS_DEVIFR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_2_Msk instead */
+#define USBHS_DEVIFR_DMA_3_Pos              27                                             /**< (USBHS_DEVIFR) DMA Channel 3 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_3_Pos)           /**< (USBHS_DEVIFR) DMA Channel 3 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_3                  USBHS_DEVIFR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_3_Msk instead */
+#define USBHS_DEVIFR_DMA_4_Pos              28                                             /**< (USBHS_DEVIFR) DMA Channel 4 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_4_Pos)           /**< (USBHS_DEVIFR) DMA Channel 4 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_4                  USBHS_DEVIFR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_4_Msk instead */
+#define USBHS_DEVIFR_DMA_5_Pos              29                                             /**< (USBHS_DEVIFR) DMA Channel 5 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_5_Pos)           /**< (USBHS_DEVIFR) DMA Channel 5 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_5                  USBHS_DEVIFR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_5_Msk instead */
+#define USBHS_DEVIFR_DMA_6_Pos              30                                             /**< (USBHS_DEVIFR) DMA Channel 6 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_6_Pos)           /**< (USBHS_DEVIFR) DMA Channel 6 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_6                  USBHS_DEVIFR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_6_Msk instead */
+#define USBHS_DEVIFR_DMA_7_Pos              31                                             /**< (USBHS_DEVIFR) DMA Channel 7 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_7_Pos)           /**< (USBHS_DEVIFR) DMA Channel 7 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_7                  USBHS_DEVIFR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_7_Msk instead */
+#define USBHS_DEVIFR_MASK                   _U_(0xFE00007F)                                /**< \deprecated (USBHS_DEVIFR) Register MASK  (Use USBHS_DEVIFR_Msk instead)  */
+#define USBHS_DEVIFR_Msk                    _U_(0xFE00007F)                                /**< (USBHS_DEVIFR) Register Mask  */
+
+#define USBHS_DEVIFR_DMA__Pos               25                                             /**< (USBHS_DEVIFR Position) DMA Channel 7 Interrupt Set */
+#define USBHS_DEVIFR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIFR_DMA__Pos)           /**< (USBHS_DEVIFR Mask) DMA_ */
+#define USBHS_DEVIFR_DMA_(value)            (USBHS_DEVIFR_DMA__Msk & ((value) << USBHS_DEVIFR_DMA__Pos))  
+
+/* -------- USBHS_DEVIMR : (USBHS Offset: 0x10) (R/ 32) Device Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPE:1;                   /**< bit:      0  Suspend Interrupt Mask                   */
+    uint32_t MSOFE:1;                   /**< bit:      1  Micro Start of Frame Interrupt Mask      */
+    uint32_t SOFE:1;                    /**< bit:      2  Start of Frame Interrupt Mask            */
+    uint32_t EORSTE:1;                  /**< bit:      3  End of Reset Interrupt Mask              */
+    uint32_t WAKEUPE:1;                 /**< bit:      4  Wake-Up Interrupt Mask                   */
+    uint32_t EORSME:1;                  /**< bit:      5  End of Resume Interrupt Mask             */
+    uint32_t UPRSME:1;                  /**< bit:      6  Upstream Resume Interrupt Mask           */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Mask                */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Mask                */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Mask                */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Mask                */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Mask                */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Mask                */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Mask                */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Mask                */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Mask                */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Mask                */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Mask             */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Mask             */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Mask             */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Mask             */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Mask             */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Mask             */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Mask             */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Mask                */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Mask             */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIMR_OFFSET                 (0x10)                                        /**<  (USBHS_DEVIMR) Device Global Interrupt Mask Register  Offset */
+
+#define USBHS_DEVIMR_SUSPE_Pos              0                                              /**< (USBHS_DEVIMR) Suspend Interrupt Mask Position */
+#define USBHS_DEVIMR_SUSPE_Msk              (_U_(0x1) << USBHS_DEVIMR_SUSPE_Pos)           /**< (USBHS_DEVIMR) Suspend Interrupt Mask Mask */
+#define USBHS_DEVIMR_SUSPE                  USBHS_DEVIMR_SUSPE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_SUSPE_Msk instead */
+#define USBHS_DEVIMR_MSOFE_Pos              1                                              /**< (USBHS_DEVIMR) Micro Start of Frame Interrupt Mask Position */
+#define USBHS_DEVIMR_MSOFE_Msk              (_U_(0x1) << USBHS_DEVIMR_MSOFE_Pos)           /**< (USBHS_DEVIMR) Micro Start of Frame Interrupt Mask Mask */
+#define USBHS_DEVIMR_MSOFE                  USBHS_DEVIMR_MSOFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_MSOFE_Msk instead */
+#define USBHS_DEVIMR_SOFE_Pos               2                                              /**< (USBHS_DEVIMR) Start of Frame Interrupt Mask Position */
+#define USBHS_DEVIMR_SOFE_Msk               (_U_(0x1) << USBHS_DEVIMR_SOFE_Pos)            /**< (USBHS_DEVIMR) Start of Frame Interrupt Mask Mask */
+#define USBHS_DEVIMR_SOFE                   USBHS_DEVIMR_SOFE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_SOFE_Msk instead */
+#define USBHS_DEVIMR_EORSTE_Pos             3                                              /**< (USBHS_DEVIMR) End of Reset Interrupt Mask Position */
+#define USBHS_DEVIMR_EORSTE_Msk             (_U_(0x1) << USBHS_DEVIMR_EORSTE_Pos)          /**< (USBHS_DEVIMR) End of Reset Interrupt Mask Mask */
+#define USBHS_DEVIMR_EORSTE                 USBHS_DEVIMR_EORSTE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_EORSTE_Msk instead */
+#define USBHS_DEVIMR_WAKEUPE_Pos            4                                              /**< (USBHS_DEVIMR) Wake-Up Interrupt Mask Position */
+#define USBHS_DEVIMR_WAKEUPE_Msk            (_U_(0x1) << USBHS_DEVIMR_WAKEUPE_Pos)         /**< (USBHS_DEVIMR) Wake-Up Interrupt Mask Mask */
+#define USBHS_DEVIMR_WAKEUPE                USBHS_DEVIMR_WAKEUPE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_WAKEUPE_Msk instead */
+#define USBHS_DEVIMR_EORSME_Pos             5                                              /**< (USBHS_DEVIMR) End of Resume Interrupt Mask Position */
+#define USBHS_DEVIMR_EORSME_Msk             (_U_(0x1) << USBHS_DEVIMR_EORSME_Pos)          /**< (USBHS_DEVIMR) End of Resume Interrupt Mask Mask */
+#define USBHS_DEVIMR_EORSME                 USBHS_DEVIMR_EORSME_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_EORSME_Msk instead */
+#define USBHS_DEVIMR_UPRSME_Pos             6                                              /**< (USBHS_DEVIMR) Upstream Resume Interrupt Mask Position */
+#define USBHS_DEVIMR_UPRSME_Msk             (_U_(0x1) << USBHS_DEVIMR_UPRSME_Pos)          /**< (USBHS_DEVIMR) Upstream Resume Interrupt Mask Mask */
+#define USBHS_DEVIMR_UPRSME                 USBHS_DEVIMR_UPRSME_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_UPRSME_Msk instead */
+#define USBHS_DEVIMR_PEP_0_Pos              12                                             /**< (USBHS_DEVIMR) Endpoint 0 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_0_Pos)           /**< (USBHS_DEVIMR) Endpoint 0 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_0                  USBHS_DEVIMR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_0_Msk instead */
+#define USBHS_DEVIMR_PEP_1_Pos              13                                             /**< (USBHS_DEVIMR) Endpoint 1 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_1_Pos)           /**< (USBHS_DEVIMR) Endpoint 1 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_1                  USBHS_DEVIMR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_1_Msk instead */
+#define USBHS_DEVIMR_PEP_2_Pos              14                                             /**< (USBHS_DEVIMR) Endpoint 2 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_2_Pos)           /**< (USBHS_DEVIMR) Endpoint 2 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_2                  USBHS_DEVIMR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_2_Msk instead */
+#define USBHS_DEVIMR_PEP_3_Pos              15                                             /**< (USBHS_DEVIMR) Endpoint 3 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_3_Pos)           /**< (USBHS_DEVIMR) Endpoint 3 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_3                  USBHS_DEVIMR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_3_Msk instead */
+#define USBHS_DEVIMR_PEP_4_Pos              16                                             /**< (USBHS_DEVIMR) Endpoint 4 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_4_Pos)           /**< (USBHS_DEVIMR) Endpoint 4 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_4                  USBHS_DEVIMR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_4_Msk instead */
+#define USBHS_DEVIMR_PEP_5_Pos              17                                             /**< (USBHS_DEVIMR) Endpoint 5 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_5_Pos)           /**< (USBHS_DEVIMR) Endpoint 5 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_5                  USBHS_DEVIMR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_5_Msk instead */
+#define USBHS_DEVIMR_PEP_6_Pos              18                                             /**< (USBHS_DEVIMR) Endpoint 6 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_6_Pos)           /**< (USBHS_DEVIMR) Endpoint 6 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_6                  USBHS_DEVIMR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_6_Msk instead */
+#define USBHS_DEVIMR_PEP_7_Pos              19                                             /**< (USBHS_DEVIMR) Endpoint 7 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_7_Pos)           /**< (USBHS_DEVIMR) Endpoint 7 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_7                  USBHS_DEVIMR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_7_Msk instead */
+#define USBHS_DEVIMR_PEP_8_Pos              20                                             /**< (USBHS_DEVIMR) Endpoint 8 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_8_Pos)           /**< (USBHS_DEVIMR) Endpoint 8 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_8                  USBHS_DEVIMR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_8_Msk instead */
+#define USBHS_DEVIMR_PEP_9_Pos              21                                             /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_9_Pos)           /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_9                  USBHS_DEVIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_9_Msk instead */
+#define USBHS_DEVIMR_DMA_1_Pos              25                                             /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_1_Pos)           /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_1                  USBHS_DEVIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_1_Msk instead */
+#define USBHS_DEVIMR_DMA_2_Pos              26                                             /**< (USBHS_DEVIMR) DMA Channel 2 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_2_Pos)           /**< (USBHS_DEVIMR) DMA Channel 2 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_2                  USBHS_DEVIMR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_2_Msk instead */
+#define USBHS_DEVIMR_DMA_3_Pos              27                                             /**< (USBHS_DEVIMR) DMA Channel 3 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_3_Pos)           /**< (USBHS_DEVIMR) DMA Channel 3 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_3                  USBHS_DEVIMR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_3_Msk instead */
+#define USBHS_DEVIMR_DMA_4_Pos              28                                             /**< (USBHS_DEVIMR) DMA Channel 4 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_4_Pos)           /**< (USBHS_DEVIMR) DMA Channel 4 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_4                  USBHS_DEVIMR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_4_Msk instead */
+#define USBHS_DEVIMR_DMA_5_Pos              29                                             /**< (USBHS_DEVIMR) DMA Channel 5 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_5_Pos)           /**< (USBHS_DEVIMR) DMA Channel 5 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_5                  USBHS_DEVIMR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_5_Msk instead */
+#define USBHS_DEVIMR_DMA_6_Pos              30                                             /**< (USBHS_DEVIMR) DMA Channel 6 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_6_Pos)           /**< (USBHS_DEVIMR) DMA Channel 6 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_6                  USBHS_DEVIMR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_6_Msk instead */
+#define USBHS_DEVIMR_DMA_7_Pos              31                                             /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_7_Pos)           /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_7                  USBHS_DEVIMR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_7_Msk instead */
+#define USBHS_DEVIMR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIMR) Register MASK  (Use USBHS_DEVIMR_Msk instead)  */
+#define USBHS_DEVIMR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIMR) Register Mask  */
+
+#define USBHS_DEVIMR_PEP__Pos               12                                             /**< (USBHS_DEVIMR Position) Endpoint x Interrupt Mask */
+#define USBHS_DEVIMR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIMR_PEP__Pos)          /**< (USBHS_DEVIMR Mask) PEP_ */
+#define USBHS_DEVIMR_PEP_(value)            (USBHS_DEVIMR_PEP__Msk & ((value) << USBHS_DEVIMR_PEP__Pos))  
+#define USBHS_DEVIMR_DMA__Pos               25                                             /**< (USBHS_DEVIMR Position) DMA Channel 7 Interrupt Mask */
+#define USBHS_DEVIMR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIMR_DMA__Pos)           /**< (USBHS_DEVIMR Mask) DMA_ */
+#define USBHS_DEVIMR_DMA_(value)            (USBHS_DEVIMR_DMA__Msk & ((value) << USBHS_DEVIMR_DMA__Pos))  
+
+/* -------- USBHS_DEVIDR : (USBHS Offset: 0x14) (/W 32) Device Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPEC:1;                  /**< bit:      0  Suspend Interrupt Disable                */
+    uint32_t MSOFEC:1;                  /**< bit:      1  Micro Start of Frame Interrupt Disable   */
+    uint32_t SOFEC:1;                   /**< bit:      2  Start of Frame Interrupt Disable         */
+    uint32_t EORSTEC:1;                 /**< bit:      3  End of Reset Interrupt Disable           */
+    uint32_t WAKEUPEC:1;                /**< bit:      4  Wake-Up Interrupt Disable                */
+    uint32_t EORSMEC:1;                 /**< bit:      5  End of Resume Interrupt Disable          */
+    uint32_t UPRSMEC:1;                 /**< bit:      6  Upstream Resume Interrupt Disable        */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Disable             */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Disable             */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Disable             */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Disable             */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Disable             */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Disable             */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Disable             */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Disable             */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Disable             */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Disable             */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Disable          */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Disable          */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Disable          */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Disable          */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Disable          */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Disable          */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Disable          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Disable             */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Disable          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIDR_OFFSET                 (0x14)                                        /**<  (USBHS_DEVIDR) Device Global Interrupt Disable Register  Offset */
+
+#define USBHS_DEVIDR_SUSPEC_Pos             0                                              /**< (USBHS_DEVIDR) Suspend Interrupt Disable Position */
+#define USBHS_DEVIDR_SUSPEC_Msk             (_U_(0x1) << USBHS_DEVIDR_SUSPEC_Pos)          /**< (USBHS_DEVIDR) Suspend Interrupt Disable Mask */
+#define USBHS_DEVIDR_SUSPEC                 USBHS_DEVIDR_SUSPEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_SUSPEC_Msk instead */
+#define USBHS_DEVIDR_MSOFEC_Pos             1                                              /**< (USBHS_DEVIDR) Micro Start of Frame Interrupt Disable Position */
+#define USBHS_DEVIDR_MSOFEC_Msk             (_U_(0x1) << USBHS_DEVIDR_MSOFEC_Pos)          /**< (USBHS_DEVIDR) Micro Start of Frame Interrupt Disable Mask */
+#define USBHS_DEVIDR_MSOFEC                 USBHS_DEVIDR_MSOFEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_MSOFEC_Msk instead */
+#define USBHS_DEVIDR_SOFEC_Pos              2                                              /**< (USBHS_DEVIDR) Start of Frame Interrupt Disable Position */
+#define USBHS_DEVIDR_SOFEC_Msk              (_U_(0x1) << USBHS_DEVIDR_SOFEC_Pos)           /**< (USBHS_DEVIDR) Start of Frame Interrupt Disable Mask */
+#define USBHS_DEVIDR_SOFEC                  USBHS_DEVIDR_SOFEC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_SOFEC_Msk instead */
+#define USBHS_DEVIDR_EORSTEC_Pos            3                                              /**< (USBHS_DEVIDR) End of Reset Interrupt Disable Position */
+#define USBHS_DEVIDR_EORSTEC_Msk            (_U_(0x1) << USBHS_DEVIDR_EORSTEC_Pos)         /**< (USBHS_DEVIDR) End of Reset Interrupt Disable Mask */
+#define USBHS_DEVIDR_EORSTEC                USBHS_DEVIDR_EORSTEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_EORSTEC_Msk instead */
+#define USBHS_DEVIDR_WAKEUPEC_Pos           4                                              /**< (USBHS_DEVIDR) Wake-Up Interrupt Disable Position */
+#define USBHS_DEVIDR_WAKEUPEC_Msk           (_U_(0x1) << USBHS_DEVIDR_WAKEUPEC_Pos)        /**< (USBHS_DEVIDR) Wake-Up Interrupt Disable Mask */
+#define USBHS_DEVIDR_WAKEUPEC               USBHS_DEVIDR_WAKEUPEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_WAKEUPEC_Msk instead */
+#define USBHS_DEVIDR_EORSMEC_Pos            5                                              /**< (USBHS_DEVIDR) End of Resume Interrupt Disable Position */
+#define USBHS_DEVIDR_EORSMEC_Msk            (_U_(0x1) << USBHS_DEVIDR_EORSMEC_Pos)         /**< (USBHS_DEVIDR) End of Resume Interrupt Disable Mask */
+#define USBHS_DEVIDR_EORSMEC                USBHS_DEVIDR_EORSMEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_EORSMEC_Msk instead */
+#define USBHS_DEVIDR_UPRSMEC_Pos            6                                              /**< (USBHS_DEVIDR) Upstream Resume Interrupt Disable Position */
+#define USBHS_DEVIDR_UPRSMEC_Msk            (_U_(0x1) << USBHS_DEVIDR_UPRSMEC_Pos)         /**< (USBHS_DEVIDR) Upstream Resume Interrupt Disable Mask */
+#define USBHS_DEVIDR_UPRSMEC                USBHS_DEVIDR_UPRSMEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_UPRSMEC_Msk instead */
+#define USBHS_DEVIDR_PEP_0_Pos              12                                             /**< (USBHS_DEVIDR) Endpoint 0 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_0_Pos)           /**< (USBHS_DEVIDR) Endpoint 0 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_0                  USBHS_DEVIDR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_0_Msk instead */
+#define USBHS_DEVIDR_PEP_1_Pos              13                                             /**< (USBHS_DEVIDR) Endpoint 1 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_1_Pos)           /**< (USBHS_DEVIDR) Endpoint 1 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_1                  USBHS_DEVIDR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_1_Msk instead */
+#define USBHS_DEVIDR_PEP_2_Pos              14                                             /**< (USBHS_DEVIDR) Endpoint 2 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_2_Pos)           /**< (USBHS_DEVIDR) Endpoint 2 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_2                  USBHS_DEVIDR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_2_Msk instead */
+#define USBHS_DEVIDR_PEP_3_Pos              15                                             /**< (USBHS_DEVIDR) Endpoint 3 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_3_Pos)           /**< (USBHS_DEVIDR) Endpoint 3 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_3                  USBHS_DEVIDR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_3_Msk instead */
+#define USBHS_DEVIDR_PEP_4_Pos              16                                             /**< (USBHS_DEVIDR) Endpoint 4 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_4_Pos)           /**< (USBHS_DEVIDR) Endpoint 4 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_4                  USBHS_DEVIDR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_4_Msk instead */
+#define USBHS_DEVIDR_PEP_5_Pos              17                                             /**< (USBHS_DEVIDR) Endpoint 5 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_5_Pos)           /**< (USBHS_DEVIDR) Endpoint 5 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_5                  USBHS_DEVIDR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_5_Msk instead */
+#define USBHS_DEVIDR_PEP_6_Pos              18                                             /**< (USBHS_DEVIDR) Endpoint 6 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_6_Pos)           /**< (USBHS_DEVIDR) Endpoint 6 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_6                  USBHS_DEVIDR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_6_Msk instead */
+#define USBHS_DEVIDR_PEP_7_Pos              19                                             /**< (USBHS_DEVIDR) Endpoint 7 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_7_Pos)           /**< (USBHS_DEVIDR) Endpoint 7 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_7                  USBHS_DEVIDR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_7_Msk instead */
+#define USBHS_DEVIDR_PEP_8_Pos              20                                             /**< (USBHS_DEVIDR) Endpoint 8 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_8_Pos)           /**< (USBHS_DEVIDR) Endpoint 8 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_8                  USBHS_DEVIDR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_8_Msk instead */
+#define USBHS_DEVIDR_PEP_9_Pos              21                                             /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_9_Pos)           /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_9                  USBHS_DEVIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_9_Msk instead */
+#define USBHS_DEVIDR_DMA_1_Pos              25                                             /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_1_Pos)           /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_1                  USBHS_DEVIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_1_Msk instead */
+#define USBHS_DEVIDR_DMA_2_Pos              26                                             /**< (USBHS_DEVIDR) DMA Channel 2 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_2_Pos)           /**< (USBHS_DEVIDR) DMA Channel 2 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_2                  USBHS_DEVIDR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_2_Msk instead */
+#define USBHS_DEVIDR_DMA_3_Pos              27                                             /**< (USBHS_DEVIDR) DMA Channel 3 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_3_Pos)           /**< (USBHS_DEVIDR) DMA Channel 3 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_3                  USBHS_DEVIDR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_3_Msk instead */
+#define USBHS_DEVIDR_DMA_4_Pos              28                                             /**< (USBHS_DEVIDR) DMA Channel 4 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_4_Pos)           /**< (USBHS_DEVIDR) DMA Channel 4 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_4                  USBHS_DEVIDR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_4_Msk instead */
+#define USBHS_DEVIDR_DMA_5_Pos              29                                             /**< (USBHS_DEVIDR) DMA Channel 5 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_5_Pos)           /**< (USBHS_DEVIDR) DMA Channel 5 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_5                  USBHS_DEVIDR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_5_Msk instead */
+#define USBHS_DEVIDR_DMA_6_Pos              30                                             /**< (USBHS_DEVIDR) DMA Channel 6 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_6_Pos)           /**< (USBHS_DEVIDR) DMA Channel 6 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_6                  USBHS_DEVIDR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_6_Msk instead */
+#define USBHS_DEVIDR_DMA_7_Pos              31                                             /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_7_Pos)           /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_7                  USBHS_DEVIDR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_7_Msk instead */
+#define USBHS_DEVIDR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIDR) Register MASK  (Use USBHS_DEVIDR_Msk instead)  */
+#define USBHS_DEVIDR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIDR) Register Mask  */
+
+#define USBHS_DEVIDR_PEP__Pos               12                                             /**< (USBHS_DEVIDR Position) Endpoint x Interrupt Disable */
+#define USBHS_DEVIDR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIDR_PEP__Pos)          /**< (USBHS_DEVIDR Mask) PEP_ */
+#define USBHS_DEVIDR_PEP_(value)            (USBHS_DEVIDR_PEP__Msk & ((value) << USBHS_DEVIDR_PEP__Pos))  
+#define USBHS_DEVIDR_DMA__Pos               25                                             /**< (USBHS_DEVIDR Position) DMA Channel 7 Interrupt Disable */
+#define USBHS_DEVIDR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIDR_DMA__Pos)           /**< (USBHS_DEVIDR Mask) DMA_ */
+#define USBHS_DEVIDR_DMA_(value)            (USBHS_DEVIDR_DMA__Msk & ((value) << USBHS_DEVIDR_DMA__Pos))  
+
+/* -------- USBHS_DEVIER : (USBHS Offset: 0x18) (/W 32) Device Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPES:1;                  /**< bit:      0  Suspend Interrupt Enable                 */
+    uint32_t MSOFES:1;                  /**< bit:      1  Micro Start of Frame Interrupt Enable    */
+    uint32_t SOFES:1;                   /**< bit:      2  Start of Frame Interrupt Enable          */
+    uint32_t EORSTES:1;                 /**< bit:      3  End of Reset Interrupt Enable            */
+    uint32_t WAKEUPES:1;                /**< bit:      4  Wake-Up Interrupt Enable                 */
+    uint32_t EORSMES:1;                 /**< bit:      5  End of Resume Interrupt Enable           */
+    uint32_t UPRSMES:1;                 /**< bit:      6  Upstream Resume Interrupt Enable         */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Enable              */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Enable              */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Enable              */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Enable              */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Enable              */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Enable              */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Enable              */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Enable              */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Enable              */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Enable              */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Enable              */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIER_OFFSET                 (0x18)                                        /**<  (USBHS_DEVIER) Device Global Interrupt Enable Register  Offset */
+
+#define USBHS_DEVIER_SUSPES_Pos             0                                              /**< (USBHS_DEVIER) Suspend Interrupt Enable Position */
+#define USBHS_DEVIER_SUSPES_Msk             (_U_(0x1) << USBHS_DEVIER_SUSPES_Pos)          /**< (USBHS_DEVIER) Suspend Interrupt Enable Mask */
+#define USBHS_DEVIER_SUSPES                 USBHS_DEVIER_SUSPES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_SUSPES_Msk instead */
+#define USBHS_DEVIER_MSOFES_Pos             1                                              /**< (USBHS_DEVIER) Micro Start of Frame Interrupt Enable Position */
+#define USBHS_DEVIER_MSOFES_Msk             (_U_(0x1) << USBHS_DEVIER_MSOFES_Pos)          /**< (USBHS_DEVIER) Micro Start of Frame Interrupt Enable Mask */
+#define USBHS_DEVIER_MSOFES                 USBHS_DEVIER_MSOFES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_MSOFES_Msk instead */
+#define USBHS_DEVIER_SOFES_Pos              2                                              /**< (USBHS_DEVIER) Start of Frame Interrupt Enable Position */
+#define USBHS_DEVIER_SOFES_Msk              (_U_(0x1) << USBHS_DEVIER_SOFES_Pos)           /**< (USBHS_DEVIER) Start of Frame Interrupt Enable Mask */
+#define USBHS_DEVIER_SOFES                  USBHS_DEVIER_SOFES_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_SOFES_Msk instead */
+#define USBHS_DEVIER_EORSTES_Pos            3                                              /**< (USBHS_DEVIER) End of Reset Interrupt Enable Position */
+#define USBHS_DEVIER_EORSTES_Msk            (_U_(0x1) << USBHS_DEVIER_EORSTES_Pos)         /**< (USBHS_DEVIER) End of Reset Interrupt Enable Mask */
+#define USBHS_DEVIER_EORSTES                USBHS_DEVIER_EORSTES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_EORSTES_Msk instead */
+#define USBHS_DEVIER_WAKEUPES_Pos           4                                              /**< (USBHS_DEVIER) Wake-Up Interrupt Enable Position */
+#define USBHS_DEVIER_WAKEUPES_Msk           (_U_(0x1) << USBHS_DEVIER_WAKEUPES_Pos)        /**< (USBHS_DEVIER) Wake-Up Interrupt Enable Mask */
+#define USBHS_DEVIER_WAKEUPES               USBHS_DEVIER_WAKEUPES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_WAKEUPES_Msk instead */
+#define USBHS_DEVIER_EORSMES_Pos            5                                              /**< (USBHS_DEVIER) End of Resume Interrupt Enable Position */
+#define USBHS_DEVIER_EORSMES_Msk            (_U_(0x1) << USBHS_DEVIER_EORSMES_Pos)         /**< (USBHS_DEVIER) End of Resume Interrupt Enable Mask */
+#define USBHS_DEVIER_EORSMES                USBHS_DEVIER_EORSMES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_EORSMES_Msk instead */
+#define USBHS_DEVIER_UPRSMES_Pos            6                                              /**< (USBHS_DEVIER) Upstream Resume Interrupt Enable Position */
+#define USBHS_DEVIER_UPRSMES_Msk            (_U_(0x1) << USBHS_DEVIER_UPRSMES_Pos)         /**< (USBHS_DEVIER) Upstream Resume Interrupt Enable Mask */
+#define USBHS_DEVIER_UPRSMES                USBHS_DEVIER_UPRSMES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_UPRSMES_Msk instead */
+#define USBHS_DEVIER_PEP_0_Pos              12                                             /**< (USBHS_DEVIER) Endpoint 0 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_0_Pos)           /**< (USBHS_DEVIER) Endpoint 0 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_0                  USBHS_DEVIER_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_0_Msk instead */
+#define USBHS_DEVIER_PEP_1_Pos              13                                             /**< (USBHS_DEVIER) Endpoint 1 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_1_Pos)           /**< (USBHS_DEVIER) Endpoint 1 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_1                  USBHS_DEVIER_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_1_Msk instead */
+#define USBHS_DEVIER_PEP_2_Pos              14                                             /**< (USBHS_DEVIER) Endpoint 2 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_2_Pos)           /**< (USBHS_DEVIER) Endpoint 2 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_2                  USBHS_DEVIER_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_2_Msk instead */
+#define USBHS_DEVIER_PEP_3_Pos              15                                             /**< (USBHS_DEVIER) Endpoint 3 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_3_Pos)           /**< (USBHS_DEVIER) Endpoint 3 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_3                  USBHS_DEVIER_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_3_Msk instead */
+#define USBHS_DEVIER_PEP_4_Pos              16                                             /**< (USBHS_DEVIER) Endpoint 4 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_4_Pos)           /**< (USBHS_DEVIER) Endpoint 4 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_4                  USBHS_DEVIER_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_4_Msk instead */
+#define USBHS_DEVIER_PEP_5_Pos              17                                             /**< (USBHS_DEVIER) Endpoint 5 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_5_Pos)           /**< (USBHS_DEVIER) Endpoint 5 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_5                  USBHS_DEVIER_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_5_Msk instead */
+#define USBHS_DEVIER_PEP_6_Pos              18                                             /**< (USBHS_DEVIER) Endpoint 6 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_6_Pos)           /**< (USBHS_DEVIER) Endpoint 6 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_6                  USBHS_DEVIER_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_6_Msk instead */
+#define USBHS_DEVIER_PEP_7_Pos              19                                             /**< (USBHS_DEVIER) Endpoint 7 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_7_Pos)           /**< (USBHS_DEVIER) Endpoint 7 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_7                  USBHS_DEVIER_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_7_Msk instead */
+#define USBHS_DEVIER_PEP_8_Pos              20                                             /**< (USBHS_DEVIER) Endpoint 8 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_8_Pos)           /**< (USBHS_DEVIER) Endpoint 8 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_8                  USBHS_DEVIER_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_8_Msk instead */
+#define USBHS_DEVIER_PEP_9_Pos              21                                             /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_9_Pos)           /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_9                  USBHS_DEVIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_9_Msk instead */
+#define USBHS_DEVIER_DMA_1_Pos              25                                             /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_1_Pos)           /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_1                  USBHS_DEVIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_1_Msk instead */
+#define USBHS_DEVIER_DMA_2_Pos              26                                             /**< (USBHS_DEVIER) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_2_Pos)           /**< (USBHS_DEVIER) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_2                  USBHS_DEVIER_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_2_Msk instead */
+#define USBHS_DEVIER_DMA_3_Pos              27                                             /**< (USBHS_DEVIER) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_3_Pos)           /**< (USBHS_DEVIER) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_3                  USBHS_DEVIER_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_3_Msk instead */
+#define USBHS_DEVIER_DMA_4_Pos              28                                             /**< (USBHS_DEVIER) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_4_Pos)           /**< (USBHS_DEVIER) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_4                  USBHS_DEVIER_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_4_Msk instead */
+#define USBHS_DEVIER_DMA_5_Pos              29                                             /**< (USBHS_DEVIER) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_5_Pos)           /**< (USBHS_DEVIER) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_5                  USBHS_DEVIER_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_5_Msk instead */
+#define USBHS_DEVIER_DMA_6_Pos              30                                             /**< (USBHS_DEVIER) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_6_Pos)           /**< (USBHS_DEVIER) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_6                  USBHS_DEVIER_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_6_Msk instead */
+#define USBHS_DEVIER_DMA_7_Pos              31                                             /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_7_Pos)           /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_7                  USBHS_DEVIER_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_7_Msk instead */
+#define USBHS_DEVIER_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIER) Register MASK  (Use USBHS_DEVIER_Msk instead)  */
+#define USBHS_DEVIER_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIER) Register Mask  */
+
+#define USBHS_DEVIER_PEP__Pos               12                                             /**< (USBHS_DEVIER Position) Endpoint x Interrupt Enable */
+#define USBHS_DEVIER_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIER_PEP__Pos)          /**< (USBHS_DEVIER Mask) PEP_ */
+#define USBHS_DEVIER_PEP_(value)            (USBHS_DEVIER_PEP__Msk & ((value) << USBHS_DEVIER_PEP__Pos))  
+#define USBHS_DEVIER_DMA__Pos               25                                             /**< (USBHS_DEVIER Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_DEVIER_DMA__Msk               (_U_(0x7F) << USBHS_DEVIER_DMA__Pos)           /**< (USBHS_DEVIER Mask) DMA_ */
+#define USBHS_DEVIER_DMA_(value)            (USBHS_DEVIER_DMA__Msk & ((value) << USBHS_DEVIER_DMA__Pos))  
+
+/* -------- USBHS_DEVEPT : (USBHS Offset: 0x1c) (R/W 32) Device Endpoint Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EPEN0:1;                   /**< bit:      0  Endpoint 0 Enable                        */
+    uint32_t EPEN1:1;                   /**< bit:      1  Endpoint 1 Enable                        */
+    uint32_t EPEN2:1;                   /**< bit:      2  Endpoint 2 Enable                        */
+    uint32_t EPEN3:1;                   /**< bit:      3  Endpoint 3 Enable                        */
+    uint32_t EPEN4:1;                   /**< bit:      4  Endpoint 4 Enable                        */
+    uint32_t EPEN5:1;                   /**< bit:      5  Endpoint 5 Enable                        */
+    uint32_t EPEN6:1;                   /**< bit:      6  Endpoint 6 Enable                        */
+    uint32_t EPEN7:1;                   /**< bit:      7  Endpoint 7 Enable                        */
+    uint32_t EPEN8:1;                   /**< bit:      8  Endpoint 8 Enable                        */
+    uint32_t EPEN9:1;                   /**< bit:      9  Endpoint 9 Enable                        */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t EPRST0:1;                  /**< bit:     16  Endpoint 0 Reset                         */
+    uint32_t EPRST1:1;                  /**< bit:     17  Endpoint 1 Reset                         */
+    uint32_t EPRST2:1;                  /**< bit:     18  Endpoint 2 Reset                         */
+    uint32_t EPRST3:1;                  /**< bit:     19  Endpoint 3 Reset                         */
+    uint32_t EPRST4:1;                  /**< bit:     20  Endpoint 4 Reset                         */
+    uint32_t EPRST5:1;                  /**< bit:     21  Endpoint 5 Reset                         */
+    uint32_t EPRST6:1;                  /**< bit:     22  Endpoint 6 Reset                         */
+    uint32_t EPRST7:1;                  /**< bit:     23  Endpoint 7 Reset                         */
+    uint32_t EPRST8:1;                  /**< bit:     24  Endpoint 8 Reset                         */
+    uint32_t EPRST9:1;                  /**< bit:     25  Endpoint 9 Reset                         */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EPEN:10;                   /**< bit:   0..9  Endpoint x Enable                        */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t EPRST:10;                  /**< bit: 16..25  Endpoint 9 Reset                         */
+    uint32_t :6;                        /**< bit: 26..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPT_OFFSET                 (0x1C)                                        /**<  (USBHS_DEVEPT) Device Endpoint Register  Offset */
+
+#define USBHS_DEVEPT_EPEN0_Pos              0                                              /**< (USBHS_DEVEPT) Endpoint 0 Enable Position */
+#define USBHS_DEVEPT_EPEN0_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN0_Pos)           /**< (USBHS_DEVEPT) Endpoint 0 Enable Mask */
+#define USBHS_DEVEPT_EPEN0                  USBHS_DEVEPT_EPEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN0_Msk instead */
+#define USBHS_DEVEPT_EPEN1_Pos              1                                              /**< (USBHS_DEVEPT) Endpoint 1 Enable Position */
+#define USBHS_DEVEPT_EPEN1_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN1_Pos)           /**< (USBHS_DEVEPT) Endpoint 1 Enable Mask */
+#define USBHS_DEVEPT_EPEN1                  USBHS_DEVEPT_EPEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN1_Msk instead */
+#define USBHS_DEVEPT_EPEN2_Pos              2                                              /**< (USBHS_DEVEPT) Endpoint 2 Enable Position */
+#define USBHS_DEVEPT_EPEN2_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN2_Pos)           /**< (USBHS_DEVEPT) Endpoint 2 Enable Mask */
+#define USBHS_DEVEPT_EPEN2                  USBHS_DEVEPT_EPEN2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN2_Msk instead */
+#define USBHS_DEVEPT_EPEN3_Pos              3                                              /**< (USBHS_DEVEPT) Endpoint 3 Enable Position */
+#define USBHS_DEVEPT_EPEN3_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN3_Pos)           /**< (USBHS_DEVEPT) Endpoint 3 Enable Mask */
+#define USBHS_DEVEPT_EPEN3                  USBHS_DEVEPT_EPEN3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN3_Msk instead */
+#define USBHS_DEVEPT_EPEN4_Pos              4                                              /**< (USBHS_DEVEPT) Endpoint 4 Enable Position */
+#define USBHS_DEVEPT_EPEN4_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN4_Pos)           /**< (USBHS_DEVEPT) Endpoint 4 Enable Mask */
+#define USBHS_DEVEPT_EPEN4                  USBHS_DEVEPT_EPEN4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN4_Msk instead */
+#define USBHS_DEVEPT_EPEN5_Pos              5                                              /**< (USBHS_DEVEPT) Endpoint 5 Enable Position */
+#define USBHS_DEVEPT_EPEN5_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN5_Pos)           /**< (USBHS_DEVEPT) Endpoint 5 Enable Mask */
+#define USBHS_DEVEPT_EPEN5                  USBHS_DEVEPT_EPEN5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN5_Msk instead */
+#define USBHS_DEVEPT_EPEN6_Pos              6                                              /**< (USBHS_DEVEPT) Endpoint 6 Enable Position */
+#define USBHS_DEVEPT_EPEN6_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN6_Pos)           /**< (USBHS_DEVEPT) Endpoint 6 Enable Mask */
+#define USBHS_DEVEPT_EPEN6                  USBHS_DEVEPT_EPEN6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN6_Msk instead */
+#define USBHS_DEVEPT_EPEN7_Pos              7                                              /**< (USBHS_DEVEPT) Endpoint 7 Enable Position */
+#define USBHS_DEVEPT_EPEN7_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN7_Pos)           /**< (USBHS_DEVEPT) Endpoint 7 Enable Mask */
+#define USBHS_DEVEPT_EPEN7                  USBHS_DEVEPT_EPEN7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN7_Msk instead */
+#define USBHS_DEVEPT_EPEN8_Pos              8                                              /**< (USBHS_DEVEPT) Endpoint 8 Enable Position */
+#define USBHS_DEVEPT_EPEN8_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN8_Pos)           /**< (USBHS_DEVEPT) Endpoint 8 Enable Mask */
+#define USBHS_DEVEPT_EPEN8                  USBHS_DEVEPT_EPEN8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN8_Msk instead */
+#define USBHS_DEVEPT_EPEN9_Pos              9                                              /**< (USBHS_DEVEPT) Endpoint 9 Enable Position */
+#define USBHS_DEVEPT_EPEN9_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN9_Pos)           /**< (USBHS_DEVEPT) Endpoint 9 Enable Mask */
+#define USBHS_DEVEPT_EPEN9                  USBHS_DEVEPT_EPEN9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN9_Msk instead */
+#define USBHS_DEVEPT_EPRST0_Pos             16                                             /**< (USBHS_DEVEPT) Endpoint 0 Reset Position */
+#define USBHS_DEVEPT_EPRST0_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST0_Pos)          /**< (USBHS_DEVEPT) Endpoint 0 Reset Mask */
+#define USBHS_DEVEPT_EPRST0                 USBHS_DEVEPT_EPRST0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST0_Msk instead */
+#define USBHS_DEVEPT_EPRST1_Pos             17                                             /**< (USBHS_DEVEPT) Endpoint 1 Reset Position */
+#define USBHS_DEVEPT_EPRST1_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST1_Pos)          /**< (USBHS_DEVEPT) Endpoint 1 Reset Mask */
+#define USBHS_DEVEPT_EPRST1                 USBHS_DEVEPT_EPRST1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST1_Msk instead */
+#define USBHS_DEVEPT_EPRST2_Pos             18                                             /**< (USBHS_DEVEPT) Endpoint 2 Reset Position */
+#define USBHS_DEVEPT_EPRST2_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST2_Pos)          /**< (USBHS_DEVEPT) Endpoint 2 Reset Mask */
+#define USBHS_DEVEPT_EPRST2                 USBHS_DEVEPT_EPRST2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST2_Msk instead */
+#define USBHS_DEVEPT_EPRST3_Pos             19                                             /**< (USBHS_DEVEPT) Endpoint 3 Reset Position */
+#define USBHS_DEVEPT_EPRST3_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST3_Pos)          /**< (USBHS_DEVEPT) Endpoint 3 Reset Mask */
+#define USBHS_DEVEPT_EPRST3                 USBHS_DEVEPT_EPRST3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST3_Msk instead */
+#define USBHS_DEVEPT_EPRST4_Pos             20                                             /**< (USBHS_DEVEPT) Endpoint 4 Reset Position */
+#define USBHS_DEVEPT_EPRST4_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST4_Pos)          /**< (USBHS_DEVEPT) Endpoint 4 Reset Mask */
+#define USBHS_DEVEPT_EPRST4                 USBHS_DEVEPT_EPRST4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST4_Msk instead */
+#define USBHS_DEVEPT_EPRST5_Pos             21                                             /**< (USBHS_DEVEPT) Endpoint 5 Reset Position */
+#define USBHS_DEVEPT_EPRST5_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST5_Pos)          /**< (USBHS_DEVEPT) Endpoint 5 Reset Mask */
+#define USBHS_DEVEPT_EPRST5                 USBHS_DEVEPT_EPRST5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST5_Msk instead */
+#define USBHS_DEVEPT_EPRST6_Pos             22                                             /**< (USBHS_DEVEPT) Endpoint 6 Reset Position */
+#define USBHS_DEVEPT_EPRST6_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST6_Pos)          /**< (USBHS_DEVEPT) Endpoint 6 Reset Mask */
+#define USBHS_DEVEPT_EPRST6                 USBHS_DEVEPT_EPRST6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST6_Msk instead */
+#define USBHS_DEVEPT_EPRST7_Pos             23                                             /**< (USBHS_DEVEPT) Endpoint 7 Reset Position */
+#define USBHS_DEVEPT_EPRST7_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST7_Pos)          /**< (USBHS_DEVEPT) Endpoint 7 Reset Mask */
+#define USBHS_DEVEPT_EPRST7                 USBHS_DEVEPT_EPRST7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST7_Msk instead */
+#define USBHS_DEVEPT_EPRST8_Pos             24                                             /**< (USBHS_DEVEPT) Endpoint 8 Reset Position */
+#define USBHS_DEVEPT_EPRST8_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST8_Pos)          /**< (USBHS_DEVEPT) Endpoint 8 Reset Mask */
+#define USBHS_DEVEPT_EPRST8                 USBHS_DEVEPT_EPRST8_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST8_Msk instead */
+#define USBHS_DEVEPT_EPRST9_Pos             25                                             /**< (USBHS_DEVEPT) Endpoint 9 Reset Position */
+#define USBHS_DEVEPT_EPRST9_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST9_Pos)          /**< (USBHS_DEVEPT) Endpoint 9 Reset Mask */
+#define USBHS_DEVEPT_EPRST9                 USBHS_DEVEPT_EPRST9_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST9_Msk instead */
+#define USBHS_DEVEPT_MASK                   _U_(0x3FF03FF)                                 /**< \deprecated (USBHS_DEVEPT) Register MASK  (Use USBHS_DEVEPT_Msk instead)  */
+#define USBHS_DEVEPT_Msk                    _U_(0x3FF03FF)                                 /**< (USBHS_DEVEPT) Register Mask  */
+
+#define USBHS_DEVEPT_EPEN_Pos               0                                              /**< (USBHS_DEVEPT Position) Endpoint x Enable */
+#define USBHS_DEVEPT_EPEN_Msk               (_U_(0x3FF) << USBHS_DEVEPT_EPEN_Pos)          /**< (USBHS_DEVEPT Mask) EPEN */
+#define USBHS_DEVEPT_EPEN(value)            (USBHS_DEVEPT_EPEN_Msk & ((value) << USBHS_DEVEPT_EPEN_Pos))  
+#define USBHS_DEVEPT_EPRST_Pos              16                                             /**< (USBHS_DEVEPT Position) Endpoint 9 Reset */
+#define USBHS_DEVEPT_EPRST_Msk              (_U_(0x3FF) << USBHS_DEVEPT_EPRST_Pos)         /**< (USBHS_DEVEPT Mask) EPRST */
+#define USBHS_DEVEPT_EPRST(value)           (USBHS_DEVEPT_EPRST_Msk & ((value) << USBHS_DEVEPT_EPRST_Pos))  
+
+/* -------- USBHS_DEVFNUM : (USBHS Offset: 0x20) (R/ 32) Device Frame Number Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
+    uint32_t FNUM:11;                   /**< bit:  3..13  Frame Number                             */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t FNCERR:1;                  /**< bit:     15  Frame Number CRC Error                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVFNUM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVFNUM_OFFSET                (0x20)                                        /**<  (USBHS_DEVFNUM) Device Frame Number Register  Offset */
+
+#define USBHS_DEVFNUM_MFNUM_Pos             0                                              /**< (USBHS_DEVFNUM) Micro Frame Number Position */
+#define USBHS_DEVFNUM_MFNUM_Msk             (_U_(0x7) << USBHS_DEVFNUM_MFNUM_Pos)          /**< (USBHS_DEVFNUM) Micro Frame Number Mask */
+#define USBHS_DEVFNUM_MFNUM(value)          (USBHS_DEVFNUM_MFNUM_Msk & ((value) << USBHS_DEVFNUM_MFNUM_Pos))
+#define USBHS_DEVFNUM_FNUM_Pos              3                                              /**< (USBHS_DEVFNUM) Frame Number Position */
+#define USBHS_DEVFNUM_FNUM_Msk              (_U_(0x7FF) << USBHS_DEVFNUM_FNUM_Pos)         /**< (USBHS_DEVFNUM) Frame Number Mask */
+#define USBHS_DEVFNUM_FNUM(value)           (USBHS_DEVFNUM_FNUM_Msk & ((value) << USBHS_DEVFNUM_FNUM_Pos))
+#define USBHS_DEVFNUM_FNCERR_Pos            15                                             /**< (USBHS_DEVFNUM) Frame Number CRC Error Position */
+#define USBHS_DEVFNUM_FNCERR_Msk            (_U_(0x1) << USBHS_DEVFNUM_FNCERR_Pos)         /**< (USBHS_DEVFNUM) Frame Number CRC Error Mask */
+#define USBHS_DEVFNUM_FNCERR                USBHS_DEVFNUM_FNCERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVFNUM_FNCERR_Msk instead */
+#define USBHS_DEVFNUM_MASK                  _U_(0xBFFF)                                    /**< \deprecated (USBHS_DEVFNUM) Register MASK  (Use USBHS_DEVFNUM_Msk instead)  */
+#define USBHS_DEVFNUM_Msk                   _U_(0xBFFF)                                    /**< (USBHS_DEVFNUM) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTCFG : (USBHS Offset: 0x100) (R/W 32) Device Endpoint Configuration Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ALLOC:1;                   /**< bit:      1  Endpoint Memory Allocate                 */
+    uint32_t EPBK:2;                    /**< bit:   2..3  Endpoint Banks                           */
+    uint32_t EPSIZE:3;                  /**< bit:   4..6  Endpoint Size                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t EPDIR:1;                   /**< bit:      8  Endpoint Direction                       */
+    uint32_t AUTOSW:1;                  /**< bit:      9  Automatic Switch                         */
+    uint32_t :1;                        /**< bit:     10  Reserved */
+    uint32_t EPTYPE:2;                  /**< bit: 11..12  Endpoint Type                            */
+    uint32_t NBTRANS:2;                 /**< bit: 13..14  Number of transactions per microframe for isochronous endpoint */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTCFG_OFFSET              (0x100)                                       /**<  (USBHS_DEVEPTCFG) Device Endpoint Configuration Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTCFG_ALLOC_Pos           1                                              /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Position */
+#define USBHS_DEVEPTCFG_ALLOC_Msk           (_U_(0x1) << USBHS_DEVEPTCFG_ALLOC_Pos)        /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Mask */
+#define USBHS_DEVEPTCFG_ALLOC               USBHS_DEVEPTCFG_ALLOC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_ALLOC_Msk instead */
+#define USBHS_DEVEPTCFG_EPBK_Pos            2                                              /**< (USBHS_DEVEPTCFG) Endpoint Banks Position */
+#define USBHS_DEVEPTCFG_EPBK_Msk            (_U_(0x3) << USBHS_DEVEPTCFG_EPBK_Pos)         /**< (USBHS_DEVEPTCFG) Endpoint Banks Mask */
+#define USBHS_DEVEPTCFG_EPBK(value)         (USBHS_DEVEPTCFG_EPBK_Msk & ((value) << USBHS_DEVEPTCFG_EPBK_Pos))
+#define   USBHS_DEVEPTCFG_EPBK_1_BANK_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Single-bank endpoint  */
+#define   USBHS_DEVEPTCFG_EPBK_2_BANK_Val   _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Double-bank endpoint  */
+#define   USBHS_DEVEPTCFG_EPBK_3_BANK_Val   _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Triple-bank endpoint  */
+#define USBHS_DEVEPTCFG_EPBK_1_BANK         (USBHS_DEVEPTCFG_EPBK_1_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Single-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPBK_2_BANK         (USBHS_DEVEPTCFG_EPBK_2_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Double-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPBK_3_BANK         (USBHS_DEVEPTCFG_EPBK_3_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Triple-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_Pos          4                                              /**< (USBHS_DEVEPTCFG) Endpoint Size Position */
+#define USBHS_DEVEPTCFG_EPSIZE_Msk          (_U_(0x7) << USBHS_DEVEPTCFG_EPSIZE_Pos)       /**< (USBHS_DEVEPTCFG) Endpoint Size Mask */
+#define USBHS_DEVEPTCFG_EPSIZE(value)       (USBHS_DEVEPTCFG_EPSIZE_Msk & ((value) << USBHS_DEVEPTCFG_EPSIZE_Pos))
+#define   USBHS_DEVEPTCFG_EPSIZE_8_BYTE_Val _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) 8 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_16_BYTE_Val _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) 16 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_32_BYTE_Val _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) 32 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_64_BYTE_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) 64 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_128_BYTE_Val _U_(0x4)                                       /**< (USBHS_DEVEPTCFG) 128 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_256_BYTE_Val _U_(0x5)                                       /**< (USBHS_DEVEPTCFG) 256 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_512_BYTE_Val _U_(0x6)                                       /**< (USBHS_DEVEPTCFG) 512 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_1024_BYTE_Val _U_(0x7)                                       /**< (USBHS_DEVEPTCFG) 1024 bytes  */
+#define USBHS_DEVEPTCFG_EPSIZE_8_BYTE       (USBHS_DEVEPTCFG_EPSIZE_8_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 8 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_16_BYTE      (USBHS_DEVEPTCFG_EPSIZE_16_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 16 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_32_BYTE      (USBHS_DEVEPTCFG_EPSIZE_32_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 32 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_64_BYTE      (USBHS_DEVEPTCFG_EPSIZE_64_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 64 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_128_BYTE     (USBHS_DEVEPTCFG_EPSIZE_128_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 128 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_256_BYTE     (USBHS_DEVEPTCFG_EPSIZE_256_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 256 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_512_BYTE     (USBHS_DEVEPTCFG_EPSIZE_512_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 512 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_1024_BYTE    (USBHS_DEVEPTCFG_EPSIZE_1024_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 1024 bytes Position  */
+#define USBHS_DEVEPTCFG_EPDIR_Pos           8                                              /**< (USBHS_DEVEPTCFG) Endpoint Direction Position */
+#define USBHS_DEVEPTCFG_EPDIR_Msk           (_U_(0x1) << USBHS_DEVEPTCFG_EPDIR_Pos)        /**< (USBHS_DEVEPTCFG) Endpoint Direction Mask */
+#define USBHS_DEVEPTCFG_EPDIR               USBHS_DEVEPTCFG_EPDIR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_EPDIR_Msk instead */
+#define   USBHS_DEVEPTCFG_EPDIR_OUT_Val     _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) The endpoint direction is OUT.  */
+#define   USBHS_DEVEPTCFG_EPDIR_IN_Val      _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) The endpoint direction is IN (nor for control endpoints).  */
+#define USBHS_DEVEPTCFG_EPDIR_OUT           (USBHS_DEVEPTCFG_EPDIR_OUT_Val << USBHS_DEVEPTCFG_EPDIR_Pos)  /**< (USBHS_DEVEPTCFG) The endpoint direction is OUT. Position  */
+#define USBHS_DEVEPTCFG_EPDIR_IN            (USBHS_DEVEPTCFG_EPDIR_IN_Val << USBHS_DEVEPTCFG_EPDIR_Pos)  /**< (USBHS_DEVEPTCFG) The endpoint direction is IN (nor for control endpoints). Position  */
+#define USBHS_DEVEPTCFG_AUTOSW_Pos          9                                              /**< (USBHS_DEVEPTCFG) Automatic Switch Position */
+#define USBHS_DEVEPTCFG_AUTOSW_Msk          (_U_(0x1) << USBHS_DEVEPTCFG_AUTOSW_Pos)       /**< (USBHS_DEVEPTCFG) Automatic Switch Mask */
+#define USBHS_DEVEPTCFG_AUTOSW              USBHS_DEVEPTCFG_AUTOSW_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_AUTOSW_Msk instead */
+#define USBHS_DEVEPTCFG_EPTYPE_Pos          11                                             /**< (USBHS_DEVEPTCFG) Endpoint Type Position */
+#define USBHS_DEVEPTCFG_EPTYPE_Msk          (_U_(0x3) << USBHS_DEVEPTCFG_EPTYPE_Pos)       /**< (USBHS_DEVEPTCFG) Endpoint Type Mask */
+#define USBHS_DEVEPTCFG_EPTYPE(value)       (USBHS_DEVEPTCFG_EPTYPE_Msk & ((value) << USBHS_DEVEPTCFG_EPTYPE_Pos))
+#define   USBHS_DEVEPTCFG_EPTYPE_CTRL_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Control  */
+#define   USBHS_DEVEPTCFG_EPTYPE_ISO_Val    _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Isochronous  */
+#define   USBHS_DEVEPTCFG_EPTYPE_BLK_Val    _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Bulk  */
+#define   USBHS_DEVEPTCFG_EPTYPE_INTRPT_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) Interrupt  */
+#define USBHS_DEVEPTCFG_EPTYPE_CTRL         (USBHS_DEVEPTCFG_EPTYPE_CTRL_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Control Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_ISO          (USBHS_DEVEPTCFG_EPTYPE_ISO_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Isochronous Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_BLK          (USBHS_DEVEPTCFG_EPTYPE_BLK_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Bulk Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_INTRPT       (USBHS_DEVEPTCFG_EPTYPE_INTRPT_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Interrupt Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_Pos         13                                             /**< (USBHS_DEVEPTCFG) Number of transactions per microframe for isochronous endpoint Position */
+#define USBHS_DEVEPTCFG_NBTRANS_Msk         (_U_(0x3) << USBHS_DEVEPTCFG_NBTRANS_Pos)      /**< (USBHS_DEVEPTCFG) Number of transactions per microframe for isochronous endpoint Mask */
+#define USBHS_DEVEPTCFG_NBTRANS(value)      (USBHS_DEVEPTCFG_NBTRANS_Msk & ((value) << USBHS_DEVEPTCFG_NBTRANS_Pos))
+#define   USBHS_DEVEPTCFG_NBTRANS_0_TRANS_Val _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Reserved to endpoint that does not have the high-bandwidth isochronous capability.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_1_TRANS_Val _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Default value: one transaction per microframe.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_2_TRANS_Val _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Two transactions per microframe. This endpoint should be configured as double-bank.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_3_TRANS_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) Three transactions per microframe. This endpoint should be configured as triple-bank.  */
+#define USBHS_DEVEPTCFG_NBTRANS_0_TRANS     (USBHS_DEVEPTCFG_NBTRANS_0_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Reserved to endpoint that does not have the high-bandwidth isochronous capability. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_1_TRANS     (USBHS_DEVEPTCFG_NBTRANS_1_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Default value: one transaction per microframe. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_2_TRANS     (USBHS_DEVEPTCFG_NBTRANS_2_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Two transactions per microframe. This endpoint should be configured as double-bank. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_3_TRANS     (USBHS_DEVEPTCFG_NBTRANS_3_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Three transactions per microframe. This endpoint should be configured as triple-bank. Position  */
+#define USBHS_DEVEPTCFG_MASK                _U_(0x7B7E)                                    /**< \deprecated (USBHS_DEVEPTCFG) Register MASK  (Use USBHS_DEVEPTCFG_Msk instead)  */
+#define USBHS_DEVEPTCFG_Msk                 _U_(0x7B7E)                                    /**< (USBHS_DEVEPTCFG) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTISR : (USBHS Offset: 0x130) (R/ 32) Device Endpoint Status Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINI:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
+    uint32_t RXOUTI:1;                  /**< bit:      1  Received OUT Data Interrupt              */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t SHORTPACKET:1;             /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t NBUSYBK:2;                 /**< bit: 12..13  Number of Busy Banks                     */
+    uint32_t CURRBK:2;                  /**< bit: 14..15  Current Bank                             */
+    uint32_t RWALL:1;                   /**< bit:     16  Read/Write Allowed                       */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t CFGOK:1;                   /**< bit:     18  Configuration OK Status                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t BYCT:11;                   /**< bit: 20..30  Byte Count                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTISR_OFFSET              (0x130)                                       /**<  (USBHS_DEVEPTISR) Device Endpoint Status Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTISR_TXINI_Pos           0                                              /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Position */
+#define USBHS_DEVEPTISR_TXINI_Msk           (_U_(0x1) << USBHS_DEVEPTISR_TXINI_Pos)        /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Mask */
+#define USBHS_DEVEPTISR_TXINI               USBHS_DEVEPTISR_TXINI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_TXINI_Msk instead */
+#define USBHS_DEVEPTISR_RXOUTI_Pos          1                                              /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Position */
+#define USBHS_DEVEPTISR_RXOUTI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_RXOUTI_Pos)       /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Mask */
+#define USBHS_DEVEPTISR_RXOUTI              USBHS_DEVEPTISR_RXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXOUTI_Msk instead */
+#define USBHS_DEVEPTISR_RXSTPI_Pos          2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_RXSTPI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_RXSTPI_Pos)       /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_RXSTPI              USBHS_DEVEPTISR_RXSTPI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_NAKOUTI_Pos         3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_NAKOUTI_Msk         (_U_(0x1) << USBHS_DEVEPTISR_NAKOUTI_Pos)      /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_NAKOUTI             USBHS_DEVEPTISR_NAKOUTI_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_NAKINI_Pos          4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_NAKINI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_NAKINI_Pos)       /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_NAKINI              USBHS_DEVEPTISR_NAKINI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_OVERFI_Pos          5                                              /**< (USBHS_DEVEPTISR) Overflow Interrupt Position */
+#define USBHS_DEVEPTISR_OVERFI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_OVERFI_Pos)       /**< (USBHS_DEVEPTISR) Overflow Interrupt Mask */
+#define USBHS_DEVEPTISR_OVERFI              USBHS_DEVEPTISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_OVERFI_Msk instead */
+#define USBHS_DEVEPTISR_STALLEDI_Pos        6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_STALLEDI_Msk        (_U_(0x1) << USBHS_DEVEPTISR_STALLEDI_Pos)     /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_STALLEDI            USBHS_DEVEPTISR_STALLEDI_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_SHORTPACKET_Pos     7                                              /**< (USBHS_DEVEPTISR) Short Packet Interrupt Position */
+#define USBHS_DEVEPTISR_SHORTPACKET_Msk     (_U_(0x1) << USBHS_DEVEPTISR_SHORTPACKET_Pos)  /**< (USBHS_DEVEPTISR) Short Packet Interrupt Mask */
+#define USBHS_DEVEPTISR_SHORTPACKET         USBHS_DEVEPTISR_SHORTPACKET_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_SHORTPACKET_Msk instead */
+#define USBHS_DEVEPTISR_DTSEQ_Pos           8                                              /**< (USBHS_DEVEPTISR) Data Toggle Sequence Position */
+#define USBHS_DEVEPTISR_DTSEQ_Msk           (_U_(0x3) << USBHS_DEVEPTISR_DTSEQ_Pos)        /**< (USBHS_DEVEPTISR) Data Toggle Sequence Mask */
+#define USBHS_DEVEPTISR_DTSEQ(value)        (USBHS_DEVEPTISR_DTSEQ_Msk & ((value) << USBHS_DEVEPTISR_DTSEQ_Pos))
+#define   USBHS_DEVEPTISR_DTSEQ_DATA0_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTISR) Data0 toggle sequence  */
+#define   USBHS_DEVEPTISR_DTSEQ_DATA1_Val   _U_(0x1)                                       /**< (USBHS_DEVEPTISR) Data1 toggle sequence  */
+#define   USBHS_DEVEPTISR_DTSEQ_DATA2_Val   _U_(0x2)                                       /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint  */
+#define   USBHS_DEVEPTISR_DTSEQ_MDATA_Val   _U_(0x3)                                       /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA0         (USBHS_DEVEPTISR_DTSEQ_DATA0_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Data0 toggle sequence Position  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA1         (USBHS_DEVEPTISR_DTSEQ_DATA1_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Data1 toggle sequence Position  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA2         (USBHS_DEVEPTISR_DTSEQ_DATA2_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint Position  */
+#define USBHS_DEVEPTISR_DTSEQ_MDATA         (USBHS_DEVEPTISR_DTSEQ_MDATA_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_Pos         12                                             /**< (USBHS_DEVEPTISR) Number of Busy Banks Position */
+#define USBHS_DEVEPTISR_NBUSYBK_Msk         (_U_(0x3) << USBHS_DEVEPTISR_NBUSYBK_Pos)      /**< (USBHS_DEVEPTISR) Number of Busy Banks Mask */
+#define USBHS_DEVEPTISR_NBUSYBK(value)      (USBHS_DEVEPTISR_NBUSYBK_Msk & ((value) << USBHS_DEVEPTISR_NBUSYBK_Pos))
+#define   USBHS_DEVEPTISR_NBUSYBK_0_BUSY_Val _U_(0x0)                                       /**< (USBHS_DEVEPTISR) 0 busy bank (all banks free)  */
+#define   USBHS_DEVEPTISR_NBUSYBK_1_BUSY_Val _U_(0x1)                                       /**< (USBHS_DEVEPTISR) 1 busy bank  */
+#define   USBHS_DEVEPTISR_NBUSYBK_2_BUSY_Val _U_(0x2)                                       /**< (USBHS_DEVEPTISR) 2 busy banks  */
+#define   USBHS_DEVEPTISR_NBUSYBK_3_BUSY_Val _U_(0x3)                                       /**< (USBHS_DEVEPTISR) 3 busy banks  */
+#define USBHS_DEVEPTISR_NBUSYBK_0_BUSY      (USBHS_DEVEPTISR_NBUSYBK_0_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 0 busy bank (all banks free) Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_1_BUSY      (USBHS_DEVEPTISR_NBUSYBK_1_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 1 busy bank Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_2_BUSY      (USBHS_DEVEPTISR_NBUSYBK_2_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 2 busy banks Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_3_BUSY      (USBHS_DEVEPTISR_NBUSYBK_3_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 3 busy banks Position  */
+#define USBHS_DEVEPTISR_CURRBK_Pos          14                                             /**< (USBHS_DEVEPTISR) Current Bank Position */
+#define USBHS_DEVEPTISR_CURRBK_Msk          (_U_(0x3) << USBHS_DEVEPTISR_CURRBK_Pos)       /**< (USBHS_DEVEPTISR) Current Bank Mask */
+#define USBHS_DEVEPTISR_CURRBK(value)       (USBHS_DEVEPTISR_CURRBK_Msk & ((value) << USBHS_DEVEPTISR_CURRBK_Pos))
+#define   USBHS_DEVEPTISR_CURRBK_BANK0_Val  _U_(0x0)                                       /**< (USBHS_DEVEPTISR) Current bank is bank0  */
+#define   USBHS_DEVEPTISR_CURRBK_BANK1_Val  _U_(0x1)                                       /**< (USBHS_DEVEPTISR) Current bank is bank1  */
+#define   USBHS_DEVEPTISR_CURRBK_BANK2_Val  _U_(0x2)                                       /**< (USBHS_DEVEPTISR) Current bank is bank2  */
+#define USBHS_DEVEPTISR_CURRBK_BANK0        (USBHS_DEVEPTISR_CURRBK_BANK0_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank0 Position  */
+#define USBHS_DEVEPTISR_CURRBK_BANK1        (USBHS_DEVEPTISR_CURRBK_BANK1_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank1 Position  */
+#define USBHS_DEVEPTISR_CURRBK_BANK2        (USBHS_DEVEPTISR_CURRBK_BANK2_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank2 Position  */
+#define USBHS_DEVEPTISR_RWALL_Pos           16                                             /**< (USBHS_DEVEPTISR) Read/Write Allowed Position */
+#define USBHS_DEVEPTISR_RWALL_Msk           (_U_(0x1) << USBHS_DEVEPTISR_RWALL_Pos)        /**< (USBHS_DEVEPTISR) Read/Write Allowed Mask */
+#define USBHS_DEVEPTISR_RWALL               USBHS_DEVEPTISR_RWALL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RWALL_Msk instead */
+#define USBHS_DEVEPTISR_CTRLDIR_Pos         17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_CTRLDIR_Msk         (_U_(0x1) << USBHS_DEVEPTISR_CTRLDIR_Pos)      /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_CTRLDIR             USBHS_DEVEPTISR_CTRLDIR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_CFGOK_Pos           18                                             /**< (USBHS_DEVEPTISR) Configuration OK Status Position */
+#define USBHS_DEVEPTISR_CFGOK_Msk           (_U_(0x1) << USBHS_DEVEPTISR_CFGOK_Pos)        /**< (USBHS_DEVEPTISR) Configuration OK Status Mask */
+#define USBHS_DEVEPTISR_CFGOK               USBHS_DEVEPTISR_CFGOK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CFGOK_Msk instead */
+#define USBHS_DEVEPTISR_BYCT_Pos            20                                             /**< (USBHS_DEVEPTISR) Byte Count Position */
+#define USBHS_DEVEPTISR_BYCT_Msk            (_U_(0x7FF) << USBHS_DEVEPTISR_BYCT_Pos)       /**< (USBHS_DEVEPTISR) Byte Count Mask */
+#define USBHS_DEVEPTISR_BYCT(value)         (USBHS_DEVEPTISR_BYCT_Msk & ((value) << USBHS_DEVEPTISR_BYCT_Pos))
+#define USBHS_DEVEPTISR_MASK                _U_(0x7FF7F3FF)                                /**< \deprecated (USBHS_DEVEPTISR) Register MASK  (Use USBHS_DEVEPTISR_Msk instead)  */
+#define USBHS_DEVEPTISR_Msk                 _U_(0x7FF7F3FF)                                /**< (USBHS_DEVEPTISR) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTICR : (USBHS Offset: 0x160) (/W 32) Device Endpoint Clear Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINIC:1;                  /**< bit:      0  Transmitted IN Data Interrupt Clear      */
+    uint32_t RXOUTIC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t SHORTPACKETC:1;            /**< bit:      7  Short Packet Interrupt Clear             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTICR_OFFSET              (0x160)                                       /**<  (USBHS_DEVEPTICR) Device Endpoint Clear Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTICR_TXINIC_Pos          0                                              /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Position */
+#define USBHS_DEVEPTICR_TXINIC_Msk          (_U_(0x1) << USBHS_DEVEPTICR_TXINIC_Pos)       /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_TXINIC              USBHS_DEVEPTICR_TXINIC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_TXINIC_Msk instead */
+#define USBHS_DEVEPTICR_RXOUTIC_Pos         1                                              /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Position */
+#define USBHS_DEVEPTICR_RXOUTIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_RXOUTIC_Pos)      /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_RXOUTIC             USBHS_DEVEPTICR_RXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_RXSTPIC_Pos         2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_RXSTPIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_RXSTPIC_Pos)      /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_RXSTPIC             USBHS_DEVEPTICR_RXSTPIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_NAKOUTIC_Pos        3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_NAKOUTIC_Msk        (_U_(0x1) << USBHS_DEVEPTICR_NAKOUTIC_Pos)     /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_NAKOUTIC            USBHS_DEVEPTICR_NAKOUTIC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_NAKINIC_Pos         4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_NAKINIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_NAKINIC_Pos)      /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_NAKINIC             USBHS_DEVEPTICR_NAKINIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_OVERFIC_Pos         5                                              /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Position */
+#define USBHS_DEVEPTICR_OVERFIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_OVERFIC_Pos)      /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_OVERFIC             USBHS_DEVEPTICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_OVERFIC_Msk instead */
+#define USBHS_DEVEPTICR_STALLEDIC_Pos       6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_STALLEDIC_Msk       (_U_(0x1) << USBHS_DEVEPTICR_STALLEDIC_Pos)    /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_STALLEDIC           USBHS_DEVEPTICR_STALLEDIC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_SHORTPACKETC_Pos    7                                              /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Position */
+#define USBHS_DEVEPTICR_SHORTPACKETC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_SHORTPACKETC_Pos)  /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_SHORTPACKETC        USBHS_DEVEPTICR_SHORTPACKETC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_SHORTPACKETC_Msk instead */
+#define USBHS_DEVEPTICR_MASK                _U_(0xFF)                                      /**< \deprecated (USBHS_DEVEPTICR) Register MASK  (Use USBHS_DEVEPTICR_Msk instead)  */
+#define USBHS_DEVEPTICR_Msk                 _U_(0xFF)                                      /**< (USBHS_DEVEPTICR) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIFR : (USBHS Offset: 0x190) (/W 32) Device Endpoint Set Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINIS:1;                  /**< bit:      0  Transmitted IN Data Interrupt Set        */
+    uint32_t RXOUTIS:1;                 /**< bit:      1  Received OUT Data Interrupt Set          */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t SHORTPACKETS:1;            /**< bit:      7  Short Packet Interrupt Set               */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Interrupt Set       */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIFR_OFFSET              (0x190)                                       /**<  (USBHS_DEVEPTIFR) Device Endpoint Set Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTIFR_TXINIS_Pos          0                                              /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Position */
+#define USBHS_DEVEPTIFR_TXINIS_Msk          (_U_(0x1) << USBHS_DEVEPTIFR_TXINIS_Pos)       /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_TXINIS              USBHS_DEVEPTIFR_TXINIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_TXINIS_Msk instead */
+#define USBHS_DEVEPTIFR_RXOUTIS_Pos         1                                              /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Position */
+#define USBHS_DEVEPTIFR_RXOUTIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_RXOUTIS_Pos)      /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_RXOUTIS             USBHS_DEVEPTIFR_RXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_RXSTPIS_Pos         2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_RXSTPIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_RXSTPIS_Pos)      /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_RXSTPIS             USBHS_DEVEPTIFR_RXSTPIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_NAKOUTIS_Pos        3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NAKOUTIS_Msk        (_U_(0x1) << USBHS_DEVEPTIFR_NAKOUTIS_Pos)     /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NAKOUTIS            USBHS_DEVEPTIFR_NAKOUTIS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_NAKINIS_Pos         4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NAKINIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_NAKINIS_Pos)      /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NAKINIS             USBHS_DEVEPTIFR_NAKINIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_OVERFIS_Pos         5                                              /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Position */
+#define USBHS_DEVEPTIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_OVERFIS_Pos)      /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_OVERFIS             USBHS_DEVEPTIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_OVERFIS_Msk instead */
+#define USBHS_DEVEPTIFR_STALLEDIS_Pos       6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_STALLEDIS_Msk       (_U_(0x1) << USBHS_DEVEPTIFR_STALLEDIS_Pos)    /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_STALLEDIS           USBHS_DEVEPTIFR_STALLEDIS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_SHORTPACKETS_Pos    7                                              /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Position */
+#define USBHS_DEVEPTIFR_SHORTPACKETS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_SHORTPACKETS_Pos)  /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_SHORTPACKETS        USBHS_DEVEPTIFR_SHORTPACKETS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_SHORTPACKETS_Msk instead */
+#define USBHS_DEVEPTIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_DEVEPTIFR_NBUSYBKS_Pos)     /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NBUSYBKS            USBHS_DEVEPTIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NBUSYBKS_Msk instead */
+#define USBHS_DEVEPTIFR_MASK                _U_(0x10FF)                                    /**< \deprecated (USBHS_DEVEPTIFR) Register MASK  (Use USBHS_DEVEPTIFR_Msk instead)  */
+#define USBHS_DEVEPTIFR_Msk                 _U_(0x10FF)                                    /**< (USBHS_DEVEPTIFR) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIMR : (USBHS Offset: 0x1c0) (R/ 32) Device Endpoint Mask Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINE:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
+    uint32_t RXOUTE:1;                  /**< bit:      1  Received OUT Data Interrupt              */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t OVERFE:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t SHORTPACKETE:1;            /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt           */
+    uint32_t KILLBK:1;                  /**< bit:     13  Kill IN Bank                             */
+    uint32_t FIFOCON:1;                 /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMA:1;               /**< bit:     16  Endpoint Interrupts Disable HDMA Request */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIMR_OFFSET              (0x1C0)                                       /**<  (USBHS_DEVEPTIMR) Device Endpoint Mask Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTIMR_TXINE_Pos           0                                              /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Position */
+#define USBHS_DEVEPTIMR_TXINE_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_TXINE_Pos)        /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Mask */
+#define USBHS_DEVEPTIMR_TXINE               USBHS_DEVEPTIMR_TXINE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_TXINE_Msk instead */
+#define USBHS_DEVEPTIMR_RXOUTE_Pos          1                                              /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Position */
+#define USBHS_DEVEPTIMR_RXOUTE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_RXOUTE_Pos)       /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Mask */
+#define USBHS_DEVEPTIMR_RXOUTE              USBHS_DEVEPTIMR_RXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_RXSTPE_Pos          2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_RXSTPE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_RXSTPE_Pos)       /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_RXSTPE              USBHS_DEVEPTIMR_RXSTPE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_NAKOUTE_Pos         3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_NAKOUTE_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_NAKOUTE_Pos)      /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_NAKOUTE             USBHS_DEVEPTIMR_NAKOUTE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_NAKINE_Pos          4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_NAKINE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_NAKINE_Pos)       /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_NAKINE              USBHS_DEVEPTIMR_NAKINE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_OVERFE_Pos          5                                              /**< (USBHS_DEVEPTIMR) Overflow Interrupt Position */
+#define USBHS_DEVEPTIMR_OVERFE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_OVERFE_Pos)       /**< (USBHS_DEVEPTIMR) Overflow Interrupt Mask */
+#define USBHS_DEVEPTIMR_OVERFE              USBHS_DEVEPTIMR_OVERFE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_OVERFE_Msk instead */
+#define USBHS_DEVEPTIMR_STALLEDE_Pos        6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_STALLEDE_Msk        (_U_(0x1) << USBHS_DEVEPTIMR_STALLEDE_Pos)     /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_STALLEDE            USBHS_DEVEPTIMR_STALLEDE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_SHORTPACKETE_Pos    7                                              /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Position */
+#define USBHS_DEVEPTIMR_SHORTPACKETE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_SHORTPACKETE_Pos)  /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Mask */
+#define USBHS_DEVEPTIMR_SHORTPACKETE        USBHS_DEVEPTIMR_SHORTPACKETE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_SHORTPACKETE_Msk instead */
+#define USBHS_DEVEPTIMR_NBUSYBKE_Pos        12                                             /**< (USBHS_DEVEPTIMR) Number of Busy Banks Interrupt Position */
+#define USBHS_DEVEPTIMR_NBUSYBKE_Msk        (_U_(0x1) << USBHS_DEVEPTIMR_NBUSYBKE_Pos)     /**< (USBHS_DEVEPTIMR) Number of Busy Banks Interrupt Mask */
+#define USBHS_DEVEPTIMR_NBUSYBKE            USBHS_DEVEPTIMR_NBUSYBKE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NBUSYBKE_Msk instead */
+#define USBHS_DEVEPTIMR_KILLBK_Pos          13                                             /**< (USBHS_DEVEPTIMR) Kill IN Bank Position */
+#define USBHS_DEVEPTIMR_KILLBK_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_KILLBK_Pos)       /**< (USBHS_DEVEPTIMR) Kill IN Bank Mask */
+#define USBHS_DEVEPTIMR_KILLBK              USBHS_DEVEPTIMR_KILLBK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_KILLBK_Msk instead */
+#define USBHS_DEVEPTIMR_FIFOCON_Pos         14                                             /**< (USBHS_DEVEPTIMR) FIFO Control Position */
+#define USBHS_DEVEPTIMR_FIFOCON_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_FIFOCON_Pos)      /**< (USBHS_DEVEPTIMR) FIFO Control Mask */
+#define USBHS_DEVEPTIMR_FIFOCON             USBHS_DEVEPTIMR_FIFOCON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_FIFOCON_Msk instead */
+#define USBHS_DEVEPTIMR_EPDISHDMA_Pos       16                                             /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Position */
+#define USBHS_DEVEPTIMR_EPDISHDMA_Msk       (_U_(0x1) << USBHS_DEVEPTIMR_EPDISHDMA_Pos)    /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Mask */
+#define USBHS_DEVEPTIMR_EPDISHDMA           USBHS_DEVEPTIMR_EPDISHDMA_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_EPDISHDMA_Msk instead */
+#define USBHS_DEVEPTIMR_NYETDIS_Pos         17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_NYETDIS_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_NYETDIS_Pos)      /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_NYETDIS             USBHS_DEVEPTIMR_NYETDIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_RSTDT_Pos           18                                             /**< (USBHS_DEVEPTIMR) Reset Data Toggle Position */
+#define USBHS_DEVEPTIMR_RSTDT_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_RSTDT_Pos)        /**< (USBHS_DEVEPTIMR) Reset Data Toggle Mask */
+#define USBHS_DEVEPTIMR_RSTDT               USBHS_DEVEPTIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RSTDT_Msk instead */
+#define USBHS_DEVEPTIMR_STALLRQ_Pos         19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_STALLRQ_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_STALLRQ_Pos)      /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_STALLRQ             USBHS_DEVEPTIMR_STALLRQ_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_MASK                _U_(0xF70FF)                                   /**< \deprecated (USBHS_DEVEPTIMR) Register MASK  (Use USBHS_DEVEPTIMR_Msk instead)  */
+#define USBHS_DEVEPTIMR_Msk                 _U_(0xF70FF)                                   /**< (USBHS_DEVEPTIMR) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIER : (USBHS Offset: 0x1f0) (/W 32) Device Endpoint Enable Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINES:1;                  /**< bit:      0  Transmitted IN Data Interrupt Enable     */
+    uint32_t RXOUTES:1;                 /**< bit:      1  Received OUT Data Interrupt Enable       */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t OVERFES:1;                 /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t SHORTPACKETES:1;           /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Interrupt Enable    */
+    uint32_t KILLBKS:1;                 /**< bit:     13  Kill IN Bank                             */
+    uint32_t FIFOCONS:1;                /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMAS:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Enable */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIER_OFFSET              (0x1F0)                                       /**<  (USBHS_DEVEPTIER) Device Endpoint Enable Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTIER_TXINES_Pos          0                                              /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Position */
+#define USBHS_DEVEPTIER_TXINES_Msk          (_U_(0x1) << USBHS_DEVEPTIER_TXINES_Pos)       /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_TXINES              USBHS_DEVEPTIER_TXINES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_TXINES_Msk instead */
+#define USBHS_DEVEPTIER_RXOUTES_Pos         1                                              /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Position */
+#define USBHS_DEVEPTIER_RXOUTES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_RXOUTES_Pos)      /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_RXOUTES             USBHS_DEVEPTIER_RXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXOUTES_Msk instead */
+#define USBHS_DEVEPTIER_RXSTPES_Pos         2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_RXSTPES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_RXSTPES_Pos)      /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_RXSTPES             USBHS_DEVEPTIER_RXSTPES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_NAKOUTES_Pos        3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NAKOUTES_Msk        (_U_(0x1) << USBHS_DEVEPTIER_NAKOUTES_Pos)     /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NAKOUTES            USBHS_DEVEPTIER_NAKOUTES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_NAKINES_Pos         4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NAKINES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_NAKINES_Pos)      /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NAKINES             USBHS_DEVEPTIER_NAKINES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_OVERFES_Pos         5                                              /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Position */
+#define USBHS_DEVEPTIER_OVERFES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_OVERFES_Pos)      /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_OVERFES             USBHS_DEVEPTIER_OVERFES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_OVERFES_Msk instead */
+#define USBHS_DEVEPTIER_STALLEDES_Pos       6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_STALLEDES_Msk       (_U_(0x1) << USBHS_DEVEPTIER_STALLEDES_Pos)    /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_STALLEDES           USBHS_DEVEPTIER_STALLEDES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_SHORTPACKETES_Pos   7                                              /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Position */
+#define USBHS_DEVEPTIER_SHORTPACKETES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_SHORTPACKETES_Pos)  /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_SHORTPACKETES       USBHS_DEVEPTIER_SHORTPACKETES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_SHORTPACKETES_Msk instead */
+#define USBHS_DEVEPTIER_NBUSYBKES_Pos       12                                             /**< (USBHS_DEVEPTIER) Number of Busy Banks Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NBUSYBKES_Msk       (_U_(0x1) << USBHS_DEVEPTIER_NBUSYBKES_Pos)    /**< (USBHS_DEVEPTIER) Number of Busy Banks Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NBUSYBKES           USBHS_DEVEPTIER_NBUSYBKES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NBUSYBKES_Msk instead */
+#define USBHS_DEVEPTIER_KILLBKS_Pos         13                                             /**< (USBHS_DEVEPTIER) Kill IN Bank Position */
+#define USBHS_DEVEPTIER_KILLBKS_Msk         (_U_(0x1) << USBHS_DEVEPTIER_KILLBKS_Pos)      /**< (USBHS_DEVEPTIER) Kill IN Bank Mask */
+#define USBHS_DEVEPTIER_KILLBKS             USBHS_DEVEPTIER_KILLBKS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_KILLBKS_Msk instead */
+#define USBHS_DEVEPTIER_FIFOCONS_Pos        14                                             /**< (USBHS_DEVEPTIER) FIFO Control Position */
+#define USBHS_DEVEPTIER_FIFOCONS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_FIFOCONS_Pos)     /**< (USBHS_DEVEPTIER) FIFO Control Mask */
+#define USBHS_DEVEPTIER_FIFOCONS            USBHS_DEVEPTIER_FIFOCONS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_FIFOCONS_Msk instead */
+#define USBHS_DEVEPTIER_EPDISHDMAS_Pos      16                                             /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Position */
+#define USBHS_DEVEPTIER_EPDISHDMAS_Msk      (_U_(0x1) << USBHS_DEVEPTIER_EPDISHDMAS_Pos)   /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_DEVEPTIER_EPDISHDMAS          USBHS_DEVEPTIER_EPDISHDMAS_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_EPDISHDMAS_Msk instead */
+#define USBHS_DEVEPTIER_NYETDISS_Pos        17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_NYETDISS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_NYETDISS_Pos)     /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_NYETDISS            USBHS_DEVEPTIER_NYETDISS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_RSTDTS_Pos          18                                             /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Position */
+#define USBHS_DEVEPTIER_RSTDTS_Msk          (_U_(0x1) << USBHS_DEVEPTIER_RSTDTS_Pos)       /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Mask */
+#define USBHS_DEVEPTIER_RSTDTS              USBHS_DEVEPTIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RSTDTS_Msk instead */
+#define USBHS_DEVEPTIER_STALLRQS_Pos        19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_STALLRQS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_STALLRQS_Pos)     /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_STALLRQS            USBHS_DEVEPTIER_STALLRQS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_MASK                _U_(0xF70FF)                                   /**< \deprecated (USBHS_DEVEPTIER) Register MASK  (Use USBHS_DEVEPTIER_Msk instead)  */
+#define USBHS_DEVEPTIER_Msk                 _U_(0xF70FF)                                   /**< (USBHS_DEVEPTIER) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIDR : (USBHS Offset: 0x220) (/W 32) Device Endpoint Disable Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINEC:1;                  /**< bit:      0  Transmitted IN Interrupt Clear           */
+    uint32_t RXOUTEC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t OVERFEC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t SHORTPACKETEC:1;           /**< bit:      7  Shortpacket Interrupt Clear              */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Interrupt Clear     */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCONC:1;                /**< bit:     14  FIFO Control Clear                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMAC:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Clear */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIDR_OFFSET              (0x220)                                       /**<  (USBHS_DEVEPTIDR) Device Endpoint Disable Register (n = 0) 0  Offset */
+
+#define USBHS_DEVEPTIDR_TXINEC_Pos          0                                              /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_TXINEC_Msk          (_U_(0x1) << USBHS_DEVEPTIDR_TXINEC_Pos)       /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_TXINEC              USBHS_DEVEPTIDR_TXINEC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_TXINEC_Msk instead */
+#define USBHS_DEVEPTIDR_RXOUTEC_Pos         1                                              /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_RXOUTEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_RXOUTEC_Pos)      /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_RXOUTEC             USBHS_DEVEPTIDR_RXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_RXSTPEC_Pos         2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_RXSTPEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_RXSTPEC_Pos)      /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_RXSTPEC             USBHS_DEVEPTIDR_RXSTPEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_NAKOUTEC_Pos        3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NAKOUTEC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_NAKOUTEC_Pos)     /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NAKOUTEC            USBHS_DEVEPTIDR_NAKOUTEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_NAKINEC_Pos         4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NAKINEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_NAKINEC_Pos)      /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NAKINEC             USBHS_DEVEPTIDR_NAKINEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_OVERFEC_Pos         5                                              /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_OVERFEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_OVERFEC_Pos)      /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_OVERFEC             USBHS_DEVEPTIDR_OVERFEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_OVERFEC_Msk instead */
+#define USBHS_DEVEPTIDR_STALLEDEC_Pos       6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_STALLEDEC_Msk       (_U_(0x1) << USBHS_DEVEPTIDR_STALLEDEC_Pos)    /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_STALLEDEC           USBHS_DEVEPTIDR_STALLEDEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC_Pos   7                                              /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_SHORTPACKETEC_Pos)  /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC       USBHS_DEVEPTIDR_SHORTPACKETEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_SHORTPACKETEC_Msk instead */
+#define USBHS_DEVEPTIDR_NBUSYBKEC_Pos       12                                             /**< (USBHS_DEVEPTIDR) Number of Busy Banks Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NBUSYBKEC_Msk       (_U_(0x1) << USBHS_DEVEPTIDR_NBUSYBKEC_Pos)    /**< (USBHS_DEVEPTIDR) Number of Busy Banks Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NBUSYBKEC           USBHS_DEVEPTIDR_NBUSYBKEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NBUSYBKEC_Msk instead */
+#define USBHS_DEVEPTIDR_FIFOCONC_Pos        14                                             /**< (USBHS_DEVEPTIDR) FIFO Control Clear Position */
+#define USBHS_DEVEPTIDR_FIFOCONC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_FIFOCONC_Pos)     /**< (USBHS_DEVEPTIDR) FIFO Control Clear Mask */
+#define USBHS_DEVEPTIDR_FIFOCONC            USBHS_DEVEPTIDR_FIFOCONC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_FIFOCONC_Msk instead */
+#define USBHS_DEVEPTIDR_EPDISHDMAC_Pos      16                                             /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Position */
+#define USBHS_DEVEPTIDR_EPDISHDMAC_Msk      (_U_(0x1) << USBHS_DEVEPTIDR_EPDISHDMAC_Pos)   /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Mask */
+#define USBHS_DEVEPTIDR_EPDISHDMAC          USBHS_DEVEPTIDR_EPDISHDMAC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_EPDISHDMAC_Msk instead */
+#define USBHS_DEVEPTIDR_NYETDISC_Pos        17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_NYETDISC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_NYETDISC_Pos)     /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_NYETDISC            USBHS_DEVEPTIDR_NYETDISC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_STALLRQC_Pos        19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_STALLRQC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_STALLRQC_Pos)     /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_STALLRQC            USBHS_DEVEPTIDR_STALLRQC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_MASK                _U_(0xB50FF)                                   /**< \deprecated (USBHS_DEVEPTIDR) Register MASK  (Use USBHS_DEVEPTIDR_Msk instead)  */
+#define USBHS_DEVEPTIDR_Msk                 _U_(0xB50FF)                                   /**< (USBHS_DEVEPTIDR) Register Mask  */
+
+
+/* -------- USBHS_HSTCTRL : (USBHS Offset: 0x400) (R/W 32) Host General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SOFE:1;                    /**< bit:      8  Start of Frame Generation Enable         */
+    uint32_t RESET:1;                   /**< bit:      9  Send USB Reset                           */
+    uint32_t RESUME:1;                  /**< bit:     10  Send USB Resume                          */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t SPDCONF:2;                 /**< bit: 12..13  Mode Configuration                       */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTCTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTCTRL_OFFSET                (0x400)                                       /**<  (USBHS_HSTCTRL) Host General Control Register  Offset */
+
+#define USBHS_HSTCTRL_SOFE_Pos              8                                              /**< (USBHS_HSTCTRL) Start of Frame Generation Enable Position */
+#define USBHS_HSTCTRL_SOFE_Msk              (_U_(0x1) << USBHS_HSTCTRL_SOFE_Pos)           /**< (USBHS_HSTCTRL) Start of Frame Generation Enable Mask */
+#define USBHS_HSTCTRL_SOFE                  USBHS_HSTCTRL_SOFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_SOFE_Msk instead */
+#define USBHS_HSTCTRL_RESET_Pos             9                                              /**< (USBHS_HSTCTRL) Send USB Reset Position */
+#define USBHS_HSTCTRL_RESET_Msk             (_U_(0x1) << USBHS_HSTCTRL_RESET_Pos)          /**< (USBHS_HSTCTRL) Send USB Reset Mask */
+#define USBHS_HSTCTRL_RESET                 USBHS_HSTCTRL_RESET_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_RESET_Msk instead */
+#define USBHS_HSTCTRL_RESUME_Pos            10                                             /**< (USBHS_HSTCTRL) Send USB Resume Position */
+#define USBHS_HSTCTRL_RESUME_Msk            (_U_(0x1) << USBHS_HSTCTRL_RESUME_Pos)         /**< (USBHS_HSTCTRL) Send USB Resume Mask */
+#define USBHS_HSTCTRL_RESUME                USBHS_HSTCTRL_RESUME_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_RESUME_Msk instead */
+#define USBHS_HSTCTRL_SPDCONF_Pos           12                                             /**< (USBHS_HSTCTRL) Mode Configuration Position */
+#define USBHS_HSTCTRL_SPDCONF_Msk           (_U_(0x3) << USBHS_HSTCTRL_SPDCONF_Pos)        /**< (USBHS_HSTCTRL) Mode Configuration Mask */
+#define USBHS_HSTCTRL_SPDCONF(value)        (USBHS_HSTCTRL_SPDCONF_Msk & ((value) << USBHS_HSTCTRL_SPDCONF_Pos))
+#define   USBHS_HSTCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable.  */
+#define   USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_HSTCTRL) Forced high speed.  */
+#define   USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability.  */
+#define USBHS_HSTCTRL_SPDCONF_NORMAL        (USBHS_HSTCTRL_SPDCONF_NORMAL_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable. Position  */
+#define USBHS_HSTCTRL_SPDCONF_LOW_POWER     (USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_HIGH_SPEED    (USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) Forced high speed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_FORCED_FS     (USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability. Position  */
+#define USBHS_HSTCTRL_MASK                  _U_(0x3700)                                    /**< \deprecated (USBHS_HSTCTRL) Register MASK  (Use USBHS_HSTCTRL_Msk instead)  */
+#define USBHS_HSTCTRL_Msk                   _U_(0x3700)                                    /**< (USBHS_HSTCTRL) Register Mask  */
+
+
+/* -------- USBHS_HSTISR : (USBHS Offset: 0x404) (R/ 32) Host Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNI:1;                  /**< bit:      0  Device Connection Interrupt              */
+    uint32_t DDISCI:1;                  /**< bit:      1  Device Disconnection Interrupt           */
+    uint32_t RSTI:1;                    /**< bit:      2  USB Reset Sent Interrupt                 */
+    uint32_t RSMEDI:1;                  /**< bit:      3  Downstream Resume Sent Interrupt         */
+    uint32_t RXRSMI:1;                  /**< bit:      4  Upstream Resume Received Interrupt       */
+    uint32_t HSOFI:1;                   /**< bit:      5  Host Start of Frame Interrupt            */
+    uint32_t HWUPI:1;                   /**< bit:      6  Host Wake-Up Interrupt                   */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt                         */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt                         */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt                         */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt                         */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt                         */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt                         */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt                         */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt                         */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt                         */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt                         */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt                  */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt                  */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt                  */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt                  */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt                  */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt                  */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt                         */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTISR_OFFSET                 (0x404)                                       /**<  (USBHS_HSTISR) Host Global Interrupt Status Register  Offset */
+
+#define USBHS_HSTISR_DCONNI_Pos             0                                              /**< (USBHS_HSTISR) Device Connection Interrupt Position */
+#define USBHS_HSTISR_DCONNI_Msk             (_U_(0x1) << USBHS_HSTISR_DCONNI_Pos)          /**< (USBHS_HSTISR) Device Connection Interrupt Mask */
+#define USBHS_HSTISR_DCONNI                 USBHS_HSTISR_DCONNI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DCONNI_Msk instead */
+#define USBHS_HSTISR_DDISCI_Pos             1                                              /**< (USBHS_HSTISR) Device Disconnection Interrupt Position */
+#define USBHS_HSTISR_DDISCI_Msk             (_U_(0x1) << USBHS_HSTISR_DDISCI_Pos)          /**< (USBHS_HSTISR) Device Disconnection Interrupt Mask */
+#define USBHS_HSTISR_DDISCI                 USBHS_HSTISR_DDISCI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DDISCI_Msk instead */
+#define USBHS_HSTISR_RSTI_Pos               2                                              /**< (USBHS_HSTISR) USB Reset Sent Interrupt Position */
+#define USBHS_HSTISR_RSTI_Msk               (_U_(0x1) << USBHS_HSTISR_RSTI_Pos)            /**< (USBHS_HSTISR) USB Reset Sent Interrupt Mask */
+#define USBHS_HSTISR_RSTI                   USBHS_HSTISR_RSTI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RSTI_Msk instead */
+#define USBHS_HSTISR_RSMEDI_Pos             3                                              /**< (USBHS_HSTISR) Downstream Resume Sent Interrupt Position */
+#define USBHS_HSTISR_RSMEDI_Msk             (_U_(0x1) << USBHS_HSTISR_RSMEDI_Pos)          /**< (USBHS_HSTISR) Downstream Resume Sent Interrupt Mask */
+#define USBHS_HSTISR_RSMEDI                 USBHS_HSTISR_RSMEDI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RSMEDI_Msk instead */
+#define USBHS_HSTISR_RXRSMI_Pos             4                                              /**< (USBHS_HSTISR) Upstream Resume Received Interrupt Position */
+#define USBHS_HSTISR_RXRSMI_Msk             (_U_(0x1) << USBHS_HSTISR_RXRSMI_Pos)          /**< (USBHS_HSTISR) Upstream Resume Received Interrupt Mask */
+#define USBHS_HSTISR_RXRSMI                 USBHS_HSTISR_RXRSMI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RXRSMI_Msk instead */
+#define USBHS_HSTISR_HSOFI_Pos              5                                              /**< (USBHS_HSTISR) Host Start of Frame Interrupt Position */
+#define USBHS_HSTISR_HSOFI_Msk              (_U_(0x1) << USBHS_HSTISR_HSOFI_Pos)           /**< (USBHS_HSTISR) Host Start of Frame Interrupt Mask */
+#define USBHS_HSTISR_HSOFI                  USBHS_HSTISR_HSOFI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_HSOFI_Msk instead */
+#define USBHS_HSTISR_HWUPI_Pos              6                                              /**< (USBHS_HSTISR) Host Wake-Up Interrupt Position */
+#define USBHS_HSTISR_HWUPI_Msk              (_U_(0x1) << USBHS_HSTISR_HWUPI_Pos)           /**< (USBHS_HSTISR) Host Wake-Up Interrupt Mask */
+#define USBHS_HSTISR_HWUPI                  USBHS_HSTISR_HWUPI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_HWUPI_Msk instead */
+#define USBHS_HSTISR_PEP_0_Pos              8                                              /**< (USBHS_HSTISR) Pipe 0 Interrupt Position */
+#define USBHS_HSTISR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_0_Pos)           /**< (USBHS_HSTISR) Pipe 0 Interrupt Mask */
+#define USBHS_HSTISR_PEP_0                  USBHS_HSTISR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_0_Msk instead */
+#define USBHS_HSTISR_PEP_1_Pos              9                                              /**< (USBHS_HSTISR) Pipe 1 Interrupt Position */
+#define USBHS_HSTISR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_1_Pos)           /**< (USBHS_HSTISR) Pipe 1 Interrupt Mask */
+#define USBHS_HSTISR_PEP_1                  USBHS_HSTISR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_1_Msk instead */
+#define USBHS_HSTISR_PEP_2_Pos              10                                             /**< (USBHS_HSTISR) Pipe 2 Interrupt Position */
+#define USBHS_HSTISR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_2_Pos)           /**< (USBHS_HSTISR) Pipe 2 Interrupt Mask */
+#define USBHS_HSTISR_PEP_2                  USBHS_HSTISR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_2_Msk instead */
+#define USBHS_HSTISR_PEP_3_Pos              11                                             /**< (USBHS_HSTISR) Pipe 3 Interrupt Position */
+#define USBHS_HSTISR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_3_Pos)           /**< (USBHS_HSTISR) Pipe 3 Interrupt Mask */
+#define USBHS_HSTISR_PEP_3                  USBHS_HSTISR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_3_Msk instead */
+#define USBHS_HSTISR_PEP_4_Pos              12                                             /**< (USBHS_HSTISR) Pipe 4 Interrupt Position */
+#define USBHS_HSTISR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_4_Pos)           /**< (USBHS_HSTISR) Pipe 4 Interrupt Mask */
+#define USBHS_HSTISR_PEP_4                  USBHS_HSTISR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_4_Msk instead */
+#define USBHS_HSTISR_PEP_5_Pos              13                                             /**< (USBHS_HSTISR) Pipe 5 Interrupt Position */
+#define USBHS_HSTISR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_5_Pos)           /**< (USBHS_HSTISR) Pipe 5 Interrupt Mask */
+#define USBHS_HSTISR_PEP_5                  USBHS_HSTISR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_5_Msk instead */
+#define USBHS_HSTISR_PEP_6_Pos              14                                             /**< (USBHS_HSTISR) Pipe 6 Interrupt Position */
+#define USBHS_HSTISR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_6_Pos)           /**< (USBHS_HSTISR) Pipe 6 Interrupt Mask */
+#define USBHS_HSTISR_PEP_6                  USBHS_HSTISR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_6_Msk instead */
+#define USBHS_HSTISR_PEP_7_Pos              15                                             /**< (USBHS_HSTISR) Pipe 7 Interrupt Position */
+#define USBHS_HSTISR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_7_Pos)           /**< (USBHS_HSTISR) Pipe 7 Interrupt Mask */
+#define USBHS_HSTISR_PEP_7                  USBHS_HSTISR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_7_Msk instead */
+#define USBHS_HSTISR_PEP_8_Pos              16                                             /**< (USBHS_HSTISR) Pipe 8 Interrupt Position */
+#define USBHS_HSTISR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_8_Pos)           /**< (USBHS_HSTISR) Pipe 8 Interrupt Mask */
+#define USBHS_HSTISR_PEP_8                  USBHS_HSTISR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_8_Msk instead */
+#define USBHS_HSTISR_PEP_9_Pos              17                                             /**< (USBHS_HSTISR) Pipe 9 Interrupt Position */
+#define USBHS_HSTISR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_9_Pos)           /**< (USBHS_HSTISR) Pipe 9 Interrupt Mask */
+#define USBHS_HSTISR_PEP_9                  USBHS_HSTISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_9_Msk instead */
+#define USBHS_HSTISR_DMA_1_Pos              25                                             /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Position */
+#define USBHS_HSTISR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_1_Pos)           /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Mask */
+#define USBHS_HSTISR_DMA_1                  USBHS_HSTISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_1_Msk instead */
+#define USBHS_HSTISR_DMA_2_Pos              26                                             /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Position */
+#define USBHS_HSTISR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_2_Pos)           /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Mask */
+#define USBHS_HSTISR_DMA_2                  USBHS_HSTISR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_2_Msk instead */
+#define USBHS_HSTISR_DMA_3_Pos              27                                             /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Position */
+#define USBHS_HSTISR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_3_Pos)           /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Mask */
+#define USBHS_HSTISR_DMA_3                  USBHS_HSTISR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_3_Msk instead */
+#define USBHS_HSTISR_DMA_4_Pos              28                                             /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Position */
+#define USBHS_HSTISR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_4_Pos)           /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Mask */
+#define USBHS_HSTISR_DMA_4                  USBHS_HSTISR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_4_Msk instead */
+#define USBHS_HSTISR_DMA_5_Pos              29                                             /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Position */
+#define USBHS_HSTISR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_5_Pos)           /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Mask */
+#define USBHS_HSTISR_DMA_5                  USBHS_HSTISR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_5_Msk instead */
+#define USBHS_HSTISR_DMA_6_Pos              30                                             /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Position */
+#define USBHS_HSTISR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_6_Pos)           /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Mask */
+#define USBHS_HSTISR_DMA_6                  USBHS_HSTISR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_6_Msk instead */
+#define USBHS_HSTISR_DMA_7_Pos              31                                             /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Position */
+#define USBHS_HSTISR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_7_Pos)           /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Mask */
+#define USBHS_HSTISR_DMA_7                  USBHS_HSTISR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_7_Msk instead */
+#define USBHS_HSTISR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTISR) Register MASK  (Use USBHS_HSTISR_Msk instead)  */
+#define USBHS_HSTISR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTISR) Register Mask  */
+
+#define USBHS_HSTISR_PEP__Pos               8                                              /**< (USBHS_HSTISR Position) Pipe x Interrupt */
+#define USBHS_HSTISR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTISR_PEP__Pos)          /**< (USBHS_HSTISR Mask) PEP_ */
+#define USBHS_HSTISR_PEP_(value)            (USBHS_HSTISR_PEP__Msk & ((value) << USBHS_HSTISR_PEP__Pos))  
+#define USBHS_HSTISR_DMA__Pos               25                                             /**< (USBHS_HSTISR Position) DMA Channel 7 Interrupt */
+#define USBHS_HSTISR_DMA__Msk               (_U_(0x7F) << USBHS_HSTISR_DMA__Pos)           /**< (USBHS_HSTISR Mask) DMA_ */
+#define USBHS_HSTISR_DMA_(value)            (USBHS_HSTISR_DMA__Msk & ((value) << USBHS_HSTISR_DMA__Pos))  
+
+/* -------- USBHS_HSTICR : (USBHS Offset: 0x408) (/W 32) Host Global Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIC:1;                 /**< bit:      0  Device Connection Interrupt Clear        */
+    uint32_t DDISCIC:1;                 /**< bit:      1  Device Disconnection Interrupt Clear     */
+    uint32_t RSTIC:1;                   /**< bit:      2  USB Reset Sent Interrupt Clear           */
+    uint32_t RSMEDIC:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Clear   */
+    uint32_t RXRSMIC:1;                 /**< bit:      4  Upstream Resume Received Interrupt Clear */
+    uint32_t HSOFIC:1;                  /**< bit:      5  Host Start of Frame Interrupt Clear      */
+    uint32_t HWUPIC:1;                  /**< bit:      6  Host Wake-Up Interrupt Clear             */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTICR_OFFSET                 (0x408)                                       /**<  (USBHS_HSTICR) Host Global Interrupt Clear Register  Offset */
+
+#define USBHS_HSTICR_DCONNIC_Pos            0                                              /**< (USBHS_HSTICR) Device Connection Interrupt Clear Position */
+#define USBHS_HSTICR_DCONNIC_Msk            (_U_(0x1) << USBHS_HSTICR_DCONNIC_Pos)         /**< (USBHS_HSTICR) Device Connection Interrupt Clear Mask */
+#define USBHS_HSTICR_DCONNIC                USBHS_HSTICR_DCONNIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_DCONNIC_Msk instead */
+#define USBHS_HSTICR_DDISCIC_Pos            1                                              /**< (USBHS_HSTICR) Device Disconnection Interrupt Clear Position */
+#define USBHS_HSTICR_DDISCIC_Msk            (_U_(0x1) << USBHS_HSTICR_DDISCIC_Pos)         /**< (USBHS_HSTICR) Device Disconnection Interrupt Clear Mask */
+#define USBHS_HSTICR_DDISCIC                USBHS_HSTICR_DDISCIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_DDISCIC_Msk instead */
+#define USBHS_HSTICR_RSTIC_Pos              2                                              /**< (USBHS_HSTICR) USB Reset Sent Interrupt Clear Position */
+#define USBHS_HSTICR_RSTIC_Msk              (_U_(0x1) << USBHS_HSTICR_RSTIC_Pos)           /**< (USBHS_HSTICR) USB Reset Sent Interrupt Clear Mask */
+#define USBHS_HSTICR_RSTIC                  USBHS_HSTICR_RSTIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RSTIC_Msk instead */
+#define USBHS_HSTICR_RSMEDIC_Pos            3                                              /**< (USBHS_HSTICR) Downstream Resume Sent Interrupt Clear Position */
+#define USBHS_HSTICR_RSMEDIC_Msk            (_U_(0x1) << USBHS_HSTICR_RSMEDIC_Pos)         /**< (USBHS_HSTICR) Downstream Resume Sent Interrupt Clear Mask */
+#define USBHS_HSTICR_RSMEDIC                USBHS_HSTICR_RSMEDIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RSMEDIC_Msk instead */
+#define USBHS_HSTICR_RXRSMIC_Pos            4                                              /**< (USBHS_HSTICR) Upstream Resume Received Interrupt Clear Position */
+#define USBHS_HSTICR_RXRSMIC_Msk            (_U_(0x1) << USBHS_HSTICR_RXRSMIC_Pos)         /**< (USBHS_HSTICR) Upstream Resume Received Interrupt Clear Mask */
+#define USBHS_HSTICR_RXRSMIC                USBHS_HSTICR_RXRSMIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RXRSMIC_Msk instead */
+#define USBHS_HSTICR_HSOFIC_Pos             5                                              /**< (USBHS_HSTICR) Host Start of Frame Interrupt Clear Position */
+#define USBHS_HSTICR_HSOFIC_Msk             (_U_(0x1) << USBHS_HSTICR_HSOFIC_Pos)          /**< (USBHS_HSTICR) Host Start of Frame Interrupt Clear Mask */
+#define USBHS_HSTICR_HSOFIC                 USBHS_HSTICR_HSOFIC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_HSOFIC_Msk instead */
+#define USBHS_HSTICR_HWUPIC_Pos             6                                              /**< (USBHS_HSTICR) Host Wake-Up Interrupt Clear Position */
+#define USBHS_HSTICR_HWUPIC_Msk             (_U_(0x1) << USBHS_HSTICR_HWUPIC_Pos)          /**< (USBHS_HSTICR) Host Wake-Up Interrupt Clear Mask */
+#define USBHS_HSTICR_HWUPIC                 USBHS_HSTICR_HWUPIC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_HWUPIC_Msk instead */
+#define USBHS_HSTICR_MASK                   _U_(0x7F)                                      /**< \deprecated (USBHS_HSTICR) Register MASK  (Use USBHS_HSTICR_Msk instead)  */
+#define USBHS_HSTICR_Msk                    _U_(0x7F)                                      /**< (USBHS_HSTICR) Register Mask  */
+
+
+/* -------- USBHS_HSTIFR : (USBHS Offset: 0x40c) (/W 32) Host Global Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIS:1;                 /**< bit:      0  Device Connection Interrupt Set          */
+    uint32_t DDISCIS:1;                 /**< bit:      1  Device Disconnection Interrupt Set       */
+    uint32_t RSTIS:1;                   /**< bit:      2  USB Reset Sent Interrupt Set             */
+    uint32_t RSMEDIS:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Set     */
+    uint32_t RXRSMIS:1;                 /**< bit:      4  Upstream Resume Received Interrupt Set   */
+    uint32_t HSOFIS:1;                  /**< bit:      5  Host Start of Frame Interrupt Set        */
+    uint32_t HWUPIS:1;                  /**< bit:      6  Host Wake-Up Interrupt Set               */
+    uint32_t :18;                       /**< bit:  7..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Set              */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Set              */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Set              */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Set              */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Set              */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Set              */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Set              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :25;                       /**< bit:  0..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Set              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIFR_OFFSET                 (0x40C)                                       /**<  (USBHS_HSTIFR) Host Global Interrupt Set Register  Offset */
+
+#define USBHS_HSTIFR_DCONNIS_Pos            0                                              /**< (USBHS_HSTIFR) Device Connection Interrupt Set Position */
+#define USBHS_HSTIFR_DCONNIS_Msk            (_U_(0x1) << USBHS_HSTIFR_DCONNIS_Pos)         /**< (USBHS_HSTIFR) Device Connection Interrupt Set Mask */
+#define USBHS_HSTIFR_DCONNIS                USBHS_HSTIFR_DCONNIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DCONNIS_Msk instead */
+#define USBHS_HSTIFR_DDISCIS_Pos            1                                              /**< (USBHS_HSTIFR) Device Disconnection Interrupt Set Position */
+#define USBHS_HSTIFR_DDISCIS_Msk            (_U_(0x1) << USBHS_HSTIFR_DDISCIS_Pos)         /**< (USBHS_HSTIFR) Device Disconnection Interrupt Set Mask */
+#define USBHS_HSTIFR_DDISCIS                USBHS_HSTIFR_DDISCIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DDISCIS_Msk instead */
+#define USBHS_HSTIFR_RSTIS_Pos              2                                              /**< (USBHS_HSTIFR) USB Reset Sent Interrupt Set Position */
+#define USBHS_HSTIFR_RSTIS_Msk              (_U_(0x1) << USBHS_HSTIFR_RSTIS_Pos)           /**< (USBHS_HSTIFR) USB Reset Sent Interrupt Set Mask */
+#define USBHS_HSTIFR_RSTIS                  USBHS_HSTIFR_RSTIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RSTIS_Msk instead */
+#define USBHS_HSTIFR_RSMEDIS_Pos            3                                              /**< (USBHS_HSTIFR) Downstream Resume Sent Interrupt Set Position */
+#define USBHS_HSTIFR_RSMEDIS_Msk            (_U_(0x1) << USBHS_HSTIFR_RSMEDIS_Pos)         /**< (USBHS_HSTIFR) Downstream Resume Sent Interrupt Set Mask */
+#define USBHS_HSTIFR_RSMEDIS                USBHS_HSTIFR_RSMEDIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RSMEDIS_Msk instead */
+#define USBHS_HSTIFR_RXRSMIS_Pos            4                                              /**< (USBHS_HSTIFR) Upstream Resume Received Interrupt Set Position */
+#define USBHS_HSTIFR_RXRSMIS_Msk            (_U_(0x1) << USBHS_HSTIFR_RXRSMIS_Pos)         /**< (USBHS_HSTIFR) Upstream Resume Received Interrupt Set Mask */
+#define USBHS_HSTIFR_RXRSMIS                USBHS_HSTIFR_RXRSMIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RXRSMIS_Msk instead */
+#define USBHS_HSTIFR_HSOFIS_Pos             5                                              /**< (USBHS_HSTIFR) Host Start of Frame Interrupt Set Position */
+#define USBHS_HSTIFR_HSOFIS_Msk             (_U_(0x1) << USBHS_HSTIFR_HSOFIS_Pos)          /**< (USBHS_HSTIFR) Host Start of Frame Interrupt Set Mask */
+#define USBHS_HSTIFR_HSOFIS                 USBHS_HSTIFR_HSOFIS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_HSOFIS_Msk instead */
+#define USBHS_HSTIFR_HWUPIS_Pos             6                                              /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Position */
+#define USBHS_HSTIFR_HWUPIS_Msk             (_U_(0x1) << USBHS_HSTIFR_HWUPIS_Pos)          /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Mask */
+#define USBHS_HSTIFR_HWUPIS                 USBHS_HSTIFR_HWUPIS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_HWUPIS_Msk instead */
+#define USBHS_HSTIFR_DMA_1_Pos              25                                             /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_1_Pos)           /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_1                  USBHS_HSTIFR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_1_Msk instead */
+#define USBHS_HSTIFR_DMA_2_Pos              26                                             /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_2_Pos)           /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_2                  USBHS_HSTIFR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_2_Msk instead */
+#define USBHS_HSTIFR_DMA_3_Pos              27                                             /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_3_Pos)           /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_3                  USBHS_HSTIFR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_3_Msk instead */
+#define USBHS_HSTIFR_DMA_4_Pos              28                                             /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_4_Pos)           /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_4                  USBHS_HSTIFR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_4_Msk instead */
+#define USBHS_HSTIFR_DMA_5_Pos              29                                             /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_5_Pos)           /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_5                  USBHS_HSTIFR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_5_Msk instead */
+#define USBHS_HSTIFR_DMA_6_Pos              30                                             /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_6_Pos)           /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_6                  USBHS_HSTIFR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_6_Msk instead */
+#define USBHS_HSTIFR_DMA_7_Pos              31                                             /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_7_Pos)           /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_7                  USBHS_HSTIFR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_7_Msk instead */
+#define USBHS_HSTIFR_MASK                   _U_(0xFE00007F)                                /**< \deprecated (USBHS_HSTIFR) Register MASK  (Use USBHS_HSTIFR_Msk instead)  */
+#define USBHS_HSTIFR_Msk                    _U_(0xFE00007F)                                /**< (USBHS_HSTIFR) Register Mask  */
+
+#define USBHS_HSTIFR_DMA__Pos               25                                             /**< (USBHS_HSTIFR Position) DMA Channel 7 Interrupt Set */
+#define USBHS_HSTIFR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIFR_DMA__Pos)           /**< (USBHS_HSTIFR Mask) DMA_ */
+#define USBHS_HSTIFR_DMA_(value)            (USBHS_HSTIFR_DMA__Msk & ((value) << USBHS_HSTIFR_DMA__Pos))  
+
+/* -------- USBHS_HSTIMR : (USBHS Offset: 0x410) (R/ 32) Host Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIE:1;                 /**< bit:      0  Device Connection Interrupt Enable       */
+    uint32_t DDISCIE:1;                 /**< bit:      1  Device Disconnection Interrupt Enable    */
+    uint32_t RSTIE:1;                   /**< bit:      2  USB Reset Sent Interrupt Enable          */
+    uint32_t RSMEDIE:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Enable  */
+    uint32_t RXRSMIE:1;                 /**< bit:      4  Upstream Resume Received Interrupt Enable */
+    uint32_t HSOFIE:1;                  /**< bit:      5  Host Start of Frame Interrupt Enable     */
+    uint32_t HWUPIE:1;                  /**< bit:      6  Host Wake-Up Interrupt Enable            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Enable                  */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Enable                  */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Enable                  */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Enable                  */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Enable                  */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Enable                  */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Enable                  */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIMR_OFFSET                 (0x410)                                       /**<  (USBHS_HSTIMR) Host Global Interrupt Mask Register  Offset */
+
+#define USBHS_HSTIMR_DCONNIE_Pos            0                                              /**< (USBHS_HSTIMR) Device Connection Interrupt Enable Position */
+#define USBHS_HSTIMR_DCONNIE_Msk            (_U_(0x1) << USBHS_HSTIMR_DCONNIE_Pos)         /**< (USBHS_HSTIMR) Device Connection Interrupt Enable Mask */
+#define USBHS_HSTIMR_DCONNIE                USBHS_HSTIMR_DCONNIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DCONNIE_Msk instead */
+#define USBHS_HSTIMR_DDISCIE_Pos            1                                              /**< (USBHS_HSTIMR) Device Disconnection Interrupt Enable Position */
+#define USBHS_HSTIMR_DDISCIE_Msk            (_U_(0x1) << USBHS_HSTIMR_DDISCIE_Pos)         /**< (USBHS_HSTIMR) Device Disconnection Interrupt Enable Mask */
+#define USBHS_HSTIMR_DDISCIE                USBHS_HSTIMR_DDISCIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DDISCIE_Msk instead */
+#define USBHS_HSTIMR_RSTIE_Pos              2                                              /**< (USBHS_HSTIMR) USB Reset Sent Interrupt Enable Position */
+#define USBHS_HSTIMR_RSTIE_Msk              (_U_(0x1) << USBHS_HSTIMR_RSTIE_Pos)           /**< (USBHS_HSTIMR) USB Reset Sent Interrupt Enable Mask */
+#define USBHS_HSTIMR_RSTIE                  USBHS_HSTIMR_RSTIE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RSTIE_Msk instead */
+#define USBHS_HSTIMR_RSMEDIE_Pos            3                                              /**< (USBHS_HSTIMR) Downstream Resume Sent Interrupt Enable Position */
+#define USBHS_HSTIMR_RSMEDIE_Msk            (_U_(0x1) << USBHS_HSTIMR_RSMEDIE_Pos)         /**< (USBHS_HSTIMR) Downstream Resume Sent Interrupt Enable Mask */
+#define USBHS_HSTIMR_RSMEDIE                USBHS_HSTIMR_RSMEDIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RSMEDIE_Msk instead */
+#define USBHS_HSTIMR_RXRSMIE_Pos            4                                              /**< (USBHS_HSTIMR) Upstream Resume Received Interrupt Enable Position */
+#define USBHS_HSTIMR_RXRSMIE_Msk            (_U_(0x1) << USBHS_HSTIMR_RXRSMIE_Pos)         /**< (USBHS_HSTIMR) Upstream Resume Received Interrupt Enable Mask */
+#define USBHS_HSTIMR_RXRSMIE                USBHS_HSTIMR_RXRSMIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RXRSMIE_Msk instead */
+#define USBHS_HSTIMR_HSOFIE_Pos             5                                              /**< (USBHS_HSTIMR) Host Start of Frame Interrupt Enable Position */
+#define USBHS_HSTIMR_HSOFIE_Msk             (_U_(0x1) << USBHS_HSTIMR_HSOFIE_Pos)          /**< (USBHS_HSTIMR) Host Start of Frame Interrupt Enable Mask */
+#define USBHS_HSTIMR_HSOFIE                 USBHS_HSTIMR_HSOFIE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_HSOFIE_Msk instead */
+#define USBHS_HSTIMR_HWUPIE_Pos             6                                              /**< (USBHS_HSTIMR) Host Wake-Up Interrupt Enable Position */
+#define USBHS_HSTIMR_HWUPIE_Msk             (_U_(0x1) << USBHS_HSTIMR_HWUPIE_Pos)          /**< (USBHS_HSTIMR) Host Wake-Up Interrupt Enable Mask */
+#define USBHS_HSTIMR_HWUPIE                 USBHS_HSTIMR_HWUPIE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_HWUPIE_Msk instead */
+#define USBHS_HSTIMR_PEP_0_Pos              8                                              /**< (USBHS_HSTIMR) Pipe 0 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_0_Pos)           /**< (USBHS_HSTIMR) Pipe 0 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_0                  USBHS_HSTIMR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_0_Msk instead */
+#define USBHS_HSTIMR_PEP_1_Pos              9                                              /**< (USBHS_HSTIMR) Pipe 1 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_1_Pos)           /**< (USBHS_HSTIMR) Pipe 1 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_1                  USBHS_HSTIMR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_1_Msk instead */
+#define USBHS_HSTIMR_PEP_2_Pos              10                                             /**< (USBHS_HSTIMR) Pipe 2 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_2_Pos)           /**< (USBHS_HSTIMR) Pipe 2 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_2                  USBHS_HSTIMR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_2_Msk instead */
+#define USBHS_HSTIMR_PEP_3_Pos              11                                             /**< (USBHS_HSTIMR) Pipe 3 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_3_Pos)           /**< (USBHS_HSTIMR) Pipe 3 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_3                  USBHS_HSTIMR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_3_Msk instead */
+#define USBHS_HSTIMR_PEP_4_Pos              12                                             /**< (USBHS_HSTIMR) Pipe 4 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_4_Pos)           /**< (USBHS_HSTIMR) Pipe 4 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_4                  USBHS_HSTIMR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_4_Msk instead */
+#define USBHS_HSTIMR_PEP_5_Pos              13                                             /**< (USBHS_HSTIMR) Pipe 5 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_5_Pos)           /**< (USBHS_HSTIMR) Pipe 5 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_5                  USBHS_HSTIMR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_5_Msk instead */
+#define USBHS_HSTIMR_PEP_6_Pos              14                                             /**< (USBHS_HSTIMR) Pipe 6 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_6_Pos)           /**< (USBHS_HSTIMR) Pipe 6 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_6                  USBHS_HSTIMR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_6_Msk instead */
+#define USBHS_HSTIMR_PEP_7_Pos              15                                             /**< (USBHS_HSTIMR) Pipe 7 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_7_Pos)           /**< (USBHS_HSTIMR) Pipe 7 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_7                  USBHS_HSTIMR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_7_Msk instead */
+#define USBHS_HSTIMR_PEP_8_Pos              16                                             /**< (USBHS_HSTIMR) Pipe 8 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_8_Pos)           /**< (USBHS_HSTIMR) Pipe 8 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_8                  USBHS_HSTIMR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_8_Msk instead */
+#define USBHS_HSTIMR_PEP_9_Pos              17                                             /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_9_Pos)           /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_9                  USBHS_HSTIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_9_Msk instead */
+#define USBHS_HSTIMR_DMA_1_Pos              25                                             /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_1_Pos)           /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_1                  USBHS_HSTIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_1_Msk instead */
+#define USBHS_HSTIMR_DMA_2_Pos              26                                             /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_2_Pos)           /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_2                  USBHS_HSTIMR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_2_Msk instead */
+#define USBHS_HSTIMR_DMA_3_Pos              27                                             /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_3_Pos)           /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_3                  USBHS_HSTIMR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_3_Msk instead */
+#define USBHS_HSTIMR_DMA_4_Pos              28                                             /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_4_Pos)           /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_4                  USBHS_HSTIMR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_4_Msk instead */
+#define USBHS_HSTIMR_DMA_5_Pos              29                                             /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_5_Pos)           /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_5                  USBHS_HSTIMR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_5_Msk instead */
+#define USBHS_HSTIMR_DMA_6_Pos              30                                             /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_6_Pos)           /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_6                  USBHS_HSTIMR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_6_Msk instead */
+#define USBHS_HSTIMR_DMA_7_Pos              31                                             /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_7_Pos)           /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_7                  USBHS_HSTIMR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_7_Msk instead */
+#define USBHS_HSTIMR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIMR) Register MASK  (Use USBHS_HSTIMR_Msk instead)  */
+#define USBHS_HSTIMR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIMR) Register Mask  */
+
+#define USBHS_HSTIMR_PEP__Pos               8                                              /**< (USBHS_HSTIMR Position) Pipe x Interrupt Enable */
+#define USBHS_HSTIMR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIMR_PEP__Pos)          /**< (USBHS_HSTIMR Mask) PEP_ */
+#define USBHS_HSTIMR_PEP_(value)            (USBHS_HSTIMR_PEP__Msk & ((value) << USBHS_HSTIMR_PEP__Pos))  
+#define USBHS_HSTIMR_DMA__Pos               25                                             /**< (USBHS_HSTIMR Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_HSTIMR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIMR_DMA__Pos)           /**< (USBHS_HSTIMR Mask) DMA_ */
+#define USBHS_HSTIMR_DMA_(value)            (USBHS_HSTIMR_DMA__Msk & ((value) << USBHS_HSTIMR_DMA__Pos))  
+
+/* -------- USBHS_HSTIDR : (USBHS Offset: 0x414) (/W 32) Host Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIEC:1;                /**< bit:      0  Device Connection Interrupt Disable      */
+    uint32_t DDISCIEC:1;                /**< bit:      1  Device Disconnection Interrupt Disable   */
+    uint32_t RSTIEC:1;                  /**< bit:      2  USB Reset Sent Interrupt Disable         */
+    uint32_t RSMEDIEC:1;                /**< bit:      3  Downstream Resume Sent Interrupt Disable */
+    uint32_t RXRSMIEC:1;                /**< bit:      4  Upstream Resume Received Interrupt Disable */
+    uint32_t HSOFIEC:1;                 /**< bit:      5  Host Start of Frame Interrupt Disable    */
+    uint32_t HWUPIEC:1;                 /**< bit:      6  Host Wake-Up Interrupt Disable           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Disable                 */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Disable                 */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Disable                 */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Disable                 */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Disable                 */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Disable                 */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Disable                 */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Disable                 */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Disable                 */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Disable                 */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Disable          */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Disable          */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Disable          */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Disable          */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Disable          */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Disable          */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Disable          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Disable                 */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Disable          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIDR_OFFSET                 (0x414)                                       /**<  (USBHS_HSTIDR) Host Global Interrupt Disable Register  Offset */
+
+#define USBHS_HSTIDR_DCONNIEC_Pos           0                                              /**< (USBHS_HSTIDR) Device Connection Interrupt Disable Position */
+#define USBHS_HSTIDR_DCONNIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_DCONNIEC_Pos)        /**< (USBHS_HSTIDR) Device Connection Interrupt Disable Mask */
+#define USBHS_HSTIDR_DCONNIEC               USBHS_HSTIDR_DCONNIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DCONNIEC_Msk instead */
+#define USBHS_HSTIDR_DDISCIEC_Pos           1                                              /**< (USBHS_HSTIDR) Device Disconnection Interrupt Disable Position */
+#define USBHS_HSTIDR_DDISCIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_DDISCIEC_Pos)        /**< (USBHS_HSTIDR) Device Disconnection Interrupt Disable Mask */
+#define USBHS_HSTIDR_DDISCIEC               USBHS_HSTIDR_DDISCIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DDISCIEC_Msk instead */
+#define USBHS_HSTIDR_RSTIEC_Pos             2                                              /**< (USBHS_HSTIDR) USB Reset Sent Interrupt Disable Position */
+#define USBHS_HSTIDR_RSTIEC_Msk             (_U_(0x1) << USBHS_HSTIDR_RSTIEC_Pos)          /**< (USBHS_HSTIDR) USB Reset Sent Interrupt Disable Mask */
+#define USBHS_HSTIDR_RSTIEC                 USBHS_HSTIDR_RSTIEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RSTIEC_Msk instead */
+#define USBHS_HSTIDR_RSMEDIEC_Pos           3                                              /**< (USBHS_HSTIDR) Downstream Resume Sent Interrupt Disable Position */
+#define USBHS_HSTIDR_RSMEDIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_RSMEDIEC_Pos)        /**< (USBHS_HSTIDR) Downstream Resume Sent Interrupt Disable Mask */
+#define USBHS_HSTIDR_RSMEDIEC               USBHS_HSTIDR_RSMEDIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RSMEDIEC_Msk instead */
+#define USBHS_HSTIDR_RXRSMIEC_Pos           4                                              /**< (USBHS_HSTIDR) Upstream Resume Received Interrupt Disable Position */
+#define USBHS_HSTIDR_RXRSMIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_RXRSMIEC_Pos)        /**< (USBHS_HSTIDR) Upstream Resume Received Interrupt Disable Mask */
+#define USBHS_HSTIDR_RXRSMIEC               USBHS_HSTIDR_RXRSMIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RXRSMIEC_Msk instead */
+#define USBHS_HSTIDR_HSOFIEC_Pos            5                                              /**< (USBHS_HSTIDR) Host Start of Frame Interrupt Disable Position */
+#define USBHS_HSTIDR_HSOFIEC_Msk            (_U_(0x1) << USBHS_HSTIDR_HSOFIEC_Pos)         /**< (USBHS_HSTIDR) Host Start of Frame Interrupt Disable Mask */
+#define USBHS_HSTIDR_HSOFIEC                USBHS_HSTIDR_HSOFIEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_HSOFIEC_Msk instead */
+#define USBHS_HSTIDR_HWUPIEC_Pos            6                                              /**< (USBHS_HSTIDR) Host Wake-Up Interrupt Disable Position */
+#define USBHS_HSTIDR_HWUPIEC_Msk            (_U_(0x1) << USBHS_HSTIDR_HWUPIEC_Pos)         /**< (USBHS_HSTIDR) Host Wake-Up Interrupt Disable Mask */
+#define USBHS_HSTIDR_HWUPIEC                USBHS_HSTIDR_HWUPIEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_HWUPIEC_Msk instead */
+#define USBHS_HSTIDR_PEP_0_Pos              8                                              /**< (USBHS_HSTIDR) Pipe 0 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_0_Pos)           /**< (USBHS_HSTIDR) Pipe 0 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_0                  USBHS_HSTIDR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_0_Msk instead */
+#define USBHS_HSTIDR_PEP_1_Pos              9                                              /**< (USBHS_HSTIDR) Pipe 1 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_1_Pos)           /**< (USBHS_HSTIDR) Pipe 1 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_1                  USBHS_HSTIDR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_1_Msk instead */
+#define USBHS_HSTIDR_PEP_2_Pos              10                                             /**< (USBHS_HSTIDR) Pipe 2 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_2_Pos)           /**< (USBHS_HSTIDR) Pipe 2 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_2                  USBHS_HSTIDR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_2_Msk instead */
+#define USBHS_HSTIDR_PEP_3_Pos              11                                             /**< (USBHS_HSTIDR) Pipe 3 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_3_Pos)           /**< (USBHS_HSTIDR) Pipe 3 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_3                  USBHS_HSTIDR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_3_Msk instead */
+#define USBHS_HSTIDR_PEP_4_Pos              12                                             /**< (USBHS_HSTIDR) Pipe 4 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_4_Pos)           /**< (USBHS_HSTIDR) Pipe 4 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_4                  USBHS_HSTIDR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_4_Msk instead */
+#define USBHS_HSTIDR_PEP_5_Pos              13                                             /**< (USBHS_HSTIDR) Pipe 5 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_5_Pos)           /**< (USBHS_HSTIDR) Pipe 5 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_5                  USBHS_HSTIDR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_5_Msk instead */
+#define USBHS_HSTIDR_PEP_6_Pos              14                                             /**< (USBHS_HSTIDR) Pipe 6 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_6_Pos)           /**< (USBHS_HSTIDR) Pipe 6 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_6                  USBHS_HSTIDR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_6_Msk instead */
+#define USBHS_HSTIDR_PEP_7_Pos              15                                             /**< (USBHS_HSTIDR) Pipe 7 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_7_Pos)           /**< (USBHS_HSTIDR) Pipe 7 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_7                  USBHS_HSTIDR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_7_Msk instead */
+#define USBHS_HSTIDR_PEP_8_Pos              16                                             /**< (USBHS_HSTIDR) Pipe 8 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_8_Pos)           /**< (USBHS_HSTIDR) Pipe 8 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_8                  USBHS_HSTIDR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_8_Msk instead */
+#define USBHS_HSTIDR_PEP_9_Pos              17                                             /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_9_Pos)           /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_9                  USBHS_HSTIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_9_Msk instead */
+#define USBHS_HSTIDR_DMA_1_Pos              25                                             /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_1_Pos)           /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_1                  USBHS_HSTIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_1_Msk instead */
+#define USBHS_HSTIDR_DMA_2_Pos              26                                             /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_2_Pos)           /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_2                  USBHS_HSTIDR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_2_Msk instead */
+#define USBHS_HSTIDR_DMA_3_Pos              27                                             /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_3_Pos)           /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_3                  USBHS_HSTIDR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_3_Msk instead */
+#define USBHS_HSTIDR_DMA_4_Pos              28                                             /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_4_Pos)           /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_4                  USBHS_HSTIDR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_4_Msk instead */
+#define USBHS_HSTIDR_DMA_5_Pos              29                                             /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_5_Pos)           /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_5                  USBHS_HSTIDR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_5_Msk instead */
+#define USBHS_HSTIDR_DMA_6_Pos              30                                             /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_6_Pos)           /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_6                  USBHS_HSTIDR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_6_Msk instead */
+#define USBHS_HSTIDR_DMA_7_Pos              31                                             /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_7_Pos)           /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_7                  USBHS_HSTIDR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_7_Msk instead */
+#define USBHS_HSTIDR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIDR) Register MASK  (Use USBHS_HSTIDR_Msk instead)  */
+#define USBHS_HSTIDR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIDR) Register Mask  */
+
+#define USBHS_HSTIDR_PEP__Pos               8                                              /**< (USBHS_HSTIDR Position) Pipe x Interrupt Disable */
+#define USBHS_HSTIDR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIDR_PEP__Pos)          /**< (USBHS_HSTIDR Mask) PEP_ */
+#define USBHS_HSTIDR_PEP_(value)            (USBHS_HSTIDR_PEP__Msk & ((value) << USBHS_HSTIDR_PEP__Pos))  
+#define USBHS_HSTIDR_DMA__Pos               25                                             /**< (USBHS_HSTIDR Position) DMA Channel 7 Interrupt Disable */
+#define USBHS_HSTIDR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIDR_DMA__Pos)           /**< (USBHS_HSTIDR Mask) DMA_ */
+#define USBHS_HSTIDR_DMA_(value)            (USBHS_HSTIDR_DMA__Msk & ((value) << USBHS_HSTIDR_DMA__Pos))  
+
+/* -------- USBHS_HSTIER : (USBHS Offset: 0x418) (/W 32) Host Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIES:1;                /**< bit:      0  Device Connection Interrupt Enable       */
+    uint32_t DDISCIES:1;                /**< bit:      1  Device Disconnection Interrupt Enable    */
+    uint32_t RSTIES:1;                  /**< bit:      2  USB Reset Sent Interrupt Enable          */
+    uint32_t RSMEDIES:1;                /**< bit:      3  Downstream Resume Sent Interrupt Enable  */
+    uint32_t RXRSMIES:1;                /**< bit:      4  Upstream Resume Received Interrupt Enable */
+    uint32_t HSOFIES:1;                 /**< bit:      5  Host Start of Frame Interrupt Enable     */
+    uint32_t HWUPIES:1;                 /**< bit:      6  Host Wake-Up Interrupt Enable            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Enable                  */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Enable                  */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Enable                  */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Enable                  */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Enable                  */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Enable                  */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Enable                  */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIER_OFFSET                 (0x418)                                       /**<  (USBHS_HSTIER) Host Global Interrupt Enable Register  Offset */
+
+#define USBHS_HSTIER_DCONNIES_Pos           0                                              /**< (USBHS_HSTIER) Device Connection Interrupt Enable Position */
+#define USBHS_HSTIER_DCONNIES_Msk           (_U_(0x1) << USBHS_HSTIER_DCONNIES_Pos)        /**< (USBHS_HSTIER) Device Connection Interrupt Enable Mask */
+#define USBHS_HSTIER_DCONNIES               USBHS_HSTIER_DCONNIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DCONNIES_Msk instead */
+#define USBHS_HSTIER_DDISCIES_Pos           1                                              /**< (USBHS_HSTIER) Device Disconnection Interrupt Enable Position */
+#define USBHS_HSTIER_DDISCIES_Msk           (_U_(0x1) << USBHS_HSTIER_DDISCIES_Pos)        /**< (USBHS_HSTIER) Device Disconnection Interrupt Enable Mask */
+#define USBHS_HSTIER_DDISCIES               USBHS_HSTIER_DDISCIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DDISCIES_Msk instead */
+#define USBHS_HSTIER_RSTIES_Pos             2                                              /**< (USBHS_HSTIER) USB Reset Sent Interrupt Enable Position */
+#define USBHS_HSTIER_RSTIES_Msk             (_U_(0x1) << USBHS_HSTIER_RSTIES_Pos)          /**< (USBHS_HSTIER) USB Reset Sent Interrupt Enable Mask */
+#define USBHS_HSTIER_RSTIES                 USBHS_HSTIER_RSTIES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RSTIES_Msk instead */
+#define USBHS_HSTIER_RSMEDIES_Pos           3                                              /**< (USBHS_HSTIER) Downstream Resume Sent Interrupt Enable Position */
+#define USBHS_HSTIER_RSMEDIES_Msk           (_U_(0x1) << USBHS_HSTIER_RSMEDIES_Pos)        /**< (USBHS_HSTIER) Downstream Resume Sent Interrupt Enable Mask */
+#define USBHS_HSTIER_RSMEDIES               USBHS_HSTIER_RSMEDIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RSMEDIES_Msk instead */
+#define USBHS_HSTIER_RXRSMIES_Pos           4                                              /**< (USBHS_HSTIER) Upstream Resume Received Interrupt Enable Position */
+#define USBHS_HSTIER_RXRSMIES_Msk           (_U_(0x1) << USBHS_HSTIER_RXRSMIES_Pos)        /**< (USBHS_HSTIER) Upstream Resume Received Interrupt Enable Mask */
+#define USBHS_HSTIER_RXRSMIES               USBHS_HSTIER_RXRSMIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RXRSMIES_Msk instead */
+#define USBHS_HSTIER_HSOFIES_Pos            5                                              /**< (USBHS_HSTIER) Host Start of Frame Interrupt Enable Position */
+#define USBHS_HSTIER_HSOFIES_Msk            (_U_(0x1) << USBHS_HSTIER_HSOFIES_Pos)         /**< (USBHS_HSTIER) Host Start of Frame Interrupt Enable Mask */
+#define USBHS_HSTIER_HSOFIES                USBHS_HSTIER_HSOFIES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_HSOFIES_Msk instead */
+#define USBHS_HSTIER_HWUPIES_Pos            6                                              /**< (USBHS_HSTIER) Host Wake-Up Interrupt Enable Position */
+#define USBHS_HSTIER_HWUPIES_Msk            (_U_(0x1) << USBHS_HSTIER_HWUPIES_Pos)         /**< (USBHS_HSTIER) Host Wake-Up Interrupt Enable Mask */
+#define USBHS_HSTIER_HWUPIES                USBHS_HSTIER_HWUPIES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_HWUPIES_Msk instead */
+#define USBHS_HSTIER_PEP_0_Pos              8                                              /**< (USBHS_HSTIER) Pipe 0 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_0_Pos)           /**< (USBHS_HSTIER) Pipe 0 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_0                  USBHS_HSTIER_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_0_Msk instead */
+#define USBHS_HSTIER_PEP_1_Pos              9                                              /**< (USBHS_HSTIER) Pipe 1 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_1_Pos)           /**< (USBHS_HSTIER) Pipe 1 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_1                  USBHS_HSTIER_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_1_Msk instead */
+#define USBHS_HSTIER_PEP_2_Pos              10                                             /**< (USBHS_HSTIER) Pipe 2 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_2_Pos)           /**< (USBHS_HSTIER) Pipe 2 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_2                  USBHS_HSTIER_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_2_Msk instead */
+#define USBHS_HSTIER_PEP_3_Pos              11                                             /**< (USBHS_HSTIER) Pipe 3 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_3_Pos)           /**< (USBHS_HSTIER) Pipe 3 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_3                  USBHS_HSTIER_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_3_Msk instead */
+#define USBHS_HSTIER_PEP_4_Pos              12                                             /**< (USBHS_HSTIER) Pipe 4 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_4_Pos)           /**< (USBHS_HSTIER) Pipe 4 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_4                  USBHS_HSTIER_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_4_Msk instead */
+#define USBHS_HSTIER_PEP_5_Pos              13                                             /**< (USBHS_HSTIER) Pipe 5 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_5_Pos)           /**< (USBHS_HSTIER) Pipe 5 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_5                  USBHS_HSTIER_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_5_Msk instead */
+#define USBHS_HSTIER_PEP_6_Pos              14                                             /**< (USBHS_HSTIER) Pipe 6 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_6_Pos)           /**< (USBHS_HSTIER) Pipe 6 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_6                  USBHS_HSTIER_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_6_Msk instead */
+#define USBHS_HSTIER_PEP_7_Pos              15                                             /**< (USBHS_HSTIER) Pipe 7 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_7_Pos)           /**< (USBHS_HSTIER) Pipe 7 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_7                  USBHS_HSTIER_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_7_Msk instead */
+#define USBHS_HSTIER_PEP_8_Pos              16                                             /**< (USBHS_HSTIER) Pipe 8 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_8_Pos)           /**< (USBHS_HSTIER) Pipe 8 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_8                  USBHS_HSTIER_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_8_Msk instead */
+#define USBHS_HSTIER_PEP_9_Pos              17                                             /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_9_Pos)           /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_9                  USBHS_HSTIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_9_Msk instead */
+#define USBHS_HSTIER_DMA_1_Pos              25                                             /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_1_Pos)           /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_1                  USBHS_HSTIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_1_Msk instead */
+#define USBHS_HSTIER_DMA_2_Pos              26                                             /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_2_Pos)           /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_2                  USBHS_HSTIER_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_2_Msk instead */
+#define USBHS_HSTIER_DMA_3_Pos              27                                             /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_3_Pos)           /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_3                  USBHS_HSTIER_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_3_Msk instead */
+#define USBHS_HSTIER_DMA_4_Pos              28                                             /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_4_Pos)           /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_4                  USBHS_HSTIER_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_4_Msk instead */
+#define USBHS_HSTIER_DMA_5_Pos              29                                             /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_5_Pos)           /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_5                  USBHS_HSTIER_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_5_Msk instead */
+#define USBHS_HSTIER_DMA_6_Pos              30                                             /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_6_Pos)           /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_6                  USBHS_HSTIER_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_6_Msk instead */
+#define USBHS_HSTIER_DMA_7_Pos              31                                             /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_7_Pos)           /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_7                  USBHS_HSTIER_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_7_Msk instead */
+#define USBHS_HSTIER_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIER) Register MASK  (Use USBHS_HSTIER_Msk instead)  */
+#define USBHS_HSTIER_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIER) Register Mask  */
+
+#define USBHS_HSTIER_PEP__Pos               8                                              /**< (USBHS_HSTIER Position) Pipe x Interrupt Enable */
+#define USBHS_HSTIER_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIER_PEP__Pos)          /**< (USBHS_HSTIER Mask) PEP_ */
+#define USBHS_HSTIER_PEP_(value)            (USBHS_HSTIER_PEP__Msk & ((value) << USBHS_HSTIER_PEP__Pos))  
+#define USBHS_HSTIER_DMA__Pos               25                                             /**< (USBHS_HSTIER Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_HSTIER_DMA__Msk               (_U_(0x7F) << USBHS_HSTIER_DMA__Pos)           /**< (USBHS_HSTIER Mask) DMA_ */
+#define USBHS_HSTIER_DMA_(value)            (USBHS_HSTIER_DMA__Msk & ((value) << USBHS_HSTIER_DMA__Pos))  
+
+/* -------- USBHS_HSTPIP : (USBHS Offset: 0x41c) (R/W 32) Host Pipe Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PEN0:1;                    /**< bit:      0  Pipe 0 Enable                            */
+    uint32_t PEN1:1;                    /**< bit:      1  Pipe 1 Enable                            */
+    uint32_t PEN2:1;                    /**< bit:      2  Pipe 2 Enable                            */
+    uint32_t PEN3:1;                    /**< bit:      3  Pipe 3 Enable                            */
+    uint32_t PEN4:1;                    /**< bit:      4  Pipe 4 Enable                            */
+    uint32_t PEN5:1;                    /**< bit:      5  Pipe 5 Enable                            */
+    uint32_t PEN6:1;                    /**< bit:      6  Pipe 6 Enable                            */
+    uint32_t PEN7:1;                    /**< bit:      7  Pipe 7 Enable                            */
+    uint32_t PEN8:1;                    /**< bit:      8  Pipe 8 Enable                            */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PRST0:1;                   /**< bit:     16  Pipe 0 Reset                             */
+    uint32_t PRST1:1;                   /**< bit:     17  Pipe 1 Reset                             */
+    uint32_t PRST2:1;                   /**< bit:     18  Pipe 2 Reset                             */
+    uint32_t PRST3:1;                   /**< bit:     19  Pipe 3 Reset                             */
+    uint32_t PRST4:1;                   /**< bit:     20  Pipe 4 Reset                             */
+    uint32_t PRST5:1;                   /**< bit:     21  Pipe 5 Reset                             */
+    uint32_t PRST6:1;                   /**< bit:     22  Pipe 6 Reset                             */
+    uint32_t PRST7:1;                   /**< bit:     23  Pipe 7 Reset                             */
+    uint32_t PRST8:1;                   /**< bit:     24  Pipe 8 Reset                             */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEN:9;                     /**< bit:   0..8  Pipe x Enable                            */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PRST:9;                    /**< bit: 16..24  Pipe 8 Reset                             */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIP_OFFSET                 (0x41C)                                       /**<  (USBHS_HSTPIP) Host Pipe Register  Offset */
+
+#define USBHS_HSTPIP_PEN0_Pos               0                                              /**< (USBHS_HSTPIP) Pipe 0 Enable Position */
+#define USBHS_HSTPIP_PEN0_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN0_Pos)            /**< (USBHS_HSTPIP) Pipe 0 Enable Mask */
+#define USBHS_HSTPIP_PEN0                   USBHS_HSTPIP_PEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN0_Msk instead */
+#define USBHS_HSTPIP_PEN1_Pos               1                                              /**< (USBHS_HSTPIP) Pipe 1 Enable Position */
+#define USBHS_HSTPIP_PEN1_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN1_Pos)            /**< (USBHS_HSTPIP) Pipe 1 Enable Mask */
+#define USBHS_HSTPIP_PEN1                   USBHS_HSTPIP_PEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN1_Msk instead */
+#define USBHS_HSTPIP_PEN2_Pos               2                                              /**< (USBHS_HSTPIP) Pipe 2 Enable Position */
+#define USBHS_HSTPIP_PEN2_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN2_Pos)            /**< (USBHS_HSTPIP) Pipe 2 Enable Mask */
+#define USBHS_HSTPIP_PEN2                   USBHS_HSTPIP_PEN2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN2_Msk instead */
+#define USBHS_HSTPIP_PEN3_Pos               3                                              /**< (USBHS_HSTPIP) Pipe 3 Enable Position */
+#define USBHS_HSTPIP_PEN3_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN3_Pos)            /**< (USBHS_HSTPIP) Pipe 3 Enable Mask */
+#define USBHS_HSTPIP_PEN3                   USBHS_HSTPIP_PEN3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN3_Msk instead */
+#define USBHS_HSTPIP_PEN4_Pos               4                                              /**< (USBHS_HSTPIP) Pipe 4 Enable Position */
+#define USBHS_HSTPIP_PEN4_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN4_Pos)            /**< (USBHS_HSTPIP) Pipe 4 Enable Mask */
+#define USBHS_HSTPIP_PEN4                   USBHS_HSTPIP_PEN4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN4_Msk instead */
+#define USBHS_HSTPIP_PEN5_Pos               5                                              /**< (USBHS_HSTPIP) Pipe 5 Enable Position */
+#define USBHS_HSTPIP_PEN5_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN5_Pos)            /**< (USBHS_HSTPIP) Pipe 5 Enable Mask */
+#define USBHS_HSTPIP_PEN5                   USBHS_HSTPIP_PEN5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN5_Msk instead */
+#define USBHS_HSTPIP_PEN6_Pos               6                                              /**< (USBHS_HSTPIP) Pipe 6 Enable Position */
+#define USBHS_HSTPIP_PEN6_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN6_Pos)            /**< (USBHS_HSTPIP) Pipe 6 Enable Mask */
+#define USBHS_HSTPIP_PEN6                   USBHS_HSTPIP_PEN6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN6_Msk instead */
+#define USBHS_HSTPIP_PEN7_Pos               7                                              /**< (USBHS_HSTPIP) Pipe 7 Enable Position */
+#define USBHS_HSTPIP_PEN7_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN7_Pos)            /**< (USBHS_HSTPIP) Pipe 7 Enable Mask */
+#define USBHS_HSTPIP_PEN7                   USBHS_HSTPIP_PEN7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN7_Msk instead */
+#define USBHS_HSTPIP_PEN8_Pos               8                                              /**< (USBHS_HSTPIP) Pipe 8 Enable Position */
+#define USBHS_HSTPIP_PEN8_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN8_Pos)            /**< (USBHS_HSTPIP) Pipe 8 Enable Mask */
+#define USBHS_HSTPIP_PEN8                   USBHS_HSTPIP_PEN8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN8_Msk instead */
+#define USBHS_HSTPIP_PRST0_Pos              16                                             /**< (USBHS_HSTPIP) Pipe 0 Reset Position */
+#define USBHS_HSTPIP_PRST0_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST0_Pos)           /**< (USBHS_HSTPIP) Pipe 0 Reset Mask */
+#define USBHS_HSTPIP_PRST0                  USBHS_HSTPIP_PRST0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST0_Msk instead */
+#define USBHS_HSTPIP_PRST1_Pos              17                                             /**< (USBHS_HSTPIP) Pipe 1 Reset Position */
+#define USBHS_HSTPIP_PRST1_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST1_Pos)           /**< (USBHS_HSTPIP) Pipe 1 Reset Mask */
+#define USBHS_HSTPIP_PRST1                  USBHS_HSTPIP_PRST1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST1_Msk instead */
+#define USBHS_HSTPIP_PRST2_Pos              18                                             /**< (USBHS_HSTPIP) Pipe 2 Reset Position */
+#define USBHS_HSTPIP_PRST2_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST2_Pos)           /**< (USBHS_HSTPIP) Pipe 2 Reset Mask */
+#define USBHS_HSTPIP_PRST2                  USBHS_HSTPIP_PRST2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST2_Msk instead */
+#define USBHS_HSTPIP_PRST3_Pos              19                                             /**< (USBHS_HSTPIP) Pipe 3 Reset Position */
+#define USBHS_HSTPIP_PRST3_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST3_Pos)           /**< (USBHS_HSTPIP) Pipe 3 Reset Mask */
+#define USBHS_HSTPIP_PRST3                  USBHS_HSTPIP_PRST3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST3_Msk instead */
+#define USBHS_HSTPIP_PRST4_Pos              20                                             /**< (USBHS_HSTPIP) Pipe 4 Reset Position */
+#define USBHS_HSTPIP_PRST4_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST4_Pos)           /**< (USBHS_HSTPIP) Pipe 4 Reset Mask */
+#define USBHS_HSTPIP_PRST4                  USBHS_HSTPIP_PRST4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST4_Msk instead */
+#define USBHS_HSTPIP_PRST5_Pos              21                                             /**< (USBHS_HSTPIP) Pipe 5 Reset Position */
+#define USBHS_HSTPIP_PRST5_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST5_Pos)           /**< (USBHS_HSTPIP) Pipe 5 Reset Mask */
+#define USBHS_HSTPIP_PRST5                  USBHS_HSTPIP_PRST5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST5_Msk instead */
+#define USBHS_HSTPIP_PRST6_Pos              22                                             /**< (USBHS_HSTPIP) Pipe 6 Reset Position */
+#define USBHS_HSTPIP_PRST6_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST6_Pos)           /**< (USBHS_HSTPIP) Pipe 6 Reset Mask */
+#define USBHS_HSTPIP_PRST6                  USBHS_HSTPIP_PRST6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST6_Msk instead */
+#define USBHS_HSTPIP_PRST7_Pos              23                                             /**< (USBHS_HSTPIP) Pipe 7 Reset Position */
+#define USBHS_HSTPIP_PRST7_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST7_Pos)           /**< (USBHS_HSTPIP) Pipe 7 Reset Mask */
+#define USBHS_HSTPIP_PRST7                  USBHS_HSTPIP_PRST7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST7_Msk instead */
+#define USBHS_HSTPIP_PRST8_Pos              24                                             /**< (USBHS_HSTPIP) Pipe 8 Reset Position */
+#define USBHS_HSTPIP_PRST8_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST8_Pos)           /**< (USBHS_HSTPIP) Pipe 8 Reset Mask */
+#define USBHS_HSTPIP_PRST8                  USBHS_HSTPIP_PRST8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST8_Msk instead */
+#define USBHS_HSTPIP_MASK                   _U_(0x1FF01FF)                                 /**< \deprecated (USBHS_HSTPIP) Register MASK  (Use USBHS_HSTPIP_Msk instead)  */
+#define USBHS_HSTPIP_Msk                    _U_(0x1FF01FF)                                 /**< (USBHS_HSTPIP) Register Mask  */
+
+#define USBHS_HSTPIP_PEN_Pos                0                                              /**< (USBHS_HSTPIP Position) Pipe x Enable */
+#define USBHS_HSTPIP_PEN_Msk                (_U_(0x1FF) << USBHS_HSTPIP_PEN_Pos)           /**< (USBHS_HSTPIP Mask) PEN */
+#define USBHS_HSTPIP_PEN(value)             (USBHS_HSTPIP_PEN_Msk & ((value) << USBHS_HSTPIP_PEN_Pos))  
+#define USBHS_HSTPIP_PRST_Pos               16                                             /**< (USBHS_HSTPIP Position) Pipe 8 Reset */
+#define USBHS_HSTPIP_PRST_Msk               (_U_(0x1FF) << USBHS_HSTPIP_PRST_Pos)          /**< (USBHS_HSTPIP Mask) PRST */
+#define USBHS_HSTPIP_PRST(value)            (USBHS_HSTPIP_PRST_Msk & ((value) << USBHS_HSTPIP_PRST_Pos))  
+
+/* -------- USBHS_HSTFNUM : (USBHS Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
+    uint32_t FNUM:11;                   /**< bit:  3..13  Frame Number                             */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t FLENHIGH:8;                /**< bit: 16..23  Frame Length                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTFNUM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTFNUM_OFFSET                (0x420)                                       /**<  (USBHS_HSTFNUM) Host Frame Number Register  Offset */
+
+#define USBHS_HSTFNUM_MFNUM_Pos             0                                              /**< (USBHS_HSTFNUM) Micro Frame Number Position */
+#define USBHS_HSTFNUM_MFNUM_Msk             (_U_(0x7) << USBHS_HSTFNUM_MFNUM_Pos)          /**< (USBHS_HSTFNUM) Micro Frame Number Mask */
+#define USBHS_HSTFNUM_MFNUM(value)          (USBHS_HSTFNUM_MFNUM_Msk & ((value) << USBHS_HSTFNUM_MFNUM_Pos))
+#define USBHS_HSTFNUM_FNUM_Pos              3                                              /**< (USBHS_HSTFNUM) Frame Number Position */
+#define USBHS_HSTFNUM_FNUM_Msk              (_U_(0x7FF) << USBHS_HSTFNUM_FNUM_Pos)         /**< (USBHS_HSTFNUM) Frame Number Mask */
+#define USBHS_HSTFNUM_FNUM(value)           (USBHS_HSTFNUM_FNUM_Msk & ((value) << USBHS_HSTFNUM_FNUM_Pos))
+#define USBHS_HSTFNUM_FLENHIGH_Pos          16                                             /**< (USBHS_HSTFNUM) Frame Length Position */
+#define USBHS_HSTFNUM_FLENHIGH_Msk          (_U_(0xFF) << USBHS_HSTFNUM_FLENHIGH_Pos)      /**< (USBHS_HSTFNUM) Frame Length Mask */
+#define USBHS_HSTFNUM_FLENHIGH(value)       (USBHS_HSTFNUM_FLENHIGH_Msk & ((value) << USBHS_HSTFNUM_FLENHIGH_Pos))
+#define USBHS_HSTFNUM_MASK                  _U_(0xFF3FFF)                                  /**< \deprecated (USBHS_HSTFNUM) Register MASK  (Use USBHS_HSTFNUM_Msk instead)  */
+#define USBHS_HSTFNUM_Msk                   _U_(0xFF3FFF)                                  /**< (USBHS_HSTFNUM) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR1 : (USBHS Offset: 0x424) (R/W 32) Host Address 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP0:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP1:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HSTADDRP2:7;               /**< bit: 16..22  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t HSTADDRP3:7;               /**< bit: 24..30  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR1_OFFSET               (0x424)                                       /**<  (USBHS_HSTADDR1) Host Address 1 Register  Offset */
+
+#define USBHS_HSTADDR1_HSTADDRP0_Pos        0                                              /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP0_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP0_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP0(value)     (USBHS_HSTADDR1_HSTADDRP0_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP0_Pos))
+#define USBHS_HSTADDR1_HSTADDRP1_Pos        8                                              /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP1_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP1_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP1(value)     (USBHS_HSTADDR1_HSTADDRP1_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP1_Pos))
+#define USBHS_HSTADDR1_HSTADDRP2_Pos        16                                             /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP2_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP2_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP2(value)     (USBHS_HSTADDR1_HSTADDRP2_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP2_Pos))
+#define USBHS_HSTADDR1_HSTADDRP3_Pos        24                                             /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP3_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP3_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP3(value)     (USBHS_HSTADDR1_HSTADDRP3_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP3_Pos))
+#define USBHS_HSTADDR1_MASK                 _U_(0x7F7F7F7F)                                /**< \deprecated (USBHS_HSTADDR1) Register MASK  (Use USBHS_HSTADDR1_Msk instead)  */
+#define USBHS_HSTADDR1_Msk                  _U_(0x7F7F7F7F)                                /**< (USBHS_HSTADDR1) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR2 : (USBHS Offset: 0x428) (R/W 32) Host Address 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP4:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP5:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HSTADDRP6:7;               /**< bit: 16..22  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t HSTADDRP7:7;               /**< bit: 24..30  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR2_OFFSET               (0x428)                                       /**<  (USBHS_HSTADDR2) Host Address 2 Register  Offset */
+
+#define USBHS_HSTADDR2_HSTADDRP4_Pos        0                                              /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP4_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP4_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP4(value)     (USBHS_HSTADDR2_HSTADDRP4_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP4_Pos))
+#define USBHS_HSTADDR2_HSTADDRP5_Pos        8                                              /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP5_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP5_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP5(value)     (USBHS_HSTADDR2_HSTADDRP5_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP5_Pos))
+#define USBHS_HSTADDR2_HSTADDRP6_Pos        16                                             /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP6_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP6_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP6(value)     (USBHS_HSTADDR2_HSTADDRP6_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP6_Pos))
+#define USBHS_HSTADDR2_HSTADDRP7_Pos        24                                             /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP7_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP7_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP7(value)     (USBHS_HSTADDR2_HSTADDRP7_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP7_Pos))
+#define USBHS_HSTADDR2_MASK                 _U_(0x7F7F7F7F)                                /**< \deprecated (USBHS_HSTADDR2) Register MASK  (Use USBHS_HSTADDR2_Msk instead)  */
+#define USBHS_HSTADDR2_Msk                  _U_(0x7F7F7F7F)                                /**< (USBHS_HSTADDR2) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR3 : (USBHS Offset: 0x42c) (R/W 32) Host Address 3 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP8:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP9:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR3_OFFSET               (0x42C)                                       /**<  (USBHS_HSTADDR3) Host Address 3 Register  Offset */
+
+#define USBHS_HSTADDR3_HSTADDRP8_Pos        0                                              /**< (USBHS_HSTADDR3) USB Host Address Position */
+#define USBHS_HSTADDR3_HSTADDRP8_Msk        (_U_(0x7F) << USBHS_HSTADDR3_HSTADDRP8_Pos)    /**< (USBHS_HSTADDR3) USB Host Address Mask */
+#define USBHS_HSTADDR3_HSTADDRP8(value)     (USBHS_HSTADDR3_HSTADDRP8_Msk & ((value) << USBHS_HSTADDR3_HSTADDRP8_Pos))
+#define USBHS_HSTADDR3_HSTADDRP9_Pos        8                                              /**< (USBHS_HSTADDR3) USB Host Address Position */
+#define USBHS_HSTADDR3_HSTADDRP9_Msk        (_U_(0x7F) << USBHS_HSTADDR3_HSTADDRP9_Pos)    /**< (USBHS_HSTADDR3) USB Host Address Mask */
+#define USBHS_HSTADDR3_HSTADDRP9(value)     (USBHS_HSTADDR3_HSTADDRP9_Msk & ((value) << USBHS_HSTADDR3_HSTADDRP9_Pos))
+#define USBHS_HSTADDR3_MASK                 _U_(0x7F7F)                                    /**< \deprecated (USBHS_HSTADDR3) Register MASK  (Use USBHS_HSTADDR3_Msk instead)  */
+#define USBHS_HSTADDR3_Msk                  _U_(0x7F7F)                                    /**< (USBHS_HSTADDR3) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPCFG : (USBHS Offset: 0x500) (R/W 32) Host Pipe Configuration Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ALLOC:1;                   /**< bit:      1  Pipe Memory Allocate                     */
+    uint32_t PBK:2;                     /**< bit:   2..3  Pipe Banks                               */
+    uint32_t PSIZE:3;                   /**< bit:   4..6  Pipe Size                                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PTOKEN:2;                  /**< bit:   8..9  Pipe Token                               */
+    uint32_t AUTOSW:1;                  /**< bit:     10  Automatic Switch                         */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t PTYPE:2;                   /**< bit: 12..13  Pipe Type                                */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t PEPNUM:4;                  /**< bit: 16..19  Pipe Endpoint Number                     */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t INTFRQ:8;                  /**< bit: 24..31  Pipe Interrupt Request Frequency         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPCFG_OFFSET              (0x500)                                       /**<  (USBHS_HSTPIPCFG) Host Pipe Configuration Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPCFG_ALLOC_Pos           1                                              /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Position */
+#define USBHS_HSTPIPCFG_ALLOC_Msk           (_U_(0x1) << USBHS_HSTPIPCFG_ALLOC_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Mask */
+#define USBHS_HSTPIPCFG_ALLOC               USBHS_HSTPIPCFG_ALLOC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_ALLOC_Msk instead */
+#define USBHS_HSTPIPCFG_PBK_Pos             2                                              /**< (USBHS_HSTPIPCFG) Pipe Banks Position */
+#define USBHS_HSTPIPCFG_PBK_Msk             (_U_(0x3) << USBHS_HSTPIPCFG_PBK_Pos)          /**< (USBHS_HSTPIPCFG) Pipe Banks Mask */
+#define USBHS_HSTPIPCFG_PBK(value)          (USBHS_HSTPIPCFG_PBK_Msk & ((value) << USBHS_HSTPIPCFG_PBK_Pos))
+#define   USBHS_HSTPIPCFG_PBK_1_BANK_Val    _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) Single-bank pipe  */
+#define   USBHS_HSTPIPCFG_PBK_2_BANK_Val    _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) Double-bank pipe  */
+#define   USBHS_HSTPIPCFG_PBK_3_BANK_Val    _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) Triple-bank pipe  */
+#define USBHS_HSTPIPCFG_PBK_1_BANK          (USBHS_HSTPIPCFG_PBK_1_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Single-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PBK_2_BANK          (USBHS_HSTPIPCFG_PBK_2_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Double-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PBK_3_BANK          (USBHS_HSTPIPCFG_PBK_3_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Triple-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PSIZE_Pos           4                                              /**< (USBHS_HSTPIPCFG) Pipe Size Position */
+#define USBHS_HSTPIPCFG_PSIZE_Msk           (_U_(0x7) << USBHS_HSTPIPCFG_PSIZE_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Size Mask */
+#define USBHS_HSTPIPCFG_PSIZE(value)        (USBHS_HSTPIPCFG_PSIZE_Msk & ((value) << USBHS_HSTPIPCFG_PSIZE_Pos))
+#define   USBHS_HSTPIPCFG_PSIZE_8_BYTE_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) 8 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_16_BYTE_Val _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) 16 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_32_BYTE_Val _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) 32 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_64_BYTE_Val _U_(0x3)                                       /**< (USBHS_HSTPIPCFG) 64 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_128_BYTE_Val _U_(0x4)                                       /**< (USBHS_HSTPIPCFG) 128 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_256_BYTE_Val _U_(0x5)                                       /**< (USBHS_HSTPIPCFG) 256 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_512_BYTE_Val _U_(0x6)                                       /**< (USBHS_HSTPIPCFG) 512 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_1024_BYTE_Val _U_(0x7)                                       /**< (USBHS_HSTPIPCFG) 1024 bytes  */
+#define USBHS_HSTPIPCFG_PSIZE_8_BYTE        (USBHS_HSTPIPCFG_PSIZE_8_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 8 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_16_BYTE       (USBHS_HSTPIPCFG_PSIZE_16_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 16 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_32_BYTE       (USBHS_HSTPIPCFG_PSIZE_32_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 32 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_64_BYTE       (USBHS_HSTPIPCFG_PSIZE_64_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 64 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_128_BYTE      (USBHS_HSTPIPCFG_PSIZE_128_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 128 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_256_BYTE      (USBHS_HSTPIPCFG_PSIZE_256_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 256 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_512_BYTE      (USBHS_HSTPIPCFG_PSIZE_512_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 512 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_1024_BYTE     (USBHS_HSTPIPCFG_PSIZE_1024_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 1024 bytes Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_Pos          8                                              /**< (USBHS_HSTPIPCFG) Pipe Token Position */
+#define USBHS_HSTPIPCFG_PTOKEN_Msk          (_U_(0x3) << USBHS_HSTPIPCFG_PTOKEN_Pos)       /**< (USBHS_HSTPIPCFG) Pipe Token Mask */
+#define USBHS_HSTPIPCFG_PTOKEN(value)       (USBHS_HSTPIPCFG_PTOKEN_Msk & ((value) << USBHS_HSTPIPCFG_PTOKEN_Pos))
+#define   USBHS_HSTPIPCFG_PTOKEN_SETUP_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) SETUP  */
+#define   USBHS_HSTPIPCFG_PTOKEN_IN_Val     _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) IN  */
+#define   USBHS_HSTPIPCFG_PTOKEN_OUT_Val    _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) OUT  */
+#define USBHS_HSTPIPCFG_PTOKEN_SETUP        (USBHS_HSTPIPCFG_PTOKEN_SETUP_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) SETUP Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_IN           (USBHS_HSTPIPCFG_PTOKEN_IN_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) IN Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_OUT          (USBHS_HSTPIPCFG_PTOKEN_OUT_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) OUT Position  */
+#define USBHS_HSTPIPCFG_AUTOSW_Pos          10                                             /**< (USBHS_HSTPIPCFG) Automatic Switch Position */
+#define USBHS_HSTPIPCFG_AUTOSW_Msk          (_U_(0x1) << USBHS_HSTPIPCFG_AUTOSW_Pos)       /**< (USBHS_HSTPIPCFG) Automatic Switch Mask */
+#define USBHS_HSTPIPCFG_AUTOSW              USBHS_HSTPIPCFG_AUTOSW_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_AUTOSW_Msk instead */
+#define USBHS_HSTPIPCFG_PTYPE_Pos           12                                             /**< (USBHS_HSTPIPCFG) Pipe Type Position */
+#define USBHS_HSTPIPCFG_PTYPE_Msk           (_U_(0x3) << USBHS_HSTPIPCFG_PTYPE_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Type Mask */
+#define USBHS_HSTPIPCFG_PTYPE(value)        (USBHS_HSTPIPCFG_PTYPE_Msk & ((value) << USBHS_HSTPIPCFG_PTYPE_Pos))
+#define   USBHS_HSTPIPCFG_PTYPE_CTRL_Val    _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) Control  */
+#define   USBHS_HSTPIPCFG_PTYPE_ISO_Val     _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) Isochronous  */
+#define   USBHS_HSTPIPCFG_PTYPE_BLK_Val     _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) Bulk  */
+#define   USBHS_HSTPIPCFG_PTYPE_INTRPT_Val  _U_(0x3)                                       /**< (USBHS_HSTPIPCFG) Interrupt  */
+#define USBHS_HSTPIPCFG_PTYPE_CTRL          (USBHS_HSTPIPCFG_PTYPE_CTRL_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Control Position  */
+#define USBHS_HSTPIPCFG_PTYPE_ISO           (USBHS_HSTPIPCFG_PTYPE_ISO_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Isochronous Position  */
+#define USBHS_HSTPIPCFG_PTYPE_BLK           (USBHS_HSTPIPCFG_PTYPE_BLK_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Bulk Position  */
+#define USBHS_HSTPIPCFG_PTYPE_INTRPT        (USBHS_HSTPIPCFG_PTYPE_INTRPT_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Interrupt Position  */
+#define USBHS_HSTPIPCFG_PEPNUM_Pos          16                                             /**< (USBHS_HSTPIPCFG) Pipe Endpoint Number Position */
+#define USBHS_HSTPIPCFG_PEPNUM_Msk          (_U_(0xF) << USBHS_HSTPIPCFG_PEPNUM_Pos)       /**< (USBHS_HSTPIPCFG) Pipe Endpoint Number Mask */
+#define USBHS_HSTPIPCFG_PEPNUM(value)       (USBHS_HSTPIPCFG_PEPNUM_Msk & ((value) << USBHS_HSTPIPCFG_PEPNUM_Pos))
+#define USBHS_HSTPIPCFG_INTFRQ_Pos          24                                             /**< (USBHS_HSTPIPCFG) Pipe Interrupt Request Frequency Position */
+#define USBHS_HSTPIPCFG_INTFRQ_Msk          (_U_(0xFF) << USBHS_HSTPIPCFG_INTFRQ_Pos)      /**< (USBHS_HSTPIPCFG) Pipe Interrupt Request Frequency Mask */
+#define USBHS_HSTPIPCFG_INTFRQ(value)       (USBHS_HSTPIPCFG_INTFRQ_Msk & ((value) << USBHS_HSTPIPCFG_INTFRQ_Pos))
+#define USBHS_HSTPIPCFG_MASK                _U_(0xFF0F377E)                                /**< \deprecated (USBHS_HSTPIPCFG) Register MASK  (Use USBHS_HSTPIPCFG_Msk instead)  */
+#define USBHS_HSTPIPCFG_Msk                 _U_(0xFF0F377E)                                /**< (USBHS_HSTPIPCFG) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPISR : (USBHS Offset: 0x530) (R/ 32) Host Pipe Status Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINI:1;                   /**< bit:      0  Received IN Data Interrupt               */
+    uint32_t TXOUTI:1;                  /**< bit:      1  Transmitted OUT Data Interrupt           */
+    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t PERRI:1;                   /**< bit:      3  Pipe Error Interrupt                     */
+    uint32_t NAKEDI:1;                  /**< bit:      4  NAKed Interrupt                          */
+    uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t SHORTPACKETI:1;            /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t NBUSYBK:2;                 /**< bit: 12..13  Number of Busy Banks                     */
+    uint32_t CURRBK:2;                  /**< bit: 14..15  Current Bank                             */
+    uint32_t RWALL:1;                   /**< bit:     16  Read/Write Allowed                       */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t CFGOK:1;                   /**< bit:     18  Configuration OK Status                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t PBYCT:11;                  /**< bit: 20..30  Pipe Byte Count                          */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPISR_OFFSET              (0x530)                                       /**<  (USBHS_HSTPIPISR) Host Pipe Status Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPISR_RXINI_Pos           0                                              /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Position */
+#define USBHS_HSTPIPISR_RXINI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_RXINI_Pos)        /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Mask */
+#define USBHS_HSTPIPISR_RXINI               USBHS_HSTPIPISR_RXINI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RXINI_Msk instead */
+#define USBHS_HSTPIPISR_TXOUTI_Pos          1                                              /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Position */
+#define USBHS_HSTPIPISR_TXOUTI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_TXOUTI_Pos)       /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Mask */
+#define USBHS_HSTPIPISR_TXOUTI              USBHS_HSTPIPISR_TXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXOUTI_Msk instead */
+#define USBHS_HSTPIPISR_TXSTPI_Pos          2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_TXSTPI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_TXSTPI_Pos)       /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_TXSTPI              USBHS_HSTPIPISR_TXSTPI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXSTPI_Msk instead */
+#define USBHS_HSTPIPISR_PERRI_Pos           3                                              /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Position */
+#define USBHS_HSTPIPISR_PERRI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_PERRI_Pos)        /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Mask */
+#define USBHS_HSTPIPISR_PERRI               USBHS_HSTPIPISR_PERRI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_PERRI_Msk instead */
+#define USBHS_HSTPIPISR_NAKEDI_Pos          4                                              /**< (USBHS_HSTPIPISR) NAKed Interrupt Position */
+#define USBHS_HSTPIPISR_NAKEDI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_NAKEDI_Pos)       /**< (USBHS_HSTPIPISR) NAKed Interrupt Mask */
+#define USBHS_HSTPIPISR_NAKEDI              USBHS_HSTPIPISR_NAKEDI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_NAKEDI_Msk instead */
+#define USBHS_HSTPIPISR_OVERFI_Pos          5                                              /**< (USBHS_HSTPIPISR) Overflow Interrupt Position */
+#define USBHS_HSTPIPISR_OVERFI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_OVERFI_Pos)       /**< (USBHS_HSTPIPISR) Overflow Interrupt Mask */
+#define USBHS_HSTPIPISR_OVERFI              USBHS_HSTPIPISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_OVERFI_Msk instead */
+#define USBHS_HSTPIPISR_RXSTALLDI_Pos       6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_RXSTALLDI_Msk       (_U_(0x1) << USBHS_HSTPIPISR_RXSTALLDI_Pos)    /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_RXSTALLDI           USBHS_HSTPIPISR_RXSTALLDI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_SHORTPACKETI_Pos    7                                              /**< (USBHS_HSTPIPISR) Short Packet Interrupt Position */
+#define USBHS_HSTPIPISR_SHORTPACKETI_Msk    (_U_(0x1) << USBHS_HSTPIPISR_SHORTPACKETI_Pos)  /**< (USBHS_HSTPIPISR) Short Packet Interrupt Mask */
+#define USBHS_HSTPIPISR_SHORTPACKETI        USBHS_HSTPIPISR_SHORTPACKETI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_SHORTPACKETI_Msk instead */
+#define USBHS_HSTPIPISR_DTSEQ_Pos           8                                              /**< (USBHS_HSTPIPISR) Data Toggle Sequence Position */
+#define USBHS_HSTPIPISR_DTSEQ_Msk           (_U_(0x3) << USBHS_HSTPIPISR_DTSEQ_Pos)        /**< (USBHS_HSTPIPISR) Data Toggle Sequence Mask */
+#define USBHS_HSTPIPISR_DTSEQ(value)        (USBHS_HSTPIPISR_DTSEQ_Msk & ((value) << USBHS_HSTPIPISR_DTSEQ_Pos))
+#define   USBHS_HSTPIPISR_DTSEQ_DATA0_Val   _U_(0x0)                                       /**< (USBHS_HSTPIPISR) Data0 toggle sequence  */
+#define   USBHS_HSTPIPISR_DTSEQ_DATA1_Val   _U_(0x1)                                       /**< (USBHS_HSTPIPISR) Data1 toggle sequence  */
+#define USBHS_HSTPIPISR_DTSEQ_DATA0         (USBHS_HSTPIPISR_DTSEQ_DATA0_Val << USBHS_HSTPIPISR_DTSEQ_Pos)  /**< (USBHS_HSTPIPISR) Data0 toggle sequence Position  */
+#define USBHS_HSTPIPISR_DTSEQ_DATA1         (USBHS_HSTPIPISR_DTSEQ_DATA1_Val << USBHS_HSTPIPISR_DTSEQ_Pos)  /**< (USBHS_HSTPIPISR) Data1 toggle sequence Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_Pos         12                                             /**< (USBHS_HSTPIPISR) Number of Busy Banks Position */
+#define USBHS_HSTPIPISR_NBUSYBK_Msk         (_U_(0x3) << USBHS_HSTPIPISR_NBUSYBK_Pos)      /**< (USBHS_HSTPIPISR) Number of Busy Banks Mask */
+#define USBHS_HSTPIPISR_NBUSYBK(value)      (USBHS_HSTPIPISR_NBUSYBK_Msk & ((value) << USBHS_HSTPIPISR_NBUSYBK_Pos))
+#define   USBHS_HSTPIPISR_NBUSYBK_0_BUSY_Val _U_(0x0)                                       /**< (USBHS_HSTPIPISR) 0 busy bank (all banks free)  */
+#define   USBHS_HSTPIPISR_NBUSYBK_1_BUSY_Val _U_(0x1)                                       /**< (USBHS_HSTPIPISR) 1 busy bank  */
+#define   USBHS_HSTPIPISR_NBUSYBK_2_BUSY_Val _U_(0x2)                                       /**< (USBHS_HSTPIPISR) 2 busy banks  */
+#define   USBHS_HSTPIPISR_NBUSYBK_3_BUSY_Val _U_(0x3)                                       /**< (USBHS_HSTPIPISR) 3 busy banks  */
+#define USBHS_HSTPIPISR_NBUSYBK_0_BUSY      (USBHS_HSTPIPISR_NBUSYBK_0_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 0 busy bank (all banks free) Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_1_BUSY      (USBHS_HSTPIPISR_NBUSYBK_1_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 1 busy bank Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_2_BUSY      (USBHS_HSTPIPISR_NBUSYBK_2_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 2 busy banks Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_3_BUSY      (USBHS_HSTPIPISR_NBUSYBK_3_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 3 busy banks Position  */
+#define USBHS_HSTPIPISR_CURRBK_Pos          14                                             /**< (USBHS_HSTPIPISR) Current Bank Position */
+#define USBHS_HSTPIPISR_CURRBK_Msk          (_U_(0x3) << USBHS_HSTPIPISR_CURRBK_Pos)       /**< (USBHS_HSTPIPISR) Current Bank Mask */
+#define USBHS_HSTPIPISR_CURRBK(value)       (USBHS_HSTPIPISR_CURRBK_Msk & ((value) << USBHS_HSTPIPISR_CURRBK_Pos))
+#define   USBHS_HSTPIPISR_CURRBK_BANK0_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPISR) Current bank is bank0  */
+#define   USBHS_HSTPIPISR_CURRBK_BANK1_Val  _U_(0x1)                                       /**< (USBHS_HSTPIPISR) Current bank is bank1  */
+#define   USBHS_HSTPIPISR_CURRBK_BANK2_Val  _U_(0x2)                                       /**< (USBHS_HSTPIPISR) Current bank is bank2  */
+#define USBHS_HSTPIPISR_CURRBK_BANK0        (USBHS_HSTPIPISR_CURRBK_BANK0_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank0 Position  */
+#define USBHS_HSTPIPISR_CURRBK_BANK1        (USBHS_HSTPIPISR_CURRBK_BANK1_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank1 Position  */
+#define USBHS_HSTPIPISR_CURRBK_BANK2        (USBHS_HSTPIPISR_CURRBK_BANK2_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank2 Position  */
+#define USBHS_HSTPIPISR_RWALL_Pos           16                                             /**< (USBHS_HSTPIPISR) Read/Write Allowed Position */
+#define USBHS_HSTPIPISR_RWALL_Msk           (_U_(0x1) << USBHS_HSTPIPISR_RWALL_Pos)        /**< (USBHS_HSTPIPISR) Read/Write Allowed Mask */
+#define USBHS_HSTPIPISR_RWALL               USBHS_HSTPIPISR_RWALL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RWALL_Msk instead */
+#define USBHS_HSTPIPISR_CFGOK_Pos           18                                             /**< (USBHS_HSTPIPISR) Configuration OK Status Position */
+#define USBHS_HSTPIPISR_CFGOK_Msk           (_U_(0x1) << USBHS_HSTPIPISR_CFGOK_Pos)        /**< (USBHS_HSTPIPISR) Configuration OK Status Mask */
+#define USBHS_HSTPIPISR_CFGOK               USBHS_HSTPIPISR_CFGOK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CFGOK_Msk instead */
+#define USBHS_HSTPIPISR_PBYCT_Pos           20                                             /**< (USBHS_HSTPIPISR) Pipe Byte Count Position */
+#define USBHS_HSTPIPISR_PBYCT_Msk           (_U_(0x7FF) << USBHS_HSTPIPISR_PBYCT_Pos)      /**< (USBHS_HSTPIPISR) Pipe Byte Count Mask */
+#define USBHS_HSTPIPISR_PBYCT(value)        (USBHS_HSTPIPISR_PBYCT_Msk & ((value) << USBHS_HSTPIPISR_PBYCT_Pos))
+#define USBHS_HSTPIPISR_MASK                _U_(0x7FF5F3FF)                                /**< \deprecated (USBHS_HSTPIPISR) Register MASK  (Use USBHS_HSTPIPISR_Msk instead)  */
+#define USBHS_HSTPIPISR_Msk                 _U_(0x7FF5F3FF)                                /**< (USBHS_HSTPIPISR) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPICR : (USBHS Offset: 0x560) (/W 32) Host Pipe Clear Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINIC:1;                  /**< bit:      0  Received IN Data Interrupt Clear         */
+    uint32_t TXOUTIC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Clear     */
+    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t NAKEDIC:1;                 /**< bit:      4  NAKed Interrupt Clear                    */
+    uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t SHORTPACKETIC:1;           /**< bit:      7  Short Packet Interrupt Clear             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPICR_OFFSET              (0x560)                                       /**<  (USBHS_HSTPIPICR) Host Pipe Clear Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPICR_RXINIC_Pos          0                                              /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Position */
+#define USBHS_HSTPIPICR_RXINIC_Msk          (_U_(0x1) << USBHS_HSTPIPICR_RXINIC_Pos)       /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_RXINIC              USBHS_HSTPIPICR_RXINIC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_RXINIC_Msk instead */
+#define USBHS_HSTPIPICR_TXOUTIC_Pos         1                                              /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Position */
+#define USBHS_HSTPIPICR_TXOUTIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_TXOUTIC_Pos)      /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_TXOUTIC             USBHS_HSTPIPICR_TXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXOUTIC_Msk instead */
+#define USBHS_HSTPIPICR_TXSTPIC_Pos         2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_TXSTPIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_TXSTPIC_Pos)      /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_TXSTPIC             USBHS_HSTPIPICR_TXSTPIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPICR_NAKEDIC_Pos         4                                              /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_NAKEDIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_NAKEDIC_Pos)      /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_NAKEDIC             USBHS_HSTPIPICR_NAKEDIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_NAKEDIC_Msk instead */
+#define USBHS_HSTPIPICR_OVERFIC_Pos         5                                              /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_OVERFIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_OVERFIC_Pos)      /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_OVERFIC             USBHS_HSTPIPICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_OVERFIC_Msk instead */
+#define USBHS_HSTPIPICR_RXSTALLDIC_Pos      6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_RXSTALLDIC_Msk      (_U_(0x1) << USBHS_HSTPIPICR_RXSTALLDIC_Pos)   /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_RXSTALLDIC          USBHS_HSTPIPICR_RXSTALLDIC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_SHORTPACKETIC_Pos   7                                              /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Position */
+#define USBHS_HSTPIPICR_SHORTPACKETIC_Msk   (_U_(0x1) << USBHS_HSTPIPICR_SHORTPACKETIC_Pos)  /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_SHORTPACKETIC       USBHS_HSTPIPICR_SHORTPACKETIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_SHORTPACKETIC_Msk instead */
+#define USBHS_HSTPIPICR_MASK                _U_(0xF7)                                      /**< \deprecated (USBHS_HSTPIPICR) Register MASK  (Use USBHS_HSTPIPICR_Msk instead)  */
+#define USBHS_HSTPIPICR_Msk                 _U_(0xF7)                                      /**< (USBHS_HSTPIPICR) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIFR : (USBHS Offset: 0x590) (/W 32) Host Pipe Set Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINIS:1;                  /**< bit:      0  Received IN Data Interrupt Set           */
+    uint32_t TXOUTIS:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Set       */
+    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t PERRIS:1;                  /**< bit:      3  Pipe Error Interrupt Set                 */
+    uint32_t NAKEDIS:1;                 /**< bit:      4  NAKed Interrupt Set                      */
+    uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t SHORTPACKETIS:1;           /**< bit:      7  Short Packet Interrupt Set               */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Set                 */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIFR_OFFSET              (0x590)                                       /**<  (USBHS_HSTPIPIFR) Host Pipe Set Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPIFR_RXINIS_Pos          0                                              /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Position */
+#define USBHS_HSTPIPIFR_RXINIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_RXINIS_Pos)       /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_RXINIS              USBHS_HSTPIPIFR_RXINIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_RXINIS_Msk instead */
+#define USBHS_HSTPIPIFR_TXOUTIS_Pos         1                                              /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Position */
+#define USBHS_HSTPIPIFR_TXOUTIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_TXOUTIS_Pos)      /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_TXOUTIS             USBHS_HSTPIPIFR_TXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXOUTIS_Msk instead */
+#define USBHS_HSTPIPIFR_TXSTPIS_Pos         2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_TXSTPIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_TXSTPIS_Pos)      /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_TXSTPIS             USBHS_HSTPIPIFR_TXSTPIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIFR_PERRIS_Pos          3                                              /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Position */
+#define USBHS_HSTPIPIFR_PERRIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_PERRIS_Pos)       /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_PERRIS              USBHS_HSTPIPIFR_PERRIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_PERRIS_Msk instead */
+#define USBHS_HSTPIPIFR_NAKEDIS_Pos         4                                              /**< (USBHS_HSTPIPIFR) NAKed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_NAKEDIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_NAKEDIS_Pos)      /**< (USBHS_HSTPIPIFR) NAKed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_NAKEDIS             USBHS_HSTPIPIFR_NAKEDIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_NAKEDIS_Msk instead */
+#define USBHS_HSTPIPIFR_OVERFIS_Pos         5                                              /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_OVERFIS_Pos)      /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_OVERFIS             USBHS_HSTPIPIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_OVERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_RXSTALLDIS_Pos      6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_RXSTALLDIS_Msk      (_U_(0x1) << USBHS_HSTPIPIFR_RXSTALLDIS_Pos)   /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_RXSTALLDIS          USBHS_HSTPIPIFR_RXSTALLDIS_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS_Pos   7                                              /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Position */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS_Msk   (_U_(0x1) << USBHS_HSTPIPIFR_SHORTPACKETIS_Pos)  /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS       USBHS_HSTPIPIFR_SHORTPACKETIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_SHORTPACKETIS_Msk instead */
+#define USBHS_HSTPIPIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Position */
+#define USBHS_HSTPIPIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_HSTPIPIFR_NBUSYBKS_Pos)     /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Mask */
+#define USBHS_HSTPIPIFR_NBUSYBKS            USBHS_HSTPIPIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_NBUSYBKS_Msk instead */
+#define USBHS_HSTPIPIFR_MASK                _U_(0x10FF)                                    /**< \deprecated (USBHS_HSTPIPIFR) Register MASK  (Use USBHS_HSTPIPIFR_Msk instead)  */
+#define USBHS_HSTPIPIFR_Msk                 _U_(0x10FF)                                    /**< (USBHS_HSTPIPIFR) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIMR : (USBHS Offset: 0x5c0) (R/ 32) Host Pipe Mask Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINE:1;                   /**< bit:      0  Received IN Data Interrupt Enable        */
+    uint32_t TXOUTE:1;                  /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
+    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t PERRE:1;                   /**< bit:      3  Pipe Error Interrupt Enable              */
+    uint32_t NAKEDE:1;                  /**< bit:      4  NAKed Interrupt Enable                   */
+    uint32_t OVERFIE:1;                 /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t SHORTPACKETIE:1;           /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt Enable    */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCON:1;                 /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PDISHDMA:1;                /**< bit:     16  Pipe Interrupts Disable HDMA Request Enable */
+    uint32_t PFREEZE:1;                 /**< bit:     17  Pipe Freeze                              */
+    uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIMR_OFFSET              (0x5C0)                                       /**<  (USBHS_HSTPIPIMR) Host Pipe Mask Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPIMR_RXINE_Pos           0                                              /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_RXINE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RXINE_Pos)        /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_RXINE               USBHS_HSTPIPIMR_RXINE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RXINE_Msk instead */
+#define USBHS_HSTPIPIMR_TXOUTE_Pos          1                                              /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_TXOUTE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_TXOUTE_Pos)       /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_TXOUTE              USBHS_HSTPIPIMR_TXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXOUTE_Msk instead */
+#define USBHS_HSTPIPIMR_TXSTPE_Pos          2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_TXSTPE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_TXSTPE_Pos)       /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_TXSTPE              USBHS_HSTPIPIMR_TXSTPE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXSTPE_Msk instead */
+#define USBHS_HSTPIPIMR_PERRE_Pos           3                                              /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_PERRE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_PERRE_Pos)        /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_PERRE               USBHS_HSTPIPIMR_PERRE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PERRE_Msk instead */
+#define USBHS_HSTPIPIMR_NAKEDE_Pos          4                                              /**< (USBHS_HSTPIPIMR) NAKed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_NAKEDE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_NAKEDE_Pos)       /**< (USBHS_HSTPIPIMR) NAKed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_NAKEDE              USBHS_HSTPIPIMR_NAKEDE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_NAKEDE_Msk instead */
+#define USBHS_HSTPIPIMR_OVERFIE_Pos         5                                              /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_OVERFIE_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_OVERFIE_Pos)      /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_OVERFIE             USBHS_HSTPIPIMR_OVERFIE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_OVERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_RXSTALLDE_Pos       6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_RXSTALLDE_Msk       (_U_(0x1) << USBHS_HSTPIPIMR_RXSTALLDE_Pos)    /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_RXSTALLDE           USBHS_HSTPIPIMR_RXSTALLDE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE_Pos   7                                              /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE_Msk   (_U_(0x1) << USBHS_HSTPIPIMR_SHORTPACKETIE_Pos)  /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE       USBHS_HSTPIPIMR_SHORTPACKETIE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_SHORTPACKETIE_Msk instead */
+#define USBHS_HSTPIPIMR_NBUSYBKE_Pos        12                                             /**< (USBHS_HSTPIPIMR) Number of Busy Banks Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_NBUSYBKE_Msk        (_U_(0x1) << USBHS_HSTPIPIMR_NBUSYBKE_Pos)     /**< (USBHS_HSTPIPIMR) Number of Busy Banks Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_NBUSYBKE            USBHS_HSTPIPIMR_NBUSYBKE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_NBUSYBKE_Msk instead */
+#define USBHS_HSTPIPIMR_FIFOCON_Pos         14                                             /**< (USBHS_HSTPIPIMR) FIFO Control Position */
+#define USBHS_HSTPIPIMR_FIFOCON_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_FIFOCON_Pos)      /**< (USBHS_HSTPIPIMR) FIFO Control Mask */
+#define USBHS_HSTPIPIMR_FIFOCON             USBHS_HSTPIPIMR_FIFOCON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_FIFOCON_Msk instead */
+#define USBHS_HSTPIPIMR_PDISHDMA_Pos        16                                             /**< (USBHS_HSTPIPIMR) Pipe Interrupts Disable HDMA Request Enable Position */
+#define USBHS_HSTPIPIMR_PDISHDMA_Msk        (_U_(0x1) << USBHS_HSTPIPIMR_PDISHDMA_Pos)     /**< (USBHS_HSTPIPIMR) Pipe Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_HSTPIPIMR_PDISHDMA            USBHS_HSTPIPIMR_PDISHDMA_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PDISHDMA_Msk instead */
+#define USBHS_HSTPIPIMR_PFREEZE_Pos         17                                             /**< (USBHS_HSTPIPIMR) Pipe Freeze Position */
+#define USBHS_HSTPIPIMR_PFREEZE_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_PFREEZE_Pos)      /**< (USBHS_HSTPIPIMR) Pipe Freeze Mask */
+#define USBHS_HSTPIPIMR_PFREEZE             USBHS_HSTPIPIMR_PFREEZE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PFREEZE_Msk instead */
+#define USBHS_HSTPIPIMR_RSTDT_Pos           18                                             /**< (USBHS_HSTPIPIMR) Reset Data Toggle Position */
+#define USBHS_HSTPIPIMR_RSTDT_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RSTDT_Pos)        /**< (USBHS_HSTPIPIMR) Reset Data Toggle Mask */
+#define USBHS_HSTPIPIMR_RSTDT               USBHS_HSTPIPIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RSTDT_Msk instead */
+#define USBHS_HSTPIPIMR_MASK                _U_(0x750FF)                                   /**< \deprecated (USBHS_HSTPIPIMR) Register MASK  (Use USBHS_HSTPIPIMR_Msk instead)  */
+#define USBHS_HSTPIPIMR_Msk                 _U_(0x750FF)                                   /**< (USBHS_HSTPIPIMR) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIER : (USBHS Offset: 0x5f0) (/W 32) Host Pipe Enable Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINES:1;                  /**< bit:      0  Received IN Data Interrupt Enable        */
+    uint32_t TXOUTES:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
+    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t PERRES:1;                  /**< bit:      3  Pipe Error Interrupt Enable              */
+    uint32_t NAKEDES:1;                 /**< bit:      4  NAKed Interrupt Enable                   */
+    uint32_t OVERFIES:1;                /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t SHORTPACKETIES:1;          /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Enable              */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t PDISHDMAS:1;               /**< bit:     16  Pipe Interrupts Disable HDMA Request Enable */
+    uint32_t PFREEZES:1;                /**< bit:     17  Pipe Freeze Enable                       */
+    uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIER_OFFSET              (0x5F0)                                       /**<  (USBHS_HSTPIPIER) Host Pipe Enable Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPIER_RXINES_Pos          0                                              /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Position */
+#define USBHS_HSTPIPIER_RXINES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RXINES_Pos)       /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_RXINES              USBHS_HSTPIPIER_RXINES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RXINES_Msk instead */
+#define USBHS_HSTPIPIER_TXOUTES_Pos         1                                              /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Position */
+#define USBHS_HSTPIPIER_TXOUTES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_TXOUTES_Pos)      /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_TXOUTES             USBHS_HSTPIPIER_TXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXOUTES_Msk instead */
+#define USBHS_HSTPIPIER_TXSTPES_Pos         2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_TXSTPES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_TXSTPES_Pos)      /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_TXSTPES             USBHS_HSTPIPIER_TXSTPES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIER_PERRES_Pos          3                                              /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Position */
+#define USBHS_HSTPIPIER_PERRES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_PERRES_Pos)       /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_PERRES              USBHS_HSTPIPIER_PERRES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PERRES_Msk instead */
+#define USBHS_HSTPIPIER_NAKEDES_Pos         4                                              /**< (USBHS_HSTPIPIER) NAKed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_NAKEDES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_NAKEDES_Pos)      /**< (USBHS_HSTPIPIER) NAKed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_NAKEDES             USBHS_HSTPIPIER_NAKEDES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_NAKEDES_Msk instead */
+#define USBHS_HSTPIPIER_OVERFIES_Pos        5                                              /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_OVERFIES_Msk        (_U_(0x1) << USBHS_HSTPIPIER_OVERFIES_Pos)     /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_OVERFIES            USBHS_HSTPIPIER_OVERFIES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_OVERFIES_Msk instead */
+#define USBHS_HSTPIPIER_RXSTALLDES_Pos      6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_RXSTALLDES_Msk      (_U_(0x1) << USBHS_HSTPIPIER_RXSTALLDES_Pos)   /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_RXSTALLDES          USBHS_HSTPIPIER_RXSTALLDES_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_SHORTPACKETIES_Pos  7                                              /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Position */
+#define USBHS_HSTPIPIER_SHORTPACKETIES_Msk  (_U_(0x1) << USBHS_HSTPIPIER_SHORTPACKETIES_Pos)  /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_SHORTPACKETIES      USBHS_HSTPIPIER_SHORTPACKETIES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_SHORTPACKETIES_Msk instead */
+#define USBHS_HSTPIPIER_NBUSYBKES_Pos       12                                             /**< (USBHS_HSTPIPIER) Number of Busy Banks Enable Position */
+#define USBHS_HSTPIPIER_NBUSYBKES_Msk       (_U_(0x1) << USBHS_HSTPIPIER_NBUSYBKES_Pos)    /**< (USBHS_HSTPIPIER) Number of Busy Banks Enable Mask */
+#define USBHS_HSTPIPIER_NBUSYBKES           USBHS_HSTPIPIER_NBUSYBKES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_NBUSYBKES_Msk instead */
+#define USBHS_HSTPIPIER_PDISHDMAS_Pos       16                                             /**< (USBHS_HSTPIPIER) Pipe Interrupts Disable HDMA Request Enable Position */
+#define USBHS_HSTPIPIER_PDISHDMAS_Msk       (_U_(0x1) << USBHS_HSTPIPIER_PDISHDMAS_Pos)    /**< (USBHS_HSTPIPIER) Pipe Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_HSTPIPIER_PDISHDMAS           USBHS_HSTPIPIER_PDISHDMAS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PDISHDMAS_Msk instead */
+#define USBHS_HSTPIPIER_PFREEZES_Pos        17                                             /**< (USBHS_HSTPIPIER) Pipe Freeze Enable Position */
+#define USBHS_HSTPIPIER_PFREEZES_Msk        (_U_(0x1) << USBHS_HSTPIPIER_PFREEZES_Pos)     /**< (USBHS_HSTPIPIER) Pipe Freeze Enable Mask */
+#define USBHS_HSTPIPIER_PFREEZES            USBHS_HSTPIPIER_PFREEZES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PFREEZES_Msk instead */
+#define USBHS_HSTPIPIER_RSTDTS_Pos          18                                             /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Position */
+#define USBHS_HSTPIPIER_RSTDTS_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RSTDTS_Pos)       /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Mask */
+#define USBHS_HSTPIPIER_RSTDTS              USBHS_HSTPIPIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RSTDTS_Msk instead */
+#define USBHS_HSTPIPIER_MASK                _U_(0x710FF)                                   /**< \deprecated (USBHS_HSTPIPIER) Register MASK  (Use USBHS_HSTPIPIER_Msk instead)  */
+#define USBHS_HSTPIPIER_Msk                 _U_(0x710FF)                                   /**< (USBHS_HSTPIPIER) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIDR : (USBHS Offset: 0x620) (/W 32) Host Pipe Disable Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINEC:1;                  /**< bit:      0  Received IN Data Interrupt Disable       */
+    uint32_t TXOUTEC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Disable   */
+    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t PERREC:1;                  /**< bit:      3  Pipe Error Interrupt Disable             */
+    uint32_t NAKEDEC:1;                 /**< bit:      4  NAKed Interrupt Disable                  */
+    uint32_t OVERFIEC:1;                /**< bit:      5  Overflow Interrupt Disable               */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t SHORTPACKETIEC:1;          /**< bit:      7  Short Packet Interrupt Disable           */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Disable             */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCONC:1;                /**< bit:     14  FIFO Control Disable                     */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PDISHDMAC:1;               /**< bit:     16  Pipe Interrupts Disable HDMA Request Disable */
+    uint32_t PFREEZEC:1;                /**< bit:     17  Pipe Freeze Disable                      */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIDR_OFFSET              (0x620)                                       /**<  (USBHS_HSTPIPIDR) Host Pipe Disable Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPIDR_RXINEC_Pos          0                                              /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_RXINEC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_RXINEC_Pos)       /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_RXINEC              USBHS_HSTPIPIDR_RXINEC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_RXINEC_Msk instead */
+#define USBHS_HSTPIPIDR_TXOUTEC_Pos         1                                              /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_TXOUTEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_TXOUTEC_Pos)      /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_TXOUTEC             USBHS_HSTPIPIDR_TXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXOUTEC_Msk instead */
+#define USBHS_HSTPIPIDR_TXSTPEC_Pos         2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_TXSTPEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_TXSTPEC_Pos)      /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_TXSTPEC             USBHS_HSTPIPIDR_TXSTPEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIDR_PERREC_Pos          3                                              /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_PERREC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_PERREC_Pos)       /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_PERREC              USBHS_HSTPIPIDR_PERREC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PERREC_Msk instead */
+#define USBHS_HSTPIPIDR_NAKEDEC_Pos         4                                              /**< (USBHS_HSTPIPIDR) NAKed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_NAKEDEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_NAKEDEC_Pos)      /**< (USBHS_HSTPIPIDR) NAKed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_NAKEDEC             USBHS_HSTPIPIDR_NAKEDEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_NAKEDEC_Msk instead */
+#define USBHS_HSTPIPIDR_OVERFIEC_Pos        5                                              /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_OVERFIEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_OVERFIEC_Pos)     /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_OVERFIEC            USBHS_HSTPIPIDR_OVERFIEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_OVERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_RXSTALLDEC_Pos      6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_RXSTALLDEC_Msk      (_U_(0x1) << USBHS_HSTPIPIDR_RXSTALLDEC_Pos)   /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_RXSTALLDEC          USBHS_HSTPIPIDR_RXSTALLDEC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos  7                                              /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk  (_U_(0x1) << USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos)  /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC      USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk instead */
+#define USBHS_HSTPIPIDR_NBUSYBKEC_Pos       12                                             /**< (USBHS_HSTPIPIDR) Number of Busy Banks Disable Position */
+#define USBHS_HSTPIPIDR_NBUSYBKEC_Msk       (_U_(0x1) << USBHS_HSTPIPIDR_NBUSYBKEC_Pos)    /**< (USBHS_HSTPIPIDR) Number of Busy Banks Disable Mask */
+#define USBHS_HSTPIPIDR_NBUSYBKEC           USBHS_HSTPIPIDR_NBUSYBKEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_NBUSYBKEC_Msk instead */
+#define USBHS_HSTPIPIDR_FIFOCONC_Pos        14                                             /**< (USBHS_HSTPIPIDR) FIFO Control Disable Position */
+#define USBHS_HSTPIPIDR_FIFOCONC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_FIFOCONC_Pos)     /**< (USBHS_HSTPIPIDR) FIFO Control Disable Mask */
+#define USBHS_HSTPIPIDR_FIFOCONC            USBHS_HSTPIPIDR_FIFOCONC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_FIFOCONC_Msk instead */
+#define USBHS_HSTPIPIDR_PDISHDMAC_Pos       16                                             /**< (USBHS_HSTPIPIDR) Pipe Interrupts Disable HDMA Request Disable Position */
+#define USBHS_HSTPIPIDR_PDISHDMAC_Msk       (_U_(0x1) << USBHS_HSTPIPIDR_PDISHDMAC_Pos)    /**< (USBHS_HSTPIPIDR) Pipe Interrupts Disable HDMA Request Disable Mask */
+#define USBHS_HSTPIPIDR_PDISHDMAC           USBHS_HSTPIPIDR_PDISHDMAC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PDISHDMAC_Msk instead */
+#define USBHS_HSTPIPIDR_PFREEZEC_Pos        17                                             /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Position */
+#define USBHS_HSTPIPIDR_PFREEZEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_PFREEZEC_Pos)     /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Mask */
+#define USBHS_HSTPIPIDR_PFREEZEC            USBHS_HSTPIPIDR_PFREEZEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PFREEZEC_Msk instead */
+#define USBHS_HSTPIPIDR_MASK                _U_(0x350FF)                                   /**< \deprecated (USBHS_HSTPIPIDR) Register MASK  (Use USBHS_HSTPIPIDR_Msk instead)  */
+#define USBHS_HSTPIPIDR_Msk                 _U_(0x350FF)                                   /**< (USBHS_HSTPIPIDR) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPINRQ : (USBHS Offset: 0x650) (R/W 32) Host Pipe IN Request Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INRQ:8;                    /**< bit:   0..7  IN Request Number before Freeze          */
+    uint32_t INMODE:1;                  /**< bit:      8  IN Request Mode                          */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPINRQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPINRQ_OFFSET             (0x650)                                       /**<  (USBHS_HSTPIPINRQ) Host Pipe IN Request Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPINRQ_INRQ_Pos           0                                              /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Position */
+#define USBHS_HSTPIPINRQ_INRQ_Msk           (_U_(0xFF) << USBHS_HSTPIPINRQ_INRQ_Pos)       /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Mask */
+#define USBHS_HSTPIPINRQ_INRQ(value)        (USBHS_HSTPIPINRQ_INRQ_Msk & ((value) << USBHS_HSTPIPINRQ_INRQ_Pos))
+#define USBHS_HSTPIPINRQ_INMODE_Pos         8                                              /**< (USBHS_HSTPIPINRQ) IN Request Mode Position */
+#define USBHS_HSTPIPINRQ_INMODE_Msk         (_U_(0x1) << USBHS_HSTPIPINRQ_INMODE_Pos)      /**< (USBHS_HSTPIPINRQ) IN Request Mode Mask */
+#define USBHS_HSTPIPINRQ_INMODE             USBHS_HSTPIPINRQ_INMODE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPINRQ_INMODE_Msk instead */
+#define USBHS_HSTPIPINRQ_MASK               _U_(0x1FF)                                     /**< \deprecated (USBHS_HSTPIPINRQ) Register MASK  (Use USBHS_HSTPIPINRQ_Msk instead)  */
+#define USBHS_HSTPIPINRQ_Msk                _U_(0x1FF)                                     /**< (USBHS_HSTPIPINRQ) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPERR : (USBHS Offset: 0x680) (R/W 32) Host Pipe Error Register (n = 0) 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATATGL:1;                 /**< bit:      0  Data Toggle Error                        */
+    uint32_t DATAPID:1;                 /**< bit:      1  Data PID Error                           */
+    uint32_t PID:1;                     /**< bit:      2  Data PID Error                           */
+    uint32_t TIMEOUT:1;                 /**< bit:      3  Time-Out Error                           */
+    uint32_t CRC16:1;                   /**< bit:      4  CRC16 Error                              */
+    uint32_t COUNTER:2;                 /**< bit:   5..6  Error Counter                            */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CRC:1;                     /**< bit:      4  CRCx6 Error                              */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPERR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPERR_OFFSET              (0x680)                                       /**<  (USBHS_HSTPIPERR) Host Pipe Error Register (n = 0) 0  Offset */
+
+#define USBHS_HSTPIPERR_DATATGL_Pos         0                                              /**< (USBHS_HSTPIPERR) Data Toggle Error Position */
+#define USBHS_HSTPIPERR_DATATGL_Msk         (_U_(0x1) << USBHS_HSTPIPERR_DATATGL_Pos)      /**< (USBHS_HSTPIPERR) Data Toggle Error Mask */
+#define USBHS_HSTPIPERR_DATATGL             USBHS_HSTPIPERR_DATATGL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_DATATGL_Msk instead */
+#define USBHS_HSTPIPERR_DATAPID_Pos         1                                              /**< (USBHS_HSTPIPERR) Data PID Error Position */
+#define USBHS_HSTPIPERR_DATAPID_Msk         (_U_(0x1) << USBHS_HSTPIPERR_DATAPID_Pos)      /**< (USBHS_HSTPIPERR) Data PID Error Mask */
+#define USBHS_HSTPIPERR_DATAPID             USBHS_HSTPIPERR_DATAPID_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_DATAPID_Msk instead */
+#define USBHS_HSTPIPERR_PID_Pos             2                                              /**< (USBHS_HSTPIPERR) Data PID Error Position */
+#define USBHS_HSTPIPERR_PID_Msk             (_U_(0x1) << USBHS_HSTPIPERR_PID_Pos)          /**< (USBHS_HSTPIPERR) Data PID Error Mask */
+#define USBHS_HSTPIPERR_PID                 USBHS_HSTPIPERR_PID_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_PID_Msk instead */
+#define USBHS_HSTPIPERR_TIMEOUT_Pos         3                                              /**< (USBHS_HSTPIPERR) Time-Out Error Position */
+#define USBHS_HSTPIPERR_TIMEOUT_Msk         (_U_(0x1) << USBHS_HSTPIPERR_TIMEOUT_Pos)      /**< (USBHS_HSTPIPERR) Time-Out Error Mask */
+#define USBHS_HSTPIPERR_TIMEOUT             USBHS_HSTPIPERR_TIMEOUT_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_TIMEOUT_Msk instead */
+#define USBHS_HSTPIPERR_CRC16_Pos           4                                              /**< (USBHS_HSTPIPERR) CRC16 Error Position */
+#define USBHS_HSTPIPERR_CRC16_Msk           (_U_(0x1) << USBHS_HSTPIPERR_CRC16_Pos)        /**< (USBHS_HSTPIPERR) CRC16 Error Mask */
+#define USBHS_HSTPIPERR_CRC16               USBHS_HSTPIPERR_CRC16_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_CRC16_Msk instead */
+#define USBHS_HSTPIPERR_COUNTER_Pos         5                                              /**< (USBHS_HSTPIPERR) Error Counter Position */
+#define USBHS_HSTPIPERR_COUNTER_Msk         (_U_(0x3) << USBHS_HSTPIPERR_COUNTER_Pos)      /**< (USBHS_HSTPIPERR) Error Counter Mask */
+#define USBHS_HSTPIPERR_COUNTER(value)      (USBHS_HSTPIPERR_COUNTER_Msk & ((value) << USBHS_HSTPIPERR_COUNTER_Pos))
+#define USBHS_HSTPIPERR_MASK                _U_(0x7F)                                      /**< \deprecated (USBHS_HSTPIPERR) Register MASK  (Use USBHS_HSTPIPERR_Msk instead)  */
+#define USBHS_HSTPIPERR_Msk                 _U_(0x7F)                                      /**< (USBHS_HSTPIPERR) Register Mask  */
+
+#define USBHS_HSTPIPERR_CRC_Pos             4                                              /**< (USBHS_HSTPIPERR Position) CRCx6 Error */
+#define USBHS_HSTPIPERR_CRC_Msk             (_U_(0x1) << USBHS_HSTPIPERR_CRC_Pos)          /**< (USBHS_HSTPIPERR Mask) CRC */
+#define USBHS_HSTPIPERR_CRC(value)          (USBHS_HSTPIPERR_CRC_Msk & ((value) << USBHS_HSTPIPERR_CRC_Pos))  
+
+/* -------- USBHS_CTRL : (USBHS Offset: 0x800) (R/W 32) General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRE:1;                  /**< bit:      4  Remote Device Connection Error Interrupt Enable */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t VBUSHWC:1;                 /**< bit:      8  VBUS Hardware Control                    */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t FRZCLK:1;                  /**< bit:     14  Freeze USB Clock                         */
+    uint32_t USBE:1;                    /**< bit:     15  USBHS Enable                             */
+    uint32_t :8;                        /**< bit: 16..23  Reserved */
+    uint32_t UID:1;                     /**< bit:     24  UID Pin Enable                           */
+    uint32_t UIMOD:1;                   /**< bit:     25  USBHS Mode                               */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_CTRL_OFFSET                   (0x800)                                       /**<  (USBHS_CTRL) General Control Register  Offset */
+
+#define USBHS_CTRL_RDERRE_Pos               4                                              /**< (USBHS_CTRL) Remote Device Connection Error Interrupt Enable Position */
+#define USBHS_CTRL_RDERRE_Msk               (_U_(0x1) << USBHS_CTRL_RDERRE_Pos)            /**< (USBHS_CTRL) Remote Device Connection Error Interrupt Enable Mask */
+#define USBHS_CTRL_RDERRE                   USBHS_CTRL_RDERRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_RDERRE_Msk instead */
+#define USBHS_CTRL_VBUSHWC_Pos              8                                              /**< (USBHS_CTRL) VBUS Hardware Control Position */
+#define USBHS_CTRL_VBUSHWC_Msk              (_U_(0x1) << USBHS_CTRL_VBUSHWC_Pos)           /**< (USBHS_CTRL) VBUS Hardware Control Mask */
+#define USBHS_CTRL_VBUSHWC                  USBHS_CTRL_VBUSHWC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_VBUSHWC_Msk instead */
+#define USBHS_CTRL_FRZCLK_Pos               14                                             /**< (USBHS_CTRL) Freeze USB Clock Position */
+#define USBHS_CTRL_FRZCLK_Msk               (_U_(0x1) << USBHS_CTRL_FRZCLK_Pos)            /**< (USBHS_CTRL) Freeze USB Clock Mask */
+#define USBHS_CTRL_FRZCLK                   USBHS_CTRL_FRZCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_FRZCLK_Msk instead */
+#define USBHS_CTRL_USBE_Pos                 15                                             /**< (USBHS_CTRL) USBHS Enable Position */
+#define USBHS_CTRL_USBE_Msk                 (_U_(0x1) << USBHS_CTRL_USBE_Pos)              /**< (USBHS_CTRL) USBHS Enable Mask */
+#define USBHS_CTRL_USBE                     USBHS_CTRL_USBE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_USBE_Msk instead */
+#define USBHS_CTRL_UID_Pos                  24                                             /**< (USBHS_CTRL) UID Pin Enable Position */
+#define USBHS_CTRL_UID_Msk                  (_U_(0x1) << USBHS_CTRL_UID_Pos)               /**< (USBHS_CTRL) UID Pin Enable Mask */
+#define USBHS_CTRL_UID                      USBHS_CTRL_UID_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UID_Msk instead */
+#define USBHS_CTRL_UIMOD_Pos                25                                             /**< (USBHS_CTRL) USBHS Mode Position */
+#define USBHS_CTRL_UIMOD_Msk                (_U_(0x1) << USBHS_CTRL_UIMOD_Pos)             /**< (USBHS_CTRL) USBHS Mode Mask */
+#define USBHS_CTRL_UIMOD                    USBHS_CTRL_UIMOD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UIMOD_Msk instead */
+#define   USBHS_CTRL_UIMOD_HOST_Val         _U_(0x0)                                       /**< (USBHS_CTRL) The module is in USB Host mode.  */
+#define   USBHS_CTRL_UIMOD_DEVICE_Val       _U_(0x1)                                       /**< (USBHS_CTRL) The module is in USB Device mode.  */
+#define USBHS_CTRL_UIMOD_HOST               (USBHS_CTRL_UIMOD_HOST_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Host mode. Position  */
+#define USBHS_CTRL_UIMOD_DEVICE             (USBHS_CTRL_UIMOD_DEVICE_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Device mode. Position  */
+#define USBHS_CTRL_MASK                     _U_(0x300C110)                                 /**< \deprecated (USBHS_CTRL) Register MASK  (Use USBHS_CTRL_Msk instead)  */
+#define USBHS_CTRL_Msk                      _U_(0x300C110)                                 /**< (USBHS_CTRL) Register Mask  */
+
+
+/* -------- USBHS_SR : (USBHS Offset: 0x804) (R/ 32) General Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRI:1;                  /**< bit:      4  Remote Device Connection Error Interrupt (Host mode only) */
+    uint32_t :7;                        /**< bit:  5..11  Reserved */
+    uint32_t SPEED:2;                   /**< bit: 12..13  Speed Status (Device mode only)          */
+    uint32_t CLKUSABLE:1;               /**< bit:     14  UTMI Clock Usable                        */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SR_OFFSET                     (0x804)                                       /**<  (USBHS_SR) General Status Register  Offset */
+
+#define USBHS_SR_RDERRI_Pos                 4                                              /**< (USBHS_SR) Remote Device Connection Error Interrupt (Host mode only) Position */
+#define USBHS_SR_RDERRI_Msk                 (_U_(0x1) << USBHS_SR_RDERRI_Pos)              /**< (USBHS_SR) Remote Device Connection Error Interrupt (Host mode only) Mask */
+#define USBHS_SR_RDERRI                     USBHS_SR_RDERRI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SR_RDERRI_Msk instead */
+#define USBHS_SR_SPEED_Pos                  12                                             /**< (USBHS_SR) Speed Status (Device mode only) Position */
+#define USBHS_SR_SPEED_Msk                  (_U_(0x3) << USBHS_SR_SPEED_Pos)               /**< (USBHS_SR) Speed Status (Device mode only) Mask */
+#define USBHS_SR_SPEED(value)               (USBHS_SR_SPEED_Msk & ((value) << USBHS_SR_SPEED_Pos))
+#define   USBHS_SR_SPEED_FULL_SPEED_Val     _U_(0x0)                                       /**< (USBHS_SR) Full-Speed mode  */
+#define   USBHS_SR_SPEED_HIGH_SPEED_Val     _U_(0x1)                                       /**< (USBHS_SR) High-Speed mode  */
+#define   USBHS_SR_SPEED_LOW_SPEED_Val      _U_(0x2)                                       /**< (USBHS_SR) Low-Speed mode  */
+#define USBHS_SR_SPEED_FULL_SPEED           (USBHS_SR_SPEED_FULL_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) Full-Speed mode Position  */
+#define USBHS_SR_SPEED_HIGH_SPEED           (USBHS_SR_SPEED_HIGH_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) High-Speed mode Position  */
+#define USBHS_SR_SPEED_LOW_SPEED            (USBHS_SR_SPEED_LOW_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) Low-Speed mode Position  */
+#define USBHS_SR_CLKUSABLE_Pos              14                                             /**< (USBHS_SR) UTMI Clock Usable Position */
+#define USBHS_SR_CLKUSABLE_Msk              (_U_(0x1) << USBHS_SR_CLKUSABLE_Pos)           /**< (USBHS_SR) UTMI Clock Usable Mask */
+#define USBHS_SR_CLKUSABLE                  USBHS_SR_CLKUSABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SR_CLKUSABLE_Msk instead */
+#define USBHS_SR_MASK                       _U_(0x7010)                                    /**< \deprecated (USBHS_SR) Register MASK  (Use USBHS_SR_Msk instead)  */
+#define USBHS_SR_Msk                        _U_(0x7010)                                    /**< (USBHS_SR) Register Mask  */
+
+
+/* -------- USBHS_SCR : (USBHS Offset: 0x808) (/W 32) General Status Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRIC:1;                 /**< bit:      4  Remote Device Connection Error Interrupt Clear */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SCR_OFFSET                    (0x808)                                       /**<  (USBHS_SCR) General Status Clear Register  Offset */
+
+#define USBHS_SCR_RDERRIC_Pos               4                                              /**< (USBHS_SCR) Remote Device Connection Error Interrupt Clear Position */
+#define USBHS_SCR_RDERRIC_Msk               (_U_(0x1) << USBHS_SCR_RDERRIC_Pos)            /**< (USBHS_SCR) Remote Device Connection Error Interrupt Clear Mask */
+#define USBHS_SCR_RDERRIC                   USBHS_SCR_RDERRIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SCR_RDERRIC_Msk instead */
+#define USBHS_SCR_MASK                      _U_(0x10)                                      /**< \deprecated (USBHS_SCR) Register MASK  (Use USBHS_SCR_Msk instead)  */
+#define USBHS_SCR_Msk                       _U_(0x10)                                      /**< (USBHS_SCR) Register Mask  */
+
+
+/* -------- USBHS_SFR : (USBHS Offset: 0x80c) (/W 32) General Status Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRIS:1;                 /**< bit:      4  Remote Device Connection Error Interrupt Set */
+    uint32_t :4;                        /**< bit:   5..8  Reserved */
+    uint32_t VBUSRQS:1;                 /**< bit:      9  VBUS Request Set                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SFR_OFFSET                    (0x80C)                                       /**<  (USBHS_SFR) General Status Set Register  Offset */
+
+#define USBHS_SFR_RDERRIS_Pos               4                                              /**< (USBHS_SFR) Remote Device Connection Error Interrupt Set Position */
+#define USBHS_SFR_RDERRIS_Msk               (_U_(0x1) << USBHS_SFR_RDERRIS_Pos)            /**< (USBHS_SFR) Remote Device Connection Error Interrupt Set Mask */
+#define USBHS_SFR_RDERRIS                   USBHS_SFR_RDERRIS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SFR_RDERRIS_Msk instead */
+#define USBHS_SFR_VBUSRQS_Pos               9                                              /**< (USBHS_SFR) VBUS Request Set Position */
+#define USBHS_SFR_VBUSRQS_Msk               (_U_(0x1) << USBHS_SFR_VBUSRQS_Pos)            /**< (USBHS_SFR) VBUS Request Set Mask */
+#define USBHS_SFR_VBUSRQS                   USBHS_SFR_VBUSRQS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SFR_VBUSRQS_Msk instead */
+#define USBHS_SFR_MASK                      _U_(0x210)                                     /**< \deprecated (USBHS_SFR) Register MASK  (Use USBHS_SFR_Msk instead)  */
+#define USBHS_SFR_Msk                       _U_(0x210)                                     /**< (USBHS_SFR) Register Mask  */
+
+
+/* -------- USBHS_TSTA1 : (USBHS Offset: 0x810) (R/W 32) General Test A1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CounterA:15;               /**< bit:  0..14  Counter A                                */
+    uint32_t LoadCntA:1;                /**< bit:     15  Load CounterA                            */
+    uint32_t CounterB:6;                /**< bit: 16..21  Counter B                                */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t LoadCntB:1;                /**< bit:     23  Load CounterB                            */
+    uint32_t SOFCntMa1:7;               /**< bit: 24..30  SOF Counter Max                          */
+    uint32_t LoadSOFCnt:1;              /**< bit:     31  Load SOF Counter                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_TSTA1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_TSTA1_OFFSET                  (0x810)                                       /**<  (USBHS_TSTA1) General Test A1 Register  Offset */
+
+#define USBHS_TSTA1_CounterA_Pos            0                                              /**< (USBHS_TSTA1) Counter A Position */
+#define USBHS_TSTA1_CounterA_Msk            (_U_(0x7FFF) << USBHS_TSTA1_CounterA_Pos)      /**< (USBHS_TSTA1) Counter A Mask */
+#define USBHS_TSTA1_CounterA(value)         (USBHS_TSTA1_CounterA_Msk & ((value) << USBHS_TSTA1_CounterA_Pos))
+#define USBHS_TSTA1_LoadCntA_Pos            15                                             /**< (USBHS_TSTA1) Load CounterA Position */
+#define USBHS_TSTA1_LoadCntA_Msk            (_U_(0x1) << USBHS_TSTA1_LoadCntA_Pos)         /**< (USBHS_TSTA1) Load CounterA Mask */
+#define USBHS_TSTA1_LoadCntA                USBHS_TSTA1_LoadCntA_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA1_LoadCntA_Msk instead */
+#define USBHS_TSTA1_CounterB_Pos            16                                             /**< (USBHS_TSTA1) Counter B Position */
+#define USBHS_TSTA1_CounterB_Msk            (_U_(0x3F) << USBHS_TSTA1_CounterB_Pos)        /**< (USBHS_TSTA1) Counter B Mask */
+#define USBHS_TSTA1_CounterB(value)         (USBHS_TSTA1_CounterB_Msk & ((value) << USBHS_TSTA1_CounterB_Pos))
+#define USBHS_TSTA1_LoadCntB_Pos            23                                             /**< (USBHS_TSTA1) Load CounterB Position */
+#define USBHS_TSTA1_LoadCntB_Msk            (_U_(0x1) << USBHS_TSTA1_LoadCntB_Pos)         /**< (USBHS_TSTA1) Load CounterB Mask */
+#define USBHS_TSTA1_LoadCntB                USBHS_TSTA1_LoadCntB_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA1_LoadCntB_Msk instead */
+#define USBHS_TSTA1_SOFCntMa1_Pos           24                                             /**< (USBHS_TSTA1) SOF Counter Max Position */
+#define USBHS_TSTA1_SOFCntMa1_Msk           (_U_(0x7F) << USBHS_TSTA1_SOFCntMa1_Pos)       /**< (USBHS_TSTA1) SOF Counter Max Mask */
+#define USBHS_TSTA1_SOFCntMa1(value)        (USBHS_TSTA1_SOFCntMa1_Msk & ((value) << USBHS_TSTA1_SOFCntMa1_Pos))
+#define USBHS_TSTA1_LoadSOFCnt_Pos          31                                             /**< (USBHS_TSTA1) Load SOF Counter Position */
+#define USBHS_TSTA1_LoadSOFCnt_Msk          (_U_(0x1) << USBHS_TSTA1_LoadSOFCnt_Pos)       /**< (USBHS_TSTA1) Load SOF Counter Mask */
+#define USBHS_TSTA1_LoadSOFCnt              USBHS_TSTA1_LoadSOFCnt_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA1_LoadSOFCnt_Msk instead */
+#define USBHS_TSTA1_MASK                    _U_(0xFFBFFFFF)                                /**< \deprecated (USBHS_TSTA1) Register MASK  (Use USBHS_TSTA1_Msk instead)  */
+#define USBHS_TSTA1_Msk                     _U_(0xFFBFFFFF)                                /**< (USBHS_TSTA1) Register Mask  */
+
+
+/* -------- USBHS_TSTA2 : (USBHS Offset: 0x814) (R/W 32) General Test A2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FullDetachEn:1;            /**< bit:      0  Full Detach Enable                       */
+    uint32_t HSSerialMode:1;            /**< bit:      1  HS Serial Mode                           */
+    uint32_t LoopBackMode:1;            /**< bit:      2  Loop-back Mode                           */
+    uint32_t DisableGatedClock:1;       /**< bit:      3  Disable Gated Clock                      */
+    uint32_t ForceSuspendMTo1:1;        /**< bit:      4  Force SuspendM to 1                      */
+    uint32_t ByPassDpll:1;              /**< bit:      5  Bypass DPLL                              */
+    uint32_t HostHSDisconnectDisable:1;  /**< bit:      6  Host HS Disconnect Disable               */
+    uint32_t ForceHSRst_50ms:1;         /**< bit:      7  Force HS Reset to 50 ms                  */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t RemovePUWhenTX:1;          /**< bit:      9  Remove Pull-up When TX                   */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t ForceSuspendMTo:1;         /**< bit:      4  Force SuspendM to x                      */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_TSTA2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_TSTA2_OFFSET                  (0x814)                                       /**<  (USBHS_TSTA2) General Test A2 Register  Offset */
+
+#define USBHS_TSTA2_FullDetachEn_Pos        0                                              /**< (USBHS_TSTA2) Full Detach Enable Position */
+#define USBHS_TSTA2_FullDetachEn_Msk        (_U_(0x1) << USBHS_TSTA2_FullDetachEn_Pos)     /**< (USBHS_TSTA2) Full Detach Enable Mask */
+#define USBHS_TSTA2_FullDetachEn            USBHS_TSTA2_FullDetachEn_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_FullDetachEn_Msk instead */
+#define USBHS_TSTA2_HSSerialMode_Pos        1                                              /**< (USBHS_TSTA2) HS Serial Mode Position */
+#define USBHS_TSTA2_HSSerialMode_Msk        (_U_(0x1) << USBHS_TSTA2_HSSerialMode_Pos)     /**< (USBHS_TSTA2) HS Serial Mode Mask */
+#define USBHS_TSTA2_HSSerialMode            USBHS_TSTA2_HSSerialMode_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_HSSerialMode_Msk instead */
+#define USBHS_TSTA2_LoopBackMode_Pos        2                                              /**< (USBHS_TSTA2) Loop-back Mode Position */
+#define USBHS_TSTA2_LoopBackMode_Msk        (_U_(0x1) << USBHS_TSTA2_LoopBackMode_Pos)     /**< (USBHS_TSTA2) Loop-back Mode Mask */
+#define USBHS_TSTA2_LoopBackMode            USBHS_TSTA2_LoopBackMode_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_LoopBackMode_Msk instead */
+#define USBHS_TSTA2_DisableGatedClock_Pos   3                                              /**< (USBHS_TSTA2) Disable Gated Clock Position */
+#define USBHS_TSTA2_DisableGatedClock_Msk   (_U_(0x1) << USBHS_TSTA2_DisableGatedClock_Pos)  /**< (USBHS_TSTA2) Disable Gated Clock Mask */
+#define USBHS_TSTA2_DisableGatedClock       USBHS_TSTA2_DisableGatedClock_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_DisableGatedClock_Msk instead */
+#define USBHS_TSTA2_ForceSuspendMTo1_Pos    4                                              /**< (USBHS_TSTA2) Force SuspendM to 1 Position */
+#define USBHS_TSTA2_ForceSuspendMTo1_Msk    (_U_(0x1) << USBHS_TSTA2_ForceSuspendMTo1_Pos)  /**< (USBHS_TSTA2) Force SuspendM to 1 Mask */
+#define USBHS_TSTA2_ForceSuspendMTo1        USBHS_TSTA2_ForceSuspendMTo1_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_ForceSuspendMTo1_Msk instead */
+#define USBHS_TSTA2_ByPassDpll_Pos          5                                              /**< (USBHS_TSTA2) Bypass DPLL Position */
+#define USBHS_TSTA2_ByPassDpll_Msk          (_U_(0x1) << USBHS_TSTA2_ByPassDpll_Pos)       /**< (USBHS_TSTA2) Bypass DPLL Mask */
+#define USBHS_TSTA2_ByPassDpll              USBHS_TSTA2_ByPassDpll_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_ByPassDpll_Msk instead */
+#define USBHS_TSTA2_HostHSDisconnectDisable_Pos 6                                              /**< (USBHS_TSTA2) Host HS Disconnect Disable Position */
+#define USBHS_TSTA2_HostHSDisconnectDisable_Msk (_U_(0x1) << USBHS_TSTA2_HostHSDisconnectDisable_Pos)  /**< (USBHS_TSTA2) Host HS Disconnect Disable Mask */
+#define USBHS_TSTA2_HostHSDisconnectDisable USBHS_TSTA2_HostHSDisconnectDisable_Msk        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_HostHSDisconnectDisable_Msk instead */
+#define USBHS_TSTA2_ForceHSRst_50ms_Pos     7                                              /**< (USBHS_TSTA2) Force HS Reset to 50 ms Position */
+#define USBHS_TSTA2_ForceHSRst_50ms_Msk     (_U_(0x1) << USBHS_TSTA2_ForceHSRst_50ms_Pos)  /**< (USBHS_TSTA2) Force HS Reset to 50 ms Mask */
+#define USBHS_TSTA2_ForceHSRst_50ms         USBHS_TSTA2_ForceHSRst_50ms_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_ForceHSRst_50ms_Msk instead */
+#define USBHS_TSTA2_RemovePUWhenTX_Pos      9                                              /**< (USBHS_TSTA2) Remove Pull-up When TX Position */
+#define USBHS_TSTA2_RemovePUWhenTX_Msk      (_U_(0x1) << USBHS_TSTA2_RemovePUWhenTX_Pos)   /**< (USBHS_TSTA2) Remove Pull-up When TX Mask */
+#define USBHS_TSTA2_RemovePUWhenTX          USBHS_TSTA2_RemovePUWhenTX_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_TSTA2_RemovePUWhenTX_Msk instead */
+#define USBHS_TSTA2_MASK                    _U_(0x2FF)                                     /**< \deprecated (USBHS_TSTA2) Register MASK  (Use USBHS_TSTA2_Msk instead)  */
+#define USBHS_TSTA2_Msk                     _U_(0x2FF)                                     /**< (USBHS_TSTA2) Register Mask  */
+
+#define USBHS_TSTA2_ForceSuspendMTo_Pos     4                                              /**< (USBHS_TSTA2 Position) Force SuspendM to x */
+#define USBHS_TSTA2_ForceSuspendMTo_Msk     (_U_(0x1) << USBHS_TSTA2_ForceSuspendMTo_Pos)  /**< (USBHS_TSTA2 Mask) ForceSuspendMTo */
+#define USBHS_TSTA2_ForceSuspendMTo(value)  (USBHS_TSTA2_ForceSuspendMTo_Msk & ((value) << USBHS_TSTA2_ForceSuspendMTo_Pos))  
+
+/* -------- USBHS_VERSION : (USBHS Offset: 0x818) (R/ 32) General Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version Number                           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:4;                     /**< bit: 16..19  Metal Fix Number                         */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_VERSION_OFFSET                (0x818)                                       /**<  (USBHS_VERSION) General Version Register  Offset */
+
+#define USBHS_VERSION_VERSION_Pos           0                                              /**< (USBHS_VERSION) Version Number Position */
+#define USBHS_VERSION_VERSION_Msk           (_U_(0xFFF) << USBHS_VERSION_VERSION_Pos)      /**< (USBHS_VERSION) Version Number Mask */
+#define USBHS_VERSION_VERSION(value)        (USBHS_VERSION_VERSION_Msk & ((value) << USBHS_VERSION_VERSION_Pos))
+#define USBHS_VERSION_MFN_Pos               16                                             /**< (USBHS_VERSION) Metal Fix Number Position */
+#define USBHS_VERSION_MFN_Msk               (_U_(0xF) << USBHS_VERSION_MFN_Pos)            /**< (USBHS_VERSION) Metal Fix Number Mask */
+#define USBHS_VERSION_MFN(value)            (USBHS_VERSION_MFN_Msk & ((value) << USBHS_VERSION_MFN_Pos))
+#define USBHS_VERSION_MASK                  _U_(0xF0FFF)                                   /**< \deprecated (USBHS_VERSION) Register MASK  (Use USBHS_VERSION_Msk instead)  */
+#define USBHS_VERSION_Msk                   _U_(0xF0FFF)                                   /**< (USBHS_VERSION) Register Mask  */
+
+
+/* -------- USBHS_FSM : (USBHS Offset: 0x82c) (R/ 32) General Finite State Machine Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDSTATE:4;                /**< bit:   0..3  Dual Role Device State                   */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_FSM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_FSM_OFFSET                    (0x82C)                                       /**<  (USBHS_FSM) General Finite State Machine Register  Offset */
+
+#define USBHS_FSM_DRDSTATE_Pos              0                                              /**< (USBHS_FSM) Dual Role Device State Position */
+#define USBHS_FSM_DRDSTATE_Msk              (_U_(0xF) << USBHS_FSM_DRDSTATE_Pos)           /**< (USBHS_FSM) Dual Role Device State Mask */
+#define USBHS_FSM_DRDSTATE(value)           (USBHS_FSM_DRDSTATE_Msk & ((value) << USBHS_FSM_DRDSTATE_Pos))
+#define   USBHS_FSM_DRDSTATE_A_IDLESTATE_Val _U_(0x0)                                       /**< (USBHS_FSM) This is the start state for A-devices (when the ID pin is 0)  */
+#define   USBHS_FSM_DRDSTATE_A_WAIT_VRISE_Val _U_(0x1)                                       /**< (USBHS_FSM) In this state, the A-device waits for the voltage on VBus to rise above the A-device VBus Valid threshold (4.4 V).  */
+#define   USBHS_FSM_DRDSTATE_A_WAIT_BCON_Val _U_(0x2)                                       /**< (USBHS_FSM) In this state, the A-device waits for the B-device to signal a connection.  */
+#define   USBHS_FSM_DRDSTATE_A_HOST_Val     _U_(0x3)                                       /**< (USBHS_FSM) In this state, the A-device that operates in Host mode is operational.  */
+#define   USBHS_FSM_DRDSTATE_A_SUSPEND_Val  _U_(0x4)                                       /**< (USBHS_FSM) The A-device operating as a host is in the Suspend mode.  */
+#define   USBHS_FSM_DRDSTATE_A_PERIPHERAL_Val _U_(0x5)                                       /**< (USBHS_FSM) The A-device operates as a peripheral.  */
+#define   USBHS_FSM_DRDSTATE_A_WAIT_VFALL_Val _U_(0x6)                                       /**< (USBHS_FSM) In this state, the A-device waits for the voltage on VBus to drop below the A-device Session Valid threshold (1.4 V).  */
+#define   USBHS_FSM_DRDSTATE_A_VBUS_ERR_Val _U_(0x7)                                       /**< (USBHS_FSM) In this state, the A-device waits for recovery of the over-current condition that caused it to enter this state.  */
+#define   USBHS_FSM_DRDSTATE_A_WAIT_DISCHARGE_Val _U_(0x8)                                       /**< (USBHS_FSM) In this state, the A-device waits for the data USB line to discharge (100 us).  */
+#define   USBHS_FSM_DRDSTATE_B_IDLE_Val     _U_(0x9)                                       /**< (USBHS_FSM) This is the start state for B-device (when the ID pin is 1).  */
+#define   USBHS_FSM_DRDSTATE_B_PERIPHERAL_Val _U_(0xA)                                       /**< (USBHS_FSM) In this state, the B-device acts as the peripheral.  */
+#define   USBHS_FSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val _U_(0xB)                                       /**< (USBHS_FSM) In this state, the B-device is in Suspend mode and waits until 3 ms before initiating the HNP protocol if requested.  */
+#define   USBHS_FSM_DRDSTATE_B_WAIT_DISCHARGE_Val _U_(0xC)                                       /**< (USBHS_FSM) In this state, the B-device waits for the data USB line to discharge (100 us)) before becoming Host.  */
+#define   USBHS_FSM_DRDSTATE_B_WAIT_ACON_Val _U_(0xD)                                       /**< (USBHS_FSM) In this state, the B-device waits for the A-device to signal a connect before becoming B-Host.  */
+#define   USBHS_FSM_DRDSTATE_B_HOST_Val     _U_(0xE)                                       /**< (USBHS_FSM) In this state, the B-device acts as the Host.  */
+#define   USBHS_FSM_DRDSTATE_B_SRP_INIT_Val _U_(0xF)                                       /**< (USBHS_FSM) In this state, the B-device attempts to start a session using the SRP protocol.  */
+#define USBHS_FSM_DRDSTATE_A_IDLESTATE      (USBHS_FSM_DRDSTATE_A_IDLESTATE_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) This is the start state for A-devices (when the ID pin is 0) Position  */
+#define USBHS_FSM_DRDSTATE_A_WAIT_VRISE     (USBHS_FSM_DRDSTATE_A_WAIT_VRISE_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device waits for the voltage on VBus to rise above the A-device VBus Valid threshold (4.4 V). Position  */
+#define USBHS_FSM_DRDSTATE_A_WAIT_BCON      (USBHS_FSM_DRDSTATE_A_WAIT_BCON_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device waits for the B-device to signal a connection. Position  */
+#define USBHS_FSM_DRDSTATE_A_HOST           (USBHS_FSM_DRDSTATE_A_HOST_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device that operates in Host mode is operational. Position  */
+#define USBHS_FSM_DRDSTATE_A_SUSPEND        (USBHS_FSM_DRDSTATE_A_SUSPEND_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) The A-device operating as a host is in the Suspend mode. Position  */
+#define USBHS_FSM_DRDSTATE_A_PERIPHERAL     (USBHS_FSM_DRDSTATE_A_PERIPHERAL_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) The A-device operates as a peripheral. Position  */
+#define USBHS_FSM_DRDSTATE_A_WAIT_VFALL     (USBHS_FSM_DRDSTATE_A_WAIT_VFALL_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device waits for the voltage on VBus to drop below the A-device Session Valid threshold (1.4 V). Position  */
+#define USBHS_FSM_DRDSTATE_A_VBUS_ERR       (USBHS_FSM_DRDSTATE_A_VBUS_ERR_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device waits for recovery of the over-current condition that caused it to enter this state. Position  */
+#define USBHS_FSM_DRDSTATE_A_WAIT_DISCHARGE (USBHS_FSM_DRDSTATE_A_WAIT_DISCHARGE_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the A-device waits for the data USB line to discharge (100 us). Position  */
+#define USBHS_FSM_DRDSTATE_B_IDLE           (USBHS_FSM_DRDSTATE_B_IDLE_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) This is the start state for B-device (when the ID pin is 1). Position  */
+#define USBHS_FSM_DRDSTATE_B_PERIPHERAL     (USBHS_FSM_DRDSTATE_B_PERIPHERAL_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device acts as the peripheral. Position  */
+#define USBHS_FSM_DRDSTATE_B_WAIT_BEGIN_HNP (USBHS_FSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device is in Suspend mode and waits until 3 ms before initiating the HNP protocol if requested. Position  */
+#define USBHS_FSM_DRDSTATE_B_WAIT_DISCHARGE (USBHS_FSM_DRDSTATE_B_WAIT_DISCHARGE_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device waits for the data USB line to discharge (100 us)) before becoming Host. Position  */
+#define USBHS_FSM_DRDSTATE_B_WAIT_ACON      (USBHS_FSM_DRDSTATE_B_WAIT_ACON_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device waits for the A-device to signal a connect before becoming B-Host. Position  */
+#define USBHS_FSM_DRDSTATE_B_HOST           (USBHS_FSM_DRDSTATE_B_HOST_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device acts as the Host. Position  */
+#define USBHS_FSM_DRDSTATE_B_SRP_INIT       (USBHS_FSM_DRDSTATE_B_SRP_INIT_Val << USBHS_FSM_DRDSTATE_Pos)  /**< (USBHS_FSM) In this state, the B-device attempts to start a session using the SRP protocol. Position  */
+#define USBHS_FSM_MASK                      _U_(0x0F)                                      /**< \deprecated (USBHS_FSM) Register MASK  (Use USBHS_FSM_Msk instead)  */
+#define USBHS_FSM_Msk                       _U_(0x0F)                                      /**< (USBHS_FSM) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief USBHS_DEVDMA hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_DEVDMANXTDSC; /**< (USBHS_DEVDMA Offset: 0x00) Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __IO uint32_t USBHS_DEVDMAADDRESS; /**< (USBHS_DEVDMA Offset: 0x04) Device DMA Channel Address Register (n = 1) */
+  __IO uint32_t USBHS_DEVDMACONTROL; /**< (USBHS_DEVDMA Offset: 0x08) Device DMA Channel Control Register (n = 1) */
+  __IO uint32_t USBHS_DEVDMASTATUS; /**< (USBHS_DEVDMA Offset: 0x0C) Device DMA Channel Status Register (n = 1) */
+} UsbhsDevdma;
+
+/** \brief USBHS_HSTDMA hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_HSTDMANXTDSC; /**< (USBHS_HSTDMA Offset: 0x00) Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __IO uint32_t USBHS_HSTDMAADDRESS; /**< (USBHS_HSTDMA Offset: 0x04) Host DMA Channel Address Register (n = 1) */
+  __IO uint32_t USBHS_HSTDMACONTROL; /**< (USBHS_HSTDMA Offset: 0x08) Host DMA Channel Control Register (n = 1) */
+  __IO uint32_t USBHS_HSTDMASTATUS; /**< (USBHS_HSTDMA Offset: 0x0C) Host DMA Channel Status Register (n = 1) */
+} UsbhsHstdma;
+
+#define USBHSDEVDMA_NUMBER 7
+#define USBHSHSTDMA_NUMBER 7
+/** \brief USBHS hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_DEVCTRL;  /**< (USBHS Offset: 0x00) Device General Control Register */
+  __I  uint32_t USBHS_DEVISR;   /**< (USBHS Offset: 0x04) Device Global Interrupt Status Register */
+  __O  uint32_t USBHS_DEVICR;   /**< (USBHS Offset: 0x08) Device Global Interrupt Clear Register */
+  __O  uint32_t USBHS_DEVIFR;   /**< (USBHS Offset: 0x0C) Device Global Interrupt Set Register */
+  __I  uint32_t USBHS_DEVIMR;   /**< (USBHS Offset: 0x10) Device Global Interrupt Mask Register */
+  __O  uint32_t USBHS_DEVIDR;   /**< (USBHS Offset: 0x14) Device Global Interrupt Disable Register */
+  __O  uint32_t USBHS_DEVIER;   /**< (USBHS Offset: 0x18) Device Global Interrupt Enable Register */
+  __IO uint32_t USBHS_DEVEPT;   /**< (USBHS Offset: 0x1C) Device Endpoint Register */
+  __I  uint32_t USBHS_DEVFNUM;  /**< (USBHS Offset: 0x20) Device Frame Number Register */
+  __I  uint8_t                        Reserved1[220];
+  __IO uint32_t USBHS_DEVEPTCFG[10]; /**< (USBHS Offset: 0x100) Device Endpoint Configuration Register (n = 0) 0 */
+  __I  uint8_t                        Reserved2[8];
+  __I  uint32_t USBHS_DEVEPTISR[10]; /**< (USBHS Offset: 0x130) Device Endpoint Status Register (n = 0) 0 */
+  __I  uint8_t                        Reserved3[8];
+  __O  uint32_t USBHS_DEVEPTICR[10]; /**< (USBHS Offset: 0x160) Device Endpoint Clear Register (n = 0) 0 */
+  __I  uint8_t                        Reserved4[8];
+  __O  uint32_t USBHS_DEVEPTIFR[10]; /**< (USBHS Offset: 0x190) Device Endpoint Set Register (n = 0) 0 */
+  __I  uint8_t                        Reserved5[8];
+  __I  uint32_t USBHS_DEVEPTIMR[10]; /**< (USBHS Offset: 0x1C0) Device Endpoint Mask Register (n = 0) 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  uint32_t USBHS_DEVEPTIER[10]; /**< (USBHS Offset: 0x1F0) Device Endpoint Enable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved7[8];
+  __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Disable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved9[128];
+  __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
+  __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
+  __O  uint32_t USBHS_HSTICR;   /**< (USBHS Offset: 0x408) Host Global Interrupt Clear Register */
+  __O  uint32_t USBHS_HSTIFR;   /**< (USBHS Offset: 0x40C) Host Global Interrupt Set Register */
+  __I  uint32_t USBHS_HSTIMR;   /**< (USBHS Offset: 0x410) Host Global Interrupt Mask Register */
+  __O  uint32_t USBHS_HSTIDR;   /**< (USBHS Offset: 0x414) Host Global Interrupt Disable Register */
+  __O  uint32_t USBHS_HSTIER;   /**< (USBHS Offset: 0x418) Host Global Interrupt Enable Register */
+  __IO uint32_t USBHS_HSTPIP;   /**< (USBHS Offset: 0x41C) Host Pipe Register */
+  __IO uint32_t USBHS_HSTFNUM;  /**< (USBHS Offset: 0x420) Host Frame Number Register */
+  __IO uint32_t USBHS_HSTADDR1; /**< (USBHS Offset: 0x424) Host Address 1 Register */
+  __IO uint32_t USBHS_HSTADDR2; /**< (USBHS Offset: 0x428) Host Address 2 Register */
+  __IO uint32_t USBHS_HSTADDR3; /**< (USBHS Offset: 0x42C) Host Address 3 Register */
+  __I  uint8_t                        Reserved10[208];
+  __IO uint32_t USBHS_HSTPIPCFG[10]; /**< (USBHS Offset: 0x500) Host Pipe Configuration Register (n = 0) 0 */
+  __I  uint8_t                        Reserved11[8];
+  __I  uint32_t USBHS_HSTPIPISR[10]; /**< (USBHS Offset: 0x530) Host Pipe Status Register (n = 0) 0 */
+  __I  uint8_t                        Reserved12[8];
+  __O  uint32_t USBHS_HSTPIPICR[10]; /**< (USBHS Offset: 0x560) Host Pipe Clear Register (n = 0) 0 */
+  __I  uint8_t                        Reserved13[8];
+  __O  uint32_t USBHS_HSTPIPIFR[10]; /**< (USBHS Offset: 0x590) Host Pipe Set Register (n = 0) 0 */
+  __I  uint8_t                        Reserved14[8];
+  __I  uint32_t USBHS_HSTPIPIMR[10]; /**< (USBHS Offset: 0x5C0) Host Pipe Mask Register (n = 0) 0 */
+  __I  uint8_t                        Reserved15[8];
+  __O  uint32_t USBHS_HSTPIPIER[10]; /**< (USBHS Offset: 0x5F0) Host Pipe Enable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved16[8];
+  __O  uint32_t USBHS_HSTPIPIDR[10]; /**< (USBHS Offset: 0x620) Host Pipe Disable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved17[8];
+  __IO uint32_t USBHS_HSTPIPINRQ[10]; /**< (USBHS Offset: 0x650) Host Pipe IN Request Register (n = 0) 0 */
+  __I  uint8_t                        Reserved18[8];
+  __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register (n = 0) 0 */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved20[128];
+  __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
+  __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
+  __O  uint32_t USBHS_SCR;      /**< (USBHS Offset: 0x808) General Status Clear Register */
+  __O  uint32_t USBHS_SFR;      /**< (USBHS Offset: 0x80C) General Status Set Register */
+  __IO uint32_t USBHS_TSTA1;    /**< (USBHS Offset: 0x810) General Test A1 Register */
+  __IO uint32_t USBHS_TSTA2;    /**< (USBHS Offset: 0x814) General Test A2 Register */
+  __I  uint32_t USBHS_VERSION;  /**< (USBHS Offset: 0x818) General Version Register */
+  __I  uint8_t                        Reserved21[16];
+  __I  uint32_t USBHS_FSM;      /**< (USBHS Offset: 0x82C) General Finite State Machine Register */
+} Usbhs;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief USBHS_DEVDMA hardware registers */
+typedef struct {  
+  __IO USBHS_DEVDMANXTDSC_Type        USBHS_DEVDMANXTDSC; /**< Offset: 0x00 (R/W  32) Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __IO USBHS_DEVDMAADDRESS_Type       USBHS_DEVDMAADDRESS; /**< Offset: 0x04 (R/W  32) Device DMA Channel Address Register (n = 1) */
+  __IO USBHS_DEVDMACONTROL_Type       USBHS_DEVDMACONTROL; /**< Offset: 0x08 (R/W  32) Device DMA Channel Control Register (n = 1) */
+  __IO USBHS_DEVDMASTATUS_Type        USBHS_DEVDMASTATUS; /**< Offset: 0x0C (R/W  32) Device DMA Channel Status Register (n = 1) */
+} UsbhsDevdma;
+
+/** \brief USBHS_HSTDMA hardware registers */
+typedef struct {  
+  __IO USBHS_HSTDMANXTDSC_Type        USBHS_HSTDMANXTDSC; /**< Offset: 0x00 (R/W  32) Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __IO USBHS_HSTDMAADDRESS_Type       USBHS_HSTDMAADDRESS; /**< Offset: 0x04 (R/W  32) Host DMA Channel Address Register (n = 1) */
+  __IO USBHS_HSTDMACONTROL_Type       USBHS_HSTDMACONTROL; /**< Offset: 0x08 (R/W  32) Host DMA Channel Control Register (n = 1) */
+  __IO USBHS_HSTDMASTATUS_Type        USBHS_HSTDMASTATUS; /**< Offset: 0x0C (R/W  32) Host DMA Channel Status Register (n = 1) */
+} UsbhsHstdma;
+
+/** \brief USBHS hardware registers */
+typedef struct {  
+  __IO USBHS_DEVCTRL_Type             USBHS_DEVCTRL;  /**< Offset: 0x00 (R/W  32) Device General Control Register */
+  __I  USBHS_DEVISR_Type              USBHS_DEVISR;   /**< Offset: 0x04 (R/   32) Device Global Interrupt Status Register */
+  __O  USBHS_DEVICR_Type              USBHS_DEVICR;   /**< Offset: 0x08 ( /W  32) Device Global Interrupt Clear Register */
+  __O  USBHS_DEVIFR_Type              USBHS_DEVIFR;   /**< Offset: 0x0C ( /W  32) Device Global Interrupt Set Register */
+  __I  USBHS_DEVIMR_Type              USBHS_DEVIMR;   /**< Offset: 0x10 (R/   32) Device Global Interrupt Mask Register */
+  __O  USBHS_DEVIDR_Type              USBHS_DEVIDR;   /**< Offset: 0x14 ( /W  32) Device Global Interrupt Disable Register */
+  __O  USBHS_DEVIER_Type              USBHS_DEVIER;   /**< Offset: 0x18 ( /W  32) Device Global Interrupt Enable Register */
+  __IO USBHS_DEVEPT_Type              USBHS_DEVEPT;   /**< Offset: 0x1C (R/W  32) Device Endpoint Register */
+  __I  USBHS_DEVFNUM_Type             USBHS_DEVFNUM;  /**< Offset: 0x20 (R/   32) Device Frame Number Register */
+  __I  uint8_t                        Reserved1[220];
+  __IO USBHS_DEVEPTCFG_Type           USBHS_DEVEPTCFG[10]; /**< Offset: 0x100 (R/W  32) Device Endpoint Configuration Register (n = 0) 0 */
+  __I  uint8_t                        Reserved2[8];
+  __I  USBHS_DEVEPTISR_Type           USBHS_DEVEPTISR[10]; /**< Offset: 0x130 (R/   32) Device Endpoint Status Register (n = 0) 0 */
+  __I  uint8_t                        Reserved3[8];
+  __O  USBHS_DEVEPTICR_Type           USBHS_DEVEPTICR[10]; /**< Offset: 0x160 ( /W  32) Device Endpoint Clear Register (n = 0) 0 */
+  __I  uint8_t                        Reserved4[8];
+  __O  USBHS_DEVEPTIFR_Type           USBHS_DEVEPTIFR[10]; /**< Offset: 0x190 ( /W  32) Device Endpoint Set Register (n = 0) 0 */
+  __I  uint8_t                        Reserved5[8];
+  __I  USBHS_DEVEPTIMR_Type           USBHS_DEVEPTIMR[10]; /**< Offset: 0x1C0 (R/   32) Device Endpoint Mask Register (n = 0) 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  USBHS_DEVEPTIER_Type           USBHS_DEVEPTIER[10]; /**< Offset: 0x1F0 ( /W  32) Device Endpoint Enable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved7[8];
+  __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Disable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved9[128];
+  __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
+  __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */
+  __O  USBHS_HSTICR_Type              USBHS_HSTICR;   /**< Offset: 0x408 ( /W  32) Host Global Interrupt Clear Register */
+  __O  USBHS_HSTIFR_Type              USBHS_HSTIFR;   /**< Offset: 0x40C ( /W  32) Host Global Interrupt Set Register */
+  __I  USBHS_HSTIMR_Type              USBHS_HSTIMR;   /**< Offset: 0x410 (R/   32) Host Global Interrupt Mask Register */
+  __O  USBHS_HSTIDR_Type              USBHS_HSTIDR;   /**< Offset: 0x414 ( /W  32) Host Global Interrupt Disable Register */
+  __O  USBHS_HSTIER_Type              USBHS_HSTIER;   /**< Offset: 0x418 ( /W  32) Host Global Interrupt Enable Register */
+  __IO USBHS_HSTPIP_Type              USBHS_HSTPIP;   /**< Offset: 0x41C (R/W  32) Host Pipe Register */
+  __IO USBHS_HSTFNUM_Type             USBHS_HSTFNUM;  /**< Offset: 0x420 (R/W  32) Host Frame Number Register */
+  __IO USBHS_HSTADDR1_Type            USBHS_HSTADDR1; /**< Offset: 0x424 (R/W  32) Host Address 1 Register */
+  __IO USBHS_HSTADDR2_Type            USBHS_HSTADDR2; /**< Offset: 0x428 (R/W  32) Host Address 2 Register */
+  __IO USBHS_HSTADDR3_Type            USBHS_HSTADDR3; /**< Offset: 0x42C (R/W  32) Host Address 3 Register */
+  __I  uint8_t                        Reserved10[208];
+  __IO USBHS_HSTPIPCFG_Type           USBHS_HSTPIPCFG[10]; /**< Offset: 0x500 (R/W  32) Host Pipe Configuration Register (n = 0) 0 */
+  __I  uint8_t                        Reserved11[8];
+  __I  USBHS_HSTPIPISR_Type           USBHS_HSTPIPISR[10]; /**< Offset: 0x530 (R/   32) Host Pipe Status Register (n = 0) 0 */
+  __I  uint8_t                        Reserved12[8];
+  __O  USBHS_HSTPIPICR_Type           USBHS_HSTPIPICR[10]; /**< Offset: 0x560 ( /W  32) Host Pipe Clear Register (n = 0) 0 */
+  __I  uint8_t                        Reserved13[8];
+  __O  USBHS_HSTPIPIFR_Type           USBHS_HSTPIPIFR[10]; /**< Offset: 0x590 ( /W  32) Host Pipe Set Register (n = 0) 0 */
+  __I  uint8_t                        Reserved14[8];
+  __I  USBHS_HSTPIPIMR_Type           USBHS_HSTPIPIMR[10]; /**< Offset: 0x5C0 (R/   32) Host Pipe Mask Register (n = 0) 0 */
+  __I  uint8_t                        Reserved15[8];
+  __O  USBHS_HSTPIPIER_Type           USBHS_HSTPIPIER[10]; /**< Offset: 0x5F0 ( /W  32) Host Pipe Enable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved16[8];
+  __O  USBHS_HSTPIPIDR_Type           USBHS_HSTPIPIDR[10]; /**< Offset: 0x620 ( /W  32) Host Pipe Disable Register (n = 0) 0 */
+  __I  uint8_t                        Reserved17[8];
+  __IO USBHS_HSTPIPINRQ_Type          USBHS_HSTPIPINRQ[10]; /**< Offset: 0x650 (R/W  32) Host Pipe IN Request Register (n = 0) 0 */
+  __I  uint8_t                        Reserved18[8];
+  __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register (n = 0) 0 */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved20[128];
+  __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
+  __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */
+  __O  USBHS_SCR_Type                 USBHS_SCR;      /**< Offset: 0x808 ( /W  32) General Status Clear Register */
+  __O  USBHS_SFR_Type                 USBHS_SFR;      /**< Offset: 0x80C ( /W  32) General Status Set Register */
+  __IO USBHS_TSTA1_Type               USBHS_TSTA1;    /**< Offset: 0x810 (R/W  32) General Test A1 Register */
+  __IO USBHS_TSTA2_Type               USBHS_TSTA2;    /**< Offset: 0x814 (R/W  32) General Test A2 Register */
+  __I  USBHS_VERSION_Type             USBHS_VERSION;  /**< Offset: 0x818 (R/   32) General Version Register */
+  __I  uint8_t                        Reserved21[16];
+  __I  USBHS_FSM_Type                 USBHS_FSM;      /**< Offset: 0x82C (R/   32) General Finite State Machine Register */
+} Usbhs;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of USB High-Speed Interface */
+
+#endif /* _SAMV71_USBHS_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/utmi.h
+++ b/asf/sam/include/samv71/component/utmi.h
@@ -1,0 +1,143 @@
+/**
+ * \file
+ *
+ * \brief Component description for UTMI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UTMI_COMPONENT_H_
+#define _SAMV71_UTMI_COMPONENT_H_
+#define _SAMV71_UTMI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 USB Transmitter Interface Macrocell
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR UTMI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define UTMI_11300                      /**< (UTMI) Module ID */
+#define REV_UTMI A                      /**< (UTMI) Module revision */
+
+/* -------- UTMI_OHCIICR : (UTMI Offset: 0x10) (R/W 32) OHCI Interrupt Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES0:1;                    /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t ARIE:1;                    /**< bit:      4  OHCI Asynchronous Resume Interrupt Enable */
+    uint32_t APPSTART:1;                /**< bit:      5  Reserved                                 */
+    uint32_t :17;                       /**< bit:  6..22  Reserved */
+    uint32_t UDPPUDIS:1;                /**< bit:     23  USB Device Pull-up Disable               */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :31;                       /**< bit:  1..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} UTMI_OHCIICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UTMI_OHCIICR_OFFSET                 (0x10)                                        /**<  (UTMI_OHCIICR) OHCI Interrupt Configuration Register  Offset */
+
+#define UTMI_OHCIICR_RES0_Pos               0                                              /**< (UTMI_OHCIICR) USB PORTx Reset Position */
+#define UTMI_OHCIICR_RES0_Msk               (_U_(0x1) << UTMI_OHCIICR_RES0_Pos)            /**< (UTMI_OHCIICR) USB PORTx Reset Mask */
+#define UTMI_OHCIICR_RES0                   UTMI_OHCIICR_RES0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_RES0_Msk instead */
+#define UTMI_OHCIICR_ARIE_Pos               4                                              /**< (UTMI_OHCIICR) OHCI Asynchronous Resume Interrupt Enable Position */
+#define UTMI_OHCIICR_ARIE_Msk               (_U_(0x1) << UTMI_OHCIICR_ARIE_Pos)            /**< (UTMI_OHCIICR) OHCI Asynchronous Resume Interrupt Enable Mask */
+#define UTMI_OHCIICR_ARIE                   UTMI_OHCIICR_ARIE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_ARIE_Msk instead */
+#define UTMI_OHCIICR_APPSTART_Pos           5                                              /**< (UTMI_OHCIICR) Reserved Position */
+#define UTMI_OHCIICR_APPSTART_Msk           (_U_(0x1) << UTMI_OHCIICR_APPSTART_Pos)        /**< (UTMI_OHCIICR) Reserved Mask */
+#define UTMI_OHCIICR_APPSTART               UTMI_OHCIICR_APPSTART_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_APPSTART_Msk instead */
+#define UTMI_OHCIICR_UDPPUDIS_Pos           23                                             /**< (UTMI_OHCIICR) USB Device Pull-up Disable Position */
+#define UTMI_OHCIICR_UDPPUDIS_Msk           (_U_(0x1) << UTMI_OHCIICR_UDPPUDIS_Pos)        /**< (UTMI_OHCIICR) USB Device Pull-up Disable Mask */
+#define UTMI_OHCIICR_UDPPUDIS               UTMI_OHCIICR_UDPPUDIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_UDPPUDIS_Msk instead */
+#define UTMI_OHCIICR_MASK                   _U_(0x800031)                                  /**< \deprecated (UTMI_OHCIICR) Register MASK  (Use UTMI_OHCIICR_Msk instead)  */
+#define UTMI_OHCIICR_Msk                    _U_(0x800031)                                  /**< (UTMI_OHCIICR) Register Mask  */
+
+#define UTMI_OHCIICR_RES_Pos                0                                              /**< (UTMI_OHCIICR Position) USB PORTx Reset */
+#define UTMI_OHCIICR_RES_Msk                (_U_(0x1) << UTMI_OHCIICR_RES_Pos)             /**< (UTMI_OHCIICR Mask) RES */
+#define UTMI_OHCIICR_RES(value)             (UTMI_OHCIICR_RES_Msk & ((value) << UTMI_OHCIICR_RES_Pos))  
+
+/* -------- UTMI_CKTRIM : (UTMI Offset: 0x30) (R/W 32) UTMI Clock Trimming Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FREQ:2;                    /**< bit:   0..1  UTMI Reference Clock Frequency           */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UTMI_CKTRIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UTMI_CKTRIM_OFFSET                  (0x30)                                        /**<  (UTMI_CKTRIM) UTMI Clock Trimming Register  Offset */
+
+#define UTMI_CKTRIM_FREQ_Pos                0                                              /**< (UTMI_CKTRIM) UTMI Reference Clock Frequency Position */
+#define UTMI_CKTRIM_FREQ_Msk                (_U_(0x3) << UTMI_CKTRIM_FREQ_Pos)             /**< (UTMI_CKTRIM) UTMI Reference Clock Frequency Mask */
+#define UTMI_CKTRIM_FREQ(value)             (UTMI_CKTRIM_FREQ_Msk & ((value) << UTMI_CKTRIM_FREQ_Pos))
+#define   UTMI_CKTRIM_FREQ_XTAL12_Val       _U_(0x0)                                       /**< (UTMI_CKTRIM) 12 MHz reference clock  */
+#define   UTMI_CKTRIM_FREQ_XTAL16_Val       _U_(0x1)                                       /**< (UTMI_CKTRIM) 16 MHz reference clock  */
+#define UTMI_CKTRIM_FREQ_XTAL12             (UTMI_CKTRIM_FREQ_XTAL12_Val << UTMI_CKTRIM_FREQ_Pos)  /**< (UTMI_CKTRIM) 12 MHz reference clock Position  */
+#define UTMI_CKTRIM_FREQ_XTAL16             (UTMI_CKTRIM_FREQ_XTAL16_Val << UTMI_CKTRIM_FREQ_Pos)  /**< (UTMI_CKTRIM) 16 MHz reference clock Position  */
+#define UTMI_CKTRIM_MASK                    _U_(0x03)                                      /**< \deprecated (UTMI_CKTRIM) Register MASK  (Use UTMI_CKTRIM_Msk instead)  */
+#define UTMI_CKTRIM_Msk                     _U_(0x03)                                      /**< (UTMI_CKTRIM) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief UTMI hardware registers */
+typedef struct {  
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t UTMI_OHCIICR;   /**< (UTMI Offset: 0x10) OHCI Interrupt Configuration Register */
+  __I  uint8_t                        Reserved2[28];
+  __IO uint32_t UTMI_CKTRIM;    /**< (UTMI Offset: 0x30) UTMI Clock Trimming Register */
+} Utmi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief UTMI hardware registers */
+typedef struct {  
+  __I  uint8_t                        Reserved1[16];
+  __IO UTMI_OHCIICR_Type              UTMI_OHCIICR;   /**< Offset: 0x10 (R/W  32) OHCI Interrupt Configuration Register */
+  __I  uint8_t                        Reserved2[28];
+  __IO UTMI_CKTRIM_Type               UTMI_CKTRIM;    /**< Offset: 0x30 (R/W  32) UTMI Clock Trimming Register */
+} Utmi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of USB Transmitter Interface Macrocell */
+
+#endif /* _SAMV71_UTMI_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/wdt.h
+++ b/asf/sam/include/samv71/component/wdt.h
@@ -1,0 +1,173 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_WDT_COMPONENT_H_
+#define _SAMV71_WDT_COMPONENT_H_
+#define _SAMV71_WDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define WDT_6080                       /**< (WDT) Module ID */
+#define REV_WDT M                      /**< (WDT) Module revision */
+
+/* -------- WDT_CR : (WDT Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
+    uint32_t :23;                       /**< bit:  1..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CR_OFFSET                       (0x00)                                        /**<  (WDT_CR) Control Register  Offset */
+
+#define WDT_CR_WDRSTT_Pos                   0                                              /**< (WDT_CR) Watchdog Restart Position */
+#define WDT_CR_WDRSTT_Msk                   (_U_(0x1) << WDT_CR_WDRSTT_Pos)                /**< (WDT_CR) Watchdog Restart Mask */
+#define WDT_CR_WDRSTT                       WDT_CR_WDRSTT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CR_WDRSTT_Msk instead */
+#define WDT_CR_KEY_Pos                      24                                             /**< (WDT_CR) Password Position */
+#define WDT_CR_KEY_Msk                      (_U_(0xFF) << WDT_CR_KEY_Pos)                  /**< (WDT_CR) Password Mask */
+#define WDT_CR_KEY(value)                   (WDT_CR_KEY_Msk & ((value) << WDT_CR_KEY_Pos))
+#define   WDT_CR_KEY_PASSWD_Val             _U_(0xA5)                                      /**< (WDT_CR) Writing any other value in this field aborts the write operation.  */
+#define WDT_CR_KEY_PASSWD                   (WDT_CR_KEY_PASSWD_Val << WDT_CR_KEY_Pos)      /**< (WDT_CR) Writing any other value in this field aborts the write operation. Position  */
+#define WDT_CR_MASK                         _U_(0xFF000001)                                /**< \deprecated (WDT_CR) Register MASK  (Use WDT_CR_Msk instead)  */
+#define WDT_CR_Msk                          _U_(0xFF000001)                                /**< (WDT_CR) Register Mask  */
+
+
+/* -------- WDT_MR : (WDT Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
+    uint32_t WDFIEN:1;                  /**< bit:     12  Watchdog Fault Interrupt Enable          */
+    uint32_t WDRSTEN:1;                 /**< bit:     13  Watchdog Reset Enable                    */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t WDDIS:1;                   /**< bit:     15  Watchdog Disable                         */
+    uint32_t WDD:12;                    /**< bit: 16..27  Watchdog Delta Value                     */
+    uint32_t WDDBGHLT:1;                /**< bit:     28  Watchdog Debug Halt                      */
+    uint32_t WDIDLEHLT:1;               /**< bit:     29  Watchdog Idle Halt                       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_MR_OFFSET                       (0x04)                                        /**<  (WDT_MR) Mode Register  Offset */
+
+#define WDT_MR_WDV_Pos                      0                                              /**< (WDT_MR) Watchdog Counter Value Position */
+#define WDT_MR_WDV_Msk                      (_U_(0xFFF) << WDT_MR_WDV_Pos)                 /**< (WDT_MR) Watchdog Counter Value Mask */
+#define WDT_MR_WDV(value)                   (WDT_MR_WDV_Msk & ((value) << WDT_MR_WDV_Pos))
+#define WDT_MR_WDFIEN_Pos                   12                                             /**< (WDT_MR) Watchdog Fault Interrupt Enable Position */
+#define WDT_MR_WDFIEN_Msk                   (_U_(0x1) << WDT_MR_WDFIEN_Pos)                /**< (WDT_MR) Watchdog Fault Interrupt Enable Mask */
+#define WDT_MR_WDFIEN                       WDT_MR_WDFIEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDFIEN_Msk instead */
+#define WDT_MR_WDRSTEN_Pos                  13                                             /**< (WDT_MR) Watchdog Reset Enable Position */
+#define WDT_MR_WDRSTEN_Msk                  (_U_(0x1) << WDT_MR_WDRSTEN_Pos)               /**< (WDT_MR) Watchdog Reset Enable Mask */
+#define WDT_MR_WDRSTEN                      WDT_MR_WDRSTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDRSTEN_Msk instead */
+#define WDT_MR_WDDIS_Pos                    15                                             /**< (WDT_MR) Watchdog Disable Position */
+#define WDT_MR_WDDIS_Msk                    (_U_(0x1) << WDT_MR_WDDIS_Pos)                 /**< (WDT_MR) Watchdog Disable Mask */
+#define WDT_MR_WDDIS                        WDT_MR_WDDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDDIS_Msk instead */
+#define WDT_MR_WDD_Pos                      16                                             /**< (WDT_MR) Watchdog Delta Value Position */
+#define WDT_MR_WDD_Msk                      (_U_(0xFFF) << WDT_MR_WDD_Pos)                 /**< (WDT_MR) Watchdog Delta Value Mask */
+#define WDT_MR_WDD(value)                   (WDT_MR_WDD_Msk & ((value) << WDT_MR_WDD_Pos))
+#define WDT_MR_WDDBGHLT_Pos                 28                                             /**< (WDT_MR) Watchdog Debug Halt Position */
+#define WDT_MR_WDDBGHLT_Msk                 (_U_(0x1) << WDT_MR_WDDBGHLT_Pos)              /**< (WDT_MR) Watchdog Debug Halt Mask */
+#define WDT_MR_WDDBGHLT                     WDT_MR_WDDBGHLT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDDBGHLT_Msk instead */
+#define WDT_MR_WDIDLEHLT_Pos                29                                             /**< (WDT_MR) Watchdog Idle Halt Position */
+#define WDT_MR_WDIDLEHLT_Msk                (_U_(0x1) << WDT_MR_WDIDLEHLT_Pos)             /**< (WDT_MR) Watchdog Idle Halt Mask */
+#define WDT_MR_WDIDLEHLT                    WDT_MR_WDIDLEHLT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDIDLEHLT_Msk instead */
+#define WDT_MR_MASK                         _U_(0x3FFFBFFF)                                /**< \deprecated (WDT_MR) Register MASK  (Use WDT_MR_Msk instead)  */
+#define WDT_MR_Msk                          _U_(0x3FFFBFFF)                                /**< (WDT_MR) Register Mask  */
+
+
+/* -------- WDT_SR : (WDT Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow (cleared on read)     */
+    uint32_t WDERR:1;                   /**< bit:      1  Watchdog Error (cleared on read)         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SR_OFFSET                       (0x08)                                        /**<  (WDT_SR) Status Register  Offset */
+
+#define WDT_SR_WDUNF_Pos                    0                                              /**< (WDT_SR) Watchdog Underflow (cleared on read) Position */
+#define WDT_SR_WDUNF_Msk                    (_U_(0x1) << WDT_SR_WDUNF_Pos)                 /**< (WDT_SR) Watchdog Underflow (cleared on read) Mask */
+#define WDT_SR_WDUNF                        WDT_SR_WDUNF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SR_WDUNF_Msk instead */
+#define WDT_SR_WDERR_Pos                    1                                              /**< (WDT_SR) Watchdog Error (cleared on read) Position */
+#define WDT_SR_WDERR_Msk                    (_U_(0x1) << WDT_SR_WDERR_Pos)                 /**< (WDT_SR) Watchdog Error (cleared on read) Mask */
+#define WDT_SR_WDERR                        WDT_SR_WDERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SR_WDERR_Msk instead */
+#define WDT_SR_MASK                         _U_(0x03)                                      /**< \deprecated (WDT_SR) Register MASK  (Use WDT_SR_Msk instead)  */
+#define WDT_SR_Msk                          _U_(0x03)                                      /**< (WDT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief WDT hardware registers */
+typedef struct {  
+  __O  uint32_t WDT_CR;         /**< (WDT Offset: 0x00) Control Register */
+  __IO uint32_t WDT_MR;         /**< (WDT Offset: 0x04) Mode Register */
+  __I  uint32_t WDT_SR;         /**< (WDT Offset: 0x08) Status Register */
+} Wdt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief WDT hardware registers */
+typedef struct {  
+  __O  WDT_CR_Type                    WDT_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO WDT_MR_Type                    WDT_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  WDT_SR_Type                    WDT_SR;         /**< Offset: 0x08 (R/   32) Status Register */
+} Wdt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Watchdog Timer */
+
+#endif /* _SAMV71_WDT_COMPONENT_H_ */

--- a/asf/sam/include/samv71/component/xdmac.h
+++ b/asf/sam/include/samv71/component/xdmac.h
@@ -1,0 +1,2548 @@
+/**
+ * \file
+ *
+ * \brief Component description for XDMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_XDMAC_COMPONENT_H_
+#define _SAMV71_XDMAC_COMPONENT_H_
+#define _SAMV71_XDMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Extensible DMA Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR XDMAC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define XDMAC_11161                      /**< (XDMAC) Module ID */
+#define REV_XDMAC H                      /**< (XDMAC) Module revision */
+
+/* -------- XDMAC_CIE : (XDMAC Offset: 0x00) (/W 32) Channel Interrupt Enable Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIE:1;                     /**< bit:      0  End of Block Interrupt Enable Bit        */
+    uint32_t LIE:1;                     /**< bit:      1  End of Linked List Interrupt Enable Bit  */
+    uint32_t DIE:1;                     /**< bit:      2  End of Disable Interrupt Enable Bit      */
+    uint32_t FIE:1;                     /**< bit:      3  End of Flush Interrupt Enable Bit        */
+    uint32_t RBIE:1;                    /**< bit:      4  Read Bus Error Interrupt Enable Bit      */
+    uint32_t WBIE:1;                    /**< bit:      5  Write Bus Error Interrupt Enable Bit     */
+    uint32_t ROIE:1;                    /**< bit:      6  Request Overflow Error Interrupt Enable Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIE_OFFSET                    (0x00)                                        /**<  (XDMAC_CIE) Channel Interrupt Enable Register (chid = 0)  Offset */
+
+#define XDMAC_CIE_BIE_Pos                   0                                              /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Position */
+#define XDMAC_CIE_BIE_Msk                   (_U_(0x1) << XDMAC_CIE_BIE_Pos)                /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Mask */
+#define XDMAC_CIE_BIE                       XDMAC_CIE_BIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_BIE_Msk instead */
+#define XDMAC_CIE_LIE_Pos                   1                                              /**< (XDMAC_CIE) End of Linked List Interrupt Enable Bit Position */
+#define XDMAC_CIE_LIE_Msk                   (_U_(0x1) << XDMAC_CIE_LIE_Pos)                /**< (XDMAC_CIE) End of Linked List Interrupt Enable Bit Mask */
+#define XDMAC_CIE_LIE                       XDMAC_CIE_LIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_LIE_Msk instead */
+#define XDMAC_CIE_DIE_Pos                   2                                              /**< (XDMAC_CIE) End of Disable Interrupt Enable Bit Position */
+#define XDMAC_CIE_DIE_Msk                   (_U_(0x1) << XDMAC_CIE_DIE_Pos)                /**< (XDMAC_CIE) End of Disable Interrupt Enable Bit Mask */
+#define XDMAC_CIE_DIE                       XDMAC_CIE_DIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_DIE_Msk instead */
+#define XDMAC_CIE_FIE_Pos                   3                                              /**< (XDMAC_CIE) End of Flush Interrupt Enable Bit Position */
+#define XDMAC_CIE_FIE_Msk                   (_U_(0x1) << XDMAC_CIE_FIE_Pos)                /**< (XDMAC_CIE) End of Flush Interrupt Enable Bit Mask */
+#define XDMAC_CIE_FIE                       XDMAC_CIE_FIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_FIE_Msk instead */
+#define XDMAC_CIE_RBIE_Pos                  4                                              /**< (XDMAC_CIE) Read Bus Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_RBIE_Msk                  (_U_(0x1) << XDMAC_CIE_RBIE_Pos)               /**< (XDMAC_CIE) Read Bus Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_RBIE                      XDMAC_CIE_RBIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_RBIE_Msk instead */
+#define XDMAC_CIE_WBIE_Pos                  5                                              /**< (XDMAC_CIE) Write Bus Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_WBIE_Msk                  (_U_(0x1) << XDMAC_CIE_WBIE_Pos)               /**< (XDMAC_CIE) Write Bus Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_WBIE                      XDMAC_CIE_WBIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_WBIE_Msk instead */
+#define XDMAC_CIE_ROIE_Pos                  6                                              /**< (XDMAC_CIE) Request Overflow Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_ROIE_Msk                  (_U_(0x1) << XDMAC_CIE_ROIE_Pos)               /**< (XDMAC_CIE) Request Overflow Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_ROIE                      XDMAC_CIE_ROIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_ROIE_Msk instead */
+#define XDMAC_CIE_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIE) Register MASK  (Use XDMAC_CIE_Msk instead)  */
+#define XDMAC_CIE_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIE) Register Mask  */
+
+
+/* -------- XDMAC_CID : (XDMAC Offset: 0x04) (/W 32) Channel Interrupt Disable Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BID:1;                     /**< bit:      0  End of Block Interrupt Disable Bit       */
+    uint32_t LID:1;                     /**< bit:      1  End of Linked List Interrupt Disable Bit */
+    uint32_t DID:1;                     /**< bit:      2  End of Disable Interrupt Disable Bit     */
+    uint32_t FID:1;                     /**< bit:      3  End of Flush Interrupt Disable Bit       */
+    uint32_t RBEID:1;                   /**< bit:      4  Read Bus Error Interrupt Disable Bit     */
+    uint32_t WBEID:1;                   /**< bit:      5  Write Bus Error Interrupt Disable Bit    */
+    uint32_t ROID:1;                    /**< bit:      6  Request Overflow Error Interrupt Disable Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CID_OFFSET                    (0x04)                                        /**<  (XDMAC_CID) Channel Interrupt Disable Register (chid = 0)  Offset */
+
+#define XDMAC_CID_BID_Pos                   0                                              /**< (XDMAC_CID) End of Block Interrupt Disable Bit Position */
+#define XDMAC_CID_BID_Msk                   (_U_(0x1) << XDMAC_CID_BID_Pos)                /**< (XDMAC_CID) End of Block Interrupt Disable Bit Mask */
+#define XDMAC_CID_BID                       XDMAC_CID_BID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_BID_Msk instead */
+#define XDMAC_CID_LID_Pos                   1                                              /**< (XDMAC_CID) End of Linked List Interrupt Disable Bit Position */
+#define XDMAC_CID_LID_Msk                   (_U_(0x1) << XDMAC_CID_LID_Pos)                /**< (XDMAC_CID) End of Linked List Interrupt Disable Bit Mask */
+#define XDMAC_CID_LID                       XDMAC_CID_LID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_LID_Msk instead */
+#define XDMAC_CID_DID_Pos                   2                                              /**< (XDMAC_CID) End of Disable Interrupt Disable Bit Position */
+#define XDMAC_CID_DID_Msk                   (_U_(0x1) << XDMAC_CID_DID_Pos)                /**< (XDMAC_CID) End of Disable Interrupt Disable Bit Mask */
+#define XDMAC_CID_DID                       XDMAC_CID_DID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_DID_Msk instead */
+#define XDMAC_CID_FID_Pos                   3                                              /**< (XDMAC_CID) End of Flush Interrupt Disable Bit Position */
+#define XDMAC_CID_FID_Msk                   (_U_(0x1) << XDMAC_CID_FID_Pos)                /**< (XDMAC_CID) End of Flush Interrupt Disable Bit Mask */
+#define XDMAC_CID_FID                       XDMAC_CID_FID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_FID_Msk instead */
+#define XDMAC_CID_RBEID_Pos                 4                                              /**< (XDMAC_CID) Read Bus Error Interrupt Disable Bit Position */
+#define XDMAC_CID_RBEID_Msk                 (_U_(0x1) << XDMAC_CID_RBEID_Pos)              /**< (XDMAC_CID) Read Bus Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_RBEID                     XDMAC_CID_RBEID_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_RBEID_Msk instead */
+#define XDMAC_CID_WBEID_Pos                 5                                              /**< (XDMAC_CID) Write Bus Error Interrupt Disable Bit Position */
+#define XDMAC_CID_WBEID_Msk                 (_U_(0x1) << XDMAC_CID_WBEID_Pos)              /**< (XDMAC_CID) Write Bus Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_WBEID                     XDMAC_CID_WBEID_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_WBEID_Msk instead */
+#define XDMAC_CID_ROID_Pos                  6                                              /**< (XDMAC_CID) Request Overflow Error Interrupt Disable Bit Position */
+#define XDMAC_CID_ROID_Msk                  (_U_(0x1) << XDMAC_CID_ROID_Pos)               /**< (XDMAC_CID) Request Overflow Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_ROID                      XDMAC_CID_ROID_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_ROID_Msk instead */
+#define XDMAC_CID_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CID) Register MASK  (Use XDMAC_CID_Msk instead)  */
+#define XDMAC_CID_Msk                       _U_(0x7F)                                      /**< (XDMAC_CID) Register Mask  */
+
+
+/* -------- XDMAC_CIM : (XDMAC Offset: 0x08) (R/ 32) Channel Interrupt Mask Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIM:1;                     /**< bit:      0  End of Block Interrupt Mask Bit          */
+    uint32_t LIM:1;                     /**< bit:      1  End of Linked List Interrupt Mask Bit    */
+    uint32_t DIM:1;                     /**< bit:      2  End of Disable Interrupt Mask Bit        */
+    uint32_t FIM:1;                     /**< bit:      3  End of Flush Interrupt Mask Bit          */
+    uint32_t RBEIM:1;                   /**< bit:      4  Read Bus Error Interrupt Mask Bit        */
+    uint32_t WBEIM:1;                   /**< bit:      5  Write Bus Error Interrupt Mask Bit       */
+    uint32_t ROIM:1;                    /**< bit:      6  Request Overflow Error Interrupt Mask Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIM_OFFSET                    (0x08)                                        /**<  (XDMAC_CIM) Channel Interrupt Mask Register (chid = 0)  Offset */
+
+#define XDMAC_CIM_BIM_Pos                   0                                              /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Position */
+#define XDMAC_CIM_BIM_Msk                   (_U_(0x1) << XDMAC_CIM_BIM_Pos)                /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Mask */
+#define XDMAC_CIM_BIM                       XDMAC_CIM_BIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_BIM_Msk instead */
+#define XDMAC_CIM_LIM_Pos                   1                                              /**< (XDMAC_CIM) End of Linked List Interrupt Mask Bit Position */
+#define XDMAC_CIM_LIM_Msk                   (_U_(0x1) << XDMAC_CIM_LIM_Pos)                /**< (XDMAC_CIM) End of Linked List Interrupt Mask Bit Mask */
+#define XDMAC_CIM_LIM                       XDMAC_CIM_LIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_LIM_Msk instead */
+#define XDMAC_CIM_DIM_Pos                   2                                              /**< (XDMAC_CIM) End of Disable Interrupt Mask Bit Position */
+#define XDMAC_CIM_DIM_Msk                   (_U_(0x1) << XDMAC_CIM_DIM_Pos)                /**< (XDMAC_CIM) End of Disable Interrupt Mask Bit Mask */
+#define XDMAC_CIM_DIM                       XDMAC_CIM_DIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_DIM_Msk instead */
+#define XDMAC_CIM_FIM_Pos                   3                                              /**< (XDMAC_CIM) End of Flush Interrupt Mask Bit Position */
+#define XDMAC_CIM_FIM_Msk                   (_U_(0x1) << XDMAC_CIM_FIM_Pos)                /**< (XDMAC_CIM) End of Flush Interrupt Mask Bit Mask */
+#define XDMAC_CIM_FIM                       XDMAC_CIM_FIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_FIM_Msk instead */
+#define XDMAC_CIM_RBEIM_Pos                 4                                              /**< (XDMAC_CIM) Read Bus Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_RBEIM_Msk                 (_U_(0x1) << XDMAC_CIM_RBEIM_Pos)              /**< (XDMAC_CIM) Read Bus Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_RBEIM                     XDMAC_CIM_RBEIM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_RBEIM_Msk instead */
+#define XDMAC_CIM_WBEIM_Pos                 5                                              /**< (XDMAC_CIM) Write Bus Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_WBEIM_Msk                 (_U_(0x1) << XDMAC_CIM_WBEIM_Pos)              /**< (XDMAC_CIM) Write Bus Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_WBEIM                     XDMAC_CIM_WBEIM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_WBEIM_Msk instead */
+#define XDMAC_CIM_ROIM_Pos                  6                                              /**< (XDMAC_CIM) Request Overflow Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_ROIM_Msk                  (_U_(0x1) << XDMAC_CIM_ROIM_Pos)               /**< (XDMAC_CIM) Request Overflow Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_ROIM                      XDMAC_CIM_ROIM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_ROIM_Msk instead */
+#define XDMAC_CIM_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIM) Register MASK  (Use XDMAC_CIM_Msk instead)  */
+#define XDMAC_CIM_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIM) Register Mask  */
+
+
+/* -------- XDMAC_CIS : (XDMAC Offset: 0x0c) (R/ 32) Channel Interrupt Status Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIS:1;                     /**< bit:      0  End of Block Interrupt Status Bit        */
+    uint32_t LIS:1;                     /**< bit:      1  End of Linked List Interrupt Status Bit  */
+    uint32_t DIS:1;                     /**< bit:      2  End of Disable Interrupt Status Bit      */
+    uint32_t FIS:1;                     /**< bit:      3  End of Flush Interrupt Status Bit        */
+    uint32_t RBEIS:1;                   /**< bit:      4  Read Bus Error Interrupt Status Bit      */
+    uint32_t WBEIS:1;                   /**< bit:      5  Write Bus Error Interrupt Status Bit     */
+    uint32_t ROIS:1;                    /**< bit:      6  Request Overflow Error Interrupt Status Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIS_OFFSET                    (0x0C)                                        /**<  (XDMAC_CIS) Channel Interrupt Status Register (chid = 0)  Offset */
+
+#define XDMAC_CIS_BIS_Pos                   0                                              /**< (XDMAC_CIS) End of Block Interrupt Status Bit Position */
+#define XDMAC_CIS_BIS_Msk                   (_U_(0x1) << XDMAC_CIS_BIS_Pos)                /**< (XDMAC_CIS) End of Block Interrupt Status Bit Mask */
+#define XDMAC_CIS_BIS                       XDMAC_CIS_BIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_BIS_Msk instead */
+#define XDMAC_CIS_LIS_Pos                   1                                              /**< (XDMAC_CIS) End of Linked List Interrupt Status Bit Position */
+#define XDMAC_CIS_LIS_Msk                   (_U_(0x1) << XDMAC_CIS_LIS_Pos)                /**< (XDMAC_CIS) End of Linked List Interrupt Status Bit Mask */
+#define XDMAC_CIS_LIS                       XDMAC_CIS_LIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_LIS_Msk instead */
+#define XDMAC_CIS_DIS_Pos                   2                                              /**< (XDMAC_CIS) End of Disable Interrupt Status Bit Position */
+#define XDMAC_CIS_DIS_Msk                   (_U_(0x1) << XDMAC_CIS_DIS_Pos)                /**< (XDMAC_CIS) End of Disable Interrupt Status Bit Mask */
+#define XDMAC_CIS_DIS                       XDMAC_CIS_DIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_DIS_Msk instead */
+#define XDMAC_CIS_FIS_Pos                   3                                              /**< (XDMAC_CIS) End of Flush Interrupt Status Bit Position */
+#define XDMAC_CIS_FIS_Msk                   (_U_(0x1) << XDMAC_CIS_FIS_Pos)                /**< (XDMAC_CIS) End of Flush Interrupt Status Bit Mask */
+#define XDMAC_CIS_FIS                       XDMAC_CIS_FIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_FIS_Msk instead */
+#define XDMAC_CIS_RBEIS_Pos                 4                                              /**< (XDMAC_CIS) Read Bus Error Interrupt Status Bit Position */
+#define XDMAC_CIS_RBEIS_Msk                 (_U_(0x1) << XDMAC_CIS_RBEIS_Pos)              /**< (XDMAC_CIS) Read Bus Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_RBEIS                     XDMAC_CIS_RBEIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_RBEIS_Msk instead */
+#define XDMAC_CIS_WBEIS_Pos                 5                                              /**< (XDMAC_CIS) Write Bus Error Interrupt Status Bit Position */
+#define XDMAC_CIS_WBEIS_Msk                 (_U_(0x1) << XDMAC_CIS_WBEIS_Pos)              /**< (XDMAC_CIS) Write Bus Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_WBEIS                     XDMAC_CIS_WBEIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_WBEIS_Msk instead */
+#define XDMAC_CIS_ROIS_Pos                  6                                              /**< (XDMAC_CIS) Request Overflow Error Interrupt Status Bit Position */
+#define XDMAC_CIS_ROIS_Msk                  (_U_(0x1) << XDMAC_CIS_ROIS_Pos)               /**< (XDMAC_CIS) Request Overflow Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_ROIS                      XDMAC_CIS_ROIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_ROIS_Msk instead */
+#define XDMAC_CIS_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIS) Register MASK  (Use XDMAC_CIS_Msk instead)  */
+#define XDMAC_CIS_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIS) Register Mask  */
+
+
+/* -------- XDMAC_CSA : (XDMAC Offset: 0x10) (R/W 32) Channel Source Address Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SA:32;                     /**< bit:  0..31  Channel x Source Address                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CSA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CSA_OFFSET                    (0x10)                                        /**<  (XDMAC_CSA) Channel Source Address Register (chid = 0)  Offset */
+
+#define XDMAC_CSA_SA_Pos                    0                                              /**< (XDMAC_CSA) Channel x Source Address Position */
+#define XDMAC_CSA_SA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CSA_SA_Pos)          /**< (XDMAC_CSA) Channel x Source Address Mask */
+#define XDMAC_CSA_SA(value)                 (XDMAC_CSA_SA_Msk & ((value) << XDMAC_CSA_SA_Pos))
+#define XDMAC_CSA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CSA) Register MASK  (Use XDMAC_CSA_Msk instead)  */
+#define XDMAC_CSA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CSA) Register Mask  */
+
+
+/* -------- XDMAC_CDA : (XDMAC Offset: 0x14) (R/W 32) Channel Destination Address Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DA:32;                     /**< bit:  0..31  Channel x Destination Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDA_OFFSET                    (0x14)                                        /**<  (XDMAC_CDA) Channel Destination Address Register (chid = 0)  Offset */
+
+#define XDMAC_CDA_DA_Pos                    0                                              /**< (XDMAC_CDA) Channel x Destination Address Position */
+#define XDMAC_CDA_DA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CDA_DA_Pos)          /**< (XDMAC_CDA) Channel x Destination Address Mask */
+#define XDMAC_CDA_DA(value)                 (XDMAC_CDA_DA_Msk & ((value) << XDMAC_CDA_DA_Pos))
+#define XDMAC_CDA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CDA) Register MASK  (Use XDMAC_CDA_Msk instead)  */
+#define XDMAC_CDA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CDA) Register Mask  */
+
+
+/* -------- XDMAC_CNDA : (XDMAC Offset: 0x18) (R/W 32) Channel Next Descriptor Address Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NDAIF:1;                   /**< bit:      0  Channel x Next Descriptor Interface      */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t NDA:30;                    /**< bit:  2..31  Channel x Next Descriptor Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CNDA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CNDA_OFFSET                   (0x18)                                        /**<  (XDMAC_CNDA) Channel Next Descriptor Address Register (chid = 0)  Offset */
+
+#define XDMAC_CNDA_NDAIF_Pos                0                                              /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Position */
+#define XDMAC_CNDA_NDAIF_Msk                (_U_(0x1) << XDMAC_CNDA_NDAIF_Pos)             /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Mask */
+#define XDMAC_CNDA_NDAIF                    XDMAC_CNDA_NDAIF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDA_NDAIF_Msk instead */
+#define XDMAC_CNDA_NDA_Pos                  2                                              /**< (XDMAC_CNDA) Channel x Next Descriptor Address Position */
+#define XDMAC_CNDA_NDA_Msk                  (_U_(0x3FFFFFFF) << XDMAC_CNDA_NDA_Pos)        /**< (XDMAC_CNDA) Channel x Next Descriptor Address Mask */
+#define XDMAC_CNDA_NDA(value)               (XDMAC_CNDA_NDA_Msk & ((value) << XDMAC_CNDA_NDA_Pos))
+#define XDMAC_CNDA_MASK                     _U_(0xFFFFFFFD)                                /**< \deprecated (XDMAC_CNDA) Register MASK  (Use XDMAC_CNDA_Msk instead)  */
+#define XDMAC_CNDA_Msk                      _U_(0xFFFFFFFD)                                /**< (XDMAC_CNDA) Register Mask  */
+
+
+/* -------- XDMAC_CNDC : (XDMAC Offset: 0x1c) (R/W 32) Channel Next Descriptor Control Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NDE:1;                     /**< bit:      0  Channel x Next Descriptor Enable         */
+    uint32_t NDSUP:1;                   /**< bit:      1  Channel x Next Descriptor Source Update  */
+    uint32_t NDDUP:1;                   /**< bit:      2  Channel x Next Descriptor Destination Update */
+    uint32_t NDVIEW:2;                  /**< bit:   3..4  Channel x Next Descriptor View           */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CNDC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CNDC_OFFSET                   (0x1C)                                        /**<  (XDMAC_CNDC) Channel Next Descriptor Control Register (chid = 0)  Offset */
+
+#define XDMAC_CNDC_NDE_Pos                  0                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Position */
+#define XDMAC_CNDC_NDE_Msk                  (_U_(0x1) << XDMAC_CNDC_NDE_Pos)               /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Mask */
+#define XDMAC_CNDC_NDE                      XDMAC_CNDC_NDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDE_Msk instead */
+#define   XDMAC_CNDC_NDE_DSCR_FETCH_DIS_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Descriptor fetch is disabled.  */
+#define   XDMAC_CNDC_NDE_DSCR_FETCH_EN_Val  _U_(0x1)                                       /**< (XDMAC_CNDC) Descriptor fetch is enabled.  */
+#define XDMAC_CNDC_NDE_DSCR_FETCH_DIS       (XDMAC_CNDC_NDE_DSCR_FETCH_DIS_Val << XDMAC_CNDC_NDE_Pos)  /**< (XDMAC_CNDC) Descriptor fetch is disabled. Position  */
+#define XDMAC_CNDC_NDE_DSCR_FETCH_EN        (XDMAC_CNDC_NDE_DSCR_FETCH_EN_Val << XDMAC_CNDC_NDE_Pos)  /**< (XDMAC_CNDC) Descriptor fetch is enabled. Position  */
+#define XDMAC_CNDC_NDSUP_Pos                1                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Source Update Position */
+#define XDMAC_CNDC_NDSUP_Msk                (_U_(0x1) << XDMAC_CNDC_NDSUP_Pos)             /**< (XDMAC_CNDC) Channel x Next Descriptor Source Update Mask */
+#define XDMAC_CNDC_NDSUP                    XDMAC_CNDC_NDSUP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDSUP_Msk instead */
+#define   XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Source parameters remain unchanged.  */
+#define   XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED_Val _U_(0x1)                                       /**< (XDMAC_CNDC) Source parameters are updated when the descriptor is retrieved.  */
+#define XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED (XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED_Val << XDMAC_CNDC_NDSUP_Pos)  /**< (XDMAC_CNDC) Source parameters remain unchanged. Position  */
+#define XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED (XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED_Val << XDMAC_CNDC_NDSUP_Pos)  /**< (XDMAC_CNDC) Source parameters are updated when the descriptor is retrieved. Position  */
+#define XDMAC_CNDC_NDDUP_Pos                2                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Destination Update Position */
+#define XDMAC_CNDC_NDDUP_Msk                (_U_(0x1) << XDMAC_CNDC_NDDUP_Pos)             /**< (XDMAC_CNDC) Channel x Next Descriptor Destination Update Mask */
+#define XDMAC_CNDC_NDDUP                    XDMAC_CNDC_NDDUP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDDUP_Msk instead */
+#define   XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Destination parameters remain unchanged.  */
+#define   XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED_Val _U_(0x1)                                       /**< (XDMAC_CNDC) Destination parameters are updated when the descriptor is retrieved.  */
+#define XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED (XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED_Val << XDMAC_CNDC_NDDUP_Pos)  /**< (XDMAC_CNDC) Destination parameters remain unchanged. Position  */
+#define XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED (XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED_Val << XDMAC_CNDC_NDDUP_Pos)  /**< (XDMAC_CNDC) Destination parameters are updated when the descriptor is retrieved. Position  */
+#define XDMAC_CNDC_NDVIEW_Pos               3                                              /**< (XDMAC_CNDC) Channel x Next Descriptor View Position */
+#define XDMAC_CNDC_NDVIEW_Msk               (_U_(0x3) << XDMAC_CNDC_NDVIEW_Pos)            /**< (XDMAC_CNDC) Channel x Next Descriptor View Mask */
+#define XDMAC_CNDC_NDVIEW(value)            (XDMAC_CNDC_NDVIEW_Msk & ((value) << XDMAC_CNDC_NDVIEW_Pos))
+#define   XDMAC_CNDC_NDVIEW_NDV0_Val        _U_(0x0)                                       /**< (XDMAC_CNDC) Next Descriptor View 0  */
+#define   XDMAC_CNDC_NDVIEW_NDV1_Val        _U_(0x1)                                       /**< (XDMAC_CNDC) Next Descriptor View 1  */
+#define   XDMAC_CNDC_NDVIEW_NDV2_Val        _U_(0x2)                                       /**< (XDMAC_CNDC) Next Descriptor View 2  */
+#define   XDMAC_CNDC_NDVIEW_NDV3_Val        _U_(0x3)                                       /**< (XDMAC_CNDC) Next Descriptor View 3  */
+#define XDMAC_CNDC_NDVIEW_NDV0              (XDMAC_CNDC_NDVIEW_NDV0_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 0 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV1              (XDMAC_CNDC_NDVIEW_NDV1_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 1 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV2              (XDMAC_CNDC_NDVIEW_NDV2_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 2 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV3              (XDMAC_CNDC_NDVIEW_NDV3_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 3 Position  */
+#define XDMAC_CNDC_MASK                     _U_(0x1F)                                      /**< \deprecated (XDMAC_CNDC) Register MASK  (Use XDMAC_CNDC_Msk instead)  */
+#define XDMAC_CNDC_Msk                      _U_(0x1F)                                      /**< (XDMAC_CNDC) Register Mask  */
+
+
+/* -------- XDMAC_CUBC : (XDMAC Offset: 0x20) (R/W 32) Channel Microblock Control Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UBLEN:24;                  /**< bit:  0..23  Channel x Microblock Length              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CUBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CUBC_OFFSET                   (0x20)                                        /**<  (XDMAC_CUBC) Channel Microblock Control Register (chid = 0)  Offset */
+
+#define XDMAC_CUBC_UBLEN_Pos                0                                              /**< (XDMAC_CUBC) Channel x Microblock Length Position */
+#define XDMAC_CUBC_UBLEN_Msk                (_U_(0xFFFFFF) << XDMAC_CUBC_UBLEN_Pos)        /**< (XDMAC_CUBC) Channel x Microblock Length Mask */
+#define XDMAC_CUBC_UBLEN(value)             (XDMAC_CUBC_UBLEN_Msk & ((value) << XDMAC_CUBC_UBLEN_Pos))
+#define XDMAC_CUBC_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CUBC) Register MASK  (Use XDMAC_CUBC_Msk instead)  */
+#define XDMAC_CUBC_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CUBC) Register Mask  */
+
+
+/* -------- XDMAC_CBC : (XDMAC Offset: 0x24) (R/W 32) Channel Block Control Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BLEN:12;                   /**< bit:  0..11  Channel x Block Length                   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CBC_OFFSET                    (0x24)                                        /**<  (XDMAC_CBC) Channel Block Control Register (chid = 0)  Offset */
+
+#define XDMAC_CBC_BLEN_Pos                  0                                              /**< (XDMAC_CBC) Channel x Block Length Position */
+#define XDMAC_CBC_BLEN_Msk                  (_U_(0xFFF) << XDMAC_CBC_BLEN_Pos)             /**< (XDMAC_CBC) Channel x Block Length Mask */
+#define XDMAC_CBC_BLEN(value)               (XDMAC_CBC_BLEN_Msk & ((value) << XDMAC_CBC_BLEN_Pos))
+#define XDMAC_CBC_MASK                      _U_(0xFFF)                                     /**< \deprecated (XDMAC_CBC) Register MASK  (Use XDMAC_CBC_Msk instead)  */
+#define XDMAC_CBC_Msk                       _U_(0xFFF)                                     /**< (XDMAC_CBC) Register Mask  */
+
+
+/* -------- XDMAC_CC : (XDMAC Offset: 0x28) (R/W 32) Channel Configuration Register (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TYPE:1;                    /**< bit:      0  Channel x Transfer Type                  */
+    uint32_t MBSIZE:2;                  /**< bit:   1..2  Channel x Memory Burst Size              */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t DSYNC:1;                   /**< bit:      4  Channel x Synchronization                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t SWREQ:1;                   /**< bit:      6  Channel x Software Request Trigger       */
+    uint32_t MEMSET:1;                  /**< bit:      7  Channel x Fill Block of Memory           */
+    uint32_t CSIZE:3;                   /**< bit:  8..10  Channel x Chunk Size                     */
+    uint32_t DWIDTH:2;                  /**< bit: 11..12  Channel x Data Width                     */
+    uint32_t SIF:1;                     /**< bit:     13  Channel x Source Interface Identifier    */
+    uint32_t DIF:1;                     /**< bit:     14  Channel x Destination Interface Identifier */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SAM:2;                     /**< bit: 16..17  Channel x Source Addressing Mode         */
+    uint32_t DAM:2;                     /**< bit: 18..19  Channel x Destination Addressing Mode    */
+    uint32_t :1;                        /**< bit:     20  Reserved */
+    uint32_t INITD:1;                   /**< bit:     21  Channel Initialization Done (this bit is read-only) */
+    uint32_t RDIP:1;                    /**< bit:     22  Read in Progress (this bit is read-only) */
+    uint32_t WRIP:1;                    /**< bit:     23  Write in Progress (this bit is read-only) */
+    uint32_t PERID:7;                   /**< bit: 24..30  Channel x Peripheral Hardware Request Line Identifier */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CC_OFFSET                     (0x28)                                        /**<  (XDMAC_CC) Channel Configuration Register (chid = 0)  Offset */
+
+#define XDMAC_CC_TYPE_Pos                   0                                              /**< (XDMAC_CC) Channel x Transfer Type Position */
+#define XDMAC_CC_TYPE_Msk                   (_U_(0x1) << XDMAC_CC_TYPE_Pos)                /**< (XDMAC_CC) Channel x Transfer Type Mask */
+#define XDMAC_CC_TYPE                       XDMAC_CC_TYPE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_TYPE_Msk instead */
+#define   XDMAC_CC_TYPE_MEM_TRAN_Val        _U_(0x0)                                       /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer).  */
+#define   XDMAC_CC_TYPE_PER_TRAN_Val        _U_(0x1)                                       /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer).  */
+#define XDMAC_CC_TYPE_MEM_TRAN              (XDMAC_CC_TYPE_MEM_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer). Position  */
+#define XDMAC_CC_TYPE_PER_TRAN              (XDMAC_CC_TYPE_PER_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer). Position  */
+#define XDMAC_CC_MBSIZE_Pos                 1                                              /**< (XDMAC_CC) Channel x Memory Burst Size Position */
+#define XDMAC_CC_MBSIZE_Msk                 (_U_(0x3) << XDMAC_CC_MBSIZE_Pos)              /**< (XDMAC_CC) Channel x Memory Burst Size Mask */
+#define XDMAC_CC_MBSIZE(value)              (XDMAC_CC_MBSIZE_Msk & ((value) << XDMAC_CC_MBSIZE_Pos))
+#define   XDMAC_CC_MBSIZE_SINGLE_Val        _U_(0x0)                                       /**< (XDMAC_CC) The memory burst size is set to one.  */
+#define   XDMAC_CC_MBSIZE_FOUR_Val          _U_(0x1)                                       /**< (XDMAC_CC) The memory burst size is set to four.  */
+#define   XDMAC_CC_MBSIZE_EIGHT_Val         _U_(0x2)                                       /**< (XDMAC_CC) The memory burst size is set to eight.  */
+#define   XDMAC_CC_MBSIZE_SIXTEEN_Val       _U_(0x3)                                       /**< (XDMAC_CC) The memory burst size is set to sixteen.  */
+#define XDMAC_CC_MBSIZE_SINGLE              (XDMAC_CC_MBSIZE_SINGLE_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to one. Position  */
+#define XDMAC_CC_MBSIZE_FOUR                (XDMAC_CC_MBSIZE_FOUR_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to four. Position  */
+#define XDMAC_CC_MBSIZE_EIGHT               (XDMAC_CC_MBSIZE_EIGHT_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to eight. Position  */
+#define XDMAC_CC_MBSIZE_SIXTEEN             (XDMAC_CC_MBSIZE_SIXTEEN_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to sixteen. Position  */
+#define XDMAC_CC_DSYNC_Pos                  4                                              /**< (XDMAC_CC) Channel x Synchronization Position */
+#define XDMAC_CC_DSYNC_Msk                  (_U_(0x1) << XDMAC_CC_DSYNC_Pos)               /**< (XDMAC_CC) Channel x Synchronization Mask */
+#define XDMAC_CC_DSYNC                      XDMAC_CC_DSYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_DSYNC_Msk instead */
+#define   XDMAC_CC_DSYNC_PER2MEM_Val        _U_(0x0)                                       /**< (XDMAC_CC) Peripheral-to-memory transfer.  */
+#define   XDMAC_CC_DSYNC_MEM2PER_Val        _U_(0x1)                                       /**< (XDMAC_CC) Memory-to-peripheral transfer.  */
+#define XDMAC_CC_DSYNC_PER2MEM              (XDMAC_CC_DSYNC_PER2MEM_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Peripheral-to-memory transfer. Position  */
+#define XDMAC_CC_DSYNC_MEM2PER              (XDMAC_CC_DSYNC_MEM2PER_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Memory-to-peripheral transfer. Position  */
+#define XDMAC_CC_SWREQ_Pos                  6                                              /**< (XDMAC_CC) Channel x Software Request Trigger Position */
+#define XDMAC_CC_SWREQ_Msk                  (_U_(0x1) << XDMAC_CC_SWREQ_Pos)               /**< (XDMAC_CC) Channel x Software Request Trigger Mask */
+#define XDMAC_CC_SWREQ                      XDMAC_CC_SWREQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_SWREQ_Msk instead */
+#define   XDMAC_CC_SWREQ_HWR_CONNECTED_Val  _U_(0x0)                                       /**< (XDMAC_CC) Hardware request line is connected to the peripheral request line.  */
+#define   XDMAC_CC_SWREQ_SWR_CONNECTED_Val  _U_(0x1)                                       /**< (XDMAC_CC) Software request is connected to the peripheral request line.  */
+#define XDMAC_CC_SWREQ_HWR_CONNECTED        (XDMAC_CC_SWREQ_HWR_CONNECTED_Val << XDMAC_CC_SWREQ_Pos)  /**< (XDMAC_CC) Hardware request line is connected to the peripheral request line. Position  */
+#define XDMAC_CC_SWREQ_SWR_CONNECTED        (XDMAC_CC_SWREQ_SWR_CONNECTED_Val << XDMAC_CC_SWREQ_Pos)  /**< (XDMAC_CC) Software request is connected to the peripheral request line. Position  */
+#define XDMAC_CC_MEMSET_Pos                 7                                              /**< (XDMAC_CC) Channel x Fill Block of Memory Position */
+#define XDMAC_CC_MEMSET_Msk                 (_U_(0x1) << XDMAC_CC_MEMSET_Pos)              /**< (XDMAC_CC) Channel x Fill Block of Memory Mask */
+#define XDMAC_CC_MEMSET                     XDMAC_CC_MEMSET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_MEMSET_Msk instead */
+#define   XDMAC_CC_MEMSET_NORMAL_MODE_Val   _U_(0x0)                                       /**< (XDMAC_CC) Memset is not activated.  */
+#define   XDMAC_CC_MEMSET_HW_MODE_Val       _U_(0x1)                                       /**< (XDMAC_CC) Sets the block of memory pointed by DA field to the specified value. This operation is performed on 8-, 16- or 32-bit basis.  */
+#define XDMAC_CC_MEMSET_NORMAL_MODE         (XDMAC_CC_MEMSET_NORMAL_MODE_Val << XDMAC_CC_MEMSET_Pos)  /**< (XDMAC_CC) Memset is not activated. Position  */
+#define XDMAC_CC_MEMSET_HW_MODE             (XDMAC_CC_MEMSET_HW_MODE_Val << XDMAC_CC_MEMSET_Pos)  /**< (XDMAC_CC) Sets the block of memory pointed by DA field to the specified value. This operation is performed on 8-, 16- or 32-bit basis. Position  */
+#define XDMAC_CC_CSIZE_Pos                  8                                              /**< (XDMAC_CC) Channel x Chunk Size Position */
+#define XDMAC_CC_CSIZE_Msk                  (_U_(0x7) << XDMAC_CC_CSIZE_Pos)               /**< (XDMAC_CC) Channel x Chunk Size Mask */
+#define XDMAC_CC_CSIZE(value)               (XDMAC_CC_CSIZE_Msk & ((value) << XDMAC_CC_CSIZE_Pos))
+#define   XDMAC_CC_CSIZE_CHK_1_Val          _U_(0x0)                                       /**< (XDMAC_CC) 1 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_2_Val          _U_(0x1)                                       /**< (XDMAC_CC) 2 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_4_Val          _U_(0x2)                                       /**< (XDMAC_CC) 4 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_8_Val          _U_(0x3)                                       /**< (XDMAC_CC) 8 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_16_Val         _U_(0x4)                                       /**< (XDMAC_CC) 16 data transferred  */
+#define XDMAC_CC_CSIZE_CHK_1                (XDMAC_CC_CSIZE_CHK_1_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 1 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_2                (XDMAC_CC_CSIZE_CHK_2_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 2 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_4                (XDMAC_CC_CSIZE_CHK_4_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 4 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_8                (XDMAC_CC_CSIZE_CHK_8_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 8 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_16               (XDMAC_CC_CSIZE_CHK_16_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 16 data transferred Position  */
+#define XDMAC_CC_DWIDTH_Pos                 11                                             /**< (XDMAC_CC) Channel x Data Width Position */
+#define XDMAC_CC_DWIDTH_Msk                 (_U_(0x3) << XDMAC_CC_DWIDTH_Pos)              /**< (XDMAC_CC) Channel x Data Width Mask */
+#define XDMAC_CC_DWIDTH(value)              (XDMAC_CC_DWIDTH_Msk & ((value) << XDMAC_CC_DWIDTH_Pos))
+#define   XDMAC_CC_DWIDTH_BYTE_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data size is set to 8 bits  */
+#define   XDMAC_CC_DWIDTH_HALFWORD_Val      _U_(0x1)                                       /**< (XDMAC_CC) The data size is set to 16 bits  */
+#define   XDMAC_CC_DWIDTH_WORD_Val          _U_(0x2)                                       /**< (XDMAC_CC) The data size is set to 32 bits  */
+#define XDMAC_CC_DWIDTH_BYTE                (XDMAC_CC_DWIDTH_BYTE_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 8 bits Position  */
+#define XDMAC_CC_DWIDTH_HALFWORD            (XDMAC_CC_DWIDTH_HALFWORD_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 16 bits Position  */
+#define XDMAC_CC_DWIDTH_WORD                (XDMAC_CC_DWIDTH_WORD_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 32 bits Position  */
+#define XDMAC_CC_SIF_Pos                    13                                             /**< (XDMAC_CC) Channel x Source Interface Identifier Position */
+#define XDMAC_CC_SIF_Msk                    (_U_(0x1) << XDMAC_CC_SIF_Pos)                 /**< (XDMAC_CC) Channel x Source Interface Identifier Mask */
+#define XDMAC_CC_SIF                        XDMAC_CC_SIF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_SIF_Msk instead */
+#define   XDMAC_CC_SIF_AHB_IF0_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data is read through the system bus interface 0.  */
+#define   XDMAC_CC_SIF_AHB_IF1_Val          _U_(0x1)                                       /**< (XDMAC_CC) The data is read through the system bus interface 1.  */
+#define XDMAC_CC_SIF_AHB_IF0                (XDMAC_CC_SIF_AHB_IF0_Val << XDMAC_CC_SIF_Pos)  /**< (XDMAC_CC) The data is read through the system bus interface 0. Position  */
+#define XDMAC_CC_SIF_AHB_IF1                (XDMAC_CC_SIF_AHB_IF1_Val << XDMAC_CC_SIF_Pos)  /**< (XDMAC_CC) The data is read through the system bus interface 1. Position  */
+#define XDMAC_CC_DIF_Pos                    14                                             /**< (XDMAC_CC) Channel x Destination Interface Identifier Position */
+#define XDMAC_CC_DIF_Msk                    (_U_(0x1) << XDMAC_CC_DIF_Pos)                 /**< (XDMAC_CC) Channel x Destination Interface Identifier Mask */
+#define XDMAC_CC_DIF                        XDMAC_CC_DIF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_DIF_Msk instead */
+#define   XDMAC_CC_DIF_AHB_IF0_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data is written through the system bus interface 0.  */
+#define   XDMAC_CC_DIF_AHB_IF1_Val          _U_(0x1)                                       /**< (XDMAC_CC) The data is written though the system bus interface 1.  */
+#define XDMAC_CC_DIF_AHB_IF0                (XDMAC_CC_DIF_AHB_IF0_Val << XDMAC_CC_DIF_Pos)  /**< (XDMAC_CC) The data is written through the system bus interface 0. Position  */
+#define XDMAC_CC_DIF_AHB_IF1                (XDMAC_CC_DIF_AHB_IF1_Val << XDMAC_CC_DIF_Pos)  /**< (XDMAC_CC) The data is written though the system bus interface 1. Position  */
+#define XDMAC_CC_SAM_Pos                    16                                             /**< (XDMAC_CC) Channel x Source Addressing Mode Position */
+#define XDMAC_CC_SAM_Msk                    (_U_(0x3) << XDMAC_CC_SAM_Pos)                 /**< (XDMAC_CC) Channel x Source Addressing Mode Mask */
+#define XDMAC_CC_SAM(value)                 (XDMAC_CC_SAM_Msk & ((value) << XDMAC_CC_SAM_Pos))
+#define   XDMAC_CC_SAM_FIXED_AM_Val         _U_(0x0)                                       /**< (XDMAC_CC) The address remains unchanged.  */
+#define   XDMAC_CC_SAM_INCREMENTED_AM_Val   _U_(0x1)                                       /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size).  */
+#define   XDMAC_CC_SAM_UBS_AM_Val           _U_(0x2)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary.  */
+#define   XDMAC_CC_SAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary.  */
+#define XDMAC_CC_SAM_FIXED_AM               (XDMAC_CC_SAM_FIXED_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The address remains unchanged. Position  */
+#define XDMAC_CC_SAM_INCREMENTED_AM         (XDMAC_CC_SAM_INCREMENTED_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size). Position  */
+#define XDMAC_CC_SAM_UBS_AM                 (XDMAC_CC_SAM_UBS_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary. Position  */
+#define XDMAC_CC_SAM_UBS_DS_AM              (XDMAC_CC_SAM_UBS_DS_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary. Position  */
+#define XDMAC_CC_DAM_Pos                    18                                             /**< (XDMAC_CC) Channel x Destination Addressing Mode Position */
+#define XDMAC_CC_DAM_Msk                    (_U_(0x3) << XDMAC_CC_DAM_Pos)                 /**< (XDMAC_CC) Channel x Destination Addressing Mode Mask */
+#define XDMAC_CC_DAM(value)                 (XDMAC_CC_DAM_Msk & ((value) << XDMAC_CC_DAM_Pos))
+#define   XDMAC_CC_DAM_FIXED_AM_Val         _U_(0x0)                                       /**< (XDMAC_CC) The address remains unchanged.  */
+#define   XDMAC_CC_DAM_INCREMENTED_AM_Val   _U_(0x1)                                       /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size).  */
+#define   XDMAC_CC_DAM_UBS_AM_Val           _U_(0x2)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary.  */
+#define   XDMAC_CC_DAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary.  */
+#define XDMAC_CC_DAM_FIXED_AM               (XDMAC_CC_DAM_FIXED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The address remains unchanged. Position  */
+#define XDMAC_CC_DAM_INCREMENTED_AM         (XDMAC_CC_DAM_INCREMENTED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size). Position  */
+#define XDMAC_CC_DAM_UBS_AM                 (XDMAC_CC_DAM_UBS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary. Position  */
+#define XDMAC_CC_DAM_UBS_DS_AM              (XDMAC_CC_DAM_UBS_DS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary. Position  */
+#define XDMAC_CC_INITD_Pos                  21                                             /**< (XDMAC_CC) Channel Initialization Done (this bit is read-only) Position */
+#define XDMAC_CC_INITD_Msk                  (_U_(0x1) << XDMAC_CC_INITD_Pos)               /**< (XDMAC_CC) Channel Initialization Done (this bit is read-only) Mask */
+#define XDMAC_CC_INITD                      XDMAC_CC_INITD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_INITD_Msk instead */
+#define   XDMAC_CC_INITD_IN_PROGRESS_Val    _U_(0x0)                                       /**< (XDMAC_CC) Channel initialization is in progress.  */
+#define   XDMAC_CC_INITD_TERMINATED_Val     _U_(0x1)                                       /**< (XDMAC_CC) Channel initialization is completed.  */
+#define XDMAC_CC_INITD_IN_PROGRESS          (XDMAC_CC_INITD_IN_PROGRESS_Val << XDMAC_CC_INITD_Pos)  /**< (XDMAC_CC) Channel initialization is in progress. Position  */
+#define XDMAC_CC_INITD_TERMINATED           (XDMAC_CC_INITD_TERMINATED_Val << XDMAC_CC_INITD_Pos)  /**< (XDMAC_CC) Channel initialization is completed. Position  */
+#define XDMAC_CC_RDIP_Pos                   22                                             /**< (XDMAC_CC) Read in Progress (this bit is read-only) Position */
+#define XDMAC_CC_RDIP_Msk                   (_U_(0x1) << XDMAC_CC_RDIP_Pos)                /**< (XDMAC_CC) Read in Progress (this bit is read-only) Mask */
+#define XDMAC_CC_RDIP                       XDMAC_CC_RDIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_RDIP_Msk instead */
+#define   XDMAC_CC_RDIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active read transaction on the bus.  */
+#define   XDMAC_CC_RDIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A read transaction is in progress.  */
+#define XDMAC_CC_RDIP_DONE                  (XDMAC_CC_RDIP_DONE_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) No active read transaction on the bus. Position  */
+#define XDMAC_CC_RDIP_IN_PROGRESS           (XDMAC_CC_RDIP_IN_PROGRESS_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) A read transaction is in progress. Position  */
+#define XDMAC_CC_WRIP_Pos                   23                                             /**< (XDMAC_CC) Write in Progress (this bit is read-only) Position */
+#define XDMAC_CC_WRIP_Msk                   (_U_(0x1) << XDMAC_CC_WRIP_Pos)                /**< (XDMAC_CC) Write in Progress (this bit is read-only) Mask */
+#define XDMAC_CC_WRIP                       XDMAC_CC_WRIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_WRIP_Msk instead */
+#define   XDMAC_CC_WRIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active write transaction on the bus.  */
+#define   XDMAC_CC_WRIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A write transaction is in progress.  */
+#define XDMAC_CC_WRIP_DONE                  (XDMAC_CC_WRIP_DONE_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) No active write transaction on the bus. Position  */
+#define XDMAC_CC_WRIP_IN_PROGRESS           (XDMAC_CC_WRIP_IN_PROGRESS_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) A write transaction is in progress. Position  */
+#define XDMAC_CC_PERID_Pos                  24                                             /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Position */
+#define XDMAC_CC_PERID_Msk                  (_U_(0x7F) << XDMAC_CC_PERID_Pos)              /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Mask */
+#define XDMAC_CC_PERID(value)               (XDMAC_CC_PERID_Msk & ((value) << XDMAC_CC_PERID_Pos))
+#define XDMAC_CC_MASK                       _U_(0x7FEF7FD7)                                /**< \deprecated (XDMAC_CC) Register MASK  (Use XDMAC_CC_Msk instead)  */
+#define XDMAC_CC_Msk                        _U_(0x7FEF7FD7)                                /**< (XDMAC_CC) Register Mask  */
+
+
+/* -------- XDMAC_CDS_MSP : (XDMAC Offset: 0x2c) (R/W 32) Channel Data Stride Memory Set Pattern (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDS_MSP:16;                /**< bit:  0..15  Channel x Source Data stride or Memory Set Pattern */
+    uint32_t DDS_MSP:16;                /**< bit: 16..31  Channel x Destination Data Stride or Memory Set Pattern */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDS_MSP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDS_MSP_OFFSET                (0x2C)                                        /**<  (XDMAC_CDS_MSP) Channel Data Stride Memory Set Pattern (chid = 0)  Offset */
+
+#define XDMAC_CDS_MSP_SDS_MSP_Pos           0                                              /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Position */
+#define XDMAC_CDS_MSP_SDS_MSP_Msk           (_U_(0xFFFF) << XDMAC_CDS_MSP_SDS_MSP_Pos)     /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Mask */
+#define XDMAC_CDS_MSP_SDS_MSP(value)        (XDMAC_CDS_MSP_SDS_MSP_Msk & ((value) << XDMAC_CDS_MSP_SDS_MSP_Pos))
+#define XDMAC_CDS_MSP_DDS_MSP_Pos           16                                             /**< (XDMAC_CDS_MSP) Channel x Destination Data Stride or Memory Set Pattern Position */
+#define XDMAC_CDS_MSP_DDS_MSP_Msk           (_U_(0xFFFF) << XDMAC_CDS_MSP_DDS_MSP_Pos)     /**< (XDMAC_CDS_MSP) Channel x Destination Data Stride or Memory Set Pattern Mask */
+#define XDMAC_CDS_MSP_DDS_MSP(value)        (XDMAC_CDS_MSP_DDS_MSP_Msk & ((value) << XDMAC_CDS_MSP_DDS_MSP_Pos))
+#define XDMAC_CDS_MSP_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CDS_MSP) Register MASK  (Use XDMAC_CDS_MSP_Msk instead)  */
+#define XDMAC_CDS_MSP_Msk                   _U_(0xFFFFFFFF)                                /**< (XDMAC_CDS_MSP) Register Mask  */
+
+
+/* -------- XDMAC_CSUS : (XDMAC Offset: 0x30) (R/W 32) Channel Source Microblock Stride (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUBS:24;                   /**< bit:  0..23  Channel x Source Microblock Stride       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CSUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CSUS_OFFSET                   (0x30)                                        /**<  (XDMAC_CSUS) Channel Source Microblock Stride (chid = 0)  Offset */
+
+#define XDMAC_CSUS_SUBS_Pos                 0                                              /**< (XDMAC_CSUS) Channel x Source Microblock Stride Position */
+#define XDMAC_CSUS_SUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CSUS_SUBS_Pos)         /**< (XDMAC_CSUS) Channel x Source Microblock Stride Mask */
+#define XDMAC_CSUS_SUBS(value)              (XDMAC_CSUS_SUBS_Msk & ((value) << XDMAC_CSUS_SUBS_Pos))
+#define XDMAC_CSUS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CSUS) Register MASK  (Use XDMAC_CSUS_Msk instead)  */
+#define XDMAC_CSUS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CSUS) Register Mask  */
+
+
+/* -------- XDMAC_CDUS : (XDMAC Offset: 0x34) (R/W 32) Channel Destination Microblock Stride (chid = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DUBS:24;                   /**< bit:  0..23  Channel x Destination Microblock Stride  */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDUS_OFFSET                   (0x34)                                        /**<  (XDMAC_CDUS) Channel Destination Microblock Stride (chid = 0)  Offset */
+
+#define XDMAC_CDUS_DUBS_Pos                 0                                              /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Position */
+#define XDMAC_CDUS_DUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CDUS_DUBS_Pos)         /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Mask */
+#define XDMAC_CDUS_DUBS(value)              (XDMAC_CDUS_DUBS_Msk & ((value) << XDMAC_CDUS_DUBS_Pos))
+#define XDMAC_CDUS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CDUS) Register MASK  (Use XDMAC_CDUS_Msk instead)  */
+#define XDMAC_CDUS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CDUS) Register Mask  */
+
+
+/* -------- XDMAC_GTYPE : (XDMAC Offset: 0x00) (R/ 32) Global Type Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NB_CH:5;                   /**< bit:   0..4  Number of Channels Minus One             */
+    uint32_t FIFO_SZ:11;                /**< bit:  5..15  Number of Bytes                          */
+    uint32_t NB_REQ:7;                  /**< bit: 16..22  Number of Peripheral Requests Minus One  */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GTYPE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GTYPE_OFFSET                  (0x00)                                        /**<  (XDMAC_GTYPE) Global Type Register  Offset */
+
+#define XDMAC_GTYPE_NB_CH_Pos               0                                              /**< (XDMAC_GTYPE) Number of Channels Minus One Position */
+#define XDMAC_GTYPE_NB_CH_Msk               (_U_(0x1F) << XDMAC_GTYPE_NB_CH_Pos)           /**< (XDMAC_GTYPE) Number of Channels Minus One Mask */
+#define XDMAC_GTYPE_NB_CH(value)            (XDMAC_GTYPE_NB_CH_Msk & ((value) << XDMAC_GTYPE_NB_CH_Pos))
+#define XDMAC_GTYPE_FIFO_SZ_Pos             5                                              /**< (XDMAC_GTYPE) Number of Bytes Position */
+#define XDMAC_GTYPE_FIFO_SZ_Msk             (_U_(0x7FF) << XDMAC_GTYPE_FIFO_SZ_Pos)        /**< (XDMAC_GTYPE) Number of Bytes Mask */
+#define XDMAC_GTYPE_FIFO_SZ(value)          (XDMAC_GTYPE_FIFO_SZ_Msk & ((value) << XDMAC_GTYPE_FIFO_SZ_Pos))
+#define XDMAC_GTYPE_NB_REQ_Pos              16                                             /**< (XDMAC_GTYPE) Number of Peripheral Requests Minus One Position */
+#define XDMAC_GTYPE_NB_REQ_Msk              (_U_(0x7F) << XDMAC_GTYPE_NB_REQ_Pos)          /**< (XDMAC_GTYPE) Number of Peripheral Requests Minus One Mask */
+#define XDMAC_GTYPE_NB_REQ(value)           (XDMAC_GTYPE_NB_REQ_Msk & ((value) << XDMAC_GTYPE_NB_REQ_Pos))
+#define XDMAC_GTYPE_MASK                    _U_(0x7FFFFF)                                  /**< \deprecated (XDMAC_GTYPE) Register MASK  (Use XDMAC_GTYPE_Msk instead)  */
+#define XDMAC_GTYPE_Msk                     _U_(0x7FFFFF)                                  /**< (XDMAC_GTYPE) Register Mask  */
+
+
+/* -------- XDMAC_GCFG : (XDMAC Offset: 0x04) (R/W 32) Global Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CGDISREG:1;                /**< bit:      0  Configuration Registers Clock Gating Disable */
+    uint32_t CGDISPIPE:1;               /**< bit:      1  Pipeline Clock Gating Disable            */
+    uint32_t CGDISFIFO:1;               /**< bit:      2  FIFO Clock Gating Disable                */
+    uint32_t CGDISIF:1;                 /**< bit:      3  Bus Interface Clock Gating Disable       */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t BXKBEN:1;                  /**< bit:      8  Boundary X Kilobyte Enable               */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GCFG_OFFSET                   (0x04)                                        /**<  (XDMAC_GCFG) Global Configuration Register  Offset */
+
+#define XDMAC_GCFG_CGDISREG_Pos             0                                              /**< (XDMAC_GCFG) Configuration Registers Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISREG_Msk             (_U_(0x1) << XDMAC_GCFG_CGDISREG_Pos)          /**< (XDMAC_GCFG) Configuration Registers Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISREG                 XDMAC_GCFG_CGDISREG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISREG_Msk instead */
+#define XDMAC_GCFG_CGDISPIPE_Pos            1                                              /**< (XDMAC_GCFG) Pipeline Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISPIPE_Msk            (_U_(0x1) << XDMAC_GCFG_CGDISPIPE_Pos)         /**< (XDMAC_GCFG) Pipeline Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISPIPE                XDMAC_GCFG_CGDISPIPE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISPIPE_Msk instead */
+#define XDMAC_GCFG_CGDISFIFO_Pos            2                                              /**< (XDMAC_GCFG) FIFO Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISFIFO_Msk            (_U_(0x1) << XDMAC_GCFG_CGDISFIFO_Pos)         /**< (XDMAC_GCFG) FIFO Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISFIFO                XDMAC_GCFG_CGDISFIFO_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISFIFO_Msk instead */
+#define XDMAC_GCFG_CGDISIF_Pos              3                                              /**< (XDMAC_GCFG) Bus Interface Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISIF_Msk              (_U_(0x1) << XDMAC_GCFG_CGDISIF_Pos)           /**< (XDMAC_GCFG) Bus Interface Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISIF                  XDMAC_GCFG_CGDISIF_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISIF_Msk instead */
+#define XDMAC_GCFG_BXKBEN_Pos               8                                              /**< (XDMAC_GCFG) Boundary X Kilobyte Enable Position */
+#define XDMAC_GCFG_BXKBEN_Msk               (_U_(0x1) << XDMAC_GCFG_BXKBEN_Pos)            /**< (XDMAC_GCFG) Boundary X Kilobyte Enable Mask */
+#define XDMAC_GCFG_BXKBEN                   XDMAC_GCFG_BXKBEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_BXKBEN_Msk instead */
+#define XDMAC_GCFG_MASK                     _U_(0x10F)                                     /**< \deprecated (XDMAC_GCFG) Register MASK  (Use XDMAC_GCFG_Msk instead)  */
+#define XDMAC_GCFG_Msk                      _U_(0x10F)                                     /**< (XDMAC_GCFG) Register Mask  */
+
+
+/* -------- XDMAC_GWAC : (XDMAC Offset: 0x08) (R/W 32) Global Weighted Arbiter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PW0:4;                     /**< bit:   0..3  Pool Weight 0                            */
+    uint32_t PW1:4;                     /**< bit:   4..7  Pool Weight 1                            */
+    uint32_t PW2:4;                     /**< bit:  8..11  Pool Weight 2                            */
+    uint32_t PW3:4;                     /**< bit: 12..15  Pool Weight 3                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GWAC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GWAC_OFFSET                   (0x08)                                        /**<  (XDMAC_GWAC) Global Weighted Arbiter Configuration Register  Offset */
+
+#define XDMAC_GWAC_PW0_Pos                  0                                              /**< (XDMAC_GWAC) Pool Weight 0 Position */
+#define XDMAC_GWAC_PW0_Msk                  (_U_(0xF) << XDMAC_GWAC_PW0_Pos)               /**< (XDMAC_GWAC) Pool Weight 0 Mask */
+#define XDMAC_GWAC_PW0(value)               (XDMAC_GWAC_PW0_Msk & ((value) << XDMAC_GWAC_PW0_Pos))
+#define XDMAC_GWAC_PW1_Pos                  4                                              /**< (XDMAC_GWAC) Pool Weight 1 Position */
+#define XDMAC_GWAC_PW1_Msk                  (_U_(0xF) << XDMAC_GWAC_PW1_Pos)               /**< (XDMAC_GWAC) Pool Weight 1 Mask */
+#define XDMAC_GWAC_PW1(value)               (XDMAC_GWAC_PW1_Msk & ((value) << XDMAC_GWAC_PW1_Pos))
+#define XDMAC_GWAC_PW2_Pos                  8                                              /**< (XDMAC_GWAC) Pool Weight 2 Position */
+#define XDMAC_GWAC_PW2_Msk                  (_U_(0xF) << XDMAC_GWAC_PW2_Pos)               /**< (XDMAC_GWAC) Pool Weight 2 Mask */
+#define XDMAC_GWAC_PW2(value)               (XDMAC_GWAC_PW2_Msk & ((value) << XDMAC_GWAC_PW2_Pos))
+#define XDMAC_GWAC_PW3_Pos                  12                                             /**< (XDMAC_GWAC) Pool Weight 3 Position */
+#define XDMAC_GWAC_PW3_Msk                  (_U_(0xF) << XDMAC_GWAC_PW3_Pos)               /**< (XDMAC_GWAC) Pool Weight 3 Mask */
+#define XDMAC_GWAC_PW3(value)               (XDMAC_GWAC_PW3_Msk & ((value) << XDMAC_GWAC_PW3_Pos))
+#define XDMAC_GWAC_MASK                     _U_(0xFFFF)                                    /**< \deprecated (XDMAC_GWAC) Register MASK  (Use XDMAC_GWAC_Msk instead)  */
+#define XDMAC_GWAC_Msk                      _U_(0xFFFF)                                    /**< (XDMAC_GWAC) Register Mask  */
+
+
+/* -------- XDMAC_GIE : (XDMAC Offset: 0x0c) (/W 32) Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IE0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Enable Bit     */
+    uint32_t IE1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Enable Bit     */
+    uint32_t IE2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Enable Bit     */
+    uint32_t IE3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Enable Bit     */
+    uint32_t IE4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Enable Bit     */
+    uint32_t IE5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Enable Bit     */
+    uint32_t IE6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Enable Bit     */
+    uint32_t IE7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Enable Bit     */
+    uint32_t IE8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Enable Bit     */
+    uint32_t IE9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Enable Bit     */
+    uint32_t IE10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Enable Bit    */
+    uint32_t IE11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Enable Bit    */
+    uint32_t IE12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Enable Bit    */
+    uint32_t IE13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Enable Bit    */
+    uint32_t IE14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Enable Bit    */
+    uint32_t IE15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Enable Bit    */
+    uint32_t IE16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Enable Bit    */
+    uint32_t IE17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Enable Bit    */
+    uint32_t IE18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Enable Bit    */
+    uint32_t IE19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Enable Bit    */
+    uint32_t IE20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Enable Bit    */
+    uint32_t IE21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Enable Bit    */
+    uint32_t IE22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Enable Bit    */
+    uint32_t IE23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Enable Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IE:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Enable Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIE_OFFSET                    (0x0C)                                        /**<  (XDMAC_GIE) Global Interrupt Enable Register  Offset */
+
+#define XDMAC_GIE_IE0_Pos                   0                                              /**< (XDMAC_GIE) XDMAC Channel 0 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE0_Msk                   (_U_(0x1) << XDMAC_GIE_IE0_Pos)                /**< (XDMAC_GIE) XDMAC Channel 0 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE0                       XDMAC_GIE_IE0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE0_Msk instead */
+#define XDMAC_GIE_IE1_Pos                   1                                              /**< (XDMAC_GIE) XDMAC Channel 1 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE1_Msk                   (_U_(0x1) << XDMAC_GIE_IE1_Pos)                /**< (XDMAC_GIE) XDMAC Channel 1 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE1                       XDMAC_GIE_IE1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE1_Msk instead */
+#define XDMAC_GIE_IE2_Pos                   2                                              /**< (XDMAC_GIE) XDMAC Channel 2 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE2_Msk                   (_U_(0x1) << XDMAC_GIE_IE2_Pos)                /**< (XDMAC_GIE) XDMAC Channel 2 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE2                       XDMAC_GIE_IE2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE2_Msk instead */
+#define XDMAC_GIE_IE3_Pos                   3                                              /**< (XDMAC_GIE) XDMAC Channel 3 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE3_Msk                   (_U_(0x1) << XDMAC_GIE_IE3_Pos)                /**< (XDMAC_GIE) XDMAC Channel 3 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE3                       XDMAC_GIE_IE3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE3_Msk instead */
+#define XDMAC_GIE_IE4_Pos                   4                                              /**< (XDMAC_GIE) XDMAC Channel 4 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE4_Msk                   (_U_(0x1) << XDMAC_GIE_IE4_Pos)                /**< (XDMAC_GIE) XDMAC Channel 4 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE4                       XDMAC_GIE_IE4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE4_Msk instead */
+#define XDMAC_GIE_IE5_Pos                   5                                              /**< (XDMAC_GIE) XDMAC Channel 5 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE5_Msk                   (_U_(0x1) << XDMAC_GIE_IE5_Pos)                /**< (XDMAC_GIE) XDMAC Channel 5 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE5                       XDMAC_GIE_IE5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE5_Msk instead */
+#define XDMAC_GIE_IE6_Pos                   6                                              /**< (XDMAC_GIE) XDMAC Channel 6 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE6_Msk                   (_U_(0x1) << XDMAC_GIE_IE6_Pos)                /**< (XDMAC_GIE) XDMAC Channel 6 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE6                       XDMAC_GIE_IE6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE6_Msk instead */
+#define XDMAC_GIE_IE7_Pos                   7                                              /**< (XDMAC_GIE) XDMAC Channel 7 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE7_Msk                   (_U_(0x1) << XDMAC_GIE_IE7_Pos)                /**< (XDMAC_GIE) XDMAC Channel 7 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE7                       XDMAC_GIE_IE7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE7_Msk instead */
+#define XDMAC_GIE_IE8_Pos                   8                                              /**< (XDMAC_GIE) XDMAC Channel 8 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE8_Msk                   (_U_(0x1) << XDMAC_GIE_IE8_Pos)                /**< (XDMAC_GIE) XDMAC Channel 8 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE8                       XDMAC_GIE_IE8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE8_Msk instead */
+#define XDMAC_GIE_IE9_Pos                   9                                              /**< (XDMAC_GIE) XDMAC Channel 9 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE9_Msk                   (_U_(0x1) << XDMAC_GIE_IE9_Pos)                /**< (XDMAC_GIE) XDMAC Channel 9 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE9                       XDMAC_GIE_IE9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE9_Msk instead */
+#define XDMAC_GIE_IE10_Pos                  10                                             /**< (XDMAC_GIE) XDMAC Channel 10 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE10_Msk                  (_U_(0x1) << XDMAC_GIE_IE10_Pos)               /**< (XDMAC_GIE) XDMAC Channel 10 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE10                      XDMAC_GIE_IE10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE10_Msk instead */
+#define XDMAC_GIE_IE11_Pos                  11                                             /**< (XDMAC_GIE) XDMAC Channel 11 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE11_Msk                  (_U_(0x1) << XDMAC_GIE_IE11_Pos)               /**< (XDMAC_GIE) XDMAC Channel 11 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE11                      XDMAC_GIE_IE11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE11_Msk instead */
+#define XDMAC_GIE_IE12_Pos                  12                                             /**< (XDMAC_GIE) XDMAC Channel 12 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE12_Msk                  (_U_(0x1) << XDMAC_GIE_IE12_Pos)               /**< (XDMAC_GIE) XDMAC Channel 12 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE12                      XDMAC_GIE_IE12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE12_Msk instead */
+#define XDMAC_GIE_IE13_Pos                  13                                             /**< (XDMAC_GIE) XDMAC Channel 13 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE13_Msk                  (_U_(0x1) << XDMAC_GIE_IE13_Pos)               /**< (XDMAC_GIE) XDMAC Channel 13 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE13                      XDMAC_GIE_IE13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE13_Msk instead */
+#define XDMAC_GIE_IE14_Pos                  14                                             /**< (XDMAC_GIE) XDMAC Channel 14 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE14_Msk                  (_U_(0x1) << XDMAC_GIE_IE14_Pos)               /**< (XDMAC_GIE) XDMAC Channel 14 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE14                      XDMAC_GIE_IE14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE14_Msk instead */
+#define XDMAC_GIE_IE15_Pos                  15                                             /**< (XDMAC_GIE) XDMAC Channel 15 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE15_Msk                  (_U_(0x1) << XDMAC_GIE_IE15_Pos)               /**< (XDMAC_GIE) XDMAC Channel 15 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE15                      XDMAC_GIE_IE15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE15_Msk instead */
+#define XDMAC_GIE_IE16_Pos                  16                                             /**< (XDMAC_GIE) XDMAC Channel 16 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE16_Msk                  (_U_(0x1) << XDMAC_GIE_IE16_Pos)               /**< (XDMAC_GIE) XDMAC Channel 16 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE16                      XDMAC_GIE_IE16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE16_Msk instead */
+#define XDMAC_GIE_IE17_Pos                  17                                             /**< (XDMAC_GIE) XDMAC Channel 17 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE17_Msk                  (_U_(0x1) << XDMAC_GIE_IE17_Pos)               /**< (XDMAC_GIE) XDMAC Channel 17 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE17                      XDMAC_GIE_IE17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE17_Msk instead */
+#define XDMAC_GIE_IE18_Pos                  18                                             /**< (XDMAC_GIE) XDMAC Channel 18 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE18_Msk                  (_U_(0x1) << XDMAC_GIE_IE18_Pos)               /**< (XDMAC_GIE) XDMAC Channel 18 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE18                      XDMAC_GIE_IE18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE18_Msk instead */
+#define XDMAC_GIE_IE19_Pos                  19                                             /**< (XDMAC_GIE) XDMAC Channel 19 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE19_Msk                  (_U_(0x1) << XDMAC_GIE_IE19_Pos)               /**< (XDMAC_GIE) XDMAC Channel 19 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE19                      XDMAC_GIE_IE19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE19_Msk instead */
+#define XDMAC_GIE_IE20_Pos                  20                                             /**< (XDMAC_GIE) XDMAC Channel 20 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE20_Msk                  (_U_(0x1) << XDMAC_GIE_IE20_Pos)               /**< (XDMAC_GIE) XDMAC Channel 20 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE20                      XDMAC_GIE_IE20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE20_Msk instead */
+#define XDMAC_GIE_IE21_Pos                  21                                             /**< (XDMAC_GIE) XDMAC Channel 21 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE21_Msk                  (_U_(0x1) << XDMAC_GIE_IE21_Pos)               /**< (XDMAC_GIE) XDMAC Channel 21 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE21                      XDMAC_GIE_IE21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE21_Msk instead */
+#define XDMAC_GIE_IE22_Pos                  22                                             /**< (XDMAC_GIE) XDMAC Channel 22 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE22_Msk                  (_U_(0x1) << XDMAC_GIE_IE22_Pos)               /**< (XDMAC_GIE) XDMAC Channel 22 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE22                      XDMAC_GIE_IE22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE22_Msk instead */
+#define XDMAC_GIE_IE23_Pos                  23                                             /**< (XDMAC_GIE) XDMAC Channel 23 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE23_Msk                  (_U_(0x1) << XDMAC_GIE_IE23_Pos)               /**< (XDMAC_GIE) XDMAC Channel 23 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE23                      XDMAC_GIE_IE23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE23_Msk instead */
+#define XDMAC_GIE_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIE) Register MASK  (Use XDMAC_GIE_Msk instead)  */
+#define XDMAC_GIE_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIE) Register Mask  */
+
+#define XDMAC_GIE_IE_Pos                    0                                              /**< (XDMAC_GIE Position) XDMAC Channel 23 Interrupt Enable Bit */
+#define XDMAC_GIE_IE_Msk                    (_U_(0xFFFFFF) << XDMAC_GIE_IE_Pos)            /**< (XDMAC_GIE Mask) IE */
+#define XDMAC_GIE_IE(value)                 (XDMAC_GIE_IE_Msk & ((value) << XDMAC_GIE_IE_Pos))  
+
+/* -------- XDMAC_GID : (XDMAC Offset: 0x10) (/W 32) Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Disable Bit    */
+    uint32_t ID1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Disable Bit    */
+    uint32_t ID2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Disable Bit    */
+    uint32_t ID3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Disable Bit    */
+    uint32_t ID4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Disable Bit    */
+    uint32_t ID5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Disable Bit    */
+    uint32_t ID6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Disable Bit    */
+    uint32_t ID7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Disable Bit    */
+    uint32_t ID8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Disable Bit    */
+    uint32_t ID9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Disable Bit    */
+    uint32_t ID10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Disable Bit   */
+    uint32_t ID11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Disable Bit   */
+    uint32_t ID12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Disable Bit   */
+    uint32_t ID13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Disable Bit   */
+    uint32_t ID14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Disable Bit   */
+    uint32_t ID15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Disable Bit   */
+    uint32_t ID16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Disable Bit   */
+    uint32_t ID17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Disable Bit   */
+    uint32_t ID18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Disable Bit   */
+    uint32_t ID19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Disable Bit   */
+    uint32_t ID20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Disable Bit   */
+    uint32_t ID21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Disable Bit   */
+    uint32_t ID22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Disable Bit   */
+    uint32_t ID23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Disable Bit   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ID:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Disable Bit   */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GID_OFFSET                    (0x10)                                        /**<  (XDMAC_GID) Global Interrupt Disable Register  Offset */
+
+#define XDMAC_GID_ID0_Pos                   0                                              /**< (XDMAC_GID) XDMAC Channel 0 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID0_Msk                   (_U_(0x1) << XDMAC_GID_ID0_Pos)                /**< (XDMAC_GID) XDMAC Channel 0 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID0                       XDMAC_GID_ID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID0_Msk instead */
+#define XDMAC_GID_ID1_Pos                   1                                              /**< (XDMAC_GID) XDMAC Channel 1 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID1_Msk                   (_U_(0x1) << XDMAC_GID_ID1_Pos)                /**< (XDMAC_GID) XDMAC Channel 1 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID1                       XDMAC_GID_ID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID1_Msk instead */
+#define XDMAC_GID_ID2_Pos                   2                                              /**< (XDMAC_GID) XDMAC Channel 2 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID2_Msk                   (_U_(0x1) << XDMAC_GID_ID2_Pos)                /**< (XDMAC_GID) XDMAC Channel 2 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID2                       XDMAC_GID_ID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID2_Msk instead */
+#define XDMAC_GID_ID3_Pos                   3                                              /**< (XDMAC_GID) XDMAC Channel 3 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID3_Msk                   (_U_(0x1) << XDMAC_GID_ID3_Pos)                /**< (XDMAC_GID) XDMAC Channel 3 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID3                       XDMAC_GID_ID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID3_Msk instead */
+#define XDMAC_GID_ID4_Pos                   4                                              /**< (XDMAC_GID) XDMAC Channel 4 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID4_Msk                   (_U_(0x1) << XDMAC_GID_ID4_Pos)                /**< (XDMAC_GID) XDMAC Channel 4 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID4                       XDMAC_GID_ID4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID4_Msk instead */
+#define XDMAC_GID_ID5_Pos                   5                                              /**< (XDMAC_GID) XDMAC Channel 5 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID5_Msk                   (_U_(0x1) << XDMAC_GID_ID5_Pos)                /**< (XDMAC_GID) XDMAC Channel 5 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID5                       XDMAC_GID_ID5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID5_Msk instead */
+#define XDMAC_GID_ID6_Pos                   6                                              /**< (XDMAC_GID) XDMAC Channel 6 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID6_Msk                   (_U_(0x1) << XDMAC_GID_ID6_Pos)                /**< (XDMAC_GID) XDMAC Channel 6 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID6                       XDMAC_GID_ID6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID6_Msk instead */
+#define XDMAC_GID_ID7_Pos                   7                                              /**< (XDMAC_GID) XDMAC Channel 7 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID7_Msk                   (_U_(0x1) << XDMAC_GID_ID7_Pos)                /**< (XDMAC_GID) XDMAC Channel 7 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID7                       XDMAC_GID_ID7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID7_Msk instead */
+#define XDMAC_GID_ID8_Pos                   8                                              /**< (XDMAC_GID) XDMAC Channel 8 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID8_Msk                   (_U_(0x1) << XDMAC_GID_ID8_Pos)                /**< (XDMAC_GID) XDMAC Channel 8 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID8                       XDMAC_GID_ID8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID8_Msk instead */
+#define XDMAC_GID_ID9_Pos                   9                                              /**< (XDMAC_GID) XDMAC Channel 9 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID9_Msk                   (_U_(0x1) << XDMAC_GID_ID9_Pos)                /**< (XDMAC_GID) XDMAC Channel 9 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID9                       XDMAC_GID_ID9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID9_Msk instead */
+#define XDMAC_GID_ID10_Pos                  10                                             /**< (XDMAC_GID) XDMAC Channel 10 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID10_Msk                  (_U_(0x1) << XDMAC_GID_ID10_Pos)               /**< (XDMAC_GID) XDMAC Channel 10 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID10                      XDMAC_GID_ID10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID10_Msk instead */
+#define XDMAC_GID_ID11_Pos                  11                                             /**< (XDMAC_GID) XDMAC Channel 11 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID11_Msk                  (_U_(0x1) << XDMAC_GID_ID11_Pos)               /**< (XDMAC_GID) XDMAC Channel 11 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID11                      XDMAC_GID_ID11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID11_Msk instead */
+#define XDMAC_GID_ID12_Pos                  12                                             /**< (XDMAC_GID) XDMAC Channel 12 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID12_Msk                  (_U_(0x1) << XDMAC_GID_ID12_Pos)               /**< (XDMAC_GID) XDMAC Channel 12 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID12                      XDMAC_GID_ID12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID12_Msk instead */
+#define XDMAC_GID_ID13_Pos                  13                                             /**< (XDMAC_GID) XDMAC Channel 13 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID13_Msk                  (_U_(0x1) << XDMAC_GID_ID13_Pos)               /**< (XDMAC_GID) XDMAC Channel 13 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID13                      XDMAC_GID_ID13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID13_Msk instead */
+#define XDMAC_GID_ID14_Pos                  14                                             /**< (XDMAC_GID) XDMAC Channel 14 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID14_Msk                  (_U_(0x1) << XDMAC_GID_ID14_Pos)               /**< (XDMAC_GID) XDMAC Channel 14 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID14                      XDMAC_GID_ID14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID14_Msk instead */
+#define XDMAC_GID_ID15_Pos                  15                                             /**< (XDMAC_GID) XDMAC Channel 15 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID15_Msk                  (_U_(0x1) << XDMAC_GID_ID15_Pos)               /**< (XDMAC_GID) XDMAC Channel 15 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID15                      XDMAC_GID_ID15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID15_Msk instead */
+#define XDMAC_GID_ID16_Pos                  16                                             /**< (XDMAC_GID) XDMAC Channel 16 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID16_Msk                  (_U_(0x1) << XDMAC_GID_ID16_Pos)               /**< (XDMAC_GID) XDMAC Channel 16 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID16                      XDMAC_GID_ID16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID16_Msk instead */
+#define XDMAC_GID_ID17_Pos                  17                                             /**< (XDMAC_GID) XDMAC Channel 17 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID17_Msk                  (_U_(0x1) << XDMAC_GID_ID17_Pos)               /**< (XDMAC_GID) XDMAC Channel 17 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID17                      XDMAC_GID_ID17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID17_Msk instead */
+#define XDMAC_GID_ID18_Pos                  18                                             /**< (XDMAC_GID) XDMAC Channel 18 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID18_Msk                  (_U_(0x1) << XDMAC_GID_ID18_Pos)               /**< (XDMAC_GID) XDMAC Channel 18 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID18                      XDMAC_GID_ID18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID18_Msk instead */
+#define XDMAC_GID_ID19_Pos                  19                                             /**< (XDMAC_GID) XDMAC Channel 19 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID19_Msk                  (_U_(0x1) << XDMAC_GID_ID19_Pos)               /**< (XDMAC_GID) XDMAC Channel 19 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID19                      XDMAC_GID_ID19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID19_Msk instead */
+#define XDMAC_GID_ID20_Pos                  20                                             /**< (XDMAC_GID) XDMAC Channel 20 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID20_Msk                  (_U_(0x1) << XDMAC_GID_ID20_Pos)               /**< (XDMAC_GID) XDMAC Channel 20 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID20                      XDMAC_GID_ID20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID20_Msk instead */
+#define XDMAC_GID_ID21_Pos                  21                                             /**< (XDMAC_GID) XDMAC Channel 21 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID21_Msk                  (_U_(0x1) << XDMAC_GID_ID21_Pos)               /**< (XDMAC_GID) XDMAC Channel 21 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID21                      XDMAC_GID_ID21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID21_Msk instead */
+#define XDMAC_GID_ID22_Pos                  22                                             /**< (XDMAC_GID) XDMAC Channel 22 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID22_Msk                  (_U_(0x1) << XDMAC_GID_ID22_Pos)               /**< (XDMAC_GID) XDMAC Channel 22 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID22                      XDMAC_GID_ID22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID22_Msk instead */
+#define XDMAC_GID_ID23_Pos                  23                                             /**< (XDMAC_GID) XDMAC Channel 23 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID23_Msk                  (_U_(0x1) << XDMAC_GID_ID23_Pos)               /**< (XDMAC_GID) XDMAC Channel 23 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID23                      XDMAC_GID_ID23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID23_Msk instead */
+#define XDMAC_GID_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GID) Register MASK  (Use XDMAC_GID_Msk instead)  */
+#define XDMAC_GID_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GID) Register Mask  */
+
+#define XDMAC_GID_ID_Pos                    0                                              /**< (XDMAC_GID Position) XDMAC Channel 23 Interrupt Disable Bit */
+#define XDMAC_GID_ID_Msk                    (_U_(0xFFFFFF) << XDMAC_GID_ID_Pos)            /**< (XDMAC_GID Mask) ID */
+#define XDMAC_GID_ID(value)                 (XDMAC_GID_ID_Msk & ((value) << XDMAC_GID_ID_Pos))  
+
+/* -------- XDMAC_GIM : (XDMAC Offset: 0x14) (R/ 32) Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IM0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Mask Bit       */
+    uint32_t IM1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Mask Bit       */
+    uint32_t IM2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Mask Bit       */
+    uint32_t IM3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Mask Bit       */
+    uint32_t IM4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Mask Bit       */
+    uint32_t IM5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Mask Bit       */
+    uint32_t IM6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Mask Bit       */
+    uint32_t IM7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Mask Bit       */
+    uint32_t IM8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Mask Bit       */
+    uint32_t IM9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Mask Bit       */
+    uint32_t IM10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Mask Bit      */
+    uint32_t IM11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Mask Bit      */
+    uint32_t IM12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Mask Bit      */
+    uint32_t IM13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Mask Bit      */
+    uint32_t IM14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Mask Bit      */
+    uint32_t IM15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Mask Bit      */
+    uint32_t IM16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Mask Bit      */
+    uint32_t IM17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Mask Bit      */
+    uint32_t IM18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Mask Bit      */
+    uint32_t IM19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Mask Bit      */
+    uint32_t IM20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Mask Bit      */
+    uint32_t IM21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Mask Bit      */
+    uint32_t IM22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Mask Bit      */
+    uint32_t IM23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Mask Bit      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IM:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Mask Bit      */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIM_OFFSET                    (0x14)                                        /**<  (XDMAC_GIM) Global Interrupt Mask Register  Offset */
+
+#define XDMAC_GIM_IM0_Pos                   0                                              /**< (XDMAC_GIM) XDMAC Channel 0 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM0_Msk                   (_U_(0x1) << XDMAC_GIM_IM0_Pos)                /**< (XDMAC_GIM) XDMAC Channel 0 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM0                       XDMAC_GIM_IM0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM0_Msk instead */
+#define XDMAC_GIM_IM1_Pos                   1                                              /**< (XDMAC_GIM) XDMAC Channel 1 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM1_Msk                   (_U_(0x1) << XDMAC_GIM_IM1_Pos)                /**< (XDMAC_GIM) XDMAC Channel 1 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM1                       XDMAC_GIM_IM1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM1_Msk instead */
+#define XDMAC_GIM_IM2_Pos                   2                                              /**< (XDMAC_GIM) XDMAC Channel 2 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM2_Msk                   (_U_(0x1) << XDMAC_GIM_IM2_Pos)                /**< (XDMAC_GIM) XDMAC Channel 2 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM2                       XDMAC_GIM_IM2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM2_Msk instead */
+#define XDMAC_GIM_IM3_Pos                   3                                              /**< (XDMAC_GIM) XDMAC Channel 3 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM3_Msk                   (_U_(0x1) << XDMAC_GIM_IM3_Pos)                /**< (XDMAC_GIM) XDMAC Channel 3 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM3                       XDMAC_GIM_IM3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM3_Msk instead */
+#define XDMAC_GIM_IM4_Pos                   4                                              /**< (XDMAC_GIM) XDMAC Channel 4 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM4_Msk                   (_U_(0x1) << XDMAC_GIM_IM4_Pos)                /**< (XDMAC_GIM) XDMAC Channel 4 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM4                       XDMAC_GIM_IM4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM4_Msk instead */
+#define XDMAC_GIM_IM5_Pos                   5                                              /**< (XDMAC_GIM) XDMAC Channel 5 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM5_Msk                   (_U_(0x1) << XDMAC_GIM_IM5_Pos)                /**< (XDMAC_GIM) XDMAC Channel 5 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM5                       XDMAC_GIM_IM5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM5_Msk instead */
+#define XDMAC_GIM_IM6_Pos                   6                                              /**< (XDMAC_GIM) XDMAC Channel 6 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM6_Msk                   (_U_(0x1) << XDMAC_GIM_IM6_Pos)                /**< (XDMAC_GIM) XDMAC Channel 6 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM6                       XDMAC_GIM_IM6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM6_Msk instead */
+#define XDMAC_GIM_IM7_Pos                   7                                              /**< (XDMAC_GIM) XDMAC Channel 7 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM7_Msk                   (_U_(0x1) << XDMAC_GIM_IM7_Pos)                /**< (XDMAC_GIM) XDMAC Channel 7 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM7                       XDMAC_GIM_IM7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM7_Msk instead */
+#define XDMAC_GIM_IM8_Pos                   8                                              /**< (XDMAC_GIM) XDMAC Channel 8 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM8_Msk                   (_U_(0x1) << XDMAC_GIM_IM8_Pos)                /**< (XDMAC_GIM) XDMAC Channel 8 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM8                       XDMAC_GIM_IM8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM8_Msk instead */
+#define XDMAC_GIM_IM9_Pos                   9                                              /**< (XDMAC_GIM) XDMAC Channel 9 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM9_Msk                   (_U_(0x1) << XDMAC_GIM_IM9_Pos)                /**< (XDMAC_GIM) XDMAC Channel 9 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM9                       XDMAC_GIM_IM9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM9_Msk instead */
+#define XDMAC_GIM_IM10_Pos                  10                                             /**< (XDMAC_GIM) XDMAC Channel 10 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM10_Msk                  (_U_(0x1) << XDMAC_GIM_IM10_Pos)               /**< (XDMAC_GIM) XDMAC Channel 10 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM10                      XDMAC_GIM_IM10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM10_Msk instead */
+#define XDMAC_GIM_IM11_Pos                  11                                             /**< (XDMAC_GIM) XDMAC Channel 11 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM11_Msk                  (_U_(0x1) << XDMAC_GIM_IM11_Pos)               /**< (XDMAC_GIM) XDMAC Channel 11 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM11                      XDMAC_GIM_IM11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM11_Msk instead */
+#define XDMAC_GIM_IM12_Pos                  12                                             /**< (XDMAC_GIM) XDMAC Channel 12 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM12_Msk                  (_U_(0x1) << XDMAC_GIM_IM12_Pos)               /**< (XDMAC_GIM) XDMAC Channel 12 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM12                      XDMAC_GIM_IM12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM12_Msk instead */
+#define XDMAC_GIM_IM13_Pos                  13                                             /**< (XDMAC_GIM) XDMAC Channel 13 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM13_Msk                  (_U_(0x1) << XDMAC_GIM_IM13_Pos)               /**< (XDMAC_GIM) XDMAC Channel 13 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM13                      XDMAC_GIM_IM13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM13_Msk instead */
+#define XDMAC_GIM_IM14_Pos                  14                                             /**< (XDMAC_GIM) XDMAC Channel 14 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM14_Msk                  (_U_(0x1) << XDMAC_GIM_IM14_Pos)               /**< (XDMAC_GIM) XDMAC Channel 14 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM14                      XDMAC_GIM_IM14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM14_Msk instead */
+#define XDMAC_GIM_IM15_Pos                  15                                             /**< (XDMAC_GIM) XDMAC Channel 15 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM15_Msk                  (_U_(0x1) << XDMAC_GIM_IM15_Pos)               /**< (XDMAC_GIM) XDMAC Channel 15 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM15                      XDMAC_GIM_IM15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM15_Msk instead */
+#define XDMAC_GIM_IM16_Pos                  16                                             /**< (XDMAC_GIM) XDMAC Channel 16 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM16_Msk                  (_U_(0x1) << XDMAC_GIM_IM16_Pos)               /**< (XDMAC_GIM) XDMAC Channel 16 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM16                      XDMAC_GIM_IM16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM16_Msk instead */
+#define XDMAC_GIM_IM17_Pos                  17                                             /**< (XDMAC_GIM) XDMAC Channel 17 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM17_Msk                  (_U_(0x1) << XDMAC_GIM_IM17_Pos)               /**< (XDMAC_GIM) XDMAC Channel 17 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM17                      XDMAC_GIM_IM17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM17_Msk instead */
+#define XDMAC_GIM_IM18_Pos                  18                                             /**< (XDMAC_GIM) XDMAC Channel 18 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM18_Msk                  (_U_(0x1) << XDMAC_GIM_IM18_Pos)               /**< (XDMAC_GIM) XDMAC Channel 18 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM18                      XDMAC_GIM_IM18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM18_Msk instead */
+#define XDMAC_GIM_IM19_Pos                  19                                             /**< (XDMAC_GIM) XDMAC Channel 19 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM19_Msk                  (_U_(0x1) << XDMAC_GIM_IM19_Pos)               /**< (XDMAC_GIM) XDMAC Channel 19 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM19                      XDMAC_GIM_IM19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM19_Msk instead */
+#define XDMAC_GIM_IM20_Pos                  20                                             /**< (XDMAC_GIM) XDMAC Channel 20 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM20_Msk                  (_U_(0x1) << XDMAC_GIM_IM20_Pos)               /**< (XDMAC_GIM) XDMAC Channel 20 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM20                      XDMAC_GIM_IM20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM20_Msk instead */
+#define XDMAC_GIM_IM21_Pos                  21                                             /**< (XDMAC_GIM) XDMAC Channel 21 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM21_Msk                  (_U_(0x1) << XDMAC_GIM_IM21_Pos)               /**< (XDMAC_GIM) XDMAC Channel 21 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM21                      XDMAC_GIM_IM21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM21_Msk instead */
+#define XDMAC_GIM_IM22_Pos                  22                                             /**< (XDMAC_GIM) XDMAC Channel 22 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM22_Msk                  (_U_(0x1) << XDMAC_GIM_IM22_Pos)               /**< (XDMAC_GIM) XDMAC Channel 22 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM22                      XDMAC_GIM_IM22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM22_Msk instead */
+#define XDMAC_GIM_IM23_Pos                  23                                             /**< (XDMAC_GIM) XDMAC Channel 23 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM23_Msk                  (_U_(0x1) << XDMAC_GIM_IM23_Pos)               /**< (XDMAC_GIM) XDMAC Channel 23 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM23                      XDMAC_GIM_IM23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM23_Msk instead */
+#define XDMAC_GIM_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIM) Register MASK  (Use XDMAC_GIM_Msk instead)  */
+#define XDMAC_GIM_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIM) Register Mask  */
+
+#define XDMAC_GIM_IM_Pos                    0                                              /**< (XDMAC_GIM Position) XDMAC Channel 23 Interrupt Mask Bit */
+#define XDMAC_GIM_IM_Msk                    (_U_(0xFFFFFF) << XDMAC_GIM_IM_Pos)            /**< (XDMAC_GIM Mask) IM */
+#define XDMAC_GIM_IM(value)                 (XDMAC_GIM_IM_Msk & ((value) << XDMAC_GIM_IM_Pos))  
+
+/* -------- XDMAC_GIS : (XDMAC Offset: 0x18) (R/ 32) Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Status Bit     */
+    uint32_t IS1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Status Bit     */
+    uint32_t IS2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Status Bit     */
+    uint32_t IS3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Status Bit     */
+    uint32_t IS4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Status Bit     */
+    uint32_t IS5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Status Bit     */
+    uint32_t IS6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Status Bit     */
+    uint32_t IS7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Status Bit     */
+    uint32_t IS8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Status Bit     */
+    uint32_t IS9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Status Bit     */
+    uint32_t IS10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Status Bit    */
+    uint32_t IS11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Status Bit    */
+    uint32_t IS12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Status Bit    */
+    uint32_t IS13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Status Bit    */
+    uint32_t IS14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Status Bit    */
+    uint32_t IS15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Status Bit    */
+    uint32_t IS16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Status Bit    */
+    uint32_t IS17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Status Bit    */
+    uint32_t IS18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Status Bit    */
+    uint32_t IS19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Status Bit    */
+    uint32_t IS20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Status Bit    */
+    uint32_t IS21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Status Bit    */
+    uint32_t IS22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Status Bit    */
+    uint32_t IS23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Status Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IS:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Status Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIS_OFFSET                    (0x18)                                        /**<  (XDMAC_GIS) Global Interrupt Status Register  Offset */
+
+#define XDMAC_GIS_IS0_Pos                   0                                              /**< (XDMAC_GIS) XDMAC Channel 0 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS0_Msk                   (_U_(0x1) << XDMAC_GIS_IS0_Pos)                /**< (XDMAC_GIS) XDMAC Channel 0 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS0                       XDMAC_GIS_IS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS0_Msk instead */
+#define XDMAC_GIS_IS1_Pos                   1                                              /**< (XDMAC_GIS) XDMAC Channel 1 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS1_Msk                   (_U_(0x1) << XDMAC_GIS_IS1_Pos)                /**< (XDMAC_GIS) XDMAC Channel 1 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS1                       XDMAC_GIS_IS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS1_Msk instead */
+#define XDMAC_GIS_IS2_Pos                   2                                              /**< (XDMAC_GIS) XDMAC Channel 2 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS2_Msk                   (_U_(0x1) << XDMAC_GIS_IS2_Pos)                /**< (XDMAC_GIS) XDMAC Channel 2 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS2                       XDMAC_GIS_IS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS2_Msk instead */
+#define XDMAC_GIS_IS3_Pos                   3                                              /**< (XDMAC_GIS) XDMAC Channel 3 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS3_Msk                   (_U_(0x1) << XDMAC_GIS_IS3_Pos)                /**< (XDMAC_GIS) XDMAC Channel 3 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS3                       XDMAC_GIS_IS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS3_Msk instead */
+#define XDMAC_GIS_IS4_Pos                   4                                              /**< (XDMAC_GIS) XDMAC Channel 4 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS4_Msk                   (_U_(0x1) << XDMAC_GIS_IS4_Pos)                /**< (XDMAC_GIS) XDMAC Channel 4 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS4                       XDMAC_GIS_IS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS4_Msk instead */
+#define XDMAC_GIS_IS5_Pos                   5                                              /**< (XDMAC_GIS) XDMAC Channel 5 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS5_Msk                   (_U_(0x1) << XDMAC_GIS_IS5_Pos)                /**< (XDMAC_GIS) XDMAC Channel 5 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS5                       XDMAC_GIS_IS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS5_Msk instead */
+#define XDMAC_GIS_IS6_Pos                   6                                              /**< (XDMAC_GIS) XDMAC Channel 6 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS6_Msk                   (_U_(0x1) << XDMAC_GIS_IS6_Pos)                /**< (XDMAC_GIS) XDMAC Channel 6 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS6                       XDMAC_GIS_IS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS6_Msk instead */
+#define XDMAC_GIS_IS7_Pos                   7                                              /**< (XDMAC_GIS) XDMAC Channel 7 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS7_Msk                   (_U_(0x1) << XDMAC_GIS_IS7_Pos)                /**< (XDMAC_GIS) XDMAC Channel 7 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS7                       XDMAC_GIS_IS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS7_Msk instead */
+#define XDMAC_GIS_IS8_Pos                   8                                              /**< (XDMAC_GIS) XDMAC Channel 8 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS8_Msk                   (_U_(0x1) << XDMAC_GIS_IS8_Pos)                /**< (XDMAC_GIS) XDMAC Channel 8 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS8                       XDMAC_GIS_IS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS8_Msk instead */
+#define XDMAC_GIS_IS9_Pos                   9                                              /**< (XDMAC_GIS) XDMAC Channel 9 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS9_Msk                   (_U_(0x1) << XDMAC_GIS_IS9_Pos)                /**< (XDMAC_GIS) XDMAC Channel 9 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS9                       XDMAC_GIS_IS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS9_Msk instead */
+#define XDMAC_GIS_IS10_Pos                  10                                             /**< (XDMAC_GIS) XDMAC Channel 10 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS10_Msk                  (_U_(0x1) << XDMAC_GIS_IS10_Pos)               /**< (XDMAC_GIS) XDMAC Channel 10 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS10                      XDMAC_GIS_IS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS10_Msk instead */
+#define XDMAC_GIS_IS11_Pos                  11                                             /**< (XDMAC_GIS) XDMAC Channel 11 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS11_Msk                  (_U_(0x1) << XDMAC_GIS_IS11_Pos)               /**< (XDMAC_GIS) XDMAC Channel 11 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS11                      XDMAC_GIS_IS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS11_Msk instead */
+#define XDMAC_GIS_IS12_Pos                  12                                             /**< (XDMAC_GIS) XDMAC Channel 12 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS12_Msk                  (_U_(0x1) << XDMAC_GIS_IS12_Pos)               /**< (XDMAC_GIS) XDMAC Channel 12 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS12                      XDMAC_GIS_IS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS12_Msk instead */
+#define XDMAC_GIS_IS13_Pos                  13                                             /**< (XDMAC_GIS) XDMAC Channel 13 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS13_Msk                  (_U_(0x1) << XDMAC_GIS_IS13_Pos)               /**< (XDMAC_GIS) XDMAC Channel 13 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS13                      XDMAC_GIS_IS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS13_Msk instead */
+#define XDMAC_GIS_IS14_Pos                  14                                             /**< (XDMAC_GIS) XDMAC Channel 14 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS14_Msk                  (_U_(0x1) << XDMAC_GIS_IS14_Pos)               /**< (XDMAC_GIS) XDMAC Channel 14 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS14                      XDMAC_GIS_IS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS14_Msk instead */
+#define XDMAC_GIS_IS15_Pos                  15                                             /**< (XDMAC_GIS) XDMAC Channel 15 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS15_Msk                  (_U_(0x1) << XDMAC_GIS_IS15_Pos)               /**< (XDMAC_GIS) XDMAC Channel 15 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS15                      XDMAC_GIS_IS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS15_Msk instead */
+#define XDMAC_GIS_IS16_Pos                  16                                             /**< (XDMAC_GIS) XDMAC Channel 16 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS16_Msk                  (_U_(0x1) << XDMAC_GIS_IS16_Pos)               /**< (XDMAC_GIS) XDMAC Channel 16 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS16                      XDMAC_GIS_IS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS16_Msk instead */
+#define XDMAC_GIS_IS17_Pos                  17                                             /**< (XDMAC_GIS) XDMAC Channel 17 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS17_Msk                  (_U_(0x1) << XDMAC_GIS_IS17_Pos)               /**< (XDMAC_GIS) XDMAC Channel 17 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS17                      XDMAC_GIS_IS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS17_Msk instead */
+#define XDMAC_GIS_IS18_Pos                  18                                             /**< (XDMAC_GIS) XDMAC Channel 18 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS18_Msk                  (_U_(0x1) << XDMAC_GIS_IS18_Pos)               /**< (XDMAC_GIS) XDMAC Channel 18 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS18                      XDMAC_GIS_IS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS18_Msk instead */
+#define XDMAC_GIS_IS19_Pos                  19                                             /**< (XDMAC_GIS) XDMAC Channel 19 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS19_Msk                  (_U_(0x1) << XDMAC_GIS_IS19_Pos)               /**< (XDMAC_GIS) XDMAC Channel 19 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS19                      XDMAC_GIS_IS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS19_Msk instead */
+#define XDMAC_GIS_IS20_Pos                  20                                             /**< (XDMAC_GIS) XDMAC Channel 20 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS20_Msk                  (_U_(0x1) << XDMAC_GIS_IS20_Pos)               /**< (XDMAC_GIS) XDMAC Channel 20 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS20                      XDMAC_GIS_IS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS20_Msk instead */
+#define XDMAC_GIS_IS21_Pos                  21                                             /**< (XDMAC_GIS) XDMAC Channel 21 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS21_Msk                  (_U_(0x1) << XDMAC_GIS_IS21_Pos)               /**< (XDMAC_GIS) XDMAC Channel 21 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS21                      XDMAC_GIS_IS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS21_Msk instead */
+#define XDMAC_GIS_IS22_Pos                  22                                             /**< (XDMAC_GIS) XDMAC Channel 22 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS22_Msk                  (_U_(0x1) << XDMAC_GIS_IS22_Pos)               /**< (XDMAC_GIS) XDMAC Channel 22 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS22                      XDMAC_GIS_IS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS22_Msk instead */
+#define XDMAC_GIS_IS23_Pos                  23                                             /**< (XDMAC_GIS) XDMAC Channel 23 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS23_Msk                  (_U_(0x1) << XDMAC_GIS_IS23_Pos)               /**< (XDMAC_GIS) XDMAC Channel 23 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS23                      XDMAC_GIS_IS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS23_Msk instead */
+#define XDMAC_GIS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIS) Register MASK  (Use XDMAC_GIS_Msk instead)  */
+#define XDMAC_GIS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIS) Register Mask  */
+
+#define XDMAC_GIS_IS_Pos                    0                                              /**< (XDMAC_GIS Position) XDMAC Channel 23 Interrupt Status Bit */
+#define XDMAC_GIS_IS_Msk                    (_U_(0xFFFFFF) << XDMAC_GIS_IS_Pos)            /**< (XDMAC_GIS Mask) IS */
+#define XDMAC_GIS_IS(value)                 (XDMAC_GIS_IS_Msk & ((value) << XDMAC_GIS_IS_Pos))  
+
+/* -------- XDMAC_GE : (XDMAC Offset: 0x1c) (/W 32) Global Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EN0:1;                     /**< bit:      0  XDMAC Channel 0 Enable Bit               */
+    uint32_t EN1:1;                     /**< bit:      1  XDMAC Channel 1 Enable Bit               */
+    uint32_t EN2:1;                     /**< bit:      2  XDMAC Channel 2 Enable Bit               */
+    uint32_t EN3:1;                     /**< bit:      3  XDMAC Channel 3 Enable Bit               */
+    uint32_t EN4:1;                     /**< bit:      4  XDMAC Channel 4 Enable Bit               */
+    uint32_t EN5:1;                     /**< bit:      5  XDMAC Channel 5 Enable Bit               */
+    uint32_t EN6:1;                     /**< bit:      6  XDMAC Channel 6 Enable Bit               */
+    uint32_t EN7:1;                     /**< bit:      7  XDMAC Channel 7 Enable Bit               */
+    uint32_t EN8:1;                     /**< bit:      8  XDMAC Channel 8 Enable Bit               */
+    uint32_t EN9:1;                     /**< bit:      9  XDMAC Channel 9 Enable Bit               */
+    uint32_t EN10:1;                    /**< bit:     10  XDMAC Channel 10 Enable Bit              */
+    uint32_t EN11:1;                    /**< bit:     11  XDMAC Channel 11 Enable Bit              */
+    uint32_t EN12:1;                    /**< bit:     12  XDMAC Channel 12 Enable Bit              */
+    uint32_t EN13:1;                    /**< bit:     13  XDMAC Channel 13 Enable Bit              */
+    uint32_t EN14:1;                    /**< bit:     14  XDMAC Channel 14 Enable Bit              */
+    uint32_t EN15:1;                    /**< bit:     15  XDMAC Channel 15 Enable Bit              */
+    uint32_t EN16:1;                    /**< bit:     16  XDMAC Channel 16 Enable Bit              */
+    uint32_t EN17:1;                    /**< bit:     17  XDMAC Channel 17 Enable Bit              */
+    uint32_t EN18:1;                    /**< bit:     18  XDMAC Channel 18 Enable Bit              */
+    uint32_t EN19:1;                    /**< bit:     19  XDMAC Channel 19 Enable Bit              */
+    uint32_t EN20:1;                    /**< bit:     20  XDMAC Channel 20 Enable Bit              */
+    uint32_t EN21:1;                    /**< bit:     21  XDMAC Channel 21 Enable Bit              */
+    uint32_t EN22:1;                    /**< bit:     22  XDMAC Channel 22 Enable Bit              */
+    uint32_t EN23:1;                    /**< bit:     23  XDMAC Channel 23 Enable Bit              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EN:24;                     /**< bit:  0..23  XDMAC Channel 23 Enable Bit              */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GE_OFFSET                     (0x1C)                                        /**<  (XDMAC_GE) Global Channel Enable Register  Offset */
+
+#define XDMAC_GE_EN0_Pos                    0                                              /**< (XDMAC_GE) XDMAC Channel 0 Enable Bit Position */
+#define XDMAC_GE_EN0_Msk                    (_U_(0x1) << XDMAC_GE_EN0_Pos)                 /**< (XDMAC_GE) XDMAC Channel 0 Enable Bit Mask */
+#define XDMAC_GE_EN0                        XDMAC_GE_EN0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN0_Msk instead */
+#define XDMAC_GE_EN1_Pos                    1                                              /**< (XDMAC_GE) XDMAC Channel 1 Enable Bit Position */
+#define XDMAC_GE_EN1_Msk                    (_U_(0x1) << XDMAC_GE_EN1_Pos)                 /**< (XDMAC_GE) XDMAC Channel 1 Enable Bit Mask */
+#define XDMAC_GE_EN1                        XDMAC_GE_EN1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN1_Msk instead */
+#define XDMAC_GE_EN2_Pos                    2                                              /**< (XDMAC_GE) XDMAC Channel 2 Enable Bit Position */
+#define XDMAC_GE_EN2_Msk                    (_U_(0x1) << XDMAC_GE_EN2_Pos)                 /**< (XDMAC_GE) XDMAC Channel 2 Enable Bit Mask */
+#define XDMAC_GE_EN2                        XDMAC_GE_EN2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN2_Msk instead */
+#define XDMAC_GE_EN3_Pos                    3                                              /**< (XDMAC_GE) XDMAC Channel 3 Enable Bit Position */
+#define XDMAC_GE_EN3_Msk                    (_U_(0x1) << XDMAC_GE_EN3_Pos)                 /**< (XDMAC_GE) XDMAC Channel 3 Enable Bit Mask */
+#define XDMAC_GE_EN3                        XDMAC_GE_EN3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN3_Msk instead */
+#define XDMAC_GE_EN4_Pos                    4                                              /**< (XDMAC_GE) XDMAC Channel 4 Enable Bit Position */
+#define XDMAC_GE_EN4_Msk                    (_U_(0x1) << XDMAC_GE_EN4_Pos)                 /**< (XDMAC_GE) XDMAC Channel 4 Enable Bit Mask */
+#define XDMAC_GE_EN4                        XDMAC_GE_EN4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN4_Msk instead */
+#define XDMAC_GE_EN5_Pos                    5                                              /**< (XDMAC_GE) XDMAC Channel 5 Enable Bit Position */
+#define XDMAC_GE_EN5_Msk                    (_U_(0x1) << XDMAC_GE_EN5_Pos)                 /**< (XDMAC_GE) XDMAC Channel 5 Enable Bit Mask */
+#define XDMAC_GE_EN5                        XDMAC_GE_EN5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN5_Msk instead */
+#define XDMAC_GE_EN6_Pos                    6                                              /**< (XDMAC_GE) XDMAC Channel 6 Enable Bit Position */
+#define XDMAC_GE_EN6_Msk                    (_U_(0x1) << XDMAC_GE_EN6_Pos)                 /**< (XDMAC_GE) XDMAC Channel 6 Enable Bit Mask */
+#define XDMAC_GE_EN6                        XDMAC_GE_EN6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN6_Msk instead */
+#define XDMAC_GE_EN7_Pos                    7                                              /**< (XDMAC_GE) XDMAC Channel 7 Enable Bit Position */
+#define XDMAC_GE_EN7_Msk                    (_U_(0x1) << XDMAC_GE_EN7_Pos)                 /**< (XDMAC_GE) XDMAC Channel 7 Enable Bit Mask */
+#define XDMAC_GE_EN7                        XDMAC_GE_EN7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN7_Msk instead */
+#define XDMAC_GE_EN8_Pos                    8                                              /**< (XDMAC_GE) XDMAC Channel 8 Enable Bit Position */
+#define XDMAC_GE_EN8_Msk                    (_U_(0x1) << XDMAC_GE_EN8_Pos)                 /**< (XDMAC_GE) XDMAC Channel 8 Enable Bit Mask */
+#define XDMAC_GE_EN8                        XDMAC_GE_EN8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN8_Msk instead */
+#define XDMAC_GE_EN9_Pos                    9                                              /**< (XDMAC_GE) XDMAC Channel 9 Enable Bit Position */
+#define XDMAC_GE_EN9_Msk                    (_U_(0x1) << XDMAC_GE_EN9_Pos)                 /**< (XDMAC_GE) XDMAC Channel 9 Enable Bit Mask */
+#define XDMAC_GE_EN9                        XDMAC_GE_EN9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN9_Msk instead */
+#define XDMAC_GE_EN10_Pos                   10                                             /**< (XDMAC_GE) XDMAC Channel 10 Enable Bit Position */
+#define XDMAC_GE_EN10_Msk                   (_U_(0x1) << XDMAC_GE_EN10_Pos)                /**< (XDMAC_GE) XDMAC Channel 10 Enable Bit Mask */
+#define XDMAC_GE_EN10                       XDMAC_GE_EN10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN10_Msk instead */
+#define XDMAC_GE_EN11_Pos                   11                                             /**< (XDMAC_GE) XDMAC Channel 11 Enable Bit Position */
+#define XDMAC_GE_EN11_Msk                   (_U_(0x1) << XDMAC_GE_EN11_Pos)                /**< (XDMAC_GE) XDMAC Channel 11 Enable Bit Mask */
+#define XDMAC_GE_EN11                       XDMAC_GE_EN11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN11_Msk instead */
+#define XDMAC_GE_EN12_Pos                   12                                             /**< (XDMAC_GE) XDMAC Channel 12 Enable Bit Position */
+#define XDMAC_GE_EN12_Msk                   (_U_(0x1) << XDMAC_GE_EN12_Pos)                /**< (XDMAC_GE) XDMAC Channel 12 Enable Bit Mask */
+#define XDMAC_GE_EN12                       XDMAC_GE_EN12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN12_Msk instead */
+#define XDMAC_GE_EN13_Pos                   13                                             /**< (XDMAC_GE) XDMAC Channel 13 Enable Bit Position */
+#define XDMAC_GE_EN13_Msk                   (_U_(0x1) << XDMAC_GE_EN13_Pos)                /**< (XDMAC_GE) XDMAC Channel 13 Enable Bit Mask */
+#define XDMAC_GE_EN13                       XDMAC_GE_EN13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN13_Msk instead */
+#define XDMAC_GE_EN14_Pos                   14                                             /**< (XDMAC_GE) XDMAC Channel 14 Enable Bit Position */
+#define XDMAC_GE_EN14_Msk                   (_U_(0x1) << XDMAC_GE_EN14_Pos)                /**< (XDMAC_GE) XDMAC Channel 14 Enable Bit Mask */
+#define XDMAC_GE_EN14                       XDMAC_GE_EN14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN14_Msk instead */
+#define XDMAC_GE_EN15_Pos                   15                                             /**< (XDMAC_GE) XDMAC Channel 15 Enable Bit Position */
+#define XDMAC_GE_EN15_Msk                   (_U_(0x1) << XDMAC_GE_EN15_Pos)                /**< (XDMAC_GE) XDMAC Channel 15 Enable Bit Mask */
+#define XDMAC_GE_EN15                       XDMAC_GE_EN15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN15_Msk instead */
+#define XDMAC_GE_EN16_Pos                   16                                             /**< (XDMAC_GE) XDMAC Channel 16 Enable Bit Position */
+#define XDMAC_GE_EN16_Msk                   (_U_(0x1) << XDMAC_GE_EN16_Pos)                /**< (XDMAC_GE) XDMAC Channel 16 Enable Bit Mask */
+#define XDMAC_GE_EN16                       XDMAC_GE_EN16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN16_Msk instead */
+#define XDMAC_GE_EN17_Pos                   17                                             /**< (XDMAC_GE) XDMAC Channel 17 Enable Bit Position */
+#define XDMAC_GE_EN17_Msk                   (_U_(0x1) << XDMAC_GE_EN17_Pos)                /**< (XDMAC_GE) XDMAC Channel 17 Enable Bit Mask */
+#define XDMAC_GE_EN17                       XDMAC_GE_EN17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN17_Msk instead */
+#define XDMAC_GE_EN18_Pos                   18                                             /**< (XDMAC_GE) XDMAC Channel 18 Enable Bit Position */
+#define XDMAC_GE_EN18_Msk                   (_U_(0x1) << XDMAC_GE_EN18_Pos)                /**< (XDMAC_GE) XDMAC Channel 18 Enable Bit Mask */
+#define XDMAC_GE_EN18                       XDMAC_GE_EN18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN18_Msk instead */
+#define XDMAC_GE_EN19_Pos                   19                                             /**< (XDMAC_GE) XDMAC Channel 19 Enable Bit Position */
+#define XDMAC_GE_EN19_Msk                   (_U_(0x1) << XDMAC_GE_EN19_Pos)                /**< (XDMAC_GE) XDMAC Channel 19 Enable Bit Mask */
+#define XDMAC_GE_EN19                       XDMAC_GE_EN19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN19_Msk instead */
+#define XDMAC_GE_EN20_Pos                   20                                             /**< (XDMAC_GE) XDMAC Channel 20 Enable Bit Position */
+#define XDMAC_GE_EN20_Msk                   (_U_(0x1) << XDMAC_GE_EN20_Pos)                /**< (XDMAC_GE) XDMAC Channel 20 Enable Bit Mask */
+#define XDMAC_GE_EN20                       XDMAC_GE_EN20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN20_Msk instead */
+#define XDMAC_GE_EN21_Pos                   21                                             /**< (XDMAC_GE) XDMAC Channel 21 Enable Bit Position */
+#define XDMAC_GE_EN21_Msk                   (_U_(0x1) << XDMAC_GE_EN21_Pos)                /**< (XDMAC_GE) XDMAC Channel 21 Enable Bit Mask */
+#define XDMAC_GE_EN21                       XDMAC_GE_EN21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN21_Msk instead */
+#define XDMAC_GE_EN22_Pos                   22                                             /**< (XDMAC_GE) XDMAC Channel 22 Enable Bit Position */
+#define XDMAC_GE_EN22_Msk                   (_U_(0x1) << XDMAC_GE_EN22_Pos)                /**< (XDMAC_GE) XDMAC Channel 22 Enable Bit Mask */
+#define XDMAC_GE_EN22                       XDMAC_GE_EN22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN22_Msk instead */
+#define XDMAC_GE_EN23_Pos                   23                                             /**< (XDMAC_GE) XDMAC Channel 23 Enable Bit Position */
+#define XDMAC_GE_EN23_Msk                   (_U_(0x1) << XDMAC_GE_EN23_Pos)                /**< (XDMAC_GE) XDMAC Channel 23 Enable Bit Mask */
+#define XDMAC_GE_EN23                       XDMAC_GE_EN23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN23_Msk instead */
+#define XDMAC_GE_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GE) Register MASK  (Use XDMAC_GE_Msk instead)  */
+#define XDMAC_GE_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GE) Register Mask  */
+
+#define XDMAC_GE_EN_Pos                     0                                              /**< (XDMAC_GE Position) XDMAC Channel 23 Enable Bit */
+#define XDMAC_GE_EN_Msk                     (_U_(0xFFFFFF) << XDMAC_GE_EN_Pos)             /**< (XDMAC_GE Mask) EN */
+#define XDMAC_GE_EN(value)                  (XDMAC_GE_EN_Msk & ((value) << XDMAC_GE_EN_Pos))  
+
+/* -------- XDMAC_GD : (XDMAC Offset: 0x20) (/W 32) Global Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DI0:1;                     /**< bit:      0  XDMAC Channel 0 Disable Bit              */
+    uint32_t DI1:1;                     /**< bit:      1  XDMAC Channel 1 Disable Bit              */
+    uint32_t DI2:1;                     /**< bit:      2  XDMAC Channel 2 Disable Bit              */
+    uint32_t DI3:1;                     /**< bit:      3  XDMAC Channel 3 Disable Bit              */
+    uint32_t DI4:1;                     /**< bit:      4  XDMAC Channel 4 Disable Bit              */
+    uint32_t DI5:1;                     /**< bit:      5  XDMAC Channel 5 Disable Bit              */
+    uint32_t DI6:1;                     /**< bit:      6  XDMAC Channel 6 Disable Bit              */
+    uint32_t DI7:1;                     /**< bit:      7  XDMAC Channel 7 Disable Bit              */
+    uint32_t DI8:1;                     /**< bit:      8  XDMAC Channel 8 Disable Bit              */
+    uint32_t DI9:1;                     /**< bit:      9  XDMAC Channel 9 Disable Bit              */
+    uint32_t DI10:1;                    /**< bit:     10  XDMAC Channel 10 Disable Bit             */
+    uint32_t DI11:1;                    /**< bit:     11  XDMAC Channel 11 Disable Bit             */
+    uint32_t DI12:1;                    /**< bit:     12  XDMAC Channel 12 Disable Bit             */
+    uint32_t DI13:1;                    /**< bit:     13  XDMAC Channel 13 Disable Bit             */
+    uint32_t DI14:1;                    /**< bit:     14  XDMAC Channel 14 Disable Bit             */
+    uint32_t DI15:1;                    /**< bit:     15  XDMAC Channel 15 Disable Bit             */
+    uint32_t DI16:1;                    /**< bit:     16  XDMAC Channel 16 Disable Bit             */
+    uint32_t DI17:1;                    /**< bit:     17  XDMAC Channel 17 Disable Bit             */
+    uint32_t DI18:1;                    /**< bit:     18  XDMAC Channel 18 Disable Bit             */
+    uint32_t DI19:1;                    /**< bit:     19  XDMAC Channel 19 Disable Bit             */
+    uint32_t DI20:1;                    /**< bit:     20  XDMAC Channel 20 Disable Bit             */
+    uint32_t DI21:1;                    /**< bit:     21  XDMAC Channel 21 Disable Bit             */
+    uint32_t DI22:1;                    /**< bit:     22  XDMAC Channel 22 Disable Bit             */
+    uint32_t DI23:1;                    /**< bit:     23  XDMAC Channel 23 Disable Bit             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DI:24;                     /**< bit:  0..23  XDMAC Channel 23 Disable Bit             */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GD_OFFSET                     (0x20)                                        /**<  (XDMAC_GD) Global Channel Disable Register  Offset */
+
+#define XDMAC_GD_DI0_Pos                    0                                              /**< (XDMAC_GD) XDMAC Channel 0 Disable Bit Position */
+#define XDMAC_GD_DI0_Msk                    (_U_(0x1) << XDMAC_GD_DI0_Pos)                 /**< (XDMAC_GD) XDMAC Channel 0 Disable Bit Mask */
+#define XDMAC_GD_DI0                        XDMAC_GD_DI0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI0_Msk instead */
+#define XDMAC_GD_DI1_Pos                    1                                              /**< (XDMAC_GD) XDMAC Channel 1 Disable Bit Position */
+#define XDMAC_GD_DI1_Msk                    (_U_(0x1) << XDMAC_GD_DI1_Pos)                 /**< (XDMAC_GD) XDMAC Channel 1 Disable Bit Mask */
+#define XDMAC_GD_DI1                        XDMAC_GD_DI1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI1_Msk instead */
+#define XDMAC_GD_DI2_Pos                    2                                              /**< (XDMAC_GD) XDMAC Channel 2 Disable Bit Position */
+#define XDMAC_GD_DI2_Msk                    (_U_(0x1) << XDMAC_GD_DI2_Pos)                 /**< (XDMAC_GD) XDMAC Channel 2 Disable Bit Mask */
+#define XDMAC_GD_DI2                        XDMAC_GD_DI2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI2_Msk instead */
+#define XDMAC_GD_DI3_Pos                    3                                              /**< (XDMAC_GD) XDMAC Channel 3 Disable Bit Position */
+#define XDMAC_GD_DI3_Msk                    (_U_(0x1) << XDMAC_GD_DI3_Pos)                 /**< (XDMAC_GD) XDMAC Channel 3 Disable Bit Mask */
+#define XDMAC_GD_DI3                        XDMAC_GD_DI3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI3_Msk instead */
+#define XDMAC_GD_DI4_Pos                    4                                              /**< (XDMAC_GD) XDMAC Channel 4 Disable Bit Position */
+#define XDMAC_GD_DI4_Msk                    (_U_(0x1) << XDMAC_GD_DI4_Pos)                 /**< (XDMAC_GD) XDMAC Channel 4 Disable Bit Mask */
+#define XDMAC_GD_DI4                        XDMAC_GD_DI4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI4_Msk instead */
+#define XDMAC_GD_DI5_Pos                    5                                              /**< (XDMAC_GD) XDMAC Channel 5 Disable Bit Position */
+#define XDMAC_GD_DI5_Msk                    (_U_(0x1) << XDMAC_GD_DI5_Pos)                 /**< (XDMAC_GD) XDMAC Channel 5 Disable Bit Mask */
+#define XDMAC_GD_DI5                        XDMAC_GD_DI5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI5_Msk instead */
+#define XDMAC_GD_DI6_Pos                    6                                              /**< (XDMAC_GD) XDMAC Channel 6 Disable Bit Position */
+#define XDMAC_GD_DI6_Msk                    (_U_(0x1) << XDMAC_GD_DI6_Pos)                 /**< (XDMAC_GD) XDMAC Channel 6 Disable Bit Mask */
+#define XDMAC_GD_DI6                        XDMAC_GD_DI6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI6_Msk instead */
+#define XDMAC_GD_DI7_Pos                    7                                              /**< (XDMAC_GD) XDMAC Channel 7 Disable Bit Position */
+#define XDMAC_GD_DI7_Msk                    (_U_(0x1) << XDMAC_GD_DI7_Pos)                 /**< (XDMAC_GD) XDMAC Channel 7 Disable Bit Mask */
+#define XDMAC_GD_DI7                        XDMAC_GD_DI7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI7_Msk instead */
+#define XDMAC_GD_DI8_Pos                    8                                              /**< (XDMAC_GD) XDMAC Channel 8 Disable Bit Position */
+#define XDMAC_GD_DI8_Msk                    (_U_(0x1) << XDMAC_GD_DI8_Pos)                 /**< (XDMAC_GD) XDMAC Channel 8 Disable Bit Mask */
+#define XDMAC_GD_DI8                        XDMAC_GD_DI8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI8_Msk instead */
+#define XDMAC_GD_DI9_Pos                    9                                              /**< (XDMAC_GD) XDMAC Channel 9 Disable Bit Position */
+#define XDMAC_GD_DI9_Msk                    (_U_(0x1) << XDMAC_GD_DI9_Pos)                 /**< (XDMAC_GD) XDMAC Channel 9 Disable Bit Mask */
+#define XDMAC_GD_DI9                        XDMAC_GD_DI9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI9_Msk instead */
+#define XDMAC_GD_DI10_Pos                   10                                             /**< (XDMAC_GD) XDMAC Channel 10 Disable Bit Position */
+#define XDMAC_GD_DI10_Msk                   (_U_(0x1) << XDMAC_GD_DI10_Pos)                /**< (XDMAC_GD) XDMAC Channel 10 Disable Bit Mask */
+#define XDMAC_GD_DI10                       XDMAC_GD_DI10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI10_Msk instead */
+#define XDMAC_GD_DI11_Pos                   11                                             /**< (XDMAC_GD) XDMAC Channel 11 Disable Bit Position */
+#define XDMAC_GD_DI11_Msk                   (_U_(0x1) << XDMAC_GD_DI11_Pos)                /**< (XDMAC_GD) XDMAC Channel 11 Disable Bit Mask */
+#define XDMAC_GD_DI11                       XDMAC_GD_DI11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI11_Msk instead */
+#define XDMAC_GD_DI12_Pos                   12                                             /**< (XDMAC_GD) XDMAC Channel 12 Disable Bit Position */
+#define XDMAC_GD_DI12_Msk                   (_U_(0x1) << XDMAC_GD_DI12_Pos)                /**< (XDMAC_GD) XDMAC Channel 12 Disable Bit Mask */
+#define XDMAC_GD_DI12                       XDMAC_GD_DI12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI12_Msk instead */
+#define XDMAC_GD_DI13_Pos                   13                                             /**< (XDMAC_GD) XDMAC Channel 13 Disable Bit Position */
+#define XDMAC_GD_DI13_Msk                   (_U_(0x1) << XDMAC_GD_DI13_Pos)                /**< (XDMAC_GD) XDMAC Channel 13 Disable Bit Mask */
+#define XDMAC_GD_DI13                       XDMAC_GD_DI13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI13_Msk instead */
+#define XDMAC_GD_DI14_Pos                   14                                             /**< (XDMAC_GD) XDMAC Channel 14 Disable Bit Position */
+#define XDMAC_GD_DI14_Msk                   (_U_(0x1) << XDMAC_GD_DI14_Pos)                /**< (XDMAC_GD) XDMAC Channel 14 Disable Bit Mask */
+#define XDMAC_GD_DI14                       XDMAC_GD_DI14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI14_Msk instead */
+#define XDMAC_GD_DI15_Pos                   15                                             /**< (XDMAC_GD) XDMAC Channel 15 Disable Bit Position */
+#define XDMAC_GD_DI15_Msk                   (_U_(0x1) << XDMAC_GD_DI15_Pos)                /**< (XDMAC_GD) XDMAC Channel 15 Disable Bit Mask */
+#define XDMAC_GD_DI15                       XDMAC_GD_DI15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI15_Msk instead */
+#define XDMAC_GD_DI16_Pos                   16                                             /**< (XDMAC_GD) XDMAC Channel 16 Disable Bit Position */
+#define XDMAC_GD_DI16_Msk                   (_U_(0x1) << XDMAC_GD_DI16_Pos)                /**< (XDMAC_GD) XDMAC Channel 16 Disable Bit Mask */
+#define XDMAC_GD_DI16                       XDMAC_GD_DI16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI16_Msk instead */
+#define XDMAC_GD_DI17_Pos                   17                                             /**< (XDMAC_GD) XDMAC Channel 17 Disable Bit Position */
+#define XDMAC_GD_DI17_Msk                   (_U_(0x1) << XDMAC_GD_DI17_Pos)                /**< (XDMAC_GD) XDMAC Channel 17 Disable Bit Mask */
+#define XDMAC_GD_DI17                       XDMAC_GD_DI17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI17_Msk instead */
+#define XDMAC_GD_DI18_Pos                   18                                             /**< (XDMAC_GD) XDMAC Channel 18 Disable Bit Position */
+#define XDMAC_GD_DI18_Msk                   (_U_(0x1) << XDMAC_GD_DI18_Pos)                /**< (XDMAC_GD) XDMAC Channel 18 Disable Bit Mask */
+#define XDMAC_GD_DI18                       XDMAC_GD_DI18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI18_Msk instead */
+#define XDMAC_GD_DI19_Pos                   19                                             /**< (XDMAC_GD) XDMAC Channel 19 Disable Bit Position */
+#define XDMAC_GD_DI19_Msk                   (_U_(0x1) << XDMAC_GD_DI19_Pos)                /**< (XDMAC_GD) XDMAC Channel 19 Disable Bit Mask */
+#define XDMAC_GD_DI19                       XDMAC_GD_DI19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI19_Msk instead */
+#define XDMAC_GD_DI20_Pos                   20                                             /**< (XDMAC_GD) XDMAC Channel 20 Disable Bit Position */
+#define XDMAC_GD_DI20_Msk                   (_U_(0x1) << XDMAC_GD_DI20_Pos)                /**< (XDMAC_GD) XDMAC Channel 20 Disable Bit Mask */
+#define XDMAC_GD_DI20                       XDMAC_GD_DI20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI20_Msk instead */
+#define XDMAC_GD_DI21_Pos                   21                                             /**< (XDMAC_GD) XDMAC Channel 21 Disable Bit Position */
+#define XDMAC_GD_DI21_Msk                   (_U_(0x1) << XDMAC_GD_DI21_Pos)                /**< (XDMAC_GD) XDMAC Channel 21 Disable Bit Mask */
+#define XDMAC_GD_DI21                       XDMAC_GD_DI21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI21_Msk instead */
+#define XDMAC_GD_DI22_Pos                   22                                             /**< (XDMAC_GD) XDMAC Channel 22 Disable Bit Position */
+#define XDMAC_GD_DI22_Msk                   (_U_(0x1) << XDMAC_GD_DI22_Pos)                /**< (XDMAC_GD) XDMAC Channel 22 Disable Bit Mask */
+#define XDMAC_GD_DI22                       XDMAC_GD_DI22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI22_Msk instead */
+#define XDMAC_GD_DI23_Pos                   23                                             /**< (XDMAC_GD) XDMAC Channel 23 Disable Bit Position */
+#define XDMAC_GD_DI23_Msk                   (_U_(0x1) << XDMAC_GD_DI23_Pos)                /**< (XDMAC_GD) XDMAC Channel 23 Disable Bit Mask */
+#define XDMAC_GD_DI23                       XDMAC_GD_DI23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI23_Msk instead */
+#define XDMAC_GD_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GD) Register MASK  (Use XDMAC_GD_Msk instead)  */
+#define XDMAC_GD_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GD) Register Mask  */
+
+#define XDMAC_GD_DI_Pos                     0                                              /**< (XDMAC_GD Position) XDMAC Channel 23 Disable Bit */
+#define XDMAC_GD_DI_Msk                     (_U_(0xFFFFFF) << XDMAC_GD_DI_Pos)             /**< (XDMAC_GD Mask) DI */
+#define XDMAC_GD_DI(value)                  (XDMAC_GD_DI_Msk & ((value) << XDMAC_GD_DI_Pos))  
+
+/* -------- XDMAC_GS : (XDMAC Offset: 0x24) (R/ 32) Global Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ST0:1;                     /**< bit:      0  XDMAC Channel 0 Status Bit               */
+    uint32_t ST1:1;                     /**< bit:      1  XDMAC Channel 1 Status Bit               */
+    uint32_t ST2:1;                     /**< bit:      2  XDMAC Channel 2 Status Bit               */
+    uint32_t ST3:1;                     /**< bit:      3  XDMAC Channel 3 Status Bit               */
+    uint32_t ST4:1;                     /**< bit:      4  XDMAC Channel 4 Status Bit               */
+    uint32_t ST5:1;                     /**< bit:      5  XDMAC Channel 5 Status Bit               */
+    uint32_t ST6:1;                     /**< bit:      6  XDMAC Channel 6 Status Bit               */
+    uint32_t ST7:1;                     /**< bit:      7  XDMAC Channel 7 Status Bit               */
+    uint32_t ST8:1;                     /**< bit:      8  XDMAC Channel 8 Status Bit               */
+    uint32_t ST9:1;                     /**< bit:      9  XDMAC Channel 9 Status Bit               */
+    uint32_t ST10:1;                    /**< bit:     10  XDMAC Channel 10 Status Bit              */
+    uint32_t ST11:1;                    /**< bit:     11  XDMAC Channel 11 Status Bit              */
+    uint32_t ST12:1;                    /**< bit:     12  XDMAC Channel 12 Status Bit              */
+    uint32_t ST13:1;                    /**< bit:     13  XDMAC Channel 13 Status Bit              */
+    uint32_t ST14:1;                    /**< bit:     14  XDMAC Channel 14 Status Bit              */
+    uint32_t ST15:1;                    /**< bit:     15  XDMAC Channel 15 Status Bit              */
+    uint32_t ST16:1;                    /**< bit:     16  XDMAC Channel 16 Status Bit              */
+    uint32_t ST17:1;                    /**< bit:     17  XDMAC Channel 17 Status Bit              */
+    uint32_t ST18:1;                    /**< bit:     18  XDMAC Channel 18 Status Bit              */
+    uint32_t ST19:1;                    /**< bit:     19  XDMAC Channel 19 Status Bit              */
+    uint32_t ST20:1;                    /**< bit:     20  XDMAC Channel 20 Status Bit              */
+    uint32_t ST21:1;                    /**< bit:     21  XDMAC Channel 21 Status Bit              */
+    uint32_t ST22:1;                    /**< bit:     22  XDMAC Channel 22 Status Bit              */
+    uint32_t ST23:1;                    /**< bit:     23  XDMAC Channel 23 Status Bit              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ST:24;                     /**< bit:  0..23  XDMAC Channel 23 Status Bit              */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GS_OFFSET                     (0x24)                                        /**<  (XDMAC_GS) Global Channel Status Register  Offset */
+
+#define XDMAC_GS_ST0_Pos                    0                                              /**< (XDMAC_GS) XDMAC Channel 0 Status Bit Position */
+#define XDMAC_GS_ST0_Msk                    (_U_(0x1) << XDMAC_GS_ST0_Pos)                 /**< (XDMAC_GS) XDMAC Channel 0 Status Bit Mask */
+#define XDMAC_GS_ST0                        XDMAC_GS_ST0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST0_Msk instead */
+#define XDMAC_GS_ST1_Pos                    1                                              /**< (XDMAC_GS) XDMAC Channel 1 Status Bit Position */
+#define XDMAC_GS_ST1_Msk                    (_U_(0x1) << XDMAC_GS_ST1_Pos)                 /**< (XDMAC_GS) XDMAC Channel 1 Status Bit Mask */
+#define XDMAC_GS_ST1                        XDMAC_GS_ST1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST1_Msk instead */
+#define XDMAC_GS_ST2_Pos                    2                                              /**< (XDMAC_GS) XDMAC Channel 2 Status Bit Position */
+#define XDMAC_GS_ST2_Msk                    (_U_(0x1) << XDMAC_GS_ST2_Pos)                 /**< (XDMAC_GS) XDMAC Channel 2 Status Bit Mask */
+#define XDMAC_GS_ST2                        XDMAC_GS_ST2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST2_Msk instead */
+#define XDMAC_GS_ST3_Pos                    3                                              /**< (XDMAC_GS) XDMAC Channel 3 Status Bit Position */
+#define XDMAC_GS_ST3_Msk                    (_U_(0x1) << XDMAC_GS_ST3_Pos)                 /**< (XDMAC_GS) XDMAC Channel 3 Status Bit Mask */
+#define XDMAC_GS_ST3                        XDMAC_GS_ST3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST3_Msk instead */
+#define XDMAC_GS_ST4_Pos                    4                                              /**< (XDMAC_GS) XDMAC Channel 4 Status Bit Position */
+#define XDMAC_GS_ST4_Msk                    (_U_(0x1) << XDMAC_GS_ST4_Pos)                 /**< (XDMAC_GS) XDMAC Channel 4 Status Bit Mask */
+#define XDMAC_GS_ST4                        XDMAC_GS_ST4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST4_Msk instead */
+#define XDMAC_GS_ST5_Pos                    5                                              /**< (XDMAC_GS) XDMAC Channel 5 Status Bit Position */
+#define XDMAC_GS_ST5_Msk                    (_U_(0x1) << XDMAC_GS_ST5_Pos)                 /**< (XDMAC_GS) XDMAC Channel 5 Status Bit Mask */
+#define XDMAC_GS_ST5                        XDMAC_GS_ST5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST5_Msk instead */
+#define XDMAC_GS_ST6_Pos                    6                                              /**< (XDMAC_GS) XDMAC Channel 6 Status Bit Position */
+#define XDMAC_GS_ST6_Msk                    (_U_(0x1) << XDMAC_GS_ST6_Pos)                 /**< (XDMAC_GS) XDMAC Channel 6 Status Bit Mask */
+#define XDMAC_GS_ST6                        XDMAC_GS_ST6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST6_Msk instead */
+#define XDMAC_GS_ST7_Pos                    7                                              /**< (XDMAC_GS) XDMAC Channel 7 Status Bit Position */
+#define XDMAC_GS_ST7_Msk                    (_U_(0x1) << XDMAC_GS_ST7_Pos)                 /**< (XDMAC_GS) XDMAC Channel 7 Status Bit Mask */
+#define XDMAC_GS_ST7                        XDMAC_GS_ST7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST7_Msk instead */
+#define XDMAC_GS_ST8_Pos                    8                                              /**< (XDMAC_GS) XDMAC Channel 8 Status Bit Position */
+#define XDMAC_GS_ST8_Msk                    (_U_(0x1) << XDMAC_GS_ST8_Pos)                 /**< (XDMAC_GS) XDMAC Channel 8 Status Bit Mask */
+#define XDMAC_GS_ST8                        XDMAC_GS_ST8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST8_Msk instead */
+#define XDMAC_GS_ST9_Pos                    9                                              /**< (XDMAC_GS) XDMAC Channel 9 Status Bit Position */
+#define XDMAC_GS_ST9_Msk                    (_U_(0x1) << XDMAC_GS_ST9_Pos)                 /**< (XDMAC_GS) XDMAC Channel 9 Status Bit Mask */
+#define XDMAC_GS_ST9                        XDMAC_GS_ST9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST9_Msk instead */
+#define XDMAC_GS_ST10_Pos                   10                                             /**< (XDMAC_GS) XDMAC Channel 10 Status Bit Position */
+#define XDMAC_GS_ST10_Msk                   (_U_(0x1) << XDMAC_GS_ST10_Pos)                /**< (XDMAC_GS) XDMAC Channel 10 Status Bit Mask */
+#define XDMAC_GS_ST10                       XDMAC_GS_ST10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST10_Msk instead */
+#define XDMAC_GS_ST11_Pos                   11                                             /**< (XDMAC_GS) XDMAC Channel 11 Status Bit Position */
+#define XDMAC_GS_ST11_Msk                   (_U_(0x1) << XDMAC_GS_ST11_Pos)                /**< (XDMAC_GS) XDMAC Channel 11 Status Bit Mask */
+#define XDMAC_GS_ST11                       XDMAC_GS_ST11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST11_Msk instead */
+#define XDMAC_GS_ST12_Pos                   12                                             /**< (XDMAC_GS) XDMAC Channel 12 Status Bit Position */
+#define XDMAC_GS_ST12_Msk                   (_U_(0x1) << XDMAC_GS_ST12_Pos)                /**< (XDMAC_GS) XDMAC Channel 12 Status Bit Mask */
+#define XDMAC_GS_ST12                       XDMAC_GS_ST12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST12_Msk instead */
+#define XDMAC_GS_ST13_Pos                   13                                             /**< (XDMAC_GS) XDMAC Channel 13 Status Bit Position */
+#define XDMAC_GS_ST13_Msk                   (_U_(0x1) << XDMAC_GS_ST13_Pos)                /**< (XDMAC_GS) XDMAC Channel 13 Status Bit Mask */
+#define XDMAC_GS_ST13                       XDMAC_GS_ST13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST13_Msk instead */
+#define XDMAC_GS_ST14_Pos                   14                                             /**< (XDMAC_GS) XDMAC Channel 14 Status Bit Position */
+#define XDMAC_GS_ST14_Msk                   (_U_(0x1) << XDMAC_GS_ST14_Pos)                /**< (XDMAC_GS) XDMAC Channel 14 Status Bit Mask */
+#define XDMAC_GS_ST14                       XDMAC_GS_ST14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST14_Msk instead */
+#define XDMAC_GS_ST15_Pos                   15                                             /**< (XDMAC_GS) XDMAC Channel 15 Status Bit Position */
+#define XDMAC_GS_ST15_Msk                   (_U_(0x1) << XDMAC_GS_ST15_Pos)                /**< (XDMAC_GS) XDMAC Channel 15 Status Bit Mask */
+#define XDMAC_GS_ST15                       XDMAC_GS_ST15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST15_Msk instead */
+#define XDMAC_GS_ST16_Pos                   16                                             /**< (XDMAC_GS) XDMAC Channel 16 Status Bit Position */
+#define XDMAC_GS_ST16_Msk                   (_U_(0x1) << XDMAC_GS_ST16_Pos)                /**< (XDMAC_GS) XDMAC Channel 16 Status Bit Mask */
+#define XDMAC_GS_ST16                       XDMAC_GS_ST16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST16_Msk instead */
+#define XDMAC_GS_ST17_Pos                   17                                             /**< (XDMAC_GS) XDMAC Channel 17 Status Bit Position */
+#define XDMAC_GS_ST17_Msk                   (_U_(0x1) << XDMAC_GS_ST17_Pos)                /**< (XDMAC_GS) XDMAC Channel 17 Status Bit Mask */
+#define XDMAC_GS_ST17                       XDMAC_GS_ST17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST17_Msk instead */
+#define XDMAC_GS_ST18_Pos                   18                                             /**< (XDMAC_GS) XDMAC Channel 18 Status Bit Position */
+#define XDMAC_GS_ST18_Msk                   (_U_(0x1) << XDMAC_GS_ST18_Pos)                /**< (XDMAC_GS) XDMAC Channel 18 Status Bit Mask */
+#define XDMAC_GS_ST18                       XDMAC_GS_ST18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST18_Msk instead */
+#define XDMAC_GS_ST19_Pos                   19                                             /**< (XDMAC_GS) XDMAC Channel 19 Status Bit Position */
+#define XDMAC_GS_ST19_Msk                   (_U_(0x1) << XDMAC_GS_ST19_Pos)                /**< (XDMAC_GS) XDMAC Channel 19 Status Bit Mask */
+#define XDMAC_GS_ST19                       XDMAC_GS_ST19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST19_Msk instead */
+#define XDMAC_GS_ST20_Pos                   20                                             /**< (XDMAC_GS) XDMAC Channel 20 Status Bit Position */
+#define XDMAC_GS_ST20_Msk                   (_U_(0x1) << XDMAC_GS_ST20_Pos)                /**< (XDMAC_GS) XDMAC Channel 20 Status Bit Mask */
+#define XDMAC_GS_ST20                       XDMAC_GS_ST20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST20_Msk instead */
+#define XDMAC_GS_ST21_Pos                   21                                             /**< (XDMAC_GS) XDMAC Channel 21 Status Bit Position */
+#define XDMAC_GS_ST21_Msk                   (_U_(0x1) << XDMAC_GS_ST21_Pos)                /**< (XDMAC_GS) XDMAC Channel 21 Status Bit Mask */
+#define XDMAC_GS_ST21                       XDMAC_GS_ST21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST21_Msk instead */
+#define XDMAC_GS_ST22_Pos                   22                                             /**< (XDMAC_GS) XDMAC Channel 22 Status Bit Position */
+#define XDMAC_GS_ST22_Msk                   (_U_(0x1) << XDMAC_GS_ST22_Pos)                /**< (XDMAC_GS) XDMAC Channel 22 Status Bit Mask */
+#define XDMAC_GS_ST22                       XDMAC_GS_ST22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST22_Msk instead */
+#define XDMAC_GS_ST23_Pos                   23                                             /**< (XDMAC_GS) XDMAC Channel 23 Status Bit Position */
+#define XDMAC_GS_ST23_Msk                   (_U_(0x1) << XDMAC_GS_ST23_Pos)                /**< (XDMAC_GS) XDMAC Channel 23 Status Bit Mask */
+#define XDMAC_GS_ST23                       XDMAC_GS_ST23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST23_Msk instead */
+#define XDMAC_GS_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GS) Register MASK  (Use XDMAC_GS_Msk instead)  */
+#define XDMAC_GS_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GS) Register Mask  */
+
+#define XDMAC_GS_ST_Pos                     0                                              /**< (XDMAC_GS Position) XDMAC Channel 23 Status Bit */
+#define XDMAC_GS_ST_Msk                     (_U_(0xFFFFFF) << XDMAC_GS_ST_Pos)             /**< (XDMAC_GS Mask) ST */
+#define XDMAC_GS_ST(value)                  (XDMAC_GS_ST_Msk & ((value) << XDMAC_GS_ST_Pos))  
+
+/* -------- XDMAC_GRS : (XDMAC Offset: 0x28) (R/W 32) Global Channel Read Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RS0:1;                     /**< bit:      0  XDMAC Channel 0 Read Suspend Bit         */
+    uint32_t RS1:1;                     /**< bit:      1  XDMAC Channel 1 Read Suspend Bit         */
+    uint32_t RS2:1;                     /**< bit:      2  XDMAC Channel 2 Read Suspend Bit         */
+    uint32_t RS3:1;                     /**< bit:      3  XDMAC Channel 3 Read Suspend Bit         */
+    uint32_t RS4:1;                     /**< bit:      4  XDMAC Channel 4 Read Suspend Bit         */
+    uint32_t RS5:1;                     /**< bit:      5  XDMAC Channel 5 Read Suspend Bit         */
+    uint32_t RS6:1;                     /**< bit:      6  XDMAC Channel 6 Read Suspend Bit         */
+    uint32_t RS7:1;                     /**< bit:      7  XDMAC Channel 7 Read Suspend Bit         */
+    uint32_t RS8:1;                     /**< bit:      8  XDMAC Channel 8 Read Suspend Bit         */
+    uint32_t RS9:1;                     /**< bit:      9  XDMAC Channel 9 Read Suspend Bit         */
+    uint32_t RS10:1;                    /**< bit:     10  XDMAC Channel 10 Read Suspend Bit        */
+    uint32_t RS11:1;                    /**< bit:     11  XDMAC Channel 11 Read Suspend Bit        */
+    uint32_t RS12:1;                    /**< bit:     12  XDMAC Channel 12 Read Suspend Bit        */
+    uint32_t RS13:1;                    /**< bit:     13  XDMAC Channel 13 Read Suspend Bit        */
+    uint32_t RS14:1;                    /**< bit:     14  XDMAC Channel 14 Read Suspend Bit        */
+    uint32_t RS15:1;                    /**< bit:     15  XDMAC Channel 15 Read Suspend Bit        */
+    uint32_t RS16:1;                    /**< bit:     16  XDMAC Channel 16 Read Suspend Bit        */
+    uint32_t RS17:1;                    /**< bit:     17  XDMAC Channel 17 Read Suspend Bit        */
+    uint32_t RS18:1;                    /**< bit:     18  XDMAC Channel 18 Read Suspend Bit        */
+    uint32_t RS19:1;                    /**< bit:     19  XDMAC Channel 19 Read Suspend Bit        */
+    uint32_t RS20:1;                    /**< bit:     20  XDMAC Channel 20 Read Suspend Bit        */
+    uint32_t RS21:1;                    /**< bit:     21  XDMAC Channel 21 Read Suspend Bit        */
+    uint32_t RS22:1;                    /**< bit:     22  XDMAC Channel 22 Read Suspend Bit        */
+    uint32_t RS23:1;                    /**< bit:     23  XDMAC Channel 23 Read Suspend Bit        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RS:24;                     /**< bit:  0..23  XDMAC Channel 23 Read Suspend Bit        */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRS_OFFSET                    (0x28)                                        /**<  (XDMAC_GRS) Global Channel Read Suspend Register  Offset */
+
+#define XDMAC_GRS_RS0_Pos                   0                                              /**< (XDMAC_GRS) XDMAC Channel 0 Read Suspend Bit Position */
+#define XDMAC_GRS_RS0_Msk                   (_U_(0x1) << XDMAC_GRS_RS0_Pos)                /**< (XDMAC_GRS) XDMAC Channel 0 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS0                       XDMAC_GRS_RS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS0_Msk instead */
+#define XDMAC_GRS_RS1_Pos                   1                                              /**< (XDMAC_GRS) XDMAC Channel 1 Read Suspend Bit Position */
+#define XDMAC_GRS_RS1_Msk                   (_U_(0x1) << XDMAC_GRS_RS1_Pos)                /**< (XDMAC_GRS) XDMAC Channel 1 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS1                       XDMAC_GRS_RS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS1_Msk instead */
+#define XDMAC_GRS_RS2_Pos                   2                                              /**< (XDMAC_GRS) XDMAC Channel 2 Read Suspend Bit Position */
+#define XDMAC_GRS_RS2_Msk                   (_U_(0x1) << XDMAC_GRS_RS2_Pos)                /**< (XDMAC_GRS) XDMAC Channel 2 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS2                       XDMAC_GRS_RS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS2_Msk instead */
+#define XDMAC_GRS_RS3_Pos                   3                                              /**< (XDMAC_GRS) XDMAC Channel 3 Read Suspend Bit Position */
+#define XDMAC_GRS_RS3_Msk                   (_U_(0x1) << XDMAC_GRS_RS3_Pos)                /**< (XDMAC_GRS) XDMAC Channel 3 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS3                       XDMAC_GRS_RS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS3_Msk instead */
+#define XDMAC_GRS_RS4_Pos                   4                                              /**< (XDMAC_GRS) XDMAC Channel 4 Read Suspend Bit Position */
+#define XDMAC_GRS_RS4_Msk                   (_U_(0x1) << XDMAC_GRS_RS4_Pos)                /**< (XDMAC_GRS) XDMAC Channel 4 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS4                       XDMAC_GRS_RS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS4_Msk instead */
+#define XDMAC_GRS_RS5_Pos                   5                                              /**< (XDMAC_GRS) XDMAC Channel 5 Read Suspend Bit Position */
+#define XDMAC_GRS_RS5_Msk                   (_U_(0x1) << XDMAC_GRS_RS5_Pos)                /**< (XDMAC_GRS) XDMAC Channel 5 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS5                       XDMAC_GRS_RS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS5_Msk instead */
+#define XDMAC_GRS_RS6_Pos                   6                                              /**< (XDMAC_GRS) XDMAC Channel 6 Read Suspend Bit Position */
+#define XDMAC_GRS_RS6_Msk                   (_U_(0x1) << XDMAC_GRS_RS6_Pos)                /**< (XDMAC_GRS) XDMAC Channel 6 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS6                       XDMAC_GRS_RS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS6_Msk instead */
+#define XDMAC_GRS_RS7_Pos                   7                                              /**< (XDMAC_GRS) XDMAC Channel 7 Read Suspend Bit Position */
+#define XDMAC_GRS_RS7_Msk                   (_U_(0x1) << XDMAC_GRS_RS7_Pos)                /**< (XDMAC_GRS) XDMAC Channel 7 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS7                       XDMAC_GRS_RS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS7_Msk instead */
+#define XDMAC_GRS_RS8_Pos                   8                                              /**< (XDMAC_GRS) XDMAC Channel 8 Read Suspend Bit Position */
+#define XDMAC_GRS_RS8_Msk                   (_U_(0x1) << XDMAC_GRS_RS8_Pos)                /**< (XDMAC_GRS) XDMAC Channel 8 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS8                       XDMAC_GRS_RS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS8_Msk instead */
+#define XDMAC_GRS_RS9_Pos                   9                                              /**< (XDMAC_GRS) XDMAC Channel 9 Read Suspend Bit Position */
+#define XDMAC_GRS_RS9_Msk                   (_U_(0x1) << XDMAC_GRS_RS9_Pos)                /**< (XDMAC_GRS) XDMAC Channel 9 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS9                       XDMAC_GRS_RS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS9_Msk instead */
+#define XDMAC_GRS_RS10_Pos                  10                                             /**< (XDMAC_GRS) XDMAC Channel 10 Read Suspend Bit Position */
+#define XDMAC_GRS_RS10_Msk                  (_U_(0x1) << XDMAC_GRS_RS10_Pos)               /**< (XDMAC_GRS) XDMAC Channel 10 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS10                      XDMAC_GRS_RS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS10_Msk instead */
+#define XDMAC_GRS_RS11_Pos                  11                                             /**< (XDMAC_GRS) XDMAC Channel 11 Read Suspend Bit Position */
+#define XDMAC_GRS_RS11_Msk                  (_U_(0x1) << XDMAC_GRS_RS11_Pos)               /**< (XDMAC_GRS) XDMAC Channel 11 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS11                      XDMAC_GRS_RS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS11_Msk instead */
+#define XDMAC_GRS_RS12_Pos                  12                                             /**< (XDMAC_GRS) XDMAC Channel 12 Read Suspend Bit Position */
+#define XDMAC_GRS_RS12_Msk                  (_U_(0x1) << XDMAC_GRS_RS12_Pos)               /**< (XDMAC_GRS) XDMAC Channel 12 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS12                      XDMAC_GRS_RS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS12_Msk instead */
+#define XDMAC_GRS_RS13_Pos                  13                                             /**< (XDMAC_GRS) XDMAC Channel 13 Read Suspend Bit Position */
+#define XDMAC_GRS_RS13_Msk                  (_U_(0x1) << XDMAC_GRS_RS13_Pos)               /**< (XDMAC_GRS) XDMAC Channel 13 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS13                      XDMAC_GRS_RS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS13_Msk instead */
+#define XDMAC_GRS_RS14_Pos                  14                                             /**< (XDMAC_GRS) XDMAC Channel 14 Read Suspend Bit Position */
+#define XDMAC_GRS_RS14_Msk                  (_U_(0x1) << XDMAC_GRS_RS14_Pos)               /**< (XDMAC_GRS) XDMAC Channel 14 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS14                      XDMAC_GRS_RS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS14_Msk instead */
+#define XDMAC_GRS_RS15_Pos                  15                                             /**< (XDMAC_GRS) XDMAC Channel 15 Read Suspend Bit Position */
+#define XDMAC_GRS_RS15_Msk                  (_U_(0x1) << XDMAC_GRS_RS15_Pos)               /**< (XDMAC_GRS) XDMAC Channel 15 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS15                      XDMAC_GRS_RS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS15_Msk instead */
+#define XDMAC_GRS_RS16_Pos                  16                                             /**< (XDMAC_GRS) XDMAC Channel 16 Read Suspend Bit Position */
+#define XDMAC_GRS_RS16_Msk                  (_U_(0x1) << XDMAC_GRS_RS16_Pos)               /**< (XDMAC_GRS) XDMAC Channel 16 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS16                      XDMAC_GRS_RS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS16_Msk instead */
+#define XDMAC_GRS_RS17_Pos                  17                                             /**< (XDMAC_GRS) XDMAC Channel 17 Read Suspend Bit Position */
+#define XDMAC_GRS_RS17_Msk                  (_U_(0x1) << XDMAC_GRS_RS17_Pos)               /**< (XDMAC_GRS) XDMAC Channel 17 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS17                      XDMAC_GRS_RS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS17_Msk instead */
+#define XDMAC_GRS_RS18_Pos                  18                                             /**< (XDMAC_GRS) XDMAC Channel 18 Read Suspend Bit Position */
+#define XDMAC_GRS_RS18_Msk                  (_U_(0x1) << XDMAC_GRS_RS18_Pos)               /**< (XDMAC_GRS) XDMAC Channel 18 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS18                      XDMAC_GRS_RS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS18_Msk instead */
+#define XDMAC_GRS_RS19_Pos                  19                                             /**< (XDMAC_GRS) XDMAC Channel 19 Read Suspend Bit Position */
+#define XDMAC_GRS_RS19_Msk                  (_U_(0x1) << XDMAC_GRS_RS19_Pos)               /**< (XDMAC_GRS) XDMAC Channel 19 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS19                      XDMAC_GRS_RS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS19_Msk instead */
+#define XDMAC_GRS_RS20_Pos                  20                                             /**< (XDMAC_GRS) XDMAC Channel 20 Read Suspend Bit Position */
+#define XDMAC_GRS_RS20_Msk                  (_U_(0x1) << XDMAC_GRS_RS20_Pos)               /**< (XDMAC_GRS) XDMAC Channel 20 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS20                      XDMAC_GRS_RS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS20_Msk instead */
+#define XDMAC_GRS_RS21_Pos                  21                                             /**< (XDMAC_GRS) XDMAC Channel 21 Read Suspend Bit Position */
+#define XDMAC_GRS_RS21_Msk                  (_U_(0x1) << XDMAC_GRS_RS21_Pos)               /**< (XDMAC_GRS) XDMAC Channel 21 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS21                      XDMAC_GRS_RS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS21_Msk instead */
+#define XDMAC_GRS_RS22_Pos                  22                                             /**< (XDMAC_GRS) XDMAC Channel 22 Read Suspend Bit Position */
+#define XDMAC_GRS_RS22_Msk                  (_U_(0x1) << XDMAC_GRS_RS22_Pos)               /**< (XDMAC_GRS) XDMAC Channel 22 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS22                      XDMAC_GRS_RS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS22_Msk instead */
+#define XDMAC_GRS_RS23_Pos                  23                                             /**< (XDMAC_GRS) XDMAC Channel 23 Read Suspend Bit Position */
+#define XDMAC_GRS_RS23_Msk                  (_U_(0x1) << XDMAC_GRS_RS23_Pos)               /**< (XDMAC_GRS) XDMAC Channel 23 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS23                      XDMAC_GRS_RS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS23_Msk instead */
+#define XDMAC_GRS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRS) Register MASK  (Use XDMAC_GRS_Msk instead)  */
+#define XDMAC_GRS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GRS) Register Mask  */
+
+#define XDMAC_GRS_RS_Pos                    0                                              /**< (XDMAC_GRS Position) XDMAC Channel 23 Read Suspend Bit */
+#define XDMAC_GRS_RS_Msk                    (_U_(0xFFFFFF) << XDMAC_GRS_RS_Pos)            /**< (XDMAC_GRS Mask) RS */
+#define XDMAC_GRS_RS(value)                 (XDMAC_GRS_RS_Msk & ((value) << XDMAC_GRS_RS_Pos))  
+
+/* -------- XDMAC_GWS : (XDMAC Offset: 0x2c) (R/W 32) Global Channel Write Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WS0:1;                     /**< bit:      0  XDMAC Channel 0 Write Suspend Bit        */
+    uint32_t WS1:1;                     /**< bit:      1  XDMAC Channel 1 Write Suspend Bit        */
+    uint32_t WS2:1;                     /**< bit:      2  XDMAC Channel 2 Write Suspend Bit        */
+    uint32_t WS3:1;                     /**< bit:      3  XDMAC Channel 3 Write Suspend Bit        */
+    uint32_t WS4:1;                     /**< bit:      4  XDMAC Channel 4 Write Suspend Bit        */
+    uint32_t WS5:1;                     /**< bit:      5  XDMAC Channel 5 Write Suspend Bit        */
+    uint32_t WS6:1;                     /**< bit:      6  XDMAC Channel 6 Write Suspend Bit        */
+    uint32_t WS7:1;                     /**< bit:      7  XDMAC Channel 7 Write Suspend Bit        */
+    uint32_t WS8:1;                     /**< bit:      8  XDMAC Channel 8 Write Suspend Bit        */
+    uint32_t WS9:1;                     /**< bit:      9  XDMAC Channel 9 Write Suspend Bit        */
+    uint32_t WS10:1;                    /**< bit:     10  XDMAC Channel 10 Write Suspend Bit       */
+    uint32_t WS11:1;                    /**< bit:     11  XDMAC Channel 11 Write Suspend Bit       */
+    uint32_t WS12:1;                    /**< bit:     12  XDMAC Channel 12 Write Suspend Bit       */
+    uint32_t WS13:1;                    /**< bit:     13  XDMAC Channel 13 Write Suspend Bit       */
+    uint32_t WS14:1;                    /**< bit:     14  XDMAC Channel 14 Write Suspend Bit       */
+    uint32_t WS15:1;                    /**< bit:     15  XDMAC Channel 15 Write Suspend Bit       */
+    uint32_t WS16:1;                    /**< bit:     16  XDMAC Channel 16 Write Suspend Bit       */
+    uint32_t WS17:1;                    /**< bit:     17  XDMAC Channel 17 Write Suspend Bit       */
+    uint32_t WS18:1;                    /**< bit:     18  XDMAC Channel 18 Write Suspend Bit       */
+    uint32_t WS19:1;                    /**< bit:     19  XDMAC Channel 19 Write Suspend Bit       */
+    uint32_t WS20:1;                    /**< bit:     20  XDMAC Channel 20 Write Suspend Bit       */
+    uint32_t WS21:1;                    /**< bit:     21  XDMAC Channel 21 Write Suspend Bit       */
+    uint32_t WS22:1;                    /**< bit:     22  XDMAC Channel 22 Write Suspend Bit       */
+    uint32_t WS23:1;                    /**< bit:     23  XDMAC Channel 23 Write Suspend Bit       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WS:24;                     /**< bit:  0..23  XDMAC Channel 23 Write Suspend Bit       */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GWS_OFFSET                    (0x2C)                                        /**<  (XDMAC_GWS) Global Channel Write Suspend Register  Offset */
+
+#define XDMAC_GWS_WS0_Pos                   0                                              /**< (XDMAC_GWS) XDMAC Channel 0 Write Suspend Bit Position */
+#define XDMAC_GWS_WS0_Msk                   (_U_(0x1) << XDMAC_GWS_WS0_Pos)                /**< (XDMAC_GWS) XDMAC Channel 0 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS0                       XDMAC_GWS_WS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS0_Msk instead */
+#define XDMAC_GWS_WS1_Pos                   1                                              /**< (XDMAC_GWS) XDMAC Channel 1 Write Suspend Bit Position */
+#define XDMAC_GWS_WS1_Msk                   (_U_(0x1) << XDMAC_GWS_WS1_Pos)                /**< (XDMAC_GWS) XDMAC Channel 1 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS1                       XDMAC_GWS_WS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS1_Msk instead */
+#define XDMAC_GWS_WS2_Pos                   2                                              /**< (XDMAC_GWS) XDMAC Channel 2 Write Suspend Bit Position */
+#define XDMAC_GWS_WS2_Msk                   (_U_(0x1) << XDMAC_GWS_WS2_Pos)                /**< (XDMAC_GWS) XDMAC Channel 2 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS2                       XDMAC_GWS_WS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS2_Msk instead */
+#define XDMAC_GWS_WS3_Pos                   3                                              /**< (XDMAC_GWS) XDMAC Channel 3 Write Suspend Bit Position */
+#define XDMAC_GWS_WS3_Msk                   (_U_(0x1) << XDMAC_GWS_WS3_Pos)                /**< (XDMAC_GWS) XDMAC Channel 3 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS3                       XDMAC_GWS_WS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS3_Msk instead */
+#define XDMAC_GWS_WS4_Pos                   4                                              /**< (XDMAC_GWS) XDMAC Channel 4 Write Suspend Bit Position */
+#define XDMAC_GWS_WS4_Msk                   (_U_(0x1) << XDMAC_GWS_WS4_Pos)                /**< (XDMAC_GWS) XDMAC Channel 4 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS4                       XDMAC_GWS_WS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS4_Msk instead */
+#define XDMAC_GWS_WS5_Pos                   5                                              /**< (XDMAC_GWS) XDMAC Channel 5 Write Suspend Bit Position */
+#define XDMAC_GWS_WS5_Msk                   (_U_(0x1) << XDMAC_GWS_WS5_Pos)                /**< (XDMAC_GWS) XDMAC Channel 5 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS5                       XDMAC_GWS_WS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS5_Msk instead */
+#define XDMAC_GWS_WS6_Pos                   6                                              /**< (XDMAC_GWS) XDMAC Channel 6 Write Suspend Bit Position */
+#define XDMAC_GWS_WS6_Msk                   (_U_(0x1) << XDMAC_GWS_WS6_Pos)                /**< (XDMAC_GWS) XDMAC Channel 6 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS6                       XDMAC_GWS_WS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS6_Msk instead */
+#define XDMAC_GWS_WS7_Pos                   7                                              /**< (XDMAC_GWS) XDMAC Channel 7 Write Suspend Bit Position */
+#define XDMAC_GWS_WS7_Msk                   (_U_(0x1) << XDMAC_GWS_WS7_Pos)                /**< (XDMAC_GWS) XDMAC Channel 7 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS7                       XDMAC_GWS_WS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS7_Msk instead */
+#define XDMAC_GWS_WS8_Pos                   8                                              /**< (XDMAC_GWS) XDMAC Channel 8 Write Suspend Bit Position */
+#define XDMAC_GWS_WS8_Msk                   (_U_(0x1) << XDMAC_GWS_WS8_Pos)                /**< (XDMAC_GWS) XDMAC Channel 8 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS8                       XDMAC_GWS_WS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS8_Msk instead */
+#define XDMAC_GWS_WS9_Pos                   9                                              /**< (XDMAC_GWS) XDMAC Channel 9 Write Suspend Bit Position */
+#define XDMAC_GWS_WS9_Msk                   (_U_(0x1) << XDMAC_GWS_WS9_Pos)                /**< (XDMAC_GWS) XDMAC Channel 9 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS9                       XDMAC_GWS_WS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS9_Msk instead */
+#define XDMAC_GWS_WS10_Pos                  10                                             /**< (XDMAC_GWS) XDMAC Channel 10 Write Suspend Bit Position */
+#define XDMAC_GWS_WS10_Msk                  (_U_(0x1) << XDMAC_GWS_WS10_Pos)               /**< (XDMAC_GWS) XDMAC Channel 10 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS10                      XDMAC_GWS_WS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS10_Msk instead */
+#define XDMAC_GWS_WS11_Pos                  11                                             /**< (XDMAC_GWS) XDMAC Channel 11 Write Suspend Bit Position */
+#define XDMAC_GWS_WS11_Msk                  (_U_(0x1) << XDMAC_GWS_WS11_Pos)               /**< (XDMAC_GWS) XDMAC Channel 11 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS11                      XDMAC_GWS_WS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS11_Msk instead */
+#define XDMAC_GWS_WS12_Pos                  12                                             /**< (XDMAC_GWS) XDMAC Channel 12 Write Suspend Bit Position */
+#define XDMAC_GWS_WS12_Msk                  (_U_(0x1) << XDMAC_GWS_WS12_Pos)               /**< (XDMAC_GWS) XDMAC Channel 12 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS12                      XDMAC_GWS_WS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS12_Msk instead */
+#define XDMAC_GWS_WS13_Pos                  13                                             /**< (XDMAC_GWS) XDMAC Channel 13 Write Suspend Bit Position */
+#define XDMAC_GWS_WS13_Msk                  (_U_(0x1) << XDMAC_GWS_WS13_Pos)               /**< (XDMAC_GWS) XDMAC Channel 13 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS13                      XDMAC_GWS_WS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS13_Msk instead */
+#define XDMAC_GWS_WS14_Pos                  14                                             /**< (XDMAC_GWS) XDMAC Channel 14 Write Suspend Bit Position */
+#define XDMAC_GWS_WS14_Msk                  (_U_(0x1) << XDMAC_GWS_WS14_Pos)               /**< (XDMAC_GWS) XDMAC Channel 14 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS14                      XDMAC_GWS_WS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS14_Msk instead */
+#define XDMAC_GWS_WS15_Pos                  15                                             /**< (XDMAC_GWS) XDMAC Channel 15 Write Suspend Bit Position */
+#define XDMAC_GWS_WS15_Msk                  (_U_(0x1) << XDMAC_GWS_WS15_Pos)               /**< (XDMAC_GWS) XDMAC Channel 15 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS15                      XDMAC_GWS_WS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS15_Msk instead */
+#define XDMAC_GWS_WS16_Pos                  16                                             /**< (XDMAC_GWS) XDMAC Channel 16 Write Suspend Bit Position */
+#define XDMAC_GWS_WS16_Msk                  (_U_(0x1) << XDMAC_GWS_WS16_Pos)               /**< (XDMAC_GWS) XDMAC Channel 16 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS16                      XDMAC_GWS_WS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS16_Msk instead */
+#define XDMAC_GWS_WS17_Pos                  17                                             /**< (XDMAC_GWS) XDMAC Channel 17 Write Suspend Bit Position */
+#define XDMAC_GWS_WS17_Msk                  (_U_(0x1) << XDMAC_GWS_WS17_Pos)               /**< (XDMAC_GWS) XDMAC Channel 17 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS17                      XDMAC_GWS_WS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS17_Msk instead */
+#define XDMAC_GWS_WS18_Pos                  18                                             /**< (XDMAC_GWS) XDMAC Channel 18 Write Suspend Bit Position */
+#define XDMAC_GWS_WS18_Msk                  (_U_(0x1) << XDMAC_GWS_WS18_Pos)               /**< (XDMAC_GWS) XDMAC Channel 18 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS18                      XDMAC_GWS_WS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS18_Msk instead */
+#define XDMAC_GWS_WS19_Pos                  19                                             /**< (XDMAC_GWS) XDMAC Channel 19 Write Suspend Bit Position */
+#define XDMAC_GWS_WS19_Msk                  (_U_(0x1) << XDMAC_GWS_WS19_Pos)               /**< (XDMAC_GWS) XDMAC Channel 19 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS19                      XDMAC_GWS_WS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS19_Msk instead */
+#define XDMAC_GWS_WS20_Pos                  20                                             /**< (XDMAC_GWS) XDMAC Channel 20 Write Suspend Bit Position */
+#define XDMAC_GWS_WS20_Msk                  (_U_(0x1) << XDMAC_GWS_WS20_Pos)               /**< (XDMAC_GWS) XDMAC Channel 20 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS20                      XDMAC_GWS_WS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS20_Msk instead */
+#define XDMAC_GWS_WS21_Pos                  21                                             /**< (XDMAC_GWS) XDMAC Channel 21 Write Suspend Bit Position */
+#define XDMAC_GWS_WS21_Msk                  (_U_(0x1) << XDMAC_GWS_WS21_Pos)               /**< (XDMAC_GWS) XDMAC Channel 21 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS21                      XDMAC_GWS_WS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS21_Msk instead */
+#define XDMAC_GWS_WS22_Pos                  22                                             /**< (XDMAC_GWS) XDMAC Channel 22 Write Suspend Bit Position */
+#define XDMAC_GWS_WS22_Msk                  (_U_(0x1) << XDMAC_GWS_WS22_Pos)               /**< (XDMAC_GWS) XDMAC Channel 22 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS22                      XDMAC_GWS_WS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS22_Msk instead */
+#define XDMAC_GWS_WS23_Pos                  23                                             /**< (XDMAC_GWS) XDMAC Channel 23 Write Suspend Bit Position */
+#define XDMAC_GWS_WS23_Msk                  (_U_(0x1) << XDMAC_GWS_WS23_Pos)               /**< (XDMAC_GWS) XDMAC Channel 23 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS23                      XDMAC_GWS_WS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS23_Msk instead */
+#define XDMAC_GWS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GWS) Register MASK  (Use XDMAC_GWS_Msk instead)  */
+#define XDMAC_GWS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GWS) Register Mask  */
+
+#define XDMAC_GWS_WS_Pos                    0                                              /**< (XDMAC_GWS Position) XDMAC Channel 23 Write Suspend Bit */
+#define XDMAC_GWS_WS_Msk                    (_U_(0xFFFFFF) << XDMAC_GWS_WS_Pos)            /**< (XDMAC_GWS Mask) WS */
+#define XDMAC_GWS_WS(value)                 (XDMAC_GWS_WS_Msk & ((value) << XDMAC_GWS_WS_Pos))  
+
+/* -------- XDMAC_GRWS : (XDMAC Offset: 0x30) (/W 32) Global Channel Read Write Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RWS0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Suspend Bit   */
+    uint32_t RWS1:1;                    /**< bit:      1  XDMAC Channel 1 Read Write Suspend Bit   */
+    uint32_t RWS2:1;                    /**< bit:      2  XDMAC Channel 2 Read Write Suspend Bit   */
+    uint32_t RWS3:1;                    /**< bit:      3  XDMAC Channel 3 Read Write Suspend Bit   */
+    uint32_t RWS4:1;                    /**< bit:      4  XDMAC Channel 4 Read Write Suspend Bit   */
+    uint32_t RWS5:1;                    /**< bit:      5  XDMAC Channel 5 Read Write Suspend Bit   */
+    uint32_t RWS6:1;                    /**< bit:      6  XDMAC Channel 6 Read Write Suspend Bit   */
+    uint32_t RWS7:1;                    /**< bit:      7  XDMAC Channel 7 Read Write Suspend Bit   */
+    uint32_t RWS8:1;                    /**< bit:      8  XDMAC Channel 8 Read Write Suspend Bit   */
+    uint32_t RWS9:1;                    /**< bit:      9  XDMAC Channel 9 Read Write Suspend Bit   */
+    uint32_t RWS10:1;                   /**< bit:     10  XDMAC Channel 10 Read Write Suspend Bit  */
+    uint32_t RWS11:1;                   /**< bit:     11  XDMAC Channel 11 Read Write Suspend Bit  */
+    uint32_t RWS12:1;                   /**< bit:     12  XDMAC Channel 12 Read Write Suspend Bit  */
+    uint32_t RWS13:1;                   /**< bit:     13  XDMAC Channel 13 Read Write Suspend Bit  */
+    uint32_t RWS14:1;                   /**< bit:     14  XDMAC Channel 14 Read Write Suspend Bit  */
+    uint32_t RWS15:1;                   /**< bit:     15  XDMAC Channel 15 Read Write Suspend Bit  */
+    uint32_t RWS16:1;                   /**< bit:     16  XDMAC Channel 16 Read Write Suspend Bit  */
+    uint32_t RWS17:1;                   /**< bit:     17  XDMAC Channel 17 Read Write Suspend Bit  */
+    uint32_t RWS18:1;                   /**< bit:     18  XDMAC Channel 18 Read Write Suspend Bit  */
+    uint32_t RWS19:1;                   /**< bit:     19  XDMAC Channel 19 Read Write Suspend Bit  */
+    uint32_t RWS20:1;                   /**< bit:     20  XDMAC Channel 20 Read Write Suspend Bit  */
+    uint32_t RWS21:1;                   /**< bit:     21  XDMAC Channel 21 Read Write Suspend Bit  */
+    uint32_t RWS22:1;                   /**< bit:     22  XDMAC Channel 22 Read Write Suspend Bit  */
+    uint32_t RWS23:1;                   /**< bit:     23  XDMAC Channel 23 Read Write Suspend Bit  */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RWS:24;                    /**< bit:  0..23  XDMAC Channel 23 Read Write Suspend Bit  */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRWS_OFFSET                   (0x30)                                        /**<  (XDMAC_GRWS) Global Channel Read Write Suspend Register  Offset */
+
+#define XDMAC_GRWS_RWS0_Pos                 0                                              /**< (XDMAC_GRWS) XDMAC Channel 0 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS0_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS0_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 0 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS0                     XDMAC_GRWS_RWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS0_Msk instead */
+#define XDMAC_GRWS_RWS1_Pos                 1                                              /**< (XDMAC_GRWS) XDMAC Channel 1 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS1_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS1_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 1 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS1                     XDMAC_GRWS_RWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS1_Msk instead */
+#define XDMAC_GRWS_RWS2_Pos                 2                                              /**< (XDMAC_GRWS) XDMAC Channel 2 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS2_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS2_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 2 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS2                     XDMAC_GRWS_RWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS2_Msk instead */
+#define XDMAC_GRWS_RWS3_Pos                 3                                              /**< (XDMAC_GRWS) XDMAC Channel 3 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS3_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS3_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 3 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS3                     XDMAC_GRWS_RWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS3_Msk instead */
+#define XDMAC_GRWS_RWS4_Pos                 4                                              /**< (XDMAC_GRWS) XDMAC Channel 4 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS4_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS4_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 4 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS4                     XDMAC_GRWS_RWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS4_Msk instead */
+#define XDMAC_GRWS_RWS5_Pos                 5                                              /**< (XDMAC_GRWS) XDMAC Channel 5 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS5_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS5_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 5 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS5                     XDMAC_GRWS_RWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS5_Msk instead */
+#define XDMAC_GRWS_RWS6_Pos                 6                                              /**< (XDMAC_GRWS) XDMAC Channel 6 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS6_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS6_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 6 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS6                     XDMAC_GRWS_RWS6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS6_Msk instead */
+#define XDMAC_GRWS_RWS7_Pos                 7                                              /**< (XDMAC_GRWS) XDMAC Channel 7 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS7_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS7_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 7 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS7                     XDMAC_GRWS_RWS7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS7_Msk instead */
+#define XDMAC_GRWS_RWS8_Pos                 8                                              /**< (XDMAC_GRWS) XDMAC Channel 8 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS8_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS8_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 8 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS8                     XDMAC_GRWS_RWS8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS8_Msk instead */
+#define XDMAC_GRWS_RWS9_Pos                 9                                              /**< (XDMAC_GRWS) XDMAC Channel 9 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS9_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS9_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 9 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS9                     XDMAC_GRWS_RWS9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS9_Msk instead */
+#define XDMAC_GRWS_RWS10_Pos                10                                             /**< (XDMAC_GRWS) XDMAC Channel 10 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS10_Msk                (_U_(0x1) << XDMAC_GRWS_RWS10_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 10 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS10                    XDMAC_GRWS_RWS10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS10_Msk instead */
+#define XDMAC_GRWS_RWS11_Pos                11                                             /**< (XDMAC_GRWS) XDMAC Channel 11 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS11_Msk                (_U_(0x1) << XDMAC_GRWS_RWS11_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 11 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS11                    XDMAC_GRWS_RWS11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS11_Msk instead */
+#define XDMAC_GRWS_RWS12_Pos                12                                             /**< (XDMAC_GRWS) XDMAC Channel 12 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS12_Msk                (_U_(0x1) << XDMAC_GRWS_RWS12_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 12 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS12                    XDMAC_GRWS_RWS12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS12_Msk instead */
+#define XDMAC_GRWS_RWS13_Pos                13                                             /**< (XDMAC_GRWS) XDMAC Channel 13 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS13_Msk                (_U_(0x1) << XDMAC_GRWS_RWS13_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 13 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS13                    XDMAC_GRWS_RWS13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS13_Msk instead */
+#define XDMAC_GRWS_RWS14_Pos                14                                             /**< (XDMAC_GRWS) XDMAC Channel 14 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS14_Msk                (_U_(0x1) << XDMAC_GRWS_RWS14_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 14 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS14                    XDMAC_GRWS_RWS14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS14_Msk instead */
+#define XDMAC_GRWS_RWS15_Pos                15                                             /**< (XDMAC_GRWS) XDMAC Channel 15 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS15_Msk                (_U_(0x1) << XDMAC_GRWS_RWS15_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 15 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS15                    XDMAC_GRWS_RWS15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS15_Msk instead */
+#define XDMAC_GRWS_RWS16_Pos                16                                             /**< (XDMAC_GRWS) XDMAC Channel 16 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS16_Msk                (_U_(0x1) << XDMAC_GRWS_RWS16_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 16 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS16                    XDMAC_GRWS_RWS16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS16_Msk instead */
+#define XDMAC_GRWS_RWS17_Pos                17                                             /**< (XDMAC_GRWS) XDMAC Channel 17 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS17_Msk                (_U_(0x1) << XDMAC_GRWS_RWS17_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 17 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS17                    XDMAC_GRWS_RWS17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS17_Msk instead */
+#define XDMAC_GRWS_RWS18_Pos                18                                             /**< (XDMAC_GRWS) XDMAC Channel 18 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS18_Msk                (_U_(0x1) << XDMAC_GRWS_RWS18_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 18 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS18                    XDMAC_GRWS_RWS18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS18_Msk instead */
+#define XDMAC_GRWS_RWS19_Pos                19                                             /**< (XDMAC_GRWS) XDMAC Channel 19 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS19_Msk                (_U_(0x1) << XDMAC_GRWS_RWS19_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 19 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS19                    XDMAC_GRWS_RWS19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS19_Msk instead */
+#define XDMAC_GRWS_RWS20_Pos                20                                             /**< (XDMAC_GRWS) XDMAC Channel 20 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS20_Msk                (_U_(0x1) << XDMAC_GRWS_RWS20_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 20 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS20                    XDMAC_GRWS_RWS20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS20_Msk instead */
+#define XDMAC_GRWS_RWS21_Pos                21                                             /**< (XDMAC_GRWS) XDMAC Channel 21 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS21_Msk                (_U_(0x1) << XDMAC_GRWS_RWS21_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 21 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS21                    XDMAC_GRWS_RWS21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS21_Msk instead */
+#define XDMAC_GRWS_RWS22_Pos                22                                             /**< (XDMAC_GRWS) XDMAC Channel 22 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS22_Msk                (_U_(0x1) << XDMAC_GRWS_RWS22_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 22 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS22                    XDMAC_GRWS_RWS22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS22_Msk instead */
+#define XDMAC_GRWS_RWS23_Pos                23                                             /**< (XDMAC_GRWS) XDMAC Channel 23 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS23_Msk                (_U_(0x1) << XDMAC_GRWS_RWS23_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 23 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS23                    XDMAC_GRWS_RWS23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS23_Msk instead */
+#define XDMAC_GRWS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRWS) Register MASK  (Use XDMAC_GRWS_Msk instead)  */
+#define XDMAC_GRWS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GRWS) Register Mask  */
+
+#define XDMAC_GRWS_RWS_Pos                  0                                              /**< (XDMAC_GRWS Position) XDMAC Channel 23 Read Write Suspend Bit */
+#define XDMAC_GRWS_RWS_Msk                  (_U_(0xFFFFFF) << XDMAC_GRWS_RWS_Pos)          /**< (XDMAC_GRWS Mask) RWS */
+#define XDMAC_GRWS_RWS(value)               (XDMAC_GRWS_RWS_Msk & ((value) << XDMAC_GRWS_RWS_Pos))  
+
+/* -------- XDMAC_GRWR : (XDMAC Offset: 0x34) (/W 32) Global Channel Read Write Resume Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RWR0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Resume Bit    */
+    uint32_t RWR1:1;                    /**< bit:      1  XDMAC Channel 1 Read Write Resume Bit    */
+    uint32_t RWR2:1;                    /**< bit:      2  XDMAC Channel 2 Read Write Resume Bit    */
+    uint32_t RWR3:1;                    /**< bit:      3  XDMAC Channel 3 Read Write Resume Bit    */
+    uint32_t RWR4:1;                    /**< bit:      4  XDMAC Channel 4 Read Write Resume Bit    */
+    uint32_t RWR5:1;                    /**< bit:      5  XDMAC Channel 5 Read Write Resume Bit    */
+    uint32_t RWR6:1;                    /**< bit:      6  XDMAC Channel 6 Read Write Resume Bit    */
+    uint32_t RWR7:1;                    /**< bit:      7  XDMAC Channel 7 Read Write Resume Bit    */
+    uint32_t RWR8:1;                    /**< bit:      8  XDMAC Channel 8 Read Write Resume Bit    */
+    uint32_t RWR9:1;                    /**< bit:      9  XDMAC Channel 9 Read Write Resume Bit    */
+    uint32_t RWR10:1;                   /**< bit:     10  XDMAC Channel 10 Read Write Resume Bit   */
+    uint32_t RWR11:1;                   /**< bit:     11  XDMAC Channel 11 Read Write Resume Bit   */
+    uint32_t RWR12:1;                   /**< bit:     12  XDMAC Channel 12 Read Write Resume Bit   */
+    uint32_t RWR13:1;                   /**< bit:     13  XDMAC Channel 13 Read Write Resume Bit   */
+    uint32_t RWR14:1;                   /**< bit:     14  XDMAC Channel 14 Read Write Resume Bit   */
+    uint32_t RWR15:1;                   /**< bit:     15  XDMAC Channel 15 Read Write Resume Bit   */
+    uint32_t RWR16:1;                   /**< bit:     16  XDMAC Channel 16 Read Write Resume Bit   */
+    uint32_t RWR17:1;                   /**< bit:     17  XDMAC Channel 17 Read Write Resume Bit   */
+    uint32_t RWR18:1;                   /**< bit:     18  XDMAC Channel 18 Read Write Resume Bit   */
+    uint32_t RWR19:1;                   /**< bit:     19  XDMAC Channel 19 Read Write Resume Bit   */
+    uint32_t RWR20:1;                   /**< bit:     20  XDMAC Channel 20 Read Write Resume Bit   */
+    uint32_t RWR21:1;                   /**< bit:     21  XDMAC Channel 21 Read Write Resume Bit   */
+    uint32_t RWR22:1;                   /**< bit:     22  XDMAC Channel 22 Read Write Resume Bit   */
+    uint32_t RWR23:1;                   /**< bit:     23  XDMAC Channel 23 Read Write Resume Bit   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RWR:24;                    /**< bit:  0..23  XDMAC Channel 23 Read Write Resume Bit   */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRWR_OFFSET                   (0x34)                                        /**<  (XDMAC_GRWR) Global Channel Read Write Resume Register  Offset */
+
+#define XDMAC_GRWR_RWR0_Pos                 0                                              /**< (XDMAC_GRWR) XDMAC Channel 0 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR0_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR0_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 0 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR0                     XDMAC_GRWR_RWR0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR0_Msk instead */
+#define XDMAC_GRWR_RWR1_Pos                 1                                              /**< (XDMAC_GRWR) XDMAC Channel 1 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR1_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR1_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 1 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR1                     XDMAC_GRWR_RWR1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR1_Msk instead */
+#define XDMAC_GRWR_RWR2_Pos                 2                                              /**< (XDMAC_GRWR) XDMAC Channel 2 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR2_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR2_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 2 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR2                     XDMAC_GRWR_RWR2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR2_Msk instead */
+#define XDMAC_GRWR_RWR3_Pos                 3                                              /**< (XDMAC_GRWR) XDMAC Channel 3 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR3_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR3_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 3 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR3                     XDMAC_GRWR_RWR3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR3_Msk instead */
+#define XDMAC_GRWR_RWR4_Pos                 4                                              /**< (XDMAC_GRWR) XDMAC Channel 4 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR4_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR4_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 4 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR4                     XDMAC_GRWR_RWR4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR4_Msk instead */
+#define XDMAC_GRWR_RWR5_Pos                 5                                              /**< (XDMAC_GRWR) XDMAC Channel 5 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR5_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR5_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 5 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR5                     XDMAC_GRWR_RWR5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR5_Msk instead */
+#define XDMAC_GRWR_RWR6_Pos                 6                                              /**< (XDMAC_GRWR) XDMAC Channel 6 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR6_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR6_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 6 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR6                     XDMAC_GRWR_RWR6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR6_Msk instead */
+#define XDMAC_GRWR_RWR7_Pos                 7                                              /**< (XDMAC_GRWR) XDMAC Channel 7 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR7_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR7_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 7 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR7                     XDMAC_GRWR_RWR7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR7_Msk instead */
+#define XDMAC_GRWR_RWR8_Pos                 8                                              /**< (XDMAC_GRWR) XDMAC Channel 8 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR8_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR8_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 8 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR8                     XDMAC_GRWR_RWR8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR8_Msk instead */
+#define XDMAC_GRWR_RWR9_Pos                 9                                              /**< (XDMAC_GRWR) XDMAC Channel 9 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR9_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR9_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 9 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR9                     XDMAC_GRWR_RWR9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR9_Msk instead */
+#define XDMAC_GRWR_RWR10_Pos                10                                             /**< (XDMAC_GRWR) XDMAC Channel 10 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR10_Msk                (_U_(0x1) << XDMAC_GRWR_RWR10_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 10 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR10                    XDMAC_GRWR_RWR10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR10_Msk instead */
+#define XDMAC_GRWR_RWR11_Pos                11                                             /**< (XDMAC_GRWR) XDMAC Channel 11 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR11_Msk                (_U_(0x1) << XDMAC_GRWR_RWR11_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 11 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR11                    XDMAC_GRWR_RWR11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR11_Msk instead */
+#define XDMAC_GRWR_RWR12_Pos                12                                             /**< (XDMAC_GRWR) XDMAC Channel 12 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR12_Msk                (_U_(0x1) << XDMAC_GRWR_RWR12_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 12 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR12                    XDMAC_GRWR_RWR12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR12_Msk instead */
+#define XDMAC_GRWR_RWR13_Pos                13                                             /**< (XDMAC_GRWR) XDMAC Channel 13 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR13_Msk                (_U_(0x1) << XDMAC_GRWR_RWR13_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 13 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR13                    XDMAC_GRWR_RWR13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR13_Msk instead */
+#define XDMAC_GRWR_RWR14_Pos                14                                             /**< (XDMAC_GRWR) XDMAC Channel 14 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR14_Msk                (_U_(0x1) << XDMAC_GRWR_RWR14_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 14 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR14                    XDMAC_GRWR_RWR14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR14_Msk instead */
+#define XDMAC_GRWR_RWR15_Pos                15                                             /**< (XDMAC_GRWR) XDMAC Channel 15 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR15_Msk                (_U_(0x1) << XDMAC_GRWR_RWR15_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 15 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR15                    XDMAC_GRWR_RWR15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR15_Msk instead */
+#define XDMAC_GRWR_RWR16_Pos                16                                             /**< (XDMAC_GRWR) XDMAC Channel 16 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR16_Msk                (_U_(0x1) << XDMAC_GRWR_RWR16_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 16 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR16                    XDMAC_GRWR_RWR16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR16_Msk instead */
+#define XDMAC_GRWR_RWR17_Pos                17                                             /**< (XDMAC_GRWR) XDMAC Channel 17 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR17_Msk                (_U_(0x1) << XDMAC_GRWR_RWR17_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 17 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR17                    XDMAC_GRWR_RWR17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR17_Msk instead */
+#define XDMAC_GRWR_RWR18_Pos                18                                             /**< (XDMAC_GRWR) XDMAC Channel 18 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR18_Msk                (_U_(0x1) << XDMAC_GRWR_RWR18_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 18 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR18                    XDMAC_GRWR_RWR18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR18_Msk instead */
+#define XDMAC_GRWR_RWR19_Pos                19                                             /**< (XDMAC_GRWR) XDMAC Channel 19 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR19_Msk                (_U_(0x1) << XDMAC_GRWR_RWR19_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 19 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR19                    XDMAC_GRWR_RWR19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR19_Msk instead */
+#define XDMAC_GRWR_RWR20_Pos                20                                             /**< (XDMAC_GRWR) XDMAC Channel 20 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR20_Msk                (_U_(0x1) << XDMAC_GRWR_RWR20_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 20 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR20                    XDMAC_GRWR_RWR20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR20_Msk instead */
+#define XDMAC_GRWR_RWR21_Pos                21                                             /**< (XDMAC_GRWR) XDMAC Channel 21 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR21_Msk                (_U_(0x1) << XDMAC_GRWR_RWR21_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 21 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR21                    XDMAC_GRWR_RWR21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR21_Msk instead */
+#define XDMAC_GRWR_RWR22_Pos                22                                             /**< (XDMAC_GRWR) XDMAC Channel 22 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR22_Msk                (_U_(0x1) << XDMAC_GRWR_RWR22_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 22 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR22                    XDMAC_GRWR_RWR22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR22_Msk instead */
+#define XDMAC_GRWR_RWR23_Pos                23                                             /**< (XDMAC_GRWR) XDMAC Channel 23 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR23_Msk                (_U_(0x1) << XDMAC_GRWR_RWR23_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 23 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR23                    XDMAC_GRWR_RWR23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR23_Msk instead */
+#define XDMAC_GRWR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRWR) Register MASK  (Use XDMAC_GRWR_Msk instead)  */
+#define XDMAC_GRWR_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GRWR) Register Mask  */
+
+#define XDMAC_GRWR_RWR_Pos                  0                                              /**< (XDMAC_GRWR Position) XDMAC Channel 23 Read Write Resume Bit */
+#define XDMAC_GRWR_RWR_Msk                  (_U_(0xFFFFFF) << XDMAC_GRWR_RWR_Pos)          /**< (XDMAC_GRWR Mask) RWR */
+#define XDMAC_GRWR_RWR(value)               (XDMAC_GRWR_RWR_Msk & ((value) << XDMAC_GRWR_RWR_Pos))  
+
+/* -------- XDMAC_GSWR : (XDMAC Offset: 0x38) (/W 32) Global Channel Software Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWREQ0:1;                  /**< bit:      0  XDMAC Channel 0 Software Request Bit     */
+    uint32_t SWREQ1:1;                  /**< bit:      1  XDMAC Channel 1 Software Request Bit     */
+    uint32_t SWREQ2:1;                  /**< bit:      2  XDMAC Channel 2 Software Request Bit     */
+    uint32_t SWREQ3:1;                  /**< bit:      3  XDMAC Channel 3 Software Request Bit     */
+    uint32_t SWREQ4:1;                  /**< bit:      4  XDMAC Channel 4 Software Request Bit     */
+    uint32_t SWREQ5:1;                  /**< bit:      5  XDMAC Channel 5 Software Request Bit     */
+    uint32_t SWREQ6:1;                  /**< bit:      6  XDMAC Channel 6 Software Request Bit     */
+    uint32_t SWREQ7:1;                  /**< bit:      7  XDMAC Channel 7 Software Request Bit     */
+    uint32_t SWREQ8:1;                  /**< bit:      8  XDMAC Channel 8 Software Request Bit     */
+    uint32_t SWREQ9:1;                  /**< bit:      9  XDMAC Channel 9 Software Request Bit     */
+    uint32_t SWREQ10:1;                 /**< bit:     10  XDMAC Channel 10 Software Request Bit    */
+    uint32_t SWREQ11:1;                 /**< bit:     11  XDMAC Channel 11 Software Request Bit    */
+    uint32_t SWREQ12:1;                 /**< bit:     12  XDMAC Channel 12 Software Request Bit    */
+    uint32_t SWREQ13:1;                 /**< bit:     13  XDMAC Channel 13 Software Request Bit    */
+    uint32_t SWREQ14:1;                 /**< bit:     14  XDMAC Channel 14 Software Request Bit    */
+    uint32_t SWREQ15:1;                 /**< bit:     15  XDMAC Channel 15 Software Request Bit    */
+    uint32_t SWREQ16:1;                 /**< bit:     16  XDMAC Channel 16 Software Request Bit    */
+    uint32_t SWREQ17:1;                 /**< bit:     17  XDMAC Channel 17 Software Request Bit    */
+    uint32_t SWREQ18:1;                 /**< bit:     18  XDMAC Channel 18 Software Request Bit    */
+    uint32_t SWREQ19:1;                 /**< bit:     19  XDMAC Channel 19 Software Request Bit    */
+    uint32_t SWREQ20:1;                 /**< bit:     20  XDMAC Channel 20 Software Request Bit    */
+    uint32_t SWREQ21:1;                 /**< bit:     21  XDMAC Channel 21 Software Request Bit    */
+    uint32_t SWREQ22:1;                 /**< bit:     22  XDMAC Channel 22 Software Request Bit    */
+    uint32_t SWREQ23:1;                 /**< bit:     23  XDMAC Channel 23 Software Request Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWREQ:24;                  /**< bit:  0..23  XDMAC Channel 23 Software Request Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWR_OFFSET                   (0x38)                                        /**<  (XDMAC_GSWR) Global Channel Software Request Register  Offset */
+
+#define XDMAC_GSWR_SWREQ0_Pos               0                                              /**< (XDMAC_GSWR) XDMAC Channel 0 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ0_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ0_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 0 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ0                   XDMAC_GSWR_SWREQ0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ0_Msk instead */
+#define XDMAC_GSWR_SWREQ1_Pos               1                                              /**< (XDMAC_GSWR) XDMAC Channel 1 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ1_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ1_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 1 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ1                   XDMAC_GSWR_SWREQ1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ1_Msk instead */
+#define XDMAC_GSWR_SWREQ2_Pos               2                                              /**< (XDMAC_GSWR) XDMAC Channel 2 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ2_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ2_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 2 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ2                   XDMAC_GSWR_SWREQ2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ2_Msk instead */
+#define XDMAC_GSWR_SWREQ3_Pos               3                                              /**< (XDMAC_GSWR) XDMAC Channel 3 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ3_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ3_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 3 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ3                   XDMAC_GSWR_SWREQ3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ3_Msk instead */
+#define XDMAC_GSWR_SWREQ4_Pos               4                                              /**< (XDMAC_GSWR) XDMAC Channel 4 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ4_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ4_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 4 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ4                   XDMAC_GSWR_SWREQ4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ4_Msk instead */
+#define XDMAC_GSWR_SWREQ5_Pos               5                                              /**< (XDMAC_GSWR) XDMAC Channel 5 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ5_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ5_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 5 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ5                   XDMAC_GSWR_SWREQ5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ5_Msk instead */
+#define XDMAC_GSWR_SWREQ6_Pos               6                                              /**< (XDMAC_GSWR) XDMAC Channel 6 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ6_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ6_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 6 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ6                   XDMAC_GSWR_SWREQ6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ6_Msk instead */
+#define XDMAC_GSWR_SWREQ7_Pos               7                                              /**< (XDMAC_GSWR) XDMAC Channel 7 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ7_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ7_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 7 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ7                   XDMAC_GSWR_SWREQ7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ7_Msk instead */
+#define XDMAC_GSWR_SWREQ8_Pos               8                                              /**< (XDMAC_GSWR) XDMAC Channel 8 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ8_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ8_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 8 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ8                   XDMAC_GSWR_SWREQ8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ8_Msk instead */
+#define XDMAC_GSWR_SWREQ9_Pos               9                                              /**< (XDMAC_GSWR) XDMAC Channel 9 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ9_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ9_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 9 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ9                   XDMAC_GSWR_SWREQ9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ9_Msk instead */
+#define XDMAC_GSWR_SWREQ10_Pos              10                                             /**< (XDMAC_GSWR) XDMAC Channel 10 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ10_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ10_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 10 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ10                  XDMAC_GSWR_SWREQ10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ10_Msk instead */
+#define XDMAC_GSWR_SWREQ11_Pos              11                                             /**< (XDMAC_GSWR) XDMAC Channel 11 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ11_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ11_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 11 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ11                  XDMAC_GSWR_SWREQ11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ11_Msk instead */
+#define XDMAC_GSWR_SWREQ12_Pos              12                                             /**< (XDMAC_GSWR) XDMAC Channel 12 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ12_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ12_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 12 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ12                  XDMAC_GSWR_SWREQ12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ12_Msk instead */
+#define XDMAC_GSWR_SWREQ13_Pos              13                                             /**< (XDMAC_GSWR) XDMAC Channel 13 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ13_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ13_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 13 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ13                  XDMAC_GSWR_SWREQ13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ13_Msk instead */
+#define XDMAC_GSWR_SWREQ14_Pos              14                                             /**< (XDMAC_GSWR) XDMAC Channel 14 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ14_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ14_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 14 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ14                  XDMAC_GSWR_SWREQ14_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ14_Msk instead */
+#define XDMAC_GSWR_SWREQ15_Pos              15                                             /**< (XDMAC_GSWR) XDMAC Channel 15 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ15_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ15_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 15 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ15                  XDMAC_GSWR_SWREQ15_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ15_Msk instead */
+#define XDMAC_GSWR_SWREQ16_Pos              16                                             /**< (XDMAC_GSWR) XDMAC Channel 16 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ16_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ16_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 16 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ16                  XDMAC_GSWR_SWREQ16_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ16_Msk instead */
+#define XDMAC_GSWR_SWREQ17_Pos              17                                             /**< (XDMAC_GSWR) XDMAC Channel 17 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ17_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ17_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 17 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ17                  XDMAC_GSWR_SWREQ17_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ17_Msk instead */
+#define XDMAC_GSWR_SWREQ18_Pos              18                                             /**< (XDMAC_GSWR) XDMAC Channel 18 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ18_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ18_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 18 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ18                  XDMAC_GSWR_SWREQ18_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ18_Msk instead */
+#define XDMAC_GSWR_SWREQ19_Pos              19                                             /**< (XDMAC_GSWR) XDMAC Channel 19 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ19_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ19_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 19 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ19                  XDMAC_GSWR_SWREQ19_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ19_Msk instead */
+#define XDMAC_GSWR_SWREQ20_Pos              20                                             /**< (XDMAC_GSWR) XDMAC Channel 20 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ20_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ20_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 20 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ20                  XDMAC_GSWR_SWREQ20_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ20_Msk instead */
+#define XDMAC_GSWR_SWREQ21_Pos              21                                             /**< (XDMAC_GSWR) XDMAC Channel 21 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ21_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ21_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 21 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ21                  XDMAC_GSWR_SWREQ21_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ21_Msk instead */
+#define XDMAC_GSWR_SWREQ22_Pos              22                                             /**< (XDMAC_GSWR) XDMAC Channel 22 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ22_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ22_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 22 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ22                  XDMAC_GSWR_SWREQ22_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ22_Msk instead */
+#define XDMAC_GSWR_SWREQ23_Pos              23                                             /**< (XDMAC_GSWR) XDMAC Channel 23 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ23_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ23_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 23 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ23                  XDMAC_GSWR_SWREQ23_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ23_Msk instead */
+#define XDMAC_GSWR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWR) Register MASK  (Use XDMAC_GSWR_Msk instead)  */
+#define XDMAC_GSWR_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWR) Register Mask  */
+
+#define XDMAC_GSWR_SWREQ_Pos                0                                              /**< (XDMAC_GSWR Position) XDMAC Channel 23 Software Request Bit */
+#define XDMAC_GSWR_SWREQ_Msk                (_U_(0xFFFFFF) << XDMAC_GSWR_SWREQ_Pos)        /**< (XDMAC_GSWR Mask) SWREQ */
+#define XDMAC_GSWR_SWREQ(value)             (XDMAC_GSWR_SWREQ_Msk & ((value) << XDMAC_GSWR_SWREQ_Pos))  
+
+/* -------- XDMAC_GSWS : (XDMAC Offset: 0x3c) (R/ 32) Global Channel Software Request Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRS0:1;                   /**< bit:      0  XDMAC Channel 0 Software Request Status Bit */
+    uint32_t SWRS1:1;                   /**< bit:      1  XDMAC Channel 1 Software Request Status Bit */
+    uint32_t SWRS2:1;                   /**< bit:      2  XDMAC Channel 2 Software Request Status Bit */
+    uint32_t SWRS3:1;                   /**< bit:      3  XDMAC Channel 3 Software Request Status Bit */
+    uint32_t SWRS4:1;                   /**< bit:      4  XDMAC Channel 4 Software Request Status Bit */
+    uint32_t SWRS5:1;                   /**< bit:      5  XDMAC Channel 5 Software Request Status Bit */
+    uint32_t SWRS6:1;                   /**< bit:      6  XDMAC Channel 6 Software Request Status Bit */
+    uint32_t SWRS7:1;                   /**< bit:      7  XDMAC Channel 7 Software Request Status Bit */
+    uint32_t SWRS8:1;                   /**< bit:      8  XDMAC Channel 8 Software Request Status Bit */
+    uint32_t SWRS9:1;                   /**< bit:      9  XDMAC Channel 9 Software Request Status Bit */
+    uint32_t SWRS10:1;                  /**< bit:     10  XDMAC Channel 10 Software Request Status Bit */
+    uint32_t SWRS11:1;                  /**< bit:     11  XDMAC Channel 11 Software Request Status Bit */
+    uint32_t SWRS12:1;                  /**< bit:     12  XDMAC Channel 12 Software Request Status Bit */
+    uint32_t SWRS13:1;                  /**< bit:     13  XDMAC Channel 13 Software Request Status Bit */
+    uint32_t SWRS14:1;                  /**< bit:     14  XDMAC Channel 14 Software Request Status Bit */
+    uint32_t SWRS15:1;                  /**< bit:     15  XDMAC Channel 15 Software Request Status Bit */
+    uint32_t SWRS16:1;                  /**< bit:     16  XDMAC Channel 16 Software Request Status Bit */
+    uint32_t SWRS17:1;                  /**< bit:     17  XDMAC Channel 17 Software Request Status Bit */
+    uint32_t SWRS18:1;                  /**< bit:     18  XDMAC Channel 18 Software Request Status Bit */
+    uint32_t SWRS19:1;                  /**< bit:     19  XDMAC Channel 19 Software Request Status Bit */
+    uint32_t SWRS20:1;                  /**< bit:     20  XDMAC Channel 20 Software Request Status Bit */
+    uint32_t SWRS21:1;                  /**< bit:     21  XDMAC Channel 21 Software Request Status Bit */
+    uint32_t SWRS22:1;                  /**< bit:     22  XDMAC Channel 22 Software Request Status Bit */
+    uint32_t SWRS23:1;                  /**< bit:     23  XDMAC Channel 23 Software Request Status Bit */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWRS:24;                   /**< bit:  0..23  XDMAC Channel 23 Software Request Status Bit */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWS_OFFSET                   (0x3C)                                        /**<  (XDMAC_GSWS) Global Channel Software Request Status Register  Offset */
+
+#define XDMAC_GSWS_SWRS0_Pos                0                                              /**< (XDMAC_GSWS) XDMAC Channel 0 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS0_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS0_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 0 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS0                    XDMAC_GSWS_SWRS0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS0_Msk instead */
+#define XDMAC_GSWS_SWRS1_Pos                1                                              /**< (XDMAC_GSWS) XDMAC Channel 1 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS1_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS1_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 1 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS1                    XDMAC_GSWS_SWRS1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS1_Msk instead */
+#define XDMAC_GSWS_SWRS2_Pos                2                                              /**< (XDMAC_GSWS) XDMAC Channel 2 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS2_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS2_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 2 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS2                    XDMAC_GSWS_SWRS2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS2_Msk instead */
+#define XDMAC_GSWS_SWRS3_Pos                3                                              /**< (XDMAC_GSWS) XDMAC Channel 3 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS3_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS3_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 3 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS3                    XDMAC_GSWS_SWRS3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS3_Msk instead */
+#define XDMAC_GSWS_SWRS4_Pos                4                                              /**< (XDMAC_GSWS) XDMAC Channel 4 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS4_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS4_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 4 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS4                    XDMAC_GSWS_SWRS4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS4_Msk instead */
+#define XDMAC_GSWS_SWRS5_Pos                5                                              /**< (XDMAC_GSWS) XDMAC Channel 5 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS5_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS5_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 5 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS5                    XDMAC_GSWS_SWRS5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS5_Msk instead */
+#define XDMAC_GSWS_SWRS6_Pos                6                                              /**< (XDMAC_GSWS) XDMAC Channel 6 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS6_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS6_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 6 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS6                    XDMAC_GSWS_SWRS6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS6_Msk instead */
+#define XDMAC_GSWS_SWRS7_Pos                7                                              /**< (XDMAC_GSWS) XDMAC Channel 7 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS7_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS7_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 7 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS7                    XDMAC_GSWS_SWRS7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS7_Msk instead */
+#define XDMAC_GSWS_SWRS8_Pos                8                                              /**< (XDMAC_GSWS) XDMAC Channel 8 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS8_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS8_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 8 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS8                    XDMAC_GSWS_SWRS8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS8_Msk instead */
+#define XDMAC_GSWS_SWRS9_Pos                9                                              /**< (XDMAC_GSWS) XDMAC Channel 9 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS9_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS9_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 9 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS9                    XDMAC_GSWS_SWRS9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS9_Msk instead */
+#define XDMAC_GSWS_SWRS10_Pos               10                                             /**< (XDMAC_GSWS) XDMAC Channel 10 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS10_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS10_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 10 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS10                   XDMAC_GSWS_SWRS10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS10_Msk instead */
+#define XDMAC_GSWS_SWRS11_Pos               11                                             /**< (XDMAC_GSWS) XDMAC Channel 11 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS11_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS11_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 11 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS11                   XDMAC_GSWS_SWRS11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS11_Msk instead */
+#define XDMAC_GSWS_SWRS12_Pos               12                                             /**< (XDMAC_GSWS) XDMAC Channel 12 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS12_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS12_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 12 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS12                   XDMAC_GSWS_SWRS12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS12_Msk instead */
+#define XDMAC_GSWS_SWRS13_Pos               13                                             /**< (XDMAC_GSWS) XDMAC Channel 13 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS13_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS13_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 13 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS13                   XDMAC_GSWS_SWRS13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS13_Msk instead */
+#define XDMAC_GSWS_SWRS14_Pos               14                                             /**< (XDMAC_GSWS) XDMAC Channel 14 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS14_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS14_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 14 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS14                   XDMAC_GSWS_SWRS14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS14_Msk instead */
+#define XDMAC_GSWS_SWRS15_Pos               15                                             /**< (XDMAC_GSWS) XDMAC Channel 15 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS15_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS15_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 15 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS15                   XDMAC_GSWS_SWRS15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS15_Msk instead */
+#define XDMAC_GSWS_SWRS16_Pos               16                                             /**< (XDMAC_GSWS) XDMAC Channel 16 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS16_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS16_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 16 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS16                   XDMAC_GSWS_SWRS16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS16_Msk instead */
+#define XDMAC_GSWS_SWRS17_Pos               17                                             /**< (XDMAC_GSWS) XDMAC Channel 17 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS17_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS17_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 17 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS17                   XDMAC_GSWS_SWRS17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS17_Msk instead */
+#define XDMAC_GSWS_SWRS18_Pos               18                                             /**< (XDMAC_GSWS) XDMAC Channel 18 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS18_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS18_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 18 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS18                   XDMAC_GSWS_SWRS18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS18_Msk instead */
+#define XDMAC_GSWS_SWRS19_Pos               19                                             /**< (XDMAC_GSWS) XDMAC Channel 19 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS19_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS19_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 19 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS19                   XDMAC_GSWS_SWRS19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS19_Msk instead */
+#define XDMAC_GSWS_SWRS20_Pos               20                                             /**< (XDMAC_GSWS) XDMAC Channel 20 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS20_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS20_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 20 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS20                   XDMAC_GSWS_SWRS20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS20_Msk instead */
+#define XDMAC_GSWS_SWRS21_Pos               21                                             /**< (XDMAC_GSWS) XDMAC Channel 21 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS21_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS21_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 21 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS21                   XDMAC_GSWS_SWRS21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS21_Msk instead */
+#define XDMAC_GSWS_SWRS22_Pos               22                                             /**< (XDMAC_GSWS) XDMAC Channel 22 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS22_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS22_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 22 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS22                   XDMAC_GSWS_SWRS22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS22_Msk instead */
+#define XDMAC_GSWS_SWRS23_Pos               23                                             /**< (XDMAC_GSWS) XDMAC Channel 23 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS23_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS23_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 23 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS23                   XDMAC_GSWS_SWRS23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS23_Msk instead */
+#define XDMAC_GSWS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWS) Register MASK  (Use XDMAC_GSWS_Msk instead)  */
+#define XDMAC_GSWS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWS) Register Mask  */
+
+#define XDMAC_GSWS_SWRS_Pos                 0                                              /**< (XDMAC_GSWS Position) XDMAC Channel 23 Software Request Status Bit */
+#define XDMAC_GSWS_SWRS_Msk                 (_U_(0xFFFFFF) << XDMAC_GSWS_SWRS_Pos)         /**< (XDMAC_GSWS Mask) SWRS */
+#define XDMAC_GSWS_SWRS(value)              (XDMAC_GSWS_SWRS_Msk & ((value) << XDMAC_GSWS_SWRS_Pos))  
+
+/* -------- XDMAC_GSWF : (XDMAC Offset: 0x40) (/W 32) Global Channel Software Flush Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWF0:1;                    /**< bit:      0  XDMAC Channel 0 Software Flush Request Bit */
+    uint32_t SWF1:1;                    /**< bit:      1  XDMAC Channel 1 Software Flush Request Bit */
+    uint32_t SWF2:1;                    /**< bit:      2  XDMAC Channel 2 Software Flush Request Bit */
+    uint32_t SWF3:1;                    /**< bit:      3  XDMAC Channel 3 Software Flush Request Bit */
+    uint32_t SWF4:1;                    /**< bit:      4  XDMAC Channel 4 Software Flush Request Bit */
+    uint32_t SWF5:1;                    /**< bit:      5  XDMAC Channel 5 Software Flush Request Bit */
+    uint32_t SWF6:1;                    /**< bit:      6  XDMAC Channel 6 Software Flush Request Bit */
+    uint32_t SWF7:1;                    /**< bit:      7  XDMAC Channel 7 Software Flush Request Bit */
+    uint32_t SWF8:1;                    /**< bit:      8  XDMAC Channel 8 Software Flush Request Bit */
+    uint32_t SWF9:1;                    /**< bit:      9  XDMAC Channel 9 Software Flush Request Bit */
+    uint32_t SWF10:1;                   /**< bit:     10  XDMAC Channel 10 Software Flush Request Bit */
+    uint32_t SWF11:1;                   /**< bit:     11  XDMAC Channel 11 Software Flush Request Bit */
+    uint32_t SWF12:1;                   /**< bit:     12  XDMAC Channel 12 Software Flush Request Bit */
+    uint32_t SWF13:1;                   /**< bit:     13  XDMAC Channel 13 Software Flush Request Bit */
+    uint32_t SWF14:1;                   /**< bit:     14  XDMAC Channel 14 Software Flush Request Bit */
+    uint32_t SWF15:1;                   /**< bit:     15  XDMAC Channel 15 Software Flush Request Bit */
+    uint32_t SWF16:1;                   /**< bit:     16  XDMAC Channel 16 Software Flush Request Bit */
+    uint32_t SWF17:1;                   /**< bit:     17  XDMAC Channel 17 Software Flush Request Bit */
+    uint32_t SWF18:1;                   /**< bit:     18  XDMAC Channel 18 Software Flush Request Bit */
+    uint32_t SWF19:1;                   /**< bit:     19  XDMAC Channel 19 Software Flush Request Bit */
+    uint32_t SWF20:1;                   /**< bit:     20  XDMAC Channel 20 Software Flush Request Bit */
+    uint32_t SWF21:1;                   /**< bit:     21  XDMAC Channel 21 Software Flush Request Bit */
+    uint32_t SWF22:1;                   /**< bit:     22  XDMAC Channel 22 Software Flush Request Bit */
+    uint32_t SWF23:1;                   /**< bit:     23  XDMAC Channel 23 Software Flush Request Bit */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWF:24;                    /**< bit:  0..23  XDMAC Channel 23 Software Flush Request Bit */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWF_OFFSET                   (0x40)                                        /**<  (XDMAC_GSWF) Global Channel Software Flush Request Register  Offset */
+
+#define XDMAC_GSWF_SWF0_Pos                 0                                              /**< (XDMAC_GSWF) XDMAC Channel 0 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF0_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF0_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 0 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF0                     XDMAC_GSWF_SWF0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF0_Msk instead */
+#define XDMAC_GSWF_SWF1_Pos                 1                                              /**< (XDMAC_GSWF) XDMAC Channel 1 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF1_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF1_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 1 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF1                     XDMAC_GSWF_SWF1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF1_Msk instead */
+#define XDMAC_GSWF_SWF2_Pos                 2                                              /**< (XDMAC_GSWF) XDMAC Channel 2 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF2_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF2_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 2 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF2                     XDMAC_GSWF_SWF2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF2_Msk instead */
+#define XDMAC_GSWF_SWF3_Pos                 3                                              /**< (XDMAC_GSWF) XDMAC Channel 3 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF3_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF3_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 3 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF3                     XDMAC_GSWF_SWF3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF3_Msk instead */
+#define XDMAC_GSWF_SWF4_Pos                 4                                              /**< (XDMAC_GSWF) XDMAC Channel 4 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF4_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF4_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 4 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF4                     XDMAC_GSWF_SWF4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF4_Msk instead */
+#define XDMAC_GSWF_SWF5_Pos                 5                                              /**< (XDMAC_GSWF) XDMAC Channel 5 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF5_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF5_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 5 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF5                     XDMAC_GSWF_SWF5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF5_Msk instead */
+#define XDMAC_GSWF_SWF6_Pos                 6                                              /**< (XDMAC_GSWF) XDMAC Channel 6 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF6_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF6_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 6 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF6                     XDMAC_GSWF_SWF6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF6_Msk instead */
+#define XDMAC_GSWF_SWF7_Pos                 7                                              /**< (XDMAC_GSWF) XDMAC Channel 7 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF7_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF7_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 7 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF7                     XDMAC_GSWF_SWF7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF7_Msk instead */
+#define XDMAC_GSWF_SWF8_Pos                 8                                              /**< (XDMAC_GSWF) XDMAC Channel 8 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF8_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF8_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 8 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF8                     XDMAC_GSWF_SWF8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF8_Msk instead */
+#define XDMAC_GSWF_SWF9_Pos                 9                                              /**< (XDMAC_GSWF) XDMAC Channel 9 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF9_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF9_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 9 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF9                     XDMAC_GSWF_SWF9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF9_Msk instead */
+#define XDMAC_GSWF_SWF10_Pos                10                                             /**< (XDMAC_GSWF) XDMAC Channel 10 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF10_Msk                (_U_(0x1) << XDMAC_GSWF_SWF10_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 10 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF10                    XDMAC_GSWF_SWF10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF10_Msk instead */
+#define XDMAC_GSWF_SWF11_Pos                11                                             /**< (XDMAC_GSWF) XDMAC Channel 11 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF11_Msk                (_U_(0x1) << XDMAC_GSWF_SWF11_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 11 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF11                    XDMAC_GSWF_SWF11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF11_Msk instead */
+#define XDMAC_GSWF_SWF12_Pos                12                                             /**< (XDMAC_GSWF) XDMAC Channel 12 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF12_Msk                (_U_(0x1) << XDMAC_GSWF_SWF12_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 12 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF12                    XDMAC_GSWF_SWF12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF12_Msk instead */
+#define XDMAC_GSWF_SWF13_Pos                13                                             /**< (XDMAC_GSWF) XDMAC Channel 13 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF13_Msk                (_U_(0x1) << XDMAC_GSWF_SWF13_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 13 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF13                    XDMAC_GSWF_SWF13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF13_Msk instead */
+#define XDMAC_GSWF_SWF14_Pos                14                                             /**< (XDMAC_GSWF) XDMAC Channel 14 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF14_Msk                (_U_(0x1) << XDMAC_GSWF_SWF14_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 14 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF14                    XDMAC_GSWF_SWF14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF14_Msk instead */
+#define XDMAC_GSWF_SWF15_Pos                15                                             /**< (XDMAC_GSWF) XDMAC Channel 15 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF15_Msk                (_U_(0x1) << XDMAC_GSWF_SWF15_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 15 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF15                    XDMAC_GSWF_SWF15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF15_Msk instead */
+#define XDMAC_GSWF_SWF16_Pos                16                                             /**< (XDMAC_GSWF) XDMAC Channel 16 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF16_Msk                (_U_(0x1) << XDMAC_GSWF_SWF16_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 16 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF16                    XDMAC_GSWF_SWF16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF16_Msk instead */
+#define XDMAC_GSWF_SWF17_Pos                17                                             /**< (XDMAC_GSWF) XDMAC Channel 17 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF17_Msk                (_U_(0x1) << XDMAC_GSWF_SWF17_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 17 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF17                    XDMAC_GSWF_SWF17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF17_Msk instead */
+#define XDMAC_GSWF_SWF18_Pos                18                                             /**< (XDMAC_GSWF) XDMAC Channel 18 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF18_Msk                (_U_(0x1) << XDMAC_GSWF_SWF18_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 18 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF18                    XDMAC_GSWF_SWF18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF18_Msk instead */
+#define XDMAC_GSWF_SWF19_Pos                19                                             /**< (XDMAC_GSWF) XDMAC Channel 19 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF19_Msk                (_U_(0x1) << XDMAC_GSWF_SWF19_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 19 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF19                    XDMAC_GSWF_SWF19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF19_Msk instead */
+#define XDMAC_GSWF_SWF20_Pos                20                                             /**< (XDMAC_GSWF) XDMAC Channel 20 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF20_Msk                (_U_(0x1) << XDMAC_GSWF_SWF20_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 20 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF20                    XDMAC_GSWF_SWF20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF20_Msk instead */
+#define XDMAC_GSWF_SWF21_Pos                21                                             /**< (XDMAC_GSWF) XDMAC Channel 21 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF21_Msk                (_U_(0x1) << XDMAC_GSWF_SWF21_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 21 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF21                    XDMAC_GSWF_SWF21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF21_Msk instead */
+#define XDMAC_GSWF_SWF22_Pos                22                                             /**< (XDMAC_GSWF) XDMAC Channel 22 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF22_Msk                (_U_(0x1) << XDMAC_GSWF_SWF22_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 22 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF22                    XDMAC_GSWF_SWF22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF22_Msk instead */
+#define XDMAC_GSWF_SWF23_Pos                23                                             /**< (XDMAC_GSWF) XDMAC Channel 23 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF23_Msk                (_U_(0x1) << XDMAC_GSWF_SWF23_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 23 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF23                    XDMAC_GSWF_SWF23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF23_Msk instead */
+#define XDMAC_GSWF_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWF) Register MASK  (Use XDMAC_GSWF_Msk instead)  */
+#define XDMAC_GSWF_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWF) Register Mask  */
+
+#define XDMAC_GSWF_SWF_Pos                  0                                              /**< (XDMAC_GSWF Position) XDMAC Channel 23 Software Flush Request Bit */
+#define XDMAC_GSWF_SWF_Msk                  (_U_(0xFFFFFF) << XDMAC_GSWF_SWF_Pos)          /**< (XDMAC_GSWF Mask) SWF */
+#define XDMAC_GSWF_SWF(value)               (XDMAC_GSWF_SWF_Msk & ((value) << XDMAC_GSWF_SWF_Pos))  
+
+/* -------- XDMAC_VERSION : (XDMAC Offset: 0xffc) (R/W 32) XDMAC Version Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:12;                /**< bit:  0..11  Version of the Hardware Module           */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MFN:3;                     /**< bit: 16..18  Metal Fix Number                         */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_VERSION_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_VERSION_OFFSET                (0xFFC)                                       /**<  (XDMAC_VERSION) XDMAC Version Register  Offset */
+
+#define XDMAC_VERSION_VERSION_Pos           0                                              /**< (XDMAC_VERSION) Version of the Hardware Module Position */
+#define XDMAC_VERSION_VERSION_Msk           (_U_(0xFFF) << XDMAC_VERSION_VERSION_Pos)      /**< (XDMAC_VERSION) Version of the Hardware Module Mask */
+#define XDMAC_VERSION_VERSION(value)        (XDMAC_VERSION_VERSION_Msk & ((value) << XDMAC_VERSION_VERSION_Pos))
+#define XDMAC_VERSION_MFN_Pos               16                                             /**< (XDMAC_VERSION) Metal Fix Number Position */
+#define XDMAC_VERSION_MFN_Msk               (_U_(0x7) << XDMAC_VERSION_MFN_Pos)            /**< (XDMAC_VERSION) Metal Fix Number Mask */
+#define XDMAC_VERSION_MFN(value)            (XDMAC_VERSION_MFN_Msk & ((value) << XDMAC_VERSION_MFN_Pos))
+#define XDMAC_VERSION_MASK                  _U_(0x70FFF)                                   /**< \deprecated (XDMAC_VERSION) Register MASK  (Use XDMAC_VERSION_Msk instead)  */
+#define XDMAC_VERSION_Msk                   _U_(0x70FFF)                                   /**< (XDMAC_VERSION) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief XDMAC_CHID hardware registers */
+typedef struct {  
+  __O  uint32_t XDMAC_CIE;      /**< (XDMAC_CHID Offset: 0x00) Channel Interrupt Enable Register (chid = 0) */
+  __O  uint32_t XDMAC_CID;      /**< (XDMAC_CHID Offset: 0x04) Channel Interrupt Disable Register (chid = 0) */
+  __I  uint32_t XDMAC_CIM;      /**< (XDMAC_CHID Offset: 0x08) Channel Interrupt Mask Register (chid = 0) */
+  __I  uint32_t XDMAC_CIS;      /**< (XDMAC_CHID Offset: 0x0C) Channel Interrupt Status Register (chid = 0) */
+  __IO uint32_t XDMAC_CSA;      /**< (XDMAC_CHID Offset: 0x10) Channel Source Address Register (chid = 0) */
+  __IO uint32_t XDMAC_CDA;      /**< (XDMAC_CHID Offset: 0x14) Channel Destination Address Register (chid = 0) */
+  __IO uint32_t XDMAC_CNDA;     /**< (XDMAC_CHID Offset: 0x18) Channel Next Descriptor Address Register (chid = 0) */
+  __IO uint32_t XDMAC_CNDC;     /**< (XDMAC_CHID Offset: 0x1C) Channel Next Descriptor Control Register (chid = 0) */
+  __IO uint32_t XDMAC_CUBC;     /**< (XDMAC_CHID Offset: 0x20) Channel Microblock Control Register (chid = 0) */
+  __IO uint32_t XDMAC_CBC;      /**< (XDMAC_CHID Offset: 0x24) Channel Block Control Register (chid = 0) */
+  __IO uint32_t XDMAC_CC;       /**< (XDMAC_CHID Offset: 0x28) Channel Configuration Register (chid = 0) */
+  __IO uint32_t XDMAC_CDS_MSP;  /**< (XDMAC_CHID Offset: 0x2C) Channel Data Stride Memory Set Pattern (chid = 0) */
+  __IO uint32_t XDMAC_CSUS;     /**< (XDMAC_CHID Offset: 0x30) Channel Source Microblock Stride (chid = 0) */
+  __IO uint32_t XDMAC_CDUS;     /**< (XDMAC_CHID Offset: 0x34) Channel Destination Microblock Stride (chid = 0) */
+  __I  uint8_t                        Reserved1[8];
+} XdmacChid;
+
+#define XDMACCHID_NUMBER 24
+/** \brief XDMAC hardware registers */
+typedef struct {  
+  __I  uint32_t XDMAC_GTYPE;    /**< (XDMAC Offset: 0x00) Global Type Register */
+  __IO uint32_t XDMAC_GCFG;     /**< (XDMAC Offset: 0x04) Global Configuration Register */
+  __IO uint32_t XDMAC_GWAC;     /**< (XDMAC Offset: 0x08) Global Weighted Arbiter Configuration Register */
+  __O  uint32_t XDMAC_GIE;      /**< (XDMAC Offset: 0x0C) Global Interrupt Enable Register */
+  __O  uint32_t XDMAC_GID;      /**< (XDMAC Offset: 0x10) Global Interrupt Disable Register */
+  __I  uint32_t XDMAC_GIM;      /**< (XDMAC Offset: 0x14) Global Interrupt Mask Register */
+  __I  uint32_t XDMAC_GIS;      /**< (XDMAC Offset: 0x18) Global Interrupt Status Register */
+  __O  uint32_t XDMAC_GE;       /**< (XDMAC Offset: 0x1C) Global Channel Enable Register */
+  __O  uint32_t XDMAC_GD;       /**< (XDMAC Offset: 0x20) Global Channel Disable Register */
+  __I  uint32_t XDMAC_GS;       /**< (XDMAC Offset: 0x24) Global Channel Status Register */
+  __IO uint32_t XDMAC_GRS;      /**< (XDMAC Offset: 0x28) Global Channel Read Suspend Register */
+  __IO uint32_t XDMAC_GWS;      /**< (XDMAC Offset: 0x2C) Global Channel Write Suspend Register */
+  __O  uint32_t XDMAC_GRWS;     /**< (XDMAC Offset: 0x30) Global Channel Read Write Suspend Register */
+  __O  uint32_t XDMAC_GRWR;     /**< (XDMAC Offset: 0x34) Global Channel Read Write Resume Register */
+  __O  uint32_t XDMAC_GSWR;     /**< (XDMAC Offset: 0x38) Global Channel Software Request Register */
+  __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
+  __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved2[2476];
+  __IO uint32_t XDMAC_VERSION;  /**< (XDMAC Offset: 0xFFC) XDMAC Version Register */
+} Xdmac;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief XDMAC_CHID hardware registers */
+typedef struct {  
+  __O  XDMAC_CIE_Type                 XDMAC_CIE;      /**< Offset: 0x00 ( /W  32) Channel Interrupt Enable Register (chid = 0) */
+  __O  XDMAC_CID_Type                 XDMAC_CID;      /**< Offset: 0x04 ( /W  32) Channel Interrupt Disable Register (chid = 0) */
+  __I  XDMAC_CIM_Type                 XDMAC_CIM;      /**< Offset: 0x08 (R/   32) Channel Interrupt Mask Register (chid = 0) */
+  __I  XDMAC_CIS_Type                 XDMAC_CIS;      /**< Offset: 0x0C (R/   32) Channel Interrupt Status Register (chid = 0) */
+  __IO XDMAC_CSA_Type                 XDMAC_CSA;      /**< Offset: 0x10 (R/W  32) Channel Source Address Register (chid = 0) */
+  __IO XDMAC_CDA_Type                 XDMAC_CDA;      /**< Offset: 0x14 (R/W  32) Channel Destination Address Register (chid = 0) */
+  __IO XDMAC_CNDA_Type                XDMAC_CNDA;     /**< Offset: 0x18 (R/W  32) Channel Next Descriptor Address Register (chid = 0) */
+  __IO XDMAC_CNDC_Type                XDMAC_CNDC;     /**< Offset: 0x1C (R/W  32) Channel Next Descriptor Control Register (chid = 0) */
+  __IO XDMAC_CUBC_Type                XDMAC_CUBC;     /**< Offset: 0x20 (R/W  32) Channel Microblock Control Register (chid = 0) */
+  __IO XDMAC_CBC_Type                 XDMAC_CBC;      /**< Offset: 0x24 (R/W  32) Channel Block Control Register (chid = 0) */
+  __IO XDMAC_CC_Type                  XDMAC_CC;       /**< Offset: 0x28 (R/W  32) Channel Configuration Register (chid = 0) */
+  __IO XDMAC_CDS_MSP_Type             XDMAC_CDS_MSP;  /**< Offset: 0x2C (R/W  32) Channel Data Stride Memory Set Pattern (chid = 0) */
+  __IO XDMAC_CSUS_Type                XDMAC_CSUS;     /**< Offset: 0x30 (R/W  32) Channel Source Microblock Stride (chid = 0) */
+  __IO XDMAC_CDUS_Type                XDMAC_CDUS;     /**< Offset: 0x34 (R/W  32) Channel Destination Microblock Stride (chid = 0) */
+  __I  uint8_t                        Reserved1[8];
+} XdmacChid;
+
+/** \brief XDMAC hardware registers */
+typedef struct {  
+  __I  XDMAC_GTYPE_Type               XDMAC_GTYPE;    /**< Offset: 0x00 (R/   32) Global Type Register */
+  __IO XDMAC_GCFG_Type                XDMAC_GCFG;     /**< Offset: 0x04 (R/W  32) Global Configuration Register */
+  __IO XDMAC_GWAC_Type                XDMAC_GWAC;     /**< Offset: 0x08 (R/W  32) Global Weighted Arbiter Configuration Register */
+  __O  XDMAC_GIE_Type                 XDMAC_GIE;      /**< Offset: 0x0C ( /W  32) Global Interrupt Enable Register */
+  __O  XDMAC_GID_Type                 XDMAC_GID;      /**< Offset: 0x10 ( /W  32) Global Interrupt Disable Register */
+  __I  XDMAC_GIM_Type                 XDMAC_GIM;      /**< Offset: 0x14 (R/   32) Global Interrupt Mask Register */
+  __I  XDMAC_GIS_Type                 XDMAC_GIS;      /**< Offset: 0x18 (R/   32) Global Interrupt Status Register */
+  __O  XDMAC_GE_Type                  XDMAC_GE;       /**< Offset: 0x1C ( /W  32) Global Channel Enable Register */
+  __O  XDMAC_GD_Type                  XDMAC_GD;       /**< Offset: 0x20 ( /W  32) Global Channel Disable Register */
+  __I  XDMAC_GS_Type                  XDMAC_GS;       /**< Offset: 0x24 (R/   32) Global Channel Status Register */
+  __IO XDMAC_GRS_Type                 XDMAC_GRS;      /**< Offset: 0x28 (R/W  32) Global Channel Read Suspend Register */
+  __IO XDMAC_GWS_Type                 XDMAC_GWS;      /**< Offset: 0x2C (R/W  32) Global Channel Write Suspend Register */
+  __O  XDMAC_GRWS_Type                XDMAC_GRWS;     /**< Offset: 0x30 ( /W  32) Global Channel Read Write Suspend Register */
+  __O  XDMAC_GRWR_Type                XDMAC_GRWR;     /**< Offset: 0x34 ( /W  32) Global Channel Read Write Resume Register */
+  __O  XDMAC_GSWR_Type                XDMAC_GSWR;     /**< Offset: 0x38 ( /W  32) Global Channel Software Request Register */
+  __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
+  __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved2[2476];
+  __IO XDMAC_VERSION_Type             XDMAC_VERSION;  /**< Offset: 0xFFC (R/W  32) XDMAC Version Register */
+} Xdmac;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Extensible DMA Controller */
+
+#endif /* _SAMV71_XDMAC_COMPONENT_H_ */

--- a/asf/sam/include/samv71/instance/acc.h
+++ b/asf/sam/include/samv71/instance/acc.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ACC_INSTANCE_H_
+#define _SAMV71_ACC_INSTANCE_H_
+
+/* ========== Register definition for ACC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ACC_CR              (0x40044000) /**< (ACC) Control Register */
+#define REG_ACC_MR              (0x40044004) /**< (ACC) Mode Register */
+#define REG_ACC_IER             (0x40044024) /**< (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR             (0x40044028) /**< (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR             (0x4004402C) /**< (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR             (0x40044030) /**< (ACC) Interrupt Status Register */
+#define REG_ACC_ACR             (0x40044094) /**< (ACC) Analog Control Register */
+#define REG_ACC_WPMR            (0x400440E4) /**< (ACC) Write Protection Mode Register */
+#define REG_ACC_WPSR            (0x400440E8) /**< (ACC) Write Protection Status Register */
+#define REG_ACC_VER             (0x400440FC) /**< (ACC) Version Register */
+
+#else
+
+#define REG_ACC_CR              (*(__O  uint32_t*)0x40044000U) /**< (ACC) Control Register */
+#define REG_ACC_MR              (*(__IO uint32_t*)0x40044004U) /**< (ACC) Mode Register */
+#define REG_ACC_IER             (*(__O  uint32_t*)0x40044024U) /**< (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR             (*(__O  uint32_t*)0x40044028U) /**< (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR             (*(__I  uint32_t*)0x4004402CU) /**< (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR             (*(__I  uint32_t*)0x40044030U) /**< (ACC) Interrupt Status Register */
+#define REG_ACC_ACR             (*(__IO uint32_t*)0x40044094U) /**< (ACC) Analog Control Register */
+#define REG_ACC_WPMR            (*(__IO uint32_t*)0x400440E4U) /**< (ACC) Write Protection Mode Register */
+#define REG_ACC_WPSR            (*(__I  uint32_t*)0x400440E8U) /**< (ACC) Write Protection Status Register */
+#define REG_ACC_VER             (*(__I  uint32_t*)0x400440FCU) /**< (ACC) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ACC peripheral ========== */
+#define ACC_INSTANCE_ID                          33         
+
+#endif /* _SAMV71_ACC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/aes.h
+++ b/asf/sam/include/samv71/instance/aes.h
@@ -1,0 +1,146 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AES
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_AES_INSTANCE_H_
+#define _SAMV71_AES_INSTANCE_H_
+
+/* ========== Register definition for AES peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AES_CR              (0x4006C000) /**< (AES) Control Register */
+#define REG_AES_MR              (0x4006C004) /**< (AES) Mode Register */
+#define REG_AES_IER             (0x4006C010) /**< (AES) Interrupt Enable Register */
+#define REG_AES_IDR             (0x4006C014) /**< (AES) Interrupt Disable Register */
+#define REG_AES_IMR             (0x4006C018) /**< (AES) Interrupt Mask Register */
+#define REG_AES_ISR             (0x4006C01C) /**< (AES) Interrupt Status Register */
+#define REG_AES_KEYWR           (0x4006C020) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR0          (0x4006C020) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR1          (0x4006C024) /**< (AES) Key Word Register 1 */
+#define REG_AES_KEYWR2          (0x4006C028) /**< (AES) Key Word Register 2 */
+#define REG_AES_KEYWR3          (0x4006C02C) /**< (AES) Key Word Register 3 */
+#define REG_AES_KEYWR4          (0x4006C030) /**< (AES) Key Word Register 4 */
+#define REG_AES_KEYWR5          (0x4006C034) /**< (AES) Key Word Register 5 */
+#define REG_AES_KEYWR6          (0x4006C038) /**< (AES) Key Word Register 6 */
+#define REG_AES_KEYWR7          (0x4006C03C) /**< (AES) Key Word Register 7 */
+#define REG_AES_IDATAR          (0x4006C040) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR0         (0x4006C040) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR1         (0x4006C044) /**< (AES) Input Data Register 1 */
+#define REG_AES_IDATAR2         (0x4006C048) /**< (AES) Input Data Register 2 */
+#define REG_AES_IDATAR3         (0x4006C04C) /**< (AES) Input Data Register 3 */
+#define REG_AES_ODATAR          (0x4006C050) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR0         (0x4006C050) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR1         (0x4006C054) /**< (AES) Output Data Register 1 */
+#define REG_AES_ODATAR2         (0x4006C058) /**< (AES) Output Data Register 2 */
+#define REG_AES_ODATAR3         (0x4006C05C) /**< (AES) Output Data Register 3 */
+#define REG_AES_IVR             (0x4006C060) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR0            (0x4006C060) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR1            (0x4006C064) /**< (AES) Initialization Vector Register 1 */
+#define REG_AES_IVR2            (0x4006C068) /**< (AES) Initialization Vector Register 2 */
+#define REG_AES_IVR3            (0x4006C06C) /**< (AES) Initialization Vector Register 3 */
+#define REG_AES_AADLENR         (0x4006C070) /**< (AES) Additional Authenticated Data Length Register */
+#define REG_AES_CLENR           (0x4006C074) /**< (AES) Plaintext/Ciphertext Length Register */
+#define REG_AES_GHASHR          (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR0         (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR1         (0x4006C07C) /**< (AES) GCM Intermediate Hash Word Register 1 */
+#define REG_AES_GHASHR2         (0x4006C080) /**< (AES) GCM Intermediate Hash Word Register 2 */
+#define REG_AES_GHASHR3         (0x4006C084) /**< (AES) GCM Intermediate Hash Word Register 3 */
+#define REG_AES_TAGR            (0x4006C088) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR0           (0x4006C088) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR1           (0x4006C08C) /**< (AES) GCM Authentication Tag Word Register 1 */
+#define REG_AES_TAGR2           (0x4006C090) /**< (AES) GCM Authentication Tag Word Register 2 */
+#define REG_AES_TAGR3           (0x4006C094) /**< (AES) GCM Authentication Tag Word Register 3 */
+#define REG_AES_CTRR            (0x4006C098) /**< (AES) GCM Encryption Counter Value Register */
+#define REG_AES_GCMHR           (0x4006C09C) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR0          (0x4006C09C) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR1          (0x4006C0A0) /**< (AES) GCM H Word Register 1 */
+#define REG_AES_GCMHR2          (0x4006C0A4) /**< (AES) GCM H Word Register 2 */
+#define REG_AES_GCMHR3          (0x4006C0A8) /**< (AES) GCM H Word Register 3 */
+#define REG_AES_VERSION         (0x4006C0FC) /**< (AES) Version Register */
+
+#else
+
+#define REG_AES_CR              (*(__O  uint32_t*)0x4006C000U) /**< (AES) Control Register */
+#define REG_AES_MR              (*(__IO uint32_t*)0x4006C004U) /**< (AES) Mode Register */
+#define REG_AES_IER             (*(__O  uint32_t*)0x4006C010U) /**< (AES) Interrupt Enable Register */
+#define REG_AES_IDR             (*(__O  uint32_t*)0x4006C014U) /**< (AES) Interrupt Disable Register */
+#define REG_AES_IMR             (*(__I  uint32_t*)0x4006C018U) /**< (AES) Interrupt Mask Register */
+#define REG_AES_ISR             (*(__I  uint32_t*)0x4006C01CU) /**< (AES) Interrupt Status Register */
+#define REG_AES_KEYWR           (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR0          (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR1          (*(__O  uint32_t*)0x4006C024U) /**< (AES) Key Word Register 1 */
+#define REG_AES_KEYWR2          (*(__O  uint32_t*)0x4006C028U) /**< (AES) Key Word Register 2 */
+#define REG_AES_KEYWR3          (*(__O  uint32_t*)0x4006C02CU) /**< (AES) Key Word Register 3 */
+#define REG_AES_KEYWR4          (*(__O  uint32_t*)0x4006C030U) /**< (AES) Key Word Register 4 */
+#define REG_AES_KEYWR5          (*(__O  uint32_t*)0x4006C034U) /**< (AES) Key Word Register 5 */
+#define REG_AES_KEYWR6          (*(__O  uint32_t*)0x4006C038U) /**< (AES) Key Word Register 6 */
+#define REG_AES_KEYWR7          (*(__O  uint32_t*)0x4006C03CU) /**< (AES) Key Word Register 7 */
+#define REG_AES_IDATAR          (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR0         (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR1         (*(__O  uint32_t*)0x4006C044U) /**< (AES) Input Data Register 1 */
+#define REG_AES_IDATAR2         (*(__O  uint32_t*)0x4006C048U) /**< (AES) Input Data Register 2 */
+#define REG_AES_IDATAR3         (*(__O  uint32_t*)0x4006C04CU) /**< (AES) Input Data Register 3 */
+#define REG_AES_ODATAR          (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR0         (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR1         (*(__I  uint32_t*)0x4006C054U) /**< (AES) Output Data Register 1 */
+#define REG_AES_ODATAR2         (*(__I  uint32_t*)0x4006C058U) /**< (AES) Output Data Register 2 */
+#define REG_AES_ODATAR3         (*(__I  uint32_t*)0x4006C05CU) /**< (AES) Output Data Register 3 */
+#define REG_AES_IVR             (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR0            (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR1            (*(__O  uint32_t*)0x4006C064U) /**< (AES) Initialization Vector Register 1 */
+#define REG_AES_IVR2            (*(__O  uint32_t*)0x4006C068U) /**< (AES) Initialization Vector Register 2 */
+#define REG_AES_IVR3            (*(__O  uint32_t*)0x4006C06CU) /**< (AES) Initialization Vector Register 3 */
+#define REG_AES_AADLENR         (*(__IO uint32_t*)0x4006C070U) /**< (AES) Additional Authenticated Data Length Register */
+#define REG_AES_CLENR           (*(__IO uint32_t*)0x4006C074U) /**< (AES) Plaintext/Ciphertext Length Register */
+#define REG_AES_GHASHR          (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR0         (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR1         (*(__IO uint32_t*)0x4006C07CU) /**< (AES) GCM Intermediate Hash Word Register 1 */
+#define REG_AES_GHASHR2         (*(__IO uint32_t*)0x4006C080U) /**< (AES) GCM Intermediate Hash Word Register 2 */
+#define REG_AES_GHASHR3         (*(__IO uint32_t*)0x4006C084U) /**< (AES) GCM Intermediate Hash Word Register 3 */
+#define REG_AES_TAGR            (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR0           (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR1           (*(__I  uint32_t*)0x4006C08CU) /**< (AES) GCM Authentication Tag Word Register 1 */
+#define REG_AES_TAGR2           (*(__I  uint32_t*)0x4006C090U) /**< (AES) GCM Authentication Tag Word Register 2 */
+#define REG_AES_TAGR3           (*(__I  uint32_t*)0x4006C094U) /**< (AES) GCM Authentication Tag Word Register 3 */
+#define REG_AES_CTRR            (*(__I  uint32_t*)0x4006C098U) /**< (AES) GCM Encryption Counter Value Register */
+#define REG_AES_GCMHR           (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR0          (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR1          (*(__IO uint32_t*)0x4006C0A0U) /**< (AES) GCM H Word Register 1 */
+#define REG_AES_GCMHR2          (*(__IO uint32_t*)0x4006C0A4U) /**< (AES) GCM H Word Register 2 */
+#define REG_AES_GCMHR3          (*(__IO uint32_t*)0x4006C0A8U) /**< (AES) GCM H Word Register 3 */
+#define REG_AES_VERSION         (*(__I  uint32_t*)0x4006C0FCU) /**< (AES) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AES peripheral ========== */
+#define AES_DMAC_ID_TX                           37         
+#define AES_DMAC_ID_RX                           38         
+#define AES_INSTANCE_ID                          56         
+
+#endif /* _SAMV71_AES_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/afec0.h
+++ b/asf/sam/include/samv71/instance/afec0.h
@@ -1,0 +1,107 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AFEC0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_AFEC0_INSTANCE_H_
+#define _SAMV71_AFEC0_INSTANCE_H_
+
+/* ========== Register definition for AFEC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AFEC0_CR            (0x4003C000) /**< (AFEC0) AFEC Control Register */
+#define REG_AFEC0_MR            (0x4003C004) /**< (AFEC0) AFEC Mode Register */
+#define REG_AFEC0_EMR           (0x4003C008) /**< (AFEC0) AFEC Extended Mode Register */
+#define REG_AFEC0_SEQ1R         (0x4003C00C) /**< (AFEC0) AFEC Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R         (0x4003C010) /**< (AFEC0) AFEC Channel Sequence 2 Register */
+#define REG_AFEC0_CHER          (0x4003C014) /**< (AFEC0) AFEC Channel Enable Register */
+#define REG_AFEC0_CHDR          (0x4003C018) /**< (AFEC0) AFEC Channel Disable Register */
+#define REG_AFEC0_CHSR          (0x4003C01C) /**< (AFEC0) AFEC Channel Status Register */
+#define REG_AFEC0_LCDR          (0x4003C020) /**< (AFEC0) AFEC Last Converted Data Register */
+#define REG_AFEC0_IER           (0x4003C024) /**< (AFEC0) AFEC Interrupt Enable Register */
+#define REG_AFEC0_IDR           (0x4003C028) /**< (AFEC0) AFEC Interrupt Disable Register */
+#define REG_AFEC0_IMR           (0x4003C02C) /**< (AFEC0) AFEC Interrupt Mask Register */
+#define REG_AFEC0_ISR           (0x4003C030) /**< (AFEC0) AFEC Interrupt Status Register */
+#define REG_AFEC0_OVER          (0x4003C04C) /**< (AFEC0) AFEC Overrun Status Register */
+#define REG_AFEC0_CWR           (0x4003C050) /**< (AFEC0) AFEC Compare Window Register */
+#define REG_AFEC0_CGR           (0x4003C054) /**< (AFEC0) AFEC Channel Gain Register */
+#define REG_AFEC0_DIFFR         (0x4003C060) /**< (AFEC0) AFEC Channel Differential Register */
+#define REG_AFEC0_CSELR         (0x4003C064) /**< (AFEC0) AFEC Channel Selection Register */
+#define REG_AFEC0_CDR           (0x4003C068) /**< (AFEC0) AFEC Channel Data Register */
+#define REG_AFEC0_COCR          (0x4003C06C) /**< (AFEC0) AFEC Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR        (0x4003C070) /**< (AFEC0) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR       (0x4003C074) /**< (AFEC0) AFEC Temperature Compare Window Register */
+#define REG_AFEC0_ACR           (0x4003C094) /**< (AFEC0) AFEC Analog Control Register */
+#define REG_AFEC0_SHMR          (0x4003C0A0) /**< (AFEC0) AFEC Sample & Hold Mode Register */
+#define REG_AFEC0_COSR          (0x4003C0D0) /**< (AFEC0) AFEC Correction Select Register */
+#define REG_AFEC0_CVR           (0x4003C0D4) /**< (AFEC0) AFEC Correction Values Register */
+#define REG_AFEC0_CECR          (0x4003C0D8) /**< (AFEC0) AFEC Channel Error Correction Register */
+#define REG_AFEC0_WPMR          (0x4003C0E4) /**< (AFEC0) AFEC Write Protection Mode Register */
+#define REG_AFEC0_WPSR          (0x4003C0E8) /**< (AFEC0) AFEC Write Protection Status Register */
+#define REG_AFEC0_VERSION       (0x4003C0FC) /**< (AFEC0) AFEC Version Register */
+
+#else
+
+#define REG_AFEC0_CR            (*(__O  uint32_t*)0x4003C000U) /**< (AFEC0) AFEC Control Register */
+#define REG_AFEC0_MR            (*(__IO uint32_t*)0x4003C004U) /**< (AFEC0) AFEC Mode Register */
+#define REG_AFEC0_EMR           (*(__IO uint32_t*)0x4003C008U) /**< (AFEC0) AFEC Extended Mode Register */
+#define REG_AFEC0_SEQ1R         (*(__IO uint32_t*)0x4003C00CU) /**< (AFEC0) AFEC Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R         (*(__IO uint32_t*)0x4003C010U) /**< (AFEC0) AFEC Channel Sequence 2 Register */
+#define REG_AFEC0_CHER          (*(__O  uint32_t*)0x4003C014U) /**< (AFEC0) AFEC Channel Enable Register */
+#define REG_AFEC0_CHDR          (*(__O  uint32_t*)0x4003C018U) /**< (AFEC0) AFEC Channel Disable Register */
+#define REG_AFEC0_CHSR          (*(__I  uint32_t*)0x4003C01CU) /**< (AFEC0) AFEC Channel Status Register */
+#define REG_AFEC0_LCDR          (*(__I  uint32_t*)0x4003C020U) /**< (AFEC0) AFEC Last Converted Data Register */
+#define REG_AFEC0_IER           (*(__O  uint32_t*)0x4003C024U) /**< (AFEC0) AFEC Interrupt Enable Register */
+#define REG_AFEC0_IDR           (*(__O  uint32_t*)0x4003C028U) /**< (AFEC0) AFEC Interrupt Disable Register */
+#define REG_AFEC0_IMR           (*(__I  uint32_t*)0x4003C02CU) /**< (AFEC0) AFEC Interrupt Mask Register */
+#define REG_AFEC0_ISR           (*(__I  uint32_t*)0x4003C030U) /**< (AFEC0) AFEC Interrupt Status Register */
+#define REG_AFEC0_OVER          (*(__I  uint32_t*)0x4003C04CU) /**< (AFEC0) AFEC Overrun Status Register */
+#define REG_AFEC0_CWR           (*(__IO uint32_t*)0x4003C050U) /**< (AFEC0) AFEC Compare Window Register */
+#define REG_AFEC0_CGR           (*(__IO uint32_t*)0x4003C054U) /**< (AFEC0) AFEC Channel Gain Register */
+#define REG_AFEC0_DIFFR         (*(__IO uint32_t*)0x4003C060U) /**< (AFEC0) AFEC Channel Differential Register */
+#define REG_AFEC0_CSELR         (*(__IO uint32_t*)0x4003C064U) /**< (AFEC0) AFEC Channel Selection Register */
+#define REG_AFEC0_CDR           (*(__I  uint32_t*)0x4003C068U) /**< (AFEC0) AFEC Channel Data Register */
+#define REG_AFEC0_COCR          (*(__IO uint32_t*)0x4003C06CU) /**< (AFEC0) AFEC Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR        (*(__IO uint32_t*)0x4003C070U) /**< (AFEC0) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR       (*(__IO uint32_t*)0x4003C074U) /**< (AFEC0) AFEC Temperature Compare Window Register */
+#define REG_AFEC0_ACR           (*(__IO uint32_t*)0x4003C094U) /**< (AFEC0) AFEC Analog Control Register */
+#define REG_AFEC0_SHMR          (*(__IO uint32_t*)0x4003C0A0U) /**< (AFEC0) AFEC Sample & Hold Mode Register */
+#define REG_AFEC0_COSR          (*(__IO uint32_t*)0x4003C0D0U) /**< (AFEC0) AFEC Correction Select Register */
+#define REG_AFEC0_CVR           (*(__IO uint32_t*)0x4003C0D4U) /**< (AFEC0) AFEC Correction Values Register */
+#define REG_AFEC0_CECR          (*(__IO uint32_t*)0x4003C0D8U) /**< (AFEC0) AFEC Channel Error Correction Register */
+#define REG_AFEC0_WPMR          (*(__IO uint32_t*)0x4003C0E4U) /**< (AFEC0) AFEC Write Protection Mode Register */
+#define REG_AFEC0_WPSR          (*(__I  uint32_t*)0x4003C0E8U) /**< (AFEC0) AFEC Write Protection Status Register */
+#define REG_AFEC0_VERSION       (*(__I  uint32_t*)0x4003C0FCU) /**< (AFEC0) AFEC Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AFEC0 peripheral ========== */
+#define AFEC0_DMAC_ID_RX                         35         
+#define AFEC0_INSTANCE_ID                        29         
+
+#endif /* _SAMV71_AFEC0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/afec1.h
+++ b/asf/sam/include/samv71/instance/afec1.h
@@ -1,0 +1,107 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AFEC1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_AFEC1_INSTANCE_H_
+#define _SAMV71_AFEC1_INSTANCE_H_
+
+/* ========== Register definition for AFEC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AFEC1_CR            (0x40064000) /**< (AFEC1) AFEC Control Register */
+#define REG_AFEC1_MR            (0x40064004) /**< (AFEC1) AFEC Mode Register */
+#define REG_AFEC1_EMR           (0x40064008) /**< (AFEC1) AFEC Extended Mode Register */
+#define REG_AFEC1_SEQ1R         (0x4006400C) /**< (AFEC1) AFEC Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R         (0x40064010) /**< (AFEC1) AFEC Channel Sequence 2 Register */
+#define REG_AFEC1_CHER          (0x40064014) /**< (AFEC1) AFEC Channel Enable Register */
+#define REG_AFEC1_CHDR          (0x40064018) /**< (AFEC1) AFEC Channel Disable Register */
+#define REG_AFEC1_CHSR          (0x4006401C) /**< (AFEC1) AFEC Channel Status Register */
+#define REG_AFEC1_LCDR          (0x40064020) /**< (AFEC1) AFEC Last Converted Data Register */
+#define REG_AFEC1_IER           (0x40064024) /**< (AFEC1) AFEC Interrupt Enable Register */
+#define REG_AFEC1_IDR           (0x40064028) /**< (AFEC1) AFEC Interrupt Disable Register */
+#define REG_AFEC1_IMR           (0x4006402C) /**< (AFEC1) AFEC Interrupt Mask Register */
+#define REG_AFEC1_ISR           (0x40064030) /**< (AFEC1) AFEC Interrupt Status Register */
+#define REG_AFEC1_OVER          (0x4006404C) /**< (AFEC1) AFEC Overrun Status Register */
+#define REG_AFEC1_CWR           (0x40064050) /**< (AFEC1) AFEC Compare Window Register */
+#define REG_AFEC1_CGR           (0x40064054) /**< (AFEC1) AFEC Channel Gain Register */
+#define REG_AFEC1_DIFFR         (0x40064060) /**< (AFEC1) AFEC Channel Differential Register */
+#define REG_AFEC1_CSELR         (0x40064064) /**< (AFEC1) AFEC Channel Selection Register */
+#define REG_AFEC1_CDR           (0x40064068) /**< (AFEC1) AFEC Channel Data Register */
+#define REG_AFEC1_COCR          (0x4006406C) /**< (AFEC1) AFEC Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR        (0x40064070) /**< (AFEC1) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR       (0x40064074) /**< (AFEC1) AFEC Temperature Compare Window Register */
+#define REG_AFEC1_ACR           (0x40064094) /**< (AFEC1) AFEC Analog Control Register */
+#define REG_AFEC1_SHMR          (0x400640A0) /**< (AFEC1) AFEC Sample & Hold Mode Register */
+#define REG_AFEC1_COSR          (0x400640D0) /**< (AFEC1) AFEC Correction Select Register */
+#define REG_AFEC1_CVR           (0x400640D4) /**< (AFEC1) AFEC Correction Values Register */
+#define REG_AFEC1_CECR          (0x400640D8) /**< (AFEC1) AFEC Channel Error Correction Register */
+#define REG_AFEC1_WPMR          (0x400640E4) /**< (AFEC1) AFEC Write Protection Mode Register */
+#define REG_AFEC1_WPSR          (0x400640E8) /**< (AFEC1) AFEC Write Protection Status Register */
+#define REG_AFEC1_VERSION       (0x400640FC) /**< (AFEC1) AFEC Version Register */
+
+#else
+
+#define REG_AFEC1_CR            (*(__O  uint32_t*)0x40064000U) /**< (AFEC1) AFEC Control Register */
+#define REG_AFEC1_MR            (*(__IO uint32_t*)0x40064004U) /**< (AFEC1) AFEC Mode Register */
+#define REG_AFEC1_EMR           (*(__IO uint32_t*)0x40064008U) /**< (AFEC1) AFEC Extended Mode Register */
+#define REG_AFEC1_SEQ1R         (*(__IO uint32_t*)0x4006400CU) /**< (AFEC1) AFEC Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R         (*(__IO uint32_t*)0x40064010U) /**< (AFEC1) AFEC Channel Sequence 2 Register */
+#define REG_AFEC1_CHER          (*(__O  uint32_t*)0x40064014U) /**< (AFEC1) AFEC Channel Enable Register */
+#define REG_AFEC1_CHDR          (*(__O  uint32_t*)0x40064018U) /**< (AFEC1) AFEC Channel Disable Register */
+#define REG_AFEC1_CHSR          (*(__I  uint32_t*)0x4006401CU) /**< (AFEC1) AFEC Channel Status Register */
+#define REG_AFEC1_LCDR          (*(__I  uint32_t*)0x40064020U) /**< (AFEC1) AFEC Last Converted Data Register */
+#define REG_AFEC1_IER           (*(__O  uint32_t*)0x40064024U) /**< (AFEC1) AFEC Interrupt Enable Register */
+#define REG_AFEC1_IDR           (*(__O  uint32_t*)0x40064028U) /**< (AFEC1) AFEC Interrupt Disable Register */
+#define REG_AFEC1_IMR           (*(__I  uint32_t*)0x4006402CU) /**< (AFEC1) AFEC Interrupt Mask Register */
+#define REG_AFEC1_ISR           (*(__I  uint32_t*)0x40064030U) /**< (AFEC1) AFEC Interrupt Status Register */
+#define REG_AFEC1_OVER          (*(__I  uint32_t*)0x4006404CU) /**< (AFEC1) AFEC Overrun Status Register */
+#define REG_AFEC1_CWR           (*(__IO uint32_t*)0x40064050U) /**< (AFEC1) AFEC Compare Window Register */
+#define REG_AFEC1_CGR           (*(__IO uint32_t*)0x40064054U) /**< (AFEC1) AFEC Channel Gain Register */
+#define REG_AFEC1_DIFFR         (*(__IO uint32_t*)0x40064060U) /**< (AFEC1) AFEC Channel Differential Register */
+#define REG_AFEC1_CSELR         (*(__IO uint32_t*)0x40064064U) /**< (AFEC1) AFEC Channel Selection Register */
+#define REG_AFEC1_CDR           (*(__I  uint32_t*)0x40064068U) /**< (AFEC1) AFEC Channel Data Register */
+#define REG_AFEC1_COCR          (*(__IO uint32_t*)0x4006406CU) /**< (AFEC1) AFEC Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR        (*(__IO uint32_t*)0x40064070U) /**< (AFEC1) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR       (*(__IO uint32_t*)0x40064074U) /**< (AFEC1) AFEC Temperature Compare Window Register */
+#define REG_AFEC1_ACR           (*(__IO uint32_t*)0x40064094U) /**< (AFEC1) AFEC Analog Control Register */
+#define REG_AFEC1_SHMR          (*(__IO uint32_t*)0x400640A0U) /**< (AFEC1) AFEC Sample & Hold Mode Register */
+#define REG_AFEC1_COSR          (*(__IO uint32_t*)0x400640D0U) /**< (AFEC1) AFEC Correction Select Register */
+#define REG_AFEC1_CVR           (*(__IO uint32_t*)0x400640D4U) /**< (AFEC1) AFEC Correction Values Register */
+#define REG_AFEC1_CECR          (*(__IO uint32_t*)0x400640D8U) /**< (AFEC1) AFEC Channel Error Correction Register */
+#define REG_AFEC1_WPMR          (*(__IO uint32_t*)0x400640E4U) /**< (AFEC1) AFEC Write Protection Mode Register */
+#define REG_AFEC1_WPSR          (*(__I  uint32_t*)0x400640E8U) /**< (AFEC1) AFEC Write Protection Status Register */
+#define REG_AFEC1_VERSION       (*(__I  uint32_t*)0x400640FCU) /**< (AFEC1) AFEC Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AFEC1 peripheral ========== */
+#define AFEC1_DMAC_ID_RX                         36         
+#define AFEC1_INSTANCE_ID                        40         
+
+#endif /* _SAMV71_AFEC1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/chipid.h
+++ b/asf/sam/include/samv71/instance/chipid.h
@@ -1,0 +1,46 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CHIPID
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_CHIPID_INSTANCE_H_
+#define _SAMV71_CHIPID_INSTANCE_H_
+
+/* ========== Register definition for CHIPID peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_CHIPID_CIDR         (0x400E0940) /**< (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID         (0x400E0944) /**< (CHIPID) Chip ID Extension Register */
+
+#else
+
+#define REG_CHIPID_CIDR         (*(__I  uint32_t*)0x400E0940U) /**< (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID         (*(__I  uint32_t*)0x400E0944U) /**< (CHIPID) Chip ID Extension Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_CHIPID_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/dacc.h
+++ b/asf/sam/include/samv71/instance/dacc.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_DACC_INSTANCE_H_
+#define _SAMV71_DACC_INSTANCE_H_
+
+/* ========== Register definition for DACC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DACC_CR             (0x40040000) /**< (DACC) Control Register */
+#define REG_DACC_MR             (0x40040004) /**< (DACC) Mode Register */
+#define REG_DACC_TRIGR          (0x40040008) /**< (DACC) Trigger Register */
+#define REG_DACC_CHER           (0x40040010) /**< (DACC) Channel Enable Register */
+#define REG_DACC_CHDR           (0x40040014) /**< (DACC) Channel Disable Register */
+#define REG_DACC_CHSR           (0x40040018) /**< (DACC) Channel Status Register */
+#define REG_DACC_CDR            (0x4004001C) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR0           (0x4004001C) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR1           (0x40040020) /**< (DACC) Conversion Data Register 1 */
+#define REG_DACC_IER            (0x40040024) /**< (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR            (0x40040028) /**< (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR            (0x4004002C) /**< (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR            (0x40040030) /**< (DACC) Interrupt Status Register */
+#define REG_DACC_ACR            (0x40040094) /**< (DACC) Analog Current Register */
+#define REG_DACC_WPMR           (0x400400E4) /**< (DACC) Write Protection Mode Register */
+#define REG_DACC_WPSR           (0x400400E8) /**< (DACC) Write Protection Status Register */
+#define REG_DACC_VERSION        (0x400400FC) /**< (DACC) Version Register */
+
+#else
+
+#define REG_DACC_CR             (*(__O  uint32_t*)0x40040000U) /**< (DACC) Control Register */
+#define REG_DACC_MR             (*(__IO uint32_t*)0x40040004U) /**< (DACC) Mode Register */
+#define REG_DACC_TRIGR          (*(__IO uint32_t*)0x40040008U) /**< (DACC) Trigger Register */
+#define REG_DACC_CHER           (*(__O  uint32_t*)0x40040010U) /**< (DACC) Channel Enable Register */
+#define REG_DACC_CHDR           (*(__O  uint32_t*)0x40040014U) /**< (DACC) Channel Disable Register */
+#define REG_DACC_CHSR           (*(__I  uint32_t*)0x40040018U) /**< (DACC) Channel Status Register */
+#define REG_DACC_CDR            (*(__O  uint32_t*)0x4004001CU) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR0           (*(__O  uint32_t*)0x4004001CU) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR1           (*(__O  uint32_t*)0x40040020U) /**< (DACC) Conversion Data Register 1 */
+#define REG_DACC_IER            (*(__O  uint32_t*)0x40040024U) /**< (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR            (*(__O  uint32_t*)0x40040028U) /**< (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR            (*(__I  uint32_t*)0x4004002CU) /**< (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR            (*(__I  uint32_t*)0x40040030U) /**< (DACC) Interrupt Status Register */
+#define REG_DACC_ACR            (*(__IO uint32_t*)0x40040094U) /**< (DACC) Analog Current Register */
+#define REG_DACC_WPMR           (*(__IO uint32_t*)0x400400E4U) /**< (DACC) Write Protection Mode Register */
+#define REG_DACC_WPSR           (*(__I  uint32_t*)0x400400E8U) /**< (DACC) Write Protection Status Register */
+#define REG_DACC_VERSION        (*(__I  uint32_t*)0x400400FCU) /**< (DACC) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DACC peripheral ========== */
+#define DACC_DMAC_ID_TX                          30         
+#define DACC_INSTANCE_ID                         30         
+
+#endif /* _SAMV71_DACC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/efc.h
+++ b/asf/sam/include/samv71/instance/efc.h
@@ -1,0 +1,61 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EFC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_EFC_INSTANCE_H_
+#define _SAMV71_EFC_INSTANCE_H_
+
+/* ========== Register definition for EFC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EEFC_FMR            (0x400E0C00) /**< (EFC) EEFC Flash Mode Register */
+#define REG_EEFC_FCR            (0x400E0C04) /**< (EFC) EEFC Flash Command Register */
+#define REG_EEFC_FSR            (0x400E0C08) /**< (EFC) EEFC Flash Status Register */
+#define REG_EEFC_FRR            (0x400E0C0C) /**< (EFC) EEFC Flash Result Register */
+#define REG_EEFC_VERSION        (0x400E0C14) /**< (EFC) EEFC Version Register */
+#define REG_EEFC_WPMR           (0x400E0CE4) /**< (EFC) Write Protection Mode Register */
+
+#else
+
+#define REG_EEFC_FMR            (*(__IO uint32_t*)0x400E0C00U) /**< (EFC) EEFC Flash Mode Register */
+#define REG_EEFC_FCR            (*(__O  uint32_t*)0x400E0C04U) /**< (EFC) EEFC Flash Command Register */
+#define REG_EEFC_FSR            (*(__I  uint32_t*)0x400E0C08U) /**< (EFC) EEFC Flash Status Register */
+#define REG_EEFC_FRR            (*(__I  uint32_t*)0x400E0C0CU) /**< (EFC) EEFC Flash Result Register */
+#define REG_EEFC_VERSION        (*(__I  uint32_t*)0x400E0C14U) /**< (EFC) EEFC Version Register */
+#define REG_EEFC_WPMR           (*(__IO uint32_t*)0x400E0CE4U) /**< (EFC) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EFC peripheral ========== */
+#define EFC_FLASH_SIZE                           2097152    
+#define EFC_PAGE_SIZE                            512        
+#define EFC_INSTANCE_ID                          6          
+#define EFC_PAGES_PR_REGION                      32         
+
+#endif /* _SAMV71_EFC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/gmac.h
+++ b/asf/sam/include/samv71/instance/gmac.h
@@ -1,0 +1,440 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_GMAC_INSTANCE_H_
+#define _SAMV71_GMAC_INSTANCE_H_
+
+/* ========== Register definition for GMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GMAC_SAB1           (0x40050088) /**< (GMAC) Specific Address 1 Bottom Register 0 */
+#define REG_GMAC_SAT1           (0x4005008C) /**< (GMAC) Specific Address 1 Top Register 0 */
+#define REG_GMAC_SAB2           (0x40050090) /**< (GMAC) Specific Address 1 Bottom Register 1 */
+#define REG_GMAC_SAT2           (0x40050094) /**< (GMAC) Specific Address 1 Top Register 1 */
+#define REG_GMAC_SAB3           (0x40050098) /**< (GMAC) Specific Address 1 Bottom Register 2 */
+#define REG_GMAC_SAT3           (0x4005009C) /**< (GMAC) Specific Address 1 Top Register 2 */
+#define REG_GMAC_SAB4           (0x400500A0) /**< (GMAC) Specific Address 1 Bottom Register 3 */
+#define REG_GMAC_SAT4           (0x400500A4) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_NCR            (0x40050000) /**< (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR          (0x40050004) /**< (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR            (0x40050008) /**< (GMAC) Network Status Register */
+#define REG_GMAC_UR             (0x4005000C) /**< (GMAC) User Register */
+#define REG_GMAC_DCFGR          (0x40050010) /**< (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR            (0x40050014) /**< (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB           (0x40050018) /**< (GMAC) Receive Buffer Queue Base Address Register */
+#define REG_GMAC_TBQB           (0x4005001C) /**< (GMAC) Transmit Buffer Queue Base Address Register */
+#define REG_GMAC_RSR            (0x40050020) /**< (GMAC) Receive Status Register */
+#define REG_GMAC_ISR            (0x40050024) /**< (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER            (0x40050028) /**< (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR            (0x4005002C) /**< (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR            (0x40050030) /**< (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN            (0x40050034) /**< (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ            (0x40050038) /**< (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ            (0x4005003C) /**< (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_TPSF           (0x40050040) /**< (GMAC) TX Partial Store and Forward Register */
+#define REG_GMAC_RPSF           (0x40050044) /**< (GMAC) RX Partial Store and Forward Register */
+#define REG_GMAC_RJFML          (0x40050048) /**< (GMAC) RX Jumbo Frame Max Length Register */
+#define REG_GMAC_HRB            (0x40050080) /**< (GMAC) Hash Register Bottom */
+#define REG_GMAC_HRT            (0x40050084) /**< (GMAC) Hash Register Top */
+#define REG_GMAC_TIDM1          (0x400500A8) /**< (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_TIDM2          (0x400500AC) /**< (GMAC) Type ID Match 2 Register */
+#define REG_GMAC_TIDM3          (0x400500B0) /**< (GMAC) Type ID Match 3 Register */
+#define REG_GMAC_TIDM4          (0x400500B4) /**< (GMAC) Type ID Match 4 Register */
+#define REG_GMAC_WOL            (0x400500B8) /**< (GMAC) Wake on LAN Register */
+#define REG_GMAC_IPGS           (0x400500BC) /**< (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN          (0x400500C0) /**< (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP          (0x400500C4) /**< (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1          (0x400500C8) /**< (GMAC) Specific Address 1 Mask Bottom Register */
+#define REG_GMAC_SAMT1          (0x400500CC) /**< (GMAC) Specific Address 1 Mask Top Register */
+#define REG_GMAC_NSC            (0x400500DC) /**< (GMAC) 1588 Timer Nanosecond Comparison Register */
+#define REG_GMAC_SCL            (0x400500E0) /**< (GMAC) 1588 Timer Second Comparison Low Register */
+#define REG_GMAC_SCH            (0x400500E4) /**< (GMAC) 1588 Timer Second Comparison High Register */
+#define REG_GMAC_EFTSH          (0x400500E8) /**< (GMAC) PTP Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_EFRSH          (0x400500EC) /**< (GMAC) PTP Event Frame Received Seconds High Register */
+#define REG_GMAC_PEFTSH         (0x400500F0) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_PEFRSH         (0x400500F4) /**< (GMAC) PTP Peer Event Frame Received Seconds High Register */
+#define REG_GMAC_MID            (0x400500FC) /**< (GMAC) Module ID Register */
+#define REG_GMAC_OTLO           (0x40050100) /**< (GMAC) Octets Transmitted Low Register */
+#define REG_GMAC_OTHI           (0x40050104) /**< (GMAC) Octets Transmitted High Register */
+#define REG_GMAC_FT             (0x40050108) /**< (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT           (0x4005010C) /**< (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT            (0x40050110) /**< (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT            (0x40050114) /**< (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64          (0x40050118) /**< (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127        (0x4005011C) /**< (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255        (0x40050120) /**< (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511        (0x40050124) /**< (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023       (0x40050128) /**< (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518       (0x4005012C) /**< (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518      (0x40050130) /**< (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR            (0x40050134) /**< (GMAC) Transmit Underruns Register */
+#define REG_GMAC_SCF            (0x40050138) /**< (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF            (0x4005013C) /**< (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC             (0x40050140) /**< (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC             (0x40050144) /**< (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF            (0x40050148) /**< (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE            (0x4005014C) /**< (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO           (0x40050150) /**< (GMAC) Octets Received Low Received Register */
+#define REG_GMAC_ORHI           (0x40050154) /**< (GMAC) Octets Received High Received Register */
+#define REG_GMAC_FR             (0x40050158) /**< (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR           (0x4005015C) /**< (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR            (0x40050160) /**< (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR            (0x40050164) /**< (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64          (0x40050168) /**< (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127        (0x4005016C) /**< (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255        (0x40050170) /**< (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511        (0x40050174) /**< (GMAC) 256 to 511 Byte Frames Received Register */
+#define REG_GMAC_TBFR1023       (0x40050178) /**< (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518       (0x4005017C) /**< (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR         (0x40050180) /**< (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR            (0x40050184) /**< (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR            (0x40050188) /**< (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR             (0x4005018C) /**< (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE           (0x40050190) /**< (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE           (0x40050194) /**< (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE            (0x40050198) /**< (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE             (0x4005019C) /**< (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE            (0x400501A0) /**< (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE            (0x400501A4) /**< (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE           (0x400501A8) /**< (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE            (0x400501AC) /**< (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE            (0x400501B0) /**< (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TISUBN         (0x400501BC) /**< (GMAC) 1588 Timer Increment Sub-nanoseconds Register */
+#define REG_GMAC_TSH            (0x400501C0) /**< (GMAC) 1588 Timer Seconds High Register */
+#define REG_GMAC_TSL            (0x400501D0) /**< (GMAC) 1588 Timer Seconds Low Register */
+#define REG_GMAC_TN             (0x400501D4) /**< (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA             (0x400501D8) /**< (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI             (0x400501DC) /**< (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTSL          (0x400501E0) /**< (GMAC) PTP Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_EFTN           (0x400501E4) /**< (GMAC) PTP Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_EFRSL          (0x400501E8) /**< (GMAC) PTP Event Frame Received Seconds Low Register */
+#define REG_GMAC_EFRN           (0x400501EC) /**< (GMAC) PTP Event Frame Received Nanoseconds Register */
+#define REG_GMAC_PEFTSL         (0x400501F0) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_PEFTN          (0x400501F4) /**< (GMAC) PTP Peer Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_PEFRSL         (0x400501F8) /**< (GMAC) PTP Peer Event Frame Received Seconds Low Register */
+#define REG_GMAC_PEFRN          (0x400501FC) /**< (GMAC) PTP Peer Event Frame Received Nanoseconds Register */
+#define REG_GMAC_ISRPQ          (0x400503FC) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_ISRPQ0         (0x400503FC) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_ISRPQ1         (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_TBQBAPQ        (0x4005043C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_TBQBAPQ0       (0x4005043C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_TBQBAPQ1       (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_RBQBAPQ        (0x4005047C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBQBAPQ0       (0x4005047C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBQBAPQ1       (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_RBSRPQ         (0x4005049C) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBSRPQ0        (0x4005049C) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBSRPQ1        (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_CBSCR          (0x400504BC) /**< (GMAC) Credit-Based Shaping Control Register */
+#define REG_GMAC_CBSISQA        (0x400504C0) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
+#define REG_GMAC_CBSISQB        (0x400504C4) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
+#define REG_GMAC_ST1RPQ         (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST1RPQ0        (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST1RPQ1        (0x40050504) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 1 */
+#define REG_GMAC_ST1RPQ2        (0x40050508) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 2 */
+#define REG_GMAC_ST1RPQ3        (0x4005050C) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 3 */
+#define REG_GMAC_ST2RPQ         (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST2RPQ0        (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST2RPQ1        (0x40050544) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 1 */
+#define REG_GMAC_ST2RPQ2        (0x40050548) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 2 */
+#define REG_GMAC_ST2RPQ3        (0x4005054C) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 3 */
+#define REG_GMAC_ST2RPQ4        (0x40050550) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 4 */
+#define REG_GMAC_ST2RPQ5        (0x40050554) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 5 */
+#define REG_GMAC_ST2RPQ6        (0x40050558) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 6 */
+#define REG_GMAC_ST2RPQ7        (0x4005055C) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 7 */
+#define REG_GMAC_IERPQ          (0x400505FC) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IERPQ0         (0x400505FC) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IERPQ1         (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_IDRPQ          (0x4005061C) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IDRPQ0         (0x4005061C) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IDRPQ1         (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_IMRPQ          (0x4005063C) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IMRPQ0         (0x4005063C) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IMRPQ1         (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_ST2ER          (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
+#define REG_GMAC_ST2ER0         (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
+#define REG_GMAC_ST2ER1         (0x400506E4) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 1 */
+#define REG_GMAC_ST2ER2         (0x400506E8) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 2 */
+#define REG_GMAC_ST2ER3         (0x400506EC) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 3 */
+#define REG_GMAC_ST2CW00        (0x40050700) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 0) */
+#define REG_GMAC_ST2CW10        (0x40050704) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 0) */
+#define REG_GMAC_ST2CW01        (0x40050708) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 1) */
+#define REG_GMAC_ST2CW11        (0x4005070C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 1) */
+#define REG_GMAC_ST2CW02        (0x40050710) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 2) */
+#define REG_GMAC_ST2CW12        (0x40050714) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 2) */
+#define REG_GMAC_ST2CW03        (0x40050718) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 3) */
+#define REG_GMAC_ST2CW13        (0x4005071C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 3) */
+#define REG_GMAC_ST2CW04        (0x40050720) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 4) */
+#define REG_GMAC_ST2CW14        (0x40050724) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 4) */
+#define REG_GMAC_ST2CW05        (0x40050728) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 5) */
+#define REG_GMAC_ST2CW15        (0x4005072C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 5) */
+#define REG_GMAC_ST2CW06        (0x40050730) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 6) */
+#define REG_GMAC_ST2CW16        (0x40050734) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 6) */
+#define REG_GMAC_ST2CW07        (0x40050738) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 7) */
+#define REG_GMAC_ST2CW17        (0x4005073C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 7) */
+#define REG_GMAC_ST2CW08        (0x40050740) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 8) */
+#define REG_GMAC_ST2CW18        (0x40050744) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 8) */
+#define REG_GMAC_ST2CW09        (0x40050748) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 9) */
+#define REG_GMAC_ST2CW19        (0x4005074C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 9) */
+#define REG_GMAC_ST2CW010       (0x40050750) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 10) */
+#define REG_GMAC_ST2CW110       (0x40050754) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 10) */
+#define REG_GMAC_ST2CW011       (0x40050758) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 11) */
+#define REG_GMAC_ST2CW111       (0x4005075C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 11) */
+#define REG_GMAC_ST2CW012       (0x40050760) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 12) */
+#define REG_GMAC_ST2CW112       (0x40050764) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 12) */
+#define REG_GMAC_ST2CW013       (0x40050768) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 13) */
+#define REG_GMAC_ST2CW113       (0x4005076C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 13) */
+#define REG_GMAC_ST2CW014       (0x40050770) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 14) */
+#define REG_GMAC_ST2CW114       (0x40050774) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 14) */
+#define REG_GMAC_ST2CW015       (0x40050778) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 15) */
+#define REG_GMAC_ST2CW115       (0x4005077C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 15) */
+#define REG_GMAC_ST2CW016       (0x40050780) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 16) */
+#define REG_GMAC_ST2CW116       (0x40050784) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 16) */
+#define REG_GMAC_ST2CW017       (0x40050788) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 17) */
+#define REG_GMAC_ST2CW117       (0x4005078C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 17) */
+#define REG_GMAC_ST2CW018       (0x40050790) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 18) */
+#define REG_GMAC_ST2CW118       (0x40050794) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 18) */
+#define REG_GMAC_ST2CW019       (0x40050798) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 19) */
+#define REG_GMAC_ST2CW119       (0x4005079C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 19) */
+#define REG_GMAC_ST2CW020       (0x400507A0) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 20) */
+#define REG_GMAC_ST2CW120       (0x400507A4) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 20) */
+#define REG_GMAC_ST2CW021       (0x400507A8) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 21) */
+#define REG_GMAC_ST2CW121       (0x400507AC) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 21) */
+#define REG_GMAC_ST2CW022       (0x400507B0) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 22) */
+#define REG_GMAC_ST2CW122       (0x400507B4) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 22) */
+#define REG_GMAC_ST2CW023       (0x400507B8) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 23) */
+#define REG_GMAC_ST2CW123       (0x400507BC) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 23) */
+
+#else
+
+#define REG_GMAC_SAB1           (*(__IO uint32_t*)0x40050088U) /**< (GMAC) Specific Address 1 Bottom Register 0 */
+#define REG_GMAC_SAT1           (*(__IO uint32_t*)0x4005008CU) /**< (GMAC) Specific Address 1 Top Register 0 */
+#define REG_GMAC_SAB2           (*(__IO uint32_t*)0x40050090U) /**< (GMAC) Specific Address 1 Bottom Register 1 */
+#define REG_GMAC_SAT2           (*(__IO uint32_t*)0x40050094U) /**< (GMAC) Specific Address 1 Top Register 1 */
+#define REG_GMAC_SAB3           (*(__IO uint32_t*)0x40050098U) /**< (GMAC) Specific Address 1 Bottom Register 2 */
+#define REG_GMAC_SAT3           (*(__IO uint32_t*)0x4005009CU) /**< (GMAC) Specific Address 1 Top Register 2 */
+#define REG_GMAC_SAB4           (*(__IO uint32_t*)0x400500A0U) /**< (GMAC) Specific Address 1 Bottom Register 3 */
+#define REG_GMAC_SAT4           (*(__IO uint32_t*)0x400500A4U) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_NCR            (*(__IO uint32_t*)0x40050000U) /**< (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR          (*(__IO uint32_t*)0x40050004U) /**< (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR            (*(__I  uint32_t*)0x40050008U) /**< (GMAC) Network Status Register */
+#define REG_GMAC_UR             (*(__IO uint32_t*)0x4005000CU) /**< (GMAC) User Register */
+#define REG_GMAC_DCFGR          (*(__IO uint32_t*)0x40050010U) /**< (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR            (*(__IO uint32_t*)0x40050014U) /**< (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB           (*(__IO uint32_t*)0x40050018U) /**< (GMAC) Receive Buffer Queue Base Address Register */
+#define REG_GMAC_TBQB           (*(__IO uint32_t*)0x4005001CU) /**< (GMAC) Transmit Buffer Queue Base Address Register */
+#define REG_GMAC_RSR            (*(__IO uint32_t*)0x40050020U) /**< (GMAC) Receive Status Register */
+#define REG_GMAC_ISR            (*(__I  uint32_t*)0x40050024U) /**< (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER            (*(__O  uint32_t*)0x40050028U) /**< (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR            (*(__O  uint32_t*)0x4005002CU) /**< (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR            (*(__IO uint32_t*)0x40050030U) /**< (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN            (*(__IO uint32_t*)0x40050034U) /**< (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ            (*(__I  uint32_t*)0x40050038U) /**< (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ            (*(__IO uint32_t*)0x4005003CU) /**< (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_TPSF           (*(__IO uint32_t*)0x40050040U) /**< (GMAC) TX Partial Store and Forward Register */
+#define REG_GMAC_RPSF           (*(__IO uint32_t*)0x40050044U) /**< (GMAC) RX Partial Store and Forward Register */
+#define REG_GMAC_RJFML          (*(__IO uint32_t*)0x40050048U) /**< (GMAC) RX Jumbo Frame Max Length Register */
+#define REG_GMAC_HRB            (*(__IO uint32_t*)0x40050080U) /**< (GMAC) Hash Register Bottom */
+#define REG_GMAC_HRT            (*(__IO uint32_t*)0x40050084U) /**< (GMAC) Hash Register Top */
+#define REG_GMAC_TIDM1          (*(__IO uint32_t*)0x400500A8U) /**< (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_TIDM2          (*(__IO uint32_t*)0x400500ACU) /**< (GMAC) Type ID Match 2 Register */
+#define REG_GMAC_TIDM3          (*(__IO uint32_t*)0x400500B0U) /**< (GMAC) Type ID Match 3 Register */
+#define REG_GMAC_TIDM4          (*(__IO uint32_t*)0x400500B4U) /**< (GMAC) Type ID Match 4 Register */
+#define REG_GMAC_WOL            (*(__IO uint32_t*)0x400500B8U) /**< (GMAC) Wake on LAN Register */
+#define REG_GMAC_IPGS           (*(__IO uint32_t*)0x400500BCU) /**< (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN          (*(__IO uint32_t*)0x400500C0U) /**< (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP          (*(__IO uint32_t*)0x400500C4U) /**< (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1          (*(__IO uint32_t*)0x400500C8U) /**< (GMAC) Specific Address 1 Mask Bottom Register */
+#define REG_GMAC_SAMT1          (*(__IO uint32_t*)0x400500CCU) /**< (GMAC) Specific Address 1 Mask Top Register */
+#define REG_GMAC_NSC            (*(__IO uint32_t*)0x400500DCU) /**< (GMAC) 1588 Timer Nanosecond Comparison Register */
+#define REG_GMAC_SCL            (*(__IO uint32_t*)0x400500E0U) /**< (GMAC) 1588 Timer Second Comparison Low Register */
+#define REG_GMAC_SCH            (*(__IO uint32_t*)0x400500E4U) /**< (GMAC) 1588 Timer Second Comparison High Register */
+#define REG_GMAC_EFTSH          (*(__I  uint32_t*)0x400500E8U) /**< (GMAC) PTP Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_EFRSH          (*(__I  uint32_t*)0x400500ECU) /**< (GMAC) PTP Event Frame Received Seconds High Register */
+#define REG_GMAC_PEFTSH         (*(__I  uint32_t*)0x400500F0U) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_PEFRSH         (*(__I  uint32_t*)0x400500F4U) /**< (GMAC) PTP Peer Event Frame Received Seconds High Register */
+#define REG_GMAC_MID            (*(__I  uint32_t*)0x400500FCU) /**< (GMAC) Module ID Register */
+#define REG_GMAC_OTLO           (*(__I  uint32_t*)0x40050100U) /**< (GMAC) Octets Transmitted Low Register */
+#define REG_GMAC_OTHI           (*(__I  uint32_t*)0x40050104U) /**< (GMAC) Octets Transmitted High Register */
+#define REG_GMAC_FT             (*(__I  uint32_t*)0x40050108U) /**< (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT           (*(__I  uint32_t*)0x4005010CU) /**< (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT            (*(__I  uint32_t*)0x40050110U) /**< (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT            (*(__I  uint32_t*)0x40050114U) /**< (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64          (*(__I  uint32_t*)0x40050118U) /**< (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127        (*(__I  uint32_t*)0x4005011CU) /**< (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255        (*(__I  uint32_t*)0x40050120U) /**< (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511        (*(__I  uint32_t*)0x40050124U) /**< (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023       (*(__I  uint32_t*)0x40050128U) /**< (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518       (*(__I  uint32_t*)0x4005012CU) /**< (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518      (*(__I  uint32_t*)0x40050130U) /**< (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR            (*(__I  uint32_t*)0x40050134U) /**< (GMAC) Transmit Underruns Register */
+#define REG_GMAC_SCF            (*(__I  uint32_t*)0x40050138U) /**< (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF            (*(__I  uint32_t*)0x4005013CU) /**< (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC             (*(__I  uint32_t*)0x40050140U) /**< (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC             (*(__I  uint32_t*)0x40050144U) /**< (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF            (*(__I  uint32_t*)0x40050148U) /**< (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE            (*(__I  uint32_t*)0x4005014CU) /**< (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO           (*(__I  uint32_t*)0x40050150U) /**< (GMAC) Octets Received Low Received Register */
+#define REG_GMAC_ORHI           (*(__I  uint32_t*)0x40050154U) /**< (GMAC) Octets Received High Received Register */
+#define REG_GMAC_FR             (*(__I  uint32_t*)0x40050158U) /**< (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR           (*(__I  uint32_t*)0x4005015CU) /**< (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR            (*(__I  uint32_t*)0x40050160U) /**< (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR            (*(__I  uint32_t*)0x40050164U) /**< (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64          (*(__I  uint32_t*)0x40050168U) /**< (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127        (*(__I  uint32_t*)0x4005016CU) /**< (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255        (*(__I  uint32_t*)0x40050170U) /**< (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511        (*(__I  uint32_t*)0x40050174U) /**< (GMAC) 256 to 511 Byte Frames Received Register */
+#define REG_GMAC_TBFR1023       (*(__I  uint32_t*)0x40050178U) /**< (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518       (*(__I  uint32_t*)0x4005017CU) /**< (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR         (*(__I  uint32_t*)0x40050180U) /**< (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR            (*(__I  uint32_t*)0x40050184U) /**< (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR            (*(__I  uint32_t*)0x40050188U) /**< (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR             (*(__I  uint32_t*)0x4005018CU) /**< (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE           (*(__I  uint32_t*)0x40050190U) /**< (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE           (*(__I  uint32_t*)0x40050194U) /**< (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE            (*(__I  uint32_t*)0x40050198U) /**< (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE             (*(__I  uint32_t*)0x4005019CU) /**< (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE            (*(__I  uint32_t*)0x400501A0U) /**< (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE            (*(__I  uint32_t*)0x400501A4U) /**< (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE           (*(__I  uint32_t*)0x400501A8U) /**< (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE            (*(__I  uint32_t*)0x400501ACU) /**< (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE            (*(__I  uint32_t*)0x400501B0U) /**< (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TISUBN         (*(__IO uint32_t*)0x400501BCU) /**< (GMAC) 1588 Timer Increment Sub-nanoseconds Register */
+#define REG_GMAC_TSH            (*(__IO uint32_t*)0x400501C0U) /**< (GMAC) 1588 Timer Seconds High Register */
+#define REG_GMAC_TSL            (*(__IO uint32_t*)0x400501D0U) /**< (GMAC) 1588 Timer Seconds Low Register */
+#define REG_GMAC_TN             (*(__IO uint32_t*)0x400501D4U) /**< (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA             (*(__O  uint32_t*)0x400501D8U) /**< (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI             (*(__IO uint32_t*)0x400501DCU) /**< (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTSL          (*(__I  uint32_t*)0x400501E0U) /**< (GMAC) PTP Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_EFTN           (*(__I  uint32_t*)0x400501E4U) /**< (GMAC) PTP Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_EFRSL          (*(__I  uint32_t*)0x400501E8U) /**< (GMAC) PTP Event Frame Received Seconds Low Register */
+#define REG_GMAC_EFRN           (*(__I  uint32_t*)0x400501ECU) /**< (GMAC) PTP Event Frame Received Nanoseconds Register */
+#define REG_GMAC_PEFTSL         (*(__I  uint32_t*)0x400501F0U) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_PEFTN          (*(__I  uint32_t*)0x400501F4U) /**< (GMAC) PTP Peer Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_PEFRSL         (*(__I  uint32_t*)0x400501F8U) /**< (GMAC) PTP Peer Event Frame Received Seconds Low Register */
+#define REG_GMAC_PEFRN          (*(__I  uint32_t*)0x400501FCU) /**< (GMAC) PTP Peer Event Frame Received Nanoseconds Register */
+#define REG_GMAC_ISRPQ          (*(__I  uint32_t*)0x400503FCU) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_ISRPQ0         (*(__I  uint32_t*)0x400503FCU) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_ISRPQ1         (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_TBQBAPQ        (*(__IO uint32_t*)0x4005043CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_TBQBAPQ0       (*(__IO uint32_t*)0x4005043CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_TBQBAPQ1       (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_RBQBAPQ        (*(__IO uint32_t*)0x4005047CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBQBAPQ0       (*(__IO uint32_t*)0x4005047CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBQBAPQ1       (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_RBSRPQ         (*(__IO uint32_t*)0x4005049CU) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBSRPQ0        (*(__IO uint32_t*)0x4005049CU) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_RBSRPQ1        (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_CBSCR          (*(__IO uint32_t*)0x400504BCU) /**< (GMAC) Credit-Based Shaping Control Register */
+#define REG_GMAC_CBSISQA        (*(__IO uint32_t*)0x400504C0U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
+#define REG_GMAC_CBSISQB        (*(__IO uint32_t*)0x400504C4U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
+#define REG_GMAC_ST1RPQ         (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST1RPQ0        (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST1RPQ1        (*(__IO uint32_t*)0x40050504U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 1 */
+#define REG_GMAC_ST1RPQ2        (*(__IO uint32_t*)0x40050508U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 2 */
+#define REG_GMAC_ST1RPQ3        (*(__IO uint32_t*)0x4005050CU) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 3 */
+#define REG_GMAC_ST2RPQ         (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST2RPQ0        (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
+#define REG_GMAC_ST2RPQ1        (*(__IO uint32_t*)0x40050544U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 1 */
+#define REG_GMAC_ST2RPQ2        (*(__IO uint32_t*)0x40050548U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 2 */
+#define REG_GMAC_ST2RPQ3        (*(__IO uint32_t*)0x4005054CU) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 3 */
+#define REG_GMAC_ST2RPQ4        (*(__IO uint32_t*)0x40050550U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 4 */
+#define REG_GMAC_ST2RPQ5        (*(__IO uint32_t*)0x40050554U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 5 */
+#define REG_GMAC_ST2RPQ6        (*(__IO uint32_t*)0x40050558U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 6 */
+#define REG_GMAC_ST2RPQ7        (*(__IO uint32_t*)0x4005055CU) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 7 */
+#define REG_GMAC_IERPQ          (*(__O  uint32_t*)0x400505FCU) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IERPQ0         (*(__O  uint32_t*)0x400505FCU) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IERPQ1         (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_IDRPQ          (*(__O  uint32_t*)0x4005061CU) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IDRPQ0         (*(__O  uint32_t*)0x4005061CU) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IDRPQ1         (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_IMRPQ          (*(__IO uint32_t*)0x4005063CU) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IMRPQ0         (*(__IO uint32_t*)0x4005063CU) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
+#define REG_GMAC_IMRPQ1         (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 1 */
+#define REG_GMAC_ST2ER          (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
+#define REG_GMAC_ST2ER0         (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
+#define REG_GMAC_ST2ER1         (*(__IO uint32_t*)0x400506E4U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 1 */
+#define REG_GMAC_ST2ER2         (*(__IO uint32_t*)0x400506E8U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 2 */
+#define REG_GMAC_ST2ER3         (*(__IO uint32_t*)0x400506ECU) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 3 */
+#define REG_GMAC_ST2CW00        (*(__IO uint32_t*)0x40050700U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 0) */
+#define REG_GMAC_ST2CW10        (*(__IO uint32_t*)0x40050704U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 0) */
+#define REG_GMAC_ST2CW01        (*(__IO uint32_t*)0x40050708U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 1) */
+#define REG_GMAC_ST2CW11        (*(__IO uint32_t*)0x4005070CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 1) */
+#define REG_GMAC_ST2CW02        (*(__IO uint32_t*)0x40050710U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 2) */
+#define REG_GMAC_ST2CW12        (*(__IO uint32_t*)0x40050714U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 2) */
+#define REG_GMAC_ST2CW03        (*(__IO uint32_t*)0x40050718U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 3) */
+#define REG_GMAC_ST2CW13        (*(__IO uint32_t*)0x4005071CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 3) */
+#define REG_GMAC_ST2CW04        (*(__IO uint32_t*)0x40050720U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 4) */
+#define REG_GMAC_ST2CW14        (*(__IO uint32_t*)0x40050724U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 4) */
+#define REG_GMAC_ST2CW05        (*(__IO uint32_t*)0x40050728U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 5) */
+#define REG_GMAC_ST2CW15        (*(__IO uint32_t*)0x4005072CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 5) */
+#define REG_GMAC_ST2CW06        (*(__IO uint32_t*)0x40050730U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 6) */
+#define REG_GMAC_ST2CW16        (*(__IO uint32_t*)0x40050734U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 6) */
+#define REG_GMAC_ST2CW07        (*(__IO uint32_t*)0x40050738U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 7) */
+#define REG_GMAC_ST2CW17        (*(__IO uint32_t*)0x4005073CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 7) */
+#define REG_GMAC_ST2CW08        (*(__IO uint32_t*)0x40050740U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 8) */
+#define REG_GMAC_ST2CW18        (*(__IO uint32_t*)0x40050744U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 8) */
+#define REG_GMAC_ST2CW09        (*(__IO uint32_t*)0x40050748U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 9) */
+#define REG_GMAC_ST2CW19        (*(__IO uint32_t*)0x4005074CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 9) */
+#define REG_GMAC_ST2CW010       (*(__IO uint32_t*)0x40050750U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 10) */
+#define REG_GMAC_ST2CW110       (*(__IO uint32_t*)0x40050754U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 10) */
+#define REG_GMAC_ST2CW011       (*(__IO uint32_t*)0x40050758U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 11) */
+#define REG_GMAC_ST2CW111       (*(__IO uint32_t*)0x4005075CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 11) */
+#define REG_GMAC_ST2CW012       (*(__IO uint32_t*)0x40050760U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 12) */
+#define REG_GMAC_ST2CW112       (*(__IO uint32_t*)0x40050764U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 12) */
+#define REG_GMAC_ST2CW013       (*(__IO uint32_t*)0x40050768U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 13) */
+#define REG_GMAC_ST2CW113       (*(__IO uint32_t*)0x4005076CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 13) */
+#define REG_GMAC_ST2CW014       (*(__IO uint32_t*)0x40050770U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 14) */
+#define REG_GMAC_ST2CW114       (*(__IO uint32_t*)0x40050774U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 14) */
+#define REG_GMAC_ST2CW015       (*(__IO uint32_t*)0x40050778U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 15) */
+#define REG_GMAC_ST2CW115       (*(__IO uint32_t*)0x4005077CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 15) */
+#define REG_GMAC_ST2CW016       (*(__IO uint32_t*)0x40050780U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 16) */
+#define REG_GMAC_ST2CW116       (*(__IO uint32_t*)0x40050784U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 16) */
+#define REG_GMAC_ST2CW017       (*(__IO uint32_t*)0x40050788U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 17) */
+#define REG_GMAC_ST2CW117       (*(__IO uint32_t*)0x4005078CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 17) */
+#define REG_GMAC_ST2CW018       (*(__IO uint32_t*)0x40050790U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 18) */
+#define REG_GMAC_ST2CW118       (*(__IO uint32_t*)0x40050794U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 18) */
+#define REG_GMAC_ST2CW019       (*(__IO uint32_t*)0x40050798U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 19) */
+#define REG_GMAC_ST2CW119       (*(__IO uint32_t*)0x4005079CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 19) */
+#define REG_GMAC_ST2CW020       (*(__IO uint32_t*)0x400507A0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 20) */
+#define REG_GMAC_ST2CW120       (*(__IO uint32_t*)0x400507A4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 20) */
+#define REG_GMAC_ST2CW021       (*(__IO uint32_t*)0x400507A8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 21) */
+#define REG_GMAC_ST2CW121       (*(__IO uint32_t*)0x400507ACU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 21) */
+#define REG_GMAC_ST2CW022       (*(__IO uint32_t*)0x400507B0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 22) */
+#define REG_GMAC_ST2CW122       (*(__IO uint32_t*)0x400507B4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 22) */
+#define REG_GMAC_ST2CW023       (*(__IO uint32_t*)0x400507B8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 23) */
+#define REG_GMAC_ST2CW123       (*(__IO uint32_t*)0x400507BCU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 23) */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for GMAC peripheral ========== */
+#define GMAC_INSTANCE_ID                         39         
+
+#endif /* _SAMV71_GMAC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/gpbr.h
+++ b/asf/sam/include/samv71/instance/gpbr.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GPBR
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_GPBR_INSTANCE_H_
+#define _SAMV71_GPBR_INSTANCE_H_
+
+/* ========== Register definition for GPBR peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GPBR_SYS_GPBR       (0x400E1890) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR0      (0x400E1890) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR1      (0x400E1894) /**< (GPBR) General Purpose Backup Register 1 */
+#define REG_GPBR_SYS_GPBR2      (0x400E1898) /**< (GPBR) General Purpose Backup Register 2 */
+#define REG_GPBR_SYS_GPBR3      (0x400E189C) /**< (GPBR) General Purpose Backup Register 3 */
+#define REG_GPBR_SYS_GPBR4      (0x400E18A0) /**< (GPBR) General Purpose Backup Register 4 */
+#define REG_GPBR_SYS_GPBR5      (0x400E18A4) /**< (GPBR) General Purpose Backup Register 5 */
+#define REG_GPBR_SYS_GPBR6      (0x400E18A8) /**< (GPBR) General Purpose Backup Register 6 */
+#define REG_GPBR_SYS_GPBR7      (0x400E18AC) /**< (GPBR) General Purpose Backup Register 7 */
+
+#else
+
+#define REG_GPBR_SYS_GPBR       (*(__IO uint32_t*)0x400E1890U) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR0      (*(__IO uint32_t*)0x400E1890U) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR1      (*(__IO uint32_t*)0x400E1894U) /**< (GPBR) General Purpose Backup Register 1 */
+#define REG_GPBR_SYS_GPBR2      (*(__IO uint32_t*)0x400E1898U) /**< (GPBR) General Purpose Backup Register 2 */
+#define REG_GPBR_SYS_GPBR3      (*(__IO uint32_t*)0x400E189CU) /**< (GPBR) General Purpose Backup Register 3 */
+#define REG_GPBR_SYS_GPBR4      (*(__IO uint32_t*)0x400E18A0U) /**< (GPBR) General Purpose Backup Register 4 */
+#define REG_GPBR_SYS_GPBR5      (*(__IO uint32_t*)0x400E18A4U) /**< (GPBR) General Purpose Backup Register 5 */
+#define REG_GPBR_SYS_GPBR6      (*(__IO uint32_t*)0x400E18A8U) /**< (GPBR) General Purpose Backup Register 6 */
+#define REG_GPBR_SYS_GPBR7      (*(__IO uint32_t*)0x400E18ACU) /**< (GPBR) General Purpose Backup Register 7 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_GPBR_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/hsmci.h
+++ b/asf/sam/include/samv71/instance/hsmci.h
@@ -1,0 +1,610 @@
+/**
+ * \file
+ *
+ * \brief Instance description for HSMCI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_HSMCI_INSTANCE_H_
+#define _SAMV71_HSMCI_INSTANCE_H_
+
+/* ========== Register definition for HSMCI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_HSMCI_CR            (0x40000000) /**< (HSMCI) Control Register */
+#define REG_HSMCI_MR            (0x40000004) /**< (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR          (0x40000008) /**< (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR          (0x4000000C) /**< (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR          (0x40000010) /**< (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR          (0x40000014) /**< (HSMCI) Command Register */
+#define REG_HSMCI_BLKR          (0x40000018) /**< (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR         (0x4000001C) /**< (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR          (0x40000020) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR0         (0x40000020) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR1         (0x40000024) /**< (HSMCI) Response Register 1 */
+#define REG_HSMCI_RSPR2         (0x40000028) /**< (HSMCI) Response Register 2 */
+#define REG_HSMCI_RSPR3         (0x4000002C) /**< (HSMCI) Response Register 3 */
+#define REG_HSMCI_RDR           (0x40000030) /**< (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR           (0x40000034) /**< (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR            (0x40000040) /**< (HSMCI) Status Register */
+#define REG_HSMCI_IER           (0x40000044) /**< (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR           (0x40000048) /**< (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR           (0x4000004C) /**< (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_DMA           (0x40000050) /**< (HSMCI) DMA Configuration Register */
+#define REG_HSMCI_CFG           (0x40000054) /**< (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR          (0x400000E4) /**< (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR          (0x400000E8) /**< (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_VERSION       (0x400000FC) /**< (HSMCI) Version Register */
+#define REG_HSMCI_FIFO          (0x40000200) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO0         (0x40000200) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO1         (0x40000204) /**< (HSMCI) FIFO Memory Aperture0 1 */
+#define REG_HSMCI_FIFO2         (0x40000208) /**< (HSMCI) FIFO Memory Aperture0 2 */
+#define REG_HSMCI_FIFO3         (0x4000020C) /**< (HSMCI) FIFO Memory Aperture0 3 */
+#define REG_HSMCI_FIFO4         (0x40000210) /**< (HSMCI) FIFO Memory Aperture0 4 */
+#define REG_HSMCI_FIFO5         (0x40000214) /**< (HSMCI) FIFO Memory Aperture0 5 */
+#define REG_HSMCI_FIFO6         (0x40000218) /**< (HSMCI) FIFO Memory Aperture0 6 */
+#define REG_HSMCI_FIFO7         (0x4000021C) /**< (HSMCI) FIFO Memory Aperture0 7 */
+#define REG_HSMCI_FIFO8         (0x40000220) /**< (HSMCI) FIFO Memory Aperture0 8 */
+#define REG_HSMCI_FIFO9         (0x40000224) /**< (HSMCI) FIFO Memory Aperture0 9 */
+#define REG_HSMCI_FIFO10        (0x40000228) /**< (HSMCI) FIFO Memory Aperture0 10 */
+#define REG_HSMCI_FIFO11        (0x4000022C) /**< (HSMCI) FIFO Memory Aperture0 11 */
+#define REG_HSMCI_FIFO12        (0x40000230) /**< (HSMCI) FIFO Memory Aperture0 12 */
+#define REG_HSMCI_FIFO13        (0x40000234) /**< (HSMCI) FIFO Memory Aperture0 13 */
+#define REG_HSMCI_FIFO14        (0x40000238) /**< (HSMCI) FIFO Memory Aperture0 14 */
+#define REG_HSMCI_FIFO15        (0x4000023C) /**< (HSMCI) FIFO Memory Aperture0 15 */
+#define REG_HSMCI_FIFO16        (0x40000240) /**< (HSMCI) FIFO Memory Aperture0 16 */
+#define REG_HSMCI_FIFO17        (0x40000244) /**< (HSMCI) FIFO Memory Aperture0 17 */
+#define REG_HSMCI_FIFO18        (0x40000248) /**< (HSMCI) FIFO Memory Aperture0 18 */
+#define REG_HSMCI_FIFO19        (0x4000024C) /**< (HSMCI) FIFO Memory Aperture0 19 */
+#define REG_HSMCI_FIFO20        (0x40000250) /**< (HSMCI) FIFO Memory Aperture0 20 */
+#define REG_HSMCI_FIFO21        (0x40000254) /**< (HSMCI) FIFO Memory Aperture0 21 */
+#define REG_HSMCI_FIFO22        (0x40000258) /**< (HSMCI) FIFO Memory Aperture0 22 */
+#define REG_HSMCI_FIFO23        (0x4000025C) /**< (HSMCI) FIFO Memory Aperture0 23 */
+#define REG_HSMCI_FIFO24        (0x40000260) /**< (HSMCI) FIFO Memory Aperture0 24 */
+#define REG_HSMCI_FIFO25        (0x40000264) /**< (HSMCI) FIFO Memory Aperture0 25 */
+#define REG_HSMCI_FIFO26        (0x40000268) /**< (HSMCI) FIFO Memory Aperture0 26 */
+#define REG_HSMCI_FIFO27        (0x4000026C) /**< (HSMCI) FIFO Memory Aperture0 27 */
+#define REG_HSMCI_FIFO28        (0x40000270) /**< (HSMCI) FIFO Memory Aperture0 28 */
+#define REG_HSMCI_FIFO29        (0x40000274) /**< (HSMCI) FIFO Memory Aperture0 29 */
+#define REG_HSMCI_FIFO30        (0x40000278) /**< (HSMCI) FIFO Memory Aperture0 30 */
+#define REG_HSMCI_FIFO31        (0x4000027C) /**< (HSMCI) FIFO Memory Aperture0 31 */
+#define REG_HSMCI_FIFO32        (0x40000280) /**< (HSMCI) FIFO Memory Aperture0 32 */
+#define REG_HSMCI_FIFO33        (0x40000284) /**< (HSMCI) FIFO Memory Aperture0 33 */
+#define REG_HSMCI_FIFO34        (0x40000288) /**< (HSMCI) FIFO Memory Aperture0 34 */
+#define REG_HSMCI_FIFO35        (0x4000028C) /**< (HSMCI) FIFO Memory Aperture0 35 */
+#define REG_HSMCI_FIFO36        (0x40000290) /**< (HSMCI) FIFO Memory Aperture0 36 */
+#define REG_HSMCI_FIFO37        (0x40000294) /**< (HSMCI) FIFO Memory Aperture0 37 */
+#define REG_HSMCI_FIFO38        (0x40000298) /**< (HSMCI) FIFO Memory Aperture0 38 */
+#define REG_HSMCI_FIFO39        (0x4000029C) /**< (HSMCI) FIFO Memory Aperture0 39 */
+#define REG_HSMCI_FIFO40        (0x400002A0) /**< (HSMCI) FIFO Memory Aperture0 40 */
+#define REG_HSMCI_FIFO41        (0x400002A4) /**< (HSMCI) FIFO Memory Aperture0 41 */
+#define REG_HSMCI_FIFO42        (0x400002A8) /**< (HSMCI) FIFO Memory Aperture0 42 */
+#define REG_HSMCI_FIFO43        (0x400002AC) /**< (HSMCI) FIFO Memory Aperture0 43 */
+#define REG_HSMCI_FIFO44        (0x400002B0) /**< (HSMCI) FIFO Memory Aperture0 44 */
+#define REG_HSMCI_FIFO45        (0x400002B4) /**< (HSMCI) FIFO Memory Aperture0 45 */
+#define REG_HSMCI_FIFO46        (0x400002B8) /**< (HSMCI) FIFO Memory Aperture0 46 */
+#define REG_HSMCI_FIFO47        (0x400002BC) /**< (HSMCI) FIFO Memory Aperture0 47 */
+#define REG_HSMCI_FIFO48        (0x400002C0) /**< (HSMCI) FIFO Memory Aperture0 48 */
+#define REG_HSMCI_FIFO49        (0x400002C4) /**< (HSMCI) FIFO Memory Aperture0 49 */
+#define REG_HSMCI_FIFO50        (0x400002C8) /**< (HSMCI) FIFO Memory Aperture0 50 */
+#define REG_HSMCI_FIFO51        (0x400002CC) /**< (HSMCI) FIFO Memory Aperture0 51 */
+#define REG_HSMCI_FIFO52        (0x400002D0) /**< (HSMCI) FIFO Memory Aperture0 52 */
+#define REG_HSMCI_FIFO53        (0x400002D4) /**< (HSMCI) FIFO Memory Aperture0 53 */
+#define REG_HSMCI_FIFO54        (0x400002D8) /**< (HSMCI) FIFO Memory Aperture0 54 */
+#define REG_HSMCI_FIFO55        (0x400002DC) /**< (HSMCI) FIFO Memory Aperture0 55 */
+#define REG_HSMCI_FIFO56        (0x400002E0) /**< (HSMCI) FIFO Memory Aperture0 56 */
+#define REG_HSMCI_FIFO57        (0x400002E4) /**< (HSMCI) FIFO Memory Aperture0 57 */
+#define REG_HSMCI_FIFO58        (0x400002E8) /**< (HSMCI) FIFO Memory Aperture0 58 */
+#define REG_HSMCI_FIFO59        (0x400002EC) /**< (HSMCI) FIFO Memory Aperture0 59 */
+#define REG_HSMCI_FIFO60        (0x400002F0) /**< (HSMCI) FIFO Memory Aperture0 60 */
+#define REG_HSMCI_FIFO61        (0x400002F4) /**< (HSMCI) FIFO Memory Aperture0 61 */
+#define REG_HSMCI_FIFO62        (0x400002F8) /**< (HSMCI) FIFO Memory Aperture0 62 */
+#define REG_HSMCI_FIFO63        (0x400002FC) /**< (HSMCI) FIFO Memory Aperture0 63 */
+#define REG_HSMCI_FIFO64        (0x40000300) /**< (HSMCI) FIFO Memory Aperture0 64 */
+#define REG_HSMCI_FIFO65        (0x40000304) /**< (HSMCI) FIFO Memory Aperture0 65 */
+#define REG_HSMCI_FIFO66        (0x40000308) /**< (HSMCI) FIFO Memory Aperture0 66 */
+#define REG_HSMCI_FIFO67        (0x4000030C) /**< (HSMCI) FIFO Memory Aperture0 67 */
+#define REG_HSMCI_FIFO68        (0x40000310) /**< (HSMCI) FIFO Memory Aperture0 68 */
+#define REG_HSMCI_FIFO69        (0x40000314) /**< (HSMCI) FIFO Memory Aperture0 69 */
+#define REG_HSMCI_FIFO70        (0x40000318) /**< (HSMCI) FIFO Memory Aperture0 70 */
+#define REG_HSMCI_FIFO71        (0x4000031C) /**< (HSMCI) FIFO Memory Aperture0 71 */
+#define REG_HSMCI_FIFO72        (0x40000320) /**< (HSMCI) FIFO Memory Aperture0 72 */
+#define REG_HSMCI_FIFO73        (0x40000324) /**< (HSMCI) FIFO Memory Aperture0 73 */
+#define REG_HSMCI_FIFO74        (0x40000328) /**< (HSMCI) FIFO Memory Aperture0 74 */
+#define REG_HSMCI_FIFO75        (0x4000032C) /**< (HSMCI) FIFO Memory Aperture0 75 */
+#define REG_HSMCI_FIFO76        (0x40000330) /**< (HSMCI) FIFO Memory Aperture0 76 */
+#define REG_HSMCI_FIFO77        (0x40000334) /**< (HSMCI) FIFO Memory Aperture0 77 */
+#define REG_HSMCI_FIFO78        (0x40000338) /**< (HSMCI) FIFO Memory Aperture0 78 */
+#define REG_HSMCI_FIFO79        (0x4000033C) /**< (HSMCI) FIFO Memory Aperture0 79 */
+#define REG_HSMCI_FIFO80        (0x40000340) /**< (HSMCI) FIFO Memory Aperture0 80 */
+#define REG_HSMCI_FIFO81        (0x40000344) /**< (HSMCI) FIFO Memory Aperture0 81 */
+#define REG_HSMCI_FIFO82        (0x40000348) /**< (HSMCI) FIFO Memory Aperture0 82 */
+#define REG_HSMCI_FIFO83        (0x4000034C) /**< (HSMCI) FIFO Memory Aperture0 83 */
+#define REG_HSMCI_FIFO84        (0x40000350) /**< (HSMCI) FIFO Memory Aperture0 84 */
+#define REG_HSMCI_FIFO85        (0x40000354) /**< (HSMCI) FIFO Memory Aperture0 85 */
+#define REG_HSMCI_FIFO86        (0x40000358) /**< (HSMCI) FIFO Memory Aperture0 86 */
+#define REG_HSMCI_FIFO87        (0x4000035C) /**< (HSMCI) FIFO Memory Aperture0 87 */
+#define REG_HSMCI_FIFO88        (0x40000360) /**< (HSMCI) FIFO Memory Aperture0 88 */
+#define REG_HSMCI_FIFO89        (0x40000364) /**< (HSMCI) FIFO Memory Aperture0 89 */
+#define REG_HSMCI_FIFO90        (0x40000368) /**< (HSMCI) FIFO Memory Aperture0 90 */
+#define REG_HSMCI_FIFO91        (0x4000036C) /**< (HSMCI) FIFO Memory Aperture0 91 */
+#define REG_HSMCI_FIFO92        (0x40000370) /**< (HSMCI) FIFO Memory Aperture0 92 */
+#define REG_HSMCI_FIFO93        (0x40000374) /**< (HSMCI) FIFO Memory Aperture0 93 */
+#define REG_HSMCI_FIFO94        (0x40000378) /**< (HSMCI) FIFO Memory Aperture0 94 */
+#define REG_HSMCI_FIFO95        (0x4000037C) /**< (HSMCI) FIFO Memory Aperture0 95 */
+#define REG_HSMCI_FIFO96        (0x40000380) /**< (HSMCI) FIFO Memory Aperture0 96 */
+#define REG_HSMCI_FIFO97        (0x40000384) /**< (HSMCI) FIFO Memory Aperture0 97 */
+#define REG_HSMCI_FIFO98        (0x40000388) /**< (HSMCI) FIFO Memory Aperture0 98 */
+#define REG_HSMCI_FIFO99        (0x4000038C) /**< (HSMCI) FIFO Memory Aperture0 99 */
+#define REG_HSMCI_FIFO100       (0x40000390) /**< (HSMCI) FIFO Memory Aperture0 100 */
+#define REG_HSMCI_FIFO101       (0x40000394) /**< (HSMCI) FIFO Memory Aperture0 101 */
+#define REG_HSMCI_FIFO102       (0x40000398) /**< (HSMCI) FIFO Memory Aperture0 102 */
+#define REG_HSMCI_FIFO103       (0x4000039C) /**< (HSMCI) FIFO Memory Aperture0 103 */
+#define REG_HSMCI_FIFO104       (0x400003A0) /**< (HSMCI) FIFO Memory Aperture0 104 */
+#define REG_HSMCI_FIFO105       (0x400003A4) /**< (HSMCI) FIFO Memory Aperture0 105 */
+#define REG_HSMCI_FIFO106       (0x400003A8) /**< (HSMCI) FIFO Memory Aperture0 106 */
+#define REG_HSMCI_FIFO107       (0x400003AC) /**< (HSMCI) FIFO Memory Aperture0 107 */
+#define REG_HSMCI_FIFO108       (0x400003B0) /**< (HSMCI) FIFO Memory Aperture0 108 */
+#define REG_HSMCI_FIFO109       (0x400003B4) /**< (HSMCI) FIFO Memory Aperture0 109 */
+#define REG_HSMCI_FIFO110       (0x400003B8) /**< (HSMCI) FIFO Memory Aperture0 110 */
+#define REG_HSMCI_FIFO111       (0x400003BC) /**< (HSMCI) FIFO Memory Aperture0 111 */
+#define REG_HSMCI_FIFO112       (0x400003C0) /**< (HSMCI) FIFO Memory Aperture0 112 */
+#define REG_HSMCI_FIFO113       (0x400003C4) /**< (HSMCI) FIFO Memory Aperture0 113 */
+#define REG_HSMCI_FIFO114       (0x400003C8) /**< (HSMCI) FIFO Memory Aperture0 114 */
+#define REG_HSMCI_FIFO115       (0x400003CC) /**< (HSMCI) FIFO Memory Aperture0 115 */
+#define REG_HSMCI_FIFO116       (0x400003D0) /**< (HSMCI) FIFO Memory Aperture0 116 */
+#define REG_HSMCI_FIFO117       (0x400003D4) /**< (HSMCI) FIFO Memory Aperture0 117 */
+#define REG_HSMCI_FIFO118       (0x400003D8) /**< (HSMCI) FIFO Memory Aperture0 118 */
+#define REG_HSMCI_FIFO119       (0x400003DC) /**< (HSMCI) FIFO Memory Aperture0 119 */
+#define REG_HSMCI_FIFO120       (0x400003E0) /**< (HSMCI) FIFO Memory Aperture0 120 */
+#define REG_HSMCI_FIFO121       (0x400003E4) /**< (HSMCI) FIFO Memory Aperture0 121 */
+#define REG_HSMCI_FIFO122       (0x400003E8) /**< (HSMCI) FIFO Memory Aperture0 122 */
+#define REG_HSMCI_FIFO123       (0x400003EC) /**< (HSMCI) FIFO Memory Aperture0 123 */
+#define REG_HSMCI_FIFO124       (0x400003F0) /**< (HSMCI) FIFO Memory Aperture0 124 */
+#define REG_HSMCI_FIFO125       (0x400003F4) /**< (HSMCI) FIFO Memory Aperture0 125 */
+#define REG_HSMCI_FIFO126       (0x400003F8) /**< (HSMCI) FIFO Memory Aperture0 126 */
+#define REG_HSMCI_FIFO127       (0x400003FC) /**< (HSMCI) FIFO Memory Aperture0 127 */
+#define REG_HSMCI_FIFO128       (0x40000400) /**< (HSMCI) FIFO Memory Aperture0 128 */
+#define REG_HSMCI_FIFO129       (0x40000404) /**< (HSMCI) FIFO Memory Aperture0 129 */
+#define REG_HSMCI_FIFO130       (0x40000408) /**< (HSMCI) FIFO Memory Aperture0 130 */
+#define REG_HSMCI_FIFO131       (0x4000040C) /**< (HSMCI) FIFO Memory Aperture0 131 */
+#define REG_HSMCI_FIFO132       (0x40000410) /**< (HSMCI) FIFO Memory Aperture0 132 */
+#define REG_HSMCI_FIFO133       (0x40000414) /**< (HSMCI) FIFO Memory Aperture0 133 */
+#define REG_HSMCI_FIFO134       (0x40000418) /**< (HSMCI) FIFO Memory Aperture0 134 */
+#define REG_HSMCI_FIFO135       (0x4000041C) /**< (HSMCI) FIFO Memory Aperture0 135 */
+#define REG_HSMCI_FIFO136       (0x40000420) /**< (HSMCI) FIFO Memory Aperture0 136 */
+#define REG_HSMCI_FIFO137       (0x40000424) /**< (HSMCI) FIFO Memory Aperture0 137 */
+#define REG_HSMCI_FIFO138       (0x40000428) /**< (HSMCI) FIFO Memory Aperture0 138 */
+#define REG_HSMCI_FIFO139       (0x4000042C) /**< (HSMCI) FIFO Memory Aperture0 139 */
+#define REG_HSMCI_FIFO140       (0x40000430) /**< (HSMCI) FIFO Memory Aperture0 140 */
+#define REG_HSMCI_FIFO141       (0x40000434) /**< (HSMCI) FIFO Memory Aperture0 141 */
+#define REG_HSMCI_FIFO142       (0x40000438) /**< (HSMCI) FIFO Memory Aperture0 142 */
+#define REG_HSMCI_FIFO143       (0x4000043C) /**< (HSMCI) FIFO Memory Aperture0 143 */
+#define REG_HSMCI_FIFO144       (0x40000440) /**< (HSMCI) FIFO Memory Aperture0 144 */
+#define REG_HSMCI_FIFO145       (0x40000444) /**< (HSMCI) FIFO Memory Aperture0 145 */
+#define REG_HSMCI_FIFO146       (0x40000448) /**< (HSMCI) FIFO Memory Aperture0 146 */
+#define REG_HSMCI_FIFO147       (0x4000044C) /**< (HSMCI) FIFO Memory Aperture0 147 */
+#define REG_HSMCI_FIFO148       (0x40000450) /**< (HSMCI) FIFO Memory Aperture0 148 */
+#define REG_HSMCI_FIFO149       (0x40000454) /**< (HSMCI) FIFO Memory Aperture0 149 */
+#define REG_HSMCI_FIFO150       (0x40000458) /**< (HSMCI) FIFO Memory Aperture0 150 */
+#define REG_HSMCI_FIFO151       (0x4000045C) /**< (HSMCI) FIFO Memory Aperture0 151 */
+#define REG_HSMCI_FIFO152       (0x40000460) /**< (HSMCI) FIFO Memory Aperture0 152 */
+#define REG_HSMCI_FIFO153       (0x40000464) /**< (HSMCI) FIFO Memory Aperture0 153 */
+#define REG_HSMCI_FIFO154       (0x40000468) /**< (HSMCI) FIFO Memory Aperture0 154 */
+#define REG_HSMCI_FIFO155       (0x4000046C) /**< (HSMCI) FIFO Memory Aperture0 155 */
+#define REG_HSMCI_FIFO156       (0x40000470) /**< (HSMCI) FIFO Memory Aperture0 156 */
+#define REG_HSMCI_FIFO157       (0x40000474) /**< (HSMCI) FIFO Memory Aperture0 157 */
+#define REG_HSMCI_FIFO158       (0x40000478) /**< (HSMCI) FIFO Memory Aperture0 158 */
+#define REG_HSMCI_FIFO159       (0x4000047C) /**< (HSMCI) FIFO Memory Aperture0 159 */
+#define REG_HSMCI_FIFO160       (0x40000480) /**< (HSMCI) FIFO Memory Aperture0 160 */
+#define REG_HSMCI_FIFO161       (0x40000484) /**< (HSMCI) FIFO Memory Aperture0 161 */
+#define REG_HSMCI_FIFO162       (0x40000488) /**< (HSMCI) FIFO Memory Aperture0 162 */
+#define REG_HSMCI_FIFO163       (0x4000048C) /**< (HSMCI) FIFO Memory Aperture0 163 */
+#define REG_HSMCI_FIFO164       (0x40000490) /**< (HSMCI) FIFO Memory Aperture0 164 */
+#define REG_HSMCI_FIFO165       (0x40000494) /**< (HSMCI) FIFO Memory Aperture0 165 */
+#define REG_HSMCI_FIFO166       (0x40000498) /**< (HSMCI) FIFO Memory Aperture0 166 */
+#define REG_HSMCI_FIFO167       (0x4000049C) /**< (HSMCI) FIFO Memory Aperture0 167 */
+#define REG_HSMCI_FIFO168       (0x400004A0) /**< (HSMCI) FIFO Memory Aperture0 168 */
+#define REG_HSMCI_FIFO169       (0x400004A4) /**< (HSMCI) FIFO Memory Aperture0 169 */
+#define REG_HSMCI_FIFO170       (0x400004A8) /**< (HSMCI) FIFO Memory Aperture0 170 */
+#define REG_HSMCI_FIFO171       (0x400004AC) /**< (HSMCI) FIFO Memory Aperture0 171 */
+#define REG_HSMCI_FIFO172       (0x400004B0) /**< (HSMCI) FIFO Memory Aperture0 172 */
+#define REG_HSMCI_FIFO173       (0x400004B4) /**< (HSMCI) FIFO Memory Aperture0 173 */
+#define REG_HSMCI_FIFO174       (0x400004B8) /**< (HSMCI) FIFO Memory Aperture0 174 */
+#define REG_HSMCI_FIFO175       (0x400004BC) /**< (HSMCI) FIFO Memory Aperture0 175 */
+#define REG_HSMCI_FIFO176       (0x400004C0) /**< (HSMCI) FIFO Memory Aperture0 176 */
+#define REG_HSMCI_FIFO177       (0x400004C4) /**< (HSMCI) FIFO Memory Aperture0 177 */
+#define REG_HSMCI_FIFO178       (0x400004C8) /**< (HSMCI) FIFO Memory Aperture0 178 */
+#define REG_HSMCI_FIFO179       (0x400004CC) /**< (HSMCI) FIFO Memory Aperture0 179 */
+#define REG_HSMCI_FIFO180       (0x400004D0) /**< (HSMCI) FIFO Memory Aperture0 180 */
+#define REG_HSMCI_FIFO181       (0x400004D4) /**< (HSMCI) FIFO Memory Aperture0 181 */
+#define REG_HSMCI_FIFO182       (0x400004D8) /**< (HSMCI) FIFO Memory Aperture0 182 */
+#define REG_HSMCI_FIFO183       (0x400004DC) /**< (HSMCI) FIFO Memory Aperture0 183 */
+#define REG_HSMCI_FIFO184       (0x400004E0) /**< (HSMCI) FIFO Memory Aperture0 184 */
+#define REG_HSMCI_FIFO185       (0x400004E4) /**< (HSMCI) FIFO Memory Aperture0 185 */
+#define REG_HSMCI_FIFO186       (0x400004E8) /**< (HSMCI) FIFO Memory Aperture0 186 */
+#define REG_HSMCI_FIFO187       (0x400004EC) /**< (HSMCI) FIFO Memory Aperture0 187 */
+#define REG_HSMCI_FIFO188       (0x400004F0) /**< (HSMCI) FIFO Memory Aperture0 188 */
+#define REG_HSMCI_FIFO189       (0x400004F4) /**< (HSMCI) FIFO Memory Aperture0 189 */
+#define REG_HSMCI_FIFO190       (0x400004F8) /**< (HSMCI) FIFO Memory Aperture0 190 */
+#define REG_HSMCI_FIFO191       (0x400004FC) /**< (HSMCI) FIFO Memory Aperture0 191 */
+#define REG_HSMCI_FIFO192       (0x40000500) /**< (HSMCI) FIFO Memory Aperture0 192 */
+#define REG_HSMCI_FIFO193       (0x40000504) /**< (HSMCI) FIFO Memory Aperture0 193 */
+#define REG_HSMCI_FIFO194       (0x40000508) /**< (HSMCI) FIFO Memory Aperture0 194 */
+#define REG_HSMCI_FIFO195       (0x4000050C) /**< (HSMCI) FIFO Memory Aperture0 195 */
+#define REG_HSMCI_FIFO196       (0x40000510) /**< (HSMCI) FIFO Memory Aperture0 196 */
+#define REG_HSMCI_FIFO197       (0x40000514) /**< (HSMCI) FIFO Memory Aperture0 197 */
+#define REG_HSMCI_FIFO198       (0x40000518) /**< (HSMCI) FIFO Memory Aperture0 198 */
+#define REG_HSMCI_FIFO199       (0x4000051C) /**< (HSMCI) FIFO Memory Aperture0 199 */
+#define REG_HSMCI_FIFO200       (0x40000520) /**< (HSMCI) FIFO Memory Aperture0 200 */
+#define REG_HSMCI_FIFO201       (0x40000524) /**< (HSMCI) FIFO Memory Aperture0 201 */
+#define REG_HSMCI_FIFO202       (0x40000528) /**< (HSMCI) FIFO Memory Aperture0 202 */
+#define REG_HSMCI_FIFO203       (0x4000052C) /**< (HSMCI) FIFO Memory Aperture0 203 */
+#define REG_HSMCI_FIFO204       (0x40000530) /**< (HSMCI) FIFO Memory Aperture0 204 */
+#define REG_HSMCI_FIFO205       (0x40000534) /**< (HSMCI) FIFO Memory Aperture0 205 */
+#define REG_HSMCI_FIFO206       (0x40000538) /**< (HSMCI) FIFO Memory Aperture0 206 */
+#define REG_HSMCI_FIFO207       (0x4000053C) /**< (HSMCI) FIFO Memory Aperture0 207 */
+#define REG_HSMCI_FIFO208       (0x40000540) /**< (HSMCI) FIFO Memory Aperture0 208 */
+#define REG_HSMCI_FIFO209       (0x40000544) /**< (HSMCI) FIFO Memory Aperture0 209 */
+#define REG_HSMCI_FIFO210       (0x40000548) /**< (HSMCI) FIFO Memory Aperture0 210 */
+#define REG_HSMCI_FIFO211       (0x4000054C) /**< (HSMCI) FIFO Memory Aperture0 211 */
+#define REG_HSMCI_FIFO212       (0x40000550) /**< (HSMCI) FIFO Memory Aperture0 212 */
+#define REG_HSMCI_FIFO213       (0x40000554) /**< (HSMCI) FIFO Memory Aperture0 213 */
+#define REG_HSMCI_FIFO214       (0x40000558) /**< (HSMCI) FIFO Memory Aperture0 214 */
+#define REG_HSMCI_FIFO215       (0x4000055C) /**< (HSMCI) FIFO Memory Aperture0 215 */
+#define REG_HSMCI_FIFO216       (0x40000560) /**< (HSMCI) FIFO Memory Aperture0 216 */
+#define REG_HSMCI_FIFO217       (0x40000564) /**< (HSMCI) FIFO Memory Aperture0 217 */
+#define REG_HSMCI_FIFO218       (0x40000568) /**< (HSMCI) FIFO Memory Aperture0 218 */
+#define REG_HSMCI_FIFO219       (0x4000056C) /**< (HSMCI) FIFO Memory Aperture0 219 */
+#define REG_HSMCI_FIFO220       (0x40000570) /**< (HSMCI) FIFO Memory Aperture0 220 */
+#define REG_HSMCI_FIFO221       (0x40000574) /**< (HSMCI) FIFO Memory Aperture0 221 */
+#define REG_HSMCI_FIFO222       (0x40000578) /**< (HSMCI) FIFO Memory Aperture0 222 */
+#define REG_HSMCI_FIFO223       (0x4000057C) /**< (HSMCI) FIFO Memory Aperture0 223 */
+#define REG_HSMCI_FIFO224       (0x40000580) /**< (HSMCI) FIFO Memory Aperture0 224 */
+#define REG_HSMCI_FIFO225       (0x40000584) /**< (HSMCI) FIFO Memory Aperture0 225 */
+#define REG_HSMCI_FIFO226       (0x40000588) /**< (HSMCI) FIFO Memory Aperture0 226 */
+#define REG_HSMCI_FIFO227       (0x4000058C) /**< (HSMCI) FIFO Memory Aperture0 227 */
+#define REG_HSMCI_FIFO228       (0x40000590) /**< (HSMCI) FIFO Memory Aperture0 228 */
+#define REG_HSMCI_FIFO229       (0x40000594) /**< (HSMCI) FIFO Memory Aperture0 229 */
+#define REG_HSMCI_FIFO230       (0x40000598) /**< (HSMCI) FIFO Memory Aperture0 230 */
+#define REG_HSMCI_FIFO231       (0x4000059C) /**< (HSMCI) FIFO Memory Aperture0 231 */
+#define REG_HSMCI_FIFO232       (0x400005A0) /**< (HSMCI) FIFO Memory Aperture0 232 */
+#define REG_HSMCI_FIFO233       (0x400005A4) /**< (HSMCI) FIFO Memory Aperture0 233 */
+#define REG_HSMCI_FIFO234       (0x400005A8) /**< (HSMCI) FIFO Memory Aperture0 234 */
+#define REG_HSMCI_FIFO235       (0x400005AC) /**< (HSMCI) FIFO Memory Aperture0 235 */
+#define REG_HSMCI_FIFO236       (0x400005B0) /**< (HSMCI) FIFO Memory Aperture0 236 */
+#define REG_HSMCI_FIFO237       (0x400005B4) /**< (HSMCI) FIFO Memory Aperture0 237 */
+#define REG_HSMCI_FIFO238       (0x400005B8) /**< (HSMCI) FIFO Memory Aperture0 238 */
+#define REG_HSMCI_FIFO239       (0x400005BC) /**< (HSMCI) FIFO Memory Aperture0 239 */
+#define REG_HSMCI_FIFO240       (0x400005C0) /**< (HSMCI) FIFO Memory Aperture0 240 */
+#define REG_HSMCI_FIFO241       (0x400005C4) /**< (HSMCI) FIFO Memory Aperture0 241 */
+#define REG_HSMCI_FIFO242       (0x400005C8) /**< (HSMCI) FIFO Memory Aperture0 242 */
+#define REG_HSMCI_FIFO243       (0x400005CC) /**< (HSMCI) FIFO Memory Aperture0 243 */
+#define REG_HSMCI_FIFO244       (0x400005D0) /**< (HSMCI) FIFO Memory Aperture0 244 */
+#define REG_HSMCI_FIFO245       (0x400005D4) /**< (HSMCI) FIFO Memory Aperture0 245 */
+#define REG_HSMCI_FIFO246       (0x400005D8) /**< (HSMCI) FIFO Memory Aperture0 246 */
+#define REG_HSMCI_FIFO247       (0x400005DC) /**< (HSMCI) FIFO Memory Aperture0 247 */
+#define REG_HSMCI_FIFO248       (0x400005E0) /**< (HSMCI) FIFO Memory Aperture0 248 */
+#define REG_HSMCI_FIFO249       (0x400005E4) /**< (HSMCI) FIFO Memory Aperture0 249 */
+#define REG_HSMCI_FIFO250       (0x400005E8) /**< (HSMCI) FIFO Memory Aperture0 250 */
+#define REG_HSMCI_FIFO251       (0x400005EC) /**< (HSMCI) FIFO Memory Aperture0 251 */
+#define REG_HSMCI_FIFO252       (0x400005F0) /**< (HSMCI) FIFO Memory Aperture0 252 */
+#define REG_HSMCI_FIFO253       (0x400005F4) /**< (HSMCI) FIFO Memory Aperture0 253 */
+#define REG_HSMCI_FIFO254       (0x400005F8) /**< (HSMCI) FIFO Memory Aperture0 254 */
+#define REG_HSMCI_FIFO255       (0x400005FC) /**< (HSMCI) FIFO Memory Aperture0 255 */
+
+#else
+
+#define REG_HSMCI_CR            (*(__O  uint32_t*)0x40000000U) /**< (HSMCI) Control Register */
+#define REG_HSMCI_MR            (*(__IO uint32_t*)0x40000004U) /**< (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR          (*(__IO uint32_t*)0x40000008U) /**< (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR          (*(__IO uint32_t*)0x4000000CU) /**< (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR          (*(__IO uint32_t*)0x40000010U) /**< (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR          (*(__O  uint32_t*)0x40000014U) /**< (HSMCI) Command Register */
+#define REG_HSMCI_BLKR          (*(__IO uint32_t*)0x40000018U) /**< (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR         (*(__IO uint32_t*)0x4000001CU) /**< (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR          (*(__I  uint32_t*)0x40000020U) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR0         (*(__I  uint32_t*)0x40000020U) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR1         (*(__I  uint32_t*)0x40000024U) /**< (HSMCI) Response Register 1 */
+#define REG_HSMCI_RSPR2         (*(__I  uint32_t*)0x40000028U) /**< (HSMCI) Response Register 2 */
+#define REG_HSMCI_RSPR3         (*(__I  uint32_t*)0x4000002CU) /**< (HSMCI) Response Register 3 */
+#define REG_HSMCI_RDR           (*(__I  uint32_t*)0x40000030U) /**< (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR           (*(__O  uint32_t*)0x40000034U) /**< (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR            (*(__I  uint32_t*)0x40000040U) /**< (HSMCI) Status Register */
+#define REG_HSMCI_IER           (*(__O  uint32_t*)0x40000044U) /**< (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR           (*(__O  uint32_t*)0x40000048U) /**< (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR           (*(__I  uint32_t*)0x4000004CU) /**< (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_DMA           (*(__IO uint32_t*)0x40000050U) /**< (HSMCI) DMA Configuration Register */
+#define REG_HSMCI_CFG           (*(__IO uint32_t*)0x40000054U) /**< (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR          (*(__IO uint32_t*)0x400000E4U) /**< (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR          (*(__I  uint32_t*)0x400000E8U) /**< (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_VERSION       (*(__I  uint32_t*)0x400000FCU) /**< (HSMCI) Version Register */
+#define REG_HSMCI_FIFO          (*(__IO uint32_t*)0x40000200U) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO0         (*(__IO uint32_t*)0x40000200U) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO1         (*(__IO uint32_t*)0x40000204U) /**< (HSMCI) FIFO Memory Aperture0 1 */
+#define REG_HSMCI_FIFO2         (*(__IO uint32_t*)0x40000208U) /**< (HSMCI) FIFO Memory Aperture0 2 */
+#define REG_HSMCI_FIFO3         (*(__IO uint32_t*)0x4000020CU) /**< (HSMCI) FIFO Memory Aperture0 3 */
+#define REG_HSMCI_FIFO4         (*(__IO uint32_t*)0x40000210U) /**< (HSMCI) FIFO Memory Aperture0 4 */
+#define REG_HSMCI_FIFO5         (*(__IO uint32_t*)0x40000214U) /**< (HSMCI) FIFO Memory Aperture0 5 */
+#define REG_HSMCI_FIFO6         (*(__IO uint32_t*)0x40000218U) /**< (HSMCI) FIFO Memory Aperture0 6 */
+#define REG_HSMCI_FIFO7         (*(__IO uint32_t*)0x4000021CU) /**< (HSMCI) FIFO Memory Aperture0 7 */
+#define REG_HSMCI_FIFO8         (*(__IO uint32_t*)0x40000220U) /**< (HSMCI) FIFO Memory Aperture0 8 */
+#define REG_HSMCI_FIFO9         (*(__IO uint32_t*)0x40000224U) /**< (HSMCI) FIFO Memory Aperture0 9 */
+#define REG_HSMCI_FIFO10        (*(__IO uint32_t*)0x40000228U) /**< (HSMCI) FIFO Memory Aperture0 10 */
+#define REG_HSMCI_FIFO11        (*(__IO uint32_t*)0x4000022CU) /**< (HSMCI) FIFO Memory Aperture0 11 */
+#define REG_HSMCI_FIFO12        (*(__IO uint32_t*)0x40000230U) /**< (HSMCI) FIFO Memory Aperture0 12 */
+#define REG_HSMCI_FIFO13        (*(__IO uint32_t*)0x40000234U) /**< (HSMCI) FIFO Memory Aperture0 13 */
+#define REG_HSMCI_FIFO14        (*(__IO uint32_t*)0x40000238U) /**< (HSMCI) FIFO Memory Aperture0 14 */
+#define REG_HSMCI_FIFO15        (*(__IO uint32_t*)0x4000023CU) /**< (HSMCI) FIFO Memory Aperture0 15 */
+#define REG_HSMCI_FIFO16        (*(__IO uint32_t*)0x40000240U) /**< (HSMCI) FIFO Memory Aperture0 16 */
+#define REG_HSMCI_FIFO17        (*(__IO uint32_t*)0x40000244U) /**< (HSMCI) FIFO Memory Aperture0 17 */
+#define REG_HSMCI_FIFO18        (*(__IO uint32_t*)0x40000248U) /**< (HSMCI) FIFO Memory Aperture0 18 */
+#define REG_HSMCI_FIFO19        (*(__IO uint32_t*)0x4000024CU) /**< (HSMCI) FIFO Memory Aperture0 19 */
+#define REG_HSMCI_FIFO20        (*(__IO uint32_t*)0x40000250U) /**< (HSMCI) FIFO Memory Aperture0 20 */
+#define REG_HSMCI_FIFO21        (*(__IO uint32_t*)0x40000254U) /**< (HSMCI) FIFO Memory Aperture0 21 */
+#define REG_HSMCI_FIFO22        (*(__IO uint32_t*)0x40000258U) /**< (HSMCI) FIFO Memory Aperture0 22 */
+#define REG_HSMCI_FIFO23        (*(__IO uint32_t*)0x4000025CU) /**< (HSMCI) FIFO Memory Aperture0 23 */
+#define REG_HSMCI_FIFO24        (*(__IO uint32_t*)0x40000260U) /**< (HSMCI) FIFO Memory Aperture0 24 */
+#define REG_HSMCI_FIFO25        (*(__IO uint32_t*)0x40000264U) /**< (HSMCI) FIFO Memory Aperture0 25 */
+#define REG_HSMCI_FIFO26        (*(__IO uint32_t*)0x40000268U) /**< (HSMCI) FIFO Memory Aperture0 26 */
+#define REG_HSMCI_FIFO27        (*(__IO uint32_t*)0x4000026CU) /**< (HSMCI) FIFO Memory Aperture0 27 */
+#define REG_HSMCI_FIFO28        (*(__IO uint32_t*)0x40000270U) /**< (HSMCI) FIFO Memory Aperture0 28 */
+#define REG_HSMCI_FIFO29        (*(__IO uint32_t*)0x40000274U) /**< (HSMCI) FIFO Memory Aperture0 29 */
+#define REG_HSMCI_FIFO30        (*(__IO uint32_t*)0x40000278U) /**< (HSMCI) FIFO Memory Aperture0 30 */
+#define REG_HSMCI_FIFO31        (*(__IO uint32_t*)0x4000027CU) /**< (HSMCI) FIFO Memory Aperture0 31 */
+#define REG_HSMCI_FIFO32        (*(__IO uint32_t*)0x40000280U) /**< (HSMCI) FIFO Memory Aperture0 32 */
+#define REG_HSMCI_FIFO33        (*(__IO uint32_t*)0x40000284U) /**< (HSMCI) FIFO Memory Aperture0 33 */
+#define REG_HSMCI_FIFO34        (*(__IO uint32_t*)0x40000288U) /**< (HSMCI) FIFO Memory Aperture0 34 */
+#define REG_HSMCI_FIFO35        (*(__IO uint32_t*)0x4000028CU) /**< (HSMCI) FIFO Memory Aperture0 35 */
+#define REG_HSMCI_FIFO36        (*(__IO uint32_t*)0x40000290U) /**< (HSMCI) FIFO Memory Aperture0 36 */
+#define REG_HSMCI_FIFO37        (*(__IO uint32_t*)0x40000294U) /**< (HSMCI) FIFO Memory Aperture0 37 */
+#define REG_HSMCI_FIFO38        (*(__IO uint32_t*)0x40000298U) /**< (HSMCI) FIFO Memory Aperture0 38 */
+#define REG_HSMCI_FIFO39        (*(__IO uint32_t*)0x4000029CU) /**< (HSMCI) FIFO Memory Aperture0 39 */
+#define REG_HSMCI_FIFO40        (*(__IO uint32_t*)0x400002A0U) /**< (HSMCI) FIFO Memory Aperture0 40 */
+#define REG_HSMCI_FIFO41        (*(__IO uint32_t*)0x400002A4U) /**< (HSMCI) FIFO Memory Aperture0 41 */
+#define REG_HSMCI_FIFO42        (*(__IO uint32_t*)0x400002A8U) /**< (HSMCI) FIFO Memory Aperture0 42 */
+#define REG_HSMCI_FIFO43        (*(__IO uint32_t*)0x400002ACU) /**< (HSMCI) FIFO Memory Aperture0 43 */
+#define REG_HSMCI_FIFO44        (*(__IO uint32_t*)0x400002B0U) /**< (HSMCI) FIFO Memory Aperture0 44 */
+#define REG_HSMCI_FIFO45        (*(__IO uint32_t*)0x400002B4U) /**< (HSMCI) FIFO Memory Aperture0 45 */
+#define REG_HSMCI_FIFO46        (*(__IO uint32_t*)0x400002B8U) /**< (HSMCI) FIFO Memory Aperture0 46 */
+#define REG_HSMCI_FIFO47        (*(__IO uint32_t*)0x400002BCU) /**< (HSMCI) FIFO Memory Aperture0 47 */
+#define REG_HSMCI_FIFO48        (*(__IO uint32_t*)0x400002C0U) /**< (HSMCI) FIFO Memory Aperture0 48 */
+#define REG_HSMCI_FIFO49        (*(__IO uint32_t*)0x400002C4U) /**< (HSMCI) FIFO Memory Aperture0 49 */
+#define REG_HSMCI_FIFO50        (*(__IO uint32_t*)0x400002C8U) /**< (HSMCI) FIFO Memory Aperture0 50 */
+#define REG_HSMCI_FIFO51        (*(__IO uint32_t*)0x400002CCU) /**< (HSMCI) FIFO Memory Aperture0 51 */
+#define REG_HSMCI_FIFO52        (*(__IO uint32_t*)0x400002D0U) /**< (HSMCI) FIFO Memory Aperture0 52 */
+#define REG_HSMCI_FIFO53        (*(__IO uint32_t*)0x400002D4U) /**< (HSMCI) FIFO Memory Aperture0 53 */
+#define REG_HSMCI_FIFO54        (*(__IO uint32_t*)0x400002D8U) /**< (HSMCI) FIFO Memory Aperture0 54 */
+#define REG_HSMCI_FIFO55        (*(__IO uint32_t*)0x400002DCU) /**< (HSMCI) FIFO Memory Aperture0 55 */
+#define REG_HSMCI_FIFO56        (*(__IO uint32_t*)0x400002E0U) /**< (HSMCI) FIFO Memory Aperture0 56 */
+#define REG_HSMCI_FIFO57        (*(__IO uint32_t*)0x400002E4U) /**< (HSMCI) FIFO Memory Aperture0 57 */
+#define REG_HSMCI_FIFO58        (*(__IO uint32_t*)0x400002E8U) /**< (HSMCI) FIFO Memory Aperture0 58 */
+#define REG_HSMCI_FIFO59        (*(__IO uint32_t*)0x400002ECU) /**< (HSMCI) FIFO Memory Aperture0 59 */
+#define REG_HSMCI_FIFO60        (*(__IO uint32_t*)0x400002F0U) /**< (HSMCI) FIFO Memory Aperture0 60 */
+#define REG_HSMCI_FIFO61        (*(__IO uint32_t*)0x400002F4U) /**< (HSMCI) FIFO Memory Aperture0 61 */
+#define REG_HSMCI_FIFO62        (*(__IO uint32_t*)0x400002F8U) /**< (HSMCI) FIFO Memory Aperture0 62 */
+#define REG_HSMCI_FIFO63        (*(__IO uint32_t*)0x400002FCU) /**< (HSMCI) FIFO Memory Aperture0 63 */
+#define REG_HSMCI_FIFO64        (*(__IO uint32_t*)0x40000300U) /**< (HSMCI) FIFO Memory Aperture0 64 */
+#define REG_HSMCI_FIFO65        (*(__IO uint32_t*)0x40000304U) /**< (HSMCI) FIFO Memory Aperture0 65 */
+#define REG_HSMCI_FIFO66        (*(__IO uint32_t*)0x40000308U) /**< (HSMCI) FIFO Memory Aperture0 66 */
+#define REG_HSMCI_FIFO67        (*(__IO uint32_t*)0x4000030CU) /**< (HSMCI) FIFO Memory Aperture0 67 */
+#define REG_HSMCI_FIFO68        (*(__IO uint32_t*)0x40000310U) /**< (HSMCI) FIFO Memory Aperture0 68 */
+#define REG_HSMCI_FIFO69        (*(__IO uint32_t*)0x40000314U) /**< (HSMCI) FIFO Memory Aperture0 69 */
+#define REG_HSMCI_FIFO70        (*(__IO uint32_t*)0x40000318U) /**< (HSMCI) FIFO Memory Aperture0 70 */
+#define REG_HSMCI_FIFO71        (*(__IO uint32_t*)0x4000031CU) /**< (HSMCI) FIFO Memory Aperture0 71 */
+#define REG_HSMCI_FIFO72        (*(__IO uint32_t*)0x40000320U) /**< (HSMCI) FIFO Memory Aperture0 72 */
+#define REG_HSMCI_FIFO73        (*(__IO uint32_t*)0x40000324U) /**< (HSMCI) FIFO Memory Aperture0 73 */
+#define REG_HSMCI_FIFO74        (*(__IO uint32_t*)0x40000328U) /**< (HSMCI) FIFO Memory Aperture0 74 */
+#define REG_HSMCI_FIFO75        (*(__IO uint32_t*)0x4000032CU) /**< (HSMCI) FIFO Memory Aperture0 75 */
+#define REG_HSMCI_FIFO76        (*(__IO uint32_t*)0x40000330U) /**< (HSMCI) FIFO Memory Aperture0 76 */
+#define REG_HSMCI_FIFO77        (*(__IO uint32_t*)0x40000334U) /**< (HSMCI) FIFO Memory Aperture0 77 */
+#define REG_HSMCI_FIFO78        (*(__IO uint32_t*)0x40000338U) /**< (HSMCI) FIFO Memory Aperture0 78 */
+#define REG_HSMCI_FIFO79        (*(__IO uint32_t*)0x4000033CU) /**< (HSMCI) FIFO Memory Aperture0 79 */
+#define REG_HSMCI_FIFO80        (*(__IO uint32_t*)0x40000340U) /**< (HSMCI) FIFO Memory Aperture0 80 */
+#define REG_HSMCI_FIFO81        (*(__IO uint32_t*)0x40000344U) /**< (HSMCI) FIFO Memory Aperture0 81 */
+#define REG_HSMCI_FIFO82        (*(__IO uint32_t*)0x40000348U) /**< (HSMCI) FIFO Memory Aperture0 82 */
+#define REG_HSMCI_FIFO83        (*(__IO uint32_t*)0x4000034CU) /**< (HSMCI) FIFO Memory Aperture0 83 */
+#define REG_HSMCI_FIFO84        (*(__IO uint32_t*)0x40000350U) /**< (HSMCI) FIFO Memory Aperture0 84 */
+#define REG_HSMCI_FIFO85        (*(__IO uint32_t*)0x40000354U) /**< (HSMCI) FIFO Memory Aperture0 85 */
+#define REG_HSMCI_FIFO86        (*(__IO uint32_t*)0x40000358U) /**< (HSMCI) FIFO Memory Aperture0 86 */
+#define REG_HSMCI_FIFO87        (*(__IO uint32_t*)0x4000035CU) /**< (HSMCI) FIFO Memory Aperture0 87 */
+#define REG_HSMCI_FIFO88        (*(__IO uint32_t*)0x40000360U) /**< (HSMCI) FIFO Memory Aperture0 88 */
+#define REG_HSMCI_FIFO89        (*(__IO uint32_t*)0x40000364U) /**< (HSMCI) FIFO Memory Aperture0 89 */
+#define REG_HSMCI_FIFO90        (*(__IO uint32_t*)0x40000368U) /**< (HSMCI) FIFO Memory Aperture0 90 */
+#define REG_HSMCI_FIFO91        (*(__IO uint32_t*)0x4000036CU) /**< (HSMCI) FIFO Memory Aperture0 91 */
+#define REG_HSMCI_FIFO92        (*(__IO uint32_t*)0x40000370U) /**< (HSMCI) FIFO Memory Aperture0 92 */
+#define REG_HSMCI_FIFO93        (*(__IO uint32_t*)0x40000374U) /**< (HSMCI) FIFO Memory Aperture0 93 */
+#define REG_HSMCI_FIFO94        (*(__IO uint32_t*)0x40000378U) /**< (HSMCI) FIFO Memory Aperture0 94 */
+#define REG_HSMCI_FIFO95        (*(__IO uint32_t*)0x4000037CU) /**< (HSMCI) FIFO Memory Aperture0 95 */
+#define REG_HSMCI_FIFO96        (*(__IO uint32_t*)0x40000380U) /**< (HSMCI) FIFO Memory Aperture0 96 */
+#define REG_HSMCI_FIFO97        (*(__IO uint32_t*)0x40000384U) /**< (HSMCI) FIFO Memory Aperture0 97 */
+#define REG_HSMCI_FIFO98        (*(__IO uint32_t*)0x40000388U) /**< (HSMCI) FIFO Memory Aperture0 98 */
+#define REG_HSMCI_FIFO99        (*(__IO uint32_t*)0x4000038CU) /**< (HSMCI) FIFO Memory Aperture0 99 */
+#define REG_HSMCI_FIFO100       (*(__IO uint32_t*)0x40000390U) /**< (HSMCI) FIFO Memory Aperture0 100 */
+#define REG_HSMCI_FIFO101       (*(__IO uint32_t*)0x40000394U) /**< (HSMCI) FIFO Memory Aperture0 101 */
+#define REG_HSMCI_FIFO102       (*(__IO uint32_t*)0x40000398U) /**< (HSMCI) FIFO Memory Aperture0 102 */
+#define REG_HSMCI_FIFO103       (*(__IO uint32_t*)0x4000039CU) /**< (HSMCI) FIFO Memory Aperture0 103 */
+#define REG_HSMCI_FIFO104       (*(__IO uint32_t*)0x400003A0U) /**< (HSMCI) FIFO Memory Aperture0 104 */
+#define REG_HSMCI_FIFO105       (*(__IO uint32_t*)0x400003A4U) /**< (HSMCI) FIFO Memory Aperture0 105 */
+#define REG_HSMCI_FIFO106       (*(__IO uint32_t*)0x400003A8U) /**< (HSMCI) FIFO Memory Aperture0 106 */
+#define REG_HSMCI_FIFO107       (*(__IO uint32_t*)0x400003ACU) /**< (HSMCI) FIFO Memory Aperture0 107 */
+#define REG_HSMCI_FIFO108       (*(__IO uint32_t*)0x400003B0U) /**< (HSMCI) FIFO Memory Aperture0 108 */
+#define REG_HSMCI_FIFO109       (*(__IO uint32_t*)0x400003B4U) /**< (HSMCI) FIFO Memory Aperture0 109 */
+#define REG_HSMCI_FIFO110       (*(__IO uint32_t*)0x400003B8U) /**< (HSMCI) FIFO Memory Aperture0 110 */
+#define REG_HSMCI_FIFO111       (*(__IO uint32_t*)0x400003BCU) /**< (HSMCI) FIFO Memory Aperture0 111 */
+#define REG_HSMCI_FIFO112       (*(__IO uint32_t*)0x400003C0U) /**< (HSMCI) FIFO Memory Aperture0 112 */
+#define REG_HSMCI_FIFO113       (*(__IO uint32_t*)0x400003C4U) /**< (HSMCI) FIFO Memory Aperture0 113 */
+#define REG_HSMCI_FIFO114       (*(__IO uint32_t*)0x400003C8U) /**< (HSMCI) FIFO Memory Aperture0 114 */
+#define REG_HSMCI_FIFO115       (*(__IO uint32_t*)0x400003CCU) /**< (HSMCI) FIFO Memory Aperture0 115 */
+#define REG_HSMCI_FIFO116       (*(__IO uint32_t*)0x400003D0U) /**< (HSMCI) FIFO Memory Aperture0 116 */
+#define REG_HSMCI_FIFO117       (*(__IO uint32_t*)0x400003D4U) /**< (HSMCI) FIFO Memory Aperture0 117 */
+#define REG_HSMCI_FIFO118       (*(__IO uint32_t*)0x400003D8U) /**< (HSMCI) FIFO Memory Aperture0 118 */
+#define REG_HSMCI_FIFO119       (*(__IO uint32_t*)0x400003DCU) /**< (HSMCI) FIFO Memory Aperture0 119 */
+#define REG_HSMCI_FIFO120       (*(__IO uint32_t*)0x400003E0U) /**< (HSMCI) FIFO Memory Aperture0 120 */
+#define REG_HSMCI_FIFO121       (*(__IO uint32_t*)0x400003E4U) /**< (HSMCI) FIFO Memory Aperture0 121 */
+#define REG_HSMCI_FIFO122       (*(__IO uint32_t*)0x400003E8U) /**< (HSMCI) FIFO Memory Aperture0 122 */
+#define REG_HSMCI_FIFO123       (*(__IO uint32_t*)0x400003ECU) /**< (HSMCI) FIFO Memory Aperture0 123 */
+#define REG_HSMCI_FIFO124       (*(__IO uint32_t*)0x400003F0U) /**< (HSMCI) FIFO Memory Aperture0 124 */
+#define REG_HSMCI_FIFO125       (*(__IO uint32_t*)0x400003F4U) /**< (HSMCI) FIFO Memory Aperture0 125 */
+#define REG_HSMCI_FIFO126       (*(__IO uint32_t*)0x400003F8U) /**< (HSMCI) FIFO Memory Aperture0 126 */
+#define REG_HSMCI_FIFO127       (*(__IO uint32_t*)0x400003FCU) /**< (HSMCI) FIFO Memory Aperture0 127 */
+#define REG_HSMCI_FIFO128       (*(__IO uint32_t*)0x40000400U) /**< (HSMCI) FIFO Memory Aperture0 128 */
+#define REG_HSMCI_FIFO129       (*(__IO uint32_t*)0x40000404U) /**< (HSMCI) FIFO Memory Aperture0 129 */
+#define REG_HSMCI_FIFO130       (*(__IO uint32_t*)0x40000408U) /**< (HSMCI) FIFO Memory Aperture0 130 */
+#define REG_HSMCI_FIFO131       (*(__IO uint32_t*)0x4000040CU) /**< (HSMCI) FIFO Memory Aperture0 131 */
+#define REG_HSMCI_FIFO132       (*(__IO uint32_t*)0x40000410U) /**< (HSMCI) FIFO Memory Aperture0 132 */
+#define REG_HSMCI_FIFO133       (*(__IO uint32_t*)0x40000414U) /**< (HSMCI) FIFO Memory Aperture0 133 */
+#define REG_HSMCI_FIFO134       (*(__IO uint32_t*)0x40000418U) /**< (HSMCI) FIFO Memory Aperture0 134 */
+#define REG_HSMCI_FIFO135       (*(__IO uint32_t*)0x4000041CU) /**< (HSMCI) FIFO Memory Aperture0 135 */
+#define REG_HSMCI_FIFO136       (*(__IO uint32_t*)0x40000420U) /**< (HSMCI) FIFO Memory Aperture0 136 */
+#define REG_HSMCI_FIFO137       (*(__IO uint32_t*)0x40000424U) /**< (HSMCI) FIFO Memory Aperture0 137 */
+#define REG_HSMCI_FIFO138       (*(__IO uint32_t*)0x40000428U) /**< (HSMCI) FIFO Memory Aperture0 138 */
+#define REG_HSMCI_FIFO139       (*(__IO uint32_t*)0x4000042CU) /**< (HSMCI) FIFO Memory Aperture0 139 */
+#define REG_HSMCI_FIFO140       (*(__IO uint32_t*)0x40000430U) /**< (HSMCI) FIFO Memory Aperture0 140 */
+#define REG_HSMCI_FIFO141       (*(__IO uint32_t*)0x40000434U) /**< (HSMCI) FIFO Memory Aperture0 141 */
+#define REG_HSMCI_FIFO142       (*(__IO uint32_t*)0x40000438U) /**< (HSMCI) FIFO Memory Aperture0 142 */
+#define REG_HSMCI_FIFO143       (*(__IO uint32_t*)0x4000043CU) /**< (HSMCI) FIFO Memory Aperture0 143 */
+#define REG_HSMCI_FIFO144       (*(__IO uint32_t*)0x40000440U) /**< (HSMCI) FIFO Memory Aperture0 144 */
+#define REG_HSMCI_FIFO145       (*(__IO uint32_t*)0x40000444U) /**< (HSMCI) FIFO Memory Aperture0 145 */
+#define REG_HSMCI_FIFO146       (*(__IO uint32_t*)0x40000448U) /**< (HSMCI) FIFO Memory Aperture0 146 */
+#define REG_HSMCI_FIFO147       (*(__IO uint32_t*)0x4000044CU) /**< (HSMCI) FIFO Memory Aperture0 147 */
+#define REG_HSMCI_FIFO148       (*(__IO uint32_t*)0x40000450U) /**< (HSMCI) FIFO Memory Aperture0 148 */
+#define REG_HSMCI_FIFO149       (*(__IO uint32_t*)0x40000454U) /**< (HSMCI) FIFO Memory Aperture0 149 */
+#define REG_HSMCI_FIFO150       (*(__IO uint32_t*)0x40000458U) /**< (HSMCI) FIFO Memory Aperture0 150 */
+#define REG_HSMCI_FIFO151       (*(__IO uint32_t*)0x4000045CU) /**< (HSMCI) FIFO Memory Aperture0 151 */
+#define REG_HSMCI_FIFO152       (*(__IO uint32_t*)0x40000460U) /**< (HSMCI) FIFO Memory Aperture0 152 */
+#define REG_HSMCI_FIFO153       (*(__IO uint32_t*)0x40000464U) /**< (HSMCI) FIFO Memory Aperture0 153 */
+#define REG_HSMCI_FIFO154       (*(__IO uint32_t*)0x40000468U) /**< (HSMCI) FIFO Memory Aperture0 154 */
+#define REG_HSMCI_FIFO155       (*(__IO uint32_t*)0x4000046CU) /**< (HSMCI) FIFO Memory Aperture0 155 */
+#define REG_HSMCI_FIFO156       (*(__IO uint32_t*)0x40000470U) /**< (HSMCI) FIFO Memory Aperture0 156 */
+#define REG_HSMCI_FIFO157       (*(__IO uint32_t*)0x40000474U) /**< (HSMCI) FIFO Memory Aperture0 157 */
+#define REG_HSMCI_FIFO158       (*(__IO uint32_t*)0x40000478U) /**< (HSMCI) FIFO Memory Aperture0 158 */
+#define REG_HSMCI_FIFO159       (*(__IO uint32_t*)0x4000047CU) /**< (HSMCI) FIFO Memory Aperture0 159 */
+#define REG_HSMCI_FIFO160       (*(__IO uint32_t*)0x40000480U) /**< (HSMCI) FIFO Memory Aperture0 160 */
+#define REG_HSMCI_FIFO161       (*(__IO uint32_t*)0x40000484U) /**< (HSMCI) FIFO Memory Aperture0 161 */
+#define REG_HSMCI_FIFO162       (*(__IO uint32_t*)0x40000488U) /**< (HSMCI) FIFO Memory Aperture0 162 */
+#define REG_HSMCI_FIFO163       (*(__IO uint32_t*)0x4000048CU) /**< (HSMCI) FIFO Memory Aperture0 163 */
+#define REG_HSMCI_FIFO164       (*(__IO uint32_t*)0x40000490U) /**< (HSMCI) FIFO Memory Aperture0 164 */
+#define REG_HSMCI_FIFO165       (*(__IO uint32_t*)0x40000494U) /**< (HSMCI) FIFO Memory Aperture0 165 */
+#define REG_HSMCI_FIFO166       (*(__IO uint32_t*)0x40000498U) /**< (HSMCI) FIFO Memory Aperture0 166 */
+#define REG_HSMCI_FIFO167       (*(__IO uint32_t*)0x4000049CU) /**< (HSMCI) FIFO Memory Aperture0 167 */
+#define REG_HSMCI_FIFO168       (*(__IO uint32_t*)0x400004A0U) /**< (HSMCI) FIFO Memory Aperture0 168 */
+#define REG_HSMCI_FIFO169       (*(__IO uint32_t*)0x400004A4U) /**< (HSMCI) FIFO Memory Aperture0 169 */
+#define REG_HSMCI_FIFO170       (*(__IO uint32_t*)0x400004A8U) /**< (HSMCI) FIFO Memory Aperture0 170 */
+#define REG_HSMCI_FIFO171       (*(__IO uint32_t*)0x400004ACU) /**< (HSMCI) FIFO Memory Aperture0 171 */
+#define REG_HSMCI_FIFO172       (*(__IO uint32_t*)0x400004B0U) /**< (HSMCI) FIFO Memory Aperture0 172 */
+#define REG_HSMCI_FIFO173       (*(__IO uint32_t*)0x400004B4U) /**< (HSMCI) FIFO Memory Aperture0 173 */
+#define REG_HSMCI_FIFO174       (*(__IO uint32_t*)0x400004B8U) /**< (HSMCI) FIFO Memory Aperture0 174 */
+#define REG_HSMCI_FIFO175       (*(__IO uint32_t*)0x400004BCU) /**< (HSMCI) FIFO Memory Aperture0 175 */
+#define REG_HSMCI_FIFO176       (*(__IO uint32_t*)0x400004C0U) /**< (HSMCI) FIFO Memory Aperture0 176 */
+#define REG_HSMCI_FIFO177       (*(__IO uint32_t*)0x400004C4U) /**< (HSMCI) FIFO Memory Aperture0 177 */
+#define REG_HSMCI_FIFO178       (*(__IO uint32_t*)0x400004C8U) /**< (HSMCI) FIFO Memory Aperture0 178 */
+#define REG_HSMCI_FIFO179       (*(__IO uint32_t*)0x400004CCU) /**< (HSMCI) FIFO Memory Aperture0 179 */
+#define REG_HSMCI_FIFO180       (*(__IO uint32_t*)0x400004D0U) /**< (HSMCI) FIFO Memory Aperture0 180 */
+#define REG_HSMCI_FIFO181       (*(__IO uint32_t*)0x400004D4U) /**< (HSMCI) FIFO Memory Aperture0 181 */
+#define REG_HSMCI_FIFO182       (*(__IO uint32_t*)0x400004D8U) /**< (HSMCI) FIFO Memory Aperture0 182 */
+#define REG_HSMCI_FIFO183       (*(__IO uint32_t*)0x400004DCU) /**< (HSMCI) FIFO Memory Aperture0 183 */
+#define REG_HSMCI_FIFO184       (*(__IO uint32_t*)0x400004E0U) /**< (HSMCI) FIFO Memory Aperture0 184 */
+#define REG_HSMCI_FIFO185       (*(__IO uint32_t*)0x400004E4U) /**< (HSMCI) FIFO Memory Aperture0 185 */
+#define REG_HSMCI_FIFO186       (*(__IO uint32_t*)0x400004E8U) /**< (HSMCI) FIFO Memory Aperture0 186 */
+#define REG_HSMCI_FIFO187       (*(__IO uint32_t*)0x400004ECU) /**< (HSMCI) FIFO Memory Aperture0 187 */
+#define REG_HSMCI_FIFO188       (*(__IO uint32_t*)0x400004F0U) /**< (HSMCI) FIFO Memory Aperture0 188 */
+#define REG_HSMCI_FIFO189       (*(__IO uint32_t*)0x400004F4U) /**< (HSMCI) FIFO Memory Aperture0 189 */
+#define REG_HSMCI_FIFO190       (*(__IO uint32_t*)0x400004F8U) /**< (HSMCI) FIFO Memory Aperture0 190 */
+#define REG_HSMCI_FIFO191       (*(__IO uint32_t*)0x400004FCU) /**< (HSMCI) FIFO Memory Aperture0 191 */
+#define REG_HSMCI_FIFO192       (*(__IO uint32_t*)0x40000500U) /**< (HSMCI) FIFO Memory Aperture0 192 */
+#define REG_HSMCI_FIFO193       (*(__IO uint32_t*)0x40000504U) /**< (HSMCI) FIFO Memory Aperture0 193 */
+#define REG_HSMCI_FIFO194       (*(__IO uint32_t*)0x40000508U) /**< (HSMCI) FIFO Memory Aperture0 194 */
+#define REG_HSMCI_FIFO195       (*(__IO uint32_t*)0x4000050CU) /**< (HSMCI) FIFO Memory Aperture0 195 */
+#define REG_HSMCI_FIFO196       (*(__IO uint32_t*)0x40000510U) /**< (HSMCI) FIFO Memory Aperture0 196 */
+#define REG_HSMCI_FIFO197       (*(__IO uint32_t*)0x40000514U) /**< (HSMCI) FIFO Memory Aperture0 197 */
+#define REG_HSMCI_FIFO198       (*(__IO uint32_t*)0x40000518U) /**< (HSMCI) FIFO Memory Aperture0 198 */
+#define REG_HSMCI_FIFO199       (*(__IO uint32_t*)0x4000051CU) /**< (HSMCI) FIFO Memory Aperture0 199 */
+#define REG_HSMCI_FIFO200       (*(__IO uint32_t*)0x40000520U) /**< (HSMCI) FIFO Memory Aperture0 200 */
+#define REG_HSMCI_FIFO201       (*(__IO uint32_t*)0x40000524U) /**< (HSMCI) FIFO Memory Aperture0 201 */
+#define REG_HSMCI_FIFO202       (*(__IO uint32_t*)0x40000528U) /**< (HSMCI) FIFO Memory Aperture0 202 */
+#define REG_HSMCI_FIFO203       (*(__IO uint32_t*)0x4000052CU) /**< (HSMCI) FIFO Memory Aperture0 203 */
+#define REG_HSMCI_FIFO204       (*(__IO uint32_t*)0x40000530U) /**< (HSMCI) FIFO Memory Aperture0 204 */
+#define REG_HSMCI_FIFO205       (*(__IO uint32_t*)0x40000534U) /**< (HSMCI) FIFO Memory Aperture0 205 */
+#define REG_HSMCI_FIFO206       (*(__IO uint32_t*)0x40000538U) /**< (HSMCI) FIFO Memory Aperture0 206 */
+#define REG_HSMCI_FIFO207       (*(__IO uint32_t*)0x4000053CU) /**< (HSMCI) FIFO Memory Aperture0 207 */
+#define REG_HSMCI_FIFO208       (*(__IO uint32_t*)0x40000540U) /**< (HSMCI) FIFO Memory Aperture0 208 */
+#define REG_HSMCI_FIFO209       (*(__IO uint32_t*)0x40000544U) /**< (HSMCI) FIFO Memory Aperture0 209 */
+#define REG_HSMCI_FIFO210       (*(__IO uint32_t*)0x40000548U) /**< (HSMCI) FIFO Memory Aperture0 210 */
+#define REG_HSMCI_FIFO211       (*(__IO uint32_t*)0x4000054CU) /**< (HSMCI) FIFO Memory Aperture0 211 */
+#define REG_HSMCI_FIFO212       (*(__IO uint32_t*)0x40000550U) /**< (HSMCI) FIFO Memory Aperture0 212 */
+#define REG_HSMCI_FIFO213       (*(__IO uint32_t*)0x40000554U) /**< (HSMCI) FIFO Memory Aperture0 213 */
+#define REG_HSMCI_FIFO214       (*(__IO uint32_t*)0x40000558U) /**< (HSMCI) FIFO Memory Aperture0 214 */
+#define REG_HSMCI_FIFO215       (*(__IO uint32_t*)0x4000055CU) /**< (HSMCI) FIFO Memory Aperture0 215 */
+#define REG_HSMCI_FIFO216       (*(__IO uint32_t*)0x40000560U) /**< (HSMCI) FIFO Memory Aperture0 216 */
+#define REG_HSMCI_FIFO217       (*(__IO uint32_t*)0x40000564U) /**< (HSMCI) FIFO Memory Aperture0 217 */
+#define REG_HSMCI_FIFO218       (*(__IO uint32_t*)0x40000568U) /**< (HSMCI) FIFO Memory Aperture0 218 */
+#define REG_HSMCI_FIFO219       (*(__IO uint32_t*)0x4000056CU) /**< (HSMCI) FIFO Memory Aperture0 219 */
+#define REG_HSMCI_FIFO220       (*(__IO uint32_t*)0x40000570U) /**< (HSMCI) FIFO Memory Aperture0 220 */
+#define REG_HSMCI_FIFO221       (*(__IO uint32_t*)0x40000574U) /**< (HSMCI) FIFO Memory Aperture0 221 */
+#define REG_HSMCI_FIFO222       (*(__IO uint32_t*)0x40000578U) /**< (HSMCI) FIFO Memory Aperture0 222 */
+#define REG_HSMCI_FIFO223       (*(__IO uint32_t*)0x4000057CU) /**< (HSMCI) FIFO Memory Aperture0 223 */
+#define REG_HSMCI_FIFO224       (*(__IO uint32_t*)0x40000580U) /**< (HSMCI) FIFO Memory Aperture0 224 */
+#define REG_HSMCI_FIFO225       (*(__IO uint32_t*)0x40000584U) /**< (HSMCI) FIFO Memory Aperture0 225 */
+#define REG_HSMCI_FIFO226       (*(__IO uint32_t*)0x40000588U) /**< (HSMCI) FIFO Memory Aperture0 226 */
+#define REG_HSMCI_FIFO227       (*(__IO uint32_t*)0x4000058CU) /**< (HSMCI) FIFO Memory Aperture0 227 */
+#define REG_HSMCI_FIFO228       (*(__IO uint32_t*)0x40000590U) /**< (HSMCI) FIFO Memory Aperture0 228 */
+#define REG_HSMCI_FIFO229       (*(__IO uint32_t*)0x40000594U) /**< (HSMCI) FIFO Memory Aperture0 229 */
+#define REG_HSMCI_FIFO230       (*(__IO uint32_t*)0x40000598U) /**< (HSMCI) FIFO Memory Aperture0 230 */
+#define REG_HSMCI_FIFO231       (*(__IO uint32_t*)0x4000059CU) /**< (HSMCI) FIFO Memory Aperture0 231 */
+#define REG_HSMCI_FIFO232       (*(__IO uint32_t*)0x400005A0U) /**< (HSMCI) FIFO Memory Aperture0 232 */
+#define REG_HSMCI_FIFO233       (*(__IO uint32_t*)0x400005A4U) /**< (HSMCI) FIFO Memory Aperture0 233 */
+#define REG_HSMCI_FIFO234       (*(__IO uint32_t*)0x400005A8U) /**< (HSMCI) FIFO Memory Aperture0 234 */
+#define REG_HSMCI_FIFO235       (*(__IO uint32_t*)0x400005ACU) /**< (HSMCI) FIFO Memory Aperture0 235 */
+#define REG_HSMCI_FIFO236       (*(__IO uint32_t*)0x400005B0U) /**< (HSMCI) FIFO Memory Aperture0 236 */
+#define REG_HSMCI_FIFO237       (*(__IO uint32_t*)0x400005B4U) /**< (HSMCI) FIFO Memory Aperture0 237 */
+#define REG_HSMCI_FIFO238       (*(__IO uint32_t*)0x400005B8U) /**< (HSMCI) FIFO Memory Aperture0 238 */
+#define REG_HSMCI_FIFO239       (*(__IO uint32_t*)0x400005BCU) /**< (HSMCI) FIFO Memory Aperture0 239 */
+#define REG_HSMCI_FIFO240       (*(__IO uint32_t*)0x400005C0U) /**< (HSMCI) FIFO Memory Aperture0 240 */
+#define REG_HSMCI_FIFO241       (*(__IO uint32_t*)0x400005C4U) /**< (HSMCI) FIFO Memory Aperture0 241 */
+#define REG_HSMCI_FIFO242       (*(__IO uint32_t*)0x400005C8U) /**< (HSMCI) FIFO Memory Aperture0 242 */
+#define REG_HSMCI_FIFO243       (*(__IO uint32_t*)0x400005CCU) /**< (HSMCI) FIFO Memory Aperture0 243 */
+#define REG_HSMCI_FIFO244       (*(__IO uint32_t*)0x400005D0U) /**< (HSMCI) FIFO Memory Aperture0 244 */
+#define REG_HSMCI_FIFO245       (*(__IO uint32_t*)0x400005D4U) /**< (HSMCI) FIFO Memory Aperture0 245 */
+#define REG_HSMCI_FIFO246       (*(__IO uint32_t*)0x400005D8U) /**< (HSMCI) FIFO Memory Aperture0 246 */
+#define REG_HSMCI_FIFO247       (*(__IO uint32_t*)0x400005DCU) /**< (HSMCI) FIFO Memory Aperture0 247 */
+#define REG_HSMCI_FIFO248       (*(__IO uint32_t*)0x400005E0U) /**< (HSMCI) FIFO Memory Aperture0 248 */
+#define REG_HSMCI_FIFO249       (*(__IO uint32_t*)0x400005E4U) /**< (HSMCI) FIFO Memory Aperture0 249 */
+#define REG_HSMCI_FIFO250       (*(__IO uint32_t*)0x400005E8U) /**< (HSMCI) FIFO Memory Aperture0 250 */
+#define REG_HSMCI_FIFO251       (*(__IO uint32_t*)0x400005ECU) /**< (HSMCI) FIFO Memory Aperture0 251 */
+#define REG_HSMCI_FIFO252       (*(__IO uint32_t*)0x400005F0U) /**< (HSMCI) FIFO Memory Aperture0 252 */
+#define REG_HSMCI_FIFO253       (*(__IO uint32_t*)0x400005F4U) /**< (HSMCI) FIFO Memory Aperture0 253 */
+#define REG_HSMCI_FIFO254       (*(__IO uint32_t*)0x400005F8U) /**< (HSMCI) FIFO Memory Aperture0 254 */
+#define REG_HSMCI_FIFO255       (*(__IO uint32_t*)0x400005FCU) /**< (HSMCI) FIFO Memory Aperture0 255 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for HSMCI peripheral ========== */
+#define HSMCI_DMAC_ID_RX                         0          
+#define HSMCI_DMAC_ID_TX                         0          
+#define HSMCI_INSTANCE_ID                        18         
+
+#endif /* _SAMV71_HSMCI_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/icm.h
+++ b/asf/sam/include/samv71/instance/icm.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ICM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ICM_INSTANCE_H_
+#define _SAMV71_ICM_INSTANCE_H_
+
+/* ========== Register definition for ICM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ICM_CFG             (0x40048000) /**< (ICM) Configuration Register */
+#define REG_ICM_CTRL            (0x40048004) /**< (ICM) Control Register */
+#define REG_ICM_SR              (0x40048008) /**< (ICM) Status Register */
+#define REG_ICM_IER             (0x40048010) /**< (ICM) Interrupt Enable Register */
+#define REG_ICM_IDR             (0x40048014) /**< (ICM) Interrupt Disable Register */
+#define REG_ICM_IMR             (0x40048018) /**< (ICM) Interrupt Mask Register */
+#define REG_ICM_ISR             (0x4004801C) /**< (ICM) Interrupt Status Register */
+#define REG_ICM_UASR            (0x40048020) /**< (ICM) Undefined Access Status Register */
+#define REG_ICM_DSCR            (0x40048030) /**< (ICM) Region Descriptor Area Start Address Register */
+#define REG_ICM_HASH            (0x40048034) /**< (ICM) Region Hash Area Start Address Register */
+#define REG_ICM_UIHVAL          (0x40048038) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL0         (0x40048038) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL1         (0x4004803C) /**< (ICM) User Initial Hash Value 0 Register 1 */
+#define REG_ICM_UIHVAL2         (0x40048040) /**< (ICM) User Initial Hash Value 0 Register 2 */
+#define REG_ICM_UIHVAL3         (0x40048044) /**< (ICM) User Initial Hash Value 0 Register 3 */
+#define REG_ICM_UIHVAL4         (0x40048048) /**< (ICM) User Initial Hash Value 0 Register 4 */
+#define REG_ICM_UIHVAL5         (0x4004804C) /**< (ICM) User Initial Hash Value 0 Register 5 */
+#define REG_ICM_UIHVAL6         (0x40048050) /**< (ICM) User Initial Hash Value 0 Register 6 */
+#define REG_ICM_UIHVAL7         (0x40048054) /**< (ICM) User Initial Hash Value 0 Register 7 */
+
+#else
+
+#define REG_ICM_CFG             (*(__IO uint32_t*)0x40048000U) /**< (ICM) Configuration Register */
+#define REG_ICM_CTRL            (*(__O  uint32_t*)0x40048004U) /**< (ICM) Control Register */
+#define REG_ICM_SR              (*(__I  uint32_t*)0x40048008U) /**< (ICM) Status Register */
+#define REG_ICM_IER             (*(__O  uint32_t*)0x40048010U) /**< (ICM) Interrupt Enable Register */
+#define REG_ICM_IDR             (*(__O  uint32_t*)0x40048014U) /**< (ICM) Interrupt Disable Register */
+#define REG_ICM_IMR             (*(__I  uint32_t*)0x40048018U) /**< (ICM) Interrupt Mask Register */
+#define REG_ICM_ISR             (*(__I  uint32_t*)0x4004801CU) /**< (ICM) Interrupt Status Register */
+#define REG_ICM_UASR            (*(__I  uint32_t*)0x40048020U) /**< (ICM) Undefined Access Status Register */
+#define REG_ICM_DSCR            (*(__IO uint32_t*)0x40048030U) /**< (ICM) Region Descriptor Area Start Address Register */
+#define REG_ICM_HASH            (*(__IO uint32_t*)0x40048034U) /**< (ICM) Region Hash Area Start Address Register */
+#define REG_ICM_UIHVAL          (*(__O  uint32_t*)0x40048038U) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL0         (*(__O  uint32_t*)0x40048038U) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL1         (*(__O  uint32_t*)0x4004803CU) /**< (ICM) User Initial Hash Value 0 Register 1 */
+#define REG_ICM_UIHVAL2         (*(__O  uint32_t*)0x40048040U) /**< (ICM) User Initial Hash Value 0 Register 2 */
+#define REG_ICM_UIHVAL3         (*(__O  uint32_t*)0x40048044U) /**< (ICM) User Initial Hash Value 0 Register 3 */
+#define REG_ICM_UIHVAL4         (*(__O  uint32_t*)0x40048048U) /**< (ICM) User Initial Hash Value 0 Register 4 */
+#define REG_ICM_UIHVAL5         (*(__O  uint32_t*)0x4004804CU) /**< (ICM) User Initial Hash Value 0 Register 5 */
+#define REG_ICM_UIHVAL6         (*(__O  uint32_t*)0x40048050U) /**< (ICM) User Initial Hash Value 0 Register 6 */
+#define REG_ICM_UIHVAL7         (*(__O  uint32_t*)0x40048054U) /**< (ICM) User Initial Hash Value 0 Register 7 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ICM peripheral ========== */
+#define ICM_INSTANCE_ID                          32         
+
+#endif /* _SAMV71_ICM_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/isi.h
+++ b/asf/sam/include/samv71/instance/isi.h
@@ -1,0 +1,98 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ISI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_ISI_INSTANCE_H_
+#define _SAMV71_ISI_INSTANCE_H_
+
+/* ========== Register definition for ISI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ISI_CFG1            (0x4004C000) /**< (ISI) ISI Configuration 1 Register */
+#define REG_ISI_CFG2            (0x4004C004) /**< (ISI) ISI Configuration 2 Register */
+#define REG_ISI_PSIZE           (0x4004C008) /**< (ISI) ISI Preview Size Register */
+#define REG_ISI_PDECF           (0x4004C00C) /**< (ISI) ISI Preview Decimation Factor Register */
+#define REG_ISI_Y2R_SET0        (0x4004C010) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+#define REG_ISI_Y2R_SET1        (0x4004C014) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+#define REG_ISI_R2Y_SET0        (0x4004C018) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+#define REG_ISI_R2Y_SET1        (0x4004C01C) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+#define REG_ISI_R2Y_SET2        (0x4004C020) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+#define REG_ISI_CR              (0x4004C024) /**< (ISI) ISI Control Register */
+#define REG_ISI_SR              (0x4004C028) /**< (ISI) ISI Status Register */
+#define REG_ISI_IER             (0x4004C02C) /**< (ISI) ISI Interrupt Enable Register */
+#define REG_ISI_IDR             (0x4004C030) /**< (ISI) ISI Interrupt Disable Register */
+#define REG_ISI_IMR             (0x4004C034) /**< (ISI) ISI Interrupt Mask Register */
+#define REG_ISI_DMA_CHER        (0x4004C038) /**< (ISI) DMA Channel Enable Register */
+#define REG_ISI_DMA_CHDR        (0x4004C03C) /**< (ISI) DMA Channel Disable Register */
+#define REG_ISI_DMA_CHSR        (0x4004C040) /**< (ISI) DMA Channel Status Register */
+#define REG_ISI_DMA_P_ADDR      (0x4004C044) /**< (ISI) DMA Preview Base Address Register */
+#define REG_ISI_DMA_P_CTRL      (0x4004C048) /**< (ISI) DMA Preview Control Register */
+#define REG_ISI_DMA_P_DSCR      (0x4004C04C) /**< (ISI) DMA Preview Descriptor Address Register */
+#define REG_ISI_DMA_C_ADDR      (0x4004C050) /**< (ISI) DMA Codec Base Address Register */
+#define REG_ISI_DMA_C_CTRL      (0x4004C054) /**< (ISI) DMA Codec Control Register */
+#define REG_ISI_DMA_C_DSCR      (0x4004C058) /**< (ISI) DMA Codec Descriptor Address Register */
+#define REG_ISI_WPMR            (0x4004C0E4) /**< (ISI) Write Protection Mode Register */
+#define REG_ISI_WPSR            (0x4004C0E8) /**< (ISI) Write Protection Status Register */
+#define REG_ISI_VERSION         (0x4004C0FC) /**< (ISI) Version Register */
+
+#else
+
+#define REG_ISI_CFG1            (*(__IO uint32_t*)0x4004C000U) /**< (ISI) ISI Configuration 1 Register */
+#define REG_ISI_CFG2            (*(__IO uint32_t*)0x4004C004U) /**< (ISI) ISI Configuration 2 Register */
+#define REG_ISI_PSIZE           (*(__IO uint32_t*)0x4004C008U) /**< (ISI) ISI Preview Size Register */
+#define REG_ISI_PDECF           (*(__IO uint32_t*)0x4004C00CU) /**< (ISI) ISI Preview Decimation Factor Register */
+#define REG_ISI_Y2R_SET0        (*(__IO uint32_t*)0x4004C010U) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+#define REG_ISI_Y2R_SET1        (*(__IO uint32_t*)0x4004C014U) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+#define REG_ISI_R2Y_SET0        (*(__IO uint32_t*)0x4004C018U) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+#define REG_ISI_R2Y_SET1        (*(__IO uint32_t*)0x4004C01CU) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+#define REG_ISI_R2Y_SET2        (*(__IO uint32_t*)0x4004C020U) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+#define REG_ISI_CR              (*(__O  uint32_t*)0x4004C024U) /**< (ISI) ISI Control Register */
+#define REG_ISI_SR              (*(__I  uint32_t*)0x4004C028U) /**< (ISI) ISI Status Register */
+#define REG_ISI_IER             (*(__O  uint32_t*)0x4004C02CU) /**< (ISI) ISI Interrupt Enable Register */
+#define REG_ISI_IDR             (*(__O  uint32_t*)0x4004C030U) /**< (ISI) ISI Interrupt Disable Register */
+#define REG_ISI_IMR             (*(__I  uint32_t*)0x4004C034U) /**< (ISI) ISI Interrupt Mask Register */
+#define REG_ISI_DMA_CHER        (*(__O  uint32_t*)0x4004C038U) /**< (ISI) DMA Channel Enable Register */
+#define REG_ISI_DMA_CHDR        (*(__O  uint32_t*)0x4004C03CU) /**< (ISI) DMA Channel Disable Register */
+#define REG_ISI_DMA_CHSR        (*(__I  uint32_t*)0x4004C040U) /**< (ISI) DMA Channel Status Register */
+#define REG_ISI_DMA_P_ADDR      (*(__IO uint32_t*)0x4004C044U) /**< (ISI) DMA Preview Base Address Register */
+#define REG_ISI_DMA_P_CTRL      (*(__IO uint32_t*)0x4004C048U) /**< (ISI) DMA Preview Control Register */
+#define REG_ISI_DMA_P_DSCR      (*(__IO uint32_t*)0x4004C04CU) /**< (ISI) DMA Preview Descriptor Address Register */
+#define REG_ISI_DMA_C_ADDR      (*(__IO uint32_t*)0x4004C050U) /**< (ISI) DMA Codec Base Address Register */
+#define REG_ISI_DMA_C_CTRL      (*(__IO uint32_t*)0x4004C054U) /**< (ISI) DMA Codec Control Register */
+#define REG_ISI_DMA_C_DSCR      (*(__IO uint32_t*)0x4004C058U) /**< (ISI) DMA Codec Descriptor Address Register */
+#define REG_ISI_WPMR            (*(__IO uint32_t*)0x4004C0E4U) /**< (ISI) Write Protection Mode Register */
+#define REG_ISI_WPSR            (*(__I  uint32_t*)0x4004C0E8U) /**< (ISI) Write Protection Status Register */
+#define REG_ISI_VERSION         (*(__I  uint32_t*)0x4004C0FCU) /**< (ISI) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ISI peripheral ========== */
+#define ISI_INSTANCE_ID                          59         
+
+#endif /* _SAMV71_ISI_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/matrix.h
+++ b/asf/sam/include/samv71/instance/matrix.h
@@ -1,0 +1,138 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MATRIX
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MATRIX_INSTANCE_H_
+#define _SAMV71_MATRIX_INSTANCE_H_
+
+/* ========== Register definition for MATRIX peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MATRIX_PRAS0        (0x40088080) /**< (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0        (0x40088084) /**< (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1        (0x40088088) /**< (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1        (0x4008808C) /**< (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2        (0x40088090) /**< (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2        (0x40088094) /**< (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3        (0x40088098) /**< (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3        (0x4008809C) /**< (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4        (0x400880A0) /**< (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4        (0x400880A4) /**< (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5        (0x400880A8) /**< (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5        (0x400880AC) /**< (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6        (0x400880B0) /**< (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6        (0x400880B4) /**< (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7        (0x400880B8) /**< (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7        (0x400880BC) /**< (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8        (0x400880C0) /**< (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8        (0x400880C4) /**< (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_MCFG         (0x40088000) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG0        (0x40088000) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG1        (0x40088004) /**< (MATRIX) Master Configuration Register 1 */
+#define REG_MATRIX_MCFG2        (0x40088008) /**< (MATRIX) Master Configuration Register 2 */
+#define REG_MATRIX_MCFG3        (0x4008800C) /**< (MATRIX) Master Configuration Register 3 */
+#define REG_MATRIX_MCFG4        (0x40088010) /**< (MATRIX) Master Configuration Register 4 */
+#define REG_MATRIX_MCFG5        (0x40088014) /**< (MATRIX) Master Configuration Register 5 */
+#define REG_MATRIX_MCFG6        (0x40088018) /**< (MATRIX) Master Configuration Register 6 */
+#define REG_MATRIX_MCFG7        (0x4008801C) /**< (MATRIX) Master Configuration Register 7 */
+#define REG_MATRIX_MCFG8        (0x40088020) /**< (MATRIX) Master Configuration Register 8 */
+#define REG_MATRIX_MCFG9        (0x40088024) /**< (MATRIX) Master Configuration Register 9 */
+#define REG_MATRIX_MCFG10       (0x40088028) /**< (MATRIX) Master Configuration Register 10 */
+#define REG_MATRIX_MCFG11       (0x4008802C) /**< (MATRIX) Master Configuration Register 11 */
+#define REG_MATRIX_SCFG         (0x40088040) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG0        (0x40088040) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG1        (0x40088044) /**< (MATRIX) Slave Configuration Register 1 */
+#define REG_MATRIX_SCFG2        (0x40088048) /**< (MATRIX) Slave Configuration Register 2 */
+#define REG_MATRIX_SCFG3        (0x4008804C) /**< (MATRIX) Slave Configuration Register 3 */
+#define REG_MATRIX_SCFG4        (0x40088050) /**< (MATRIX) Slave Configuration Register 4 */
+#define REG_MATRIX_SCFG5        (0x40088054) /**< (MATRIX) Slave Configuration Register 5 */
+#define REG_MATRIX_SCFG6        (0x40088058) /**< (MATRIX) Slave Configuration Register 6 */
+#define REG_MATRIX_SCFG7        (0x4008805C) /**< (MATRIX) Slave Configuration Register 7 */
+#define REG_MATRIX_SCFG8        (0x40088060) /**< (MATRIX) Slave Configuration Register 8 */
+#define REG_MATRIX_MRCR         (0x40088100) /**< (MATRIX) Master Remap Control Register */
+#define REG_CCFG_CAN0           (0x40088110) /**< (MATRIX) CAN0 Configuration Register */
+#define REG_CCFG_SYSIO          (0x40088114) /**< (MATRIX) System I/O and CAN1 Configuration Register */
+#define REG_CCFG_SMCNFCS        (0x40088124) /**< (MATRIX) SMC NAND Flash Chip Select Configuration Register */
+#define REG_MATRIX_WPMR         (0x400881E4) /**< (MATRIX) Write Protection Mode Register */
+#define REG_MATRIX_WPSR         (0x400881E8) /**< (MATRIX) Write Protection Status Register */
+#define REG_MATRIX_VERSION      (0x400881FC) /**< (MATRIX) Version Register */
+
+#else
+
+#define REG_MATRIX_PRAS0        (*(__IO uint32_t*)0x40088080U) /**< (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0        (*(__IO uint32_t*)0x40088084U) /**< (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1        (*(__IO uint32_t*)0x40088088U) /**< (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1        (*(__IO uint32_t*)0x4008808CU) /**< (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2        (*(__IO uint32_t*)0x40088090U) /**< (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2        (*(__IO uint32_t*)0x40088094U) /**< (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3        (*(__IO uint32_t*)0x40088098U) /**< (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3        (*(__IO uint32_t*)0x4008809CU) /**< (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4        (*(__IO uint32_t*)0x400880A0U) /**< (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4        (*(__IO uint32_t*)0x400880A4U) /**< (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5        (*(__IO uint32_t*)0x400880A8U) /**< (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5        (*(__IO uint32_t*)0x400880ACU) /**< (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6        (*(__IO uint32_t*)0x400880B0U) /**< (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6        (*(__IO uint32_t*)0x400880B4U) /**< (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7        (*(__IO uint32_t*)0x400880B8U) /**< (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7        (*(__IO uint32_t*)0x400880BCU) /**< (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8        (*(__IO uint32_t*)0x400880C0U) /**< (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8        (*(__IO uint32_t*)0x400880C4U) /**< (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_MCFG         (*(__IO uint32_t*)0x40088000U) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG0        (*(__IO uint32_t*)0x40088000U) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG1        (*(__IO uint32_t*)0x40088004U) /**< (MATRIX) Master Configuration Register 1 */
+#define REG_MATRIX_MCFG2        (*(__IO uint32_t*)0x40088008U) /**< (MATRIX) Master Configuration Register 2 */
+#define REG_MATRIX_MCFG3        (*(__IO uint32_t*)0x4008800CU) /**< (MATRIX) Master Configuration Register 3 */
+#define REG_MATRIX_MCFG4        (*(__IO uint32_t*)0x40088010U) /**< (MATRIX) Master Configuration Register 4 */
+#define REG_MATRIX_MCFG5        (*(__IO uint32_t*)0x40088014U) /**< (MATRIX) Master Configuration Register 5 */
+#define REG_MATRIX_MCFG6        (*(__IO uint32_t*)0x40088018U) /**< (MATRIX) Master Configuration Register 6 */
+#define REG_MATRIX_MCFG7        (*(__IO uint32_t*)0x4008801CU) /**< (MATRIX) Master Configuration Register 7 */
+#define REG_MATRIX_MCFG8        (*(__IO uint32_t*)0x40088020U) /**< (MATRIX) Master Configuration Register 8 */
+#define REG_MATRIX_MCFG9        (*(__IO uint32_t*)0x40088024U) /**< (MATRIX) Master Configuration Register 9 */
+#define REG_MATRIX_MCFG10       (*(__IO uint32_t*)0x40088028U) /**< (MATRIX) Master Configuration Register 10 */
+#define REG_MATRIX_MCFG11       (*(__IO uint32_t*)0x4008802CU) /**< (MATRIX) Master Configuration Register 11 */
+#define REG_MATRIX_SCFG         (*(__IO uint32_t*)0x40088040U) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG0        (*(__IO uint32_t*)0x40088040U) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG1        (*(__IO uint32_t*)0x40088044U) /**< (MATRIX) Slave Configuration Register 1 */
+#define REG_MATRIX_SCFG2        (*(__IO uint32_t*)0x40088048U) /**< (MATRIX) Slave Configuration Register 2 */
+#define REG_MATRIX_SCFG3        (*(__IO uint32_t*)0x4008804CU) /**< (MATRIX) Slave Configuration Register 3 */
+#define REG_MATRIX_SCFG4        (*(__IO uint32_t*)0x40088050U) /**< (MATRIX) Slave Configuration Register 4 */
+#define REG_MATRIX_SCFG5        (*(__IO uint32_t*)0x40088054U) /**< (MATRIX) Slave Configuration Register 5 */
+#define REG_MATRIX_SCFG6        (*(__IO uint32_t*)0x40088058U) /**< (MATRIX) Slave Configuration Register 6 */
+#define REG_MATRIX_SCFG7        (*(__IO uint32_t*)0x4008805CU) /**< (MATRIX) Slave Configuration Register 7 */
+#define REG_MATRIX_SCFG8        (*(__IO uint32_t*)0x40088060U) /**< (MATRIX) Slave Configuration Register 8 */
+#define REG_MATRIX_MRCR         (*(__IO uint32_t*)0x40088100U) /**< (MATRIX) Master Remap Control Register */
+#define REG_CCFG_CAN0           (*(__IO uint32_t*)0x40088110U) /**< (MATRIX) CAN0 Configuration Register */
+#define REG_CCFG_SYSIO          (*(__IO uint32_t*)0x40088114U) /**< (MATRIX) System I/O and CAN1 Configuration Register */
+#define REG_CCFG_SMCNFCS        (*(__IO uint32_t*)0x40088124U) /**< (MATRIX) SMC NAND Flash Chip Select Configuration Register */
+#define REG_MATRIX_WPMR         (*(__IO uint32_t*)0x400881E4U) /**< (MATRIX) Write Protection Mode Register */
+#define REG_MATRIX_WPSR         (*(__I  uint32_t*)0x400881E8U) /**< (MATRIX) Write Protection Status Register */
+#define REG_MATRIX_VERSION      (*(__I  uint32_t*)0x400881FCU) /**< (MATRIX) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_MATRIX_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/mcan0.h
+++ b/asf/sam/include/samv71/instance/mcan0.h
@@ -1,0 +1,138 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCAN0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MCAN0_INSTANCE_H_
+#define _SAMV71_MCAN0_INSTANCE_H_
+
+/* ========== Register definition for MCAN0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCAN0_CREL          (0x40030000) /**< (MCAN0) Core Release Register */
+#define REG_MCAN0_ENDN          (0x40030004) /**< (MCAN0) Endian Register */
+#define REG_MCAN0_CUST          (0x40030008) /**< (MCAN0) Customer Register */
+#define REG_MCAN0_FBTP          (0x4003000C) /**< (MCAN0) Fast Bit Timing and Prescaler Register */
+#define REG_MCAN0_TEST          (0x40030010) /**< (MCAN0) Test Register */
+#define REG_MCAN0_RWD           (0x40030014) /**< (MCAN0) RAM Watchdog Register */
+#define REG_MCAN0_CCCR          (0x40030018) /**< (MCAN0) CC Control Register */
+#define REG_MCAN0_BTP           (0x4003001C) /**< (MCAN0) Bit Timing and Prescaler Register */
+#define REG_MCAN0_TSCC          (0x40030020) /**< (MCAN0) Timestamp Counter Configuration Register */
+#define REG_MCAN0_TSCV          (0x40030024) /**< (MCAN0) Timestamp Counter Value Register */
+#define REG_MCAN0_TOCC          (0x40030028) /**< (MCAN0) Timeout Counter Configuration Register */
+#define REG_MCAN0_TOCV          (0x4003002C) /**< (MCAN0) Timeout Counter Value Register */
+#define REG_MCAN0_ECR           (0x40030040) /**< (MCAN0) Error Counter Register */
+#define REG_MCAN0_PSR           (0x40030044) /**< (MCAN0) Protocol Status Register */
+#define REG_MCAN0_IR            (0x40030050) /**< (MCAN0) Interrupt Register */
+#define REG_MCAN0_IE            (0x40030054) /**< (MCAN0) Interrupt Enable Register */
+#define REG_MCAN0_ILS           (0x40030058) /**< (MCAN0) Interrupt Line Select Register */
+#define REG_MCAN0_ILE           (0x4003005C) /**< (MCAN0) Interrupt Line Enable Register */
+#define REG_MCAN0_GFC           (0x40030080) /**< (MCAN0) Global Filter Configuration Register */
+#define REG_MCAN0_SIDFC         (0x40030084) /**< (MCAN0) Standard ID Filter Configuration Register */
+#define REG_MCAN0_XIDFC         (0x40030088) /**< (MCAN0) Extended ID Filter Configuration Register */
+#define REG_MCAN0_XIDAM         (0x40030090) /**< (MCAN0) Extended ID AND Mask Register */
+#define REG_MCAN0_HPMS          (0x40030094) /**< (MCAN0) High Priority Message Status Register */
+#define REG_MCAN0_NDAT1         (0x40030098) /**< (MCAN0) New Data 1 Register */
+#define REG_MCAN0_NDAT2         (0x4003009C) /**< (MCAN0) New Data 2 Register */
+#define REG_MCAN0_RXF0C         (0x400300A0) /**< (MCAN0) Receive FIFO 0 Configuration Register */
+#define REG_MCAN0_RXF0S         (0x400300A4) /**< (MCAN0) Receive FIFO 0 Status Register */
+#define REG_MCAN0_RXF0A         (0x400300A8) /**< (MCAN0) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN0_RXBC          (0x400300AC) /**< (MCAN0) Receive Rx Buffer Configuration Register */
+#define REG_MCAN0_RXF1C         (0x400300B0) /**< (MCAN0) Receive FIFO 1 Configuration Register */
+#define REG_MCAN0_RXF1S         (0x400300B4) /**< (MCAN0) Receive FIFO 1 Status Register */
+#define REG_MCAN0_RXF1A         (0x400300B8) /**< (MCAN0) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN0_RXESC         (0x400300BC) /**< (MCAN0) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN0_TXBC          (0x400300C0) /**< (MCAN0) Transmit Buffer Configuration Register */
+#define REG_MCAN0_TXFQS         (0x400300C4) /**< (MCAN0) Transmit FIFO/Queue Status Register */
+#define REG_MCAN0_TXESC         (0x400300C8) /**< (MCAN0) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN0_TXBRP         (0x400300CC) /**< (MCAN0) Transmit Buffer Request Pending Register */
+#define REG_MCAN0_TXBAR         (0x400300D0) /**< (MCAN0) Transmit Buffer Add Request Register */
+#define REG_MCAN0_TXBCR         (0x400300D4) /**< (MCAN0) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN0_TXBTO         (0x400300D8) /**< (MCAN0) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN0_TXBCF         (0x400300DC) /**< (MCAN0) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN0_TXBTIE        (0x400300E0) /**< (MCAN0) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN0_TXBCIE        (0x400300E4) /**< (MCAN0) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN0_TXEFC         (0x400300F0) /**< (MCAN0) Transmit Event FIFO Configuration Register */
+#define REG_MCAN0_TXEFS         (0x400300F4) /**< (MCAN0) Transmit Event FIFO Status Register */
+#define REG_MCAN0_TXEFA         (0x400300F8) /**< (MCAN0) Transmit Event FIFO Acknowledge Register */
+
+#else
+
+#define REG_MCAN0_CREL          (*(__I  uint32_t*)0x40030000U) /**< (MCAN0) Core Release Register */
+#define REG_MCAN0_ENDN          (*(__I  uint32_t*)0x40030004U) /**< (MCAN0) Endian Register */
+#define REG_MCAN0_CUST          (*(__IO uint32_t*)0x40030008U) /**< (MCAN0) Customer Register */
+#define REG_MCAN0_FBTP          (*(__IO uint32_t*)0x4003000CU) /**< (MCAN0) Fast Bit Timing and Prescaler Register */
+#define REG_MCAN0_TEST          (*(__IO uint32_t*)0x40030010U) /**< (MCAN0) Test Register */
+#define REG_MCAN0_RWD           (*(__IO uint32_t*)0x40030014U) /**< (MCAN0) RAM Watchdog Register */
+#define REG_MCAN0_CCCR          (*(__IO uint32_t*)0x40030018U) /**< (MCAN0) CC Control Register */
+#define REG_MCAN0_BTP           (*(__IO uint32_t*)0x4003001CU) /**< (MCAN0) Bit Timing and Prescaler Register */
+#define REG_MCAN0_TSCC          (*(__IO uint32_t*)0x40030020U) /**< (MCAN0) Timestamp Counter Configuration Register */
+#define REG_MCAN0_TSCV          (*(__IO uint32_t*)0x40030024U) /**< (MCAN0) Timestamp Counter Value Register */
+#define REG_MCAN0_TOCC          (*(__IO uint32_t*)0x40030028U) /**< (MCAN0) Timeout Counter Configuration Register */
+#define REG_MCAN0_TOCV          (*(__IO uint32_t*)0x4003002CU) /**< (MCAN0) Timeout Counter Value Register */
+#define REG_MCAN0_ECR           (*(__I  uint32_t*)0x40030040U) /**< (MCAN0) Error Counter Register */
+#define REG_MCAN0_PSR           (*(__I  uint32_t*)0x40030044U) /**< (MCAN0) Protocol Status Register */
+#define REG_MCAN0_IR            (*(__IO uint32_t*)0x40030050U) /**< (MCAN0) Interrupt Register */
+#define REG_MCAN0_IE            (*(__IO uint32_t*)0x40030054U) /**< (MCAN0) Interrupt Enable Register */
+#define REG_MCAN0_ILS           (*(__IO uint32_t*)0x40030058U) /**< (MCAN0) Interrupt Line Select Register */
+#define REG_MCAN0_ILE           (*(__IO uint32_t*)0x4003005CU) /**< (MCAN0) Interrupt Line Enable Register */
+#define REG_MCAN0_GFC           (*(__IO uint32_t*)0x40030080U) /**< (MCAN0) Global Filter Configuration Register */
+#define REG_MCAN0_SIDFC         (*(__IO uint32_t*)0x40030084U) /**< (MCAN0) Standard ID Filter Configuration Register */
+#define REG_MCAN0_XIDFC         (*(__IO uint32_t*)0x40030088U) /**< (MCAN0) Extended ID Filter Configuration Register */
+#define REG_MCAN0_XIDAM         (*(__IO uint32_t*)0x40030090U) /**< (MCAN0) Extended ID AND Mask Register */
+#define REG_MCAN0_HPMS          (*(__I  uint32_t*)0x40030094U) /**< (MCAN0) High Priority Message Status Register */
+#define REG_MCAN0_NDAT1         (*(__IO uint32_t*)0x40030098U) /**< (MCAN0) New Data 1 Register */
+#define REG_MCAN0_NDAT2         (*(__IO uint32_t*)0x4003009CU) /**< (MCAN0) New Data 2 Register */
+#define REG_MCAN0_RXF0C         (*(__IO uint32_t*)0x400300A0U) /**< (MCAN0) Receive FIFO 0 Configuration Register */
+#define REG_MCAN0_RXF0S         (*(__I  uint32_t*)0x400300A4U) /**< (MCAN0) Receive FIFO 0 Status Register */
+#define REG_MCAN0_RXF0A         (*(__IO uint32_t*)0x400300A8U) /**< (MCAN0) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN0_RXBC          (*(__IO uint32_t*)0x400300ACU) /**< (MCAN0) Receive Rx Buffer Configuration Register */
+#define REG_MCAN0_RXF1C         (*(__IO uint32_t*)0x400300B0U) /**< (MCAN0) Receive FIFO 1 Configuration Register */
+#define REG_MCAN0_RXF1S         (*(__I  uint32_t*)0x400300B4U) /**< (MCAN0) Receive FIFO 1 Status Register */
+#define REG_MCAN0_RXF1A         (*(__IO uint32_t*)0x400300B8U) /**< (MCAN0) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN0_RXESC         (*(__IO uint32_t*)0x400300BCU) /**< (MCAN0) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN0_TXBC          (*(__IO uint32_t*)0x400300C0U) /**< (MCAN0) Transmit Buffer Configuration Register */
+#define REG_MCAN0_TXFQS         (*(__I  uint32_t*)0x400300C4U) /**< (MCAN0) Transmit FIFO/Queue Status Register */
+#define REG_MCAN0_TXESC         (*(__IO uint32_t*)0x400300C8U) /**< (MCAN0) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN0_TXBRP         (*(__I  uint32_t*)0x400300CCU) /**< (MCAN0) Transmit Buffer Request Pending Register */
+#define REG_MCAN0_TXBAR         (*(__IO uint32_t*)0x400300D0U) /**< (MCAN0) Transmit Buffer Add Request Register */
+#define REG_MCAN0_TXBCR         (*(__IO uint32_t*)0x400300D4U) /**< (MCAN0) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN0_TXBTO         (*(__I  uint32_t*)0x400300D8U) /**< (MCAN0) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN0_TXBCF         (*(__I  uint32_t*)0x400300DCU) /**< (MCAN0) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN0_TXBTIE        (*(__IO uint32_t*)0x400300E0U) /**< (MCAN0) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN0_TXBCIE        (*(__IO uint32_t*)0x400300E4U) /**< (MCAN0) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN0_TXEFC         (*(__IO uint32_t*)0x400300F0U) /**< (MCAN0) Transmit Event FIFO Configuration Register */
+#define REG_MCAN0_TXEFS         (*(__I  uint32_t*)0x400300F4U) /**< (MCAN0) Transmit Event FIFO Status Register */
+#define REG_MCAN0_TXEFA         (*(__IO uint32_t*)0x400300F8U) /**< (MCAN0) Transmit Event FIFO Acknowledge Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCAN0 peripheral ========== */
+#define MCAN0_INSTANCE_ID                        35         
+
+#endif /* _SAMV71_MCAN0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/mcan1.h
+++ b/asf/sam/include/samv71/instance/mcan1.h
@@ -1,0 +1,138 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCAN1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MCAN1_INSTANCE_H_
+#define _SAMV71_MCAN1_INSTANCE_H_
+
+/* ========== Register definition for MCAN1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCAN1_CREL          (0x40034000) /**< (MCAN1) Core Release Register */
+#define REG_MCAN1_ENDN          (0x40034004) /**< (MCAN1) Endian Register */
+#define REG_MCAN1_CUST          (0x40034008) /**< (MCAN1) Customer Register */
+#define REG_MCAN1_FBTP          (0x4003400C) /**< (MCAN1) Fast Bit Timing and Prescaler Register */
+#define REG_MCAN1_TEST          (0x40034010) /**< (MCAN1) Test Register */
+#define REG_MCAN1_RWD           (0x40034014) /**< (MCAN1) RAM Watchdog Register */
+#define REG_MCAN1_CCCR          (0x40034018) /**< (MCAN1) CC Control Register */
+#define REG_MCAN1_BTP           (0x4003401C) /**< (MCAN1) Bit Timing and Prescaler Register */
+#define REG_MCAN1_TSCC          (0x40034020) /**< (MCAN1) Timestamp Counter Configuration Register */
+#define REG_MCAN1_TSCV          (0x40034024) /**< (MCAN1) Timestamp Counter Value Register */
+#define REG_MCAN1_TOCC          (0x40034028) /**< (MCAN1) Timeout Counter Configuration Register */
+#define REG_MCAN1_TOCV          (0x4003402C) /**< (MCAN1) Timeout Counter Value Register */
+#define REG_MCAN1_ECR           (0x40034040) /**< (MCAN1) Error Counter Register */
+#define REG_MCAN1_PSR           (0x40034044) /**< (MCAN1) Protocol Status Register */
+#define REG_MCAN1_IR            (0x40034050) /**< (MCAN1) Interrupt Register */
+#define REG_MCAN1_IE            (0x40034054) /**< (MCAN1) Interrupt Enable Register */
+#define REG_MCAN1_ILS           (0x40034058) /**< (MCAN1) Interrupt Line Select Register */
+#define REG_MCAN1_ILE           (0x4003405C) /**< (MCAN1) Interrupt Line Enable Register */
+#define REG_MCAN1_GFC           (0x40034080) /**< (MCAN1) Global Filter Configuration Register */
+#define REG_MCAN1_SIDFC         (0x40034084) /**< (MCAN1) Standard ID Filter Configuration Register */
+#define REG_MCAN1_XIDFC         (0x40034088) /**< (MCAN1) Extended ID Filter Configuration Register */
+#define REG_MCAN1_XIDAM         (0x40034090) /**< (MCAN1) Extended ID AND Mask Register */
+#define REG_MCAN1_HPMS          (0x40034094) /**< (MCAN1) High Priority Message Status Register */
+#define REG_MCAN1_NDAT1         (0x40034098) /**< (MCAN1) New Data 1 Register */
+#define REG_MCAN1_NDAT2         (0x4003409C) /**< (MCAN1) New Data 2 Register */
+#define REG_MCAN1_RXF0C         (0x400340A0) /**< (MCAN1) Receive FIFO 0 Configuration Register */
+#define REG_MCAN1_RXF0S         (0x400340A4) /**< (MCAN1) Receive FIFO 0 Status Register */
+#define REG_MCAN1_RXF0A         (0x400340A8) /**< (MCAN1) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN1_RXBC          (0x400340AC) /**< (MCAN1) Receive Rx Buffer Configuration Register */
+#define REG_MCAN1_RXF1C         (0x400340B0) /**< (MCAN1) Receive FIFO 1 Configuration Register */
+#define REG_MCAN1_RXF1S         (0x400340B4) /**< (MCAN1) Receive FIFO 1 Status Register */
+#define REG_MCAN1_RXF1A         (0x400340B8) /**< (MCAN1) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN1_RXESC         (0x400340BC) /**< (MCAN1) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN1_TXBC          (0x400340C0) /**< (MCAN1) Transmit Buffer Configuration Register */
+#define REG_MCAN1_TXFQS         (0x400340C4) /**< (MCAN1) Transmit FIFO/Queue Status Register */
+#define REG_MCAN1_TXESC         (0x400340C8) /**< (MCAN1) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN1_TXBRP         (0x400340CC) /**< (MCAN1) Transmit Buffer Request Pending Register */
+#define REG_MCAN1_TXBAR         (0x400340D0) /**< (MCAN1) Transmit Buffer Add Request Register */
+#define REG_MCAN1_TXBCR         (0x400340D4) /**< (MCAN1) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN1_TXBTO         (0x400340D8) /**< (MCAN1) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN1_TXBCF         (0x400340DC) /**< (MCAN1) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN1_TXBTIE        (0x400340E0) /**< (MCAN1) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN1_TXBCIE        (0x400340E4) /**< (MCAN1) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN1_TXEFC         (0x400340F0) /**< (MCAN1) Transmit Event FIFO Configuration Register */
+#define REG_MCAN1_TXEFS         (0x400340F4) /**< (MCAN1) Transmit Event FIFO Status Register */
+#define REG_MCAN1_TXEFA         (0x400340F8) /**< (MCAN1) Transmit Event FIFO Acknowledge Register */
+
+#else
+
+#define REG_MCAN1_CREL          (*(__I  uint32_t*)0x40034000U) /**< (MCAN1) Core Release Register */
+#define REG_MCAN1_ENDN          (*(__I  uint32_t*)0x40034004U) /**< (MCAN1) Endian Register */
+#define REG_MCAN1_CUST          (*(__IO uint32_t*)0x40034008U) /**< (MCAN1) Customer Register */
+#define REG_MCAN1_FBTP          (*(__IO uint32_t*)0x4003400CU) /**< (MCAN1) Fast Bit Timing and Prescaler Register */
+#define REG_MCAN1_TEST          (*(__IO uint32_t*)0x40034010U) /**< (MCAN1) Test Register */
+#define REG_MCAN1_RWD           (*(__IO uint32_t*)0x40034014U) /**< (MCAN1) RAM Watchdog Register */
+#define REG_MCAN1_CCCR          (*(__IO uint32_t*)0x40034018U) /**< (MCAN1) CC Control Register */
+#define REG_MCAN1_BTP           (*(__IO uint32_t*)0x4003401CU) /**< (MCAN1) Bit Timing and Prescaler Register */
+#define REG_MCAN1_TSCC          (*(__IO uint32_t*)0x40034020U) /**< (MCAN1) Timestamp Counter Configuration Register */
+#define REG_MCAN1_TSCV          (*(__IO uint32_t*)0x40034024U) /**< (MCAN1) Timestamp Counter Value Register */
+#define REG_MCAN1_TOCC          (*(__IO uint32_t*)0x40034028U) /**< (MCAN1) Timeout Counter Configuration Register */
+#define REG_MCAN1_TOCV          (*(__IO uint32_t*)0x4003402CU) /**< (MCAN1) Timeout Counter Value Register */
+#define REG_MCAN1_ECR           (*(__I  uint32_t*)0x40034040U) /**< (MCAN1) Error Counter Register */
+#define REG_MCAN1_PSR           (*(__I  uint32_t*)0x40034044U) /**< (MCAN1) Protocol Status Register */
+#define REG_MCAN1_IR            (*(__IO uint32_t*)0x40034050U) /**< (MCAN1) Interrupt Register */
+#define REG_MCAN1_IE            (*(__IO uint32_t*)0x40034054U) /**< (MCAN1) Interrupt Enable Register */
+#define REG_MCAN1_ILS           (*(__IO uint32_t*)0x40034058U) /**< (MCAN1) Interrupt Line Select Register */
+#define REG_MCAN1_ILE           (*(__IO uint32_t*)0x4003405CU) /**< (MCAN1) Interrupt Line Enable Register */
+#define REG_MCAN1_GFC           (*(__IO uint32_t*)0x40034080U) /**< (MCAN1) Global Filter Configuration Register */
+#define REG_MCAN1_SIDFC         (*(__IO uint32_t*)0x40034084U) /**< (MCAN1) Standard ID Filter Configuration Register */
+#define REG_MCAN1_XIDFC         (*(__IO uint32_t*)0x40034088U) /**< (MCAN1) Extended ID Filter Configuration Register */
+#define REG_MCAN1_XIDAM         (*(__IO uint32_t*)0x40034090U) /**< (MCAN1) Extended ID AND Mask Register */
+#define REG_MCAN1_HPMS          (*(__I  uint32_t*)0x40034094U) /**< (MCAN1) High Priority Message Status Register */
+#define REG_MCAN1_NDAT1         (*(__IO uint32_t*)0x40034098U) /**< (MCAN1) New Data 1 Register */
+#define REG_MCAN1_NDAT2         (*(__IO uint32_t*)0x4003409CU) /**< (MCAN1) New Data 2 Register */
+#define REG_MCAN1_RXF0C         (*(__IO uint32_t*)0x400340A0U) /**< (MCAN1) Receive FIFO 0 Configuration Register */
+#define REG_MCAN1_RXF0S         (*(__I  uint32_t*)0x400340A4U) /**< (MCAN1) Receive FIFO 0 Status Register */
+#define REG_MCAN1_RXF0A         (*(__IO uint32_t*)0x400340A8U) /**< (MCAN1) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN1_RXBC          (*(__IO uint32_t*)0x400340ACU) /**< (MCAN1) Receive Rx Buffer Configuration Register */
+#define REG_MCAN1_RXF1C         (*(__IO uint32_t*)0x400340B0U) /**< (MCAN1) Receive FIFO 1 Configuration Register */
+#define REG_MCAN1_RXF1S         (*(__I  uint32_t*)0x400340B4U) /**< (MCAN1) Receive FIFO 1 Status Register */
+#define REG_MCAN1_RXF1A         (*(__IO uint32_t*)0x400340B8U) /**< (MCAN1) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN1_RXESC         (*(__IO uint32_t*)0x400340BCU) /**< (MCAN1) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN1_TXBC          (*(__IO uint32_t*)0x400340C0U) /**< (MCAN1) Transmit Buffer Configuration Register */
+#define REG_MCAN1_TXFQS         (*(__I  uint32_t*)0x400340C4U) /**< (MCAN1) Transmit FIFO/Queue Status Register */
+#define REG_MCAN1_TXESC         (*(__IO uint32_t*)0x400340C8U) /**< (MCAN1) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN1_TXBRP         (*(__I  uint32_t*)0x400340CCU) /**< (MCAN1) Transmit Buffer Request Pending Register */
+#define REG_MCAN1_TXBAR         (*(__IO uint32_t*)0x400340D0U) /**< (MCAN1) Transmit Buffer Add Request Register */
+#define REG_MCAN1_TXBCR         (*(__IO uint32_t*)0x400340D4U) /**< (MCAN1) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN1_TXBTO         (*(__I  uint32_t*)0x400340D8U) /**< (MCAN1) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN1_TXBCF         (*(__I  uint32_t*)0x400340DCU) /**< (MCAN1) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN1_TXBTIE        (*(__IO uint32_t*)0x400340E0U) /**< (MCAN1) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN1_TXBCIE        (*(__IO uint32_t*)0x400340E4U) /**< (MCAN1) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN1_TXEFC         (*(__IO uint32_t*)0x400340F0U) /**< (MCAN1) Transmit Event FIFO Configuration Register */
+#define REG_MCAN1_TXEFS         (*(__I  uint32_t*)0x400340F4U) /**< (MCAN1) Transmit Event FIFO Status Register */
+#define REG_MCAN1_TXEFA         (*(__IO uint32_t*)0x400340F8U) /**< (MCAN1) Transmit Event FIFO Acknowledge Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCAN1 peripheral ========== */
+#define MCAN1_INSTANCE_ID                        37         
+
+#endif /* _SAMV71_MCAN1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/mlb.h
+++ b/asf/sam/include/samv71/instance/mlb.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MLB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_MLB_INSTANCE_H_
+#define _SAMV71_MLB_INSTANCE_H_
+
+/* ========== Register definition for MLB peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MLB_MLBC0           (0x40068000) /**< (MLB) MediaLB Control 0 Register */
+#define REG_MLB_MS0             (0x4006800C) /**< (MLB) MediaLB Channel Status 0 Register */
+#define REG_MLB_MS1             (0x40068014) /**< (MLB) MediaLB Channel Status1 Register */
+#define REG_MLB_MSS             (0x40068020) /**< (MLB) MediaLB System Status Register */
+#define REG_MLB_MSD             (0x40068024) /**< (MLB) MediaLB System Data Register */
+#define REG_MLB_MIEN            (0x4006802C) /**< (MLB) MediaLB Interrupt Enable Register */
+#define REG_MLB_MLBC1           (0x4006803C) /**< (MLB) MediaLB Control 1 Register */
+#define REG_MLB_HCTL            (0x40068080) /**< (MLB) HBI Control Register */
+#define REG_MLB_HCMR            (0x40068088) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR0           (0x40068088) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR1           (0x4006808C) /**< (MLB) HBI Channel Mask 0 Register 1 */
+#define REG_MLB_HCER            (0x40068090) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER0           (0x40068090) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER1           (0x40068094) /**< (MLB) HBI Channel Error 0 Register 1 */
+#define REG_MLB_HCBR            (0x40068098) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR0           (0x40068098) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR1           (0x4006809C) /**< (MLB) HBI Channel Busy 0 Register 1 */
+#define REG_MLB_MDAT            (0x400680C0) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT0           (0x400680C0) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT1           (0x400680C4) /**< (MLB) MIF Data 0 Register 1 */
+#define REG_MLB_MDAT2           (0x400680C8) /**< (MLB) MIF Data 0 Register 2 */
+#define REG_MLB_MDAT3           (0x400680CC) /**< (MLB) MIF Data 0 Register 3 */
+#define REG_MLB_MDWE            (0x400680D0) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE0           (0x400680D0) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE1           (0x400680D4) /**< (MLB) MIF Data Write Enable 0 Register 1 */
+#define REG_MLB_MDWE2           (0x400680D8) /**< (MLB) MIF Data Write Enable 0 Register 2 */
+#define REG_MLB_MDWE3           (0x400680DC) /**< (MLB) MIF Data Write Enable 0 Register 3 */
+#define REG_MLB_MCTL            (0x400680E0) /**< (MLB) MIF Control Register */
+#define REG_MLB_MADR            (0x400680E4) /**< (MLB) MIF Address Register */
+#define REG_MLB_ACTL            (0x400683C0) /**< (MLB) AHB Control Register */
+#define REG_MLB_ACSR            (0x400683D0) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR0           (0x400683D0) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR1           (0x400683D4) /**< (MLB) AHB Channel Status 0 Register 1 */
+#define REG_MLB_ACMR            (0x400683D8) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR0           (0x400683D8) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR1           (0x400683DC) /**< (MLB) AHB Channel Mask 0 Register 1 */
+
+#else
+
+#define REG_MLB_MLBC0           (*(__IO uint32_t*)0x40068000U) /**< (MLB) MediaLB Control 0 Register */
+#define REG_MLB_MS0             (*(__IO uint32_t*)0x4006800CU) /**< (MLB) MediaLB Channel Status 0 Register */
+#define REG_MLB_MS1             (*(__IO uint32_t*)0x40068014U) /**< (MLB) MediaLB Channel Status1 Register */
+#define REG_MLB_MSS             (*(__IO uint32_t*)0x40068020U) /**< (MLB) MediaLB System Status Register */
+#define REG_MLB_MSD             (*(__I  uint32_t*)0x40068024U) /**< (MLB) MediaLB System Data Register */
+#define REG_MLB_MIEN            (*(__IO uint32_t*)0x4006802CU) /**< (MLB) MediaLB Interrupt Enable Register */
+#define REG_MLB_MLBC1           (*(__IO uint32_t*)0x4006803CU) /**< (MLB) MediaLB Control 1 Register */
+#define REG_MLB_HCTL            (*(__IO uint32_t*)0x40068080U) /**< (MLB) HBI Control Register */
+#define REG_MLB_HCMR            (*(__IO uint32_t*)0x40068088U) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR0           (*(__IO uint32_t*)0x40068088U) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR1           (*(__IO uint32_t*)0x4006808CU) /**< (MLB) HBI Channel Mask 0 Register 1 */
+#define REG_MLB_HCER            (*(__I  uint32_t*)0x40068090U) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER0           (*(__I  uint32_t*)0x40068090U) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER1           (*(__I  uint32_t*)0x40068094U) /**< (MLB) HBI Channel Error 0 Register 1 */
+#define REG_MLB_HCBR            (*(__I  uint32_t*)0x40068098U) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR0           (*(__I  uint32_t*)0x40068098U) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR1           (*(__I  uint32_t*)0x4006809CU) /**< (MLB) HBI Channel Busy 0 Register 1 */
+#define REG_MLB_MDAT            (*(__IO uint32_t*)0x400680C0U) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT0           (*(__IO uint32_t*)0x400680C0U) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT1           (*(__IO uint32_t*)0x400680C4U) /**< (MLB) MIF Data 0 Register 1 */
+#define REG_MLB_MDAT2           (*(__IO uint32_t*)0x400680C8U) /**< (MLB) MIF Data 0 Register 2 */
+#define REG_MLB_MDAT3           (*(__IO uint32_t*)0x400680CCU) /**< (MLB) MIF Data 0 Register 3 */
+#define REG_MLB_MDWE            (*(__IO uint32_t*)0x400680D0U) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE0           (*(__IO uint32_t*)0x400680D0U) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE1           (*(__IO uint32_t*)0x400680D4U) /**< (MLB) MIF Data Write Enable 0 Register 1 */
+#define REG_MLB_MDWE2           (*(__IO uint32_t*)0x400680D8U) /**< (MLB) MIF Data Write Enable 0 Register 2 */
+#define REG_MLB_MDWE3           (*(__IO uint32_t*)0x400680DCU) /**< (MLB) MIF Data Write Enable 0 Register 3 */
+#define REG_MLB_MCTL            (*(__IO uint32_t*)0x400680E0U) /**< (MLB) MIF Control Register */
+#define REG_MLB_MADR            (*(__IO uint32_t*)0x400680E4U) /**< (MLB) MIF Address Register */
+#define REG_MLB_ACTL            (*(__IO uint32_t*)0x400683C0U) /**< (MLB) AHB Control Register */
+#define REG_MLB_ACSR            (*(__IO uint32_t*)0x400683D0U) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR0           (*(__IO uint32_t*)0x400683D0U) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR1           (*(__IO uint32_t*)0x400683D4U) /**< (MLB) AHB Channel Status 0 Register 1 */
+#define REG_MLB_ACMR            (*(__IO uint32_t*)0x400683D8U) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR0           (*(__IO uint32_t*)0x400683D8U) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR1           (*(__IO uint32_t*)0x400683DCU) /**< (MLB) AHB Channel Mask 0 Register 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MLB peripheral ========== */
+#define MLB_INSTANCE_ID                          53         
+
+#endif /* _SAMV71_MLB_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pioa.h
+++ b/asf/sam/include/samv71/instance/pioa.h
@@ -1,0 +1,161 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOA
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIOA_INSTANCE_H_
+#define _SAMV71_PIOA_INSTANCE_H_
+
+/* ========== Register definition for PIOA peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOA_PER            (0x400E0E00) /**< (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR            (0x400E0E04) /**< (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR            (0x400E0E08) /**< (PIOA) PIO Status Register */
+#define REG_PIOA_OER            (0x400E0E10) /**< (PIOA) Output Enable Register */
+#define REG_PIOA_ODR            (0x400E0E14) /**< (PIOA) Output Disable Register */
+#define REG_PIOA_OSR            (0x400E0E18) /**< (PIOA) Output Status Register */
+#define REG_PIOA_IFER           (0x400E0E20) /**< (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR           (0x400E0E24) /**< (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR           (0x400E0E28) /**< (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR           (0x400E0E30) /**< (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR           (0x400E0E34) /**< (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR           (0x400E0E38) /**< (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR           (0x400E0E3C) /**< (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER            (0x400E0E40) /**< (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR            (0x400E0E44) /**< (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR            (0x400E0E48) /**< (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR            (0x400E0E4C) /**< (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER           (0x400E0E50) /**< (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR           (0x400E0E54) /**< (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR           (0x400E0E58) /**< (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR           (0x400E0E60) /**< (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER           (0x400E0E64) /**< (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR           (0x400E0E68) /**< (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR         (0x400E0E70) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR0        (0x400E0E70) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR1        (0x400E0E74) /**< (PIOA) Peripheral ABCD Select Register 1 */
+#define REG_PIOA_IFSCDR         (0x400E0E80) /**< (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER         (0x400E0E84) /**< (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR         (0x400E0E88) /**< (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR           (0x400E0E8C) /**< (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR          (0x400E0E90) /**< (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER          (0x400E0E94) /**< (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR          (0x400E0E98) /**< (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER           (0x400E0EA0) /**< (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR           (0x400E0EA4) /**< (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR           (0x400E0EA8) /**< (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER          (0x400E0EB0) /**< (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR          (0x400E0EB4) /**< (PIOA) Additional Interrupt Modes Disable Register */
+#define REG_PIOA_AIMMR          (0x400E0EB8) /**< (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR            (0x400E0EC0) /**< (PIOA) Edge Select Register */
+#define REG_PIOA_LSR            (0x400E0EC4) /**< (PIOA) Level Select Register */
+#define REG_PIOA_ELSR           (0x400E0EC8) /**< (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR         (0x400E0ED0) /**< (PIOA) Falling Edge/Low-Level Select Register */
+#define REG_PIOA_REHLSR         (0x400E0ED4) /**< (PIOA) Rising Edge/High-Level Select Register */
+#define REG_PIOA_FRLHSR         (0x400E0ED8) /**< (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR         (0x400E0EE0) /**< (PIOA) Lock Status */
+#define REG_PIOA_WPMR           (0x400E0EE4) /**< (PIOA) Write Protection Mode Register */
+#define REG_PIOA_WPSR           (0x400E0EE8) /**< (PIOA) Write Protection Status Register */
+#define REG_PIOA_VERSION        (0x400E0EFC) /**< (PIOA) Version Register */
+#define REG_PIOA_SCHMITT        (0x400E0F00) /**< (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DRIVER         (0x400E0F18) /**< (PIOA) I/O Drive Register */
+#define REG_PIOA_PCMR           (0x400E0F50) /**< (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER          (0x400E0F54) /**< (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR          (0x400E0F58) /**< (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR          (0x400E0F5C) /**< (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR          (0x400E0F60) /**< (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR          (0x400E0F64) /**< (PIOA) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOA_PER            (*(__O  uint32_t*)0x400E0E00U) /**< (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR            (*(__O  uint32_t*)0x400E0E04U) /**< (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR            (*(__I  uint32_t*)0x400E0E08U) /**< (PIOA) PIO Status Register */
+#define REG_PIOA_OER            (*(__O  uint32_t*)0x400E0E10U) /**< (PIOA) Output Enable Register */
+#define REG_PIOA_ODR            (*(__O  uint32_t*)0x400E0E14U) /**< (PIOA) Output Disable Register */
+#define REG_PIOA_OSR            (*(__I  uint32_t*)0x400E0E18U) /**< (PIOA) Output Status Register */
+#define REG_PIOA_IFER           (*(__O  uint32_t*)0x400E0E20U) /**< (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR           (*(__O  uint32_t*)0x400E0E24U) /**< (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR           (*(__I  uint32_t*)0x400E0E28U) /**< (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR           (*(__O  uint32_t*)0x400E0E30U) /**< (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR           (*(__O  uint32_t*)0x400E0E34U) /**< (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR           (*(__IO uint32_t*)0x400E0E38U) /**< (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR           (*(__I  uint32_t*)0x400E0E3CU) /**< (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER            (*(__O  uint32_t*)0x400E0E40U) /**< (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR            (*(__O  uint32_t*)0x400E0E44U) /**< (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR            (*(__I  uint32_t*)0x400E0E48U) /**< (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR            (*(__I  uint32_t*)0x400E0E4CU) /**< (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER           (*(__O  uint32_t*)0x400E0E50U) /**< (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR           (*(__O  uint32_t*)0x400E0E54U) /**< (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR           (*(__I  uint32_t*)0x400E0E58U) /**< (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR           (*(__O  uint32_t*)0x400E0E60U) /**< (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER           (*(__O  uint32_t*)0x400E0E64U) /**< (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR           (*(__I  uint32_t*)0x400E0E68U) /**< (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR         (*(__IO uint32_t*)0x400E0E70U) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR0        (*(__IO uint32_t*)0x400E0E70U) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR1        (*(__IO uint32_t*)0x400E0E74U) /**< (PIOA) Peripheral ABCD Select Register 1 */
+#define REG_PIOA_IFSCDR         (*(__O  uint32_t*)0x400E0E80U) /**< (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER         (*(__O  uint32_t*)0x400E0E84U) /**< (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR         (*(__I  uint32_t*)0x400E0E88U) /**< (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR           (*(__IO uint32_t*)0x400E0E8CU) /**< (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR          (*(__O  uint32_t*)0x400E0E90U) /**< (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER          (*(__O  uint32_t*)0x400E0E94U) /**< (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR          (*(__I  uint32_t*)0x400E0E98U) /**< (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER           (*(__O  uint32_t*)0x400E0EA0U) /**< (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR           (*(__O  uint32_t*)0x400E0EA4U) /**< (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR           (*(__I  uint32_t*)0x400E0EA8U) /**< (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER          (*(__O  uint32_t*)0x400E0EB0U) /**< (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR          (*(__O  uint32_t*)0x400E0EB4U) /**< (PIOA) Additional Interrupt Modes Disable Register */
+#define REG_PIOA_AIMMR          (*(__I  uint32_t*)0x400E0EB8U) /**< (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR            (*(__O  uint32_t*)0x400E0EC0U) /**< (PIOA) Edge Select Register */
+#define REG_PIOA_LSR            (*(__O  uint32_t*)0x400E0EC4U) /**< (PIOA) Level Select Register */
+#define REG_PIOA_ELSR           (*(__I  uint32_t*)0x400E0EC8U) /**< (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR         (*(__O  uint32_t*)0x400E0ED0U) /**< (PIOA) Falling Edge/Low-Level Select Register */
+#define REG_PIOA_REHLSR         (*(__O  uint32_t*)0x400E0ED4U) /**< (PIOA) Rising Edge/High-Level Select Register */
+#define REG_PIOA_FRLHSR         (*(__I  uint32_t*)0x400E0ED8U) /**< (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR         (*(__I  uint32_t*)0x400E0EE0U) /**< (PIOA) Lock Status */
+#define REG_PIOA_WPMR           (*(__IO uint32_t*)0x400E0EE4U) /**< (PIOA) Write Protection Mode Register */
+#define REG_PIOA_WPSR           (*(__I  uint32_t*)0x400E0EE8U) /**< (PIOA) Write Protection Status Register */
+#define REG_PIOA_VERSION        (*(__I  uint32_t*)0x400E0EFCU) /**< (PIOA) Version Register */
+#define REG_PIOA_SCHMITT        (*(__IO uint32_t*)0x400E0F00U) /**< (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DRIVER         (*(__IO uint32_t*)0x400E0F18U) /**< (PIOA) I/O Drive Register */
+#define REG_PIOA_PCMR           (*(__IO uint32_t*)0x400E0F50U) /**< (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER          (*(__O  uint32_t*)0x400E0F54U) /**< (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR          (*(__O  uint32_t*)0x400E0F58U) /**< (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR          (*(__I  uint32_t*)0x400E0F5CU) /**< (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR          (*(__I  uint32_t*)0x400E0F60U) /**< (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR          (*(__I  uint32_t*)0x400E0F64U) /**< (PIOA) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOA peripheral ========== */
+#define PIOA_DMAC_ID_RX                          34         
+#define PIOA_INSTANCE_ID                         10         
+
+#endif /* _SAMV71_PIOA_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/piob.h
+++ b/asf/sam/include/samv71/instance/piob.h
@@ -1,0 +1,160 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIOB_INSTANCE_H_
+#define _SAMV71_PIOB_INSTANCE_H_
+
+/* ========== Register definition for PIOB peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOB_PER            (0x400E1000) /**< (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR            (0x400E1004) /**< (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR            (0x400E1008) /**< (PIOB) PIO Status Register */
+#define REG_PIOB_OER            (0x400E1010) /**< (PIOB) Output Enable Register */
+#define REG_PIOB_ODR            (0x400E1014) /**< (PIOB) Output Disable Register */
+#define REG_PIOB_OSR            (0x400E1018) /**< (PIOB) Output Status Register */
+#define REG_PIOB_IFER           (0x400E1020) /**< (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR           (0x400E1024) /**< (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR           (0x400E1028) /**< (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR           (0x400E1030) /**< (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR           (0x400E1034) /**< (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR           (0x400E1038) /**< (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR           (0x400E103C) /**< (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER            (0x400E1040) /**< (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR            (0x400E1044) /**< (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR            (0x400E1048) /**< (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR            (0x400E104C) /**< (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER           (0x400E1050) /**< (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR           (0x400E1054) /**< (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR           (0x400E1058) /**< (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR           (0x400E1060) /**< (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER           (0x400E1064) /**< (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR           (0x400E1068) /**< (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR         (0x400E1070) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR0        (0x400E1070) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR1        (0x400E1074) /**< (PIOB) Peripheral ABCD Select Register 1 */
+#define REG_PIOB_IFSCDR         (0x400E1080) /**< (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER         (0x400E1084) /**< (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR         (0x400E1088) /**< (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR           (0x400E108C) /**< (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR          (0x400E1090) /**< (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER          (0x400E1094) /**< (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR          (0x400E1098) /**< (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER           (0x400E10A0) /**< (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR           (0x400E10A4) /**< (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR           (0x400E10A8) /**< (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER          (0x400E10B0) /**< (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR          (0x400E10B4) /**< (PIOB) Additional Interrupt Modes Disable Register */
+#define REG_PIOB_AIMMR          (0x400E10B8) /**< (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR            (0x400E10C0) /**< (PIOB) Edge Select Register */
+#define REG_PIOB_LSR            (0x400E10C4) /**< (PIOB) Level Select Register */
+#define REG_PIOB_ELSR           (0x400E10C8) /**< (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR         (0x400E10D0) /**< (PIOB) Falling Edge/Low-Level Select Register */
+#define REG_PIOB_REHLSR         (0x400E10D4) /**< (PIOB) Rising Edge/High-Level Select Register */
+#define REG_PIOB_FRLHSR         (0x400E10D8) /**< (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR         (0x400E10E0) /**< (PIOB) Lock Status */
+#define REG_PIOB_WPMR           (0x400E10E4) /**< (PIOB) Write Protection Mode Register */
+#define REG_PIOB_WPSR           (0x400E10E8) /**< (PIOB) Write Protection Status Register */
+#define REG_PIOB_VERSION        (0x400E10FC) /**< (PIOB) Version Register */
+#define REG_PIOB_SCHMITT        (0x400E1100) /**< (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DRIVER         (0x400E1118) /**< (PIOB) I/O Drive Register */
+#define REG_PIOB_PCMR           (0x400E1150) /**< (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER          (0x400E1154) /**< (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR          (0x400E1158) /**< (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR          (0x400E115C) /**< (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR          (0x400E1160) /**< (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR          (0x400E1164) /**< (PIOB) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOB_PER            (*(__O  uint32_t*)0x400E1000U) /**< (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR            (*(__O  uint32_t*)0x400E1004U) /**< (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR            (*(__I  uint32_t*)0x400E1008U) /**< (PIOB) PIO Status Register */
+#define REG_PIOB_OER            (*(__O  uint32_t*)0x400E1010U) /**< (PIOB) Output Enable Register */
+#define REG_PIOB_ODR            (*(__O  uint32_t*)0x400E1014U) /**< (PIOB) Output Disable Register */
+#define REG_PIOB_OSR            (*(__I  uint32_t*)0x400E1018U) /**< (PIOB) Output Status Register */
+#define REG_PIOB_IFER           (*(__O  uint32_t*)0x400E1020U) /**< (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR           (*(__O  uint32_t*)0x400E1024U) /**< (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR           (*(__I  uint32_t*)0x400E1028U) /**< (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR           (*(__O  uint32_t*)0x400E1030U) /**< (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR           (*(__O  uint32_t*)0x400E1034U) /**< (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR           (*(__IO uint32_t*)0x400E1038U) /**< (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR           (*(__I  uint32_t*)0x400E103CU) /**< (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER            (*(__O  uint32_t*)0x400E1040U) /**< (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR            (*(__O  uint32_t*)0x400E1044U) /**< (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR            (*(__I  uint32_t*)0x400E1048U) /**< (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR            (*(__I  uint32_t*)0x400E104CU) /**< (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER           (*(__O  uint32_t*)0x400E1050U) /**< (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR           (*(__O  uint32_t*)0x400E1054U) /**< (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR           (*(__I  uint32_t*)0x400E1058U) /**< (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR           (*(__O  uint32_t*)0x400E1060U) /**< (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER           (*(__O  uint32_t*)0x400E1064U) /**< (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR           (*(__I  uint32_t*)0x400E1068U) /**< (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR         (*(__IO uint32_t*)0x400E1070U) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR0        (*(__IO uint32_t*)0x400E1070U) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR1        (*(__IO uint32_t*)0x400E1074U) /**< (PIOB) Peripheral ABCD Select Register 1 */
+#define REG_PIOB_IFSCDR         (*(__O  uint32_t*)0x400E1080U) /**< (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER         (*(__O  uint32_t*)0x400E1084U) /**< (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR         (*(__I  uint32_t*)0x400E1088U) /**< (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR           (*(__IO uint32_t*)0x400E108CU) /**< (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR          (*(__O  uint32_t*)0x400E1090U) /**< (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER          (*(__O  uint32_t*)0x400E1094U) /**< (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR          (*(__I  uint32_t*)0x400E1098U) /**< (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER           (*(__O  uint32_t*)0x400E10A0U) /**< (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR           (*(__O  uint32_t*)0x400E10A4U) /**< (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR           (*(__I  uint32_t*)0x400E10A8U) /**< (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER          (*(__O  uint32_t*)0x400E10B0U) /**< (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR          (*(__O  uint32_t*)0x400E10B4U) /**< (PIOB) Additional Interrupt Modes Disable Register */
+#define REG_PIOB_AIMMR          (*(__I  uint32_t*)0x400E10B8U) /**< (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR            (*(__O  uint32_t*)0x400E10C0U) /**< (PIOB) Edge Select Register */
+#define REG_PIOB_LSR            (*(__O  uint32_t*)0x400E10C4U) /**< (PIOB) Level Select Register */
+#define REG_PIOB_ELSR           (*(__I  uint32_t*)0x400E10C8U) /**< (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR         (*(__O  uint32_t*)0x400E10D0U) /**< (PIOB) Falling Edge/Low-Level Select Register */
+#define REG_PIOB_REHLSR         (*(__O  uint32_t*)0x400E10D4U) /**< (PIOB) Rising Edge/High-Level Select Register */
+#define REG_PIOB_FRLHSR         (*(__I  uint32_t*)0x400E10D8U) /**< (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR         (*(__I  uint32_t*)0x400E10E0U) /**< (PIOB) Lock Status */
+#define REG_PIOB_WPMR           (*(__IO uint32_t*)0x400E10E4U) /**< (PIOB) Write Protection Mode Register */
+#define REG_PIOB_WPSR           (*(__I  uint32_t*)0x400E10E8U) /**< (PIOB) Write Protection Status Register */
+#define REG_PIOB_VERSION        (*(__I  uint32_t*)0x400E10FCU) /**< (PIOB) Version Register */
+#define REG_PIOB_SCHMITT        (*(__IO uint32_t*)0x400E1100U) /**< (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DRIVER         (*(__IO uint32_t*)0x400E1118U) /**< (PIOB) I/O Drive Register */
+#define REG_PIOB_PCMR           (*(__IO uint32_t*)0x400E1150U) /**< (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER          (*(__O  uint32_t*)0x400E1154U) /**< (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR          (*(__O  uint32_t*)0x400E1158U) /**< (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR          (*(__I  uint32_t*)0x400E115CU) /**< (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR          (*(__I  uint32_t*)0x400E1160U) /**< (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR          (*(__I  uint32_t*)0x400E1164U) /**< (PIOB) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOB peripheral ========== */
+#define PIOB_INSTANCE_ID                         11         
+
+#endif /* _SAMV71_PIOB_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pioc.h
+++ b/asf/sam/include/samv71/instance/pioc.h
@@ -1,0 +1,160 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIOC_INSTANCE_H_
+#define _SAMV71_PIOC_INSTANCE_H_
+
+/* ========== Register definition for PIOC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOC_PER            (0x400E1200) /**< (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR            (0x400E1204) /**< (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR            (0x400E1208) /**< (PIOC) PIO Status Register */
+#define REG_PIOC_OER            (0x400E1210) /**< (PIOC) Output Enable Register */
+#define REG_PIOC_ODR            (0x400E1214) /**< (PIOC) Output Disable Register */
+#define REG_PIOC_OSR            (0x400E1218) /**< (PIOC) Output Status Register */
+#define REG_PIOC_IFER           (0x400E1220) /**< (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR           (0x400E1224) /**< (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR           (0x400E1228) /**< (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR           (0x400E1230) /**< (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR           (0x400E1234) /**< (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR           (0x400E1238) /**< (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR           (0x400E123C) /**< (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER            (0x400E1240) /**< (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR            (0x400E1244) /**< (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR            (0x400E1248) /**< (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR            (0x400E124C) /**< (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER           (0x400E1250) /**< (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR           (0x400E1254) /**< (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR           (0x400E1258) /**< (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR           (0x400E1260) /**< (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER           (0x400E1264) /**< (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR           (0x400E1268) /**< (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR         (0x400E1270) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR0        (0x400E1270) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR1        (0x400E1274) /**< (PIOC) Peripheral ABCD Select Register 1 */
+#define REG_PIOC_IFSCDR         (0x400E1280) /**< (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER         (0x400E1284) /**< (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR         (0x400E1288) /**< (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR           (0x400E128C) /**< (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR          (0x400E1290) /**< (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER          (0x400E1294) /**< (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR          (0x400E1298) /**< (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER           (0x400E12A0) /**< (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR           (0x400E12A4) /**< (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR           (0x400E12A8) /**< (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER          (0x400E12B0) /**< (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR          (0x400E12B4) /**< (PIOC) Additional Interrupt Modes Disable Register */
+#define REG_PIOC_AIMMR          (0x400E12B8) /**< (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR            (0x400E12C0) /**< (PIOC) Edge Select Register */
+#define REG_PIOC_LSR            (0x400E12C4) /**< (PIOC) Level Select Register */
+#define REG_PIOC_ELSR           (0x400E12C8) /**< (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR         (0x400E12D0) /**< (PIOC) Falling Edge/Low-Level Select Register */
+#define REG_PIOC_REHLSR         (0x400E12D4) /**< (PIOC) Rising Edge/High-Level Select Register */
+#define REG_PIOC_FRLHSR         (0x400E12D8) /**< (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR         (0x400E12E0) /**< (PIOC) Lock Status */
+#define REG_PIOC_WPMR           (0x400E12E4) /**< (PIOC) Write Protection Mode Register */
+#define REG_PIOC_WPSR           (0x400E12E8) /**< (PIOC) Write Protection Status Register */
+#define REG_PIOC_VERSION        (0x400E12FC) /**< (PIOC) Version Register */
+#define REG_PIOC_SCHMITT        (0x400E1300) /**< (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DRIVER         (0x400E1318) /**< (PIOC) I/O Drive Register */
+#define REG_PIOC_PCMR           (0x400E1350) /**< (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER          (0x400E1354) /**< (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR          (0x400E1358) /**< (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR          (0x400E135C) /**< (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR          (0x400E1360) /**< (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR          (0x400E1364) /**< (PIOC) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOC_PER            (*(__O  uint32_t*)0x400E1200U) /**< (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR            (*(__O  uint32_t*)0x400E1204U) /**< (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR            (*(__I  uint32_t*)0x400E1208U) /**< (PIOC) PIO Status Register */
+#define REG_PIOC_OER            (*(__O  uint32_t*)0x400E1210U) /**< (PIOC) Output Enable Register */
+#define REG_PIOC_ODR            (*(__O  uint32_t*)0x400E1214U) /**< (PIOC) Output Disable Register */
+#define REG_PIOC_OSR            (*(__I  uint32_t*)0x400E1218U) /**< (PIOC) Output Status Register */
+#define REG_PIOC_IFER           (*(__O  uint32_t*)0x400E1220U) /**< (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR           (*(__O  uint32_t*)0x400E1224U) /**< (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR           (*(__I  uint32_t*)0x400E1228U) /**< (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR           (*(__O  uint32_t*)0x400E1230U) /**< (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR           (*(__O  uint32_t*)0x400E1234U) /**< (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR           (*(__IO uint32_t*)0x400E1238U) /**< (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR           (*(__I  uint32_t*)0x400E123CU) /**< (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER            (*(__O  uint32_t*)0x400E1240U) /**< (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR            (*(__O  uint32_t*)0x400E1244U) /**< (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR            (*(__I  uint32_t*)0x400E1248U) /**< (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR            (*(__I  uint32_t*)0x400E124CU) /**< (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER           (*(__O  uint32_t*)0x400E1250U) /**< (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR           (*(__O  uint32_t*)0x400E1254U) /**< (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR           (*(__I  uint32_t*)0x400E1258U) /**< (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR           (*(__O  uint32_t*)0x400E1260U) /**< (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER           (*(__O  uint32_t*)0x400E1264U) /**< (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR           (*(__I  uint32_t*)0x400E1268U) /**< (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR         (*(__IO uint32_t*)0x400E1270U) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR0        (*(__IO uint32_t*)0x400E1270U) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR1        (*(__IO uint32_t*)0x400E1274U) /**< (PIOC) Peripheral ABCD Select Register 1 */
+#define REG_PIOC_IFSCDR         (*(__O  uint32_t*)0x400E1280U) /**< (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER         (*(__O  uint32_t*)0x400E1284U) /**< (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR         (*(__I  uint32_t*)0x400E1288U) /**< (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR           (*(__IO uint32_t*)0x400E128CU) /**< (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR          (*(__O  uint32_t*)0x400E1290U) /**< (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER          (*(__O  uint32_t*)0x400E1294U) /**< (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR          (*(__I  uint32_t*)0x400E1298U) /**< (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER           (*(__O  uint32_t*)0x400E12A0U) /**< (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR           (*(__O  uint32_t*)0x400E12A4U) /**< (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR           (*(__I  uint32_t*)0x400E12A8U) /**< (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER          (*(__O  uint32_t*)0x400E12B0U) /**< (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR          (*(__O  uint32_t*)0x400E12B4U) /**< (PIOC) Additional Interrupt Modes Disable Register */
+#define REG_PIOC_AIMMR          (*(__I  uint32_t*)0x400E12B8U) /**< (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR            (*(__O  uint32_t*)0x400E12C0U) /**< (PIOC) Edge Select Register */
+#define REG_PIOC_LSR            (*(__O  uint32_t*)0x400E12C4U) /**< (PIOC) Level Select Register */
+#define REG_PIOC_ELSR           (*(__I  uint32_t*)0x400E12C8U) /**< (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR         (*(__O  uint32_t*)0x400E12D0U) /**< (PIOC) Falling Edge/Low-Level Select Register */
+#define REG_PIOC_REHLSR         (*(__O  uint32_t*)0x400E12D4U) /**< (PIOC) Rising Edge/High-Level Select Register */
+#define REG_PIOC_FRLHSR         (*(__I  uint32_t*)0x400E12D8U) /**< (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR         (*(__I  uint32_t*)0x400E12E0U) /**< (PIOC) Lock Status */
+#define REG_PIOC_WPMR           (*(__IO uint32_t*)0x400E12E4U) /**< (PIOC) Write Protection Mode Register */
+#define REG_PIOC_WPSR           (*(__I  uint32_t*)0x400E12E8U) /**< (PIOC) Write Protection Status Register */
+#define REG_PIOC_VERSION        (*(__I  uint32_t*)0x400E12FCU) /**< (PIOC) Version Register */
+#define REG_PIOC_SCHMITT        (*(__IO uint32_t*)0x400E1300U) /**< (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DRIVER         (*(__IO uint32_t*)0x400E1318U) /**< (PIOC) I/O Drive Register */
+#define REG_PIOC_PCMR           (*(__IO uint32_t*)0x400E1350U) /**< (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER          (*(__O  uint32_t*)0x400E1354U) /**< (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR          (*(__O  uint32_t*)0x400E1358U) /**< (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR          (*(__I  uint32_t*)0x400E135CU) /**< (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR          (*(__I  uint32_t*)0x400E1360U) /**< (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR          (*(__I  uint32_t*)0x400E1364U) /**< (PIOC) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOC peripheral ========== */
+#define PIOC_INSTANCE_ID                         12         
+
+#endif /* _SAMV71_PIOC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/piod.h
+++ b/asf/sam/include/samv71/instance/piod.h
@@ -1,0 +1,160 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOD
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIOD_INSTANCE_H_
+#define _SAMV71_PIOD_INSTANCE_H_
+
+/* ========== Register definition for PIOD peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOD_PER            (0x400E1400) /**< (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR            (0x400E1404) /**< (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR            (0x400E1408) /**< (PIOD) PIO Status Register */
+#define REG_PIOD_OER            (0x400E1410) /**< (PIOD) Output Enable Register */
+#define REG_PIOD_ODR            (0x400E1414) /**< (PIOD) Output Disable Register */
+#define REG_PIOD_OSR            (0x400E1418) /**< (PIOD) Output Status Register */
+#define REG_PIOD_IFER           (0x400E1420) /**< (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR           (0x400E1424) /**< (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR           (0x400E1428) /**< (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR           (0x400E1430) /**< (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR           (0x400E1434) /**< (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR           (0x400E1438) /**< (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR           (0x400E143C) /**< (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER            (0x400E1440) /**< (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR            (0x400E1444) /**< (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR            (0x400E1448) /**< (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR            (0x400E144C) /**< (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER           (0x400E1450) /**< (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR           (0x400E1454) /**< (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR           (0x400E1458) /**< (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR           (0x400E1460) /**< (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER           (0x400E1464) /**< (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR           (0x400E1468) /**< (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR         (0x400E1470) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR0        (0x400E1470) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR1        (0x400E1474) /**< (PIOD) Peripheral ABCD Select Register 1 */
+#define REG_PIOD_IFSCDR         (0x400E1480) /**< (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER         (0x400E1484) /**< (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR         (0x400E1488) /**< (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR           (0x400E148C) /**< (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR          (0x400E1490) /**< (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER          (0x400E1494) /**< (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR          (0x400E1498) /**< (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER           (0x400E14A0) /**< (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR           (0x400E14A4) /**< (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR           (0x400E14A8) /**< (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER          (0x400E14B0) /**< (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR          (0x400E14B4) /**< (PIOD) Additional Interrupt Modes Disable Register */
+#define REG_PIOD_AIMMR          (0x400E14B8) /**< (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR            (0x400E14C0) /**< (PIOD) Edge Select Register */
+#define REG_PIOD_LSR            (0x400E14C4) /**< (PIOD) Level Select Register */
+#define REG_PIOD_ELSR           (0x400E14C8) /**< (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR         (0x400E14D0) /**< (PIOD) Falling Edge/Low-Level Select Register */
+#define REG_PIOD_REHLSR         (0x400E14D4) /**< (PIOD) Rising Edge/High-Level Select Register */
+#define REG_PIOD_FRLHSR         (0x400E14D8) /**< (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR         (0x400E14E0) /**< (PIOD) Lock Status */
+#define REG_PIOD_WPMR           (0x400E14E4) /**< (PIOD) Write Protection Mode Register */
+#define REG_PIOD_WPSR           (0x400E14E8) /**< (PIOD) Write Protection Status Register */
+#define REG_PIOD_VERSION        (0x400E14FC) /**< (PIOD) Version Register */
+#define REG_PIOD_SCHMITT        (0x400E1500) /**< (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DRIVER         (0x400E1518) /**< (PIOD) I/O Drive Register */
+#define REG_PIOD_PCMR           (0x400E1550) /**< (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER          (0x400E1554) /**< (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR          (0x400E1558) /**< (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR          (0x400E155C) /**< (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR          (0x400E1560) /**< (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR          (0x400E1564) /**< (PIOD) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOD_PER            (*(__O  uint32_t*)0x400E1400U) /**< (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR            (*(__O  uint32_t*)0x400E1404U) /**< (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR            (*(__I  uint32_t*)0x400E1408U) /**< (PIOD) PIO Status Register */
+#define REG_PIOD_OER            (*(__O  uint32_t*)0x400E1410U) /**< (PIOD) Output Enable Register */
+#define REG_PIOD_ODR            (*(__O  uint32_t*)0x400E1414U) /**< (PIOD) Output Disable Register */
+#define REG_PIOD_OSR            (*(__I  uint32_t*)0x400E1418U) /**< (PIOD) Output Status Register */
+#define REG_PIOD_IFER           (*(__O  uint32_t*)0x400E1420U) /**< (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR           (*(__O  uint32_t*)0x400E1424U) /**< (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR           (*(__I  uint32_t*)0x400E1428U) /**< (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR           (*(__O  uint32_t*)0x400E1430U) /**< (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR           (*(__O  uint32_t*)0x400E1434U) /**< (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR           (*(__IO uint32_t*)0x400E1438U) /**< (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR           (*(__I  uint32_t*)0x400E143CU) /**< (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER            (*(__O  uint32_t*)0x400E1440U) /**< (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR            (*(__O  uint32_t*)0x400E1444U) /**< (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR            (*(__I  uint32_t*)0x400E1448U) /**< (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR            (*(__I  uint32_t*)0x400E144CU) /**< (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER           (*(__O  uint32_t*)0x400E1450U) /**< (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR           (*(__O  uint32_t*)0x400E1454U) /**< (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR           (*(__I  uint32_t*)0x400E1458U) /**< (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR           (*(__O  uint32_t*)0x400E1460U) /**< (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER           (*(__O  uint32_t*)0x400E1464U) /**< (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR           (*(__I  uint32_t*)0x400E1468U) /**< (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR         (*(__IO uint32_t*)0x400E1470U) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR0        (*(__IO uint32_t*)0x400E1470U) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR1        (*(__IO uint32_t*)0x400E1474U) /**< (PIOD) Peripheral ABCD Select Register 1 */
+#define REG_PIOD_IFSCDR         (*(__O  uint32_t*)0x400E1480U) /**< (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER         (*(__O  uint32_t*)0x400E1484U) /**< (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR         (*(__I  uint32_t*)0x400E1488U) /**< (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR           (*(__IO uint32_t*)0x400E148CU) /**< (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR          (*(__O  uint32_t*)0x400E1490U) /**< (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER          (*(__O  uint32_t*)0x400E1494U) /**< (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR          (*(__I  uint32_t*)0x400E1498U) /**< (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER           (*(__O  uint32_t*)0x400E14A0U) /**< (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR           (*(__O  uint32_t*)0x400E14A4U) /**< (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR           (*(__I  uint32_t*)0x400E14A8U) /**< (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER          (*(__O  uint32_t*)0x400E14B0U) /**< (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR          (*(__O  uint32_t*)0x400E14B4U) /**< (PIOD) Additional Interrupt Modes Disable Register */
+#define REG_PIOD_AIMMR          (*(__I  uint32_t*)0x400E14B8U) /**< (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR            (*(__O  uint32_t*)0x400E14C0U) /**< (PIOD) Edge Select Register */
+#define REG_PIOD_LSR            (*(__O  uint32_t*)0x400E14C4U) /**< (PIOD) Level Select Register */
+#define REG_PIOD_ELSR           (*(__I  uint32_t*)0x400E14C8U) /**< (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR         (*(__O  uint32_t*)0x400E14D0U) /**< (PIOD) Falling Edge/Low-Level Select Register */
+#define REG_PIOD_REHLSR         (*(__O  uint32_t*)0x400E14D4U) /**< (PIOD) Rising Edge/High-Level Select Register */
+#define REG_PIOD_FRLHSR         (*(__I  uint32_t*)0x400E14D8U) /**< (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR         (*(__I  uint32_t*)0x400E14E0U) /**< (PIOD) Lock Status */
+#define REG_PIOD_WPMR           (*(__IO uint32_t*)0x400E14E4U) /**< (PIOD) Write Protection Mode Register */
+#define REG_PIOD_WPSR           (*(__I  uint32_t*)0x400E14E8U) /**< (PIOD) Write Protection Status Register */
+#define REG_PIOD_VERSION        (*(__I  uint32_t*)0x400E14FCU) /**< (PIOD) Version Register */
+#define REG_PIOD_SCHMITT        (*(__IO uint32_t*)0x400E1500U) /**< (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DRIVER         (*(__IO uint32_t*)0x400E1518U) /**< (PIOD) I/O Drive Register */
+#define REG_PIOD_PCMR           (*(__IO uint32_t*)0x400E1550U) /**< (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER          (*(__O  uint32_t*)0x400E1554U) /**< (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR          (*(__O  uint32_t*)0x400E1558U) /**< (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR          (*(__I  uint32_t*)0x400E155CU) /**< (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR          (*(__I  uint32_t*)0x400E1560U) /**< (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR          (*(__I  uint32_t*)0x400E1564U) /**< (PIOD) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOD peripheral ========== */
+#define PIOD_INSTANCE_ID                         16         
+
+#endif /* _SAMV71_PIOD_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pioe.h
+++ b/asf/sam/include/samv71/instance/pioe.h
@@ -1,0 +1,160 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOE
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PIOE_INSTANCE_H_
+#define _SAMV71_PIOE_INSTANCE_H_
+
+/* ========== Register definition for PIOE peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOE_PER            (0x400E1600) /**< (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR            (0x400E1604) /**< (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR            (0x400E1608) /**< (PIOE) PIO Status Register */
+#define REG_PIOE_OER            (0x400E1610) /**< (PIOE) Output Enable Register */
+#define REG_PIOE_ODR            (0x400E1614) /**< (PIOE) Output Disable Register */
+#define REG_PIOE_OSR            (0x400E1618) /**< (PIOE) Output Status Register */
+#define REG_PIOE_IFER           (0x400E1620) /**< (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR           (0x400E1624) /**< (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR           (0x400E1628) /**< (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR           (0x400E1630) /**< (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR           (0x400E1634) /**< (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR           (0x400E1638) /**< (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR           (0x400E163C) /**< (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER            (0x400E1640) /**< (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR            (0x400E1644) /**< (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR            (0x400E1648) /**< (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR            (0x400E164C) /**< (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER           (0x400E1650) /**< (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR           (0x400E1654) /**< (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR           (0x400E1658) /**< (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR           (0x400E1660) /**< (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER           (0x400E1664) /**< (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR           (0x400E1668) /**< (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR         (0x400E1670) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR0        (0x400E1670) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR1        (0x400E1674) /**< (PIOE) Peripheral ABCD Select Register 1 */
+#define REG_PIOE_IFSCDR         (0x400E1680) /**< (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER         (0x400E1684) /**< (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR         (0x400E1688) /**< (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR           (0x400E168C) /**< (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR          (0x400E1690) /**< (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER          (0x400E1694) /**< (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR          (0x400E1698) /**< (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER           (0x400E16A0) /**< (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR           (0x400E16A4) /**< (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR           (0x400E16A8) /**< (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER          (0x400E16B0) /**< (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR          (0x400E16B4) /**< (PIOE) Additional Interrupt Modes Disable Register */
+#define REG_PIOE_AIMMR          (0x400E16B8) /**< (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR            (0x400E16C0) /**< (PIOE) Edge Select Register */
+#define REG_PIOE_LSR            (0x400E16C4) /**< (PIOE) Level Select Register */
+#define REG_PIOE_ELSR           (0x400E16C8) /**< (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR         (0x400E16D0) /**< (PIOE) Falling Edge/Low-Level Select Register */
+#define REG_PIOE_REHLSR         (0x400E16D4) /**< (PIOE) Rising Edge/High-Level Select Register */
+#define REG_PIOE_FRLHSR         (0x400E16D8) /**< (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR         (0x400E16E0) /**< (PIOE) Lock Status */
+#define REG_PIOE_WPMR           (0x400E16E4) /**< (PIOE) Write Protection Mode Register */
+#define REG_PIOE_WPSR           (0x400E16E8) /**< (PIOE) Write Protection Status Register */
+#define REG_PIOE_VERSION        (0x400E16FC) /**< (PIOE) Version Register */
+#define REG_PIOE_SCHMITT        (0x400E1700) /**< (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DRIVER         (0x400E1718) /**< (PIOE) I/O Drive Register */
+#define REG_PIOE_PCMR           (0x400E1750) /**< (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER          (0x400E1754) /**< (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR          (0x400E1758) /**< (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR          (0x400E175C) /**< (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR          (0x400E1760) /**< (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR          (0x400E1764) /**< (PIOE) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOE_PER            (*(__O  uint32_t*)0x400E1600U) /**< (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR            (*(__O  uint32_t*)0x400E1604U) /**< (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR            (*(__I  uint32_t*)0x400E1608U) /**< (PIOE) PIO Status Register */
+#define REG_PIOE_OER            (*(__O  uint32_t*)0x400E1610U) /**< (PIOE) Output Enable Register */
+#define REG_PIOE_ODR            (*(__O  uint32_t*)0x400E1614U) /**< (PIOE) Output Disable Register */
+#define REG_PIOE_OSR            (*(__I  uint32_t*)0x400E1618U) /**< (PIOE) Output Status Register */
+#define REG_PIOE_IFER           (*(__O  uint32_t*)0x400E1620U) /**< (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR           (*(__O  uint32_t*)0x400E1624U) /**< (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR           (*(__I  uint32_t*)0x400E1628U) /**< (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR           (*(__O  uint32_t*)0x400E1630U) /**< (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR           (*(__O  uint32_t*)0x400E1634U) /**< (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR           (*(__IO uint32_t*)0x400E1638U) /**< (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR           (*(__I  uint32_t*)0x400E163CU) /**< (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER            (*(__O  uint32_t*)0x400E1640U) /**< (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR            (*(__O  uint32_t*)0x400E1644U) /**< (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR            (*(__I  uint32_t*)0x400E1648U) /**< (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR            (*(__I  uint32_t*)0x400E164CU) /**< (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER           (*(__O  uint32_t*)0x400E1650U) /**< (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR           (*(__O  uint32_t*)0x400E1654U) /**< (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR           (*(__I  uint32_t*)0x400E1658U) /**< (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR           (*(__O  uint32_t*)0x400E1660U) /**< (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER           (*(__O  uint32_t*)0x400E1664U) /**< (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR           (*(__I  uint32_t*)0x400E1668U) /**< (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR         (*(__IO uint32_t*)0x400E1670U) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR0        (*(__IO uint32_t*)0x400E1670U) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR1        (*(__IO uint32_t*)0x400E1674U) /**< (PIOE) Peripheral ABCD Select Register 1 */
+#define REG_PIOE_IFSCDR         (*(__O  uint32_t*)0x400E1680U) /**< (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER         (*(__O  uint32_t*)0x400E1684U) /**< (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR         (*(__I  uint32_t*)0x400E1688U) /**< (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR           (*(__IO uint32_t*)0x400E168CU) /**< (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR          (*(__O  uint32_t*)0x400E1690U) /**< (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER          (*(__O  uint32_t*)0x400E1694U) /**< (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR          (*(__I  uint32_t*)0x400E1698U) /**< (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER           (*(__O  uint32_t*)0x400E16A0U) /**< (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR           (*(__O  uint32_t*)0x400E16A4U) /**< (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR           (*(__I  uint32_t*)0x400E16A8U) /**< (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER          (*(__O  uint32_t*)0x400E16B0U) /**< (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR          (*(__O  uint32_t*)0x400E16B4U) /**< (PIOE) Additional Interrupt Modes Disable Register */
+#define REG_PIOE_AIMMR          (*(__I  uint32_t*)0x400E16B8U) /**< (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR            (*(__O  uint32_t*)0x400E16C0U) /**< (PIOE) Edge Select Register */
+#define REG_PIOE_LSR            (*(__O  uint32_t*)0x400E16C4U) /**< (PIOE) Level Select Register */
+#define REG_PIOE_ELSR           (*(__I  uint32_t*)0x400E16C8U) /**< (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR         (*(__O  uint32_t*)0x400E16D0U) /**< (PIOE) Falling Edge/Low-Level Select Register */
+#define REG_PIOE_REHLSR         (*(__O  uint32_t*)0x400E16D4U) /**< (PIOE) Rising Edge/High-Level Select Register */
+#define REG_PIOE_FRLHSR         (*(__I  uint32_t*)0x400E16D8U) /**< (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR         (*(__I  uint32_t*)0x400E16E0U) /**< (PIOE) Lock Status */
+#define REG_PIOE_WPMR           (*(__IO uint32_t*)0x400E16E4U) /**< (PIOE) Write Protection Mode Register */
+#define REG_PIOE_WPSR           (*(__I  uint32_t*)0x400E16E8U) /**< (PIOE) Write Protection Status Register */
+#define REG_PIOE_VERSION        (*(__I  uint32_t*)0x400E16FCU) /**< (PIOE) Version Register */
+#define REG_PIOE_SCHMITT        (*(__IO uint32_t*)0x400E1700U) /**< (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DRIVER         (*(__IO uint32_t*)0x400E1718U) /**< (PIOE) I/O Drive Register */
+#define REG_PIOE_PCMR           (*(__IO uint32_t*)0x400E1750U) /**< (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER          (*(__O  uint32_t*)0x400E1754U) /**< (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR          (*(__O  uint32_t*)0x400E1758U) /**< (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR          (*(__I  uint32_t*)0x400E175CU) /**< (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR          (*(__I  uint32_t*)0x400E1760U) /**< (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR          (*(__I  uint32_t*)0x400E1764U) /**< (PIOE) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOE peripheral ========== */
+#define PIOE_INSTANCE_ID                         17         
+
+#endif /* _SAMV71_PIOE_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pmc.h
+++ b/asf/sam/include/samv71/instance/pmc.h
@@ -1,0 +1,142 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PMC_INSTANCE_H_
+#define _SAMV71_PMC_INSTANCE_H_
+
+/* ========== Register definition for PMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PMC_SCER            (0x400E0600) /**< (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR            (0x400E0604) /**< (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR            (0x400E0608) /**< (PMC) System Clock Status Register */
+#define REG_PMC_PCER0           (0x400E0610) /**< (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0           (0x400E0614) /**< (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0           (0x400E0618) /**< (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_UCKR           (0x400E061C) /**< (PMC) UTMI Clock Register */
+#define REG_CKGR_MOR            (0x400E0620) /**< (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR           (0x400E0624) /**< (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR          (0x400E0628) /**< (PMC) PLLA Register */
+#define REG_PMC_MCKR            (0x400E0630) /**< (PMC) Master Clock Register */
+#define REG_PMC_USB             (0x400E0638) /**< (PMC) USB Clock Register */
+#define REG_PMC_PCK             (0x400E0640) /**< (PMC) Programmable Clock Register (chid = 0) 0 */
+#define REG_PMC_PCK0            (0x400E0640) /**< (PMC) Programmable Clock Register (chid = 0) 0 */
+#define REG_PMC_PCK1            (0x400E0644) /**< (PMC) Programmable Clock Register (chid = 0) 1 */
+#define REG_PMC_PCK2            (0x400E0648) /**< (PMC) Programmable Clock Register (chid = 0) 2 */
+#define REG_PMC_PCK3            (0x400E064C) /**< (PMC) Programmable Clock Register (chid = 0) 3 */
+#define REG_PMC_PCK4            (0x400E0650) /**< (PMC) Programmable Clock Register (chid = 0) 4 */
+#define REG_PMC_PCK5            (0x400E0654) /**< (PMC) Programmable Clock Register (chid = 0) 5 */
+#define REG_PMC_PCK6            (0x400E0658) /**< (PMC) Programmable Clock Register (chid = 0) 6 */
+#define REG_PMC_PCK7            (0x400E065C) /**< (PMC) Programmable Clock Register (chid = 0) 7 */
+#define REG_PMC_IER             (0x400E0660) /**< (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR             (0x400E0664) /**< (PMC) Interrupt Disable Register */
+#define REG_PMC_SR              (0x400E0668) /**< (PMC) Status Register */
+#define REG_PMC_IMR             (0x400E066C) /**< (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR            (0x400E0670) /**< (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR            (0x400E0674) /**< (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR            (0x400E0678) /**< (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR            (0x400E06E4) /**< (PMC) Write Protection Mode Register */
+#define REG_PMC_WPSR            (0x400E06E8) /**< (PMC) Write Protection Status Register */
+#define REG_PMC_VERSION         (0x400E06FC) /**< (PMC) Version Register */
+#define REG_PMC_PCER1           (0x400E0700) /**< (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1           (0x400E0704) /**< (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1           (0x400E0708) /**< (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_PCR             (0x400E070C) /**< (PMC) Peripheral Control Register */
+#define REG_PMC_OCR             (0x400E0710) /**< (PMC) Oscillator Calibration Register */
+#define REG_PMC_SLPWK_ER0       (0x400E0714) /**< (PMC) SleepWalking Enable Register 0 */
+#define REG_PMC_SLPWK_DR0       (0x400E0718) /**< (PMC) SleepWalking Disable Register 0 */
+#define REG_PMC_SLPWK_SR0       (0x400E071C) /**< (PMC) SleepWalking Status Register 0 */
+#define REG_PMC_SLPWK_ASR0      (0x400E0720) /**< (PMC) SleepWalking Activity Status Register 0 */
+#define REG_PMC_PMMR            (0x400E0730) /**< (PMC) PLL Maximum Multiplier Value Register */
+#define REG_PMC_SLPWK_ER1       (0x400E0734) /**< (PMC) SleepWalking Enable Register 1 */
+#define REG_PMC_SLPWK_DR1       (0x400E0738) /**< (PMC) SleepWalking Disable Register 1 */
+#define REG_PMC_SLPWK_SR1       (0x400E073C) /**< (PMC) SleepWalking Status Register 1 */
+#define REG_PMC_SLPWK_ASR1      (0x400E0740) /**< (PMC) SleepWalking Activity Status Register 1 */
+#define REG_PMC_SLPWK_AIPR      (0x400E0744) /**< (PMC) SleepWalking Activity In Progress Register */
+#define REG_PMC_APLLACR         (0x400E0758) /**< (PMC) Audio PLL Analog Configuration Register */
+#define REG_PMC_WMST            (0x400E075C) /**< (PMC) Wait Mode Startup Time Register */
+
+#else
+
+#define REG_PMC_SCER            (*(__O  uint32_t*)0x400E0600U) /**< (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR            (*(__O  uint32_t*)0x400E0604U) /**< (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR            (*(__I  uint32_t*)0x400E0608U) /**< (PMC) System Clock Status Register */
+#define REG_PMC_PCER0           (*(__O  uint32_t*)0x400E0610U) /**< (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0           (*(__O  uint32_t*)0x400E0614U) /**< (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0           (*(__I  uint32_t*)0x400E0618U) /**< (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_UCKR           (*(__IO uint32_t*)0x400E061CU) /**< (PMC) UTMI Clock Register */
+#define REG_CKGR_MOR            (*(__IO uint32_t*)0x400E0620U) /**< (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR           (*(__IO uint32_t*)0x400E0624U) /**< (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR          (*(__IO uint32_t*)0x400E0628U) /**< (PMC) PLLA Register */
+#define REG_PMC_MCKR            (*(__IO uint32_t*)0x400E0630U) /**< (PMC) Master Clock Register */
+#define REG_PMC_USB             (*(__IO uint32_t*)0x400E0638U) /**< (PMC) USB Clock Register */
+#define REG_PMC_PCK             (*(__IO uint32_t*)0x400E0640U) /**< (PMC) Programmable Clock Register (chid = 0) 0 */
+#define REG_PMC_PCK0            (*(__IO uint32_t*)0x400E0640U) /**< (PMC) Programmable Clock Register (chid = 0) 0 */
+#define REG_PMC_PCK1            (*(__IO uint32_t*)0x400E0644U) /**< (PMC) Programmable Clock Register (chid = 0) 1 */
+#define REG_PMC_PCK2            (*(__IO uint32_t*)0x400E0648U) /**< (PMC) Programmable Clock Register (chid = 0) 2 */
+#define REG_PMC_PCK3            (*(__IO uint32_t*)0x400E064CU) /**< (PMC) Programmable Clock Register (chid = 0) 3 */
+#define REG_PMC_PCK4            (*(__IO uint32_t*)0x400E0650U) /**< (PMC) Programmable Clock Register (chid = 0) 4 */
+#define REG_PMC_PCK5            (*(__IO uint32_t*)0x400E0654U) /**< (PMC) Programmable Clock Register (chid = 0) 5 */
+#define REG_PMC_PCK6            (*(__IO uint32_t*)0x400E0658U) /**< (PMC) Programmable Clock Register (chid = 0) 6 */
+#define REG_PMC_PCK7            (*(__IO uint32_t*)0x400E065CU) /**< (PMC) Programmable Clock Register (chid = 0) 7 */
+#define REG_PMC_IER             (*(__O  uint32_t*)0x400E0660U) /**< (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR             (*(__O  uint32_t*)0x400E0664U) /**< (PMC) Interrupt Disable Register */
+#define REG_PMC_SR              (*(__I  uint32_t*)0x400E0668U) /**< (PMC) Status Register */
+#define REG_PMC_IMR             (*(__I  uint32_t*)0x400E066CU) /**< (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR            (*(__IO uint32_t*)0x400E0670U) /**< (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR            (*(__IO uint32_t*)0x400E0674U) /**< (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR            (*(__O  uint32_t*)0x400E0678U) /**< (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR            (*(__IO uint32_t*)0x400E06E4U) /**< (PMC) Write Protection Mode Register */
+#define REG_PMC_WPSR            (*(__I  uint32_t*)0x400E06E8U) /**< (PMC) Write Protection Status Register */
+#define REG_PMC_VERSION         (*(__I  uint32_t*)0x400E06FCU) /**< (PMC) Version Register */
+#define REG_PMC_PCER1           (*(__O  uint32_t*)0x400E0700U) /**< (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1           (*(__O  uint32_t*)0x400E0704U) /**< (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1           (*(__I  uint32_t*)0x400E0708U) /**< (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_PCR             (*(__IO uint32_t*)0x400E070CU) /**< (PMC) Peripheral Control Register */
+#define REG_PMC_OCR             (*(__IO uint32_t*)0x400E0710U) /**< (PMC) Oscillator Calibration Register */
+#define REG_PMC_SLPWK_ER0       (*(__O  uint32_t*)0x400E0714U) /**< (PMC) SleepWalking Enable Register 0 */
+#define REG_PMC_SLPWK_DR0       (*(__O  uint32_t*)0x400E0718U) /**< (PMC) SleepWalking Disable Register 0 */
+#define REG_PMC_SLPWK_SR0       (*(__I  uint32_t*)0x400E071CU) /**< (PMC) SleepWalking Status Register 0 */
+#define REG_PMC_SLPWK_ASR0      (*(__I  uint32_t*)0x400E0720U) /**< (PMC) SleepWalking Activity Status Register 0 */
+#define REG_PMC_PMMR            (*(__IO uint32_t*)0x400E0730U) /**< (PMC) PLL Maximum Multiplier Value Register */
+#define REG_PMC_SLPWK_ER1       (*(__O  uint32_t*)0x400E0734U) /**< (PMC) SleepWalking Enable Register 1 */
+#define REG_PMC_SLPWK_DR1       (*(__O  uint32_t*)0x400E0738U) /**< (PMC) SleepWalking Disable Register 1 */
+#define REG_PMC_SLPWK_SR1       (*(__I  uint32_t*)0x400E073CU) /**< (PMC) SleepWalking Status Register 1 */
+#define REG_PMC_SLPWK_ASR1      (*(__I  uint32_t*)0x400E0740U) /**< (PMC) SleepWalking Activity Status Register 1 */
+#define REG_PMC_SLPWK_AIPR      (*(__I  uint32_t*)0x400E0744U) /**< (PMC) SleepWalking Activity In Progress Register */
+#define REG_PMC_APLLACR         (*(__IO uint32_t*)0x400E0758U) /**< (PMC) Audio PLL Analog Configuration Register */
+#define REG_PMC_WMST            (*(__IO uint32_t*)0x400E075CU) /**< (PMC) Wait Mode Startup Time Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PMC peripheral ========== */
+#define PMC_INSTANCE_ID                          5          
+
+#endif /* _SAMV71_PMC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pwm0.h
+++ b/asf/sam/include/samv71/instance/pwm0.h
@@ -1,0 +1,267 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PWM0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PWM0_INSTANCE_H_
+#define _SAMV71_PWM0_INSTANCE_H_
+
+/* ========== Register definition for PWM0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PWM0_CMPV0          (0x40020130) /**< (PWM0) PWM Comparison 0 Value Register 0 */
+#define REG_PWM0_CMPVUPD0       (0x40020134) /**< (PWM0) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM0_CMPM0          (0x40020138) /**< (PWM0) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM0_CMPMUPD0       (0x4002013C) /**< (PWM0) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM0_CMPV1          (0x40020140) /**< (PWM0) PWM Comparison 0 Value Register 1 */
+#define REG_PWM0_CMPVUPD1       (0x40020144) /**< (PWM0) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM0_CMPM1          (0x40020148) /**< (PWM0) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM0_CMPMUPD1       (0x4002014C) /**< (PWM0) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM0_CMPV2          (0x40020150) /**< (PWM0) PWM Comparison 0 Value Register 2 */
+#define REG_PWM0_CMPVUPD2       (0x40020154) /**< (PWM0) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM0_CMPM2          (0x40020158) /**< (PWM0) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM0_CMPMUPD2       (0x4002015C) /**< (PWM0) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM0_CMPV3          (0x40020160) /**< (PWM0) PWM Comparison 0 Value Register 3 */
+#define REG_PWM0_CMPVUPD3       (0x40020164) /**< (PWM0) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM0_CMPM3          (0x40020168) /**< (PWM0) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM0_CMPMUPD3       (0x4002016C) /**< (PWM0) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM0_CMPV4          (0x40020170) /**< (PWM0) PWM Comparison 0 Value Register 4 */
+#define REG_PWM0_CMPVUPD4       (0x40020174) /**< (PWM0) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM0_CMPM4          (0x40020178) /**< (PWM0) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM0_CMPMUPD4       (0x4002017C) /**< (PWM0) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM0_CMPV5          (0x40020180) /**< (PWM0) PWM Comparison 0 Value Register 5 */
+#define REG_PWM0_CMPVUPD5       (0x40020184) /**< (PWM0) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM0_CMPM5          (0x40020188) /**< (PWM0) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM0_CMPMUPD5       (0x4002018C) /**< (PWM0) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM0_CMPV6          (0x40020190) /**< (PWM0) PWM Comparison 0 Value Register 6 */
+#define REG_PWM0_CMPVUPD6       (0x40020194) /**< (PWM0) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM0_CMPM6          (0x40020198) /**< (PWM0) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM0_CMPMUPD6       (0x4002019C) /**< (PWM0) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM0_CMPV7          (0x400201A0) /**< (PWM0) PWM Comparison 0 Value Register 7 */
+#define REG_PWM0_CMPVUPD7       (0x400201A4) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM0_CMPM7          (0x400201A8) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM0_CMPMUPD7       (0x400201AC) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM0_CMR0           (0x40020200) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 0 */
+#define REG_PWM0_CDTY0          (0x40020204) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
+#define REG_PWM0_CDTYUPD0       (0x40020208) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CPRD0          (0x4002020C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 0 */
+#define REG_PWM0_CPRDUPD0       (0x40020210) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CCNT0          (0x40020214) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 0 */
+#define REG_PWM0_DT0            (0x40020218) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 0 */
+#define REG_PWM0_DTUPD0         (0x4002021C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CMR1           (0x40020220) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 1 */
+#define REG_PWM0_CDTY1          (0x40020224) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
+#define REG_PWM0_CDTYUPD1       (0x40020228) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CPRD1          (0x4002022C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 1 */
+#define REG_PWM0_CPRDUPD1       (0x40020230) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CCNT1          (0x40020234) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 1 */
+#define REG_PWM0_DT1            (0x40020238) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 1 */
+#define REG_PWM0_DTUPD1         (0x4002023C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CMR2           (0x40020240) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 2 */
+#define REG_PWM0_CDTY2          (0x40020244) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
+#define REG_PWM0_CDTYUPD2       (0x40020248) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CPRD2          (0x4002024C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 2 */
+#define REG_PWM0_CPRDUPD2       (0x40020250) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CCNT2          (0x40020254) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 2 */
+#define REG_PWM0_DT2            (0x40020258) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 2 */
+#define REG_PWM0_DTUPD2         (0x4002025C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CMR3           (0x40020260) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 3 */
+#define REG_PWM0_CDTY3          (0x40020264) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
+#define REG_PWM0_CDTYUPD3       (0x40020268) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CPRD3          (0x4002026C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 3 */
+#define REG_PWM0_CPRDUPD3       (0x40020270) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CCNT3          (0x40020274) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 3 */
+#define REG_PWM0_DT3            (0x40020278) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 3 */
+#define REG_PWM0_DTUPD3         (0x4002027C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CLK            (0x40020000) /**< (PWM0) PWM Clock Register */
+#define REG_PWM0_ENA            (0x40020004) /**< (PWM0) PWM Enable Register */
+#define REG_PWM0_DIS            (0x40020008) /**< (PWM0) PWM Disable Register */
+#define REG_PWM0_SR             (0x4002000C) /**< (PWM0) PWM Status Register */
+#define REG_PWM0_IER1           (0x40020010) /**< (PWM0) PWM Interrupt Enable Register 1 */
+#define REG_PWM0_IDR1           (0x40020014) /**< (PWM0) PWM Interrupt Disable Register 1 */
+#define REG_PWM0_IMR1           (0x40020018) /**< (PWM0) PWM Interrupt Mask Register 1 */
+#define REG_PWM0_ISR1           (0x4002001C) /**< (PWM0) PWM Interrupt Status Register 1 */
+#define REG_PWM0_SCM            (0x40020020) /**< (PWM0) PWM Sync Channels Mode Register */
+#define REG_PWM0_DMAR           (0x40020024) /**< (PWM0) PWM DMA Register */
+#define REG_PWM0_SCUC           (0x40020028) /**< (PWM0) PWM Sync Channels Update Control Register */
+#define REG_PWM0_SCUP           (0x4002002C) /**< (PWM0) PWM Sync Channels Update Period Register */
+#define REG_PWM0_SCUPUPD        (0x40020030) /**< (PWM0) PWM Sync Channels Update Period Update Register */
+#define REG_PWM0_IER2           (0x40020034) /**< (PWM0) PWM Interrupt Enable Register 2 */
+#define REG_PWM0_IDR2           (0x40020038) /**< (PWM0) PWM Interrupt Disable Register 2 */
+#define REG_PWM0_IMR2           (0x4002003C) /**< (PWM0) PWM Interrupt Mask Register 2 */
+#define REG_PWM0_ISR2           (0x40020040) /**< (PWM0) PWM Interrupt Status Register 2 */
+#define REG_PWM0_OOV            (0x40020044) /**< (PWM0) PWM Output Override Value Register */
+#define REG_PWM0_OS             (0x40020048) /**< (PWM0) PWM Output Selection Register */
+#define REG_PWM0_OSS            (0x4002004C) /**< (PWM0) PWM Output Selection Set Register */
+#define REG_PWM0_OSC            (0x40020050) /**< (PWM0) PWM Output Selection Clear Register */
+#define REG_PWM0_OSSUPD         (0x40020054) /**< (PWM0) PWM Output Selection Set Update Register */
+#define REG_PWM0_OSCUPD         (0x40020058) /**< (PWM0) PWM Output Selection Clear Update Register */
+#define REG_PWM0_FMR            (0x4002005C) /**< (PWM0) PWM Fault Mode Register */
+#define REG_PWM0_FSR            (0x40020060) /**< (PWM0) PWM Fault Status Register */
+#define REG_PWM0_FCR            (0x40020064) /**< (PWM0) PWM Fault Clear Register */
+#define REG_PWM0_FPV1           (0x40020068) /**< (PWM0) PWM Fault Protection Value Register 1 */
+#define REG_PWM0_FPE            (0x4002006C) /**< (PWM0) PWM Fault Protection Enable Register */
+#define REG_PWM0_ELMR           (0x4002007C) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR0          (0x4002007C) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR1          (0x40020080) /**< (PWM0) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM0_SSPR           (0x400200A0) /**< (PWM0) PWM Spread Spectrum Register */
+#define REG_PWM0_SSPUP          (0x400200A4) /**< (PWM0) PWM Spread Spectrum Update Register */
+#define REG_PWM0_SMMR           (0x400200B0) /**< (PWM0) PWM Stepper Motor Mode Register */
+#define REG_PWM0_FPV2           (0x400200C0) /**< (PWM0) PWM Fault Protection Value 2 Register */
+#define REG_PWM0_WPCR           (0x400200E4) /**< (PWM0) PWM Write Protection Control Register */
+#define REG_PWM0_WPSR           (0x400200E8) /**< (PWM0) PWM Write Protection Status Register */
+#define REG_PWM0_VERSION        (0x400200FC) /**< (PWM0) Version Register */
+#define REG_PWM0_CMUPD0         (0x40020400) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM0_CMUPD1         (0x40020420) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM0_ETRG1          (0x4002042C) /**< (PWM0) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM0_LEBR1          (0x40020430) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM0_CMUPD2         (0x40020440) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM0_ETRG2          (0x4002044C) /**< (PWM0) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM0_LEBR2          (0x40020450) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM0_CMUPD3         (0x40020460) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 3) */
+
+#else
+
+#define REG_PWM0_CMPV0          (*(__IO uint32_t*)0x40020130U) /**< (PWM0) PWM Comparison 0 Value Register 0 */
+#define REG_PWM0_CMPVUPD0       (*(__O  uint32_t*)0x40020134U) /**< (PWM0) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM0_CMPM0          (*(__IO uint32_t*)0x40020138U) /**< (PWM0) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM0_CMPMUPD0       (*(__O  uint32_t*)0x4002013CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM0_CMPV1          (*(__IO uint32_t*)0x40020140U) /**< (PWM0) PWM Comparison 0 Value Register 1 */
+#define REG_PWM0_CMPVUPD1       (*(__O  uint32_t*)0x40020144U) /**< (PWM0) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM0_CMPM1          (*(__IO uint32_t*)0x40020148U) /**< (PWM0) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM0_CMPMUPD1       (*(__O  uint32_t*)0x4002014CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM0_CMPV2          (*(__IO uint32_t*)0x40020150U) /**< (PWM0) PWM Comparison 0 Value Register 2 */
+#define REG_PWM0_CMPVUPD2       (*(__O  uint32_t*)0x40020154U) /**< (PWM0) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM0_CMPM2          (*(__IO uint32_t*)0x40020158U) /**< (PWM0) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM0_CMPMUPD2       (*(__O  uint32_t*)0x4002015CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM0_CMPV3          (*(__IO uint32_t*)0x40020160U) /**< (PWM0) PWM Comparison 0 Value Register 3 */
+#define REG_PWM0_CMPVUPD3       (*(__O  uint32_t*)0x40020164U) /**< (PWM0) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM0_CMPM3          (*(__IO uint32_t*)0x40020168U) /**< (PWM0) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM0_CMPMUPD3       (*(__O  uint32_t*)0x4002016CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM0_CMPV4          (*(__IO uint32_t*)0x40020170U) /**< (PWM0) PWM Comparison 0 Value Register 4 */
+#define REG_PWM0_CMPVUPD4       (*(__O  uint32_t*)0x40020174U) /**< (PWM0) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM0_CMPM4          (*(__IO uint32_t*)0x40020178U) /**< (PWM0) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM0_CMPMUPD4       (*(__O  uint32_t*)0x4002017CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM0_CMPV5          (*(__IO uint32_t*)0x40020180U) /**< (PWM0) PWM Comparison 0 Value Register 5 */
+#define REG_PWM0_CMPVUPD5       (*(__O  uint32_t*)0x40020184U) /**< (PWM0) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM0_CMPM5          (*(__IO uint32_t*)0x40020188U) /**< (PWM0) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM0_CMPMUPD5       (*(__O  uint32_t*)0x4002018CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM0_CMPV6          (*(__IO uint32_t*)0x40020190U) /**< (PWM0) PWM Comparison 0 Value Register 6 */
+#define REG_PWM0_CMPVUPD6       (*(__O  uint32_t*)0x40020194U) /**< (PWM0) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM0_CMPM6          (*(__IO uint32_t*)0x40020198U) /**< (PWM0) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM0_CMPMUPD6       (*(__O  uint32_t*)0x4002019CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM0_CMPV7          (*(__IO uint32_t*)0x400201A0U) /**< (PWM0) PWM Comparison 0 Value Register 7 */
+#define REG_PWM0_CMPVUPD7       (*(__O  uint32_t*)0x400201A4U) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM0_CMPM7          (*(__IO uint32_t*)0x400201A8U) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM0_CMPMUPD7       (*(__O  uint32_t*)0x400201ACU) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM0_CMR0           (*(__IO uint32_t*)0x40020200U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 0 */
+#define REG_PWM0_CDTY0          (*(__IO uint32_t*)0x40020204U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
+#define REG_PWM0_CDTYUPD0       (*(__O  uint32_t*)0x40020208U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CPRD0          (*(__IO uint32_t*)0x4002020CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 0 */
+#define REG_PWM0_CPRDUPD0       (*(__O  uint32_t*)0x40020210U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CCNT0          (*(__I  uint32_t*)0x40020214U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 0 */
+#define REG_PWM0_DT0            (*(__IO uint32_t*)0x40020218U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 0 */
+#define REG_PWM0_DTUPD0         (*(__O  uint32_t*)0x4002021CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
+#define REG_PWM0_CMR1           (*(__IO uint32_t*)0x40020220U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 1 */
+#define REG_PWM0_CDTY1          (*(__IO uint32_t*)0x40020224U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
+#define REG_PWM0_CDTYUPD1       (*(__O  uint32_t*)0x40020228U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CPRD1          (*(__IO uint32_t*)0x4002022CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 1 */
+#define REG_PWM0_CPRDUPD1       (*(__O  uint32_t*)0x40020230U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CCNT1          (*(__I  uint32_t*)0x40020234U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 1 */
+#define REG_PWM0_DT1            (*(__IO uint32_t*)0x40020238U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 1 */
+#define REG_PWM0_DTUPD1         (*(__O  uint32_t*)0x4002023CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
+#define REG_PWM0_CMR2           (*(__IO uint32_t*)0x40020240U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 2 */
+#define REG_PWM0_CDTY2          (*(__IO uint32_t*)0x40020244U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
+#define REG_PWM0_CDTYUPD2       (*(__O  uint32_t*)0x40020248U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CPRD2          (*(__IO uint32_t*)0x4002024CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 2 */
+#define REG_PWM0_CPRDUPD2       (*(__O  uint32_t*)0x40020250U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CCNT2          (*(__I  uint32_t*)0x40020254U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 2 */
+#define REG_PWM0_DT2            (*(__IO uint32_t*)0x40020258U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 2 */
+#define REG_PWM0_DTUPD2         (*(__O  uint32_t*)0x4002025CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
+#define REG_PWM0_CMR3           (*(__IO uint32_t*)0x40020260U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 3 */
+#define REG_PWM0_CDTY3          (*(__IO uint32_t*)0x40020264U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
+#define REG_PWM0_CDTYUPD3       (*(__O  uint32_t*)0x40020268U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CPRD3          (*(__IO uint32_t*)0x4002026CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 3 */
+#define REG_PWM0_CPRDUPD3       (*(__O  uint32_t*)0x40020270U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CCNT3          (*(__I  uint32_t*)0x40020274U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 3 */
+#define REG_PWM0_DT3            (*(__IO uint32_t*)0x40020278U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 3 */
+#define REG_PWM0_DTUPD3         (*(__O  uint32_t*)0x4002027CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CLK            (*(__IO uint32_t*)0x40020000U) /**< (PWM0) PWM Clock Register */
+#define REG_PWM0_ENA            (*(__O  uint32_t*)0x40020004U) /**< (PWM0) PWM Enable Register */
+#define REG_PWM0_DIS            (*(__O  uint32_t*)0x40020008U) /**< (PWM0) PWM Disable Register */
+#define REG_PWM0_SR             (*(__I  uint32_t*)0x4002000CU) /**< (PWM0) PWM Status Register */
+#define REG_PWM0_IER1           (*(__O  uint32_t*)0x40020010U) /**< (PWM0) PWM Interrupt Enable Register 1 */
+#define REG_PWM0_IDR1           (*(__O  uint32_t*)0x40020014U) /**< (PWM0) PWM Interrupt Disable Register 1 */
+#define REG_PWM0_IMR1           (*(__I  uint32_t*)0x40020018U) /**< (PWM0) PWM Interrupt Mask Register 1 */
+#define REG_PWM0_ISR1           (*(__I  uint32_t*)0x4002001CU) /**< (PWM0) PWM Interrupt Status Register 1 */
+#define REG_PWM0_SCM            (*(__IO uint32_t*)0x40020020U) /**< (PWM0) PWM Sync Channels Mode Register */
+#define REG_PWM0_DMAR           (*(__O  uint32_t*)0x40020024U) /**< (PWM0) PWM DMA Register */
+#define REG_PWM0_SCUC           (*(__IO uint32_t*)0x40020028U) /**< (PWM0) PWM Sync Channels Update Control Register */
+#define REG_PWM0_SCUP           (*(__IO uint32_t*)0x4002002CU) /**< (PWM0) PWM Sync Channels Update Period Register */
+#define REG_PWM0_SCUPUPD        (*(__O  uint32_t*)0x40020030U) /**< (PWM0) PWM Sync Channels Update Period Update Register */
+#define REG_PWM0_IER2           (*(__O  uint32_t*)0x40020034U) /**< (PWM0) PWM Interrupt Enable Register 2 */
+#define REG_PWM0_IDR2           (*(__O  uint32_t*)0x40020038U) /**< (PWM0) PWM Interrupt Disable Register 2 */
+#define REG_PWM0_IMR2           (*(__I  uint32_t*)0x4002003CU) /**< (PWM0) PWM Interrupt Mask Register 2 */
+#define REG_PWM0_ISR2           (*(__I  uint32_t*)0x40020040U) /**< (PWM0) PWM Interrupt Status Register 2 */
+#define REG_PWM0_OOV            (*(__IO uint32_t*)0x40020044U) /**< (PWM0) PWM Output Override Value Register */
+#define REG_PWM0_OS             (*(__IO uint32_t*)0x40020048U) /**< (PWM0) PWM Output Selection Register */
+#define REG_PWM0_OSS            (*(__O  uint32_t*)0x4002004CU) /**< (PWM0) PWM Output Selection Set Register */
+#define REG_PWM0_OSC            (*(__O  uint32_t*)0x40020050U) /**< (PWM0) PWM Output Selection Clear Register */
+#define REG_PWM0_OSSUPD         (*(__O  uint32_t*)0x40020054U) /**< (PWM0) PWM Output Selection Set Update Register */
+#define REG_PWM0_OSCUPD         (*(__O  uint32_t*)0x40020058U) /**< (PWM0) PWM Output Selection Clear Update Register */
+#define REG_PWM0_FMR            (*(__IO uint32_t*)0x4002005CU) /**< (PWM0) PWM Fault Mode Register */
+#define REG_PWM0_FSR            (*(__I  uint32_t*)0x40020060U) /**< (PWM0) PWM Fault Status Register */
+#define REG_PWM0_FCR            (*(__O  uint32_t*)0x40020064U) /**< (PWM0) PWM Fault Clear Register */
+#define REG_PWM0_FPV1           (*(__IO uint32_t*)0x40020068U) /**< (PWM0) PWM Fault Protection Value Register 1 */
+#define REG_PWM0_FPE            (*(__IO uint32_t*)0x4002006CU) /**< (PWM0) PWM Fault Protection Enable Register */
+#define REG_PWM0_ELMR           (*(__IO uint32_t*)0x4002007CU) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR0          (*(__IO uint32_t*)0x4002007CU) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR1          (*(__IO uint32_t*)0x40020080U) /**< (PWM0) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM0_SSPR           (*(__IO uint32_t*)0x400200A0U) /**< (PWM0) PWM Spread Spectrum Register */
+#define REG_PWM0_SSPUP          (*(__O  uint32_t*)0x400200A4U) /**< (PWM0) PWM Spread Spectrum Update Register */
+#define REG_PWM0_SMMR           (*(__IO uint32_t*)0x400200B0U) /**< (PWM0) PWM Stepper Motor Mode Register */
+#define REG_PWM0_FPV2           (*(__IO uint32_t*)0x400200C0U) /**< (PWM0) PWM Fault Protection Value 2 Register */
+#define REG_PWM0_WPCR           (*(__O  uint32_t*)0x400200E4U) /**< (PWM0) PWM Write Protection Control Register */
+#define REG_PWM0_WPSR           (*(__I  uint32_t*)0x400200E8U) /**< (PWM0) PWM Write Protection Status Register */
+#define REG_PWM0_VERSION        (*(__I  uint32_t*)0x400200FCU) /**< (PWM0) Version Register */
+#define REG_PWM0_CMUPD0         (*(__O  uint32_t*)0x40020400U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM0_CMUPD1         (*(__O  uint32_t*)0x40020420U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM0_ETRG1          (*(__IO uint32_t*)0x4002042CU) /**< (PWM0) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM0_LEBR1          (*(__IO uint32_t*)0x40020430U) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM0_CMUPD2         (*(__O  uint32_t*)0x40020440U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM0_ETRG2          (*(__IO uint32_t*)0x4002044CU) /**< (PWM0) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM0_LEBR2          (*(__IO uint32_t*)0x40020450U) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM0_CMUPD3         (*(__O  uint32_t*)0x40020460U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 3) */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PWM0 peripheral ========== */
+#define PWM0_DMAC_ID_TX                          13         
+#define PWM0_INSTANCE_ID                         31         
+
+#endif /* _SAMV71_PWM0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/pwm1.h
+++ b/asf/sam/include/samv71/instance/pwm1.h
@@ -1,0 +1,267 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PWM1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_PWM1_INSTANCE_H_
+#define _SAMV71_PWM1_INSTANCE_H_
+
+/* ========== Register definition for PWM1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PWM1_CMPV0          (0x4005C130) /**< (PWM1) PWM Comparison 0 Value Register 0 */
+#define REG_PWM1_CMPVUPD0       (0x4005C134) /**< (PWM1) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM1_CMPM0          (0x4005C138) /**< (PWM1) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM1_CMPMUPD0       (0x4005C13C) /**< (PWM1) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM1_CMPV1          (0x4005C140) /**< (PWM1) PWM Comparison 0 Value Register 1 */
+#define REG_PWM1_CMPVUPD1       (0x4005C144) /**< (PWM1) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM1_CMPM1          (0x4005C148) /**< (PWM1) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM1_CMPMUPD1       (0x4005C14C) /**< (PWM1) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM1_CMPV2          (0x4005C150) /**< (PWM1) PWM Comparison 0 Value Register 2 */
+#define REG_PWM1_CMPVUPD2       (0x4005C154) /**< (PWM1) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM1_CMPM2          (0x4005C158) /**< (PWM1) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM1_CMPMUPD2       (0x4005C15C) /**< (PWM1) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM1_CMPV3          (0x4005C160) /**< (PWM1) PWM Comparison 0 Value Register 3 */
+#define REG_PWM1_CMPVUPD3       (0x4005C164) /**< (PWM1) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM1_CMPM3          (0x4005C168) /**< (PWM1) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM1_CMPMUPD3       (0x4005C16C) /**< (PWM1) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM1_CMPV4          (0x4005C170) /**< (PWM1) PWM Comparison 0 Value Register 4 */
+#define REG_PWM1_CMPVUPD4       (0x4005C174) /**< (PWM1) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM1_CMPM4          (0x4005C178) /**< (PWM1) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM1_CMPMUPD4       (0x4005C17C) /**< (PWM1) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM1_CMPV5          (0x4005C180) /**< (PWM1) PWM Comparison 0 Value Register 5 */
+#define REG_PWM1_CMPVUPD5       (0x4005C184) /**< (PWM1) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM1_CMPM5          (0x4005C188) /**< (PWM1) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM1_CMPMUPD5       (0x4005C18C) /**< (PWM1) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM1_CMPV6          (0x4005C190) /**< (PWM1) PWM Comparison 0 Value Register 6 */
+#define REG_PWM1_CMPVUPD6       (0x4005C194) /**< (PWM1) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM1_CMPM6          (0x4005C198) /**< (PWM1) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM1_CMPMUPD6       (0x4005C19C) /**< (PWM1) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM1_CMPV7          (0x4005C1A0) /**< (PWM1) PWM Comparison 0 Value Register 7 */
+#define REG_PWM1_CMPVUPD7       (0x4005C1A4) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM1_CMPM7          (0x4005C1A8) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM1_CMPMUPD7       (0x4005C1AC) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM1_CMR0           (0x4005C200) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 0 */
+#define REG_PWM1_CDTY0          (0x4005C204) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
+#define REG_PWM1_CDTYUPD0       (0x4005C208) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CPRD0          (0x4005C20C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 0 */
+#define REG_PWM1_CPRDUPD0       (0x4005C210) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CCNT0          (0x4005C214) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 0 */
+#define REG_PWM1_DT0            (0x4005C218) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 0 */
+#define REG_PWM1_DTUPD0         (0x4005C21C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CMR1           (0x4005C220) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 1 */
+#define REG_PWM1_CDTY1          (0x4005C224) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
+#define REG_PWM1_CDTYUPD1       (0x4005C228) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CPRD1          (0x4005C22C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 1 */
+#define REG_PWM1_CPRDUPD1       (0x4005C230) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CCNT1          (0x4005C234) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 1 */
+#define REG_PWM1_DT1            (0x4005C238) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 1 */
+#define REG_PWM1_DTUPD1         (0x4005C23C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CMR2           (0x4005C240) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 2 */
+#define REG_PWM1_CDTY2          (0x4005C244) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
+#define REG_PWM1_CDTYUPD2       (0x4005C248) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CPRD2          (0x4005C24C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 2 */
+#define REG_PWM1_CPRDUPD2       (0x4005C250) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CCNT2          (0x4005C254) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 2 */
+#define REG_PWM1_DT2            (0x4005C258) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 2 */
+#define REG_PWM1_DTUPD2         (0x4005C25C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CMR3           (0x4005C260) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 3 */
+#define REG_PWM1_CDTY3          (0x4005C264) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
+#define REG_PWM1_CDTYUPD3       (0x4005C268) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CPRD3          (0x4005C26C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 3 */
+#define REG_PWM1_CPRDUPD3       (0x4005C270) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CCNT3          (0x4005C274) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 3 */
+#define REG_PWM1_DT3            (0x4005C278) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 3 */
+#define REG_PWM1_DTUPD3         (0x4005C27C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CLK            (0x4005C000) /**< (PWM1) PWM Clock Register */
+#define REG_PWM1_ENA            (0x4005C004) /**< (PWM1) PWM Enable Register */
+#define REG_PWM1_DIS            (0x4005C008) /**< (PWM1) PWM Disable Register */
+#define REG_PWM1_SR             (0x4005C00C) /**< (PWM1) PWM Status Register */
+#define REG_PWM1_IER1           (0x4005C010) /**< (PWM1) PWM Interrupt Enable Register 1 */
+#define REG_PWM1_IDR1           (0x4005C014) /**< (PWM1) PWM Interrupt Disable Register 1 */
+#define REG_PWM1_IMR1           (0x4005C018) /**< (PWM1) PWM Interrupt Mask Register 1 */
+#define REG_PWM1_ISR1           (0x4005C01C) /**< (PWM1) PWM Interrupt Status Register 1 */
+#define REG_PWM1_SCM            (0x4005C020) /**< (PWM1) PWM Sync Channels Mode Register */
+#define REG_PWM1_DMAR           (0x4005C024) /**< (PWM1) PWM DMA Register */
+#define REG_PWM1_SCUC           (0x4005C028) /**< (PWM1) PWM Sync Channels Update Control Register */
+#define REG_PWM1_SCUP           (0x4005C02C) /**< (PWM1) PWM Sync Channels Update Period Register */
+#define REG_PWM1_SCUPUPD        (0x4005C030) /**< (PWM1) PWM Sync Channels Update Period Update Register */
+#define REG_PWM1_IER2           (0x4005C034) /**< (PWM1) PWM Interrupt Enable Register 2 */
+#define REG_PWM1_IDR2           (0x4005C038) /**< (PWM1) PWM Interrupt Disable Register 2 */
+#define REG_PWM1_IMR2           (0x4005C03C) /**< (PWM1) PWM Interrupt Mask Register 2 */
+#define REG_PWM1_ISR2           (0x4005C040) /**< (PWM1) PWM Interrupt Status Register 2 */
+#define REG_PWM1_OOV            (0x4005C044) /**< (PWM1) PWM Output Override Value Register */
+#define REG_PWM1_OS             (0x4005C048) /**< (PWM1) PWM Output Selection Register */
+#define REG_PWM1_OSS            (0x4005C04C) /**< (PWM1) PWM Output Selection Set Register */
+#define REG_PWM1_OSC            (0x4005C050) /**< (PWM1) PWM Output Selection Clear Register */
+#define REG_PWM1_OSSUPD         (0x4005C054) /**< (PWM1) PWM Output Selection Set Update Register */
+#define REG_PWM1_OSCUPD         (0x4005C058) /**< (PWM1) PWM Output Selection Clear Update Register */
+#define REG_PWM1_FMR            (0x4005C05C) /**< (PWM1) PWM Fault Mode Register */
+#define REG_PWM1_FSR            (0x4005C060) /**< (PWM1) PWM Fault Status Register */
+#define REG_PWM1_FCR            (0x4005C064) /**< (PWM1) PWM Fault Clear Register */
+#define REG_PWM1_FPV1           (0x4005C068) /**< (PWM1) PWM Fault Protection Value Register 1 */
+#define REG_PWM1_FPE            (0x4005C06C) /**< (PWM1) PWM Fault Protection Enable Register */
+#define REG_PWM1_ELMR           (0x4005C07C) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR0          (0x4005C07C) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR1          (0x4005C080) /**< (PWM1) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM1_SSPR           (0x4005C0A0) /**< (PWM1) PWM Spread Spectrum Register */
+#define REG_PWM1_SSPUP          (0x4005C0A4) /**< (PWM1) PWM Spread Spectrum Update Register */
+#define REG_PWM1_SMMR           (0x4005C0B0) /**< (PWM1) PWM Stepper Motor Mode Register */
+#define REG_PWM1_FPV2           (0x4005C0C0) /**< (PWM1) PWM Fault Protection Value 2 Register */
+#define REG_PWM1_WPCR           (0x4005C0E4) /**< (PWM1) PWM Write Protection Control Register */
+#define REG_PWM1_WPSR           (0x4005C0E8) /**< (PWM1) PWM Write Protection Status Register */
+#define REG_PWM1_VERSION        (0x4005C0FC) /**< (PWM1) Version Register */
+#define REG_PWM1_CMUPD0         (0x4005C400) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM1_CMUPD1         (0x4005C420) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM1_ETRG1          (0x4005C42C) /**< (PWM1) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM1_LEBR1          (0x4005C430) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM1_CMUPD2         (0x4005C440) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM1_ETRG2          (0x4005C44C) /**< (PWM1) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM1_LEBR2          (0x4005C450) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM1_CMUPD3         (0x4005C460) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 3) */
+
+#else
+
+#define REG_PWM1_CMPV0          (*(__IO uint32_t*)0x4005C130U) /**< (PWM1) PWM Comparison 0 Value Register 0 */
+#define REG_PWM1_CMPVUPD0       (*(__O  uint32_t*)0x4005C134U) /**< (PWM1) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM1_CMPM0          (*(__IO uint32_t*)0x4005C138U) /**< (PWM1) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM1_CMPMUPD0       (*(__O  uint32_t*)0x4005C13CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM1_CMPV1          (*(__IO uint32_t*)0x4005C140U) /**< (PWM1) PWM Comparison 0 Value Register 1 */
+#define REG_PWM1_CMPVUPD1       (*(__O  uint32_t*)0x4005C144U) /**< (PWM1) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM1_CMPM1          (*(__IO uint32_t*)0x4005C148U) /**< (PWM1) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM1_CMPMUPD1       (*(__O  uint32_t*)0x4005C14CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM1_CMPV2          (*(__IO uint32_t*)0x4005C150U) /**< (PWM1) PWM Comparison 0 Value Register 2 */
+#define REG_PWM1_CMPVUPD2       (*(__O  uint32_t*)0x4005C154U) /**< (PWM1) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM1_CMPM2          (*(__IO uint32_t*)0x4005C158U) /**< (PWM1) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM1_CMPMUPD2       (*(__O  uint32_t*)0x4005C15CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM1_CMPV3          (*(__IO uint32_t*)0x4005C160U) /**< (PWM1) PWM Comparison 0 Value Register 3 */
+#define REG_PWM1_CMPVUPD3       (*(__O  uint32_t*)0x4005C164U) /**< (PWM1) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM1_CMPM3          (*(__IO uint32_t*)0x4005C168U) /**< (PWM1) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM1_CMPMUPD3       (*(__O  uint32_t*)0x4005C16CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM1_CMPV4          (*(__IO uint32_t*)0x4005C170U) /**< (PWM1) PWM Comparison 0 Value Register 4 */
+#define REG_PWM1_CMPVUPD4       (*(__O  uint32_t*)0x4005C174U) /**< (PWM1) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM1_CMPM4          (*(__IO uint32_t*)0x4005C178U) /**< (PWM1) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM1_CMPMUPD4       (*(__O  uint32_t*)0x4005C17CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM1_CMPV5          (*(__IO uint32_t*)0x4005C180U) /**< (PWM1) PWM Comparison 0 Value Register 5 */
+#define REG_PWM1_CMPVUPD5       (*(__O  uint32_t*)0x4005C184U) /**< (PWM1) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM1_CMPM5          (*(__IO uint32_t*)0x4005C188U) /**< (PWM1) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM1_CMPMUPD5       (*(__O  uint32_t*)0x4005C18CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM1_CMPV6          (*(__IO uint32_t*)0x4005C190U) /**< (PWM1) PWM Comparison 0 Value Register 6 */
+#define REG_PWM1_CMPVUPD6       (*(__O  uint32_t*)0x4005C194U) /**< (PWM1) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM1_CMPM6          (*(__IO uint32_t*)0x4005C198U) /**< (PWM1) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM1_CMPMUPD6       (*(__O  uint32_t*)0x4005C19CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM1_CMPV7          (*(__IO uint32_t*)0x4005C1A0U) /**< (PWM1) PWM Comparison 0 Value Register 7 */
+#define REG_PWM1_CMPVUPD7       (*(__O  uint32_t*)0x4005C1A4U) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM1_CMPM7          (*(__IO uint32_t*)0x4005C1A8U) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM1_CMPMUPD7       (*(__O  uint32_t*)0x4005C1ACU) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM1_CMR0           (*(__IO uint32_t*)0x4005C200U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 0 */
+#define REG_PWM1_CDTY0          (*(__IO uint32_t*)0x4005C204U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
+#define REG_PWM1_CDTYUPD0       (*(__O  uint32_t*)0x4005C208U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CPRD0          (*(__IO uint32_t*)0x4005C20CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 0 */
+#define REG_PWM1_CPRDUPD0       (*(__O  uint32_t*)0x4005C210U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CCNT0          (*(__I  uint32_t*)0x4005C214U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 0 */
+#define REG_PWM1_DT0            (*(__IO uint32_t*)0x4005C218U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 0 */
+#define REG_PWM1_DTUPD0         (*(__O  uint32_t*)0x4005C21CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
+#define REG_PWM1_CMR1           (*(__IO uint32_t*)0x4005C220U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 1 */
+#define REG_PWM1_CDTY1          (*(__IO uint32_t*)0x4005C224U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
+#define REG_PWM1_CDTYUPD1       (*(__O  uint32_t*)0x4005C228U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CPRD1          (*(__IO uint32_t*)0x4005C22CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 1 */
+#define REG_PWM1_CPRDUPD1       (*(__O  uint32_t*)0x4005C230U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CCNT1          (*(__I  uint32_t*)0x4005C234U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 1 */
+#define REG_PWM1_DT1            (*(__IO uint32_t*)0x4005C238U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 1 */
+#define REG_PWM1_DTUPD1         (*(__O  uint32_t*)0x4005C23CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
+#define REG_PWM1_CMR2           (*(__IO uint32_t*)0x4005C240U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 2 */
+#define REG_PWM1_CDTY2          (*(__IO uint32_t*)0x4005C244U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
+#define REG_PWM1_CDTYUPD2       (*(__O  uint32_t*)0x4005C248U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CPRD2          (*(__IO uint32_t*)0x4005C24CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 2 */
+#define REG_PWM1_CPRDUPD2       (*(__O  uint32_t*)0x4005C250U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CCNT2          (*(__I  uint32_t*)0x4005C254U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 2 */
+#define REG_PWM1_DT2            (*(__IO uint32_t*)0x4005C258U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 2 */
+#define REG_PWM1_DTUPD2         (*(__O  uint32_t*)0x4005C25CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
+#define REG_PWM1_CMR3           (*(__IO uint32_t*)0x4005C260U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 3 */
+#define REG_PWM1_CDTY3          (*(__IO uint32_t*)0x4005C264U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
+#define REG_PWM1_CDTYUPD3       (*(__O  uint32_t*)0x4005C268U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CPRD3          (*(__IO uint32_t*)0x4005C26CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 3 */
+#define REG_PWM1_CPRDUPD3       (*(__O  uint32_t*)0x4005C270U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CCNT3          (*(__I  uint32_t*)0x4005C274U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 3 */
+#define REG_PWM1_DT3            (*(__IO uint32_t*)0x4005C278U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 3 */
+#define REG_PWM1_DTUPD3         (*(__O  uint32_t*)0x4005C27CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CLK            (*(__IO uint32_t*)0x4005C000U) /**< (PWM1) PWM Clock Register */
+#define REG_PWM1_ENA            (*(__O  uint32_t*)0x4005C004U) /**< (PWM1) PWM Enable Register */
+#define REG_PWM1_DIS            (*(__O  uint32_t*)0x4005C008U) /**< (PWM1) PWM Disable Register */
+#define REG_PWM1_SR             (*(__I  uint32_t*)0x4005C00CU) /**< (PWM1) PWM Status Register */
+#define REG_PWM1_IER1           (*(__O  uint32_t*)0x4005C010U) /**< (PWM1) PWM Interrupt Enable Register 1 */
+#define REG_PWM1_IDR1           (*(__O  uint32_t*)0x4005C014U) /**< (PWM1) PWM Interrupt Disable Register 1 */
+#define REG_PWM1_IMR1           (*(__I  uint32_t*)0x4005C018U) /**< (PWM1) PWM Interrupt Mask Register 1 */
+#define REG_PWM1_ISR1           (*(__I  uint32_t*)0x4005C01CU) /**< (PWM1) PWM Interrupt Status Register 1 */
+#define REG_PWM1_SCM            (*(__IO uint32_t*)0x4005C020U) /**< (PWM1) PWM Sync Channels Mode Register */
+#define REG_PWM1_DMAR           (*(__O  uint32_t*)0x4005C024U) /**< (PWM1) PWM DMA Register */
+#define REG_PWM1_SCUC           (*(__IO uint32_t*)0x4005C028U) /**< (PWM1) PWM Sync Channels Update Control Register */
+#define REG_PWM1_SCUP           (*(__IO uint32_t*)0x4005C02CU) /**< (PWM1) PWM Sync Channels Update Period Register */
+#define REG_PWM1_SCUPUPD        (*(__O  uint32_t*)0x4005C030U) /**< (PWM1) PWM Sync Channels Update Period Update Register */
+#define REG_PWM1_IER2           (*(__O  uint32_t*)0x4005C034U) /**< (PWM1) PWM Interrupt Enable Register 2 */
+#define REG_PWM1_IDR2           (*(__O  uint32_t*)0x4005C038U) /**< (PWM1) PWM Interrupt Disable Register 2 */
+#define REG_PWM1_IMR2           (*(__I  uint32_t*)0x4005C03CU) /**< (PWM1) PWM Interrupt Mask Register 2 */
+#define REG_PWM1_ISR2           (*(__I  uint32_t*)0x4005C040U) /**< (PWM1) PWM Interrupt Status Register 2 */
+#define REG_PWM1_OOV            (*(__IO uint32_t*)0x4005C044U) /**< (PWM1) PWM Output Override Value Register */
+#define REG_PWM1_OS             (*(__IO uint32_t*)0x4005C048U) /**< (PWM1) PWM Output Selection Register */
+#define REG_PWM1_OSS            (*(__O  uint32_t*)0x4005C04CU) /**< (PWM1) PWM Output Selection Set Register */
+#define REG_PWM1_OSC            (*(__O  uint32_t*)0x4005C050U) /**< (PWM1) PWM Output Selection Clear Register */
+#define REG_PWM1_OSSUPD         (*(__O  uint32_t*)0x4005C054U) /**< (PWM1) PWM Output Selection Set Update Register */
+#define REG_PWM1_OSCUPD         (*(__O  uint32_t*)0x4005C058U) /**< (PWM1) PWM Output Selection Clear Update Register */
+#define REG_PWM1_FMR            (*(__IO uint32_t*)0x4005C05CU) /**< (PWM1) PWM Fault Mode Register */
+#define REG_PWM1_FSR            (*(__I  uint32_t*)0x4005C060U) /**< (PWM1) PWM Fault Status Register */
+#define REG_PWM1_FCR            (*(__O  uint32_t*)0x4005C064U) /**< (PWM1) PWM Fault Clear Register */
+#define REG_PWM1_FPV1           (*(__IO uint32_t*)0x4005C068U) /**< (PWM1) PWM Fault Protection Value Register 1 */
+#define REG_PWM1_FPE            (*(__IO uint32_t*)0x4005C06CU) /**< (PWM1) PWM Fault Protection Enable Register */
+#define REG_PWM1_ELMR           (*(__IO uint32_t*)0x4005C07CU) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR0          (*(__IO uint32_t*)0x4005C07CU) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR1          (*(__IO uint32_t*)0x4005C080U) /**< (PWM1) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM1_SSPR           (*(__IO uint32_t*)0x4005C0A0U) /**< (PWM1) PWM Spread Spectrum Register */
+#define REG_PWM1_SSPUP          (*(__O  uint32_t*)0x4005C0A4U) /**< (PWM1) PWM Spread Spectrum Update Register */
+#define REG_PWM1_SMMR           (*(__IO uint32_t*)0x4005C0B0U) /**< (PWM1) PWM Stepper Motor Mode Register */
+#define REG_PWM1_FPV2           (*(__IO uint32_t*)0x4005C0C0U) /**< (PWM1) PWM Fault Protection Value 2 Register */
+#define REG_PWM1_WPCR           (*(__O  uint32_t*)0x4005C0E4U) /**< (PWM1) PWM Write Protection Control Register */
+#define REG_PWM1_WPSR           (*(__I  uint32_t*)0x4005C0E8U) /**< (PWM1) PWM Write Protection Status Register */
+#define REG_PWM1_VERSION        (*(__I  uint32_t*)0x4005C0FCU) /**< (PWM1) Version Register */
+#define REG_PWM1_CMUPD0         (*(__O  uint32_t*)0x4005C400U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM1_CMUPD1         (*(__O  uint32_t*)0x4005C420U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM1_ETRG1          (*(__IO uint32_t*)0x4005C42CU) /**< (PWM1) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM1_LEBR1          (*(__IO uint32_t*)0x4005C430U) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM1_CMUPD2         (*(__O  uint32_t*)0x4005C440U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM1_ETRG2          (*(__IO uint32_t*)0x4005C44CU) /**< (PWM1) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM1_LEBR2          (*(__IO uint32_t*)0x4005C450U) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM1_CMUPD3         (*(__O  uint32_t*)0x4005C460U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 3) */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PWM1 peripheral ========== */
+#define PWM1_DMAC_ID_TX                          39         
+#define PWM1_INSTANCE_ID                         60         
+
+#endif /* _SAMV71_PWM1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/qspi.h
+++ b/asf/sam/include/samv71/instance/qspi.h
@@ -1,0 +1,82 @@
+/**
+ * \file
+ *
+ * \brief Instance description for QSPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_QSPI_INSTANCE_H_
+#define _SAMV71_QSPI_INSTANCE_H_
+
+/* ========== Register definition for QSPI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_QSPI_CR             (0x4007C000) /**< (QSPI) Control Register */
+#define REG_QSPI_MR             (0x4007C004) /**< (QSPI) Mode Register */
+#define REG_QSPI_RDR            (0x4007C008) /**< (QSPI) Receive Data Register */
+#define REG_QSPI_TDR            (0x4007C00C) /**< (QSPI) Transmit Data Register */
+#define REG_QSPI_SR             (0x4007C010) /**< (QSPI) Status Register */
+#define REG_QSPI_IER            (0x4007C014) /**< (QSPI) Interrupt Enable Register */
+#define REG_QSPI_IDR            (0x4007C018) /**< (QSPI) Interrupt Disable Register */
+#define REG_QSPI_IMR            (0x4007C01C) /**< (QSPI) Interrupt Mask Register */
+#define REG_QSPI_SCR            (0x4007C020) /**< (QSPI) Serial Clock Register */
+#define REG_QSPI_IAR            (0x4007C030) /**< (QSPI) Instruction Address Register */
+#define REG_QSPI_ICR            (0x4007C034) /**< (QSPI) Instruction Code Register */
+#define REG_QSPI_IFR            (0x4007C038) /**< (QSPI) Instruction Frame Register */
+#define REG_QSPI_SMR            (0x4007C040) /**< (QSPI) Scrambling Mode Register */
+#define REG_QSPI_SKR            (0x4007C044) /**< (QSPI) Scrambling Key Register */
+#define REG_QSPI_WPMR           (0x4007C0E4) /**< (QSPI) Write Protection Mode Register */
+#define REG_QSPI_WPSR           (0x4007C0E8) /**< (QSPI) Write Protection Status Register */
+#define REG_QSPI_VERSION        (0x4007C0FC) /**< (QSPI) Version Register */
+
+#else
+
+#define REG_QSPI_CR             (*(__O  uint32_t*)0x4007C000U) /**< (QSPI) Control Register */
+#define REG_QSPI_MR             (*(__IO uint32_t*)0x4007C004U) /**< (QSPI) Mode Register */
+#define REG_QSPI_RDR            (*(__I  uint32_t*)0x4007C008U) /**< (QSPI) Receive Data Register */
+#define REG_QSPI_TDR            (*(__O  uint32_t*)0x4007C00CU) /**< (QSPI) Transmit Data Register */
+#define REG_QSPI_SR             (*(__I  uint32_t*)0x4007C010U) /**< (QSPI) Status Register */
+#define REG_QSPI_IER            (*(__O  uint32_t*)0x4007C014U) /**< (QSPI) Interrupt Enable Register */
+#define REG_QSPI_IDR            (*(__O  uint32_t*)0x4007C018U) /**< (QSPI) Interrupt Disable Register */
+#define REG_QSPI_IMR            (*(__I  uint32_t*)0x4007C01CU) /**< (QSPI) Interrupt Mask Register */
+#define REG_QSPI_SCR            (*(__IO uint32_t*)0x4007C020U) /**< (QSPI) Serial Clock Register */
+#define REG_QSPI_IAR            (*(__IO uint32_t*)0x4007C030U) /**< (QSPI) Instruction Address Register */
+#define REG_QSPI_ICR            (*(__IO uint32_t*)0x4007C034U) /**< (QSPI) Instruction Code Register */
+#define REG_QSPI_IFR            (*(__IO uint32_t*)0x4007C038U) /**< (QSPI) Instruction Frame Register */
+#define REG_QSPI_SMR            (*(__IO uint32_t*)0x4007C040U) /**< (QSPI) Scrambling Mode Register */
+#define REG_QSPI_SKR            (*(__O  uint32_t*)0x4007C044U) /**< (QSPI) Scrambling Key Register */
+#define REG_QSPI_WPMR           (*(__IO uint32_t*)0x4007C0E4U) /**< (QSPI) Write Protection Mode Register */
+#define REG_QSPI_WPSR           (*(__I  uint32_t*)0x4007C0E8U) /**< (QSPI) Write Protection Status Register */
+#define REG_QSPI_VERSION        (*(__I  uint32_t*)0x4007C0FCU) /**< (QSPI) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for QSPI peripheral ========== */
+#define QSPI_DMAC_ID_RX                          6          
+#define QSPI_DMAC_ID_TX                          5          
+#define QSPI_INSTANCE_ID                         43         
+
+#endif /* _SAMV71_QSPI_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/rstc.h
+++ b/asf/sam/include/samv71/instance/rstc.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RSTC_INSTANCE_H_
+#define _SAMV71_RSTC_INSTANCE_H_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSTC_CR             (0x400E1800) /**< (RSTC) Control Register */
+#define REG_RSTC_SR             (0x400E1804) /**< (RSTC) Status Register */
+#define REG_RSTC_MR             (0x400E1808) /**< (RSTC) Mode Register */
+
+#else
+
+#define REG_RSTC_CR             (*(__O  uint32_t*)0x400E1800U) /**< (RSTC) Control Register */
+#define REG_RSTC_SR             (*(__I  uint32_t*)0x400E1804U) /**< (RSTC) Status Register */
+#define REG_RSTC_MR             (*(__IO uint32_t*)0x400E1808U) /**< (RSTC) Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSTC peripheral ========== */
+#define RSTC_INSTANCE_ID                         1          
+
+#endif /* _SAMV71_RSTC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/rswdt.h
+++ b/asf/sam/include/samv71/instance/rswdt.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSWDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RSWDT_INSTANCE_H_
+#define _SAMV71_RSWDT_INSTANCE_H_
+
+/* ========== Register definition for RSWDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSWDT_CR            (0x400E1900) /**< (RSWDT) Control Register */
+#define REG_RSWDT_MR            (0x400E1904) /**< (RSWDT) Mode Register */
+#define REG_RSWDT_SR            (0x400E1908) /**< (RSWDT) Status Register */
+
+#else
+
+#define REG_RSWDT_CR            (*(__O  uint32_t*)0x400E1900U) /**< (RSWDT) Control Register */
+#define REG_RSWDT_MR            (*(__IO uint32_t*)0x400E1904U) /**< (RSWDT) Mode Register */
+#define REG_RSWDT_SR            (*(__I  uint32_t*)0x400E1908U) /**< (RSWDT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSWDT peripheral ========== */
+#define RSWDT_INSTANCE_ID                        63         
+
+#endif /* _SAMV71_RSWDT_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/rtc.h
+++ b/asf/sam/include/samv71/instance/rtc.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RTC_INSTANCE_H_
+#define _SAMV71_RTC_INSTANCE_H_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTC_CR              (0x400E1860) /**< (RTC) Control Register */
+#define REG_RTC_MR              (0x400E1864) /**< (RTC) Mode Register */
+#define REG_RTC_TIMR            (0x400E1868) /**< (RTC) Time Register */
+#define REG_RTC_CALR            (0x400E186C) /**< (RTC) Calendar Register */
+#define REG_RTC_TIMALR          (0x400E1870) /**< (RTC) Time Alarm Register */
+#define REG_RTC_CALALR          (0x400E1874) /**< (RTC) Calendar Alarm Register */
+#define REG_RTC_SR              (0x400E1878) /**< (RTC) Status Register */
+#define REG_RTC_SCCR            (0x400E187C) /**< (RTC) Status Clear Command Register */
+#define REG_RTC_IER             (0x400E1880) /**< (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
+#define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
+#define REG_RTC_VERSION         (0x400E195C) /**< (RTC) Version Register */
+
+#else
+
+#define REG_RTC_CR              (*(__IO uint32_t*)0x400E1860U) /**< (RTC) Control Register */
+#define REG_RTC_MR              (*(__IO uint32_t*)0x400E1864U) /**< (RTC) Mode Register */
+#define REG_RTC_TIMR            (*(__IO uint32_t*)0x400E1868U) /**< (RTC) Time Register */
+#define REG_RTC_CALR            (*(__IO uint32_t*)0x400E186CU) /**< (RTC) Calendar Register */
+#define REG_RTC_TIMALR          (*(__IO uint32_t*)0x400E1870U) /**< (RTC) Time Alarm Register */
+#define REG_RTC_CALALR          (*(__IO uint32_t*)0x400E1874U) /**< (RTC) Calendar Alarm Register */
+#define REG_RTC_SR              (*(__I  uint32_t*)0x400E1878U) /**< (RTC) Status Register */
+#define REG_RTC_SCCR            (*(__O  uint32_t*)0x400E187CU) /**< (RTC) Status Clear Command Register */
+#define REG_RTC_IER             (*(__O  uint32_t*)0x400E1880U) /**< (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
+#define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
+#define REG_RTC_VERSION         (*(__I  uint32_t*)0x400E195CU) /**< (RTC) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTC peripheral ========== */
+#define RTC_INSTANCE_ID                          2          
+
+#endif /* _SAMV71_RTC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/rtt.h
+++ b/asf/sam/include/samv71/instance/rtt.h
@@ -1,0 +1,54 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_RTT_INSTANCE_H_
+#define _SAMV71_RTT_INSTANCE_H_
+
+/* ========== Register definition for RTT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTT_MR              (0x400E1830) /**< (RTT) Mode Register */
+#define REG_RTT_AR              (0x400E1834) /**< (RTT) Alarm Register */
+#define REG_RTT_VR              (0x400E1838) /**< (RTT) Value Register */
+#define REG_RTT_SR              (0x400E183C) /**< (RTT) Status Register */
+
+#else
+
+#define REG_RTT_MR              (*(__IO uint32_t*)0x400E1830U) /**< (RTT) Mode Register */
+#define REG_RTT_AR              (*(__IO uint32_t*)0x400E1834U) /**< (RTT) Alarm Register */
+#define REG_RTT_VR              (*(__I  uint32_t*)0x400E1838U) /**< (RTT) Value Register */
+#define REG_RTT_SR              (*(__I  uint32_t*)0x400E183CU) /**< (RTT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTT peripheral ========== */
+#define RTT_INSTANCE_ID                          3          
+
+#endif /* _SAMV71_RTT_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/sdramc.h
+++ b/asf/sam/include/samv71/instance/sdramc.h
@@ -1,0 +1,74 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SDRAMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SDRAMC_INSTANCE_H_
+#define _SAMV71_SDRAMC_INSTANCE_H_
+
+/* ========== Register definition for SDRAMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SDRAMC_MR           (0x40084000) /**< (SDRAMC) SDRAMC Mode Register */
+#define REG_SDRAMC_TR           (0x40084004) /**< (SDRAMC) SDRAMC Refresh Timer Register */
+#define REG_SDRAMC_CR           (0x40084008) /**< (SDRAMC) SDRAMC Configuration Register */
+#define REG_SDRAMC_LPR          (0x40084010) /**< (SDRAMC) SDRAMC Low Power Register */
+#define REG_SDRAMC_IER          (0x40084014) /**< (SDRAMC) SDRAMC Interrupt Enable Register */
+#define REG_SDRAMC_IDR          (0x40084018) /**< (SDRAMC) SDRAMC Interrupt Disable Register */
+#define REG_SDRAMC_IMR          (0x4008401C) /**< (SDRAMC) SDRAMC Interrupt Mask Register */
+#define REG_SDRAMC_ISR          (0x40084020) /**< (SDRAMC) SDRAMC Interrupt Status Register */
+#define REG_SDRAMC_MDR          (0x40084024) /**< (SDRAMC) SDRAMC Memory Device Register */
+#define REG_SDRAMC_CFR1         (0x40084028) /**< (SDRAMC) SDRAMC Configuration Register 1 */
+#define REG_SDRAMC_OCMS         (0x4008402C) /**< (SDRAMC) SDRAMC OCMS Register */
+#define REG_SDRAMC_OCMS_KEY1    (0x40084030) /**< (SDRAMC) SDRAMC OCMS KEY1 Register */
+#define REG_SDRAMC_OCMS_KEY2    (0x40084034) /**< (SDRAMC) SDRAMC OCMS KEY2 Register */
+#define REG_SDRAMC_VERSION      (0x400840FC) /**< (SDRAMC) SDRAMC Version Register */
+
+#else
+
+#define REG_SDRAMC_MR           (*(__IO uint32_t*)0x40084000U) /**< (SDRAMC) SDRAMC Mode Register */
+#define REG_SDRAMC_TR           (*(__IO uint32_t*)0x40084004U) /**< (SDRAMC) SDRAMC Refresh Timer Register */
+#define REG_SDRAMC_CR           (*(__IO uint32_t*)0x40084008U) /**< (SDRAMC) SDRAMC Configuration Register */
+#define REG_SDRAMC_LPR          (*(__IO uint32_t*)0x40084010U) /**< (SDRAMC) SDRAMC Low Power Register */
+#define REG_SDRAMC_IER          (*(__O  uint32_t*)0x40084014U) /**< (SDRAMC) SDRAMC Interrupt Enable Register */
+#define REG_SDRAMC_IDR          (*(__O  uint32_t*)0x40084018U) /**< (SDRAMC) SDRAMC Interrupt Disable Register */
+#define REG_SDRAMC_IMR          (*(__I  uint32_t*)0x4008401CU) /**< (SDRAMC) SDRAMC Interrupt Mask Register */
+#define REG_SDRAMC_ISR          (*(__I  uint32_t*)0x40084020U) /**< (SDRAMC) SDRAMC Interrupt Status Register */
+#define REG_SDRAMC_MDR          (*(__IO uint32_t*)0x40084024U) /**< (SDRAMC) SDRAMC Memory Device Register */
+#define REG_SDRAMC_CFR1         (*(__IO uint32_t*)0x40084028U) /**< (SDRAMC) SDRAMC Configuration Register 1 */
+#define REG_SDRAMC_OCMS         (*(__IO uint32_t*)0x4008402CU) /**< (SDRAMC) SDRAMC OCMS Register */
+#define REG_SDRAMC_OCMS_KEY1    (*(__O  uint32_t*)0x40084030U) /**< (SDRAMC) SDRAMC OCMS KEY1 Register */
+#define REG_SDRAMC_OCMS_KEY2    (*(__O  uint32_t*)0x40084034U) /**< (SDRAMC) SDRAMC OCMS KEY2 Register */
+#define REG_SDRAMC_VERSION      (*(__I  uint32_t*)0x400840FCU) /**< (SDRAMC) SDRAMC Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SDRAMC peripheral ========== */
+#define SDRAMC_INSTANCE_ID                       62         
+
+#endif /* _SAMV71_SDRAMC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/smc.h
+++ b/asf/sam/include/samv71/instance/smc.h
@@ -1,0 +1,90 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SMC_INSTANCE_H_
+#define _SAMV71_SMC_INSTANCE_H_
+
+/* ========== Register definition for SMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SMC_SETUP0          (0x40080000) /**< (SMC) SMC Setup Register (CS_number = 0) 0 */
+#define REG_SMC_PULSE0          (0x40080004) /**< (SMC) SMC Pulse Register (CS_number = 0) 0 */
+#define REG_SMC_CYCLE0          (0x40080008) /**< (SMC) SMC Cycle Register (CS_number = 0) 0 */
+#define REG_SMC_MODE0           (0x4008000C) /**< (SMC) SMC Mode Register (CS_number = 0) 0 */
+#define REG_SMC_SETUP1          (0x40080010) /**< (SMC) SMC Setup Register (CS_number = 0) 1 */
+#define REG_SMC_PULSE1          (0x40080014) /**< (SMC) SMC Pulse Register (CS_number = 0) 1 */
+#define REG_SMC_CYCLE1          (0x40080018) /**< (SMC) SMC Cycle Register (CS_number = 0) 1 */
+#define REG_SMC_MODE1           (0x4008001C) /**< (SMC) SMC Mode Register (CS_number = 0) 1 */
+#define REG_SMC_SETUP2          (0x40080020) /**< (SMC) SMC Setup Register (CS_number = 0) 2 */
+#define REG_SMC_PULSE2          (0x40080024) /**< (SMC) SMC Pulse Register (CS_number = 0) 2 */
+#define REG_SMC_CYCLE2          (0x40080028) /**< (SMC) SMC Cycle Register (CS_number = 0) 2 */
+#define REG_SMC_MODE2           (0x4008002C) /**< (SMC) SMC Mode Register (CS_number = 0) 2 */
+#define REG_SMC_SETUP3          (0x40080030) /**< (SMC) SMC Setup Register (CS_number = 0) 3 */
+#define REG_SMC_PULSE3          (0x40080034) /**< (SMC) SMC Pulse Register (CS_number = 0) 3 */
+#define REG_SMC_CYCLE3          (0x40080038) /**< (SMC) SMC Cycle Register (CS_number = 0) 3 */
+#define REG_SMC_MODE3           (0x4008003C) /**< (SMC) SMC Mode Register (CS_number = 0) 3 */
+#define REG_SMC_OCMS            (0x40080080) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (0x40080084) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (0x40080088) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
+#define REG_SMC_WPMR            (0x400800E4) /**< (SMC) SMC Write Protection Mode Register */
+#define REG_SMC_WPSR            (0x400800E8) /**< (SMC) SMC Write Protection Status Register */
+#define REG_SMC_VERSION         (0x400800FC) /**< (SMC) SMC Version Register */
+
+#else
+
+#define REG_SMC_SETUP0          (*(__IO uint32_t*)0x40080000U) /**< (SMC) SMC Setup Register (CS_number = 0) 0 */
+#define REG_SMC_PULSE0          (*(__IO uint32_t*)0x40080004U) /**< (SMC) SMC Pulse Register (CS_number = 0) 0 */
+#define REG_SMC_CYCLE0          (*(__IO uint32_t*)0x40080008U) /**< (SMC) SMC Cycle Register (CS_number = 0) 0 */
+#define REG_SMC_MODE0           (*(__IO uint32_t*)0x4008000CU) /**< (SMC) SMC Mode Register (CS_number = 0) 0 */
+#define REG_SMC_SETUP1          (*(__IO uint32_t*)0x40080010U) /**< (SMC) SMC Setup Register (CS_number = 0) 1 */
+#define REG_SMC_PULSE1          (*(__IO uint32_t*)0x40080014U) /**< (SMC) SMC Pulse Register (CS_number = 0) 1 */
+#define REG_SMC_CYCLE1          (*(__IO uint32_t*)0x40080018U) /**< (SMC) SMC Cycle Register (CS_number = 0) 1 */
+#define REG_SMC_MODE1           (*(__IO uint32_t*)0x4008001CU) /**< (SMC) SMC Mode Register (CS_number = 0) 1 */
+#define REG_SMC_SETUP2          (*(__IO uint32_t*)0x40080020U) /**< (SMC) SMC Setup Register (CS_number = 0) 2 */
+#define REG_SMC_PULSE2          (*(__IO uint32_t*)0x40080024U) /**< (SMC) SMC Pulse Register (CS_number = 0) 2 */
+#define REG_SMC_CYCLE2          (*(__IO uint32_t*)0x40080028U) /**< (SMC) SMC Cycle Register (CS_number = 0) 2 */
+#define REG_SMC_MODE2           (*(__IO uint32_t*)0x4008002CU) /**< (SMC) SMC Mode Register (CS_number = 0) 2 */
+#define REG_SMC_SETUP3          (*(__IO uint32_t*)0x40080030U) /**< (SMC) SMC Setup Register (CS_number = 0) 3 */
+#define REG_SMC_PULSE3          (*(__IO uint32_t*)0x40080034U) /**< (SMC) SMC Pulse Register (CS_number = 0) 3 */
+#define REG_SMC_CYCLE3          (*(__IO uint32_t*)0x40080038U) /**< (SMC) SMC Cycle Register (CS_number = 0) 3 */
+#define REG_SMC_MODE3           (*(__IO uint32_t*)0x4008003CU) /**< (SMC) SMC Mode Register (CS_number = 0) 3 */
+#define REG_SMC_OCMS            (*(__IO uint32_t*)0x40080080U) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (*(__O  uint32_t*)0x40080084U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (*(__O  uint32_t*)0x40080088U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
+#define REG_SMC_WPMR            (*(__IO uint32_t*)0x400800E4U) /**< (SMC) SMC Write Protection Mode Register */
+#define REG_SMC_WPSR            (*(__I  uint32_t*)0x400800E8U) /**< (SMC) SMC Write Protection Status Register */
+#define REG_SMC_VERSION         (*(__I  uint32_t*)0x400800FCU) /**< (SMC) SMC Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SMC peripheral ========== */
+#define SMC_INSTANCE_ID                          9          
+
+#endif /* _SAMV71_SMC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/spi0.h
+++ b/asf/sam/include/samv71/instance/spi0.h
@@ -1,0 +1,80 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SPI0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SPI0_INSTANCE_H_
+#define _SAMV71_SPI0_INSTANCE_H_
+
+/* ========== Register definition for SPI0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SPI0_CR             (0x40008000) /**< (SPI0) Control Register */
+#define REG_SPI0_MR             (0x40008004) /**< (SPI0) Mode Register */
+#define REG_SPI0_RDR            (0x40008008) /**< (SPI0) Receive Data Register */
+#define REG_SPI0_TDR            (0x4000800C) /**< (SPI0) Transmit Data Register */
+#define REG_SPI0_SR             (0x40008010) /**< (SPI0) Status Register */
+#define REG_SPI0_IER            (0x40008014) /**< (SPI0) Interrupt Enable Register */
+#define REG_SPI0_IDR            (0x40008018) /**< (SPI0) Interrupt Disable Register */
+#define REG_SPI0_IMR            (0x4000801C) /**< (SPI0) Interrupt Mask Register */
+#define REG_SPI0_CSR            (0x40008030) /**< (SPI0) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI0_CSR0           (0x40008030) /**< (SPI0) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI0_CSR1           (0x40008034) /**< (SPI0) Chip Select Register (CS_number = 0) 1 */
+#define REG_SPI0_CSR2           (0x40008038) /**< (SPI0) Chip Select Register (CS_number = 0) 2 */
+#define REG_SPI0_CSR3           (0x4000803C) /**< (SPI0) Chip Select Register (CS_number = 0) 3 */
+#define REG_SPI0_WPMR           (0x400080E4) /**< (SPI0) Write Protection Mode Register */
+#define REG_SPI0_WPSR           (0x400080E8) /**< (SPI0) Write Protection Status Register */
+#define REG_SPI0_VERSION        (0x400080FC) /**< (SPI0) Version Register */
+
+#else
+
+#define REG_SPI0_CR             (*(__O  uint32_t*)0x40008000U) /**< (SPI0) Control Register */
+#define REG_SPI0_MR             (*(__IO uint32_t*)0x40008004U) /**< (SPI0) Mode Register */
+#define REG_SPI0_RDR            (*(__I  uint32_t*)0x40008008U) /**< (SPI0) Receive Data Register */
+#define REG_SPI0_TDR            (*(__O  uint32_t*)0x4000800CU) /**< (SPI0) Transmit Data Register */
+#define REG_SPI0_SR             (*(__I  uint32_t*)0x40008010U) /**< (SPI0) Status Register */
+#define REG_SPI0_IER            (*(__O  uint32_t*)0x40008014U) /**< (SPI0) Interrupt Enable Register */
+#define REG_SPI0_IDR            (*(__O  uint32_t*)0x40008018U) /**< (SPI0) Interrupt Disable Register */
+#define REG_SPI0_IMR            (*(__I  uint32_t*)0x4000801CU) /**< (SPI0) Interrupt Mask Register */
+#define REG_SPI0_CSR            (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI0_CSR0           (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI0_CSR1           (*(__IO uint32_t*)0x40008034U) /**< (SPI0) Chip Select Register (CS_number = 0) 1 */
+#define REG_SPI0_CSR2           (*(__IO uint32_t*)0x40008038U) /**< (SPI0) Chip Select Register (CS_number = 0) 2 */
+#define REG_SPI0_CSR3           (*(__IO uint32_t*)0x4000803CU) /**< (SPI0) Chip Select Register (CS_number = 0) 3 */
+#define REG_SPI0_WPMR           (*(__IO uint32_t*)0x400080E4U) /**< (SPI0) Write Protection Mode Register */
+#define REG_SPI0_WPSR           (*(__I  uint32_t*)0x400080E8U) /**< (SPI0) Write Protection Status Register */
+#define REG_SPI0_VERSION        (*(__I  uint32_t*)0x400080FCU) /**< (SPI0) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SPI0 peripheral ========== */
+#define SPI0_DMAC_ID_RX                          2          
+#define SPI0_DMAC_ID_TX                          1          
+#define SPI0_INSTANCE_ID                         21         
+
+#endif /* _SAMV71_SPI0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/spi1.h
+++ b/asf/sam/include/samv71/instance/spi1.h
@@ -1,0 +1,80 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SPI1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SPI1_INSTANCE_H_
+#define _SAMV71_SPI1_INSTANCE_H_
+
+/* ========== Register definition for SPI1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SPI1_CR             (0x40058000) /**< (SPI1) Control Register */
+#define REG_SPI1_MR             (0x40058004) /**< (SPI1) Mode Register */
+#define REG_SPI1_RDR            (0x40058008) /**< (SPI1) Receive Data Register */
+#define REG_SPI1_TDR            (0x4005800C) /**< (SPI1) Transmit Data Register */
+#define REG_SPI1_SR             (0x40058010) /**< (SPI1) Status Register */
+#define REG_SPI1_IER            (0x40058014) /**< (SPI1) Interrupt Enable Register */
+#define REG_SPI1_IDR            (0x40058018) /**< (SPI1) Interrupt Disable Register */
+#define REG_SPI1_IMR            (0x4005801C) /**< (SPI1) Interrupt Mask Register */
+#define REG_SPI1_CSR            (0x40058030) /**< (SPI1) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI1_CSR0           (0x40058030) /**< (SPI1) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI1_CSR1           (0x40058034) /**< (SPI1) Chip Select Register (CS_number = 0) 1 */
+#define REG_SPI1_CSR2           (0x40058038) /**< (SPI1) Chip Select Register (CS_number = 0) 2 */
+#define REG_SPI1_CSR3           (0x4005803C) /**< (SPI1) Chip Select Register (CS_number = 0) 3 */
+#define REG_SPI1_WPMR           (0x400580E4) /**< (SPI1) Write Protection Mode Register */
+#define REG_SPI1_WPSR           (0x400580E8) /**< (SPI1) Write Protection Status Register */
+#define REG_SPI1_VERSION        (0x400580FC) /**< (SPI1) Version Register */
+
+#else
+
+#define REG_SPI1_CR             (*(__O  uint32_t*)0x40058000U) /**< (SPI1) Control Register */
+#define REG_SPI1_MR             (*(__IO uint32_t*)0x40058004U) /**< (SPI1) Mode Register */
+#define REG_SPI1_RDR            (*(__I  uint32_t*)0x40058008U) /**< (SPI1) Receive Data Register */
+#define REG_SPI1_TDR            (*(__O  uint32_t*)0x4005800CU) /**< (SPI1) Transmit Data Register */
+#define REG_SPI1_SR             (*(__I  uint32_t*)0x40058010U) /**< (SPI1) Status Register */
+#define REG_SPI1_IER            (*(__O  uint32_t*)0x40058014U) /**< (SPI1) Interrupt Enable Register */
+#define REG_SPI1_IDR            (*(__O  uint32_t*)0x40058018U) /**< (SPI1) Interrupt Disable Register */
+#define REG_SPI1_IMR            (*(__I  uint32_t*)0x4005801CU) /**< (SPI1) Interrupt Mask Register */
+#define REG_SPI1_CSR            (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI1_CSR0           (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register (CS_number = 0) 0 */
+#define REG_SPI1_CSR1           (*(__IO uint32_t*)0x40058034U) /**< (SPI1) Chip Select Register (CS_number = 0) 1 */
+#define REG_SPI1_CSR2           (*(__IO uint32_t*)0x40058038U) /**< (SPI1) Chip Select Register (CS_number = 0) 2 */
+#define REG_SPI1_CSR3           (*(__IO uint32_t*)0x4005803CU) /**< (SPI1) Chip Select Register (CS_number = 0) 3 */
+#define REG_SPI1_WPMR           (*(__IO uint32_t*)0x400580E4U) /**< (SPI1) Write Protection Mode Register */
+#define REG_SPI1_WPSR           (*(__I  uint32_t*)0x400580E8U) /**< (SPI1) Write Protection Status Register */
+#define REG_SPI1_VERSION        (*(__I  uint32_t*)0x400580FCU) /**< (SPI1) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SPI1 peripheral ========== */
+#define SPI1_DMAC_ID_RX                          4          
+#define SPI1_DMAC_ID_TX                          3          
+#define SPI1_INSTANCE_ID                         42         
+
+#endif /* _SAMV71_SPI1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/ssc.h
+++ b/asf/sam/include/samv71/instance/ssc.h
@@ -1,0 +1,86 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SSC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SSC_INSTANCE_H_
+#define _SAMV71_SSC_INSTANCE_H_
+
+/* ========== Register definition for SSC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SSC_CR              (0x40004000) /**< (SSC) Control Register */
+#define REG_SSC_CMR             (0x40004004) /**< (SSC) Clock Mode Register */
+#define REG_SSC_RCMR            (0x40004010) /**< (SSC) Receive Clock Mode Register */
+#define REG_SSC_RFMR            (0x40004014) /**< (SSC) Receive Frame Mode Register */
+#define REG_SSC_TCMR            (0x40004018) /**< (SSC) Transmit Clock Mode Register */
+#define REG_SSC_TFMR            (0x4000401C) /**< (SSC) Transmit Frame Mode Register */
+#define REG_SSC_RHR             (0x40004020) /**< (SSC) Receive Holding Register */
+#define REG_SSC_THR             (0x40004024) /**< (SSC) Transmit Holding Register */
+#define REG_SSC_RSHR            (0x40004030) /**< (SSC) Receive Sync. Holding Register */
+#define REG_SSC_TSHR            (0x40004034) /**< (SSC) Transmit Sync. Holding Register */
+#define REG_SSC_RC0R            (0x40004038) /**< (SSC) Receive Compare 0 Register */
+#define REG_SSC_RC1R            (0x4000403C) /**< (SSC) Receive Compare 1 Register */
+#define REG_SSC_SR              (0x40004040) /**< (SSC) Status Register */
+#define REG_SSC_IER             (0x40004044) /**< (SSC) Interrupt Enable Register */
+#define REG_SSC_IDR             (0x40004048) /**< (SSC) Interrupt Disable Register */
+#define REG_SSC_IMR             (0x4000404C) /**< (SSC) Interrupt Mask Register */
+#define REG_SSC_WPMR            (0x400040E4) /**< (SSC) Write Protection Mode Register */
+#define REG_SSC_WPSR            (0x400040E8) /**< (SSC) Write Protection Status Register */
+#define REG_SSC_VERSION         (0x400040FC) /**< (SSC) Version Register */
+
+#else
+
+#define REG_SSC_CR              (*(__O  uint32_t*)0x40004000U) /**< (SSC) Control Register */
+#define REG_SSC_CMR             (*(__IO uint32_t*)0x40004004U) /**< (SSC) Clock Mode Register */
+#define REG_SSC_RCMR            (*(__IO uint32_t*)0x40004010U) /**< (SSC) Receive Clock Mode Register */
+#define REG_SSC_RFMR            (*(__IO uint32_t*)0x40004014U) /**< (SSC) Receive Frame Mode Register */
+#define REG_SSC_TCMR            (*(__IO uint32_t*)0x40004018U) /**< (SSC) Transmit Clock Mode Register */
+#define REG_SSC_TFMR            (*(__IO uint32_t*)0x4000401CU) /**< (SSC) Transmit Frame Mode Register */
+#define REG_SSC_RHR             (*(__I  uint32_t*)0x40004020U) /**< (SSC) Receive Holding Register */
+#define REG_SSC_THR             (*(__O  uint32_t*)0x40004024U) /**< (SSC) Transmit Holding Register */
+#define REG_SSC_RSHR            (*(__I  uint32_t*)0x40004030U) /**< (SSC) Receive Sync. Holding Register */
+#define REG_SSC_TSHR            (*(__IO uint32_t*)0x40004034U) /**< (SSC) Transmit Sync. Holding Register */
+#define REG_SSC_RC0R            (*(__IO uint32_t*)0x40004038U) /**< (SSC) Receive Compare 0 Register */
+#define REG_SSC_RC1R            (*(__IO uint32_t*)0x4000403CU) /**< (SSC) Receive Compare 1 Register */
+#define REG_SSC_SR              (*(__I  uint32_t*)0x40004040U) /**< (SSC) Status Register */
+#define REG_SSC_IER             (*(__O  uint32_t*)0x40004044U) /**< (SSC) Interrupt Enable Register */
+#define REG_SSC_IDR             (*(__O  uint32_t*)0x40004048U) /**< (SSC) Interrupt Disable Register */
+#define REG_SSC_IMR             (*(__I  uint32_t*)0x4000404CU) /**< (SSC) Interrupt Mask Register */
+#define REG_SSC_WPMR            (*(__IO uint32_t*)0x400040E4U) /**< (SSC) Write Protection Mode Register */
+#define REG_SSC_WPSR            (*(__I  uint32_t*)0x400040E8U) /**< (SSC) Write Protection Status Register */
+#define REG_SSC_VERSION         (*(__I  uint32_t*)0x400040FCU) /**< (SSC) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SSC peripheral ========== */
+#define SSC_DMAC_ID_RX                           33         
+#define SSC_DMAC_ID_TX                           32         
+#define SSC_INSTANCE_ID                          22         
+
+#endif /* _SAMV71_SSC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/supc.h
+++ b/asf/sam/include/samv71/instance/supc.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SUPC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_SUPC_INSTANCE_H_
+#define _SAMV71_SUPC_INSTANCE_H_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SUPC_CR             (0x400E1810) /**< (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR           (0x400E1814) /**< (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR             (0x400E1818) /**< (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR           (0x400E181C) /**< (SUPC) Supply Controller Wakeup Mode Register */
+#define REG_SUPC_WUIR           (0x400E1820) /**< (SUPC) Supply Controller Wakeup Inputs Register */
+#define REG_SUPC_SR             (0x400E1824) /**< (SUPC) Supply Controller Status Register */
+#define REG_SUPC_SYSC_VERSION   (0x400E190C) /**< (SUPC) Version Register */
+
+#else
+
+#define REG_SUPC_CR             (*(__O  uint32_t*)0x400E1810U) /**< (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR           (*(__IO uint32_t*)0x400E1814U) /**< (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR             (*(__IO uint32_t*)0x400E1818U) /**< (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR           (*(__IO uint32_t*)0x400E181CU) /**< (SUPC) Supply Controller Wakeup Mode Register */
+#define REG_SUPC_WUIR           (*(__IO uint32_t*)0x400E1820U) /**< (SUPC) Supply Controller Wakeup Inputs Register */
+#define REG_SUPC_SR             (*(__I  uint32_t*)0x400E1824U) /**< (SUPC) Supply Controller Status Register */
+#define REG_SUPC_SYSC_VERSION   (*(__I  uint32_t*)0x400E190CU) /**< (SUPC) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SUPC peripheral ========== */
+#define SUPC_INSTANCE_ID                         0          
+
+#endif /* _SAMV71_SUPC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/tc0.h
+++ b/asf/sam/include/samv71/instance/tc0.h
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TC0_INSTANCE_H_
+#define _SAMV71_TC0_INSTANCE_H_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC0_CCR0            (0x4000C000) /**< (TC0) Channel Control Register (channel = 0) 0 */
+#define REG_TC0_CMR0            (0x4000C004) /**< (TC0) Channel Mode Register (channel = 0) 0 */
+#define REG_TC0_SMMR0           (0x4000C008) /**< (TC0) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC0_RAB0            (0x4000C00C) /**< (TC0) Register AB (channel = 0) 0 */
+#define REG_TC0_CV0             (0x4000C010) /**< (TC0) Counter Value (channel = 0) 0 */
+#define REG_TC0_RA0             (0x4000C014) /**< (TC0) Register A (channel = 0) 0 */
+#define REG_TC0_RB0             (0x4000C018) /**< (TC0) Register B (channel = 0) 0 */
+#define REG_TC0_RC0             (0x4000C01C) /**< (TC0) Register C (channel = 0) 0 */
+#define REG_TC0_SR0             (0x4000C020) /**< (TC0) Status Register (channel = 0) 0 */
+#define REG_TC0_IER0            (0x4000C024) /**< (TC0) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC0_IDR0            (0x4000C028) /**< (TC0) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC0_IMR0            (0x4000C02C) /**< (TC0) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC0_EMR0            (0x4000C030) /**< (TC0) Extended Mode Register (channel = 0) 0 */
+#define REG_TC0_CCR1            (0x4000C040) /**< (TC0) Channel Control Register (channel = 0) 1 */
+#define REG_TC0_CMR1            (0x4000C044) /**< (TC0) Channel Mode Register (channel = 0) 1 */
+#define REG_TC0_SMMR1           (0x4000C048) /**< (TC0) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC0_RAB1            (0x4000C04C) /**< (TC0) Register AB (channel = 0) 1 */
+#define REG_TC0_CV1             (0x4000C050) /**< (TC0) Counter Value (channel = 0) 1 */
+#define REG_TC0_RA1             (0x4000C054) /**< (TC0) Register A (channel = 0) 1 */
+#define REG_TC0_RB1             (0x4000C058) /**< (TC0) Register B (channel = 0) 1 */
+#define REG_TC0_RC1             (0x4000C05C) /**< (TC0) Register C (channel = 0) 1 */
+#define REG_TC0_SR1             (0x4000C060) /**< (TC0) Status Register (channel = 0) 1 */
+#define REG_TC0_IER1            (0x4000C064) /**< (TC0) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC0_IDR1            (0x4000C068) /**< (TC0) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC0_IMR1            (0x4000C06C) /**< (TC0) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC0_EMR1            (0x4000C070) /**< (TC0) Extended Mode Register (channel = 0) 1 */
+#define REG_TC0_CCR2            (0x4000C080) /**< (TC0) Channel Control Register (channel = 0) 2 */
+#define REG_TC0_CMR2            (0x4000C084) /**< (TC0) Channel Mode Register (channel = 0) 2 */
+#define REG_TC0_SMMR2           (0x4000C088) /**< (TC0) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC0_RAB2            (0x4000C08C) /**< (TC0) Register AB (channel = 0) 2 */
+#define REG_TC0_CV2             (0x4000C090) /**< (TC0) Counter Value (channel = 0) 2 */
+#define REG_TC0_RA2             (0x4000C094) /**< (TC0) Register A (channel = 0) 2 */
+#define REG_TC0_RB2             (0x4000C098) /**< (TC0) Register B (channel = 0) 2 */
+#define REG_TC0_RC2             (0x4000C09C) /**< (TC0) Register C (channel = 0) 2 */
+#define REG_TC0_SR2             (0x4000C0A0) /**< (TC0) Status Register (channel = 0) 2 */
+#define REG_TC0_IER2            (0x4000C0A4) /**< (TC0) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC0_IDR2            (0x4000C0A8) /**< (TC0) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC0_IMR2            (0x4000C0AC) /**< (TC0) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC0_EMR2            (0x4000C0B0) /**< (TC0) Extended Mode Register (channel = 0) 2 */
+#define REG_TC0_BCR             (0x4000C0C0) /**< (TC0) Block Control Register */
+#define REG_TC0_BMR             (0x4000C0C4) /**< (TC0) Block Mode Register */
+#define REG_TC0_QIER            (0x4000C0C8) /**< (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR            (0x4000C0CC) /**< (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR            (0x4000C0D0) /**< (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR            (0x4000C0D4) /**< (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR             (0x4000C0D8) /**< (TC0) Fault Mode Register */
+#define REG_TC0_WPMR            (0x4000C0E4) /**< (TC0) Write Protection Mode Register */
+#define REG_TC0_VER             (0x4000C0FC) /**< (TC0) Version Register */
+
+#else
+
+#define REG_TC0_CCR0            (*(__O  uint32_t*)0x4000C000U) /**< (TC0) Channel Control Register (channel = 0) 0 */
+#define REG_TC0_CMR0            (*(__IO uint32_t*)0x4000C004U) /**< (TC0) Channel Mode Register (channel = 0) 0 */
+#define REG_TC0_SMMR0           (*(__IO uint32_t*)0x4000C008U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC0_RAB0            (*(__I  uint32_t*)0x4000C00CU) /**< (TC0) Register AB (channel = 0) 0 */
+#define REG_TC0_CV0             (*(__I  uint32_t*)0x4000C010U) /**< (TC0) Counter Value (channel = 0) 0 */
+#define REG_TC0_RA0             (*(__IO uint32_t*)0x4000C014U) /**< (TC0) Register A (channel = 0) 0 */
+#define REG_TC0_RB0             (*(__IO uint32_t*)0x4000C018U) /**< (TC0) Register B (channel = 0) 0 */
+#define REG_TC0_RC0             (*(__IO uint32_t*)0x4000C01CU) /**< (TC0) Register C (channel = 0) 0 */
+#define REG_TC0_SR0             (*(__I  uint32_t*)0x4000C020U) /**< (TC0) Status Register (channel = 0) 0 */
+#define REG_TC0_IER0            (*(__O  uint32_t*)0x4000C024U) /**< (TC0) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC0_IDR0            (*(__O  uint32_t*)0x4000C028U) /**< (TC0) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC0_IMR0            (*(__I  uint32_t*)0x4000C02CU) /**< (TC0) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC0_EMR0            (*(__IO uint32_t*)0x4000C030U) /**< (TC0) Extended Mode Register (channel = 0) 0 */
+#define REG_TC0_CCR1            (*(__O  uint32_t*)0x4000C040U) /**< (TC0) Channel Control Register (channel = 0) 1 */
+#define REG_TC0_CMR1            (*(__IO uint32_t*)0x4000C044U) /**< (TC0) Channel Mode Register (channel = 0) 1 */
+#define REG_TC0_SMMR1           (*(__IO uint32_t*)0x4000C048U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC0_RAB1            (*(__I  uint32_t*)0x4000C04CU) /**< (TC0) Register AB (channel = 0) 1 */
+#define REG_TC0_CV1             (*(__I  uint32_t*)0x4000C050U) /**< (TC0) Counter Value (channel = 0) 1 */
+#define REG_TC0_RA1             (*(__IO uint32_t*)0x4000C054U) /**< (TC0) Register A (channel = 0) 1 */
+#define REG_TC0_RB1             (*(__IO uint32_t*)0x4000C058U) /**< (TC0) Register B (channel = 0) 1 */
+#define REG_TC0_RC1             (*(__IO uint32_t*)0x4000C05CU) /**< (TC0) Register C (channel = 0) 1 */
+#define REG_TC0_SR1             (*(__I  uint32_t*)0x4000C060U) /**< (TC0) Status Register (channel = 0) 1 */
+#define REG_TC0_IER1            (*(__O  uint32_t*)0x4000C064U) /**< (TC0) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC0_IDR1            (*(__O  uint32_t*)0x4000C068U) /**< (TC0) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC0_IMR1            (*(__I  uint32_t*)0x4000C06CU) /**< (TC0) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC0_EMR1            (*(__IO uint32_t*)0x4000C070U) /**< (TC0) Extended Mode Register (channel = 0) 1 */
+#define REG_TC0_CCR2            (*(__O  uint32_t*)0x4000C080U) /**< (TC0) Channel Control Register (channel = 0) 2 */
+#define REG_TC0_CMR2            (*(__IO uint32_t*)0x4000C084U) /**< (TC0) Channel Mode Register (channel = 0) 2 */
+#define REG_TC0_SMMR2           (*(__IO uint32_t*)0x4000C088U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC0_RAB2            (*(__I  uint32_t*)0x4000C08CU) /**< (TC0) Register AB (channel = 0) 2 */
+#define REG_TC0_CV2             (*(__I  uint32_t*)0x4000C090U) /**< (TC0) Counter Value (channel = 0) 2 */
+#define REG_TC0_RA2             (*(__IO uint32_t*)0x4000C094U) /**< (TC0) Register A (channel = 0) 2 */
+#define REG_TC0_RB2             (*(__IO uint32_t*)0x4000C098U) /**< (TC0) Register B (channel = 0) 2 */
+#define REG_TC0_RC2             (*(__IO uint32_t*)0x4000C09CU) /**< (TC0) Register C (channel = 0) 2 */
+#define REG_TC0_SR2             (*(__I  uint32_t*)0x4000C0A0U) /**< (TC0) Status Register (channel = 0) 2 */
+#define REG_TC0_IER2            (*(__O  uint32_t*)0x4000C0A4U) /**< (TC0) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC0_IDR2            (*(__O  uint32_t*)0x4000C0A8U) /**< (TC0) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC0_IMR2            (*(__I  uint32_t*)0x4000C0ACU) /**< (TC0) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC0_EMR2            (*(__IO uint32_t*)0x4000C0B0U) /**< (TC0) Extended Mode Register (channel = 0) 2 */
+#define REG_TC0_BCR             (*(__O  uint32_t*)0x4000C0C0U) /**< (TC0) Block Control Register */
+#define REG_TC0_BMR             (*(__IO uint32_t*)0x4000C0C4U) /**< (TC0) Block Mode Register */
+#define REG_TC0_QIER            (*(__O  uint32_t*)0x4000C0C8U) /**< (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR            (*(__O  uint32_t*)0x4000C0CCU) /**< (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR            (*(__I  uint32_t*)0x4000C0D0U) /**< (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR            (*(__I  uint32_t*)0x4000C0D4U) /**< (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR             (*(__IO uint32_t*)0x4000C0D8U) /**< (TC0) Fault Mode Register */
+#define REG_TC0_WPMR            (*(__IO uint32_t*)0x4000C0E4U) /**< (TC0) Write Protection Mode Register */
+#define REG_TC0_VER             (*(__I  uint32_t*)0x4000C0FCU) /**< (TC0) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC0 peripheral ========== */
+#define TC0_DMAC_ID_RX                           40         
+#define TC0_INSTANCE_ID_CHANNEL0                 23         
+#define TC0_INSTANCE_ID_CHANNEL1                 24         
+#define TC0_INSTANCE_ID_CHANNEL2                 25         
+
+#endif /* _SAMV71_TC0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/tc1.h
+++ b/asf/sam/include/samv71/instance/tc1.h
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TC1_INSTANCE_H_
+#define _SAMV71_TC1_INSTANCE_H_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC1_CCR0            (0x40010000) /**< (TC1) Channel Control Register (channel = 0) 0 */
+#define REG_TC1_CMR0            (0x40010004) /**< (TC1) Channel Mode Register (channel = 0) 0 */
+#define REG_TC1_SMMR0           (0x40010008) /**< (TC1) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC1_RAB0            (0x4001000C) /**< (TC1) Register AB (channel = 0) 0 */
+#define REG_TC1_CV0             (0x40010010) /**< (TC1) Counter Value (channel = 0) 0 */
+#define REG_TC1_RA0             (0x40010014) /**< (TC1) Register A (channel = 0) 0 */
+#define REG_TC1_RB0             (0x40010018) /**< (TC1) Register B (channel = 0) 0 */
+#define REG_TC1_RC0             (0x4001001C) /**< (TC1) Register C (channel = 0) 0 */
+#define REG_TC1_SR0             (0x40010020) /**< (TC1) Status Register (channel = 0) 0 */
+#define REG_TC1_IER0            (0x40010024) /**< (TC1) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC1_IDR0            (0x40010028) /**< (TC1) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC1_IMR0            (0x4001002C) /**< (TC1) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC1_EMR0            (0x40010030) /**< (TC1) Extended Mode Register (channel = 0) 0 */
+#define REG_TC1_CCR1            (0x40010040) /**< (TC1) Channel Control Register (channel = 0) 1 */
+#define REG_TC1_CMR1            (0x40010044) /**< (TC1) Channel Mode Register (channel = 0) 1 */
+#define REG_TC1_SMMR1           (0x40010048) /**< (TC1) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC1_RAB1            (0x4001004C) /**< (TC1) Register AB (channel = 0) 1 */
+#define REG_TC1_CV1             (0x40010050) /**< (TC1) Counter Value (channel = 0) 1 */
+#define REG_TC1_RA1             (0x40010054) /**< (TC1) Register A (channel = 0) 1 */
+#define REG_TC1_RB1             (0x40010058) /**< (TC1) Register B (channel = 0) 1 */
+#define REG_TC1_RC1             (0x4001005C) /**< (TC1) Register C (channel = 0) 1 */
+#define REG_TC1_SR1             (0x40010060) /**< (TC1) Status Register (channel = 0) 1 */
+#define REG_TC1_IER1            (0x40010064) /**< (TC1) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC1_IDR1            (0x40010068) /**< (TC1) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC1_IMR1            (0x4001006C) /**< (TC1) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC1_EMR1            (0x40010070) /**< (TC1) Extended Mode Register (channel = 0) 1 */
+#define REG_TC1_CCR2            (0x40010080) /**< (TC1) Channel Control Register (channel = 0) 2 */
+#define REG_TC1_CMR2            (0x40010084) /**< (TC1) Channel Mode Register (channel = 0) 2 */
+#define REG_TC1_SMMR2           (0x40010088) /**< (TC1) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC1_RAB2            (0x4001008C) /**< (TC1) Register AB (channel = 0) 2 */
+#define REG_TC1_CV2             (0x40010090) /**< (TC1) Counter Value (channel = 0) 2 */
+#define REG_TC1_RA2             (0x40010094) /**< (TC1) Register A (channel = 0) 2 */
+#define REG_TC1_RB2             (0x40010098) /**< (TC1) Register B (channel = 0) 2 */
+#define REG_TC1_RC2             (0x4001009C) /**< (TC1) Register C (channel = 0) 2 */
+#define REG_TC1_SR2             (0x400100A0) /**< (TC1) Status Register (channel = 0) 2 */
+#define REG_TC1_IER2            (0x400100A4) /**< (TC1) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC1_IDR2            (0x400100A8) /**< (TC1) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC1_IMR2            (0x400100AC) /**< (TC1) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC1_EMR2            (0x400100B0) /**< (TC1) Extended Mode Register (channel = 0) 2 */
+#define REG_TC1_BCR             (0x400100C0) /**< (TC1) Block Control Register */
+#define REG_TC1_BMR             (0x400100C4) /**< (TC1) Block Mode Register */
+#define REG_TC1_QIER            (0x400100C8) /**< (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR            (0x400100CC) /**< (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR            (0x400100D0) /**< (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR            (0x400100D4) /**< (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR             (0x400100D8) /**< (TC1) Fault Mode Register */
+#define REG_TC1_WPMR            (0x400100E4) /**< (TC1) Write Protection Mode Register */
+#define REG_TC1_VER             (0x400100FC) /**< (TC1) Version Register */
+
+#else
+
+#define REG_TC1_CCR0            (*(__O  uint32_t*)0x40010000U) /**< (TC1) Channel Control Register (channel = 0) 0 */
+#define REG_TC1_CMR0            (*(__IO uint32_t*)0x40010004U) /**< (TC1) Channel Mode Register (channel = 0) 0 */
+#define REG_TC1_SMMR0           (*(__IO uint32_t*)0x40010008U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC1_RAB0            (*(__I  uint32_t*)0x4001000CU) /**< (TC1) Register AB (channel = 0) 0 */
+#define REG_TC1_CV0             (*(__I  uint32_t*)0x40010010U) /**< (TC1) Counter Value (channel = 0) 0 */
+#define REG_TC1_RA0             (*(__IO uint32_t*)0x40010014U) /**< (TC1) Register A (channel = 0) 0 */
+#define REG_TC1_RB0             (*(__IO uint32_t*)0x40010018U) /**< (TC1) Register B (channel = 0) 0 */
+#define REG_TC1_RC0             (*(__IO uint32_t*)0x4001001CU) /**< (TC1) Register C (channel = 0) 0 */
+#define REG_TC1_SR0             (*(__I  uint32_t*)0x40010020U) /**< (TC1) Status Register (channel = 0) 0 */
+#define REG_TC1_IER0            (*(__O  uint32_t*)0x40010024U) /**< (TC1) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC1_IDR0            (*(__O  uint32_t*)0x40010028U) /**< (TC1) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC1_IMR0            (*(__I  uint32_t*)0x4001002CU) /**< (TC1) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC1_EMR0            (*(__IO uint32_t*)0x40010030U) /**< (TC1) Extended Mode Register (channel = 0) 0 */
+#define REG_TC1_CCR1            (*(__O  uint32_t*)0x40010040U) /**< (TC1) Channel Control Register (channel = 0) 1 */
+#define REG_TC1_CMR1            (*(__IO uint32_t*)0x40010044U) /**< (TC1) Channel Mode Register (channel = 0) 1 */
+#define REG_TC1_SMMR1           (*(__IO uint32_t*)0x40010048U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC1_RAB1            (*(__I  uint32_t*)0x4001004CU) /**< (TC1) Register AB (channel = 0) 1 */
+#define REG_TC1_CV1             (*(__I  uint32_t*)0x40010050U) /**< (TC1) Counter Value (channel = 0) 1 */
+#define REG_TC1_RA1             (*(__IO uint32_t*)0x40010054U) /**< (TC1) Register A (channel = 0) 1 */
+#define REG_TC1_RB1             (*(__IO uint32_t*)0x40010058U) /**< (TC1) Register B (channel = 0) 1 */
+#define REG_TC1_RC1             (*(__IO uint32_t*)0x4001005CU) /**< (TC1) Register C (channel = 0) 1 */
+#define REG_TC1_SR1             (*(__I  uint32_t*)0x40010060U) /**< (TC1) Status Register (channel = 0) 1 */
+#define REG_TC1_IER1            (*(__O  uint32_t*)0x40010064U) /**< (TC1) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC1_IDR1            (*(__O  uint32_t*)0x40010068U) /**< (TC1) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC1_IMR1            (*(__I  uint32_t*)0x4001006CU) /**< (TC1) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC1_EMR1            (*(__IO uint32_t*)0x40010070U) /**< (TC1) Extended Mode Register (channel = 0) 1 */
+#define REG_TC1_CCR2            (*(__O  uint32_t*)0x40010080U) /**< (TC1) Channel Control Register (channel = 0) 2 */
+#define REG_TC1_CMR2            (*(__IO uint32_t*)0x40010084U) /**< (TC1) Channel Mode Register (channel = 0) 2 */
+#define REG_TC1_SMMR2           (*(__IO uint32_t*)0x40010088U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC1_RAB2            (*(__I  uint32_t*)0x4001008CU) /**< (TC1) Register AB (channel = 0) 2 */
+#define REG_TC1_CV2             (*(__I  uint32_t*)0x40010090U) /**< (TC1) Counter Value (channel = 0) 2 */
+#define REG_TC1_RA2             (*(__IO uint32_t*)0x40010094U) /**< (TC1) Register A (channel = 0) 2 */
+#define REG_TC1_RB2             (*(__IO uint32_t*)0x40010098U) /**< (TC1) Register B (channel = 0) 2 */
+#define REG_TC1_RC2             (*(__IO uint32_t*)0x4001009CU) /**< (TC1) Register C (channel = 0) 2 */
+#define REG_TC1_SR2             (*(__I  uint32_t*)0x400100A0U) /**< (TC1) Status Register (channel = 0) 2 */
+#define REG_TC1_IER2            (*(__O  uint32_t*)0x400100A4U) /**< (TC1) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC1_IDR2            (*(__O  uint32_t*)0x400100A8U) /**< (TC1) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC1_IMR2            (*(__I  uint32_t*)0x400100ACU) /**< (TC1) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC1_EMR2            (*(__IO uint32_t*)0x400100B0U) /**< (TC1) Extended Mode Register (channel = 0) 2 */
+#define REG_TC1_BCR             (*(__O  uint32_t*)0x400100C0U) /**< (TC1) Block Control Register */
+#define REG_TC1_BMR             (*(__IO uint32_t*)0x400100C4U) /**< (TC1) Block Mode Register */
+#define REG_TC1_QIER            (*(__O  uint32_t*)0x400100C8U) /**< (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR            (*(__O  uint32_t*)0x400100CCU) /**< (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR            (*(__I  uint32_t*)0x400100D0U) /**< (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR            (*(__I  uint32_t*)0x400100D4U) /**< (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR             (*(__IO uint32_t*)0x400100D8U) /**< (TC1) Fault Mode Register */
+#define REG_TC1_WPMR            (*(__IO uint32_t*)0x400100E4U) /**< (TC1) Write Protection Mode Register */
+#define REG_TC1_VER             (*(__I  uint32_t*)0x400100FCU) /**< (TC1) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC1 peripheral ========== */
+#define TC1_DMAC_ID_RX                           41         
+#define TC1_INSTANCE_ID_CHANNEL0                 26         
+#define TC1_INSTANCE_ID_CHANNEL1                 27         
+#define TC1_INSTANCE_ID_CHANNEL2                 28         
+
+#endif /* _SAMV71_TC1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/tc2.h
+++ b/asf/sam/include/samv71/instance/tc2.h
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TC2_INSTANCE_H_
+#define _SAMV71_TC2_INSTANCE_H_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC2_CCR0            (0x40014000) /**< (TC2) Channel Control Register (channel = 0) 0 */
+#define REG_TC2_CMR0            (0x40014004) /**< (TC2) Channel Mode Register (channel = 0) 0 */
+#define REG_TC2_SMMR0           (0x40014008) /**< (TC2) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC2_RAB0            (0x4001400C) /**< (TC2) Register AB (channel = 0) 0 */
+#define REG_TC2_CV0             (0x40014010) /**< (TC2) Counter Value (channel = 0) 0 */
+#define REG_TC2_RA0             (0x40014014) /**< (TC2) Register A (channel = 0) 0 */
+#define REG_TC2_RB0             (0x40014018) /**< (TC2) Register B (channel = 0) 0 */
+#define REG_TC2_RC0             (0x4001401C) /**< (TC2) Register C (channel = 0) 0 */
+#define REG_TC2_SR0             (0x40014020) /**< (TC2) Status Register (channel = 0) 0 */
+#define REG_TC2_IER0            (0x40014024) /**< (TC2) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC2_IDR0            (0x40014028) /**< (TC2) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC2_IMR0            (0x4001402C) /**< (TC2) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC2_EMR0            (0x40014030) /**< (TC2) Extended Mode Register (channel = 0) 0 */
+#define REG_TC2_CCR1            (0x40014040) /**< (TC2) Channel Control Register (channel = 0) 1 */
+#define REG_TC2_CMR1            (0x40014044) /**< (TC2) Channel Mode Register (channel = 0) 1 */
+#define REG_TC2_SMMR1           (0x40014048) /**< (TC2) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC2_RAB1            (0x4001404C) /**< (TC2) Register AB (channel = 0) 1 */
+#define REG_TC2_CV1             (0x40014050) /**< (TC2) Counter Value (channel = 0) 1 */
+#define REG_TC2_RA1             (0x40014054) /**< (TC2) Register A (channel = 0) 1 */
+#define REG_TC2_RB1             (0x40014058) /**< (TC2) Register B (channel = 0) 1 */
+#define REG_TC2_RC1             (0x4001405C) /**< (TC2) Register C (channel = 0) 1 */
+#define REG_TC2_SR1             (0x40014060) /**< (TC2) Status Register (channel = 0) 1 */
+#define REG_TC2_IER1            (0x40014064) /**< (TC2) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC2_IDR1            (0x40014068) /**< (TC2) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC2_IMR1            (0x4001406C) /**< (TC2) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC2_EMR1            (0x40014070) /**< (TC2) Extended Mode Register (channel = 0) 1 */
+#define REG_TC2_CCR2            (0x40014080) /**< (TC2) Channel Control Register (channel = 0) 2 */
+#define REG_TC2_CMR2            (0x40014084) /**< (TC2) Channel Mode Register (channel = 0) 2 */
+#define REG_TC2_SMMR2           (0x40014088) /**< (TC2) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC2_RAB2            (0x4001408C) /**< (TC2) Register AB (channel = 0) 2 */
+#define REG_TC2_CV2             (0x40014090) /**< (TC2) Counter Value (channel = 0) 2 */
+#define REG_TC2_RA2             (0x40014094) /**< (TC2) Register A (channel = 0) 2 */
+#define REG_TC2_RB2             (0x40014098) /**< (TC2) Register B (channel = 0) 2 */
+#define REG_TC2_RC2             (0x4001409C) /**< (TC2) Register C (channel = 0) 2 */
+#define REG_TC2_SR2             (0x400140A0) /**< (TC2) Status Register (channel = 0) 2 */
+#define REG_TC2_IER2            (0x400140A4) /**< (TC2) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC2_IDR2            (0x400140A8) /**< (TC2) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC2_IMR2            (0x400140AC) /**< (TC2) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC2_EMR2            (0x400140B0) /**< (TC2) Extended Mode Register (channel = 0) 2 */
+#define REG_TC2_BCR             (0x400140C0) /**< (TC2) Block Control Register */
+#define REG_TC2_BMR             (0x400140C4) /**< (TC2) Block Mode Register */
+#define REG_TC2_QIER            (0x400140C8) /**< (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR            (0x400140CC) /**< (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR            (0x400140D0) /**< (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR            (0x400140D4) /**< (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR             (0x400140D8) /**< (TC2) Fault Mode Register */
+#define REG_TC2_WPMR            (0x400140E4) /**< (TC2) Write Protection Mode Register */
+#define REG_TC2_VER             (0x400140FC) /**< (TC2) Version Register */
+
+#else
+
+#define REG_TC2_CCR0            (*(__O  uint32_t*)0x40014000U) /**< (TC2) Channel Control Register (channel = 0) 0 */
+#define REG_TC2_CMR0            (*(__IO uint32_t*)0x40014004U) /**< (TC2) Channel Mode Register (channel = 0) 0 */
+#define REG_TC2_SMMR0           (*(__IO uint32_t*)0x40014008U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC2_RAB0            (*(__I  uint32_t*)0x4001400CU) /**< (TC2) Register AB (channel = 0) 0 */
+#define REG_TC2_CV0             (*(__I  uint32_t*)0x40014010U) /**< (TC2) Counter Value (channel = 0) 0 */
+#define REG_TC2_RA0             (*(__IO uint32_t*)0x40014014U) /**< (TC2) Register A (channel = 0) 0 */
+#define REG_TC2_RB0             (*(__IO uint32_t*)0x40014018U) /**< (TC2) Register B (channel = 0) 0 */
+#define REG_TC2_RC0             (*(__IO uint32_t*)0x4001401CU) /**< (TC2) Register C (channel = 0) 0 */
+#define REG_TC2_SR0             (*(__I  uint32_t*)0x40014020U) /**< (TC2) Status Register (channel = 0) 0 */
+#define REG_TC2_IER0            (*(__O  uint32_t*)0x40014024U) /**< (TC2) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC2_IDR0            (*(__O  uint32_t*)0x40014028U) /**< (TC2) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC2_IMR0            (*(__I  uint32_t*)0x4001402CU) /**< (TC2) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC2_EMR0            (*(__IO uint32_t*)0x40014030U) /**< (TC2) Extended Mode Register (channel = 0) 0 */
+#define REG_TC2_CCR1            (*(__O  uint32_t*)0x40014040U) /**< (TC2) Channel Control Register (channel = 0) 1 */
+#define REG_TC2_CMR1            (*(__IO uint32_t*)0x40014044U) /**< (TC2) Channel Mode Register (channel = 0) 1 */
+#define REG_TC2_SMMR1           (*(__IO uint32_t*)0x40014048U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC2_RAB1            (*(__I  uint32_t*)0x4001404CU) /**< (TC2) Register AB (channel = 0) 1 */
+#define REG_TC2_CV1             (*(__I  uint32_t*)0x40014050U) /**< (TC2) Counter Value (channel = 0) 1 */
+#define REG_TC2_RA1             (*(__IO uint32_t*)0x40014054U) /**< (TC2) Register A (channel = 0) 1 */
+#define REG_TC2_RB1             (*(__IO uint32_t*)0x40014058U) /**< (TC2) Register B (channel = 0) 1 */
+#define REG_TC2_RC1             (*(__IO uint32_t*)0x4001405CU) /**< (TC2) Register C (channel = 0) 1 */
+#define REG_TC2_SR1             (*(__I  uint32_t*)0x40014060U) /**< (TC2) Status Register (channel = 0) 1 */
+#define REG_TC2_IER1            (*(__O  uint32_t*)0x40014064U) /**< (TC2) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC2_IDR1            (*(__O  uint32_t*)0x40014068U) /**< (TC2) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC2_IMR1            (*(__I  uint32_t*)0x4001406CU) /**< (TC2) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC2_EMR1            (*(__IO uint32_t*)0x40014070U) /**< (TC2) Extended Mode Register (channel = 0) 1 */
+#define REG_TC2_CCR2            (*(__O  uint32_t*)0x40014080U) /**< (TC2) Channel Control Register (channel = 0) 2 */
+#define REG_TC2_CMR2            (*(__IO uint32_t*)0x40014084U) /**< (TC2) Channel Mode Register (channel = 0) 2 */
+#define REG_TC2_SMMR2           (*(__IO uint32_t*)0x40014088U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC2_RAB2            (*(__I  uint32_t*)0x4001408CU) /**< (TC2) Register AB (channel = 0) 2 */
+#define REG_TC2_CV2             (*(__I  uint32_t*)0x40014090U) /**< (TC2) Counter Value (channel = 0) 2 */
+#define REG_TC2_RA2             (*(__IO uint32_t*)0x40014094U) /**< (TC2) Register A (channel = 0) 2 */
+#define REG_TC2_RB2             (*(__IO uint32_t*)0x40014098U) /**< (TC2) Register B (channel = 0) 2 */
+#define REG_TC2_RC2             (*(__IO uint32_t*)0x4001409CU) /**< (TC2) Register C (channel = 0) 2 */
+#define REG_TC2_SR2             (*(__I  uint32_t*)0x400140A0U) /**< (TC2) Status Register (channel = 0) 2 */
+#define REG_TC2_IER2            (*(__O  uint32_t*)0x400140A4U) /**< (TC2) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC2_IDR2            (*(__O  uint32_t*)0x400140A8U) /**< (TC2) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC2_IMR2            (*(__I  uint32_t*)0x400140ACU) /**< (TC2) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC2_EMR2            (*(__IO uint32_t*)0x400140B0U) /**< (TC2) Extended Mode Register (channel = 0) 2 */
+#define REG_TC2_BCR             (*(__O  uint32_t*)0x400140C0U) /**< (TC2) Block Control Register */
+#define REG_TC2_BMR             (*(__IO uint32_t*)0x400140C4U) /**< (TC2) Block Mode Register */
+#define REG_TC2_QIER            (*(__O  uint32_t*)0x400140C8U) /**< (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR            (*(__O  uint32_t*)0x400140CCU) /**< (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR            (*(__I  uint32_t*)0x400140D0U) /**< (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR            (*(__I  uint32_t*)0x400140D4U) /**< (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR             (*(__IO uint32_t*)0x400140D8U) /**< (TC2) Fault Mode Register */
+#define REG_TC2_WPMR            (*(__IO uint32_t*)0x400140E4U) /**< (TC2) Write Protection Mode Register */
+#define REG_TC2_VER             (*(__I  uint32_t*)0x400140FCU) /**< (TC2) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC2 peripheral ========== */
+#define TC2_DMAC_ID_RX                           42         
+#define TC2_INSTANCE_ID_CHANNEL0                 47         
+#define TC2_INSTANCE_ID_CHANNEL1                 48         
+#define TC2_INSTANCE_ID_CHANNEL2                 49         
+
+#endif /* _SAMV71_TC2_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/tc3.h
+++ b/asf/sam/include/samv71/instance/tc3.h
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC3
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TC3_INSTANCE_H_
+#define _SAMV71_TC3_INSTANCE_H_
+
+/* ========== Register definition for TC3 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC3_CCR0            (0x40054000) /**< (TC3) Channel Control Register (channel = 0) 0 */
+#define REG_TC3_CMR0            (0x40054004) /**< (TC3) Channel Mode Register (channel = 0) 0 */
+#define REG_TC3_SMMR0           (0x40054008) /**< (TC3) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC3_RAB0            (0x4005400C) /**< (TC3) Register AB (channel = 0) 0 */
+#define REG_TC3_CV0             (0x40054010) /**< (TC3) Counter Value (channel = 0) 0 */
+#define REG_TC3_RA0             (0x40054014) /**< (TC3) Register A (channel = 0) 0 */
+#define REG_TC3_RB0             (0x40054018) /**< (TC3) Register B (channel = 0) 0 */
+#define REG_TC3_RC0             (0x4005401C) /**< (TC3) Register C (channel = 0) 0 */
+#define REG_TC3_SR0             (0x40054020) /**< (TC3) Status Register (channel = 0) 0 */
+#define REG_TC3_IER0            (0x40054024) /**< (TC3) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC3_IDR0            (0x40054028) /**< (TC3) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC3_IMR0            (0x4005402C) /**< (TC3) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC3_EMR0            (0x40054030) /**< (TC3) Extended Mode Register (channel = 0) 0 */
+#define REG_TC3_CCR1            (0x40054040) /**< (TC3) Channel Control Register (channel = 0) 1 */
+#define REG_TC3_CMR1            (0x40054044) /**< (TC3) Channel Mode Register (channel = 0) 1 */
+#define REG_TC3_SMMR1           (0x40054048) /**< (TC3) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC3_RAB1            (0x4005404C) /**< (TC3) Register AB (channel = 0) 1 */
+#define REG_TC3_CV1             (0x40054050) /**< (TC3) Counter Value (channel = 0) 1 */
+#define REG_TC3_RA1             (0x40054054) /**< (TC3) Register A (channel = 0) 1 */
+#define REG_TC3_RB1             (0x40054058) /**< (TC3) Register B (channel = 0) 1 */
+#define REG_TC3_RC1             (0x4005405C) /**< (TC3) Register C (channel = 0) 1 */
+#define REG_TC3_SR1             (0x40054060) /**< (TC3) Status Register (channel = 0) 1 */
+#define REG_TC3_IER1            (0x40054064) /**< (TC3) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC3_IDR1            (0x40054068) /**< (TC3) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC3_IMR1            (0x4005406C) /**< (TC3) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC3_EMR1            (0x40054070) /**< (TC3) Extended Mode Register (channel = 0) 1 */
+#define REG_TC3_CCR2            (0x40054080) /**< (TC3) Channel Control Register (channel = 0) 2 */
+#define REG_TC3_CMR2            (0x40054084) /**< (TC3) Channel Mode Register (channel = 0) 2 */
+#define REG_TC3_SMMR2           (0x40054088) /**< (TC3) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC3_RAB2            (0x4005408C) /**< (TC3) Register AB (channel = 0) 2 */
+#define REG_TC3_CV2             (0x40054090) /**< (TC3) Counter Value (channel = 0) 2 */
+#define REG_TC3_RA2             (0x40054094) /**< (TC3) Register A (channel = 0) 2 */
+#define REG_TC3_RB2             (0x40054098) /**< (TC3) Register B (channel = 0) 2 */
+#define REG_TC3_RC2             (0x4005409C) /**< (TC3) Register C (channel = 0) 2 */
+#define REG_TC3_SR2             (0x400540A0) /**< (TC3) Status Register (channel = 0) 2 */
+#define REG_TC3_IER2            (0x400540A4) /**< (TC3) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC3_IDR2            (0x400540A8) /**< (TC3) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC3_IMR2            (0x400540AC) /**< (TC3) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC3_EMR2            (0x400540B0) /**< (TC3) Extended Mode Register (channel = 0) 2 */
+#define REG_TC3_BCR             (0x400540C0) /**< (TC3) Block Control Register */
+#define REG_TC3_BMR             (0x400540C4) /**< (TC3) Block Mode Register */
+#define REG_TC3_QIER            (0x400540C8) /**< (TC3) QDEC Interrupt Enable Register */
+#define REG_TC3_QIDR            (0x400540CC) /**< (TC3) QDEC Interrupt Disable Register */
+#define REG_TC3_QIMR            (0x400540D0) /**< (TC3) QDEC Interrupt Mask Register */
+#define REG_TC3_QISR            (0x400540D4) /**< (TC3) QDEC Interrupt Status Register */
+#define REG_TC3_FMR             (0x400540D8) /**< (TC3) Fault Mode Register */
+#define REG_TC3_WPMR            (0x400540E4) /**< (TC3) Write Protection Mode Register */
+#define REG_TC3_VER             (0x400540FC) /**< (TC3) Version Register */
+
+#else
+
+#define REG_TC3_CCR0            (*(__O  uint32_t*)0x40054000U) /**< (TC3) Channel Control Register (channel = 0) 0 */
+#define REG_TC3_CMR0            (*(__IO uint32_t*)0x40054004U) /**< (TC3) Channel Mode Register (channel = 0) 0 */
+#define REG_TC3_SMMR0           (*(__IO uint32_t*)0x40054008U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC3_RAB0            (*(__I  uint32_t*)0x4005400CU) /**< (TC3) Register AB (channel = 0) 0 */
+#define REG_TC3_CV0             (*(__I  uint32_t*)0x40054010U) /**< (TC3) Counter Value (channel = 0) 0 */
+#define REG_TC3_RA0             (*(__IO uint32_t*)0x40054014U) /**< (TC3) Register A (channel = 0) 0 */
+#define REG_TC3_RB0             (*(__IO uint32_t*)0x40054018U) /**< (TC3) Register B (channel = 0) 0 */
+#define REG_TC3_RC0             (*(__IO uint32_t*)0x4005401CU) /**< (TC3) Register C (channel = 0) 0 */
+#define REG_TC3_SR0             (*(__I  uint32_t*)0x40054020U) /**< (TC3) Status Register (channel = 0) 0 */
+#define REG_TC3_IER0            (*(__O  uint32_t*)0x40054024U) /**< (TC3) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC3_IDR0            (*(__O  uint32_t*)0x40054028U) /**< (TC3) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC3_IMR0            (*(__I  uint32_t*)0x4005402CU) /**< (TC3) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC3_EMR0            (*(__IO uint32_t*)0x40054030U) /**< (TC3) Extended Mode Register (channel = 0) 0 */
+#define REG_TC3_CCR1            (*(__O  uint32_t*)0x40054040U) /**< (TC3) Channel Control Register (channel = 0) 1 */
+#define REG_TC3_CMR1            (*(__IO uint32_t*)0x40054044U) /**< (TC3) Channel Mode Register (channel = 0) 1 */
+#define REG_TC3_SMMR1           (*(__IO uint32_t*)0x40054048U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC3_RAB1            (*(__I  uint32_t*)0x4005404CU) /**< (TC3) Register AB (channel = 0) 1 */
+#define REG_TC3_CV1             (*(__I  uint32_t*)0x40054050U) /**< (TC3) Counter Value (channel = 0) 1 */
+#define REG_TC3_RA1             (*(__IO uint32_t*)0x40054054U) /**< (TC3) Register A (channel = 0) 1 */
+#define REG_TC3_RB1             (*(__IO uint32_t*)0x40054058U) /**< (TC3) Register B (channel = 0) 1 */
+#define REG_TC3_RC1             (*(__IO uint32_t*)0x4005405CU) /**< (TC3) Register C (channel = 0) 1 */
+#define REG_TC3_SR1             (*(__I  uint32_t*)0x40054060U) /**< (TC3) Status Register (channel = 0) 1 */
+#define REG_TC3_IER1            (*(__O  uint32_t*)0x40054064U) /**< (TC3) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC3_IDR1            (*(__O  uint32_t*)0x40054068U) /**< (TC3) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC3_IMR1            (*(__I  uint32_t*)0x4005406CU) /**< (TC3) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC3_EMR1            (*(__IO uint32_t*)0x40054070U) /**< (TC3) Extended Mode Register (channel = 0) 1 */
+#define REG_TC3_CCR2            (*(__O  uint32_t*)0x40054080U) /**< (TC3) Channel Control Register (channel = 0) 2 */
+#define REG_TC3_CMR2            (*(__IO uint32_t*)0x40054084U) /**< (TC3) Channel Mode Register (channel = 0) 2 */
+#define REG_TC3_SMMR2           (*(__IO uint32_t*)0x40054088U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC3_RAB2            (*(__I  uint32_t*)0x4005408CU) /**< (TC3) Register AB (channel = 0) 2 */
+#define REG_TC3_CV2             (*(__I  uint32_t*)0x40054090U) /**< (TC3) Counter Value (channel = 0) 2 */
+#define REG_TC3_RA2             (*(__IO uint32_t*)0x40054094U) /**< (TC3) Register A (channel = 0) 2 */
+#define REG_TC3_RB2             (*(__IO uint32_t*)0x40054098U) /**< (TC3) Register B (channel = 0) 2 */
+#define REG_TC3_RC2             (*(__IO uint32_t*)0x4005409CU) /**< (TC3) Register C (channel = 0) 2 */
+#define REG_TC3_SR2             (*(__I  uint32_t*)0x400540A0U) /**< (TC3) Status Register (channel = 0) 2 */
+#define REG_TC3_IER2            (*(__O  uint32_t*)0x400540A4U) /**< (TC3) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC3_IDR2            (*(__O  uint32_t*)0x400540A8U) /**< (TC3) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC3_IMR2            (*(__I  uint32_t*)0x400540ACU) /**< (TC3) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC3_EMR2            (*(__IO uint32_t*)0x400540B0U) /**< (TC3) Extended Mode Register (channel = 0) 2 */
+#define REG_TC3_BCR             (*(__O  uint32_t*)0x400540C0U) /**< (TC3) Block Control Register */
+#define REG_TC3_BMR             (*(__IO uint32_t*)0x400540C4U) /**< (TC3) Block Mode Register */
+#define REG_TC3_QIER            (*(__O  uint32_t*)0x400540C8U) /**< (TC3) QDEC Interrupt Enable Register */
+#define REG_TC3_QIDR            (*(__O  uint32_t*)0x400540CCU) /**< (TC3) QDEC Interrupt Disable Register */
+#define REG_TC3_QIMR            (*(__I  uint32_t*)0x400540D0U) /**< (TC3) QDEC Interrupt Mask Register */
+#define REG_TC3_QISR            (*(__I  uint32_t*)0x400540D4U) /**< (TC3) QDEC Interrupt Status Register */
+#define REG_TC3_FMR             (*(__IO uint32_t*)0x400540D8U) /**< (TC3) Fault Mode Register */
+#define REG_TC3_WPMR            (*(__IO uint32_t*)0x400540E4U) /**< (TC3) Write Protection Mode Register */
+#define REG_TC3_VER             (*(__I  uint32_t*)0x400540FCU) /**< (TC3) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC3 peripheral ========== */
+#define TC3_DMAC_ID_RX                           43         
+#define TC3_INSTANCE_ID_CHANNEL0                 50         
+#define TC3_INSTANCE_ID_CHANNEL1                 51         
+#define TC3_INSTANCE_ID_CHANNEL2                 52         
+
+#endif /* _SAMV71_TC3_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/trng.h
+++ b/asf/sam/include/samv71/instance/trng.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TRNG_INSTANCE_H_
+#define _SAMV71_TRNG_INSTANCE_H_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRNG_CR             (0x40070000) /**< (TRNG) Control Register */
+#define REG_TRNG_IER            (0x40070010) /**< (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR            (0x40070014) /**< (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR            (0x40070018) /**< (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR            (0x4007001C) /**< (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA          (0x40070050) /**< (TRNG) Output Data Register */
+#define REG_TRNG_VERSION        (0x400700FC) /**< (TRNG) Version Register */
+
+#else
+
+#define REG_TRNG_CR             (*(__O  uint32_t*)0x40070000U) /**< (TRNG) Control Register */
+#define REG_TRNG_IER            (*(__O  uint32_t*)0x40070010U) /**< (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR            (*(__O  uint32_t*)0x40070014U) /**< (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR            (*(__I  uint32_t*)0x40070018U) /**< (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR            (*(__I  uint32_t*)0x4007001CU) /**< (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA          (*(__I  uint32_t*)0x40070050U) /**< (TRNG) Output Data Register */
+#define REG_TRNG_VERSION        (*(__I  uint32_t*)0x400700FCU) /**< (TRNG) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRNG peripheral ========== */
+#define TRNG_INSTANCE_ID                         57         
+
+#endif /* _SAMV71_TRNG_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/twihs0.h
+++ b/asf/sam/include/samv71/instance/twihs0.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TWIHS0_INSTANCE_H_
+#define _SAMV71_TWIHS0_INSTANCE_H_
+
+/* ========== Register definition for TWIHS0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS0_CR           (0x40018000) /**< (TWIHS0) Control Register */
+#define REG_TWIHS0_MMR          (0x40018004) /**< (TWIHS0) Master Mode Register */
+#define REG_TWIHS0_SMR          (0x40018008) /**< (TWIHS0) Slave Mode Register */
+#define REG_TWIHS0_IADR         (0x4001800C) /**< (TWIHS0) Internal Address Register */
+#define REG_TWIHS0_CWGR         (0x40018010) /**< (TWIHS0) Clock Waveform Generator Register */
+#define REG_TWIHS0_SR           (0x40018020) /**< (TWIHS0) Status Register */
+#define REG_TWIHS0_IER          (0x40018024) /**< (TWIHS0) Interrupt Enable Register */
+#define REG_TWIHS0_IDR          (0x40018028) /**< (TWIHS0) Interrupt Disable Register */
+#define REG_TWIHS0_IMR          (0x4001802C) /**< (TWIHS0) Interrupt Mask Register */
+#define REG_TWIHS0_RHR          (0x40018030) /**< (TWIHS0) Receive Holding Register */
+#define REG_TWIHS0_THR          (0x40018034) /**< (TWIHS0) Transmit Holding Register */
+#define REG_TWIHS0_SMBTR        (0x40018038) /**< (TWIHS0) SMBus Timing Register */
+#define REG_TWIHS0_FILTR        (0x40018044) /**< (TWIHS0) Filter Register */
+#define REG_TWIHS0_SWMR         (0x4001804C) /**< (TWIHS0) SleepWalking Matching Register */
+#define REG_TWIHS0_DR           (0x400180D0) /**< (TWIHS0) Debug Register */
+#define REG_TWIHS0_WPMR         (0x400180E4) /**< (TWIHS0) Write Protection Mode Register */
+#define REG_TWIHS0_WPSR         (0x400180E8) /**< (TWIHS0) Write Protection Status Register */
+#define REG_TWIHS0_VER          (0x400180FC) /**< (TWIHS0) Version Register */
+
+#else
+
+#define REG_TWIHS0_CR           (*(__O  uint32_t*)0x40018000U) /**< (TWIHS0) Control Register */
+#define REG_TWIHS0_MMR          (*(__IO uint32_t*)0x40018004U) /**< (TWIHS0) Master Mode Register */
+#define REG_TWIHS0_SMR          (*(__IO uint32_t*)0x40018008U) /**< (TWIHS0) Slave Mode Register */
+#define REG_TWIHS0_IADR         (*(__IO uint32_t*)0x4001800CU) /**< (TWIHS0) Internal Address Register */
+#define REG_TWIHS0_CWGR         (*(__IO uint32_t*)0x40018010U) /**< (TWIHS0) Clock Waveform Generator Register */
+#define REG_TWIHS0_SR           (*(__I  uint32_t*)0x40018020U) /**< (TWIHS0) Status Register */
+#define REG_TWIHS0_IER          (*(__O  uint32_t*)0x40018024U) /**< (TWIHS0) Interrupt Enable Register */
+#define REG_TWIHS0_IDR          (*(__O  uint32_t*)0x40018028U) /**< (TWIHS0) Interrupt Disable Register */
+#define REG_TWIHS0_IMR          (*(__I  uint32_t*)0x4001802CU) /**< (TWIHS0) Interrupt Mask Register */
+#define REG_TWIHS0_RHR          (*(__I  uint32_t*)0x40018030U) /**< (TWIHS0) Receive Holding Register */
+#define REG_TWIHS0_THR          (*(__O  uint32_t*)0x40018034U) /**< (TWIHS0) Transmit Holding Register */
+#define REG_TWIHS0_SMBTR        (*(__IO uint32_t*)0x40018038U) /**< (TWIHS0) SMBus Timing Register */
+#define REG_TWIHS0_FILTR        (*(__IO uint32_t*)0x40018044U) /**< (TWIHS0) Filter Register */
+#define REG_TWIHS0_SWMR         (*(__IO uint32_t*)0x4001804CU) /**< (TWIHS0) SleepWalking Matching Register */
+#define REG_TWIHS0_DR           (*(__I  uint32_t*)0x400180D0U) /**< (TWIHS0) Debug Register */
+#define REG_TWIHS0_WPMR         (*(__IO uint32_t*)0x400180E4U) /**< (TWIHS0) Write Protection Mode Register */
+#define REG_TWIHS0_WPSR         (*(__I  uint32_t*)0x400180E8U) /**< (TWIHS0) Write Protection Status Register */
+#define REG_TWIHS0_VER          (*(__I  uint32_t*)0x400180FCU) /**< (TWIHS0) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS0 peripheral ========== */
+#define TWIHS0_DMAC_ID_RX                        15         
+#define TWIHS0_DMAC_ID_TX                        14         
+#define TWIHS0_INSTANCE_ID                       19         
+
+#endif /* _SAMV71_TWIHS0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/twihs1.h
+++ b/asf/sam/include/samv71/instance/twihs1.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TWIHS1_INSTANCE_H_
+#define _SAMV71_TWIHS1_INSTANCE_H_
+
+/* ========== Register definition for TWIHS1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS1_CR           (0x4001C000) /**< (TWIHS1) Control Register */
+#define REG_TWIHS1_MMR          (0x4001C004) /**< (TWIHS1) Master Mode Register */
+#define REG_TWIHS1_SMR          (0x4001C008) /**< (TWIHS1) Slave Mode Register */
+#define REG_TWIHS1_IADR         (0x4001C00C) /**< (TWIHS1) Internal Address Register */
+#define REG_TWIHS1_CWGR         (0x4001C010) /**< (TWIHS1) Clock Waveform Generator Register */
+#define REG_TWIHS1_SR           (0x4001C020) /**< (TWIHS1) Status Register */
+#define REG_TWIHS1_IER          (0x4001C024) /**< (TWIHS1) Interrupt Enable Register */
+#define REG_TWIHS1_IDR          (0x4001C028) /**< (TWIHS1) Interrupt Disable Register */
+#define REG_TWIHS1_IMR          (0x4001C02C) /**< (TWIHS1) Interrupt Mask Register */
+#define REG_TWIHS1_RHR          (0x4001C030) /**< (TWIHS1) Receive Holding Register */
+#define REG_TWIHS1_THR          (0x4001C034) /**< (TWIHS1) Transmit Holding Register */
+#define REG_TWIHS1_SMBTR        (0x4001C038) /**< (TWIHS1) SMBus Timing Register */
+#define REG_TWIHS1_FILTR        (0x4001C044) /**< (TWIHS1) Filter Register */
+#define REG_TWIHS1_SWMR         (0x4001C04C) /**< (TWIHS1) SleepWalking Matching Register */
+#define REG_TWIHS1_DR           (0x4001C0D0) /**< (TWIHS1) Debug Register */
+#define REG_TWIHS1_WPMR         (0x4001C0E4) /**< (TWIHS1) Write Protection Mode Register */
+#define REG_TWIHS1_WPSR         (0x4001C0E8) /**< (TWIHS1) Write Protection Status Register */
+#define REG_TWIHS1_VER          (0x4001C0FC) /**< (TWIHS1) Version Register */
+
+#else
+
+#define REG_TWIHS1_CR           (*(__O  uint32_t*)0x4001C000U) /**< (TWIHS1) Control Register */
+#define REG_TWIHS1_MMR          (*(__IO uint32_t*)0x4001C004U) /**< (TWIHS1) Master Mode Register */
+#define REG_TWIHS1_SMR          (*(__IO uint32_t*)0x4001C008U) /**< (TWIHS1) Slave Mode Register */
+#define REG_TWIHS1_IADR         (*(__IO uint32_t*)0x4001C00CU) /**< (TWIHS1) Internal Address Register */
+#define REG_TWIHS1_CWGR         (*(__IO uint32_t*)0x4001C010U) /**< (TWIHS1) Clock Waveform Generator Register */
+#define REG_TWIHS1_SR           (*(__I  uint32_t*)0x4001C020U) /**< (TWIHS1) Status Register */
+#define REG_TWIHS1_IER          (*(__O  uint32_t*)0x4001C024U) /**< (TWIHS1) Interrupt Enable Register */
+#define REG_TWIHS1_IDR          (*(__O  uint32_t*)0x4001C028U) /**< (TWIHS1) Interrupt Disable Register */
+#define REG_TWIHS1_IMR          (*(__I  uint32_t*)0x4001C02CU) /**< (TWIHS1) Interrupt Mask Register */
+#define REG_TWIHS1_RHR          (*(__I  uint32_t*)0x4001C030U) /**< (TWIHS1) Receive Holding Register */
+#define REG_TWIHS1_THR          (*(__O  uint32_t*)0x4001C034U) /**< (TWIHS1) Transmit Holding Register */
+#define REG_TWIHS1_SMBTR        (*(__IO uint32_t*)0x4001C038U) /**< (TWIHS1) SMBus Timing Register */
+#define REG_TWIHS1_FILTR        (*(__IO uint32_t*)0x4001C044U) /**< (TWIHS1) Filter Register */
+#define REG_TWIHS1_SWMR         (*(__IO uint32_t*)0x4001C04CU) /**< (TWIHS1) SleepWalking Matching Register */
+#define REG_TWIHS1_DR           (*(__I  uint32_t*)0x4001C0D0U) /**< (TWIHS1) Debug Register */
+#define REG_TWIHS1_WPMR         (*(__IO uint32_t*)0x4001C0E4U) /**< (TWIHS1) Write Protection Mode Register */
+#define REG_TWIHS1_WPSR         (*(__I  uint32_t*)0x4001C0E8U) /**< (TWIHS1) Write Protection Status Register */
+#define REG_TWIHS1_VER          (*(__I  uint32_t*)0x4001C0FCU) /**< (TWIHS1) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS1 peripheral ========== */
+#define TWIHS1_DMAC_ID_RX                        17         
+#define TWIHS1_DMAC_ID_TX                        16         
+#define TWIHS1_INSTANCE_ID                       20         
+
+#endif /* _SAMV71_TWIHS1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/twihs2.h
+++ b/asf/sam/include/samv71/instance/twihs2.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_TWIHS2_INSTANCE_H_
+#define _SAMV71_TWIHS2_INSTANCE_H_
+
+/* ========== Register definition for TWIHS2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS2_CR           (0x40060000) /**< (TWIHS2) Control Register */
+#define REG_TWIHS2_MMR          (0x40060004) /**< (TWIHS2) Master Mode Register */
+#define REG_TWIHS2_SMR          (0x40060008) /**< (TWIHS2) Slave Mode Register */
+#define REG_TWIHS2_IADR         (0x4006000C) /**< (TWIHS2) Internal Address Register */
+#define REG_TWIHS2_CWGR         (0x40060010) /**< (TWIHS2) Clock Waveform Generator Register */
+#define REG_TWIHS2_SR           (0x40060020) /**< (TWIHS2) Status Register */
+#define REG_TWIHS2_IER          (0x40060024) /**< (TWIHS2) Interrupt Enable Register */
+#define REG_TWIHS2_IDR          (0x40060028) /**< (TWIHS2) Interrupt Disable Register */
+#define REG_TWIHS2_IMR          (0x4006002C) /**< (TWIHS2) Interrupt Mask Register */
+#define REG_TWIHS2_RHR          (0x40060030) /**< (TWIHS2) Receive Holding Register */
+#define REG_TWIHS2_THR          (0x40060034) /**< (TWIHS2) Transmit Holding Register */
+#define REG_TWIHS2_SMBTR        (0x40060038) /**< (TWIHS2) SMBus Timing Register */
+#define REG_TWIHS2_FILTR        (0x40060044) /**< (TWIHS2) Filter Register */
+#define REG_TWIHS2_SWMR         (0x4006004C) /**< (TWIHS2) SleepWalking Matching Register */
+#define REG_TWIHS2_DR           (0x400600D0) /**< (TWIHS2) Debug Register */
+#define REG_TWIHS2_WPMR         (0x400600E4) /**< (TWIHS2) Write Protection Mode Register */
+#define REG_TWIHS2_WPSR         (0x400600E8) /**< (TWIHS2) Write Protection Status Register */
+#define REG_TWIHS2_VER          (0x400600FC) /**< (TWIHS2) Version Register */
+
+#else
+
+#define REG_TWIHS2_CR           (*(__O  uint32_t*)0x40060000U) /**< (TWIHS2) Control Register */
+#define REG_TWIHS2_MMR          (*(__IO uint32_t*)0x40060004U) /**< (TWIHS2) Master Mode Register */
+#define REG_TWIHS2_SMR          (*(__IO uint32_t*)0x40060008U) /**< (TWIHS2) Slave Mode Register */
+#define REG_TWIHS2_IADR         (*(__IO uint32_t*)0x4006000CU) /**< (TWIHS2) Internal Address Register */
+#define REG_TWIHS2_CWGR         (*(__IO uint32_t*)0x40060010U) /**< (TWIHS2) Clock Waveform Generator Register */
+#define REG_TWIHS2_SR           (*(__I  uint32_t*)0x40060020U) /**< (TWIHS2) Status Register */
+#define REG_TWIHS2_IER          (*(__O  uint32_t*)0x40060024U) /**< (TWIHS2) Interrupt Enable Register */
+#define REG_TWIHS2_IDR          (*(__O  uint32_t*)0x40060028U) /**< (TWIHS2) Interrupt Disable Register */
+#define REG_TWIHS2_IMR          (*(__I  uint32_t*)0x4006002CU) /**< (TWIHS2) Interrupt Mask Register */
+#define REG_TWIHS2_RHR          (*(__I  uint32_t*)0x40060030U) /**< (TWIHS2) Receive Holding Register */
+#define REG_TWIHS2_THR          (*(__O  uint32_t*)0x40060034U) /**< (TWIHS2) Transmit Holding Register */
+#define REG_TWIHS2_SMBTR        (*(__IO uint32_t*)0x40060038U) /**< (TWIHS2) SMBus Timing Register */
+#define REG_TWIHS2_FILTR        (*(__IO uint32_t*)0x40060044U) /**< (TWIHS2) Filter Register */
+#define REG_TWIHS2_SWMR         (*(__IO uint32_t*)0x4006004CU) /**< (TWIHS2) SleepWalking Matching Register */
+#define REG_TWIHS2_DR           (*(__I  uint32_t*)0x400600D0U) /**< (TWIHS2) Debug Register */
+#define REG_TWIHS2_WPMR         (*(__IO uint32_t*)0x400600E4U) /**< (TWIHS2) Write Protection Mode Register */
+#define REG_TWIHS2_WPSR         (*(__I  uint32_t*)0x400600E8U) /**< (TWIHS2) Write Protection Status Register */
+#define REG_TWIHS2_VER          (*(__I  uint32_t*)0x400600FCU) /**< (TWIHS2) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS2 peripheral ========== */
+#define TWIHS2_DMAC_ID_RX                        19         
+#define TWIHS2_DMAC_ID_TX                        18         
+#define TWIHS2_INSTANCE_ID                       41         
+
+#endif /* _SAMV71_TWIHS2_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/uart0.h
+++ b/asf/sam/include/samv71/instance/uart0.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART0_INSTANCE_H_
+#define _SAMV71_UART0_INSTANCE_H_
+
+/* ========== Register definition for UART0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART0_CR            (0x400E0800) /**< (UART0) Control Register */
+#define REG_UART0_MR            (0x400E0804) /**< (UART0) Mode Register */
+#define REG_UART0_IER           (0x400E0808) /**< (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR           (0x400E080C) /**< (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR           (0x400E0810) /**< (UART0) Interrupt Mask Register */
+#define REG_UART0_SR            (0x400E0814) /**< (UART0) Status Register */
+#define REG_UART0_RHR           (0x400E0818) /**< (UART0) Receive Holding Register */
+#define REG_UART0_THR           (0x400E081C) /**< (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR          (0x400E0820) /**< (UART0) Baud Rate Generator Register */
+#define REG_UART0_CMPR          (0x400E0824) /**< (UART0) Comparison Register */
+#define REG_UART0_WPMR          (0x400E08E4) /**< (UART0) Write Protection Mode Register */
+#define REG_UART0_VERSION       (0x400E08FC) /**< (UART0) Version Register */
+
+#else
+
+#define REG_UART0_CR            (*(__O  uint32_t*)0x400E0800U) /**< (UART0) Control Register */
+#define REG_UART0_MR            (*(__IO uint32_t*)0x400E0804U) /**< (UART0) Mode Register */
+#define REG_UART0_IER           (*(__O  uint32_t*)0x400E0808U) /**< (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR           (*(__O  uint32_t*)0x400E080CU) /**< (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR           (*(__I  uint32_t*)0x400E0810U) /**< (UART0) Interrupt Mask Register */
+#define REG_UART0_SR            (*(__I  uint32_t*)0x400E0814U) /**< (UART0) Status Register */
+#define REG_UART0_RHR           (*(__I  uint32_t*)0x400E0818U) /**< (UART0) Receive Holding Register */
+#define REG_UART0_THR           (*(__O  uint32_t*)0x400E081CU) /**< (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR          (*(__IO uint32_t*)0x400E0820U) /**< (UART0) Baud Rate Generator Register */
+#define REG_UART0_CMPR          (*(__IO uint32_t*)0x400E0824U) /**< (UART0) Comparison Register */
+#define REG_UART0_WPMR          (*(__IO uint32_t*)0x400E08E4U) /**< (UART0) Write Protection Mode Register */
+#define REG_UART0_VERSION       (*(__I  uint32_t*)0x400E08FCU) /**< (UART0) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART0 peripheral ========== */
+#define UART0_DMAC_ID_RX                         21         
+#define UART0_DMAC_ID_TX                         20         
+#define UART0_INSTANCE_ID                        7          
+
+#endif /* _SAMV71_UART0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/uart1.h
+++ b/asf/sam/include/samv71/instance/uart1.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART1_INSTANCE_H_
+#define _SAMV71_UART1_INSTANCE_H_
+
+/* ========== Register definition for UART1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART1_CR            (0x400E0A00) /**< (UART1) Control Register */
+#define REG_UART1_MR            (0x400E0A04) /**< (UART1) Mode Register */
+#define REG_UART1_IER           (0x400E0A08) /**< (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR           (0x400E0A0C) /**< (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR           (0x400E0A10) /**< (UART1) Interrupt Mask Register */
+#define REG_UART1_SR            (0x400E0A14) /**< (UART1) Status Register */
+#define REG_UART1_RHR           (0x400E0A18) /**< (UART1) Receive Holding Register */
+#define REG_UART1_THR           (0x400E0A1C) /**< (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR          (0x400E0A20) /**< (UART1) Baud Rate Generator Register */
+#define REG_UART1_CMPR          (0x400E0A24) /**< (UART1) Comparison Register */
+#define REG_UART1_WPMR          (0x400E0AE4) /**< (UART1) Write Protection Mode Register */
+#define REG_UART1_VERSION       (0x400E0AFC) /**< (UART1) Version Register */
+
+#else
+
+#define REG_UART1_CR            (*(__O  uint32_t*)0x400E0A00U) /**< (UART1) Control Register */
+#define REG_UART1_MR            (*(__IO uint32_t*)0x400E0A04U) /**< (UART1) Mode Register */
+#define REG_UART1_IER           (*(__O  uint32_t*)0x400E0A08U) /**< (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR           (*(__O  uint32_t*)0x400E0A0CU) /**< (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR           (*(__I  uint32_t*)0x400E0A10U) /**< (UART1) Interrupt Mask Register */
+#define REG_UART1_SR            (*(__I  uint32_t*)0x400E0A14U) /**< (UART1) Status Register */
+#define REG_UART1_RHR           (*(__I  uint32_t*)0x400E0A18U) /**< (UART1) Receive Holding Register */
+#define REG_UART1_THR           (*(__O  uint32_t*)0x400E0A1CU) /**< (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR          (*(__IO uint32_t*)0x400E0A20U) /**< (UART1) Baud Rate Generator Register */
+#define REG_UART1_CMPR          (*(__IO uint32_t*)0x400E0A24U) /**< (UART1) Comparison Register */
+#define REG_UART1_WPMR          (*(__IO uint32_t*)0x400E0AE4U) /**< (UART1) Write Protection Mode Register */
+#define REG_UART1_VERSION       (*(__I  uint32_t*)0x400E0AFCU) /**< (UART1) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART1 peripheral ========== */
+#define UART1_DMAC_ID_RX                         23         
+#define UART1_DMAC_ID_TX                         22         
+#define UART1_INSTANCE_ID                        8          
+
+#endif /* _SAMV71_UART1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/uart2.h
+++ b/asf/sam/include/samv71/instance/uart2.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART2_INSTANCE_H_
+#define _SAMV71_UART2_INSTANCE_H_
+
+/* ========== Register definition for UART2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART2_CR            (0x400E1A00) /**< (UART2) Control Register */
+#define REG_UART2_MR            (0x400E1A04) /**< (UART2) Mode Register */
+#define REG_UART2_IER           (0x400E1A08) /**< (UART2) Interrupt Enable Register */
+#define REG_UART2_IDR           (0x400E1A0C) /**< (UART2) Interrupt Disable Register */
+#define REG_UART2_IMR           (0x400E1A10) /**< (UART2) Interrupt Mask Register */
+#define REG_UART2_SR            (0x400E1A14) /**< (UART2) Status Register */
+#define REG_UART2_RHR           (0x400E1A18) /**< (UART2) Receive Holding Register */
+#define REG_UART2_THR           (0x400E1A1C) /**< (UART2) Transmit Holding Register */
+#define REG_UART2_BRGR          (0x400E1A20) /**< (UART2) Baud Rate Generator Register */
+#define REG_UART2_CMPR          (0x400E1A24) /**< (UART2) Comparison Register */
+#define REG_UART2_WPMR          (0x400E1AE4) /**< (UART2) Write Protection Mode Register */
+#define REG_UART2_VERSION       (0x400E1AFC) /**< (UART2) Version Register */
+
+#else
+
+#define REG_UART2_CR            (*(__O  uint32_t*)0x400E1A00U) /**< (UART2) Control Register */
+#define REG_UART2_MR            (*(__IO uint32_t*)0x400E1A04U) /**< (UART2) Mode Register */
+#define REG_UART2_IER           (*(__O  uint32_t*)0x400E1A08U) /**< (UART2) Interrupt Enable Register */
+#define REG_UART2_IDR           (*(__O  uint32_t*)0x400E1A0CU) /**< (UART2) Interrupt Disable Register */
+#define REG_UART2_IMR           (*(__I  uint32_t*)0x400E1A10U) /**< (UART2) Interrupt Mask Register */
+#define REG_UART2_SR            (*(__I  uint32_t*)0x400E1A14U) /**< (UART2) Status Register */
+#define REG_UART2_RHR           (*(__I  uint32_t*)0x400E1A18U) /**< (UART2) Receive Holding Register */
+#define REG_UART2_THR           (*(__O  uint32_t*)0x400E1A1CU) /**< (UART2) Transmit Holding Register */
+#define REG_UART2_BRGR          (*(__IO uint32_t*)0x400E1A20U) /**< (UART2) Baud Rate Generator Register */
+#define REG_UART2_CMPR          (*(__IO uint32_t*)0x400E1A24U) /**< (UART2) Comparison Register */
+#define REG_UART2_WPMR          (*(__IO uint32_t*)0x400E1AE4U) /**< (UART2) Write Protection Mode Register */
+#define REG_UART2_VERSION       (*(__I  uint32_t*)0x400E1AFCU) /**< (UART2) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART2 peripheral ========== */
+#define UART2_DMAC_ID_RX                         25         
+#define UART2_DMAC_ID_TX                         24         
+#define UART2_INSTANCE_ID                        44         
+
+#endif /* _SAMV71_UART2_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/uart3.h
+++ b/asf/sam/include/samv71/instance/uart3.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART3
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART3_INSTANCE_H_
+#define _SAMV71_UART3_INSTANCE_H_
+
+/* ========== Register definition for UART3 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART3_CR            (0x400E1C00) /**< (UART3) Control Register */
+#define REG_UART3_MR            (0x400E1C04) /**< (UART3) Mode Register */
+#define REG_UART3_IER           (0x400E1C08) /**< (UART3) Interrupt Enable Register */
+#define REG_UART3_IDR           (0x400E1C0C) /**< (UART3) Interrupt Disable Register */
+#define REG_UART3_IMR           (0x400E1C10) /**< (UART3) Interrupt Mask Register */
+#define REG_UART3_SR            (0x400E1C14) /**< (UART3) Status Register */
+#define REG_UART3_RHR           (0x400E1C18) /**< (UART3) Receive Holding Register */
+#define REG_UART3_THR           (0x400E1C1C) /**< (UART3) Transmit Holding Register */
+#define REG_UART3_BRGR          (0x400E1C20) /**< (UART3) Baud Rate Generator Register */
+#define REG_UART3_CMPR          (0x400E1C24) /**< (UART3) Comparison Register */
+#define REG_UART3_WPMR          (0x400E1CE4) /**< (UART3) Write Protection Mode Register */
+#define REG_UART3_VERSION       (0x400E1CFC) /**< (UART3) Version Register */
+
+#else
+
+#define REG_UART3_CR            (*(__O  uint32_t*)0x400E1C00U) /**< (UART3) Control Register */
+#define REG_UART3_MR            (*(__IO uint32_t*)0x400E1C04U) /**< (UART3) Mode Register */
+#define REG_UART3_IER           (*(__O  uint32_t*)0x400E1C08U) /**< (UART3) Interrupt Enable Register */
+#define REG_UART3_IDR           (*(__O  uint32_t*)0x400E1C0CU) /**< (UART3) Interrupt Disable Register */
+#define REG_UART3_IMR           (*(__I  uint32_t*)0x400E1C10U) /**< (UART3) Interrupt Mask Register */
+#define REG_UART3_SR            (*(__I  uint32_t*)0x400E1C14U) /**< (UART3) Status Register */
+#define REG_UART3_RHR           (*(__I  uint32_t*)0x400E1C18U) /**< (UART3) Receive Holding Register */
+#define REG_UART3_THR           (*(__O  uint32_t*)0x400E1C1CU) /**< (UART3) Transmit Holding Register */
+#define REG_UART3_BRGR          (*(__IO uint32_t*)0x400E1C20U) /**< (UART3) Baud Rate Generator Register */
+#define REG_UART3_CMPR          (*(__IO uint32_t*)0x400E1C24U) /**< (UART3) Comparison Register */
+#define REG_UART3_WPMR          (*(__IO uint32_t*)0x400E1CE4U) /**< (UART3) Write Protection Mode Register */
+#define REG_UART3_VERSION       (*(__I  uint32_t*)0x400E1CFCU) /**< (UART3) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART3 peripheral ========== */
+#define UART3_DMAC_ID_RX                         27         
+#define UART3_DMAC_ID_TX                         26         
+#define UART3_INSTANCE_ID                        45         
+
+#endif /* _SAMV71_UART3_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/uart4.h
+++ b/asf/sam/include/samv71/instance/uart4.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART4
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UART4_INSTANCE_H_
+#define _SAMV71_UART4_INSTANCE_H_
+
+/* ========== Register definition for UART4 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART4_CR            (0x400E1E00) /**< (UART4) Control Register */
+#define REG_UART4_MR            (0x400E1E04) /**< (UART4) Mode Register */
+#define REG_UART4_IER           (0x400E1E08) /**< (UART4) Interrupt Enable Register */
+#define REG_UART4_IDR           (0x400E1E0C) /**< (UART4) Interrupt Disable Register */
+#define REG_UART4_IMR           (0x400E1E10) /**< (UART4) Interrupt Mask Register */
+#define REG_UART4_SR            (0x400E1E14) /**< (UART4) Status Register */
+#define REG_UART4_RHR           (0x400E1E18) /**< (UART4) Receive Holding Register */
+#define REG_UART4_THR           (0x400E1E1C) /**< (UART4) Transmit Holding Register */
+#define REG_UART4_BRGR          (0x400E1E20) /**< (UART4) Baud Rate Generator Register */
+#define REG_UART4_CMPR          (0x400E1E24) /**< (UART4) Comparison Register */
+#define REG_UART4_WPMR          (0x400E1EE4) /**< (UART4) Write Protection Mode Register */
+#define REG_UART4_VERSION       (0x400E1EFC) /**< (UART4) Version Register */
+
+#else
+
+#define REG_UART4_CR            (*(__O  uint32_t*)0x400E1E00U) /**< (UART4) Control Register */
+#define REG_UART4_MR            (*(__IO uint32_t*)0x400E1E04U) /**< (UART4) Mode Register */
+#define REG_UART4_IER           (*(__O  uint32_t*)0x400E1E08U) /**< (UART4) Interrupt Enable Register */
+#define REG_UART4_IDR           (*(__O  uint32_t*)0x400E1E0CU) /**< (UART4) Interrupt Disable Register */
+#define REG_UART4_IMR           (*(__I  uint32_t*)0x400E1E10U) /**< (UART4) Interrupt Mask Register */
+#define REG_UART4_SR            (*(__I  uint32_t*)0x400E1E14U) /**< (UART4) Status Register */
+#define REG_UART4_RHR           (*(__I  uint32_t*)0x400E1E18U) /**< (UART4) Receive Holding Register */
+#define REG_UART4_THR           (*(__O  uint32_t*)0x400E1E1CU) /**< (UART4) Transmit Holding Register */
+#define REG_UART4_BRGR          (*(__IO uint32_t*)0x400E1E20U) /**< (UART4) Baud Rate Generator Register */
+#define REG_UART4_CMPR          (*(__IO uint32_t*)0x400E1E24U) /**< (UART4) Comparison Register */
+#define REG_UART4_WPMR          (*(__IO uint32_t*)0x400E1EE4U) /**< (UART4) Write Protection Mode Register */
+#define REG_UART4_VERSION       (*(__I  uint32_t*)0x400E1EFCU) /**< (UART4) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART4 peripheral ========== */
+#define UART4_DMAC_ID_RX                         29         
+#define UART4_DMAC_ID_TX                         28         
+#define UART4_INSTANCE_ID                        46         
+
+#endif /* _SAMV71_UART4_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/usart0.h
+++ b/asf/sam/include/samv71/instance/usart0.h
@@ -1,0 +1,112 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USART0_INSTANCE_H_
+#define _SAMV71_USART0_INSTANCE_H_
+
+/* ========== Register definition for USART0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART0_US_CR        (0x40024000) /**< (USART0) Control Register */
+#define REG_USART0_US_MR        (0x40024004) /**< (USART0) Mode Register */
+#define REG_USART0_US_IER       (0x40024008) /**< (USART0) Interrupt Enable Register */
+#define REG_USART0_US_IDR       (0x4002400C) /**< (USART0) Interrupt Disable Register */
+#define REG_USART0_US_IMR       (0x40024010) /**< (USART0) Interrupt Mask Register */
+#define REG_USART0_US_CSR       (0x40024014) /**< (USART0) Channel Status Register */
+#define REG_USART0_US_RHR       (0x40024018) /**< (USART0) Receive Holding Register */
+#define REG_USART0_US_THR       (0x4002401C) /**< (USART0) Transmit Holding Register */
+#define REG_USART0_US_BRGR      (0x40024020) /**< (USART0) Baud Rate Generator Register */
+#define REG_USART0_US_RTOR      (0x40024024) /**< (USART0) Receiver Timeout Register */
+#define REG_USART0_US_TTGR      (0x40024028) /**< (USART0) Transmitter Timeguard Register */
+#define REG_USART0_US_FIDI      (0x40024040) /**< (USART0) FI DI Ratio Register */
+#define REG_USART0_US_NER       (0x40024044) /**< (USART0) Number of Errors Register */
+#define REG_USART0_US_IF        (0x4002404C) /**< (USART0) IrDA Filter Register */
+#define REG_USART0_US_MAN       (0x40024050) /**< (USART0) Manchester Configuration Register */
+#define REG_USART0_US_LINMR     (0x40024054) /**< (USART0) LIN Mode Register */
+#define REG_USART0_US_LINIR     (0x40024058) /**< (USART0) LIN Identifier Register */
+#define REG_USART0_US_LINBRR    (0x4002405C) /**< (USART0) LIN Baud Rate Register */
+#define REG_USART0_US_LONMR     (0x40024060) /**< (USART0) LON Mode Register */
+#define REG_USART0_US_LONPR     (0x40024064) /**< (USART0) LON Preamble Register */
+#define REG_USART0_US_LONDL     (0x40024068) /**< (USART0) LON Data Length Register */
+#define REG_USART0_US_LONL2HDR  (0x4002406C) /**< (USART0) LON L2HDR Register */
+#define REG_USART0_US_LONBL     (0x40024070) /**< (USART0) LON Backlog Register */
+#define REG_USART0_US_LONB1TX   (0x40024074) /**< (USART0) LON Beta1 Tx Register */
+#define REG_USART0_US_LONB1RX   (0x40024078) /**< (USART0) LON Beta1 Rx Register */
+#define REG_USART0_US_LONPRIO   (0x4002407C) /**< (USART0) LON Priority Register */
+#define REG_USART0_US_IDTTX     (0x40024080) /**< (USART0) LON IDT Tx Register */
+#define REG_USART0_US_IDTRX     (0x40024084) /**< (USART0) LON IDT Rx Register */
+#define REG_USART0_US_ICDIFF    (0x40024088) /**< (USART0) IC DIFF Register */
+#define REG_USART0_US_WPMR      (0x400240E4) /**< (USART0) Write Protection Mode Register */
+#define REG_USART0_US_WPSR      (0x400240E8) /**< (USART0) Write Protection Status Register */
+#define REG_USART0_US_VERSION   (0x400240FC) /**< (USART0) Version Register */
+
+#else
+
+#define REG_USART0_US_CR        (*(__O  uint32_t*)0x40024000U) /**< (USART0) Control Register */
+#define REG_USART0_US_MR        (*(__IO uint32_t*)0x40024004U) /**< (USART0) Mode Register */
+#define REG_USART0_US_IER       (*(__O  uint32_t*)0x40024008U) /**< (USART0) Interrupt Enable Register */
+#define REG_USART0_US_IDR       (*(__O  uint32_t*)0x4002400CU) /**< (USART0) Interrupt Disable Register */
+#define REG_USART0_US_IMR       (*(__I  uint32_t*)0x40024010U) /**< (USART0) Interrupt Mask Register */
+#define REG_USART0_US_CSR       (*(__I  uint32_t*)0x40024014U) /**< (USART0) Channel Status Register */
+#define REG_USART0_US_RHR       (*(__I  uint32_t*)0x40024018U) /**< (USART0) Receive Holding Register */
+#define REG_USART0_US_THR       (*(__O  uint32_t*)0x4002401CU) /**< (USART0) Transmit Holding Register */
+#define REG_USART0_US_BRGR      (*(__IO uint32_t*)0x40024020U) /**< (USART0) Baud Rate Generator Register */
+#define REG_USART0_US_RTOR      (*(__IO uint32_t*)0x40024024U) /**< (USART0) Receiver Timeout Register */
+#define REG_USART0_US_TTGR      (*(__IO uint32_t*)0x40024028U) /**< (USART0) Transmitter Timeguard Register */
+#define REG_USART0_US_FIDI      (*(__IO uint32_t*)0x40024040U) /**< (USART0) FI DI Ratio Register */
+#define REG_USART0_US_NER       (*(__I  uint32_t*)0x40024044U) /**< (USART0) Number of Errors Register */
+#define REG_USART0_US_IF        (*(__IO uint32_t*)0x4002404CU) /**< (USART0) IrDA Filter Register */
+#define REG_USART0_US_MAN       (*(__IO uint32_t*)0x40024050U) /**< (USART0) Manchester Configuration Register */
+#define REG_USART0_US_LINMR     (*(__IO uint32_t*)0x40024054U) /**< (USART0) LIN Mode Register */
+#define REG_USART0_US_LINIR     (*(__IO uint32_t*)0x40024058U) /**< (USART0) LIN Identifier Register */
+#define REG_USART0_US_LINBRR    (*(__I  uint32_t*)0x4002405CU) /**< (USART0) LIN Baud Rate Register */
+#define REG_USART0_US_LONMR     (*(__IO uint32_t*)0x40024060U) /**< (USART0) LON Mode Register */
+#define REG_USART0_US_LONPR     (*(__IO uint32_t*)0x40024064U) /**< (USART0) LON Preamble Register */
+#define REG_USART0_US_LONDL     (*(__IO uint32_t*)0x40024068U) /**< (USART0) LON Data Length Register */
+#define REG_USART0_US_LONL2HDR  (*(__IO uint32_t*)0x4002406CU) /**< (USART0) LON L2HDR Register */
+#define REG_USART0_US_LONBL     (*(__I  uint32_t*)0x40024070U) /**< (USART0) LON Backlog Register */
+#define REG_USART0_US_LONB1TX   (*(__IO uint32_t*)0x40024074U) /**< (USART0) LON Beta1 Tx Register */
+#define REG_USART0_US_LONB1RX   (*(__IO uint32_t*)0x40024078U) /**< (USART0) LON Beta1 Rx Register */
+#define REG_USART0_US_LONPRIO   (*(__IO uint32_t*)0x4002407CU) /**< (USART0) LON Priority Register */
+#define REG_USART0_US_IDTTX     (*(__IO uint32_t*)0x40024080U) /**< (USART0) LON IDT Tx Register */
+#define REG_USART0_US_IDTRX     (*(__IO uint32_t*)0x40024084U) /**< (USART0) LON IDT Rx Register */
+#define REG_USART0_US_ICDIFF    (*(__IO uint32_t*)0x40024088U) /**< (USART0) IC DIFF Register */
+#define REG_USART0_US_WPMR      (*(__IO uint32_t*)0x400240E4U) /**< (USART0) Write Protection Mode Register */
+#define REG_USART0_US_WPSR      (*(__I  uint32_t*)0x400240E8U) /**< (USART0) Write Protection Status Register */
+#define REG_USART0_US_VERSION   (*(__I  uint32_t*)0x400240FCU) /**< (USART0) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART0 peripheral ========== */
+#define USART0_DMAC_ID_RX                        8          
+#define USART0_DMAC_ID_TX                        7          
+#define USART0_INSTANCE_ID                       13         
+
+#endif /* _SAMV71_USART0_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/usart1.h
+++ b/asf/sam/include/samv71/instance/usart1.h
@@ -1,0 +1,112 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USART1_INSTANCE_H_
+#define _SAMV71_USART1_INSTANCE_H_
+
+/* ========== Register definition for USART1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART1_US_CR        (0x40028000) /**< (USART1) Control Register */
+#define REG_USART1_US_MR        (0x40028004) /**< (USART1) Mode Register */
+#define REG_USART1_US_IER       (0x40028008) /**< (USART1) Interrupt Enable Register */
+#define REG_USART1_US_IDR       (0x4002800C) /**< (USART1) Interrupt Disable Register */
+#define REG_USART1_US_IMR       (0x40028010) /**< (USART1) Interrupt Mask Register */
+#define REG_USART1_US_CSR       (0x40028014) /**< (USART1) Channel Status Register */
+#define REG_USART1_US_RHR       (0x40028018) /**< (USART1) Receive Holding Register */
+#define REG_USART1_US_THR       (0x4002801C) /**< (USART1) Transmit Holding Register */
+#define REG_USART1_US_BRGR      (0x40028020) /**< (USART1) Baud Rate Generator Register */
+#define REG_USART1_US_RTOR      (0x40028024) /**< (USART1) Receiver Timeout Register */
+#define REG_USART1_US_TTGR      (0x40028028) /**< (USART1) Transmitter Timeguard Register */
+#define REG_USART1_US_FIDI      (0x40028040) /**< (USART1) FI DI Ratio Register */
+#define REG_USART1_US_NER       (0x40028044) /**< (USART1) Number of Errors Register */
+#define REG_USART1_US_IF        (0x4002804C) /**< (USART1) IrDA Filter Register */
+#define REG_USART1_US_MAN       (0x40028050) /**< (USART1) Manchester Configuration Register */
+#define REG_USART1_US_LINMR     (0x40028054) /**< (USART1) LIN Mode Register */
+#define REG_USART1_US_LINIR     (0x40028058) /**< (USART1) LIN Identifier Register */
+#define REG_USART1_US_LINBRR    (0x4002805C) /**< (USART1) LIN Baud Rate Register */
+#define REG_USART1_US_LONMR     (0x40028060) /**< (USART1) LON Mode Register */
+#define REG_USART1_US_LONPR     (0x40028064) /**< (USART1) LON Preamble Register */
+#define REG_USART1_US_LONDL     (0x40028068) /**< (USART1) LON Data Length Register */
+#define REG_USART1_US_LONL2HDR  (0x4002806C) /**< (USART1) LON L2HDR Register */
+#define REG_USART1_US_LONBL     (0x40028070) /**< (USART1) LON Backlog Register */
+#define REG_USART1_US_LONB1TX   (0x40028074) /**< (USART1) LON Beta1 Tx Register */
+#define REG_USART1_US_LONB1RX   (0x40028078) /**< (USART1) LON Beta1 Rx Register */
+#define REG_USART1_US_LONPRIO   (0x4002807C) /**< (USART1) LON Priority Register */
+#define REG_USART1_US_IDTTX     (0x40028080) /**< (USART1) LON IDT Tx Register */
+#define REG_USART1_US_IDTRX     (0x40028084) /**< (USART1) LON IDT Rx Register */
+#define REG_USART1_US_ICDIFF    (0x40028088) /**< (USART1) IC DIFF Register */
+#define REG_USART1_US_WPMR      (0x400280E4) /**< (USART1) Write Protection Mode Register */
+#define REG_USART1_US_WPSR      (0x400280E8) /**< (USART1) Write Protection Status Register */
+#define REG_USART1_US_VERSION   (0x400280FC) /**< (USART1) Version Register */
+
+#else
+
+#define REG_USART1_US_CR        (*(__O  uint32_t*)0x40028000U) /**< (USART1) Control Register */
+#define REG_USART1_US_MR        (*(__IO uint32_t*)0x40028004U) /**< (USART1) Mode Register */
+#define REG_USART1_US_IER       (*(__O  uint32_t*)0x40028008U) /**< (USART1) Interrupt Enable Register */
+#define REG_USART1_US_IDR       (*(__O  uint32_t*)0x4002800CU) /**< (USART1) Interrupt Disable Register */
+#define REG_USART1_US_IMR       (*(__I  uint32_t*)0x40028010U) /**< (USART1) Interrupt Mask Register */
+#define REG_USART1_US_CSR       (*(__I  uint32_t*)0x40028014U) /**< (USART1) Channel Status Register */
+#define REG_USART1_US_RHR       (*(__I  uint32_t*)0x40028018U) /**< (USART1) Receive Holding Register */
+#define REG_USART1_US_THR       (*(__O  uint32_t*)0x4002801CU) /**< (USART1) Transmit Holding Register */
+#define REG_USART1_US_BRGR      (*(__IO uint32_t*)0x40028020U) /**< (USART1) Baud Rate Generator Register */
+#define REG_USART1_US_RTOR      (*(__IO uint32_t*)0x40028024U) /**< (USART1) Receiver Timeout Register */
+#define REG_USART1_US_TTGR      (*(__IO uint32_t*)0x40028028U) /**< (USART1) Transmitter Timeguard Register */
+#define REG_USART1_US_FIDI      (*(__IO uint32_t*)0x40028040U) /**< (USART1) FI DI Ratio Register */
+#define REG_USART1_US_NER       (*(__I  uint32_t*)0x40028044U) /**< (USART1) Number of Errors Register */
+#define REG_USART1_US_IF        (*(__IO uint32_t*)0x4002804CU) /**< (USART1) IrDA Filter Register */
+#define REG_USART1_US_MAN       (*(__IO uint32_t*)0x40028050U) /**< (USART1) Manchester Configuration Register */
+#define REG_USART1_US_LINMR     (*(__IO uint32_t*)0x40028054U) /**< (USART1) LIN Mode Register */
+#define REG_USART1_US_LINIR     (*(__IO uint32_t*)0x40028058U) /**< (USART1) LIN Identifier Register */
+#define REG_USART1_US_LINBRR    (*(__I  uint32_t*)0x4002805CU) /**< (USART1) LIN Baud Rate Register */
+#define REG_USART1_US_LONMR     (*(__IO uint32_t*)0x40028060U) /**< (USART1) LON Mode Register */
+#define REG_USART1_US_LONPR     (*(__IO uint32_t*)0x40028064U) /**< (USART1) LON Preamble Register */
+#define REG_USART1_US_LONDL     (*(__IO uint32_t*)0x40028068U) /**< (USART1) LON Data Length Register */
+#define REG_USART1_US_LONL2HDR  (*(__IO uint32_t*)0x4002806CU) /**< (USART1) LON L2HDR Register */
+#define REG_USART1_US_LONBL     (*(__I  uint32_t*)0x40028070U) /**< (USART1) LON Backlog Register */
+#define REG_USART1_US_LONB1TX   (*(__IO uint32_t*)0x40028074U) /**< (USART1) LON Beta1 Tx Register */
+#define REG_USART1_US_LONB1RX   (*(__IO uint32_t*)0x40028078U) /**< (USART1) LON Beta1 Rx Register */
+#define REG_USART1_US_LONPRIO   (*(__IO uint32_t*)0x4002807CU) /**< (USART1) LON Priority Register */
+#define REG_USART1_US_IDTTX     (*(__IO uint32_t*)0x40028080U) /**< (USART1) LON IDT Tx Register */
+#define REG_USART1_US_IDTRX     (*(__IO uint32_t*)0x40028084U) /**< (USART1) LON IDT Rx Register */
+#define REG_USART1_US_ICDIFF    (*(__IO uint32_t*)0x40028088U) /**< (USART1) IC DIFF Register */
+#define REG_USART1_US_WPMR      (*(__IO uint32_t*)0x400280E4U) /**< (USART1) Write Protection Mode Register */
+#define REG_USART1_US_WPSR      (*(__I  uint32_t*)0x400280E8U) /**< (USART1) Write Protection Status Register */
+#define REG_USART1_US_VERSION   (*(__I  uint32_t*)0x400280FCU) /**< (USART1) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART1 peripheral ========== */
+#define USART1_DMAC_ID_RX                        10         
+#define USART1_DMAC_ID_TX                        9          
+#define USART1_INSTANCE_ID                       14         
+
+#endif /* _SAMV71_USART1_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/usart2.h
+++ b/asf/sam/include/samv71/instance/usart2.h
@@ -1,0 +1,112 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USART2_INSTANCE_H_
+#define _SAMV71_USART2_INSTANCE_H_
+
+/* ========== Register definition for USART2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART2_US_CR        (0x4002C000) /**< (USART2) Control Register */
+#define REG_USART2_US_MR        (0x4002C004) /**< (USART2) Mode Register */
+#define REG_USART2_US_IER       (0x4002C008) /**< (USART2) Interrupt Enable Register */
+#define REG_USART2_US_IDR       (0x4002C00C) /**< (USART2) Interrupt Disable Register */
+#define REG_USART2_US_IMR       (0x4002C010) /**< (USART2) Interrupt Mask Register */
+#define REG_USART2_US_CSR       (0x4002C014) /**< (USART2) Channel Status Register */
+#define REG_USART2_US_RHR       (0x4002C018) /**< (USART2) Receive Holding Register */
+#define REG_USART2_US_THR       (0x4002C01C) /**< (USART2) Transmit Holding Register */
+#define REG_USART2_US_BRGR      (0x4002C020) /**< (USART2) Baud Rate Generator Register */
+#define REG_USART2_US_RTOR      (0x4002C024) /**< (USART2) Receiver Timeout Register */
+#define REG_USART2_US_TTGR      (0x4002C028) /**< (USART2) Transmitter Timeguard Register */
+#define REG_USART2_US_FIDI      (0x4002C040) /**< (USART2) FI DI Ratio Register */
+#define REG_USART2_US_NER       (0x4002C044) /**< (USART2) Number of Errors Register */
+#define REG_USART2_US_IF        (0x4002C04C) /**< (USART2) IrDA Filter Register */
+#define REG_USART2_US_MAN       (0x4002C050) /**< (USART2) Manchester Configuration Register */
+#define REG_USART2_US_LINMR     (0x4002C054) /**< (USART2) LIN Mode Register */
+#define REG_USART2_US_LINIR     (0x4002C058) /**< (USART2) LIN Identifier Register */
+#define REG_USART2_US_LINBRR    (0x4002C05C) /**< (USART2) LIN Baud Rate Register */
+#define REG_USART2_US_LONMR     (0x4002C060) /**< (USART2) LON Mode Register */
+#define REG_USART2_US_LONPR     (0x4002C064) /**< (USART2) LON Preamble Register */
+#define REG_USART2_US_LONDL     (0x4002C068) /**< (USART2) LON Data Length Register */
+#define REG_USART2_US_LONL2HDR  (0x4002C06C) /**< (USART2) LON L2HDR Register */
+#define REG_USART2_US_LONBL     (0x4002C070) /**< (USART2) LON Backlog Register */
+#define REG_USART2_US_LONB1TX   (0x4002C074) /**< (USART2) LON Beta1 Tx Register */
+#define REG_USART2_US_LONB1RX   (0x4002C078) /**< (USART2) LON Beta1 Rx Register */
+#define REG_USART2_US_LONPRIO   (0x4002C07C) /**< (USART2) LON Priority Register */
+#define REG_USART2_US_IDTTX     (0x4002C080) /**< (USART2) LON IDT Tx Register */
+#define REG_USART2_US_IDTRX     (0x4002C084) /**< (USART2) LON IDT Rx Register */
+#define REG_USART2_US_ICDIFF    (0x4002C088) /**< (USART2) IC DIFF Register */
+#define REG_USART2_US_WPMR      (0x4002C0E4) /**< (USART2) Write Protection Mode Register */
+#define REG_USART2_US_WPSR      (0x4002C0E8) /**< (USART2) Write Protection Status Register */
+#define REG_USART2_US_VERSION   (0x4002C0FC) /**< (USART2) Version Register */
+
+#else
+
+#define REG_USART2_US_CR        (*(__O  uint32_t*)0x4002C000U) /**< (USART2) Control Register */
+#define REG_USART2_US_MR        (*(__IO uint32_t*)0x4002C004U) /**< (USART2) Mode Register */
+#define REG_USART2_US_IER       (*(__O  uint32_t*)0x4002C008U) /**< (USART2) Interrupt Enable Register */
+#define REG_USART2_US_IDR       (*(__O  uint32_t*)0x4002C00CU) /**< (USART2) Interrupt Disable Register */
+#define REG_USART2_US_IMR       (*(__I  uint32_t*)0x4002C010U) /**< (USART2) Interrupt Mask Register */
+#define REG_USART2_US_CSR       (*(__I  uint32_t*)0x4002C014U) /**< (USART2) Channel Status Register */
+#define REG_USART2_US_RHR       (*(__I  uint32_t*)0x4002C018U) /**< (USART2) Receive Holding Register */
+#define REG_USART2_US_THR       (*(__O  uint32_t*)0x4002C01CU) /**< (USART2) Transmit Holding Register */
+#define REG_USART2_US_BRGR      (*(__IO uint32_t*)0x4002C020U) /**< (USART2) Baud Rate Generator Register */
+#define REG_USART2_US_RTOR      (*(__IO uint32_t*)0x4002C024U) /**< (USART2) Receiver Timeout Register */
+#define REG_USART2_US_TTGR      (*(__IO uint32_t*)0x4002C028U) /**< (USART2) Transmitter Timeguard Register */
+#define REG_USART2_US_FIDI      (*(__IO uint32_t*)0x4002C040U) /**< (USART2) FI DI Ratio Register */
+#define REG_USART2_US_NER       (*(__I  uint32_t*)0x4002C044U) /**< (USART2) Number of Errors Register */
+#define REG_USART2_US_IF        (*(__IO uint32_t*)0x4002C04CU) /**< (USART2) IrDA Filter Register */
+#define REG_USART2_US_MAN       (*(__IO uint32_t*)0x4002C050U) /**< (USART2) Manchester Configuration Register */
+#define REG_USART2_US_LINMR     (*(__IO uint32_t*)0x4002C054U) /**< (USART2) LIN Mode Register */
+#define REG_USART2_US_LINIR     (*(__IO uint32_t*)0x4002C058U) /**< (USART2) LIN Identifier Register */
+#define REG_USART2_US_LINBRR    (*(__I  uint32_t*)0x4002C05CU) /**< (USART2) LIN Baud Rate Register */
+#define REG_USART2_US_LONMR     (*(__IO uint32_t*)0x4002C060U) /**< (USART2) LON Mode Register */
+#define REG_USART2_US_LONPR     (*(__IO uint32_t*)0x4002C064U) /**< (USART2) LON Preamble Register */
+#define REG_USART2_US_LONDL     (*(__IO uint32_t*)0x4002C068U) /**< (USART2) LON Data Length Register */
+#define REG_USART2_US_LONL2HDR  (*(__IO uint32_t*)0x4002C06CU) /**< (USART2) LON L2HDR Register */
+#define REG_USART2_US_LONBL     (*(__I  uint32_t*)0x4002C070U) /**< (USART2) LON Backlog Register */
+#define REG_USART2_US_LONB1TX   (*(__IO uint32_t*)0x4002C074U) /**< (USART2) LON Beta1 Tx Register */
+#define REG_USART2_US_LONB1RX   (*(__IO uint32_t*)0x4002C078U) /**< (USART2) LON Beta1 Rx Register */
+#define REG_USART2_US_LONPRIO   (*(__IO uint32_t*)0x4002C07CU) /**< (USART2) LON Priority Register */
+#define REG_USART2_US_IDTTX     (*(__IO uint32_t*)0x4002C080U) /**< (USART2) LON IDT Tx Register */
+#define REG_USART2_US_IDTRX     (*(__IO uint32_t*)0x4002C084U) /**< (USART2) LON IDT Rx Register */
+#define REG_USART2_US_ICDIFF    (*(__IO uint32_t*)0x4002C088U) /**< (USART2) IC DIFF Register */
+#define REG_USART2_US_WPMR      (*(__IO uint32_t*)0x4002C0E4U) /**< (USART2) Write Protection Mode Register */
+#define REG_USART2_US_WPSR      (*(__I  uint32_t*)0x4002C0E8U) /**< (USART2) Write Protection Status Register */
+#define REG_USART2_US_VERSION   (*(__I  uint32_t*)0x4002C0FCU) /**< (USART2) Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART2 peripheral ========== */
+#define USART2_DMAC_ID_RX                        12         
+#define USART2_DMAC_ID_TX                        11         
+#define USART2_INSTANCE_ID                       15         
+
+#endif /* _SAMV71_USART2_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/usbhs.h
+++ b/asf/sam/include/samv71/instance/usbhs.h
@@ -1,0 +1,568 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USBHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_USBHS_INSTANCE_H_
+#define _SAMV71_USBHS_INSTANCE_H_
+
+/* ========== Register definition for USBHS peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USBHS_DEVDMANXTDSC0 (0x40038310) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (0x40038314) /**< (USBHS) Device DMA Channel Address Register (n = 1) 0 */
+#define REG_USBHS_DEVDMACONTROL0 (0x40038318) /**< (USBHS) Device DMA Channel Control Register (n = 1) 0 */
+#define REG_USBHS_DEVDMASTATUS0 (0x4003831C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (0x40038320) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (0x40038324) /**< (USBHS) Device DMA Channel Address Register (n = 1) 1 */
+#define REG_USBHS_DEVDMACONTROL1 (0x40038328) /**< (USBHS) Device DMA Channel Control Register (n = 1) 1 */
+#define REG_USBHS_DEVDMASTATUS1 (0x4003832C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (0x40038330) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (0x40038334) /**< (USBHS) Device DMA Channel Address Register (n = 1) 2 */
+#define REG_USBHS_DEVDMACONTROL2 (0x40038338) /**< (USBHS) Device DMA Channel Control Register (n = 1) 2 */
+#define REG_USBHS_DEVDMASTATUS2 (0x4003833C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (0x40038340) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (0x40038344) /**< (USBHS) Device DMA Channel Address Register (n = 1) 3 */
+#define REG_USBHS_DEVDMACONTROL3 (0x40038348) /**< (USBHS) Device DMA Channel Control Register (n = 1) 3 */
+#define REG_USBHS_DEVDMASTATUS3 (0x4003834C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (0x40038350) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (0x40038354) /**< (USBHS) Device DMA Channel Address Register (n = 1) 4 */
+#define REG_USBHS_DEVDMACONTROL4 (0x40038358) /**< (USBHS) Device DMA Channel Control Register (n = 1) 4 */
+#define REG_USBHS_DEVDMASTATUS4 (0x4003835C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (0x40038360) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (0x40038364) /**< (USBHS) Device DMA Channel Address Register (n = 1) 5 */
+#define REG_USBHS_DEVDMACONTROL5 (0x40038368) /**< (USBHS) Device DMA Channel Control Register (n = 1) 5 */
+#define REG_USBHS_DEVDMASTATUS5 (0x4003836C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (0x40038370) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (0x40038374) /**< (USBHS) Device DMA Channel Address Register (n = 1) 6 */
+#define REG_USBHS_DEVDMACONTROL6 (0x40038378) /**< (USBHS) Device DMA Channel Control Register (n = 1) 6 */
+#define REG_USBHS_DEVDMASTATUS6 (0x4003837C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (0x40038710) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (0x40038714) /**< (USBHS) Host DMA Channel Address Register (n = 1) 0 */
+#define REG_USBHS_HSTDMACONTROL0 (0x40038718) /**< (USBHS) Host DMA Channel Control Register (n = 1) 0 */
+#define REG_USBHS_HSTDMASTATUS0 (0x4003871C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (0x40038720) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (0x40038724) /**< (USBHS) Host DMA Channel Address Register (n = 1) 1 */
+#define REG_USBHS_HSTDMACONTROL1 (0x40038728) /**< (USBHS) Host DMA Channel Control Register (n = 1) 1 */
+#define REG_USBHS_HSTDMASTATUS1 (0x4003872C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (0x40038730) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (0x40038734) /**< (USBHS) Host DMA Channel Address Register (n = 1) 2 */
+#define REG_USBHS_HSTDMACONTROL2 (0x40038738) /**< (USBHS) Host DMA Channel Control Register (n = 1) 2 */
+#define REG_USBHS_HSTDMASTATUS2 (0x4003873C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (0x40038740) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (0x40038744) /**< (USBHS) Host DMA Channel Address Register (n = 1) 3 */
+#define REG_USBHS_HSTDMACONTROL3 (0x40038748) /**< (USBHS) Host DMA Channel Control Register (n = 1) 3 */
+#define REG_USBHS_HSTDMASTATUS3 (0x4003874C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (0x40038750) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (0x40038754) /**< (USBHS) Host DMA Channel Address Register (n = 1) 4 */
+#define REG_USBHS_HSTDMACONTROL4 (0x40038758) /**< (USBHS) Host DMA Channel Control Register (n = 1) 4 */
+#define REG_USBHS_HSTDMASTATUS4 (0x4003875C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (0x40038760) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (0x40038764) /**< (USBHS) Host DMA Channel Address Register (n = 1) 5 */
+#define REG_USBHS_HSTDMACONTROL5 (0x40038768) /**< (USBHS) Host DMA Channel Control Register (n = 1) 5 */
+#define REG_USBHS_HSTDMASTATUS5 (0x4003876C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (0x40038770) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (0x40038774) /**< (USBHS) Host DMA Channel Address Register (n = 1) 6 */
+#define REG_USBHS_HSTDMACONTROL6 (0x40038778) /**< (USBHS) Host DMA Channel Control Register (n = 1) 6 */
+#define REG_USBHS_HSTDMASTATUS6 (0x4003877C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_DEVCTRL       (0x40038000) /**< (USBHS) Device General Control Register */
+#define REG_USBHS_DEVISR        (0x40038004) /**< (USBHS) Device Global Interrupt Status Register */
+#define REG_USBHS_DEVICR        (0x40038008) /**< (USBHS) Device Global Interrupt Clear Register */
+#define REG_USBHS_DEVIFR        (0x4003800C) /**< (USBHS) Device Global Interrupt Set Register */
+#define REG_USBHS_DEVIMR        (0x40038010) /**< (USBHS) Device Global Interrupt Mask Register */
+#define REG_USBHS_DEVIDR        (0x40038014) /**< (USBHS) Device Global Interrupt Disable Register */
+#define REG_USBHS_DEVIER        (0x40038018) /**< (USBHS) Device Global Interrupt Enable Register */
+#define REG_USBHS_DEVEPT        (0x4003801C) /**< (USBHS) Device Endpoint Register */
+#define REG_USBHS_DEVFNUM       (0x40038020) /**< (USBHS) Device Frame Number Register */
+#define REG_USBHS_DEVEPTCFG     (0x40038100) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTCFG0    (0x40038100) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTCFG1    (0x40038104) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTCFG2    (0x40038108) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTCFG3    (0x4003810C) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTCFG4    (0x40038110) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTCFG5    (0x40038114) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTCFG6    (0x40038118) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTCFG7    (0x4003811C) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTCFG8    (0x40038120) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTCFG9    (0x40038124) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTISR     (0x40038130) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTISR0    (0x40038130) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTISR1    (0x40038134) /**< (USBHS) Device Endpoint Status Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTISR2    (0x40038138) /**< (USBHS) Device Endpoint Status Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTISR3    (0x4003813C) /**< (USBHS) Device Endpoint Status Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTISR4    (0x40038140) /**< (USBHS) Device Endpoint Status Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTISR5    (0x40038144) /**< (USBHS) Device Endpoint Status Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTISR6    (0x40038148) /**< (USBHS) Device Endpoint Status Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTISR7    (0x4003814C) /**< (USBHS) Device Endpoint Status Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTISR8    (0x40038150) /**< (USBHS) Device Endpoint Status Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTISR9    (0x40038154) /**< (USBHS) Device Endpoint Status Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTICR     (0x40038160) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTICR0    (0x40038160) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTICR1    (0x40038164) /**< (USBHS) Device Endpoint Clear Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTICR2    (0x40038168) /**< (USBHS) Device Endpoint Clear Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTICR3    (0x4003816C) /**< (USBHS) Device Endpoint Clear Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTICR4    (0x40038170) /**< (USBHS) Device Endpoint Clear Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTICR5    (0x40038174) /**< (USBHS) Device Endpoint Clear Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTICR6    (0x40038178) /**< (USBHS) Device Endpoint Clear Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTICR7    (0x4003817C) /**< (USBHS) Device Endpoint Clear Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTICR8    (0x40038180) /**< (USBHS) Device Endpoint Clear Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTICR9    (0x40038184) /**< (USBHS) Device Endpoint Clear Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIFR     (0x40038190) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIFR0    (0x40038190) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIFR1    (0x40038194) /**< (USBHS) Device Endpoint Set Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIFR2    (0x40038198) /**< (USBHS) Device Endpoint Set Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIFR3    (0x4003819C) /**< (USBHS) Device Endpoint Set Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIFR4    (0x400381A0) /**< (USBHS) Device Endpoint Set Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIFR5    (0x400381A4) /**< (USBHS) Device Endpoint Set Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIFR6    (0x400381A8) /**< (USBHS) Device Endpoint Set Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIFR7    (0x400381AC) /**< (USBHS) Device Endpoint Set Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIFR8    (0x400381B0) /**< (USBHS) Device Endpoint Set Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIFR9    (0x400381B4) /**< (USBHS) Device Endpoint Set Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIMR     (0x400381C0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIMR0    (0x400381C0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIMR1    (0x400381C4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIMR2    (0x400381C8) /**< (USBHS) Device Endpoint Mask Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIMR3    (0x400381CC) /**< (USBHS) Device Endpoint Mask Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIMR4    (0x400381D0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIMR5    (0x400381D4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIMR6    (0x400381D8) /**< (USBHS) Device Endpoint Mask Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIMR7    (0x400381DC) /**< (USBHS) Device Endpoint Mask Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIMR8    (0x400381E0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIMR9    (0x400381E4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIER     (0x400381F0) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIER0    (0x400381F0) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIER1    (0x400381F4) /**< (USBHS) Device Endpoint Enable Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIER2    (0x400381F8) /**< (USBHS) Device Endpoint Enable Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIER3    (0x400381FC) /**< (USBHS) Device Endpoint Enable Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIER4    (0x40038200) /**< (USBHS) Device Endpoint Enable Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIER5    (0x40038204) /**< (USBHS) Device Endpoint Enable Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIER6    (0x40038208) /**< (USBHS) Device Endpoint Enable Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIER7    (0x4003820C) /**< (USBHS) Device Endpoint Enable Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIER8    (0x40038210) /**< (USBHS) Device Endpoint Enable Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIER9    (0x40038214) /**< (USBHS) Device Endpoint Enable Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIDR     (0x40038220) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIDR0    (0x40038220) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIDR1    (0x40038224) /**< (USBHS) Device Endpoint Disable Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIDR2    (0x40038228) /**< (USBHS) Device Endpoint Disable Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIDR3    (0x4003822C) /**< (USBHS) Device Endpoint Disable Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIDR4    (0x40038230) /**< (USBHS) Device Endpoint Disable Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIDR5    (0x40038234) /**< (USBHS) Device Endpoint Disable Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIDR6    (0x40038238) /**< (USBHS) Device Endpoint Disable Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIDR7    (0x4003823C) /**< (USBHS) Device Endpoint Disable Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIDR8    (0x40038240) /**< (USBHS) Device Endpoint Disable Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIDR9    (0x40038244) /**< (USBHS) Device Endpoint Disable Register (n = 0) 9 */
+#define REG_USBHS_HSTCTRL       (0x40038400) /**< (USBHS) Host General Control Register */
+#define REG_USBHS_HSTISR        (0x40038404) /**< (USBHS) Host Global Interrupt Status Register */
+#define REG_USBHS_HSTICR        (0x40038408) /**< (USBHS) Host Global Interrupt Clear Register */
+#define REG_USBHS_HSTIFR        (0x4003840C) /**< (USBHS) Host Global Interrupt Set Register */
+#define REG_USBHS_HSTIMR        (0x40038410) /**< (USBHS) Host Global Interrupt Mask Register */
+#define REG_USBHS_HSTIDR        (0x40038414) /**< (USBHS) Host Global Interrupt Disable Register */
+#define REG_USBHS_HSTIER        (0x40038418) /**< (USBHS) Host Global Interrupt Enable Register */
+#define REG_USBHS_HSTPIP        (0x4003841C) /**< (USBHS) Host Pipe Register */
+#define REG_USBHS_HSTFNUM       (0x40038420) /**< (USBHS) Host Frame Number Register */
+#define REG_USBHS_HSTADDR1      (0x40038424) /**< (USBHS) Host Address 1 Register */
+#define REG_USBHS_HSTADDR2      (0x40038428) /**< (USBHS) Host Address 2 Register */
+#define REG_USBHS_HSTADDR3      (0x4003842C) /**< (USBHS) Host Address 3 Register */
+#define REG_USBHS_HSTPIPCFG     (0x40038500) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPCFG0    (0x40038500) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPCFG1    (0x40038504) /**< (USBHS) Host Pipe Configuration Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPCFG2    (0x40038508) /**< (USBHS) Host Pipe Configuration Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPCFG3    (0x4003850C) /**< (USBHS) Host Pipe Configuration Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPCFG4    (0x40038510) /**< (USBHS) Host Pipe Configuration Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPCFG5    (0x40038514) /**< (USBHS) Host Pipe Configuration Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPCFG6    (0x40038518) /**< (USBHS) Host Pipe Configuration Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPCFG7    (0x4003851C) /**< (USBHS) Host Pipe Configuration Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPCFG8    (0x40038520) /**< (USBHS) Host Pipe Configuration Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPCFG9    (0x40038524) /**< (USBHS) Host Pipe Configuration Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPISR     (0x40038530) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPISR0    (0x40038530) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPISR1    (0x40038534) /**< (USBHS) Host Pipe Status Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPISR2    (0x40038538) /**< (USBHS) Host Pipe Status Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPISR3    (0x4003853C) /**< (USBHS) Host Pipe Status Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPISR4    (0x40038540) /**< (USBHS) Host Pipe Status Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPISR5    (0x40038544) /**< (USBHS) Host Pipe Status Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPISR6    (0x40038548) /**< (USBHS) Host Pipe Status Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPISR7    (0x4003854C) /**< (USBHS) Host Pipe Status Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPISR8    (0x40038550) /**< (USBHS) Host Pipe Status Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPISR9    (0x40038554) /**< (USBHS) Host Pipe Status Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPICR     (0x40038560) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPICR0    (0x40038560) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPICR1    (0x40038564) /**< (USBHS) Host Pipe Clear Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPICR2    (0x40038568) /**< (USBHS) Host Pipe Clear Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPICR3    (0x4003856C) /**< (USBHS) Host Pipe Clear Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPICR4    (0x40038570) /**< (USBHS) Host Pipe Clear Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPICR5    (0x40038574) /**< (USBHS) Host Pipe Clear Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPICR6    (0x40038578) /**< (USBHS) Host Pipe Clear Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPICR7    (0x4003857C) /**< (USBHS) Host Pipe Clear Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPICR8    (0x40038580) /**< (USBHS) Host Pipe Clear Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPICR9    (0x40038584) /**< (USBHS) Host Pipe Clear Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIFR     (0x40038590) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIFR0    (0x40038590) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIFR1    (0x40038594) /**< (USBHS) Host Pipe Set Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIFR2    (0x40038598) /**< (USBHS) Host Pipe Set Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIFR3    (0x4003859C) /**< (USBHS) Host Pipe Set Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIFR4    (0x400385A0) /**< (USBHS) Host Pipe Set Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIFR5    (0x400385A4) /**< (USBHS) Host Pipe Set Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIFR6    (0x400385A8) /**< (USBHS) Host Pipe Set Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIFR7    (0x400385AC) /**< (USBHS) Host Pipe Set Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIFR8    (0x400385B0) /**< (USBHS) Host Pipe Set Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIFR9    (0x400385B4) /**< (USBHS) Host Pipe Set Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIMR     (0x400385C0) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIMR0    (0x400385C0) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIMR1    (0x400385C4) /**< (USBHS) Host Pipe Mask Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIMR2    (0x400385C8) /**< (USBHS) Host Pipe Mask Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIMR3    (0x400385CC) /**< (USBHS) Host Pipe Mask Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIMR4    (0x400385D0) /**< (USBHS) Host Pipe Mask Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIMR5    (0x400385D4) /**< (USBHS) Host Pipe Mask Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIMR6    (0x400385D8) /**< (USBHS) Host Pipe Mask Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIMR7    (0x400385DC) /**< (USBHS) Host Pipe Mask Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIMR8    (0x400385E0) /**< (USBHS) Host Pipe Mask Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIMR9    (0x400385E4) /**< (USBHS) Host Pipe Mask Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIER     (0x400385F0) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIER0    (0x400385F0) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIER1    (0x400385F4) /**< (USBHS) Host Pipe Enable Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIER2    (0x400385F8) /**< (USBHS) Host Pipe Enable Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIER3    (0x400385FC) /**< (USBHS) Host Pipe Enable Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIER4    (0x40038600) /**< (USBHS) Host Pipe Enable Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIER5    (0x40038604) /**< (USBHS) Host Pipe Enable Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIER6    (0x40038608) /**< (USBHS) Host Pipe Enable Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIER7    (0x4003860C) /**< (USBHS) Host Pipe Enable Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIER8    (0x40038610) /**< (USBHS) Host Pipe Enable Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIER9    (0x40038614) /**< (USBHS) Host Pipe Enable Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIDR     (0x40038620) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIDR0    (0x40038620) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIDR1    (0x40038624) /**< (USBHS) Host Pipe Disable Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIDR2    (0x40038628) /**< (USBHS) Host Pipe Disable Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIDR3    (0x4003862C) /**< (USBHS) Host Pipe Disable Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIDR4    (0x40038630) /**< (USBHS) Host Pipe Disable Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIDR5    (0x40038634) /**< (USBHS) Host Pipe Disable Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIDR6    (0x40038638) /**< (USBHS) Host Pipe Disable Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIDR7    (0x4003863C) /**< (USBHS) Host Pipe Disable Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIDR8    (0x40038640) /**< (USBHS) Host Pipe Disable Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIDR9    (0x40038644) /**< (USBHS) Host Pipe Disable Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPINRQ    (0x40038650) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPINRQ0   (0x40038650) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPINRQ1   (0x40038654) /**< (USBHS) Host Pipe IN Request Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPINRQ2   (0x40038658) /**< (USBHS) Host Pipe IN Request Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPINRQ3   (0x4003865C) /**< (USBHS) Host Pipe IN Request Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPINRQ4   (0x40038660) /**< (USBHS) Host Pipe IN Request Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPINRQ5   (0x40038664) /**< (USBHS) Host Pipe IN Request Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPINRQ6   (0x40038668) /**< (USBHS) Host Pipe IN Request Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPINRQ7   (0x4003866C) /**< (USBHS) Host Pipe IN Request Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPINRQ8   (0x40038670) /**< (USBHS) Host Pipe IN Request Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPINRQ9   (0x40038674) /**< (USBHS) Host Pipe IN Request Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPERR     (0x40038680) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPERR0    (0x40038680) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPERR1    (0x40038684) /**< (USBHS) Host Pipe Error Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPERR2    (0x40038688) /**< (USBHS) Host Pipe Error Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPERR3    (0x4003868C) /**< (USBHS) Host Pipe Error Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPERR4    (0x40038690) /**< (USBHS) Host Pipe Error Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPERR5    (0x40038694) /**< (USBHS) Host Pipe Error Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPERR6    (0x40038698) /**< (USBHS) Host Pipe Error Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPERR7    (0x4003869C) /**< (USBHS) Host Pipe Error Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPERR8    (0x400386A0) /**< (USBHS) Host Pipe Error Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPERR9    (0x400386A4) /**< (USBHS) Host Pipe Error Register (n = 0) 9 */
+#define REG_USBHS_CTRL          (0x40038800) /**< (USBHS) General Control Register */
+#define REG_USBHS_SR            (0x40038804) /**< (USBHS) General Status Register */
+#define REG_USBHS_SCR           (0x40038808) /**< (USBHS) General Status Clear Register */
+#define REG_USBHS_SFR           (0x4003880C) /**< (USBHS) General Status Set Register */
+#define REG_USBHS_TSTA1         (0x40038810) /**< (USBHS) General Test A1 Register */
+#define REG_USBHS_TSTA2         (0x40038814) /**< (USBHS) General Test A2 Register */
+#define REG_USBHS_VERSION       (0x40038818) /**< (USBHS) General Version Register */
+#define REG_USBHS_FSM           (0x4003882C) /**< (USBHS) General Finite State Machine Register */
+
+#else
+
+#define REG_USBHS_DEVDMANXTDSC0 (*(__IO uint32_t*)0x40038310U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (*(__IO uint32_t*)0x40038314U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 0 */
+#define REG_USBHS_DEVDMACONTROL0 (*(__IO uint32_t*)0x40038318U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 0 */
+#define REG_USBHS_DEVDMASTATUS0 (*(__IO uint32_t*)0x4003831CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (*(__IO uint32_t*)0x40038320U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (*(__IO uint32_t*)0x40038324U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 1 */
+#define REG_USBHS_DEVDMACONTROL1 (*(__IO uint32_t*)0x40038328U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 1 */
+#define REG_USBHS_DEVDMASTATUS1 (*(__IO uint32_t*)0x4003832CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (*(__IO uint32_t*)0x40038330U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (*(__IO uint32_t*)0x40038334U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 2 */
+#define REG_USBHS_DEVDMACONTROL2 (*(__IO uint32_t*)0x40038338U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 2 */
+#define REG_USBHS_DEVDMASTATUS2 (*(__IO uint32_t*)0x4003833CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (*(__IO uint32_t*)0x40038340U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (*(__IO uint32_t*)0x40038344U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 3 */
+#define REG_USBHS_DEVDMACONTROL3 (*(__IO uint32_t*)0x40038348U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 3 */
+#define REG_USBHS_DEVDMASTATUS3 (*(__IO uint32_t*)0x4003834CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (*(__IO uint32_t*)0x40038350U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (*(__IO uint32_t*)0x40038354U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 4 */
+#define REG_USBHS_DEVDMACONTROL4 (*(__IO uint32_t*)0x40038358U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 4 */
+#define REG_USBHS_DEVDMASTATUS4 (*(__IO uint32_t*)0x4003835CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (*(__IO uint32_t*)0x40038360U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (*(__IO uint32_t*)0x40038364U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 5 */
+#define REG_USBHS_DEVDMACONTROL5 (*(__IO uint32_t*)0x40038368U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 5 */
+#define REG_USBHS_DEVDMASTATUS5 (*(__IO uint32_t*)0x4003836CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (*(__IO uint32_t*)0x40038370U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (*(__IO uint32_t*)0x40038374U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 6 */
+#define REG_USBHS_DEVDMACONTROL6 (*(__IO uint32_t*)0x40038378U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 6 */
+#define REG_USBHS_DEVDMASTATUS6 (*(__IO uint32_t*)0x4003837CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (*(__IO uint32_t*)0x40038710U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (*(__IO uint32_t*)0x40038714U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 0 */
+#define REG_USBHS_HSTDMACONTROL0 (*(__IO uint32_t*)0x40038718U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 0 */
+#define REG_USBHS_HSTDMASTATUS0 (*(__IO uint32_t*)0x4003871CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (*(__IO uint32_t*)0x40038720U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (*(__IO uint32_t*)0x40038724U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 1 */
+#define REG_USBHS_HSTDMACONTROL1 (*(__IO uint32_t*)0x40038728U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 1 */
+#define REG_USBHS_HSTDMASTATUS1 (*(__IO uint32_t*)0x4003872CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (*(__IO uint32_t*)0x40038730U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (*(__IO uint32_t*)0x40038734U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 2 */
+#define REG_USBHS_HSTDMACONTROL2 (*(__IO uint32_t*)0x40038738U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 2 */
+#define REG_USBHS_HSTDMASTATUS2 (*(__IO uint32_t*)0x4003873CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (*(__IO uint32_t*)0x40038740U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (*(__IO uint32_t*)0x40038744U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 3 */
+#define REG_USBHS_HSTDMACONTROL3 (*(__IO uint32_t*)0x40038748U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 3 */
+#define REG_USBHS_HSTDMASTATUS3 (*(__IO uint32_t*)0x4003874CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (*(__IO uint32_t*)0x40038750U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (*(__IO uint32_t*)0x40038754U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 4 */
+#define REG_USBHS_HSTDMACONTROL4 (*(__IO uint32_t*)0x40038758U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 4 */
+#define REG_USBHS_HSTDMASTATUS4 (*(__IO uint32_t*)0x4003875CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (*(__IO uint32_t*)0x40038760U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (*(__IO uint32_t*)0x40038764U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 5 */
+#define REG_USBHS_HSTDMACONTROL5 (*(__IO uint32_t*)0x40038768U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 5 */
+#define REG_USBHS_HSTDMASTATUS5 (*(__IO uint32_t*)0x4003876CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (*(__IO uint32_t*)0x40038770U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (*(__IO uint32_t*)0x40038774U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 6 */
+#define REG_USBHS_HSTDMACONTROL6 (*(__IO uint32_t*)0x40038778U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 6 */
+#define REG_USBHS_HSTDMASTATUS6 (*(__IO uint32_t*)0x4003877CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_DEVCTRL       (*(__IO uint32_t*)0x40038000U) /**< (USBHS) Device General Control Register */
+#define REG_USBHS_DEVISR        (*(__I  uint32_t*)0x40038004U) /**< (USBHS) Device Global Interrupt Status Register */
+#define REG_USBHS_DEVICR        (*(__O  uint32_t*)0x40038008U) /**< (USBHS) Device Global Interrupt Clear Register */
+#define REG_USBHS_DEVIFR        (*(__O  uint32_t*)0x4003800CU) /**< (USBHS) Device Global Interrupt Set Register */
+#define REG_USBHS_DEVIMR        (*(__I  uint32_t*)0x40038010U) /**< (USBHS) Device Global Interrupt Mask Register */
+#define REG_USBHS_DEVIDR        (*(__O  uint32_t*)0x40038014U) /**< (USBHS) Device Global Interrupt Disable Register */
+#define REG_USBHS_DEVIER        (*(__O  uint32_t*)0x40038018U) /**< (USBHS) Device Global Interrupt Enable Register */
+#define REG_USBHS_DEVEPT        (*(__IO uint32_t*)0x4003801CU) /**< (USBHS) Device Endpoint Register */
+#define REG_USBHS_DEVFNUM       (*(__I  uint32_t*)0x40038020U) /**< (USBHS) Device Frame Number Register */
+#define REG_USBHS_DEVEPTCFG     (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTCFG0    (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTCFG1    (*(__IO uint32_t*)0x40038104U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTCFG2    (*(__IO uint32_t*)0x40038108U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTCFG3    (*(__IO uint32_t*)0x4003810CU) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTCFG4    (*(__IO uint32_t*)0x40038110U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTCFG5    (*(__IO uint32_t*)0x40038114U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTCFG6    (*(__IO uint32_t*)0x40038118U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTCFG7    (*(__IO uint32_t*)0x4003811CU) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTCFG8    (*(__IO uint32_t*)0x40038120U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTCFG9    (*(__IO uint32_t*)0x40038124U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTISR     (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTISR0    (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTISR1    (*(__I  uint32_t*)0x40038134U) /**< (USBHS) Device Endpoint Status Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTISR2    (*(__I  uint32_t*)0x40038138U) /**< (USBHS) Device Endpoint Status Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTISR3    (*(__I  uint32_t*)0x4003813CU) /**< (USBHS) Device Endpoint Status Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTISR4    (*(__I  uint32_t*)0x40038140U) /**< (USBHS) Device Endpoint Status Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTISR5    (*(__I  uint32_t*)0x40038144U) /**< (USBHS) Device Endpoint Status Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTISR6    (*(__I  uint32_t*)0x40038148U) /**< (USBHS) Device Endpoint Status Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTISR7    (*(__I  uint32_t*)0x4003814CU) /**< (USBHS) Device Endpoint Status Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTISR8    (*(__I  uint32_t*)0x40038150U) /**< (USBHS) Device Endpoint Status Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTISR9    (*(__I  uint32_t*)0x40038154U) /**< (USBHS) Device Endpoint Status Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTICR     (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTICR0    (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTICR1    (*(__O  uint32_t*)0x40038164U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTICR2    (*(__O  uint32_t*)0x40038168U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTICR3    (*(__O  uint32_t*)0x4003816CU) /**< (USBHS) Device Endpoint Clear Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTICR4    (*(__O  uint32_t*)0x40038170U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTICR5    (*(__O  uint32_t*)0x40038174U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTICR6    (*(__O  uint32_t*)0x40038178U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTICR7    (*(__O  uint32_t*)0x4003817CU) /**< (USBHS) Device Endpoint Clear Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTICR8    (*(__O  uint32_t*)0x40038180U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTICR9    (*(__O  uint32_t*)0x40038184U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIFR     (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIFR0    (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIFR1    (*(__O  uint32_t*)0x40038194U) /**< (USBHS) Device Endpoint Set Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIFR2    (*(__O  uint32_t*)0x40038198U) /**< (USBHS) Device Endpoint Set Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIFR3    (*(__O  uint32_t*)0x4003819CU) /**< (USBHS) Device Endpoint Set Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIFR4    (*(__O  uint32_t*)0x400381A0U) /**< (USBHS) Device Endpoint Set Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIFR5    (*(__O  uint32_t*)0x400381A4U) /**< (USBHS) Device Endpoint Set Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIFR6    (*(__O  uint32_t*)0x400381A8U) /**< (USBHS) Device Endpoint Set Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIFR7    (*(__O  uint32_t*)0x400381ACU) /**< (USBHS) Device Endpoint Set Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIFR8    (*(__O  uint32_t*)0x400381B0U) /**< (USBHS) Device Endpoint Set Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIFR9    (*(__O  uint32_t*)0x400381B4U) /**< (USBHS) Device Endpoint Set Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIMR     (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIMR0    (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIMR1    (*(__I  uint32_t*)0x400381C4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIMR2    (*(__I  uint32_t*)0x400381C8U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIMR3    (*(__I  uint32_t*)0x400381CCU) /**< (USBHS) Device Endpoint Mask Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIMR4    (*(__I  uint32_t*)0x400381D0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIMR5    (*(__I  uint32_t*)0x400381D4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIMR6    (*(__I  uint32_t*)0x400381D8U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIMR7    (*(__I  uint32_t*)0x400381DCU) /**< (USBHS) Device Endpoint Mask Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIMR8    (*(__I  uint32_t*)0x400381E0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIMR9    (*(__I  uint32_t*)0x400381E4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIER     (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIER0    (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIER1    (*(__O  uint32_t*)0x400381F4U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIER2    (*(__O  uint32_t*)0x400381F8U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIER3    (*(__O  uint32_t*)0x400381FCU) /**< (USBHS) Device Endpoint Enable Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIER4    (*(__O  uint32_t*)0x40038200U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIER5    (*(__O  uint32_t*)0x40038204U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIER6    (*(__O  uint32_t*)0x40038208U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIER7    (*(__O  uint32_t*)0x4003820CU) /**< (USBHS) Device Endpoint Enable Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIER8    (*(__O  uint32_t*)0x40038210U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIER9    (*(__O  uint32_t*)0x40038214U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTIDR     (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIDR0    (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
+#define REG_USBHS_DEVEPTIDR1    (*(__O  uint32_t*)0x40038224U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 1 */
+#define REG_USBHS_DEVEPTIDR2    (*(__O  uint32_t*)0x40038228U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 2 */
+#define REG_USBHS_DEVEPTIDR3    (*(__O  uint32_t*)0x4003822CU) /**< (USBHS) Device Endpoint Disable Register (n = 0) 3 */
+#define REG_USBHS_DEVEPTIDR4    (*(__O  uint32_t*)0x40038230U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 4 */
+#define REG_USBHS_DEVEPTIDR5    (*(__O  uint32_t*)0x40038234U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 5 */
+#define REG_USBHS_DEVEPTIDR6    (*(__O  uint32_t*)0x40038238U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 6 */
+#define REG_USBHS_DEVEPTIDR7    (*(__O  uint32_t*)0x4003823CU) /**< (USBHS) Device Endpoint Disable Register (n = 0) 7 */
+#define REG_USBHS_DEVEPTIDR8    (*(__O  uint32_t*)0x40038240U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 8 */
+#define REG_USBHS_DEVEPTIDR9    (*(__O  uint32_t*)0x40038244U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 9 */
+#define REG_USBHS_HSTCTRL       (*(__IO uint32_t*)0x40038400U) /**< (USBHS) Host General Control Register */
+#define REG_USBHS_HSTISR        (*(__I  uint32_t*)0x40038404U) /**< (USBHS) Host Global Interrupt Status Register */
+#define REG_USBHS_HSTICR        (*(__O  uint32_t*)0x40038408U) /**< (USBHS) Host Global Interrupt Clear Register */
+#define REG_USBHS_HSTIFR        (*(__O  uint32_t*)0x4003840CU) /**< (USBHS) Host Global Interrupt Set Register */
+#define REG_USBHS_HSTIMR        (*(__I  uint32_t*)0x40038410U) /**< (USBHS) Host Global Interrupt Mask Register */
+#define REG_USBHS_HSTIDR        (*(__O  uint32_t*)0x40038414U) /**< (USBHS) Host Global Interrupt Disable Register */
+#define REG_USBHS_HSTIER        (*(__O  uint32_t*)0x40038418U) /**< (USBHS) Host Global Interrupt Enable Register */
+#define REG_USBHS_HSTPIP        (*(__IO uint32_t*)0x4003841CU) /**< (USBHS) Host Pipe Register */
+#define REG_USBHS_HSTFNUM       (*(__IO uint32_t*)0x40038420U) /**< (USBHS) Host Frame Number Register */
+#define REG_USBHS_HSTADDR1      (*(__IO uint32_t*)0x40038424U) /**< (USBHS) Host Address 1 Register */
+#define REG_USBHS_HSTADDR2      (*(__IO uint32_t*)0x40038428U) /**< (USBHS) Host Address 2 Register */
+#define REG_USBHS_HSTADDR3      (*(__IO uint32_t*)0x4003842CU) /**< (USBHS) Host Address 3 Register */
+#define REG_USBHS_HSTPIPCFG     (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPCFG0    (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPCFG1    (*(__IO uint32_t*)0x40038504U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPCFG2    (*(__IO uint32_t*)0x40038508U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPCFG3    (*(__IO uint32_t*)0x4003850CU) /**< (USBHS) Host Pipe Configuration Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPCFG4    (*(__IO uint32_t*)0x40038510U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPCFG5    (*(__IO uint32_t*)0x40038514U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPCFG6    (*(__IO uint32_t*)0x40038518U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPCFG7    (*(__IO uint32_t*)0x4003851CU) /**< (USBHS) Host Pipe Configuration Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPCFG8    (*(__IO uint32_t*)0x40038520U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPCFG9    (*(__IO uint32_t*)0x40038524U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPISR     (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPISR0    (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPISR1    (*(__I  uint32_t*)0x40038534U) /**< (USBHS) Host Pipe Status Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPISR2    (*(__I  uint32_t*)0x40038538U) /**< (USBHS) Host Pipe Status Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPISR3    (*(__I  uint32_t*)0x4003853CU) /**< (USBHS) Host Pipe Status Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPISR4    (*(__I  uint32_t*)0x40038540U) /**< (USBHS) Host Pipe Status Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPISR5    (*(__I  uint32_t*)0x40038544U) /**< (USBHS) Host Pipe Status Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPISR6    (*(__I  uint32_t*)0x40038548U) /**< (USBHS) Host Pipe Status Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPISR7    (*(__I  uint32_t*)0x4003854CU) /**< (USBHS) Host Pipe Status Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPISR8    (*(__I  uint32_t*)0x40038550U) /**< (USBHS) Host Pipe Status Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPISR9    (*(__I  uint32_t*)0x40038554U) /**< (USBHS) Host Pipe Status Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPICR     (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPICR0    (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPICR1    (*(__O  uint32_t*)0x40038564U) /**< (USBHS) Host Pipe Clear Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPICR2    (*(__O  uint32_t*)0x40038568U) /**< (USBHS) Host Pipe Clear Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPICR3    (*(__O  uint32_t*)0x4003856CU) /**< (USBHS) Host Pipe Clear Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPICR4    (*(__O  uint32_t*)0x40038570U) /**< (USBHS) Host Pipe Clear Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPICR5    (*(__O  uint32_t*)0x40038574U) /**< (USBHS) Host Pipe Clear Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPICR6    (*(__O  uint32_t*)0x40038578U) /**< (USBHS) Host Pipe Clear Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPICR7    (*(__O  uint32_t*)0x4003857CU) /**< (USBHS) Host Pipe Clear Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPICR8    (*(__O  uint32_t*)0x40038580U) /**< (USBHS) Host Pipe Clear Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPICR9    (*(__O  uint32_t*)0x40038584U) /**< (USBHS) Host Pipe Clear Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIFR     (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIFR0    (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIFR1    (*(__O  uint32_t*)0x40038594U) /**< (USBHS) Host Pipe Set Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIFR2    (*(__O  uint32_t*)0x40038598U) /**< (USBHS) Host Pipe Set Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIFR3    (*(__O  uint32_t*)0x4003859CU) /**< (USBHS) Host Pipe Set Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIFR4    (*(__O  uint32_t*)0x400385A0U) /**< (USBHS) Host Pipe Set Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIFR5    (*(__O  uint32_t*)0x400385A4U) /**< (USBHS) Host Pipe Set Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIFR6    (*(__O  uint32_t*)0x400385A8U) /**< (USBHS) Host Pipe Set Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIFR7    (*(__O  uint32_t*)0x400385ACU) /**< (USBHS) Host Pipe Set Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIFR8    (*(__O  uint32_t*)0x400385B0U) /**< (USBHS) Host Pipe Set Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIFR9    (*(__O  uint32_t*)0x400385B4U) /**< (USBHS) Host Pipe Set Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIMR     (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIMR0    (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIMR1    (*(__I  uint32_t*)0x400385C4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIMR2    (*(__I  uint32_t*)0x400385C8U) /**< (USBHS) Host Pipe Mask Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIMR3    (*(__I  uint32_t*)0x400385CCU) /**< (USBHS) Host Pipe Mask Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIMR4    (*(__I  uint32_t*)0x400385D0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIMR5    (*(__I  uint32_t*)0x400385D4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIMR6    (*(__I  uint32_t*)0x400385D8U) /**< (USBHS) Host Pipe Mask Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIMR7    (*(__I  uint32_t*)0x400385DCU) /**< (USBHS) Host Pipe Mask Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIMR8    (*(__I  uint32_t*)0x400385E0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIMR9    (*(__I  uint32_t*)0x400385E4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIER     (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIER0    (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIER1    (*(__O  uint32_t*)0x400385F4U) /**< (USBHS) Host Pipe Enable Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIER2    (*(__O  uint32_t*)0x400385F8U) /**< (USBHS) Host Pipe Enable Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIER3    (*(__O  uint32_t*)0x400385FCU) /**< (USBHS) Host Pipe Enable Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIER4    (*(__O  uint32_t*)0x40038600U) /**< (USBHS) Host Pipe Enable Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIER5    (*(__O  uint32_t*)0x40038604U) /**< (USBHS) Host Pipe Enable Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIER6    (*(__O  uint32_t*)0x40038608U) /**< (USBHS) Host Pipe Enable Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIER7    (*(__O  uint32_t*)0x4003860CU) /**< (USBHS) Host Pipe Enable Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIER8    (*(__O  uint32_t*)0x40038610U) /**< (USBHS) Host Pipe Enable Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIER9    (*(__O  uint32_t*)0x40038614U) /**< (USBHS) Host Pipe Enable Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPIDR     (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIDR0    (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPIDR1    (*(__O  uint32_t*)0x40038624U) /**< (USBHS) Host Pipe Disable Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPIDR2    (*(__O  uint32_t*)0x40038628U) /**< (USBHS) Host Pipe Disable Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPIDR3    (*(__O  uint32_t*)0x4003862CU) /**< (USBHS) Host Pipe Disable Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPIDR4    (*(__O  uint32_t*)0x40038630U) /**< (USBHS) Host Pipe Disable Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPIDR5    (*(__O  uint32_t*)0x40038634U) /**< (USBHS) Host Pipe Disable Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPIDR6    (*(__O  uint32_t*)0x40038638U) /**< (USBHS) Host Pipe Disable Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPIDR7    (*(__O  uint32_t*)0x4003863CU) /**< (USBHS) Host Pipe Disable Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPIDR8    (*(__O  uint32_t*)0x40038640U) /**< (USBHS) Host Pipe Disable Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPIDR9    (*(__O  uint32_t*)0x40038644U) /**< (USBHS) Host Pipe Disable Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPINRQ    (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPINRQ0   (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPINRQ1   (*(__IO uint32_t*)0x40038654U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPINRQ2   (*(__IO uint32_t*)0x40038658U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPINRQ3   (*(__IO uint32_t*)0x4003865CU) /**< (USBHS) Host Pipe IN Request Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPINRQ4   (*(__IO uint32_t*)0x40038660U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPINRQ5   (*(__IO uint32_t*)0x40038664U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPINRQ6   (*(__IO uint32_t*)0x40038668U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPINRQ7   (*(__IO uint32_t*)0x4003866CU) /**< (USBHS) Host Pipe IN Request Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPINRQ8   (*(__IO uint32_t*)0x40038670U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPINRQ9   (*(__IO uint32_t*)0x40038674U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPERR     (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPERR0    (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
+#define REG_USBHS_HSTPIPERR1    (*(__IO uint32_t*)0x40038684U) /**< (USBHS) Host Pipe Error Register (n = 0) 1 */
+#define REG_USBHS_HSTPIPERR2    (*(__IO uint32_t*)0x40038688U) /**< (USBHS) Host Pipe Error Register (n = 0) 2 */
+#define REG_USBHS_HSTPIPERR3    (*(__IO uint32_t*)0x4003868CU) /**< (USBHS) Host Pipe Error Register (n = 0) 3 */
+#define REG_USBHS_HSTPIPERR4    (*(__IO uint32_t*)0x40038690U) /**< (USBHS) Host Pipe Error Register (n = 0) 4 */
+#define REG_USBHS_HSTPIPERR5    (*(__IO uint32_t*)0x40038694U) /**< (USBHS) Host Pipe Error Register (n = 0) 5 */
+#define REG_USBHS_HSTPIPERR6    (*(__IO uint32_t*)0x40038698U) /**< (USBHS) Host Pipe Error Register (n = 0) 6 */
+#define REG_USBHS_HSTPIPERR7    (*(__IO uint32_t*)0x4003869CU) /**< (USBHS) Host Pipe Error Register (n = 0) 7 */
+#define REG_USBHS_HSTPIPERR8    (*(__IO uint32_t*)0x400386A0U) /**< (USBHS) Host Pipe Error Register (n = 0) 8 */
+#define REG_USBHS_HSTPIPERR9    (*(__IO uint32_t*)0x400386A4U) /**< (USBHS) Host Pipe Error Register (n = 0) 9 */
+#define REG_USBHS_CTRL          (*(__IO uint32_t*)0x40038800U) /**< (USBHS) General Control Register */
+#define REG_USBHS_SR            (*(__I  uint32_t*)0x40038804U) /**< (USBHS) General Status Register */
+#define REG_USBHS_SCR           (*(__O  uint32_t*)0x40038808U) /**< (USBHS) General Status Clear Register */
+#define REG_USBHS_SFR           (*(__O  uint32_t*)0x4003880CU) /**< (USBHS) General Status Set Register */
+#define REG_USBHS_TSTA1         (*(__IO uint32_t*)0x40038810U) /**< (USBHS) General Test A1 Register */
+#define REG_USBHS_TSTA2         (*(__IO uint32_t*)0x40038814U) /**< (USBHS) General Test A2 Register */
+#define REG_USBHS_VERSION       (*(__I  uint32_t*)0x40038818U) /**< (USBHS) General Version Register */
+#define REG_USBHS_FSM           (*(__I  uint32_t*)0x4003882CU) /**< (USBHS) General Finite State Machine Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USBHS peripheral ========== */
+#define USBHS_INSTANCE_ID                        34         
+
+#endif /* _SAMV71_USBHS_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/utmi.h
+++ b/asf/sam/include/samv71/instance/utmi.h
@@ -1,0 +1,46 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UTMI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_UTMI_INSTANCE_H_
+#define _SAMV71_UTMI_INSTANCE_H_
+
+/* ========== Register definition for UTMI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UTMI_OHCIICR        (0x400E0410) /**< (UTMI) OHCI Interrupt Configuration Register */
+#define REG_UTMI_CKTRIM         (0x400E0430) /**< (UTMI) UTMI Clock Trimming Register */
+
+#else
+
+#define REG_UTMI_OHCIICR        (*(__IO uint32_t*)0x400E0410U) /**< (UTMI) OHCI Interrupt Configuration Register */
+#define REG_UTMI_CKTRIM         (*(__IO uint32_t*)0x400E0430U) /**< (UTMI) UTMI Clock Trimming Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_UTMI_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/wdt.h
+++ b/asf/sam/include/samv71/instance/wdt.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_WDT_INSTANCE_H_
+#define _SAMV71_WDT_INSTANCE_H_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_WDT_CR              (0x400E1850) /**< (WDT) Control Register */
+#define REG_WDT_MR              (0x400E1854) /**< (WDT) Mode Register */
+#define REG_WDT_SR              (0x400E1858) /**< (WDT) Status Register */
+
+#else
+
+#define REG_WDT_CR              (*(__O  uint32_t*)0x400E1850U) /**< (WDT) Control Register */
+#define REG_WDT_MR              (*(__IO uint32_t*)0x400E1854U) /**< (WDT) Mode Register */
+#define REG_WDT_SR              (*(__I  uint32_t*)0x400E1858U) /**< (WDT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for WDT peripheral ========== */
+#define WDT_INSTANCE_ID                          4          
+
+#endif /* _SAMV71_WDT_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/xdmac.h
+++ b/asf/sam/include/samv71/instance/xdmac.h
@@ -1,0 +1,754 @@
+/**
+ * \file
+ *
+ * \brief Instance description for XDMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71_XDMAC_INSTANCE_H_
+#define _SAMV71_XDMAC_INSTANCE_H_
+
+/* ========== Register definition for XDMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_XDMAC_CIE0          (0x40078050) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 0 */
+#define REG_XDMAC_CID0          (0x40078054) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 0 */
+#define REG_XDMAC_CIM0          (0x40078058) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 0 */
+#define REG_XDMAC_CIS0          (0x4007805C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 0 */
+#define REG_XDMAC_CSA0          (0x40078060) /**< (XDMAC) Channel Source Address Register (chid = 0) 0 */
+#define REG_XDMAC_CDA0          (0x40078064) /**< (XDMAC) Channel Destination Address Register (chid = 0) 0 */
+#define REG_XDMAC_CNDA0         (0x40078068) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 0 */
+#define REG_XDMAC_CNDC0         (0x4007806C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 0 */
+#define REG_XDMAC_CUBC0         (0x40078070) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 0 */
+#define REG_XDMAC_CBC0          (0x40078074) /**< (XDMAC) Channel Block Control Register (chid = 0) 0 */
+#define REG_XDMAC_CC0           (0x40078078) /**< (XDMAC) Channel Configuration Register (chid = 0) 0 */
+#define REG_XDMAC_CDS_MSP0      (0x4007807C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 0 */
+#define REG_XDMAC_CSUS0         (0x40078080) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 0 */
+#define REG_XDMAC_CDUS0         (0x40078084) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 0 */
+#define REG_XDMAC_CIE1          (0x40078090) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 1 */
+#define REG_XDMAC_CID1          (0x40078094) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 1 */
+#define REG_XDMAC_CIM1          (0x40078098) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 1 */
+#define REG_XDMAC_CIS1          (0x4007809C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 1 */
+#define REG_XDMAC_CSA1          (0x400780A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 1 */
+#define REG_XDMAC_CDA1          (0x400780A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 1 */
+#define REG_XDMAC_CNDA1         (0x400780A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 1 */
+#define REG_XDMAC_CNDC1         (0x400780AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 1 */
+#define REG_XDMAC_CUBC1         (0x400780B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 1 */
+#define REG_XDMAC_CBC1          (0x400780B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 1 */
+#define REG_XDMAC_CC1           (0x400780B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 1 */
+#define REG_XDMAC_CDS_MSP1      (0x400780BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 1 */
+#define REG_XDMAC_CSUS1         (0x400780C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 1 */
+#define REG_XDMAC_CDUS1         (0x400780C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 1 */
+#define REG_XDMAC_CIE2          (0x400780D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 2 */
+#define REG_XDMAC_CID2          (0x400780D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 2 */
+#define REG_XDMAC_CIM2          (0x400780D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 2 */
+#define REG_XDMAC_CIS2          (0x400780DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 2 */
+#define REG_XDMAC_CSA2          (0x400780E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 2 */
+#define REG_XDMAC_CDA2          (0x400780E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 2 */
+#define REG_XDMAC_CNDA2         (0x400780E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 2 */
+#define REG_XDMAC_CNDC2         (0x400780EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 2 */
+#define REG_XDMAC_CUBC2         (0x400780F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 2 */
+#define REG_XDMAC_CBC2          (0x400780F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 2 */
+#define REG_XDMAC_CC2           (0x400780F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 2 */
+#define REG_XDMAC_CDS_MSP2      (0x400780FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 2 */
+#define REG_XDMAC_CSUS2         (0x40078100) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 2 */
+#define REG_XDMAC_CDUS2         (0x40078104) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 2 */
+#define REG_XDMAC_CIE3          (0x40078110) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 3 */
+#define REG_XDMAC_CID3          (0x40078114) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 3 */
+#define REG_XDMAC_CIM3          (0x40078118) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 3 */
+#define REG_XDMAC_CIS3          (0x4007811C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 3 */
+#define REG_XDMAC_CSA3          (0x40078120) /**< (XDMAC) Channel Source Address Register (chid = 0) 3 */
+#define REG_XDMAC_CDA3          (0x40078124) /**< (XDMAC) Channel Destination Address Register (chid = 0) 3 */
+#define REG_XDMAC_CNDA3         (0x40078128) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 3 */
+#define REG_XDMAC_CNDC3         (0x4007812C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 3 */
+#define REG_XDMAC_CUBC3         (0x40078130) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 3 */
+#define REG_XDMAC_CBC3          (0x40078134) /**< (XDMAC) Channel Block Control Register (chid = 0) 3 */
+#define REG_XDMAC_CC3           (0x40078138) /**< (XDMAC) Channel Configuration Register (chid = 0) 3 */
+#define REG_XDMAC_CDS_MSP3      (0x4007813C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 3 */
+#define REG_XDMAC_CSUS3         (0x40078140) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 3 */
+#define REG_XDMAC_CDUS3         (0x40078144) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 3 */
+#define REG_XDMAC_CIE4          (0x40078150) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 4 */
+#define REG_XDMAC_CID4          (0x40078154) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 4 */
+#define REG_XDMAC_CIM4          (0x40078158) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 4 */
+#define REG_XDMAC_CIS4          (0x4007815C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 4 */
+#define REG_XDMAC_CSA4          (0x40078160) /**< (XDMAC) Channel Source Address Register (chid = 0) 4 */
+#define REG_XDMAC_CDA4          (0x40078164) /**< (XDMAC) Channel Destination Address Register (chid = 0) 4 */
+#define REG_XDMAC_CNDA4         (0x40078168) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 4 */
+#define REG_XDMAC_CNDC4         (0x4007816C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 4 */
+#define REG_XDMAC_CUBC4         (0x40078170) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 4 */
+#define REG_XDMAC_CBC4          (0x40078174) /**< (XDMAC) Channel Block Control Register (chid = 0) 4 */
+#define REG_XDMAC_CC4           (0x40078178) /**< (XDMAC) Channel Configuration Register (chid = 0) 4 */
+#define REG_XDMAC_CDS_MSP4      (0x4007817C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 4 */
+#define REG_XDMAC_CSUS4         (0x40078180) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 4 */
+#define REG_XDMAC_CDUS4         (0x40078184) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 4 */
+#define REG_XDMAC_CIE5          (0x40078190) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 5 */
+#define REG_XDMAC_CID5          (0x40078194) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 5 */
+#define REG_XDMAC_CIM5          (0x40078198) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 5 */
+#define REG_XDMAC_CIS5          (0x4007819C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 5 */
+#define REG_XDMAC_CSA5          (0x400781A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 5 */
+#define REG_XDMAC_CDA5          (0x400781A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 5 */
+#define REG_XDMAC_CNDA5         (0x400781A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 5 */
+#define REG_XDMAC_CNDC5         (0x400781AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 5 */
+#define REG_XDMAC_CUBC5         (0x400781B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 5 */
+#define REG_XDMAC_CBC5          (0x400781B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 5 */
+#define REG_XDMAC_CC5           (0x400781B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 5 */
+#define REG_XDMAC_CDS_MSP5      (0x400781BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 5 */
+#define REG_XDMAC_CSUS5         (0x400781C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 5 */
+#define REG_XDMAC_CDUS5         (0x400781C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 5 */
+#define REG_XDMAC_CIE6          (0x400781D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 6 */
+#define REG_XDMAC_CID6          (0x400781D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 6 */
+#define REG_XDMAC_CIM6          (0x400781D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 6 */
+#define REG_XDMAC_CIS6          (0x400781DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 6 */
+#define REG_XDMAC_CSA6          (0x400781E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 6 */
+#define REG_XDMAC_CDA6          (0x400781E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 6 */
+#define REG_XDMAC_CNDA6         (0x400781E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 6 */
+#define REG_XDMAC_CNDC6         (0x400781EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 6 */
+#define REG_XDMAC_CUBC6         (0x400781F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 6 */
+#define REG_XDMAC_CBC6          (0x400781F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 6 */
+#define REG_XDMAC_CC6           (0x400781F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 6 */
+#define REG_XDMAC_CDS_MSP6      (0x400781FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 6 */
+#define REG_XDMAC_CSUS6         (0x40078200) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 6 */
+#define REG_XDMAC_CDUS6         (0x40078204) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 6 */
+#define REG_XDMAC_CIE7          (0x40078210) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 7 */
+#define REG_XDMAC_CID7          (0x40078214) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 7 */
+#define REG_XDMAC_CIM7          (0x40078218) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 7 */
+#define REG_XDMAC_CIS7          (0x4007821C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 7 */
+#define REG_XDMAC_CSA7          (0x40078220) /**< (XDMAC) Channel Source Address Register (chid = 0) 7 */
+#define REG_XDMAC_CDA7          (0x40078224) /**< (XDMAC) Channel Destination Address Register (chid = 0) 7 */
+#define REG_XDMAC_CNDA7         (0x40078228) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 7 */
+#define REG_XDMAC_CNDC7         (0x4007822C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 7 */
+#define REG_XDMAC_CUBC7         (0x40078230) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 7 */
+#define REG_XDMAC_CBC7          (0x40078234) /**< (XDMAC) Channel Block Control Register (chid = 0) 7 */
+#define REG_XDMAC_CC7           (0x40078238) /**< (XDMAC) Channel Configuration Register (chid = 0) 7 */
+#define REG_XDMAC_CDS_MSP7      (0x4007823C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 7 */
+#define REG_XDMAC_CSUS7         (0x40078240) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 7 */
+#define REG_XDMAC_CDUS7         (0x40078244) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 7 */
+#define REG_XDMAC_CIE8          (0x40078250) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 8 */
+#define REG_XDMAC_CID8          (0x40078254) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 8 */
+#define REG_XDMAC_CIM8          (0x40078258) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 8 */
+#define REG_XDMAC_CIS8          (0x4007825C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 8 */
+#define REG_XDMAC_CSA8          (0x40078260) /**< (XDMAC) Channel Source Address Register (chid = 0) 8 */
+#define REG_XDMAC_CDA8          (0x40078264) /**< (XDMAC) Channel Destination Address Register (chid = 0) 8 */
+#define REG_XDMAC_CNDA8         (0x40078268) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 8 */
+#define REG_XDMAC_CNDC8         (0x4007826C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 8 */
+#define REG_XDMAC_CUBC8         (0x40078270) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 8 */
+#define REG_XDMAC_CBC8          (0x40078274) /**< (XDMAC) Channel Block Control Register (chid = 0) 8 */
+#define REG_XDMAC_CC8           (0x40078278) /**< (XDMAC) Channel Configuration Register (chid = 0) 8 */
+#define REG_XDMAC_CDS_MSP8      (0x4007827C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 8 */
+#define REG_XDMAC_CSUS8         (0x40078280) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 8 */
+#define REG_XDMAC_CDUS8         (0x40078284) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 8 */
+#define REG_XDMAC_CIE9          (0x40078290) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 9 */
+#define REG_XDMAC_CID9          (0x40078294) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 9 */
+#define REG_XDMAC_CIM9          (0x40078298) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 9 */
+#define REG_XDMAC_CIS9          (0x4007829C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 9 */
+#define REG_XDMAC_CSA9          (0x400782A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 9 */
+#define REG_XDMAC_CDA9          (0x400782A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 9 */
+#define REG_XDMAC_CNDA9         (0x400782A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 9 */
+#define REG_XDMAC_CNDC9         (0x400782AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 9 */
+#define REG_XDMAC_CUBC9         (0x400782B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 9 */
+#define REG_XDMAC_CBC9          (0x400782B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 9 */
+#define REG_XDMAC_CC9           (0x400782B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 9 */
+#define REG_XDMAC_CDS_MSP9      (0x400782BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 9 */
+#define REG_XDMAC_CSUS9         (0x400782C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 9 */
+#define REG_XDMAC_CDUS9         (0x400782C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 9 */
+#define REG_XDMAC_CIE10         (0x400782D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 10 */
+#define REG_XDMAC_CID10         (0x400782D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 10 */
+#define REG_XDMAC_CIM10         (0x400782D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 10 */
+#define REG_XDMAC_CIS10         (0x400782DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 10 */
+#define REG_XDMAC_CSA10         (0x400782E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 10 */
+#define REG_XDMAC_CDA10         (0x400782E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 10 */
+#define REG_XDMAC_CNDA10        (0x400782E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 10 */
+#define REG_XDMAC_CNDC10        (0x400782EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 10 */
+#define REG_XDMAC_CUBC10        (0x400782F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 10 */
+#define REG_XDMAC_CBC10         (0x400782F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 10 */
+#define REG_XDMAC_CC10          (0x400782F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 10 */
+#define REG_XDMAC_CDS_MSP10     (0x400782FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 10 */
+#define REG_XDMAC_CSUS10        (0x40078300) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 10 */
+#define REG_XDMAC_CDUS10        (0x40078304) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 10 */
+#define REG_XDMAC_CIE11         (0x40078310) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 11 */
+#define REG_XDMAC_CID11         (0x40078314) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 11 */
+#define REG_XDMAC_CIM11         (0x40078318) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 11 */
+#define REG_XDMAC_CIS11         (0x4007831C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 11 */
+#define REG_XDMAC_CSA11         (0x40078320) /**< (XDMAC) Channel Source Address Register (chid = 0) 11 */
+#define REG_XDMAC_CDA11         (0x40078324) /**< (XDMAC) Channel Destination Address Register (chid = 0) 11 */
+#define REG_XDMAC_CNDA11        (0x40078328) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 11 */
+#define REG_XDMAC_CNDC11        (0x4007832C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 11 */
+#define REG_XDMAC_CUBC11        (0x40078330) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 11 */
+#define REG_XDMAC_CBC11         (0x40078334) /**< (XDMAC) Channel Block Control Register (chid = 0) 11 */
+#define REG_XDMAC_CC11          (0x40078338) /**< (XDMAC) Channel Configuration Register (chid = 0) 11 */
+#define REG_XDMAC_CDS_MSP11     (0x4007833C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 11 */
+#define REG_XDMAC_CSUS11        (0x40078340) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 11 */
+#define REG_XDMAC_CDUS11        (0x40078344) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 11 */
+#define REG_XDMAC_CIE12         (0x40078350) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 12 */
+#define REG_XDMAC_CID12         (0x40078354) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 12 */
+#define REG_XDMAC_CIM12         (0x40078358) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 12 */
+#define REG_XDMAC_CIS12         (0x4007835C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 12 */
+#define REG_XDMAC_CSA12         (0x40078360) /**< (XDMAC) Channel Source Address Register (chid = 0) 12 */
+#define REG_XDMAC_CDA12         (0x40078364) /**< (XDMAC) Channel Destination Address Register (chid = 0) 12 */
+#define REG_XDMAC_CNDA12        (0x40078368) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 12 */
+#define REG_XDMAC_CNDC12        (0x4007836C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 12 */
+#define REG_XDMAC_CUBC12        (0x40078370) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 12 */
+#define REG_XDMAC_CBC12         (0x40078374) /**< (XDMAC) Channel Block Control Register (chid = 0) 12 */
+#define REG_XDMAC_CC12          (0x40078378) /**< (XDMAC) Channel Configuration Register (chid = 0) 12 */
+#define REG_XDMAC_CDS_MSP12     (0x4007837C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 12 */
+#define REG_XDMAC_CSUS12        (0x40078380) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 12 */
+#define REG_XDMAC_CDUS12        (0x40078384) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 12 */
+#define REG_XDMAC_CIE13         (0x40078390) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 13 */
+#define REG_XDMAC_CID13         (0x40078394) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 13 */
+#define REG_XDMAC_CIM13         (0x40078398) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 13 */
+#define REG_XDMAC_CIS13         (0x4007839C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 13 */
+#define REG_XDMAC_CSA13         (0x400783A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 13 */
+#define REG_XDMAC_CDA13         (0x400783A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 13 */
+#define REG_XDMAC_CNDA13        (0x400783A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 13 */
+#define REG_XDMAC_CNDC13        (0x400783AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 13 */
+#define REG_XDMAC_CUBC13        (0x400783B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 13 */
+#define REG_XDMAC_CBC13         (0x400783B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 13 */
+#define REG_XDMAC_CC13          (0x400783B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 13 */
+#define REG_XDMAC_CDS_MSP13     (0x400783BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 13 */
+#define REG_XDMAC_CSUS13        (0x400783C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 13 */
+#define REG_XDMAC_CDUS13        (0x400783C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 13 */
+#define REG_XDMAC_CIE14         (0x400783D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 14 */
+#define REG_XDMAC_CID14         (0x400783D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 14 */
+#define REG_XDMAC_CIM14         (0x400783D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 14 */
+#define REG_XDMAC_CIS14         (0x400783DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 14 */
+#define REG_XDMAC_CSA14         (0x400783E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 14 */
+#define REG_XDMAC_CDA14         (0x400783E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 14 */
+#define REG_XDMAC_CNDA14        (0x400783E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 14 */
+#define REG_XDMAC_CNDC14        (0x400783EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 14 */
+#define REG_XDMAC_CUBC14        (0x400783F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 14 */
+#define REG_XDMAC_CBC14         (0x400783F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 14 */
+#define REG_XDMAC_CC14          (0x400783F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 14 */
+#define REG_XDMAC_CDS_MSP14     (0x400783FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 14 */
+#define REG_XDMAC_CSUS14        (0x40078400) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 14 */
+#define REG_XDMAC_CDUS14        (0x40078404) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 14 */
+#define REG_XDMAC_CIE15         (0x40078410) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 15 */
+#define REG_XDMAC_CID15         (0x40078414) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 15 */
+#define REG_XDMAC_CIM15         (0x40078418) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 15 */
+#define REG_XDMAC_CIS15         (0x4007841C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 15 */
+#define REG_XDMAC_CSA15         (0x40078420) /**< (XDMAC) Channel Source Address Register (chid = 0) 15 */
+#define REG_XDMAC_CDA15         (0x40078424) /**< (XDMAC) Channel Destination Address Register (chid = 0) 15 */
+#define REG_XDMAC_CNDA15        (0x40078428) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 15 */
+#define REG_XDMAC_CNDC15        (0x4007842C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 15 */
+#define REG_XDMAC_CUBC15        (0x40078430) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 15 */
+#define REG_XDMAC_CBC15         (0x40078434) /**< (XDMAC) Channel Block Control Register (chid = 0) 15 */
+#define REG_XDMAC_CC15          (0x40078438) /**< (XDMAC) Channel Configuration Register (chid = 0) 15 */
+#define REG_XDMAC_CDS_MSP15     (0x4007843C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 15 */
+#define REG_XDMAC_CSUS15        (0x40078440) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 15 */
+#define REG_XDMAC_CDUS15        (0x40078444) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 15 */
+#define REG_XDMAC_CIE16         (0x40078450) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 16 */
+#define REG_XDMAC_CID16         (0x40078454) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 16 */
+#define REG_XDMAC_CIM16         (0x40078458) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 16 */
+#define REG_XDMAC_CIS16         (0x4007845C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 16 */
+#define REG_XDMAC_CSA16         (0x40078460) /**< (XDMAC) Channel Source Address Register (chid = 0) 16 */
+#define REG_XDMAC_CDA16         (0x40078464) /**< (XDMAC) Channel Destination Address Register (chid = 0) 16 */
+#define REG_XDMAC_CNDA16        (0x40078468) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 16 */
+#define REG_XDMAC_CNDC16        (0x4007846C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 16 */
+#define REG_XDMAC_CUBC16        (0x40078470) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 16 */
+#define REG_XDMAC_CBC16         (0x40078474) /**< (XDMAC) Channel Block Control Register (chid = 0) 16 */
+#define REG_XDMAC_CC16          (0x40078478) /**< (XDMAC) Channel Configuration Register (chid = 0) 16 */
+#define REG_XDMAC_CDS_MSP16     (0x4007847C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 16 */
+#define REG_XDMAC_CSUS16        (0x40078480) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 16 */
+#define REG_XDMAC_CDUS16        (0x40078484) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 16 */
+#define REG_XDMAC_CIE17         (0x40078490) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 17 */
+#define REG_XDMAC_CID17         (0x40078494) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 17 */
+#define REG_XDMAC_CIM17         (0x40078498) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 17 */
+#define REG_XDMAC_CIS17         (0x4007849C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 17 */
+#define REG_XDMAC_CSA17         (0x400784A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 17 */
+#define REG_XDMAC_CDA17         (0x400784A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 17 */
+#define REG_XDMAC_CNDA17        (0x400784A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 17 */
+#define REG_XDMAC_CNDC17        (0x400784AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 17 */
+#define REG_XDMAC_CUBC17        (0x400784B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 17 */
+#define REG_XDMAC_CBC17         (0x400784B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 17 */
+#define REG_XDMAC_CC17          (0x400784B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 17 */
+#define REG_XDMAC_CDS_MSP17     (0x400784BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 17 */
+#define REG_XDMAC_CSUS17        (0x400784C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 17 */
+#define REG_XDMAC_CDUS17        (0x400784C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 17 */
+#define REG_XDMAC_CIE18         (0x400784D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 18 */
+#define REG_XDMAC_CID18         (0x400784D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 18 */
+#define REG_XDMAC_CIM18         (0x400784D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 18 */
+#define REG_XDMAC_CIS18         (0x400784DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 18 */
+#define REG_XDMAC_CSA18         (0x400784E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 18 */
+#define REG_XDMAC_CDA18         (0x400784E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 18 */
+#define REG_XDMAC_CNDA18        (0x400784E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 18 */
+#define REG_XDMAC_CNDC18        (0x400784EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 18 */
+#define REG_XDMAC_CUBC18        (0x400784F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 18 */
+#define REG_XDMAC_CBC18         (0x400784F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 18 */
+#define REG_XDMAC_CC18          (0x400784F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 18 */
+#define REG_XDMAC_CDS_MSP18     (0x400784FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 18 */
+#define REG_XDMAC_CSUS18        (0x40078500) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 18 */
+#define REG_XDMAC_CDUS18        (0x40078504) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 18 */
+#define REG_XDMAC_CIE19         (0x40078510) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 19 */
+#define REG_XDMAC_CID19         (0x40078514) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 19 */
+#define REG_XDMAC_CIM19         (0x40078518) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 19 */
+#define REG_XDMAC_CIS19         (0x4007851C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 19 */
+#define REG_XDMAC_CSA19         (0x40078520) /**< (XDMAC) Channel Source Address Register (chid = 0) 19 */
+#define REG_XDMAC_CDA19         (0x40078524) /**< (XDMAC) Channel Destination Address Register (chid = 0) 19 */
+#define REG_XDMAC_CNDA19        (0x40078528) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 19 */
+#define REG_XDMAC_CNDC19        (0x4007852C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 19 */
+#define REG_XDMAC_CUBC19        (0x40078530) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 19 */
+#define REG_XDMAC_CBC19         (0x40078534) /**< (XDMAC) Channel Block Control Register (chid = 0) 19 */
+#define REG_XDMAC_CC19          (0x40078538) /**< (XDMAC) Channel Configuration Register (chid = 0) 19 */
+#define REG_XDMAC_CDS_MSP19     (0x4007853C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 19 */
+#define REG_XDMAC_CSUS19        (0x40078540) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 19 */
+#define REG_XDMAC_CDUS19        (0x40078544) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 19 */
+#define REG_XDMAC_CIE20         (0x40078550) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 20 */
+#define REG_XDMAC_CID20         (0x40078554) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 20 */
+#define REG_XDMAC_CIM20         (0x40078558) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 20 */
+#define REG_XDMAC_CIS20         (0x4007855C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 20 */
+#define REG_XDMAC_CSA20         (0x40078560) /**< (XDMAC) Channel Source Address Register (chid = 0) 20 */
+#define REG_XDMAC_CDA20         (0x40078564) /**< (XDMAC) Channel Destination Address Register (chid = 0) 20 */
+#define REG_XDMAC_CNDA20        (0x40078568) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 20 */
+#define REG_XDMAC_CNDC20        (0x4007856C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 20 */
+#define REG_XDMAC_CUBC20        (0x40078570) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 20 */
+#define REG_XDMAC_CBC20         (0x40078574) /**< (XDMAC) Channel Block Control Register (chid = 0) 20 */
+#define REG_XDMAC_CC20          (0x40078578) /**< (XDMAC) Channel Configuration Register (chid = 0) 20 */
+#define REG_XDMAC_CDS_MSP20     (0x4007857C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 20 */
+#define REG_XDMAC_CSUS20        (0x40078580) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 20 */
+#define REG_XDMAC_CDUS20        (0x40078584) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 20 */
+#define REG_XDMAC_CIE21         (0x40078590) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 21 */
+#define REG_XDMAC_CID21         (0x40078594) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 21 */
+#define REG_XDMAC_CIM21         (0x40078598) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 21 */
+#define REG_XDMAC_CIS21         (0x4007859C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 21 */
+#define REG_XDMAC_CSA21         (0x400785A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 21 */
+#define REG_XDMAC_CDA21         (0x400785A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 21 */
+#define REG_XDMAC_CNDA21        (0x400785A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 21 */
+#define REG_XDMAC_CNDC21        (0x400785AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 21 */
+#define REG_XDMAC_CUBC21        (0x400785B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 21 */
+#define REG_XDMAC_CBC21         (0x400785B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 21 */
+#define REG_XDMAC_CC21          (0x400785B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 21 */
+#define REG_XDMAC_CDS_MSP21     (0x400785BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 21 */
+#define REG_XDMAC_CSUS21        (0x400785C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 21 */
+#define REG_XDMAC_CDUS21        (0x400785C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 21 */
+#define REG_XDMAC_CIE22         (0x400785D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 22 */
+#define REG_XDMAC_CID22         (0x400785D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 22 */
+#define REG_XDMAC_CIM22         (0x400785D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 22 */
+#define REG_XDMAC_CIS22         (0x400785DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 22 */
+#define REG_XDMAC_CSA22         (0x400785E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 22 */
+#define REG_XDMAC_CDA22         (0x400785E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 22 */
+#define REG_XDMAC_CNDA22        (0x400785E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 22 */
+#define REG_XDMAC_CNDC22        (0x400785EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 22 */
+#define REG_XDMAC_CUBC22        (0x400785F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 22 */
+#define REG_XDMAC_CBC22         (0x400785F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 22 */
+#define REG_XDMAC_CC22          (0x400785F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 22 */
+#define REG_XDMAC_CDS_MSP22     (0x400785FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 22 */
+#define REG_XDMAC_CSUS22        (0x40078600) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 22 */
+#define REG_XDMAC_CDUS22        (0x40078604) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 22 */
+#define REG_XDMAC_CIE23         (0x40078610) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 23 */
+#define REG_XDMAC_CID23         (0x40078614) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 23 */
+#define REG_XDMAC_CIM23         (0x40078618) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 23 */
+#define REG_XDMAC_CIS23         (0x4007861C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 23 */
+#define REG_XDMAC_CSA23         (0x40078620) /**< (XDMAC) Channel Source Address Register (chid = 0) 23 */
+#define REG_XDMAC_CDA23         (0x40078624) /**< (XDMAC) Channel Destination Address Register (chid = 0) 23 */
+#define REG_XDMAC_CNDA23        (0x40078628) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 23 */
+#define REG_XDMAC_CNDC23        (0x4007862C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 23 */
+#define REG_XDMAC_CUBC23        (0x40078630) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 23 */
+#define REG_XDMAC_CBC23         (0x40078634) /**< (XDMAC) Channel Block Control Register (chid = 0) 23 */
+#define REG_XDMAC_CC23          (0x40078638) /**< (XDMAC) Channel Configuration Register (chid = 0) 23 */
+#define REG_XDMAC_CDS_MSP23     (0x4007863C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 23 */
+#define REG_XDMAC_CSUS23        (0x40078640) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_CDUS23        (0x40078644) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_GTYPE         (0x40078000) /**< (XDMAC) Global Type Register */
+#define REG_XDMAC_GCFG          (0x40078004) /**< (XDMAC) Global Configuration Register */
+#define REG_XDMAC_GWAC          (0x40078008) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
+#define REG_XDMAC_GIE           (0x4007800C) /**< (XDMAC) Global Interrupt Enable Register */
+#define REG_XDMAC_GID           (0x40078010) /**< (XDMAC) Global Interrupt Disable Register */
+#define REG_XDMAC_GIM           (0x40078014) /**< (XDMAC) Global Interrupt Mask Register */
+#define REG_XDMAC_GIS           (0x40078018) /**< (XDMAC) Global Interrupt Status Register */
+#define REG_XDMAC_GE            (0x4007801C) /**< (XDMAC) Global Channel Enable Register */
+#define REG_XDMAC_GD            (0x40078020) /**< (XDMAC) Global Channel Disable Register */
+#define REG_XDMAC_GS            (0x40078024) /**< (XDMAC) Global Channel Status Register */
+#define REG_XDMAC_GRS           (0x40078028) /**< (XDMAC) Global Channel Read Suspend Register */
+#define REG_XDMAC_GWS           (0x4007802C) /**< (XDMAC) Global Channel Write Suspend Register */
+#define REG_XDMAC_GRWS          (0x40078030) /**< (XDMAC) Global Channel Read Write Suspend Register */
+#define REG_XDMAC_GRWR          (0x40078034) /**< (XDMAC) Global Channel Read Write Resume Register */
+#define REG_XDMAC_GSWR          (0x40078038) /**< (XDMAC) Global Channel Software Request Register */
+#define REG_XDMAC_GSWS          (0x4007803C) /**< (XDMAC) Global Channel Software Request Status Register */
+#define REG_XDMAC_GSWF          (0x40078040) /**< (XDMAC) Global Channel Software Flush Request Register */
+#define REG_XDMAC_VERSION       (0x40078FFC) /**< (XDMAC) XDMAC Version Register */
+
+#else
+
+#define REG_XDMAC_CIE0          (*(__O  uint32_t*)0x40078050U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 0 */
+#define REG_XDMAC_CID0          (*(__O  uint32_t*)0x40078054U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 0 */
+#define REG_XDMAC_CIM0          (*(__I  uint32_t*)0x40078058U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 0 */
+#define REG_XDMAC_CIS0          (*(__I  uint32_t*)0x4007805CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 0 */
+#define REG_XDMAC_CSA0          (*(__IO uint32_t*)0x40078060U) /**< (XDMAC) Channel Source Address Register (chid = 0) 0 */
+#define REG_XDMAC_CDA0          (*(__IO uint32_t*)0x40078064U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 0 */
+#define REG_XDMAC_CNDA0         (*(__IO uint32_t*)0x40078068U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 0 */
+#define REG_XDMAC_CNDC0         (*(__IO uint32_t*)0x4007806CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 0 */
+#define REG_XDMAC_CUBC0         (*(__IO uint32_t*)0x40078070U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 0 */
+#define REG_XDMAC_CBC0          (*(__IO uint32_t*)0x40078074U) /**< (XDMAC) Channel Block Control Register (chid = 0) 0 */
+#define REG_XDMAC_CC0           (*(__IO uint32_t*)0x40078078U) /**< (XDMAC) Channel Configuration Register (chid = 0) 0 */
+#define REG_XDMAC_CDS_MSP0      (*(__IO uint32_t*)0x4007807CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 0 */
+#define REG_XDMAC_CSUS0         (*(__IO uint32_t*)0x40078080U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 0 */
+#define REG_XDMAC_CDUS0         (*(__IO uint32_t*)0x40078084U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 0 */
+#define REG_XDMAC_CIE1          (*(__O  uint32_t*)0x40078090U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 1 */
+#define REG_XDMAC_CID1          (*(__O  uint32_t*)0x40078094U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 1 */
+#define REG_XDMAC_CIM1          (*(__I  uint32_t*)0x40078098U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 1 */
+#define REG_XDMAC_CIS1          (*(__I  uint32_t*)0x4007809CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 1 */
+#define REG_XDMAC_CSA1          (*(__IO uint32_t*)0x400780A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 1 */
+#define REG_XDMAC_CDA1          (*(__IO uint32_t*)0x400780A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 1 */
+#define REG_XDMAC_CNDA1         (*(__IO uint32_t*)0x400780A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 1 */
+#define REG_XDMAC_CNDC1         (*(__IO uint32_t*)0x400780ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 1 */
+#define REG_XDMAC_CUBC1         (*(__IO uint32_t*)0x400780B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 1 */
+#define REG_XDMAC_CBC1          (*(__IO uint32_t*)0x400780B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 1 */
+#define REG_XDMAC_CC1           (*(__IO uint32_t*)0x400780B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 1 */
+#define REG_XDMAC_CDS_MSP1      (*(__IO uint32_t*)0x400780BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 1 */
+#define REG_XDMAC_CSUS1         (*(__IO uint32_t*)0x400780C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 1 */
+#define REG_XDMAC_CDUS1         (*(__IO uint32_t*)0x400780C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 1 */
+#define REG_XDMAC_CIE2          (*(__O  uint32_t*)0x400780D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 2 */
+#define REG_XDMAC_CID2          (*(__O  uint32_t*)0x400780D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 2 */
+#define REG_XDMAC_CIM2          (*(__I  uint32_t*)0x400780D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 2 */
+#define REG_XDMAC_CIS2          (*(__I  uint32_t*)0x400780DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 2 */
+#define REG_XDMAC_CSA2          (*(__IO uint32_t*)0x400780E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 2 */
+#define REG_XDMAC_CDA2          (*(__IO uint32_t*)0x400780E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 2 */
+#define REG_XDMAC_CNDA2         (*(__IO uint32_t*)0x400780E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 2 */
+#define REG_XDMAC_CNDC2         (*(__IO uint32_t*)0x400780ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 2 */
+#define REG_XDMAC_CUBC2         (*(__IO uint32_t*)0x400780F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 2 */
+#define REG_XDMAC_CBC2          (*(__IO uint32_t*)0x400780F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 2 */
+#define REG_XDMAC_CC2           (*(__IO uint32_t*)0x400780F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 2 */
+#define REG_XDMAC_CDS_MSP2      (*(__IO uint32_t*)0x400780FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 2 */
+#define REG_XDMAC_CSUS2         (*(__IO uint32_t*)0x40078100U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 2 */
+#define REG_XDMAC_CDUS2         (*(__IO uint32_t*)0x40078104U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 2 */
+#define REG_XDMAC_CIE3          (*(__O  uint32_t*)0x40078110U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 3 */
+#define REG_XDMAC_CID3          (*(__O  uint32_t*)0x40078114U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 3 */
+#define REG_XDMAC_CIM3          (*(__I  uint32_t*)0x40078118U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 3 */
+#define REG_XDMAC_CIS3          (*(__I  uint32_t*)0x4007811CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 3 */
+#define REG_XDMAC_CSA3          (*(__IO uint32_t*)0x40078120U) /**< (XDMAC) Channel Source Address Register (chid = 0) 3 */
+#define REG_XDMAC_CDA3          (*(__IO uint32_t*)0x40078124U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 3 */
+#define REG_XDMAC_CNDA3         (*(__IO uint32_t*)0x40078128U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 3 */
+#define REG_XDMAC_CNDC3         (*(__IO uint32_t*)0x4007812CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 3 */
+#define REG_XDMAC_CUBC3         (*(__IO uint32_t*)0x40078130U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 3 */
+#define REG_XDMAC_CBC3          (*(__IO uint32_t*)0x40078134U) /**< (XDMAC) Channel Block Control Register (chid = 0) 3 */
+#define REG_XDMAC_CC3           (*(__IO uint32_t*)0x40078138U) /**< (XDMAC) Channel Configuration Register (chid = 0) 3 */
+#define REG_XDMAC_CDS_MSP3      (*(__IO uint32_t*)0x4007813CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 3 */
+#define REG_XDMAC_CSUS3         (*(__IO uint32_t*)0x40078140U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 3 */
+#define REG_XDMAC_CDUS3         (*(__IO uint32_t*)0x40078144U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 3 */
+#define REG_XDMAC_CIE4          (*(__O  uint32_t*)0x40078150U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 4 */
+#define REG_XDMAC_CID4          (*(__O  uint32_t*)0x40078154U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 4 */
+#define REG_XDMAC_CIM4          (*(__I  uint32_t*)0x40078158U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 4 */
+#define REG_XDMAC_CIS4          (*(__I  uint32_t*)0x4007815CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 4 */
+#define REG_XDMAC_CSA4          (*(__IO uint32_t*)0x40078160U) /**< (XDMAC) Channel Source Address Register (chid = 0) 4 */
+#define REG_XDMAC_CDA4          (*(__IO uint32_t*)0x40078164U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 4 */
+#define REG_XDMAC_CNDA4         (*(__IO uint32_t*)0x40078168U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 4 */
+#define REG_XDMAC_CNDC4         (*(__IO uint32_t*)0x4007816CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 4 */
+#define REG_XDMAC_CUBC4         (*(__IO uint32_t*)0x40078170U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 4 */
+#define REG_XDMAC_CBC4          (*(__IO uint32_t*)0x40078174U) /**< (XDMAC) Channel Block Control Register (chid = 0) 4 */
+#define REG_XDMAC_CC4           (*(__IO uint32_t*)0x40078178U) /**< (XDMAC) Channel Configuration Register (chid = 0) 4 */
+#define REG_XDMAC_CDS_MSP4      (*(__IO uint32_t*)0x4007817CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 4 */
+#define REG_XDMAC_CSUS4         (*(__IO uint32_t*)0x40078180U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 4 */
+#define REG_XDMAC_CDUS4         (*(__IO uint32_t*)0x40078184U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 4 */
+#define REG_XDMAC_CIE5          (*(__O  uint32_t*)0x40078190U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 5 */
+#define REG_XDMAC_CID5          (*(__O  uint32_t*)0x40078194U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 5 */
+#define REG_XDMAC_CIM5          (*(__I  uint32_t*)0x40078198U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 5 */
+#define REG_XDMAC_CIS5          (*(__I  uint32_t*)0x4007819CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 5 */
+#define REG_XDMAC_CSA5          (*(__IO uint32_t*)0x400781A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 5 */
+#define REG_XDMAC_CDA5          (*(__IO uint32_t*)0x400781A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 5 */
+#define REG_XDMAC_CNDA5         (*(__IO uint32_t*)0x400781A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 5 */
+#define REG_XDMAC_CNDC5         (*(__IO uint32_t*)0x400781ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 5 */
+#define REG_XDMAC_CUBC5         (*(__IO uint32_t*)0x400781B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 5 */
+#define REG_XDMAC_CBC5          (*(__IO uint32_t*)0x400781B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 5 */
+#define REG_XDMAC_CC5           (*(__IO uint32_t*)0x400781B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 5 */
+#define REG_XDMAC_CDS_MSP5      (*(__IO uint32_t*)0x400781BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 5 */
+#define REG_XDMAC_CSUS5         (*(__IO uint32_t*)0x400781C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 5 */
+#define REG_XDMAC_CDUS5         (*(__IO uint32_t*)0x400781C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 5 */
+#define REG_XDMAC_CIE6          (*(__O  uint32_t*)0x400781D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 6 */
+#define REG_XDMAC_CID6          (*(__O  uint32_t*)0x400781D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 6 */
+#define REG_XDMAC_CIM6          (*(__I  uint32_t*)0x400781D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 6 */
+#define REG_XDMAC_CIS6          (*(__I  uint32_t*)0x400781DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 6 */
+#define REG_XDMAC_CSA6          (*(__IO uint32_t*)0x400781E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 6 */
+#define REG_XDMAC_CDA6          (*(__IO uint32_t*)0x400781E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 6 */
+#define REG_XDMAC_CNDA6         (*(__IO uint32_t*)0x400781E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 6 */
+#define REG_XDMAC_CNDC6         (*(__IO uint32_t*)0x400781ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 6 */
+#define REG_XDMAC_CUBC6         (*(__IO uint32_t*)0x400781F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 6 */
+#define REG_XDMAC_CBC6          (*(__IO uint32_t*)0x400781F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 6 */
+#define REG_XDMAC_CC6           (*(__IO uint32_t*)0x400781F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 6 */
+#define REG_XDMAC_CDS_MSP6      (*(__IO uint32_t*)0x400781FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 6 */
+#define REG_XDMAC_CSUS6         (*(__IO uint32_t*)0x40078200U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 6 */
+#define REG_XDMAC_CDUS6         (*(__IO uint32_t*)0x40078204U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 6 */
+#define REG_XDMAC_CIE7          (*(__O  uint32_t*)0x40078210U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 7 */
+#define REG_XDMAC_CID7          (*(__O  uint32_t*)0x40078214U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 7 */
+#define REG_XDMAC_CIM7          (*(__I  uint32_t*)0x40078218U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 7 */
+#define REG_XDMAC_CIS7          (*(__I  uint32_t*)0x4007821CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 7 */
+#define REG_XDMAC_CSA7          (*(__IO uint32_t*)0x40078220U) /**< (XDMAC) Channel Source Address Register (chid = 0) 7 */
+#define REG_XDMAC_CDA7          (*(__IO uint32_t*)0x40078224U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 7 */
+#define REG_XDMAC_CNDA7         (*(__IO uint32_t*)0x40078228U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 7 */
+#define REG_XDMAC_CNDC7         (*(__IO uint32_t*)0x4007822CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 7 */
+#define REG_XDMAC_CUBC7         (*(__IO uint32_t*)0x40078230U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 7 */
+#define REG_XDMAC_CBC7          (*(__IO uint32_t*)0x40078234U) /**< (XDMAC) Channel Block Control Register (chid = 0) 7 */
+#define REG_XDMAC_CC7           (*(__IO uint32_t*)0x40078238U) /**< (XDMAC) Channel Configuration Register (chid = 0) 7 */
+#define REG_XDMAC_CDS_MSP7      (*(__IO uint32_t*)0x4007823CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 7 */
+#define REG_XDMAC_CSUS7         (*(__IO uint32_t*)0x40078240U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 7 */
+#define REG_XDMAC_CDUS7         (*(__IO uint32_t*)0x40078244U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 7 */
+#define REG_XDMAC_CIE8          (*(__O  uint32_t*)0x40078250U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 8 */
+#define REG_XDMAC_CID8          (*(__O  uint32_t*)0x40078254U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 8 */
+#define REG_XDMAC_CIM8          (*(__I  uint32_t*)0x40078258U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 8 */
+#define REG_XDMAC_CIS8          (*(__I  uint32_t*)0x4007825CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 8 */
+#define REG_XDMAC_CSA8          (*(__IO uint32_t*)0x40078260U) /**< (XDMAC) Channel Source Address Register (chid = 0) 8 */
+#define REG_XDMAC_CDA8          (*(__IO uint32_t*)0x40078264U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 8 */
+#define REG_XDMAC_CNDA8         (*(__IO uint32_t*)0x40078268U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 8 */
+#define REG_XDMAC_CNDC8         (*(__IO uint32_t*)0x4007826CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 8 */
+#define REG_XDMAC_CUBC8         (*(__IO uint32_t*)0x40078270U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 8 */
+#define REG_XDMAC_CBC8          (*(__IO uint32_t*)0x40078274U) /**< (XDMAC) Channel Block Control Register (chid = 0) 8 */
+#define REG_XDMAC_CC8           (*(__IO uint32_t*)0x40078278U) /**< (XDMAC) Channel Configuration Register (chid = 0) 8 */
+#define REG_XDMAC_CDS_MSP8      (*(__IO uint32_t*)0x4007827CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 8 */
+#define REG_XDMAC_CSUS8         (*(__IO uint32_t*)0x40078280U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 8 */
+#define REG_XDMAC_CDUS8         (*(__IO uint32_t*)0x40078284U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 8 */
+#define REG_XDMAC_CIE9          (*(__O  uint32_t*)0x40078290U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 9 */
+#define REG_XDMAC_CID9          (*(__O  uint32_t*)0x40078294U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 9 */
+#define REG_XDMAC_CIM9          (*(__I  uint32_t*)0x40078298U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 9 */
+#define REG_XDMAC_CIS9          (*(__I  uint32_t*)0x4007829CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 9 */
+#define REG_XDMAC_CSA9          (*(__IO uint32_t*)0x400782A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 9 */
+#define REG_XDMAC_CDA9          (*(__IO uint32_t*)0x400782A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 9 */
+#define REG_XDMAC_CNDA9         (*(__IO uint32_t*)0x400782A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 9 */
+#define REG_XDMAC_CNDC9         (*(__IO uint32_t*)0x400782ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 9 */
+#define REG_XDMAC_CUBC9         (*(__IO uint32_t*)0x400782B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 9 */
+#define REG_XDMAC_CBC9          (*(__IO uint32_t*)0x400782B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 9 */
+#define REG_XDMAC_CC9           (*(__IO uint32_t*)0x400782B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 9 */
+#define REG_XDMAC_CDS_MSP9      (*(__IO uint32_t*)0x400782BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 9 */
+#define REG_XDMAC_CSUS9         (*(__IO uint32_t*)0x400782C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 9 */
+#define REG_XDMAC_CDUS9         (*(__IO uint32_t*)0x400782C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 9 */
+#define REG_XDMAC_CIE10         (*(__O  uint32_t*)0x400782D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 10 */
+#define REG_XDMAC_CID10         (*(__O  uint32_t*)0x400782D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 10 */
+#define REG_XDMAC_CIM10         (*(__I  uint32_t*)0x400782D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 10 */
+#define REG_XDMAC_CIS10         (*(__I  uint32_t*)0x400782DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 10 */
+#define REG_XDMAC_CSA10         (*(__IO uint32_t*)0x400782E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 10 */
+#define REG_XDMAC_CDA10         (*(__IO uint32_t*)0x400782E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 10 */
+#define REG_XDMAC_CNDA10        (*(__IO uint32_t*)0x400782E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 10 */
+#define REG_XDMAC_CNDC10        (*(__IO uint32_t*)0x400782ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 10 */
+#define REG_XDMAC_CUBC10        (*(__IO uint32_t*)0x400782F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 10 */
+#define REG_XDMAC_CBC10         (*(__IO uint32_t*)0x400782F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 10 */
+#define REG_XDMAC_CC10          (*(__IO uint32_t*)0x400782F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 10 */
+#define REG_XDMAC_CDS_MSP10     (*(__IO uint32_t*)0x400782FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 10 */
+#define REG_XDMAC_CSUS10        (*(__IO uint32_t*)0x40078300U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 10 */
+#define REG_XDMAC_CDUS10        (*(__IO uint32_t*)0x40078304U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 10 */
+#define REG_XDMAC_CIE11         (*(__O  uint32_t*)0x40078310U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 11 */
+#define REG_XDMAC_CID11         (*(__O  uint32_t*)0x40078314U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 11 */
+#define REG_XDMAC_CIM11         (*(__I  uint32_t*)0x40078318U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 11 */
+#define REG_XDMAC_CIS11         (*(__I  uint32_t*)0x4007831CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 11 */
+#define REG_XDMAC_CSA11         (*(__IO uint32_t*)0x40078320U) /**< (XDMAC) Channel Source Address Register (chid = 0) 11 */
+#define REG_XDMAC_CDA11         (*(__IO uint32_t*)0x40078324U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 11 */
+#define REG_XDMAC_CNDA11        (*(__IO uint32_t*)0x40078328U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 11 */
+#define REG_XDMAC_CNDC11        (*(__IO uint32_t*)0x4007832CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 11 */
+#define REG_XDMAC_CUBC11        (*(__IO uint32_t*)0x40078330U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 11 */
+#define REG_XDMAC_CBC11         (*(__IO uint32_t*)0x40078334U) /**< (XDMAC) Channel Block Control Register (chid = 0) 11 */
+#define REG_XDMAC_CC11          (*(__IO uint32_t*)0x40078338U) /**< (XDMAC) Channel Configuration Register (chid = 0) 11 */
+#define REG_XDMAC_CDS_MSP11     (*(__IO uint32_t*)0x4007833CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 11 */
+#define REG_XDMAC_CSUS11        (*(__IO uint32_t*)0x40078340U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 11 */
+#define REG_XDMAC_CDUS11        (*(__IO uint32_t*)0x40078344U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 11 */
+#define REG_XDMAC_CIE12         (*(__O  uint32_t*)0x40078350U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 12 */
+#define REG_XDMAC_CID12         (*(__O  uint32_t*)0x40078354U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 12 */
+#define REG_XDMAC_CIM12         (*(__I  uint32_t*)0x40078358U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 12 */
+#define REG_XDMAC_CIS12         (*(__I  uint32_t*)0x4007835CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 12 */
+#define REG_XDMAC_CSA12         (*(__IO uint32_t*)0x40078360U) /**< (XDMAC) Channel Source Address Register (chid = 0) 12 */
+#define REG_XDMAC_CDA12         (*(__IO uint32_t*)0x40078364U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 12 */
+#define REG_XDMAC_CNDA12        (*(__IO uint32_t*)0x40078368U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 12 */
+#define REG_XDMAC_CNDC12        (*(__IO uint32_t*)0x4007836CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 12 */
+#define REG_XDMAC_CUBC12        (*(__IO uint32_t*)0x40078370U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 12 */
+#define REG_XDMAC_CBC12         (*(__IO uint32_t*)0x40078374U) /**< (XDMAC) Channel Block Control Register (chid = 0) 12 */
+#define REG_XDMAC_CC12          (*(__IO uint32_t*)0x40078378U) /**< (XDMAC) Channel Configuration Register (chid = 0) 12 */
+#define REG_XDMAC_CDS_MSP12     (*(__IO uint32_t*)0x4007837CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 12 */
+#define REG_XDMAC_CSUS12        (*(__IO uint32_t*)0x40078380U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 12 */
+#define REG_XDMAC_CDUS12        (*(__IO uint32_t*)0x40078384U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 12 */
+#define REG_XDMAC_CIE13         (*(__O  uint32_t*)0x40078390U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 13 */
+#define REG_XDMAC_CID13         (*(__O  uint32_t*)0x40078394U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 13 */
+#define REG_XDMAC_CIM13         (*(__I  uint32_t*)0x40078398U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 13 */
+#define REG_XDMAC_CIS13         (*(__I  uint32_t*)0x4007839CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 13 */
+#define REG_XDMAC_CSA13         (*(__IO uint32_t*)0x400783A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 13 */
+#define REG_XDMAC_CDA13         (*(__IO uint32_t*)0x400783A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 13 */
+#define REG_XDMAC_CNDA13        (*(__IO uint32_t*)0x400783A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 13 */
+#define REG_XDMAC_CNDC13        (*(__IO uint32_t*)0x400783ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 13 */
+#define REG_XDMAC_CUBC13        (*(__IO uint32_t*)0x400783B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 13 */
+#define REG_XDMAC_CBC13         (*(__IO uint32_t*)0x400783B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 13 */
+#define REG_XDMAC_CC13          (*(__IO uint32_t*)0x400783B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 13 */
+#define REG_XDMAC_CDS_MSP13     (*(__IO uint32_t*)0x400783BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 13 */
+#define REG_XDMAC_CSUS13        (*(__IO uint32_t*)0x400783C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 13 */
+#define REG_XDMAC_CDUS13        (*(__IO uint32_t*)0x400783C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 13 */
+#define REG_XDMAC_CIE14         (*(__O  uint32_t*)0x400783D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 14 */
+#define REG_XDMAC_CID14         (*(__O  uint32_t*)0x400783D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 14 */
+#define REG_XDMAC_CIM14         (*(__I  uint32_t*)0x400783D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 14 */
+#define REG_XDMAC_CIS14         (*(__I  uint32_t*)0x400783DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 14 */
+#define REG_XDMAC_CSA14         (*(__IO uint32_t*)0x400783E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 14 */
+#define REG_XDMAC_CDA14         (*(__IO uint32_t*)0x400783E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 14 */
+#define REG_XDMAC_CNDA14        (*(__IO uint32_t*)0x400783E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 14 */
+#define REG_XDMAC_CNDC14        (*(__IO uint32_t*)0x400783ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 14 */
+#define REG_XDMAC_CUBC14        (*(__IO uint32_t*)0x400783F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 14 */
+#define REG_XDMAC_CBC14         (*(__IO uint32_t*)0x400783F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 14 */
+#define REG_XDMAC_CC14          (*(__IO uint32_t*)0x400783F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 14 */
+#define REG_XDMAC_CDS_MSP14     (*(__IO uint32_t*)0x400783FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 14 */
+#define REG_XDMAC_CSUS14        (*(__IO uint32_t*)0x40078400U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 14 */
+#define REG_XDMAC_CDUS14        (*(__IO uint32_t*)0x40078404U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 14 */
+#define REG_XDMAC_CIE15         (*(__O  uint32_t*)0x40078410U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 15 */
+#define REG_XDMAC_CID15         (*(__O  uint32_t*)0x40078414U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 15 */
+#define REG_XDMAC_CIM15         (*(__I  uint32_t*)0x40078418U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 15 */
+#define REG_XDMAC_CIS15         (*(__I  uint32_t*)0x4007841CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 15 */
+#define REG_XDMAC_CSA15         (*(__IO uint32_t*)0x40078420U) /**< (XDMAC) Channel Source Address Register (chid = 0) 15 */
+#define REG_XDMAC_CDA15         (*(__IO uint32_t*)0x40078424U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 15 */
+#define REG_XDMAC_CNDA15        (*(__IO uint32_t*)0x40078428U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 15 */
+#define REG_XDMAC_CNDC15        (*(__IO uint32_t*)0x4007842CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 15 */
+#define REG_XDMAC_CUBC15        (*(__IO uint32_t*)0x40078430U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 15 */
+#define REG_XDMAC_CBC15         (*(__IO uint32_t*)0x40078434U) /**< (XDMAC) Channel Block Control Register (chid = 0) 15 */
+#define REG_XDMAC_CC15          (*(__IO uint32_t*)0x40078438U) /**< (XDMAC) Channel Configuration Register (chid = 0) 15 */
+#define REG_XDMAC_CDS_MSP15     (*(__IO uint32_t*)0x4007843CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 15 */
+#define REG_XDMAC_CSUS15        (*(__IO uint32_t*)0x40078440U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 15 */
+#define REG_XDMAC_CDUS15        (*(__IO uint32_t*)0x40078444U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 15 */
+#define REG_XDMAC_CIE16         (*(__O  uint32_t*)0x40078450U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 16 */
+#define REG_XDMAC_CID16         (*(__O  uint32_t*)0x40078454U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 16 */
+#define REG_XDMAC_CIM16         (*(__I  uint32_t*)0x40078458U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 16 */
+#define REG_XDMAC_CIS16         (*(__I  uint32_t*)0x4007845CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 16 */
+#define REG_XDMAC_CSA16         (*(__IO uint32_t*)0x40078460U) /**< (XDMAC) Channel Source Address Register (chid = 0) 16 */
+#define REG_XDMAC_CDA16         (*(__IO uint32_t*)0x40078464U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 16 */
+#define REG_XDMAC_CNDA16        (*(__IO uint32_t*)0x40078468U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 16 */
+#define REG_XDMAC_CNDC16        (*(__IO uint32_t*)0x4007846CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 16 */
+#define REG_XDMAC_CUBC16        (*(__IO uint32_t*)0x40078470U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 16 */
+#define REG_XDMAC_CBC16         (*(__IO uint32_t*)0x40078474U) /**< (XDMAC) Channel Block Control Register (chid = 0) 16 */
+#define REG_XDMAC_CC16          (*(__IO uint32_t*)0x40078478U) /**< (XDMAC) Channel Configuration Register (chid = 0) 16 */
+#define REG_XDMAC_CDS_MSP16     (*(__IO uint32_t*)0x4007847CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 16 */
+#define REG_XDMAC_CSUS16        (*(__IO uint32_t*)0x40078480U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 16 */
+#define REG_XDMAC_CDUS16        (*(__IO uint32_t*)0x40078484U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 16 */
+#define REG_XDMAC_CIE17         (*(__O  uint32_t*)0x40078490U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 17 */
+#define REG_XDMAC_CID17         (*(__O  uint32_t*)0x40078494U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 17 */
+#define REG_XDMAC_CIM17         (*(__I  uint32_t*)0x40078498U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 17 */
+#define REG_XDMAC_CIS17         (*(__I  uint32_t*)0x4007849CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 17 */
+#define REG_XDMAC_CSA17         (*(__IO uint32_t*)0x400784A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 17 */
+#define REG_XDMAC_CDA17         (*(__IO uint32_t*)0x400784A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 17 */
+#define REG_XDMAC_CNDA17        (*(__IO uint32_t*)0x400784A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 17 */
+#define REG_XDMAC_CNDC17        (*(__IO uint32_t*)0x400784ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 17 */
+#define REG_XDMAC_CUBC17        (*(__IO uint32_t*)0x400784B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 17 */
+#define REG_XDMAC_CBC17         (*(__IO uint32_t*)0x400784B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 17 */
+#define REG_XDMAC_CC17          (*(__IO uint32_t*)0x400784B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 17 */
+#define REG_XDMAC_CDS_MSP17     (*(__IO uint32_t*)0x400784BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 17 */
+#define REG_XDMAC_CSUS17        (*(__IO uint32_t*)0x400784C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 17 */
+#define REG_XDMAC_CDUS17        (*(__IO uint32_t*)0x400784C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 17 */
+#define REG_XDMAC_CIE18         (*(__O  uint32_t*)0x400784D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 18 */
+#define REG_XDMAC_CID18         (*(__O  uint32_t*)0x400784D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 18 */
+#define REG_XDMAC_CIM18         (*(__I  uint32_t*)0x400784D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 18 */
+#define REG_XDMAC_CIS18         (*(__I  uint32_t*)0x400784DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 18 */
+#define REG_XDMAC_CSA18         (*(__IO uint32_t*)0x400784E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 18 */
+#define REG_XDMAC_CDA18         (*(__IO uint32_t*)0x400784E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 18 */
+#define REG_XDMAC_CNDA18        (*(__IO uint32_t*)0x400784E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 18 */
+#define REG_XDMAC_CNDC18        (*(__IO uint32_t*)0x400784ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 18 */
+#define REG_XDMAC_CUBC18        (*(__IO uint32_t*)0x400784F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 18 */
+#define REG_XDMAC_CBC18         (*(__IO uint32_t*)0x400784F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 18 */
+#define REG_XDMAC_CC18          (*(__IO uint32_t*)0x400784F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 18 */
+#define REG_XDMAC_CDS_MSP18     (*(__IO uint32_t*)0x400784FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 18 */
+#define REG_XDMAC_CSUS18        (*(__IO uint32_t*)0x40078500U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 18 */
+#define REG_XDMAC_CDUS18        (*(__IO uint32_t*)0x40078504U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 18 */
+#define REG_XDMAC_CIE19         (*(__O  uint32_t*)0x40078510U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 19 */
+#define REG_XDMAC_CID19         (*(__O  uint32_t*)0x40078514U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 19 */
+#define REG_XDMAC_CIM19         (*(__I  uint32_t*)0x40078518U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 19 */
+#define REG_XDMAC_CIS19         (*(__I  uint32_t*)0x4007851CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 19 */
+#define REG_XDMAC_CSA19         (*(__IO uint32_t*)0x40078520U) /**< (XDMAC) Channel Source Address Register (chid = 0) 19 */
+#define REG_XDMAC_CDA19         (*(__IO uint32_t*)0x40078524U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 19 */
+#define REG_XDMAC_CNDA19        (*(__IO uint32_t*)0x40078528U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 19 */
+#define REG_XDMAC_CNDC19        (*(__IO uint32_t*)0x4007852CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 19 */
+#define REG_XDMAC_CUBC19        (*(__IO uint32_t*)0x40078530U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 19 */
+#define REG_XDMAC_CBC19         (*(__IO uint32_t*)0x40078534U) /**< (XDMAC) Channel Block Control Register (chid = 0) 19 */
+#define REG_XDMAC_CC19          (*(__IO uint32_t*)0x40078538U) /**< (XDMAC) Channel Configuration Register (chid = 0) 19 */
+#define REG_XDMAC_CDS_MSP19     (*(__IO uint32_t*)0x4007853CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 19 */
+#define REG_XDMAC_CSUS19        (*(__IO uint32_t*)0x40078540U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 19 */
+#define REG_XDMAC_CDUS19        (*(__IO uint32_t*)0x40078544U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 19 */
+#define REG_XDMAC_CIE20         (*(__O  uint32_t*)0x40078550U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 20 */
+#define REG_XDMAC_CID20         (*(__O  uint32_t*)0x40078554U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 20 */
+#define REG_XDMAC_CIM20         (*(__I  uint32_t*)0x40078558U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 20 */
+#define REG_XDMAC_CIS20         (*(__I  uint32_t*)0x4007855CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 20 */
+#define REG_XDMAC_CSA20         (*(__IO uint32_t*)0x40078560U) /**< (XDMAC) Channel Source Address Register (chid = 0) 20 */
+#define REG_XDMAC_CDA20         (*(__IO uint32_t*)0x40078564U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 20 */
+#define REG_XDMAC_CNDA20        (*(__IO uint32_t*)0x40078568U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 20 */
+#define REG_XDMAC_CNDC20        (*(__IO uint32_t*)0x4007856CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 20 */
+#define REG_XDMAC_CUBC20        (*(__IO uint32_t*)0x40078570U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 20 */
+#define REG_XDMAC_CBC20         (*(__IO uint32_t*)0x40078574U) /**< (XDMAC) Channel Block Control Register (chid = 0) 20 */
+#define REG_XDMAC_CC20          (*(__IO uint32_t*)0x40078578U) /**< (XDMAC) Channel Configuration Register (chid = 0) 20 */
+#define REG_XDMAC_CDS_MSP20     (*(__IO uint32_t*)0x4007857CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 20 */
+#define REG_XDMAC_CSUS20        (*(__IO uint32_t*)0x40078580U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 20 */
+#define REG_XDMAC_CDUS20        (*(__IO uint32_t*)0x40078584U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 20 */
+#define REG_XDMAC_CIE21         (*(__O  uint32_t*)0x40078590U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 21 */
+#define REG_XDMAC_CID21         (*(__O  uint32_t*)0x40078594U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 21 */
+#define REG_XDMAC_CIM21         (*(__I  uint32_t*)0x40078598U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 21 */
+#define REG_XDMAC_CIS21         (*(__I  uint32_t*)0x4007859CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 21 */
+#define REG_XDMAC_CSA21         (*(__IO uint32_t*)0x400785A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 21 */
+#define REG_XDMAC_CDA21         (*(__IO uint32_t*)0x400785A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 21 */
+#define REG_XDMAC_CNDA21        (*(__IO uint32_t*)0x400785A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 21 */
+#define REG_XDMAC_CNDC21        (*(__IO uint32_t*)0x400785ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 21 */
+#define REG_XDMAC_CUBC21        (*(__IO uint32_t*)0x400785B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 21 */
+#define REG_XDMAC_CBC21         (*(__IO uint32_t*)0x400785B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 21 */
+#define REG_XDMAC_CC21          (*(__IO uint32_t*)0x400785B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 21 */
+#define REG_XDMAC_CDS_MSP21     (*(__IO uint32_t*)0x400785BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 21 */
+#define REG_XDMAC_CSUS21        (*(__IO uint32_t*)0x400785C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 21 */
+#define REG_XDMAC_CDUS21        (*(__IO uint32_t*)0x400785C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 21 */
+#define REG_XDMAC_CIE22         (*(__O  uint32_t*)0x400785D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 22 */
+#define REG_XDMAC_CID22         (*(__O  uint32_t*)0x400785D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 22 */
+#define REG_XDMAC_CIM22         (*(__I  uint32_t*)0x400785D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 22 */
+#define REG_XDMAC_CIS22         (*(__I  uint32_t*)0x400785DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 22 */
+#define REG_XDMAC_CSA22         (*(__IO uint32_t*)0x400785E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 22 */
+#define REG_XDMAC_CDA22         (*(__IO uint32_t*)0x400785E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 22 */
+#define REG_XDMAC_CNDA22        (*(__IO uint32_t*)0x400785E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 22 */
+#define REG_XDMAC_CNDC22        (*(__IO uint32_t*)0x400785ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 22 */
+#define REG_XDMAC_CUBC22        (*(__IO uint32_t*)0x400785F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 22 */
+#define REG_XDMAC_CBC22         (*(__IO uint32_t*)0x400785F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 22 */
+#define REG_XDMAC_CC22          (*(__IO uint32_t*)0x400785F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 22 */
+#define REG_XDMAC_CDS_MSP22     (*(__IO uint32_t*)0x400785FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 22 */
+#define REG_XDMAC_CSUS22        (*(__IO uint32_t*)0x40078600U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 22 */
+#define REG_XDMAC_CDUS22        (*(__IO uint32_t*)0x40078604U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 22 */
+#define REG_XDMAC_CIE23         (*(__O  uint32_t*)0x40078610U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 23 */
+#define REG_XDMAC_CID23         (*(__O  uint32_t*)0x40078614U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 23 */
+#define REG_XDMAC_CIM23         (*(__I  uint32_t*)0x40078618U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 23 */
+#define REG_XDMAC_CIS23         (*(__I  uint32_t*)0x4007861CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 23 */
+#define REG_XDMAC_CSA23         (*(__IO uint32_t*)0x40078620U) /**< (XDMAC) Channel Source Address Register (chid = 0) 23 */
+#define REG_XDMAC_CDA23         (*(__IO uint32_t*)0x40078624U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 23 */
+#define REG_XDMAC_CNDA23        (*(__IO uint32_t*)0x40078628U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 23 */
+#define REG_XDMAC_CNDC23        (*(__IO uint32_t*)0x4007862CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 23 */
+#define REG_XDMAC_CUBC23        (*(__IO uint32_t*)0x40078630U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 23 */
+#define REG_XDMAC_CBC23         (*(__IO uint32_t*)0x40078634U) /**< (XDMAC) Channel Block Control Register (chid = 0) 23 */
+#define REG_XDMAC_CC23          (*(__IO uint32_t*)0x40078638U) /**< (XDMAC) Channel Configuration Register (chid = 0) 23 */
+#define REG_XDMAC_CDS_MSP23     (*(__IO uint32_t*)0x4007863CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 23 */
+#define REG_XDMAC_CSUS23        (*(__IO uint32_t*)0x40078640U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_CDUS23        (*(__IO uint32_t*)0x40078644U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_GTYPE         (*(__I  uint32_t*)0x40078000U) /**< (XDMAC) Global Type Register */
+#define REG_XDMAC_GCFG          (*(__IO uint32_t*)0x40078004U) /**< (XDMAC) Global Configuration Register */
+#define REG_XDMAC_GWAC          (*(__IO uint32_t*)0x40078008U) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
+#define REG_XDMAC_GIE           (*(__O  uint32_t*)0x4007800CU) /**< (XDMAC) Global Interrupt Enable Register */
+#define REG_XDMAC_GID           (*(__O  uint32_t*)0x40078010U) /**< (XDMAC) Global Interrupt Disable Register */
+#define REG_XDMAC_GIM           (*(__I  uint32_t*)0x40078014U) /**< (XDMAC) Global Interrupt Mask Register */
+#define REG_XDMAC_GIS           (*(__I  uint32_t*)0x40078018U) /**< (XDMAC) Global Interrupt Status Register */
+#define REG_XDMAC_GE            (*(__O  uint32_t*)0x4007801CU) /**< (XDMAC) Global Channel Enable Register */
+#define REG_XDMAC_GD            (*(__O  uint32_t*)0x40078020U) /**< (XDMAC) Global Channel Disable Register */
+#define REG_XDMAC_GS            (*(__I  uint32_t*)0x40078024U) /**< (XDMAC) Global Channel Status Register */
+#define REG_XDMAC_GRS           (*(__IO uint32_t*)0x40078028U) /**< (XDMAC) Global Channel Read Suspend Register */
+#define REG_XDMAC_GWS           (*(__IO uint32_t*)0x4007802CU) /**< (XDMAC) Global Channel Write Suspend Register */
+#define REG_XDMAC_GRWS          (*(__O  uint32_t*)0x40078030U) /**< (XDMAC) Global Channel Read Write Suspend Register */
+#define REG_XDMAC_GRWR          (*(__O  uint32_t*)0x40078034U) /**< (XDMAC) Global Channel Read Write Resume Register */
+#define REG_XDMAC_GSWR          (*(__O  uint32_t*)0x40078038U) /**< (XDMAC) Global Channel Software Request Register */
+#define REG_XDMAC_GSWS          (*(__I  uint32_t*)0x4007803CU) /**< (XDMAC) Global Channel Software Request Status Register */
+#define REG_XDMAC_GSWF          (*(__O  uint32_t*)0x40078040U) /**< (XDMAC) Global Channel Software Flush Request Register */
+#define REG_XDMAC_VERSION       (*(__IO uint32_t*)0x40078FFCU) /**< (XDMAC) XDMAC Version Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for XDMAC peripheral ========== */
+#define XDMAC_INSTANCE_ID                        58         
+
+#endif /* _SAMV71_XDMAC_INSTANCE_ */

--- a/asf/sam/include/samv71/pio/samv71j19.h
+++ b/asf/sam/include/samv71/pio/samv71j19.h
@@ -1,0 +1,1016 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J19_PIO_H_
+#define _SAMV71J19_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+
+#endif /* _SAMV71J19_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71j20.h
+++ b/asf/sam/include/samv71/pio/samv71j20.h
@@ -1,0 +1,1027 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J20_PIO_H_
+#define _SAMV71J20_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+
+#endif /* _SAMV71J20_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71j21.h
+++ b/asf/sam/include/samv71/pio/samv71j21.h
@@ -1,0 +1,1027 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J21_PIO_H_
+#define _SAMV71J21_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+
+#endif /* _SAMV71J21_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71n19.h
+++ b/asf/sam/include/samv71/pio/samv71n19.h
@@ -1,0 +1,1165 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N19_PIO_H_
+#define _SAMV71N19_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+
+#endif /* _SAMV71N19_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71n20.h
+++ b/asf/sam/include/samv71/pio/samv71n20.h
@@ -1,0 +1,1154 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N20_PIO_H_
+#define _SAMV71N20_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+
+#endif /* _SAMV71N20_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71n21.h
+++ b/asf/sam/include/samv71/pio/samv71n21.h
@@ -1,0 +1,1154 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N21_PIO_H_
+#define _SAMV71N21_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+
+#endif /* _SAMV71N21_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71q19.h
+++ b/asf/sam/include/samv71/pio/samv71q19.h
@@ -1,0 +1,2332 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71Q19_PIO_H_
+#define _SAMV71Q19_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SDRAMC peripheral ========== */
+#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
+#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
+
+#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
+#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
+
+#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
+#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
+
+#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
+#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
+
+#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
+#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
+
+#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
+#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
+
+#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
+#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
+
+#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
+#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
+
+#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
+#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
+
+#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
+#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
+
+#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
+#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
+
+#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
+#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
+
+#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
+#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
+
+#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
+#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
+
+#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
+#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
+
+#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
+#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
+
+#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
+#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
+
+#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
+#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
+
+#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
+#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
+
+#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
+#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
+
+#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
+#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
+
+#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
+#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
+
+#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
+#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
+
+#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
+#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
+
+#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
+#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
+
+#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
+#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
+
+#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
+#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
+
+#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
+#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
+
+#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
+#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
+
+#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
+#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
+
+#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
+#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
+
+#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
+#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
+
+#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
+#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
+
+#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
+#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
+
+#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
+#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
+
+#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
+#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
+
+#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
+#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
+
+#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
+#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
+
+#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
+#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
+
+#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
+#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
+
+#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
+#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
+
+#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
+#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
+
+#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
+#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
+
+#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
+#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
+
+#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
+#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
+
+#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
+#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
+
+#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
+#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
+
+#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
+#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
+
+#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
+#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
+
+#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
+
+#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
+
+#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
+
+#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
+
+#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
+#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
+
+#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
+
+#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
+
+#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
+#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
+
+#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
+#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
+
+#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
+#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
+
+#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
+#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
+
+#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
+#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
+
+#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
+#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
+
+#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
+#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
+
+#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
+#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
+
+#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
+#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
+
+#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
+#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
+
+/* ========== PIO definition for SMC peripheral ========== */
+#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
+#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
+#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
+#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
+#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
+#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
+#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
+#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
+#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
+#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
+#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
+#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
+#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
+#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
+#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
+#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
+#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
+#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
+#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
+#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
+#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
+#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
+#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
+#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
+#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
+#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
+#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
+#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
+#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
+#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
+#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
+#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
+#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
+#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
+#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
+#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
+#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
+#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
+#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
+#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
+#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
+#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
+#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
+#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
+#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
+#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
+#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
+#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
+#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
+#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
+#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
+#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
+#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
+#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
+#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
+#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
+#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
+#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
+#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
+#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
+#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+
+#endif /* _SAMV71Q19_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71q20.h
+++ b/asf/sam/include/samv71/pio/samv71q20.h
@@ -1,0 +1,2332 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-08-25T14:00:00Z */
+#ifndef _SAMV71Q20_PIO_H_
+#define _SAMV71Q20_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SDRAMC peripheral ========== */
+#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
+#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
+
+#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
+#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
+
+#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
+#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
+
+#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
+#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
+
+#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
+#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
+
+#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
+#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
+
+#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
+#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
+
+#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
+#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
+
+#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
+#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
+
+#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
+#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
+
+#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
+#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
+
+#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
+#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
+
+#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
+#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
+
+#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
+#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
+
+#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
+#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
+
+#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
+#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
+
+#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
+#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
+
+#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
+#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
+
+#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
+#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
+
+#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
+#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
+
+#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
+#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
+
+#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
+#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
+
+#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
+#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
+
+#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
+#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
+
+#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
+#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
+
+#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
+#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
+
+#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
+#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
+
+#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
+#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
+
+#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
+#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
+
+#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
+#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
+
+#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
+#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
+
+#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
+#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
+
+#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
+#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
+
+#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
+#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
+
+#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
+#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
+
+#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
+#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
+
+#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
+#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
+
+#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
+#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
+
+#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
+#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
+
+#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
+#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
+
+#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
+#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
+
+#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
+#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
+
+#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
+#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
+
+#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
+#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
+
+#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
+#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
+
+#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
+#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
+
+#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
+#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
+
+#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
+#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
+
+#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
+#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
+
+#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
+
+#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
+
+#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
+
+#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
+
+#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
+#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
+
+#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
+
+#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
+
+#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
+#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
+
+#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
+#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
+
+#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
+#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
+
+#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
+#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
+
+#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
+#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
+
+#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
+#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
+
+#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
+#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
+
+#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
+#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
+
+#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
+#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
+
+#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
+#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
+
+/* ========== PIO definition for SMC peripheral ========== */
+#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
+#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
+#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
+#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
+#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
+#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
+#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
+#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
+#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
+#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
+#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
+#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
+#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
+#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
+#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
+#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
+#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
+#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
+#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
+#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
+#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
+#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
+#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
+#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
+#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
+#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
+#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
+#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
+#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
+#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
+#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
+#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
+#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
+#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
+#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
+#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
+#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
+#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
+#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
+#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
+#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
+#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
+#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
+#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
+#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
+#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
+#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
+#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
+#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
+#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
+#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
+#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
+#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
+#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
+#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
+#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
+#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
+#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
+#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
+#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
+#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+
+#endif /* _SAMV71Q20_PIO_H_ */

--- a/asf/sam/include/samv71/pio/samv71q21.h
+++ b/asf/sam/include/samv71/pio/samv71q21.h
@@ -1,0 +1,2332 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71Q21_PIO_H_
+#define _SAMV71Q21_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for SDRAMC peripheral ========== */
+#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
+#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
+
+#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
+#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
+
+#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
+#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
+
+#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
+#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
+
+#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
+#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
+
+#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
+#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
+
+#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
+#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
+
+#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
+#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
+
+#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
+#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
+
+#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
+#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
+
+#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
+#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
+
+#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
+#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
+
+#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
+#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
+
+#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
+#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
+
+#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
+#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
+
+#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
+#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
+
+#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
+#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
+
+#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
+#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
+
+#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
+#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
+
+#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
+#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
+
+#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
+#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
+
+#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
+#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
+
+#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
+#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
+
+#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
+#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
+
+#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
+#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
+
+#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
+#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
+
+#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
+#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
+
+#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
+#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
+
+#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
+#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
+
+#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
+#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
+
+#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
+#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
+
+#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
+#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
+
+#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
+#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
+
+#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
+#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
+
+#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
+#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
+
+#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
+#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
+
+#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
+#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
+
+#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
+#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
+
+#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
+#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
+
+#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
+#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
+
+#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
+#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
+
+#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
+#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
+
+#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
+#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
+
+#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
+#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
+
+#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
+#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
+
+#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
+#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
+
+#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
+#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
+
+#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
+#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
+
+#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
+#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
+
+#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
+
+#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
+
+#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
+#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
+
+#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
+#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
+
+#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
+#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
+
+#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
+
+#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
+#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
+
+#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
+#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
+
+#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
+#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
+
+#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
+#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
+
+#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
+#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
+
+#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
+#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
+
+#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
+#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
+
+#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
+#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
+
+#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
+#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
+
+#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
+#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
+
+#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
+#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
+
+#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
+#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
+
+/* ========== PIO definition for SMC peripheral ========== */
+#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
+#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
+#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
+#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
+#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
+#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
+#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
+#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
+#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
+#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
+#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
+#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
+#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
+#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
+#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
+#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
+#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
+#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
+#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
+#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
+#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
+#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
+#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
+#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
+#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
+#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
+#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
+#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
+#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
+#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
+#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
+#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
+#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
+#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
+#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
+#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
+#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
+#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
+#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
+#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
+#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
+#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
+#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
+#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
+#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
+#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
+#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
+#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
+#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
+#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
+#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
+#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
+#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
+#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
+#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
+#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
+#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
+#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
+#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
+#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
+#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
+#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
+#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
+#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
+#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
+#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
+#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
+#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
+#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
+#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
+#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
+#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
+#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
+#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
+#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
+#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
+#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
+#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
+#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
+#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
+#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
+#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
+#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
+#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
+#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
+#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
+#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
+#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
+#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
+#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
+#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
+#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
+#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
+#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
+#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
+#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
+#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
+#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
+#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
+#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
+#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
+#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
+#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
+#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
+#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
+#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
+#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
+#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
+#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+
+#endif /* _SAMV71Q21_PIO_H_ */

--- a/asf/sam/include/samv71/samv71j19.h
+++ b/asf/sam/include/samv71/samv71j19.h
@@ -1,0 +1,848 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J19_H_
+#define _SAMV71J19_H_
+
+/** \addtogroup SAMV71J19_definitions SAMV71J19 definitions
+  This file defines all structures and symbols for SAMV71J19:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J19_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J19 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J19 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J19 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J19 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J19 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J19 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J19 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J19 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J19 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J19 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J19 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J19 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J19 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71J19 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J19 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J19 Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J19 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J19 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J19 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J19 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J19 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J19 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J19 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J19 Analog Front-End Controller (AFEC0) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J19 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J19 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J19 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J19 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J19 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J19 Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J19 Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J19 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J19 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J19 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J19 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J19 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J19 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J19 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J19 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J19 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J19 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J19 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J19 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J19 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J19 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J19 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J19 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J19 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J19 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J19 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J19 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J19 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J19 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J19 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J19 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J19 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J19 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J19 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J19 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J19 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71J19 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J19 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J19 Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J19 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J19 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J19 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J19 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J19 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J19 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J19 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J19 Analog Front-End Controller (AFEC0) */
+  void* pvReserved30;
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J19 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J19 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J19 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J19 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J19 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J19 Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J19 Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J19 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J19 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J19 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J19 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J19 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J19 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J19 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J19 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J19 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J19 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J19 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J19 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J19 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J19 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J19 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J19 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J19 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J19_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J19_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J19 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J19_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J19_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J19_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J19_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J19_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J19*/
+/* ************************************************************************** */
+#include "pio/samv71j19.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J19*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J19 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J19 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J19 definitions */
+
+
+#endif /* _SAMV71J19_H_ */

--- a/asf/sam/include/samv71/samv71j20.h
+++ b/asf/sam/include/samv71/samv71j20.h
@@ -1,0 +1,859 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J20_H_
+#define _SAMV71J20_H_
+
+/** \addtogroup SAMV71J20_definitions SAMV71J20 definitions
+  This file defines all structures and symbols for SAMV71J20:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J20_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J20 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J20 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J20 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J20 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J20 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J20 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J20 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J20 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J20 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J20 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J20 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J20 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J20 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71J20 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J20 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J20 Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J20 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J20 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J20 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J20 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J20 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J20 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J20 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J20 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71J20 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J20 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J20 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J20 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J20 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J20 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J20 Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J20 Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J20 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J20 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J20 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J20 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J20 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J20 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J20 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J20 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J20 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J20 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J20 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J20 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J20 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J20 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J20 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J20 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J20 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J20 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J20 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J20 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J20 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J20 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J20 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J20 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J20 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J20 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J20 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J20 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J20 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71J20 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J20 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J20 Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J20 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J20 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J20 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J20 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J20 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J20 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J20 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J20 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71J20 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J20 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J20 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J20 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J20 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J20 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J20 Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J20 Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J20 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J20 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J20 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J20 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J20 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J20 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J20 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J20 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J20 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J20 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J20 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J20 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J20 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J20 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J20 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J20 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J20 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J20_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J20_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J20 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J20_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J20_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J20_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J20_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J20_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J20*/
+/* ************************************************************************** */
+#include "pio/samv71j20.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J20*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J20 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J20 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J20 definitions */
+
+
+#endif /* _SAMV71J20_H_ */

--- a/asf/sam/include/samv71/samv71j21.h
+++ b/asf/sam/include/samv71/samv71j21.h
@@ -1,0 +1,859 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71J21_H_
+#define _SAMV71J21_H_
+
+/** \addtogroup SAMV71J21_definitions SAMV71J21 definitions
+  This file defines all structures and symbols for SAMV71J21:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J21_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J21 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J21 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J21 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J21 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J21 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J21 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J21 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J21 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J21 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J21 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J21 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J21 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J21 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71J21 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J21 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J21 Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J21 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J21 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J21 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J21 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J21 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J21 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J21 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J21 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71J21 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J21 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J21 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J21 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J21 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J21 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J21 Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J21 Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J21 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J21 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J21 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J21 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J21 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J21 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J21 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J21 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J21 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J21 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J21 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J21 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J21 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J21 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J21 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J21 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J21 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J21 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J21 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J21 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J21 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J21 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J21 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J21 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J21 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J21 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J21 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J21 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J21 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71J21 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J21 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J21 Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J21 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J21 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J21 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J21 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J21 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J21 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J21 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J21 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71J21 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J21 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J21 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J21 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J21 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J21 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J21 Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J21 Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J21 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J21 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J21 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J21 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J21 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J21 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J21 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J21 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J21 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J21 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J21 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J21 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J21 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J21 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J21 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J21 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J21 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J21_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J21_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J21 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J21_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J21_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J21_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J21_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J21_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J21*/
+/* ************************************************************************** */
+#include "pio/samv71j21.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J21*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J21 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J21 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J21 definitions */
+
+
+#endif /* _SAMV71J21_H_ */

--- a/asf/sam/include/samv71/samv71n19.h
+++ b/asf/sam/include/samv71/samv71n19.h
@@ -1,0 +1,900 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N19_H_
+#define _SAMV71N19_H_
+
+/** \addtogroup SAMV71N19_definitions SAMV71N19 definitions
+  This file defines all structures and symbols for SAMV71N19:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N19_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N19 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N19 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N19 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N19 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N19 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N19 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N19 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N19 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N19 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N19 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N19 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N19 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N19 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N19 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N19 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N19 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N19 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N19 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N19 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N19 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N19 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N19 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N19 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N19 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N19 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71N19 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N19 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N19 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N19 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N19 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N19 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N19 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N19 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N19 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N19 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N19 Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N19 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N19 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N19 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N19 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N19 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N19 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N19 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N19 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N19 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N19 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N19 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N19 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N19 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N19 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N19 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N19 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N19 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N19 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N19 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N19 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N19 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N19 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N19 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N19 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N19 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N19 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N19 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N19 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N19 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N19 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N19 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N19 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N19 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N19 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N19 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N19 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N19 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N19 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N19 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N19 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N19 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71N19 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N19 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N19 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N19 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N19 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N19 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N19 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N19 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N19 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N19 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N19 Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N19 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N19 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N19 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N19 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N19 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N19 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N19 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N19 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N19 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N19 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N19 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N19 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N19 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N19 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N19 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N19 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N19 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N19_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N19_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N19 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N19_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N19_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N19_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N19_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N19_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N19*/
+/* ************************************************************************** */
+#include "pio/samv71n19.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N19*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N19 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N19 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N19 definitions */
+
+
+#endif /* _SAMV71N19_H_ */

--- a/asf/sam/include/samv71/samv71n20.h
+++ b/asf/sam/include/samv71/samv71n20.h
@@ -1,0 +1,890 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N20_H_
+#define _SAMV71N20_H_
+
+/** \addtogroup SAMV71N20_definitions SAMV71N20 definitions
+  This file defines all structures and symbols for SAMV71N20:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N20_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N20 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N20 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N20 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N20 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N20 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N20 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N20 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N20 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N20 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N20 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N20 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N20 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N20 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N20 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N20 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N20 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N20 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N20 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N20 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N20 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N20 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N20 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N20 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N20 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N20 Analog Front-End Controller (AFEC0) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N20 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N20 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N20 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N20 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N20 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N20 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N20 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N20 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N20 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N20 Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N20 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N20 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N20 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N20 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N20 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N20 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N20 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N20 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N20 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N20 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N20 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N20 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N20 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N20 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N20 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N20 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N20 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N20 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N20 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N20 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N20 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N20 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N20 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N20 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N20 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N20 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N20 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N20 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N20 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N20 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N20 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N20 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N20 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N20 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N20 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N20 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N20 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N20 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N20 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N20 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N20 Analog Front-End Controller (AFEC0) */
+  void* pvReserved30;
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N20 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N20 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N20 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N20 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N20 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N20 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N20 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N20 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N20 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N20 Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N20 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N20 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N20 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N20 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N20 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N20 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N20 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N20 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N20 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N20 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N20 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N20 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N20 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N20 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N20 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N20 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N20 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N20_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N20_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N20 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N20_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N20_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N20_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N20_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N20_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N20*/
+/* ************************************************************************** */
+#include "pio/samv71n20.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N20*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N20 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N20 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N20 definitions */
+
+
+#endif /* _SAMV71N20_H_ */

--- a/asf/sam/include/samv71/samv71n21.h
+++ b/asf/sam/include/samv71/samv71n21.h
@@ -1,0 +1,890 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71N21_H_
+#define _SAMV71N21_H_
+
+/** \addtogroup SAMV71N21_definitions SAMV71N21 definitions
+  This file defines all structures and symbols for SAMV71N21:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N21_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N21 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N21 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N21 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N21 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N21 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N21 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N21 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N21 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N21 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N21 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N21 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N21 Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N21 Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N21 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N21 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N21 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N21 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N21 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N21 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N21 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N21 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N21 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N21 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N21 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N21 Analog Front-End Controller (AFEC0) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N21 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N21 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N21 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N21 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N21 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N21 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N21 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N21 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N21 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N21 Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N21 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N21 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N21 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N21 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N21 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N21 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N21 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N21 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N21 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N21 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N21 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N21 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N21 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N21 Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N21 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N21 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N21 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N21 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N21 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N21 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N21 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N21 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N21 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N21 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N21 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N21 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N21 Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N21 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N21 Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N21 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N21 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N21 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N21 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N21 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N21 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N21 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N21 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N21 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N21 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N21 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N21 Analog Front-End Controller (AFEC0) */
+  void* pvReserved30;
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N21 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N21 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N21 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N21 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N21 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N21 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N21 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N21 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N21 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N21 Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N21 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N21 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N21 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N21 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N21 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N21 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N21 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N21 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N21 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N21 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N21 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N21 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N21 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N21 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N21 Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N21 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N21 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N21_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N21_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N21 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N21_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N21_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N21_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N21_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N21_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N21*/
+/* ************************************************************************** */
+#include "pio/samv71n21.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N21*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N21 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N21 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N21 definitions */
+
+
+#endif /* _SAMV71N21_H_ */

--- a/asf/sam/include/samv71/samv71q19.h
+++ b/asf/sam/include/samv71/samv71q19.h
@@ -1,0 +1,946 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q19
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71Q19_H_
+#define _SAMV71Q19_H_
+
+/** \addtogroup SAMV71Q19_definitions SAMV71Q19 definitions
+  This file defines all structures and symbols for SAMV71Q19:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q19_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q19 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q19 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q19 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q19 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q19 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q19 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q19 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q19 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q19 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q19 Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q19 Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q19 Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q19 Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q19 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q19 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q19 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q19 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q19 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q19 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q19 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q19 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q19 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q19 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q19 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q19 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q19 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q19 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q19 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q19 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q19 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q19 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q19 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q19 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q19 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q19 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q19 Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q19 Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q19 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q19 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q19 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q19 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q19 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q19 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q19 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q19 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q19 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q19 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q19 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q19 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q19 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q19 Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q19 SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q19 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q19 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q19 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q19 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q19 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q19 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q19 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q19 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q19 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q19 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q19 Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q19 Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q19 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q19 Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q19 Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q19 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q19 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q19 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q19 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q19 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q19 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q19 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q19 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q19 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q19 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q19 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q19 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q19 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q19 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q19 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q19 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q19 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q19 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q19 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q19 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q19 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q19 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q19 Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q19 Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q19 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q19 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q19 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q19 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q19 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q19 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q19 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q19 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q19 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q19 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q19 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q19 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q19 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q19 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q19 Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q19 SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q19 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q19 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q19 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q19_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q19_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q19 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q19_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q19_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q19_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q19_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q19_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q19*/
+/* ************************************************************************** */
+#include "pio/samv71q19.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q19*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q19 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q19 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q19 definitions */
+
+
+#endif /* _SAMV71Q19_H_ */

--- a/asf/sam/include/samv71/samv71q20.h
+++ b/asf/sam/include/samv71/samv71q20.h
@@ -1,0 +1,946 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q20
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-08-25T14:00:00Z */
+#ifndef _SAMV71Q20_H_
+#define _SAMV71Q20_H_
+
+/** \addtogroup SAMV71Q20_definitions SAMV71Q20 definitions
+  This file defines all structures and symbols for SAMV71Q20:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q20_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q20 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q20 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q20 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q20 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q20 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q20 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q20 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q20 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q20 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q20 Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q20 Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q20 Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q20 Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q20 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q20 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q20 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q20 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q20 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q20 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q20 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q20 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q20 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q20 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q20 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q20 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q20 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q20 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q20 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q20 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q20 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q20 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q20 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q20 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q20 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q20 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q20 Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q20 Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q20 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q20 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q20 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q20 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q20 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q20 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q20 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q20 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q20 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q20 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q20 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q20 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q20 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q20 Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q20 SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q20 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q20 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q20 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q20 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q20 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q20 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q20 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q20 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q20 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q20 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q20 Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q20 Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q20 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q20 Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q20 Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q20 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q20 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q20 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q20 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q20 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q20 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q20 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q20 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q20 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q20 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q20 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q20 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q20 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q20 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q20 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q20 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q20 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q20 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q20 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q20 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q20 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q20 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q20 Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q20 Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q20 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q20 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q20 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q20 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q20 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q20 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q20 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q20 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q20 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q20 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q20 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q20 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q20 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q20 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q20 Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q20 SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q20 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q20 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q20 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q20_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q20_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q20 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q20_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q20_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q20_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q20_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q20_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q20*/
+/* ************************************************************************** */
+#include "pio/samv71q20.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q20*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q20 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q20 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q20 definitions */
+
+
+#endif /* _SAMV71Q20_H_ */

--- a/asf/sam/include/samv71/samv71q21.h
+++ b/asf/sam/include/samv71/samv71q21.h
@@ -1,0 +1,946 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q21
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2017-01-08T14:00:00Z */
+#ifndef _SAMV71Q21_H_
+#define _SAMV71Q21_H_
+
+/** \addtogroup SAMV71Q21_definitions SAMV71Q21 definitions
+  This file defines all structures and symbols for SAMV71Q21:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q21_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q21 specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q21 Supply Controller (SUPC)  */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q21 Reset Controller (RSTC)   */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q21 Real-time Clock (RTC)     */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q21 Real-time Timer (RTT)     */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q21 Watchdog Timer (WDT)      */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q21 Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q21 Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q21 Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q21 Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q21 Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q21 Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q21 Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q21 High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q21 Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q21 Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q21 Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q21 Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q21 Timer Counter (TC0)       */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q21 Timer Counter (TC0)       */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q21 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q21 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q21 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q21 Timer Counter (TC1)       */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q21 Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q21 Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q21 Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q21 Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q21 Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q21 USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q21 Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q21 Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q21 Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q21 Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q21 Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q21 Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q21 Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q21 Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q21 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q21 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q21 Timer Counter (TC2)       */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q21 Timer Counter (TC3)       */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q21 Timer Counter (TC3)       */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q21 Timer Counter (TC3)       */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q21 MediaLB (MLB)             */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q21 Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q21 True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q21 Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q21 Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q21 Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q21 Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q21 SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q21 Reinforced Safety Watchdog Timer (RSWDT) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q21 Floating Point Unit (FPU) */
+
+  PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q21 Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q21 Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q21 Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q21 Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q21 Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q21 Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q21 Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q21 Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q21 Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q21 Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q21 Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q21 Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q21 Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q21 High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q21 Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q21 Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q21 Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q21 Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q21 Timer Counter (TC0)  */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q21 Timer Counter (TC0)  */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q21 Timer Counter (TC0)  */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q21 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q21 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q21 Timer Counter (TC1)  */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q21 Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q21 Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q21 Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q21 Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q21 Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q21 USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q21 Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q21 Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q21 Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q21 Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q21 Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q21 Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q21 Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q21 Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q21 Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q21 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q21 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q21 Timer Counter (TC2)  */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q21 Timer Counter (TC3)  */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q21 Timer Counter (TC3)  */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q21 Timer Counter (TC3)  */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q21 MediaLB (MLB)        */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q21 Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q21 True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q21 Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q21 Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q21 Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q21 Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q21 SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q21 Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pvReserved64;
+  void* pvReserved65;
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q21 Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q21 Floating Point Unit (FPU) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q21_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q21_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q21 */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q21_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q21_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q21_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q21_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q21_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q21*/
+/* ************************************************************************** */
+#include "pio/samv71q21.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q21*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q21 */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q21 */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q21 definitions */
+
+
+#endif /* _SAMV71Q21_H_ */

--- a/asf/sam/include/samv71b/README
+++ b/asf/sam/include/samv71b/README
@@ -1,0 +1,49 @@
+Atmel SAM V71B
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMV71B Series Device Support (2.4.182)
+   http://packs.download.atmel.com/Atmel.SAMV71_DFP.2.4.182.atpack
+
+Status:
+   version 2.4.182
+
+Purpose:
+   Official package for SAM V71B.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMV71_DFP.2.4.182.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch Lst:
+   * Core IRQ and interrupt handler names changed to alligne with CMSIS names.
+     Old names mapped as aliases to new names. Several errors in SVD files
+     corrected. Missing TC1 and TC2 to instance definitions added to header
+     files. TC, USART and USBHS module changed (for revB devices) to reflect
+     the modes according to the datasheet.
+   * Updated device XML for rev. B devices. Updated/added SVD files.
+   * Renamed some Cortex-M interrupt handlers. Added TCM configuration fuses.
+   * Corrected number of TC channels.
+   * Fixed ECF parameters.
+   * Added rev B devices. Added core peripherals. Updated headers, startup
+     code and linker scripts.

--- a/asf/sam/include/samv71b/component-version.h
+++ b/asf/sam/include/samv71b/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2019 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 2
+#define COMPONENT_VERSION_MINOR 4
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 20004
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 182
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "2.4"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2019-01-31 14:15:13"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/asf/sam/include/samv71b/component/acc.h
+++ b/asf/sam/include/samv71b/component/acc.h
@@ -1,0 +1,390 @@
+/**
+ * \file
+ *
+ * \brief Component description for ACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ACC_COMPONENT_H_
+#define _SAMV71_ACC_COMPONENT_H_
+#define _SAMV71_ACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Analog Comparator Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ACC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ACC_6490                       /**< (ACC) Module ID */
+#define REV_ACC J                      /**< (ACC) Module revision */
+
+/* -------- ACC_CR : (ACC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_CR_OFFSET                       (0x00)                                        /**<  (ACC_CR) Control Register  Offset */
+
+#define ACC_CR_SWRST_Pos                    0                                              /**< (ACC_CR) Software Reset Position */
+#define ACC_CR_SWRST_Msk                    (_U_(0x1) << ACC_CR_SWRST_Pos)                 /**< (ACC_CR) Software Reset Mask */
+#define ACC_CR_SWRST                        ACC_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_CR_SWRST_Msk instead */
+#define ACC_CR_MASK                         _U_(0x01)                                      /**< \deprecated (ACC_CR) Register MASK  (Use ACC_CR_Msk instead)  */
+#define ACC_CR_Msk                          _U_(0x01)                                      /**< (ACC_CR) Register Mask  */
+
+
+/* -------- ACC_MR : (ACC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SELMINUS:3;                /**< bit:   0..2  Selection for Minus Comparator Input     */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SELPLUS:3;                 /**< bit:   4..6  Selection For Plus Comparator Input      */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t ACEN:1;                    /**< bit:      8  Analog Comparator Enable                 */
+    uint32_t EDGETYP:2;                 /**< bit:  9..10  Edge Type                                */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t INV:1;                     /**< bit:     12  Invert Comparator Output                 */
+    uint32_t SELFS:1;                   /**< bit:     13  Selection Of Fault Source                */
+    uint32_t FE:1;                      /**< bit:     14  Fault Enable                             */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_MR_OFFSET                       (0x04)                                        /**<  (ACC_MR) Mode Register  Offset */
+
+#define ACC_MR_SELMINUS_Pos                 0                                              /**< (ACC_MR) Selection for Minus Comparator Input Position */
+#define ACC_MR_SELMINUS_Msk                 (_U_(0x7) << ACC_MR_SELMINUS_Pos)              /**< (ACC_MR) Selection for Minus Comparator Input Mask */
+#define ACC_MR_SELMINUS(value)              (ACC_MR_SELMINUS_Msk & ((value) << ACC_MR_SELMINUS_Pos))
+#define   ACC_MR_SELMINUS_TS_Val            _U_(0x0)                                       /**< (ACC_MR) Select TS  */
+#define   ACC_MR_SELMINUS_VREFP_Val         _U_(0x1)                                       /**< (ACC_MR) Select VREFP  */
+#define   ACC_MR_SELMINUS_DAC0_Val          _U_(0x2)                                       /**< (ACC_MR) Select DAC0  */
+#define   ACC_MR_SELMINUS_DAC1_Val          _U_(0x3)                                       /**< (ACC_MR) Select DAC1  */
+#define   ACC_MR_SELMINUS_AFE0_AD0_Val      _U_(0x4)                                       /**< (ACC_MR) Select AFE0_AD0  */
+#define   ACC_MR_SELMINUS_AFE0_AD1_Val      _U_(0x5)                                       /**< (ACC_MR) Select AFE0_AD1  */
+#define   ACC_MR_SELMINUS_AFE0_AD2_Val      _U_(0x6)                                       /**< (ACC_MR) Select AFE0_AD2  */
+#define   ACC_MR_SELMINUS_AFE0_AD3_Val      _U_(0x7)                                       /**< (ACC_MR) Select AFE0_AD3  */
+#define ACC_MR_SELMINUS_TS                  (ACC_MR_SELMINUS_TS_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select TS Position  */
+#define ACC_MR_SELMINUS_VREFP               (ACC_MR_SELMINUS_VREFP_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select VREFP Position  */
+#define ACC_MR_SELMINUS_DAC0                (ACC_MR_SELMINUS_DAC0_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select DAC0 Position  */
+#define ACC_MR_SELMINUS_DAC1                (ACC_MR_SELMINUS_DAC1_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select DAC1 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD0            (ACC_MR_SELMINUS_AFE0_AD0_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD0 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD1            (ACC_MR_SELMINUS_AFE0_AD1_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD1 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD2            (ACC_MR_SELMINUS_AFE0_AD2_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD2 Position  */
+#define ACC_MR_SELMINUS_AFE0_AD3            (ACC_MR_SELMINUS_AFE0_AD3_Val << ACC_MR_SELMINUS_Pos)  /**< (ACC_MR) Select AFE0_AD3 Position  */
+#define ACC_MR_SELPLUS_Pos                  4                                              /**< (ACC_MR) Selection For Plus Comparator Input Position */
+#define ACC_MR_SELPLUS_Msk                  (_U_(0x7) << ACC_MR_SELPLUS_Pos)               /**< (ACC_MR) Selection For Plus Comparator Input Mask */
+#define ACC_MR_SELPLUS(value)               (ACC_MR_SELPLUS_Msk & ((value) << ACC_MR_SELPLUS_Pos))
+#define   ACC_MR_SELPLUS_AFE0_AD0_Val       _U_(0x0)                                       /**< (ACC_MR) Select AFE0_AD0  */
+#define   ACC_MR_SELPLUS_AFE0_AD1_Val       _U_(0x1)                                       /**< (ACC_MR) Select AFE0_AD1  */
+#define   ACC_MR_SELPLUS_AFE0_AD2_Val       _U_(0x2)                                       /**< (ACC_MR) Select AFE0_AD2  */
+#define   ACC_MR_SELPLUS_AFE0_AD3_Val       _U_(0x3)                                       /**< (ACC_MR) Select AFE0_AD3  */
+#define   ACC_MR_SELPLUS_AFE0_AD4_Val       _U_(0x4)                                       /**< (ACC_MR) Select AFE0_AD4  */
+#define   ACC_MR_SELPLUS_AFE0_AD5_Val       _U_(0x5)                                       /**< (ACC_MR) Select AFE0_AD5  */
+#define   ACC_MR_SELPLUS_AFE1_AD0_Val       _U_(0x6)                                       /**< (ACC_MR) Select AFE1_AD0  */
+#define   ACC_MR_SELPLUS_AFE1_AD1_Val       _U_(0x7)                                       /**< (ACC_MR) Select AFE1_AD1  */
+#define ACC_MR_SELPLUS_AFE0_AD0             (ACC_MR_SELPLUS_AFE0_AD0_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD0 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD1             (ACC_MR_SELPLUS_AFE0_AD1_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD1 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD2             (ACC_MR_SELPLUS_AFE0_AD2_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD2 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD3             (ACC_MR_SELPLUS_AFE0_AD3_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD3 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD4             (ACC_MR_SELPLUS_AFE0_AD4_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD4 Position  */
+#define ACC_MR_SELPLUS_AFE0_AD5             (ACC_MR_SELPLUS_AFE0_AD5_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE0_AD5 Position  */
+#define ACC_MR_SELPLUS_AFE1_AD0             (ACC_MR_SELPLUS_AFE1_AD0_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE1_AD0 Position  */
+#define ACC_MR_SELPLUS_AFE1_AD1             (ACC_MR_SELPLUS_AFE1_AD1_Val << ACC_MR_SELPLUS_Pos)  /**< (ACC_MR) Select AFE1_AD1 Position  */
+#define ACC_MR_ACEN_Pos                     8                                              /**< (ACC_MR) Analog Comparator Enable Position */
+#define ACC_MR_ACEN_Msk                     (_U_(0x1) << ACC_MR_ACEN_Pos)                  /**< (ACC_MR) Analog Comparator Enable Mask */
+#define ACC_MR_ACEN                         ACC_MR_ACEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_ACEN_Msk instead */
+#define   ACC_MR_ACEN_DIS_Val               _U_(0x0)                                       /**< (ACC_MR) Analog comparator disabled.  */
+#define   ACC_MR_ACEN_EN_Val                _U_(0x1)                                       /**< (ACC_MR) Analog comparator enabled.  */
+#define ACC_MR_ACEN_DIS                     (ACC_MR_ACEN_DIS_Val << ACC_MR_ACEN_Pos)       /**< (ACC_MR) Analog comparator disabled. Position  */
+#define ACC_MR_ACEN_EN                      (ACC_MR_ACEN_EN_Val << ACC_MR_ACEN_Pos)        /**< (ACC_MR) Analog comparator enabled. Position  */
+#define ACC_MR_EDGETYP_Pos                  9                                              /**< (ACC_MR) Edge Type Position */
+#define ACC_MR_EDGETYP_Msk                  (_U_(0x3) << ACC_MR_EDGETYP_Pos)               /**< (ACC_MR) Edge Type Mask */
+#define ACC_MR_EDGETYP(value)               (ACC_MR_EDGETYP_Msk & ((value) << ACC_MR_EDGETYP_Pos))
+#define   ACC_MR_EDGETYP_RISING_Val         _U_(0x0)                                       /**< (ACC_MR) Only rising edge of comparator output  */
+#define   ACC_MR_EDGETYP_FALLING_Val        _U_(0x1)                                       /**< (ACC_MR) Falling edge of comparator output  */
+#define   ACC_MR_EDGETYP_ANY_Val            _U_(0x2)                                       /**< (ACC_MR) Any edge of comparator output  */
+#define ACC_MR_EDGETYP_RISING               (ACC_MR_EDGETYP_RISING_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Only rising edge of comparator output Position  */
+#define ACC_MR_EDGETYP_FALLING              (ACC_MR_EDGETYP_FALLING_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Falling edge of comparator output Position  */
+#define ACC_MR_EDGETYP_ANY                  (ACC_MR_EDGETYP_ANY_Val << ACC_MR_EDGETYP_Pos)  /**< (ACC_MR) Any edge of comparator output Position  */
+#define ACC_MR_INV_Pos                      12                                             /**< (ACC_MR) Invert Comparator Output Position */
+#define ACC_MR_INV_Msk                      (_U_(0x1) << ACC_MR_INV_Pos)                   /**< (ACC_MR) Invert Comparator Output Mask */
+#define ACC_MR_INV                          ACC_MR_INV_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_INV_Msk instead */
+#define   ACC_MR_INV_DIS_Val                _U_(0x0)                                       /**< (ACC_MR) Analog comparator output is directly processed.  */
+#define   ACC_MR_INV_EN_Val                 _U_(0x1)                                       /**< (ACC_MR) Analog comparator output is inverted prior to being processed.  */
+#define ACC_MR_INV_DIS                      (ACC_MR_INV_DIS_Val << ACC_MR_INV_Pos)         /**< (ACC_MR) Analog comparator output is directly processed. Position  */
+#define ACC_MR_INV_EN                       (ACC_MR_INV_EN_Val << ACC_MR_INV_Pos)          /**< (ACC_MR) Analog comparator output is inverted prior to being processed. Position  */
+#define ACC_MR_SELFS_Pos                    13                                             /**< (ACC_MR) Selection Of Fault Source Position */
+#define ACC_MR_SELFS_Msk                    (_U_(0x1) << ACC_MR_SELFS_Pos)                 /**< (ACC_MR) Selection Of Fault Source Mask */
+#define ACC_MR_SELFS                        ACC_MR_SELFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_SELFS_Msk instead */
+#define   ACC_MR_SELFS_CE_Val               _U_(0x0)                                       /**< (ACC_MR) The CE flag is used to drive the FAULT output.  */
+#define   ACC_MR_SELFS_OUTPUT_Val           _U_(0x1)                                       /**< (ACC_MR) The output of the analog comparator flag is used to drive the FAULT output.  */
+#define ACC_MR_SELFS_CE                     (ACC_MR_SELFS_CE_Val << ACC_MR_SELFS_Pos)      /**< (ACC_MR) The CE flag is used to drive the FAULT output. Position  */
+#define ACC_MR_SELFS_OUTPUT                 (ACC_MR_SELFS_OUTPUT_Val << ACC_MR_SELFS_Pos)  /**< (ACC_MR) The output of the analog comparator flag is used to drive the FAULT output. Position  */
+#define ACC_MR_FE_Pos                       14                                             /**< (ACC_MR) Fault Enable Position */
+#define ACC_MR_FE_Msk                       (_U_(0x1) << ACC_MR_FE_Pos)                    /**< (ACC_MR) Fault Enable Mask */
+#define ACC_MR_FE                           ACC_MR_FE_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_MR_FE_Msk instead */
+#define   ACC_MR_FE_DIS_Val                 _U_(0x0)                                       /**< (ACC_MR) The FAULT output is tied to 0.  */
+#define   ACC_MR_FE_EN_Val                  _U_(0x1)                                       /**< (ACC_MR) The FAULT output is driven by the signal defined by SELFS.  */
+#define ACC_MR_FE_DIS                       (ACC_MR_FE_DIS_Val << ACC_MR_FE_Pos)           /**< (ACC_MR) The FAULT output is tied to 0. Position  */
+#define ACC_MR_FE_EN                        (ACC_MR_FE_EN_Val << ACC_MR_FE_Pos)            /**< (ACC_MR) The FAULT output is driven by the signal defined by SELFS. Position  */
+#define ACC_MR_MASK                         _U_(0x7777)                                    /**< \deprecated (ACC_MR) Register MASK  (Use ACC_MR_Msk instead)  */
+#define ACC_MR_Msk                          _U_(0x7777)                                    /**< (ACC_MR) Register Mask  */
+
+
+/* -------- ACC_IER : (ACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IER_OFFSET                      (0x24)                                        /**<  (ACC_IER) Interrupt Enable Register  Offset */
+
+#define ACC_IER_CE_Pos                      0                                              /**< (ACC_IER) Comparison Edge Position */
+#define ACC_IER_CE_Msk                      (_U_(0x1) << ACC_IER_CE_Pos)                   /**< (ACC_IER) Comparison Edge Mask */
+#define ACC_IER_CE                          ACC_IER_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IER_CE_Msk instead */
+#define ACC_IER_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IER) Register MASK  (Use ACC_IER_Msk instead)  */
+#define ACC_IER_Msk                         _U_(0x01)                                      /**< (ACC_IER) Register Mask  */
+
+
+/* -------- ACC_IDR : (ACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IDR_OFFSET                      (0x28)                                        /**<  (ACC_IDR) Interrupt Disable Register  Offset */
+
+#define ACC_IDR_CE_Pos                      0                                              /**< (ACC_IDR) Comparison Edge Position */
+#define ACC_IDR_CE_Msk                      (_U_(0x1) << ACC_IDR_CE_Pos)                   /**< (ACC_IDR) Comparison Edge Mask */
+#define ACC_IDR_CE                          ACC_IDR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IDR_CE_Msk instead */
+#define ACC_IDR_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IDR) Register MASK  (Use ACC_IDR_Msk instead)  */
+#define ACC_IDR_Msk                         _U_(0x01)                                      /**< (ACC_IDR) Register Mask  */
+
+
+/* -------- ACC_IMR : (ACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_IMR_OFFSET                      (0x2C)                                        /**<  (ACC_IMR) Interrupt Mask Register  Offset */
+
+#define ACC_IMR_CE_Pos                      0                                              /**< (ACC_IMR) Comparison Edge Position */
+#define ACC_IMR_CE_Msk                      (_U_(0x1) << ACC_IMR_CE_Pos)                   /**< (ACC_IMR) Comparison Edge Mask */
+#define ACC_IMR_CE                          ACC_IMR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_IMR_CE_Msk instead */
+#define ACC_IMR_MASK                        _U_(0x01)                                      /**< \deprecated (ACC_IMR) Register MASK  (Use ACC_IMR_Msk instead)  */
+#define ACC_IMR_Msk                         _U_(0x01)                                      /**< (ACC_IMR) Register Mask  */
+
+
+/* -------- ACC_ISR : (ACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CE:1;                      /**< bit:      0  Comparison Edge (cleared on read)        */
+    uint32_t SCO:1;                     /**< bit:      1  Synchronized Comparator Output           */
+    uint32_t :29;                       /**< bit:  2..30  Reserved */
+    uint32_t MASK:1;                    /**< bit:     31  Flag Mask                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_ISR_OFFSET                      (0x30)                                        /**<  (ACC_ISR) Interrupt Status Register  Offset */
+
+#define ACC_ISR_CE_Pos                      0                                              /**< (ACC_ISR) Comparison Edge (cleared on read) Position */
+#define ACC_ISR_CE_Msk                      (_U_(0x1) << ACC_ISR_CE_Pos)                   /**< (ACC_ISR) Comparison Edge (cleared on read) Mask */
+#define ACC_ISR_CE                          ACC_ISR_CE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_CE_Msk instead */
+#define ACC_ISR_SCO_Pos                     1                                              /**< (ACC_ISR) Synchronized Comparator Output Position */
+#define ACC_ISR_SCO_Msk                     (_U_(0x1) << ACC_ISR_SCO_Pos)                  /**< (ACC_ISR) Synchronized Comparator Output Mask */
+#define ACC_ISR_SCO                         ACC_ISR_SCO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_SCO_Msk instead */
+#define ACC_ISR_MASK_Pos                    31                                             /**< (ACC_ISR) Flag Mask Position */
+#define ACC_ISR_MASK_Msk                    (_U_(0x1) << ACC_ISR_MASK_Pos)                 /**< (ACC_ISR) Flag Mask Mask */
+#define ACC_ISR_MASK                        ACC_ISR_MASK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ISR_MASK_Msk instead */
+#define ACC_ISR_Msk                         _U_(0x80000003)                                /**< (ACC_ISR) Register Mask  */
+
+
+/* -------- ACC_ACR : (ACC Offset: 0x94) (R/W 32) Analog Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISEL:1;                    /**< bit:      0  Current Selection                        */
+    uint32_t HYST:2;                    /**< bit:   1..2  Hysteresis Selection                     */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_ACR_OFFSET                      (0x94)                                        /**<  (ACC_ACR) Analog Control Register  Offset */
+
+#define ACC_ACR_ISEL_Pos                    0                                              /**< (ACC_ACR) Current Selection Position */
+#define ACC_ACR_ISEL_Msk                    (_U_(0x1) << ACC_ACR_ISEL_Pos)                 /**< (ACC_ACR) Current Selection Mask */
+#define ACC_ACR_ISEL                        ACC_ACR_ISEL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_ACR_ISEL_Msk instead */
+#define   ACC_ACR_ISEL_LOPW_Val             _U_(0x0)                                       /**< (ACC_ACR) Low-power option.  */
+#define   ACC_ACR_ISEL_HISP_Val             _U_(0x1)                                       /**< (ACC_ACR) High-speed option.  */
+#define ACC_ACR_ISEL_LOPW                   (ACC_ACR_ISEL_LOPW_Val << ACC_ACR_ISEL_Pos)    /**< (ACC_ACR) Low-power option. Position  */
+#define ACC_ACR_ISEL_HISP                   (ACC_ACR_ISEL_HISP_Val << ACC_ACR_ISEL_Pos)    /**< (ACC_ACR) High-speed option. Position  */
+#define ACC_ACR_HYST_Pos                    1                                              /**< (ACC_ACR) Hysteresis Selection Position */
+#define ACC_ACR_HYST_Msk                    (_U_(0x3) << ACC_ACR_HYST_Pos)                 /**< (ACC_ACR) Hysteresis Selection Mask */
+#define ACC_ACR_HYST(value)                 (ACC_ACR_HYST_Msk & ((value) << ACC_ACR_HYST_Pos))
+#define ACC_ACR_MASK                        _U_(0x07)                                      /**< \deprecated (ACC_ACR) Register MASK  (Use ACC_ACR_Msk instead)  */
+#define ACC_ACR_Msk                         _U_(0x07)                                      /**< (ACC_ACR) Register Mask  */
+
+
+/* -------- ACC_WPMR : (ACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_WPMR_OFFSET                     (0xE4)                                        /**<  (ACC_WPMR) Write Protection Mode Register  Offset */
+
+#define ACC_WPMR_WPEN_Pos                   0                                              /**< (ACC_WPMR) Write Protection Enable Position */
+#define ACC_WPMR_WPEN_Msk                   (_U_(0x1) << ACC_WPMR_WPEN_Pos)                /**< (ACC_WPMR) Write Protection Enable Mask */
+#define ACC_WPMR_WPEN                       ACC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_WPMR_WPEN_Msk instead */
+#define ACC_WPMR_WPKEY_Pos                  8                                              /**< (ACC_WPMR) Write Protection Key Position */
+#define ACC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << ACC_WPMR_WPKEY_Pos)          /**< (ACC_WPMR) Write Protection Key Mask */
+#define ACC_WPMR_WPKEY(value)               (ACC_WPMR_WPKEY_Msk & ((value) << ACC_WPMR_WPKEY_Pos))
+#define   ACC_WPMR_WPKEY_PASSWD_Val         _U_(0x414343)                                  /**< (ACC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define ACC_WPMR_WPKEY_PASSWD               (ACC_WPMR_WPKEY_PASSWD_Val << ACC_WPMR_WPKEY_Pos)  /**< (ACC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define ACC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (ACC_WPMR) Register MASK  (Use ACC_WPMR_Msk instead)  */
+#define ACC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (ACC_WPMR) Register Mask  */
+
+
+/* -------- ACC_WPSR : (ACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ACC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACC_WPSR_OFFSET                     (0xE8)                                        /**<  (ACC_WPSR) Write Protection Status Register  Offset */
+
+#define ACC_WPSR_WPVS_Pos                   0                                              /**< (ACC_WPSR) Write Protection Violation Status Position */
+#define ACC_WPSR_WPVS_Msk                   (_U_(0x1) << ACC_WPSR_WPVS_Pos)                /**< (ACC_WPSR) Write Protection Violation Status Mask */
+#define ACC_WPSR_WPVS                       ACC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ACC_WPSR_WPVS_Msk instead */
+#define ACC_WPSR_MASK                       _U_(0x01)                                      /**< \deprecated (ACC_WPSR) Register MASK  (Use ACC_WPSR_Msk instead)  */
+#define ACC_WPSR_Msk                        _U_(0x01)                                      /**< (ACC_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ACC hardware registers */
+typedef struct {  
+  __O  uint32_t ACC_CR;         /**< (ACC Offset: 0x00) Control Register */
+  __IO uint32_t ACC_MR;         /**< (ACC Offset: 0x04) Mode Register */
+  __I  uint8_t                        Reserved1[28];
+  __O  uint32_t ACC_IER;        /**< (ACC Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t ACC_IDR;        /**< (ACC Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t ACC_IMR;        /**< (ACC Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t ACC_ISR;        /**< (ACC Offset: 0x30) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO uint32_t ACC_ACR;        /**< (ACC Offset: 0x94) Analog Control Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO uint32_t ACC_WPMR;       /**< (ACC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t ACC_WPSR;       /**< (ACC Offset: 0xE8) Write Protection Status Register */
+} Acc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ACC hardware registers */
+typedef struct {  
+  __O  ACC_CR_Type                    ACC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO ACC_MR_Type                    ACC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  uint8_t                        Reserved1[28];
+  __O  ACC_IER_Type                   ACC_IER;        /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  ACC_IDR_Type                   ACC_IDR;        /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  ACC_IMR_Type                   ACC_IMR;        /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  ACC_ISR_Type                   ACC_ISR;        /**< Offset: 0x30 (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO ACC_ACR_Type                   ACC_ACR;        /**< Offset: 0x94 (R/W  32) Analog Control Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO ACC_WPMR_Type                  ACC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  ACC_WPSR_Type                  ACC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Acc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Comparator Controller */
+
+#endif /* _SAMV71_ACC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/aes.h
+++ b/asf/sam/include/samv71b/component/aes.h
@@ -1,0 +1,586 @@
+/**
+ * \file
+ *
+ * \brief Component description for AES
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_AES_COMPONENT_H_
+#define _SAMV71_AES_COMPONENT_H_
+#define _SAMV71_AES_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Advanced Encryption Standard
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AES */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define AES_6149                       /**< (AES) Module ID */
+#define REV_AES W                      /**< (AES) Module revision */
+
+/* -------- AES_CR : (AES Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t START:1;                   /**< bit:      0  Start Processing                         */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      8  Software Reset                           */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t LOADSEED:1;                /**< bit:     16  Random Number Generator Seed Loading     */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CR_OFFSET                       (0x00)                                        /**<  (AES_CR) Control Register  Offset */
+
+#define AES_CR_START_Pos                    0                                              /**< (AES_CR) Start Processing Position */
+#define AES_CR_START_Msk                    (_U_(0x1) << AES_CR_START_Pos)                 /**< (AES_CR) Start Processing Mask */
+#define AES_CR_START                        AES_CR_START_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_START_Msk instead */
+#define AES_CR_SWRST_Pos                    8                                              /**< (AES_CR) Software Reset Position */
+#define AES_CR_SWRST_Msk                    (_U_(0x1) << AES_CR_SWRST_Pos)                 /**< (AES_CR) Software Reset Mask */
+#define AES_CR_SWRST                        AES_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_SWRST_Msk instead */
+#define AES_CR_LOADSEED_Pos                 16                                             /**< (AES_CR) Random Number Generator Seed Loading Position */
+#define AES_CR_LOADSEED_Msk                 (_U_(0x1) << AES_CR_LOADSEED_Pos)              /**< (AES_CR) Random Number Generator Seed Loading Mask */
+#define AES_CR_LOADSEED                     AES_CR_LOADSEED_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_LOADSEED_Msk instead */
+#define AES_CR_MASK                         _U_(0x10101)                                   /**< \deprecated (AES_CR) Register MASK  (Use AES_CR_Msk instead)  */
+#define AES_CR_Msk                          _U_(0x10101)                                   /**< (AES_CR) Register Mask  */
+
+
+/* -------- AES_MR : (AES Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CIPHER:1;                  /**< bit:      0  Processing Mode                          */
+    uint32_t GTAGEN:1;                  /**< bit:      1  GCM Automatic Tag Generation Enable      */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t DUALBUFF:1;                /**< bit:      3  Dual Input Buffer                        */
+    uint32_t PROCDLY:4;                 /**< bit:   4..7  Processing Delay                         */
+    uint32_t SMOD:2;                    /**< bit:   8..9  Start Mode                               */
+    uint32_t KEYSIZE:2;                 /**< bit: 10..11  Key Size                                 */
+    uint32_t OPMOD:3;                   /**< bit: 12..14  Operating Mode                           */
+    uint32_t LOD:1;                     /**< bit:     15  Last Output Data Mode                    */
+    uint32_t CFBS:3;                    /**< bit: 16..18  Cipher Feedback Data Size                */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t CKEY:4;                    /**< bit: 20..23  Countermeasure Key                       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_MR_OFFSET                       (0x04)                                        /**<  (AES_MR) Mode Register  Offset */
+
+#define AES_MR_CIPHER_Pos                   0                                              /**< (AES_MR) Processing Mode Position */
+#define AES_MR_CIPHER_Msk                   (_U_(0x1) << AES_MR_CIPHER_Pos)                /**< (AES_MR) Processing Mode Mask */
+#define AES_MR_CIPHER                       AES_MR_CIPHER_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_CIPHER_Msk instead */
+#define AES_MR_GTAGEN_Pos                   1                                              /**< (AES_MR) GCM Automatic Tag Generation Enable Position */
+#define AES_MR_GTAGEN_Msk                   (_U_(0x1) << AES_MR_GTAGEN_Pos)                /**< (AES_MR) GCM Automatic Tag Generation Enable Mask */
+#define AES_MR_GTAGEN                       AES_MR_GTAGEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_GTAGEN_Msk instead */
+#define AES_MR_DUALBUFF_Pos                 3                                              /**< (AES_MR) Dual Input Buffer Position */
+#define AES_MR_DUALBUFF_Msk                 (_U_(0x1) << AES_MR_DUALBUFF_Pos)              /**< (AES_MR) Dual Input Buffer Mask */
+#define AES_MR_DUALBUFF                     AES_MR_DUALBUFF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_DUALBUFF_Msk instead */
+#define   AES_MR_DUALBUFF_INACTIVE_Val      _U_(0x0)                                       /**< (AES_MR) AES_IDATARx cannot be written during processing of previous block.  */
+#define   AES_MR_DUALBUFF_ACTIVE_Val        _U_(0x1)                                       /**< (AES_MR) AES_IDATARx can be written during processing of previous block when SMOD = 2. It speeds up the overall runtime of large files.  */
+#define AES_MR_DUALBUFF_INACTIVE            (AES_MR_DUALBUFF_INACTIVE_Val << AES_MR_DUALBUFF_Pos)  /**< (AES_MR) AES_IDATARx cannot be written during processing of previous block. Position  */
+#define AES_MR_DUALBUFF_ACTIVE              (AES_MR_DUALBUFF_ACTIVE_Val << AES_MR_DUALBUFF_Pos)  /**< (AES_MR) AES_IDATARx can be written during processing of previous block when SMOD = 2. It speeds up the overall runtime of large files. Position  */
+#define AES_MR_PROCDLY_Pos                  4                                              /**< (AES_MR) Processing Delay Position */
+#define AES_MR_PROCDLY_Msk                  (_U_(0xF) << AES_MR_PROCDLY_Pos)               /**< (AES_MR) Processing Delay Mask */
+#define AES_MR_PROCDLY(value)               (AES_MR_PROCDLY_Msk & ((value) << AES_MR_PROCDLY_Pos))
+#define AES_MR_SMOD_Pos                     8                                              /**< (AES_MR) Start Mode Position */
+#define AES_MR_SMOD_Msk                     (_U_(0x3) << AES_MR_SMOD_Pos)                  /**< (AES_MR) Start Mode Mask */
+#define AES_MR_SMOD(value)                  (AES_MR_SMOD_Msk & ((value) << AES_MR_SMOD_Pos))
+#define   AES_MR_SMOD_MANUAL_START_Val      _U_(0x0)                                       /**< (AES_MR) Manual Mode  */
+#define   AES_MR_SMOD_AUTO_START_Val        _U_(0x1)                                       /**< (AES_MR) Auto Mode  */
+#define   AES_MR_SMOD_IDATAR0_START_Val     _U_(0x2)                                       /**< (AES_MR) AES_IDATAR0 access only Auto Mode (DMA)  */
+#define AES_MR_SMOD_MANUAL_START            (AES_MR_SMOD_MANUAL_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) Manual Mode Position  */
+#define AES_MR_SMOD_AUTO_START              (AES_MR_SMOD_AUTO_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) Auto Mode Position  */
+#define AES_MR_SMOD_IDATAR0_START           (AES_MR_SMOD_IDATAR0_START_Val << AES_MR_SMOD_Pos)  /**< (AES_MR) AES_IDATAR0 access only Auto Mode (DMA) Position  */
+#define AES_MR_KEYSIZE_Pos                  10                                             /**< (AES_MR) Key Size Position */
+#define AES_MR_KEYSIZE_Msk                  (_U_(0x3) << AES_MR_KEYSIZE_Pos)               /**< (AES_MR) Key Size Mask */
+#define AES_MR_KEYSIZE(value)               (AES_MR_KEYSIZE_Msk & ((value) << AES_MR_KEYSIZE_Pos))
+#define   AES_MR_KEYSIZE_AES128_Val         _U_(0x0)                                       /**< (AES_MR) AES Key Size is 128 bits  */
+#define   AES_MR_KEYSIZE_AES192_Val         _U_(0x1)                                       /**< (AES_MR) AES Key Size is 192 bits  */
+#define   AES_MR_KEYSIZE_AES256_Val         _U_(0x2)                                       /**< (AES_MR) AES Key Size is 256 bits  */
+#define AES_MR_KEYSIZE_AES128               (AES_MR_KEYSIZE_AES128_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 128 bits Position  */
+#define AES_MR_KEYSIZE_AES192               (AES_MR_KEYSIZE_AES192_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 192 bits Position  */
+#define AES_MR_KEYSIZE_AES256               (AES_MR_KEYSIZE_AES256_Val << AES_MR_KEYSIZE_Pos)  /**< (AES_MR) AES Key Size is 256 bits Position  */
+#define AES_MR_OPMOD_Pos                    12                                             /**< (AES_MR) Operating Mode Position */
+#define AES_MR_OPMOD_Msk                    (_U_(0x7) << AES_MR_OPMOD_Pos)                 /**< (AES_MR) Operating Mode Mask */
+#define AES_MR_OPMOD(value)                 (AES_MR_OPMOD_Msk & ((value) << AES_MR_OPMOD_Pos))
+#define   AES_MR_OPMOD_ECB_Val              _U_(0x0)                                       /**< (AES_MR) ECB: Electronic Code Book mode  */
+#define   AES_MR_OPMOD_CBC_Val              _U_(0x1)                                       /**< (AES_MR) CBC: Cipher Block Chaining mode  */
+#define   AES_MR_OPMOD_OFB_Val              _U_(0x2)                                       /**< (AES_MR) OFB: Output Feedback mode  */
+#define   AES_MR_OPMOD_CFB_Val              _U_(0x3)                                       /**< (AES_MR) CFB: Cipher Feedback mode  */
+#define   AES_MR_OPMOD_CTR_Val              _U_(0x4)                                       /**< (AES_MR) CTR: Counter mode (16-bit internal counter)  */
+#define   AES_MR_OPMOD_GCM_Val              _U_(0x5)                                       /**< (AES_MR) GCM: Galois/Counter mode  */
+#define AES_MR_OPMOD_ECB                    (AES_MR_OPMOD_ECB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) ECB: Electronic Code Book mode Position  */
+#define AES_MR_OPMOD_CBC                    (AES_MR_OPMOD_CBC_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CBC: Cipher Block Chaining mode Position  */
+#define AES_MR_OPMOD_OFB                    (AES_MR_OPMOD_OFB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) OFB: Output Feedback mode Position  */
+#define AES_MR_OPMOD_CFB                    (AES_MR_OPMOD_CFB_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CFB: Cipher Feedback mode Position  */
+#define AES_MR_OPMOD_CTR                    (AES_MR_OPMOD_CTR_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) CTR: Counter mode (16-bit internal counter) Position  */
+#define AES_MR_OPMOD_GCM                    (AES_MR_OPMOD_GCM_Val << AES_MR_OPMOD_Pos)     /**< (AES_MR) GCM: Galois/Counter mode Position  */
+#define AES_MR_LOD_Pos                      15                                             /**< (AES_MR) Last Output Data Mode Position */
+#define AES_MR_LOD_Msk                      (_U_(0x1) << AES_MR_LOD_Pos)                   /**< (AES_MR) Last Output Data Mode Mask */
+#define AES_MR_LOD                          AES_MR_LOD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_MR_LOD_Msk instead */
+#define AES_MR_CFBS_Pos                     16                                             /**< (AES_MR) Cipher Feedback Data Size Position */
+#define AES_MR_CFBS_Msk                     (_U_(0x7) << AES_MR_CFBS_Pos)                  /**< (AES_MR) Cipher Feedback Data Size Mask */
+#define AES_MR_CFBS(value)                  (AES_MR_CFBS_Msk & ((value) << AES_MR_CFBS_Pos))
+#define   AES_MR_CFBS_SIZE_128BIT_Val       _U_(0x0)                                       /**< (AES_MR) 128-bit  */
+#define   AES_MR_CFBS_SIZE_64BIT_Val        _U_(0x1)                                       /**< (AES_MR) 64-bit  */
+#define   AES_MR_CFBS_SIZE_32BIT_Val        _U_(0x2)                                       /**< (AES_MR) 32-bit  */
+#define   AES_MR_CFBS_SIZE_16BIT_Val        _U_(0x3)                                       /**< (AES_MR) 16-bit  */
+#define   AES_MR_CFBS_SIZE_8BIT_Val         _U_(0x4)                                       /**< (AES_MR) 8-bit  */
+#define AES_MR_CFBS_SIZE_128BIT             (AES_MR_CFBS_SIZE_128BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 128-bit Position  */
+#define AES_MR_CFBS_SIZE_64BIT              (AES_MR_CFBS_SIZE_64BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 64-bit Position  */
+#define AES_MR_CFBS_SIZE_32BIT              (AES_MR_CFBS_SIZE_32BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 32-bit Position  */
+#define AES_MR_CFBS_SIZE_16BIT              (AES_MR_CFBS_SIZE_16BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 16-bit Position  */
+#define AES_MR_CFBS_SIZE_8BIT               (AES_MR_CFBS_SIZE_8BIT_Val << AES_MR_CFBS_Pos)  /**< (AES_MR) 8-bit Position  */
+#define AES_MR_CKEY_Pos                     20                                             /**< (AES_MR) Countermeasure Key Position */
+#define AES_MR_CKEY_Msk                     (_U_(0xF) << AES_MR_CKEY_Pos)                  /**< (AES_MR) Countermeasure Key Mask */
+#define AES_MR_CKEY(value)                  (AES_MR_CKEY_Msk & ((value) << AES_MR_CKEY_Pos))
+#define   AES_MR_CKEY_PASSWD_Val            _U_(0xE)                                       /**< (AES_MR) This field must be written with 0xE to allow CMTYPx bit configuration changes. Any other values will abort the write operation in CMTYPx bits.Always reads as 0.  */
+#define AES_MR_CKEY_PASSWD                  (AES_MR_CKEY_PASSWD_Val << AES_MR_CKEY_Pos)    /**< (AES_MR) This field must be written with 0xE to allow CMTYPx bit configuration changes. Any other values will abort the write operation in CMTYPx bits.Always reads as 0. Position  */
+#define AES_MR_MASK                         _U_(0xF7FFFB)                                  /**< \deprecated (AES_MR) Register MASK  (Use AES_MR_Msk instead)  */
+#define AES_MR_Msk                          _U_(0xF7FFFB)                                  /**< (AES_MR) Register Mask  */
+
+
+/* -------- AES_IER : (AES Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Enable */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Enable           */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IER_OFFSET                      (0x10)                                        /**<  (AES_IER) Interrupt Enable Register  Offset */
+
+#define AES_IER_DATRDY_Pos                  0                                              /**< (AES_IER) Data Ready Interrupt Enable Position */
+#define AES_IER_DATRDY_Msk                  (_U_(0x1) << AES_IER_DATRDY_Pos)               /**< (AES_IER) Data Ready Interrupt Enable Mask */
+#define AES_IER_DATRDY                      AES_IER_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_DATRDY_Msk instead */
+#define AES_IER_URAD_Pos                    8                                              /**< (AES_IER) Unspecified Register Access Detection Interrupt Enable Position */
+#define AES_IER_URAD_Msk                    (_U_(0x1) << AES_IER_URAD_Pos)                 /**< (AES_IER) Unspecified Register Access Detection Interrupt Enable Mask */
+#define AES_IER_URAD                        AES_IER_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_URAD_Msk instead */
+#define AES_IER_TAGRDY_Pos                  16                                             /**< (AES_IER) GCM Tag Ready Interrupt Enable Position */
+#define AES_IER_TAGRDY_Msk                  (_U_(0x1) << AES_IER_TAGRDY_Pos)               /**< (AES_IER) GCM Tag Ready Interrupt Enable Mask */
+#define AES_IER_TAGRDY                      AES_IER_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IER_TAGRDY_Msk instead */
+#define AES_IER_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IER) Register MASK  (Use AES_IER_Msk instead)  */
+#define AES_IER_Msk                         _U_(0x10101)                                   /**< (AES_IER) Register Mask  */
+
+
+/* -------- AES_IDR : (AES Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Disable */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Disable          */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IDR_OFFSET                      (0x14)                                        /**<  (AES_IDR) Interrupt Disable Register  Offset */
+
+#define AES_IDR_DATRDY_Pos                  0                                              /**< (AES_IDR) Data Ready Interrupt Disable Position */
+#define AES_IDR_DATRDY_Msk                  (_U_(0x1) << AES_IDR_DATRDY_Pos)               /**< (AES_IDR) Data Ready Interrupt Disable Mask */
+#define AES_IDR_DATRDY                      AES_IDR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_DATRDY_Msk instead */
+#define AES_IDR_URAD_Pos                    8                                              /**< (AES_IDR) Unspecified Register Access Detection Interrupt Disable Position */
+#define AES_IDR_URAD_Msk                    (_U_(0x1) << AES_IDR_URAD_Pos)                 /**< (AES_IDR) Unspecified Register Access Detection Interrupt Disable Mask */
+#define AES_IDR_URAD                        AES_IDR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_URAD_Msk instead */
+#define AES_IDR_TAGRDY_Pos                  16                                             /**< (AES_IDR) GCM Tag Ready Interrupt Disable Position */
+#define AES_IDR_TAGRDY_Msk                  (_U_(0x1) << AES_IDR_TAGRDY_Pos)               /**< (AES_IDR) GCM Tag Ready Interrupt Disable Mask */
+#define AES_IDR_TAGRDY                      AES_IDR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IDR_TAGRDY_Msk instead */
+#define AES_IDR_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IDR) Register MASK  (Use AES_IDR_Msk instead)  */
+#define AES_IDR_Msk                         _U_(0x10101)                                   /**< (AES_IDR) Register Mask  */
+
+
+/* -------- AES_IMR : (AES Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Interrupt Mask */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready Interrupt Mask             */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IMR_OFFSET                      (0x18)                                        /**<  (AES_IMR) Interrupt Mask Register  Offset */
+
+#define AES_IMR_DATRDY_Pos                  0                                              /**< (AES_IMR) Data Ready Interrupt Mask Position */
+#define AES_IMR_DATRDY_Msk                  (_U_(0x1) << AES_IMR_DATRDY_Pos)               /**< (AES_IMR) Data Ready Interrupt Mask Mask */
+#define AES_IMR_DATRDY                      AES_IMR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_DATRDY_Msk instead */
+#define AES_IMR_URAD_Pos                    8                                              /**< (AES_IMR) Unspecified Register Access Detection Interrupt Mask Position */
+#define AES_IMR_URAD_Msk                    (_U_(0x1) << AES_IMR_URAD_Pos)                 /**< (AES_IMR) Unspecified Register Access Detection Interrupt Mask Mask */
+#define AES_IMR_URAD                        AES_IMR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_URAD_Msk instead */
+#define AES_IMR_TAGRDY_Pos                  16                                             /**< (AES_IMR) GCM Tag Ready Interrupt Mask Position */
+#define AES_IMR_TAGRDY_Msk                  (_U_(0x1) << AES_IMR_TAGRDY_Pos)               /**< (AES_IMR) GCM Tag Ready Interrupt Mask Mask */
+#define AES_IMR_TAGRDY                      AES_IMR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_IMR_TAGRDY_Msk instead */
+#define AES_IMR_MASK                        _U_(0x10101)                                   /**< \deprecated (AES_IMR) Register MASK  (Use AES_IMR_Msk instead)  */
+#define AES_IMR_Msk                         _U_(0x10101)                                   /**< (AES_IMR) Register Mask  */
+
+
+/* -------- AES_ISR : (AES Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t URAD:1;                    /**< bit:      8  Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t URAT:4;                    /**< bit: 12..15  Unspecified Register Access (cleared by writing SWRST in AES_CR) */
+    uint32_t TAGRDY:1;                  /**< bit:     16  GCM Tag Ready                            */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_ISR_OFFSET                      (0x1C)                                        /**<  (AES_ISR) Interrupt Status Register  Offset */
+
+#define AES_ISR_DATRDY_Pos                  0                                              /**< (AES_ISR) Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) Position */
+#define AES_ISR_DATRDY_Msk                  (_U_(0x1) << AES_ISR_DATRDY_Pos)               /**< (AES_ISR) Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) Mask */
+#define AES_ISR_DATRDY                      AES_ISR_DATRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_DATRDY_Msk instead */
+#define AES_ISR_URAD_Pos                    8                                              /**< (AES_ISR) Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) Position */
+#define AES_ISR_URAD_Msk                    (_U_(0x1) << AES_ISR_URAD_Pos)                 /**< (AES_ISR) Unspecified Register Access Detection Status (cleared by writing SWRST in AES_CR) Mask */
+#define AES_ISR_URAD                        AES_ISR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_URAD_Msk instead */
+#define AES_ISR_URAT_Pos                    12                                             /**< (AES_ISR) Unspecified Register Access (cleared by writing SWRST in AES_CR) Position */
+#define AES_ISR_URAT_Msk                    (_U_(0xF) << AES_ISR_URAT_Pos)                 /**< (AES_ISR) Unspecified Register Access (cleared by writing SWRST in AES_CR) Mask */
+#define AES_ISR_URAT(value)                 (AES_ISR_URAT_Msk & ((value) << AES_ISR_URAT_Pos))
+#define   AES_ISR_URAT_IDR_WR_PROCESSING_Val _U_(0x0)                                       /**< (AES_ISR) Input Data Register written during the data processing when SMOD = 0x2 mode.  */
+#define   AES_ISR_URAT_ODR_RD_PROCESSING_Val _U_(0x1)                                       /**< (AES_ISR) Output Data Register read during the data processing.  */
+#define   AES_ISR_URAT_MR_WR_PROCESSING_Val _U_(0x2)                                       /**< (AES_ISR) Mode Register written during the data processing.  */
+#define   AES_ISR_URAT_ODR_RD_SUBKGEN_Val   _U_(0x3)                                       /**< (AES_ISR) Output Data Register read during the sub-keys generation.  */
+#define   AES_ISR_URAT_MR_WR_SUBKGEN_Val    _U_(0x4)                                       /**< (AES_ISR) Mode Register written during the sub-keys generation.  */
+#define   AES_ISR_URAT_WOR_RD_ACCESS_Val    _U_(0x5)                                       /**< (AES_ISR) Write-only register read access.  */
+#define AES_ISR_URAT_IDR_WR_PROCESSING      (AES_ISR_URAT_IDR_WR_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Input Data Register written during the data processing when SMOD = 0x2 mode. Position  */
+#define AES_ISR_URAT_ODR_RD_PROCESSING      (AES_ISR_URAT_ODR_RD_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Output Data Register read during the data processing. Position  */
+#define AES_ISR_URAT_MR_WR_PROCESSING       (AES_ISR_URAT_MR_WR_PROCESSING_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Mode Register written during the data processing. Position  */
+#define AES_ISR_URAT_ODR_RD_SUBKGEN         (AES_ISR_URAT_ODR_RD_SUBKGEN_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Output Data Register read during the sub-keys generation. Position  */
+#define AES_ISR_URAT_MR_WR_SUBKGEN          (AES_ISR_URAT_MR_WR_SUBKGEN_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Mode Register written during the sub-keys generation. Position  */
+#define AES_ISR_URAT_WOR_RD_ACCESS          (AES_ISR_URAT_WOR_RD_ACCESS_Val << AES_ISR_URAT_Pos)  /**< (AES_ISR) Write-only register read access. Position  */
+#define AES_ISR_TAGRDY_Pos                  16                                             /**< (AES_ISR) GCM Tag Ready Position */
+#define AES_ISR_TAGRDY_Msk                  (_U_(0x1) << AES_ISR_TAGRDY_Pos)               /**< (AES_ISR) GCM Tag Ready Mask */
+#define AES_ISR_TAGRDY                      AES_ISR_TAGRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_ISR_TAGRDY_Msk instead */
+#define AES_ISR_MASK                        _U_(0x1F101)                                   /**< \deprecated (AES_ISR) Register MASK  (Use AES_ISR_Msk instead)  */
+#define AES_ISR_Msk                         _U_(0x1F101)                                   /**< (AES_ISR) Register Mask  */
+
+
+/* -------- AES_KEYWR : (AES Offset: 0x20) (/W 32) Key Word Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEYW:32;                   /**< bit:  0..31  Key Word                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_KEYWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_KEYWR_OFFSET                    (0x20)                                        /**<  (AES_KEYWR) Key Word Register  Offset */
+
+#define AES_KEYWR_KEYW_Pos                  0                                              /**< (AES_KEYWR) Key Word Position */
+#define AES_KEYWR_KEYW_Msk                  (_U_(0xFFFFFFFF) << AES_KEYWR_KEYW_Pos)        /**< (AES_KEYWR) Key Word Mask */
+#define AES_KEYWR_KEYW(value)               (AES_KEYWR_KEYW_Msk & ((value) << AES_KEYWR_KEYW_Pos))
+#define AES_KEYWR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_KEYWR) Register MASK  (Use AES_KEYWR_Msk instead)  */
+#define AES_KEYWR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_KEYWR) Register Mask  */
+
+
+/* -------- AES_IDATAR : (AES Offset: 0x40) (/W 32) Input Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDATA:32;                  /**< bit:  0..31  Input Data Word                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IDATAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IDATAR_OFFSET                   (0x40)                                        /**<  (AES_IDATAR) Input Data Register  Offset */
+
+#define AES_IDATAR_IDATA_Pos                0                                              /**< (AES_IDATAR) Input Data Word Position */
+#define AES_IDATAR_IDATA_Msk                (_U_(0xFFFFFFFF) << AES_IDATAR_IDATA_Pos)      /**< (AES_IDATAR) Input Data Word Mask */
+#define AES_IDATAR_IDATA(value)             (AES_IDATAR_IDATA_Msk & ((value) << AES_IDATAR_IDATA_Pos))
+#define AES_IDATAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_IDATAR) Register MASK  (Use AES_IDATAR_Msk instead)  */
+#define AES_IDATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_IDATAR) Register Mask  */
+
+
+/* -------- AES_ODATAR : (AES Offset: 0x50) (R/ 32) Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_ODATAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_ODATAR_OFFSET                   (0x50)                                        /**<  (AES_ODATAR) Output Data Register  Offset */
+
+#define AES_ODATAR_ODATA_Pos                0                                              /**< (AES_ODATAR) Output Data Position */
+#define AES_ODATAR_ODATA_Msk                (_U_(0xFFFFFFFF) << AES_ODATAR_ODATA_Pos)      /**< (AES_ODATAR) Output Data Mask */
+#define AES_ODATAR_ODATA(value)             (AES_ODATAR_ODATA_Msk & ((value) << AES_ODATAR_ODATA_Pos))
+#define AES_ODATAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_ODATAR) Register MASK  (Use AES_ODATAR_Msk instead)  */
+#define AES_ODATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_ODATAR) Register Mask  */
+
+
+/* -------- AES_IVR : (AES Offset: 0x60) (/W 32) Initialization Vector Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IV:32;                     /**< bit:  0..31  Initialization Vector                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_IVR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_IVR_OFFSET                      (0x60)                                        /**<  (AES_IVR) Initialization Vector Register  Offset */
+
+#define AES_IVR_IV_Pos                      0                                              /**< (AES_IVR) Initialization Vector Position */
+#define AES_IVR_IV_Msk                      (_U_(0xFFFFFFFF) << AES_IVR_IV_Pos)            /**< (AES_IVR) Initialization Vector Mask */
+#define AES_IVR_IV(value)                   (AES_IVR_IV_Msk & ((value) << AES_IVR_IV_Pos))
+#define AES_IVR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (AES_IVR) Register MASK  (Use AES_IVR_Msk instead)  */
+#define AES_IVR_Msk                         _U_(0xFFFFFFFF)                                /**< (AES_IVR) Register Mask  */
+
+
+/* -------- AES_AADLENR : (AES Offset: 0x70) (R/W 32) Additional Authenticated Data Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AADLEN:32;                 /**< bit:  0..31  Additional Authenticated Data Length     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_AADLENR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_AADLENR_OFFSET                  (0x70)                                        /**<  (AES_AADLENR) Additional Authenticated Data Length Register  Offset */
+
+#define AES_AADLENR_AADLEN_Pos              0                                              /**< (AES_AADLENR) Additional Authenticated Data Length Position */
+#define AES_AADLENR_AADLEN_Msk              (_U_(0xFFFFFFFF) << AES_AADLENR_AADLEN_Pos)    /**< (AES_AADLENR) Additional Authenticated Data Length Mask */
+#define AES_AADLENR_AADLEN(value)           (AES_AADLENR_AADLEN_Msk & ((value) << AES_AADLENR_AADLEN_Pos))
+#define AES_AADLENR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (AES_AADLENR) Register MASK  (Use AES_AADLENR_Msk instead)  */
+#define AES_AADLENR_Msk                     _U_(0xFFFFFFFF)                                /**< (AES_AADLENR) Register Mask  */
+
+
+/* -------- AES_CLENR : (AES Offset: 0x74) (R/W 32) Plaintext/Ciphertext Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLEN:32;                   /**< bit:  0..31  Plaintext/Ciphertext Length              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CLENR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CLENR_OFFSET                    (0x74)                                        /**<  (AES_CLENR) Plaintext/Ciphertext Length Register  Offset */
+
+#define AES_CLENR_CLEN_Pos                  0                                              /**< (AES_CLENR) Plaintext/Ciphertext Length Position */
+#define AES_CLENR_CLEN_Msk                  (_U_(0xFFFFFFFF) << AES_CLENR_CLEN_Pos)        /**< (AES_CLENR) Plaintext/Ciphertext Length Mask */
+#define AES_CLENR_CLEN(value)               (AES_CLENR_CLEN_Msk & ((value) << AES_CLENR_CLEN_Pos))
+#define AES_CLENR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_CLENR) Register MASK  (Use AES_CLENR_Msk instead)  */
+#define AES_CLENR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_CLENR) Register Mask  */
+
+
+/* -------- AES_GHASHR : (AES Offset: 0x78) (R/W 32) GCM Intermediate Hash Word Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GHASH:32;                  /**< bit:  0..31  Intermediate GCM Hash Word x             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_GHASHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_GHASHR_OFFSET                   (0x78)                                        /**<  (AES_GHASHR) GCM Intermediate Hash Word Register  Offset */
+
+#define AES_GHASHR_GHASH_Pos                0                                              /**< (AES_GHASHR) Intermediate GCM Hash Word x Position */
+#define AES_GHASHR_GHASH_Msk                (_U_(0xFFFFFFFF) << AES_GHASHR_GHASH_Pos)      /**< (AES_GHASHR) Intermediate GCM Hash Word x Mask */
+#define AES_GHASHR_GHASH(value)             (AES_GHASHR_GHASH_Msk & ((value) << AES_GHASHR_GHASH_Pos))
+#define AES_GHASHR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AES_GHASHR) Register MASK  (Use AES_GHASHR_Msk instead)  */
+#define AES_GHASHR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_GHASHR) Register Mask  */
+
+
+/* -------- AES_TAGR : (AES Offset: 0x88) (R/ 32) GCM Authentication Tag Word Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TAG:32;                    /**< bit:  0..31  GCM Authentication Tag x                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_TAGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_TAGR_OFFSET                     (0x88)                                        /**<  (AES_TAGR) GCM Authentication Tag Word Register  Offset */
+
+#define AES_TAGR_TAG_Pos                    0                                              /**< (AES_TAGR) GCM Authentication Tag x Position */
+#define AES_TAGR_TAG_Msk                    (_U_(0xFFFFFFFF) << AES_TAGR_TAG_Pos)          /**< (AES_TAGR) GCM Authentication Tag x Mask */
+#define AES_TAGR_TAG(value)                 (AES_TAGR_TAG_Msk & ((value) << AES_TAGR_TAG_Pos))
+#define AES_TAGR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AES_TAGR) Register MASK  (Use AES_TAGR_Msk instead)  */
+#define AES_TAGR_Msk                        _U_(0xFFFFFFFF)                                /**< (AES_TAGR) Register Mask  */
+
+
+/* -------- AES_CTRR : (AES Offset: 0x98) (R/ 32) GCM Encryption Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CTR:32;                    /**< bit:  0..31  GCM Encryption Counter                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_CTRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CTRR_OFFSET                     (0x98)                                        /**<  (AES_CTRR) GCM Encryption Counter Value Register  Offset */
+
+#define AES_CTRR_CTR_Pos                    0                                              /**< (AES_CTRR) GCM Encryption Counter Position */
+#define AES_CTRR_CTR_Msk                    (_U_(0xFFFFFFFF) << AES_CTRR_CTR_Pos)          /**< (AES_CTRR) GCM Encryption Counter Mask */
+#define AES_CTRR_CTR(value)                 (AES_CTRR_CTR_Msk & ((value) << AES_CTRR_CTR_Pos))
+#define AES_CTRR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AES_CTRR) Register MASK  (Use AES_CTRR_Msk instead)  */
+#define AES_CTRR_Msk                        _U_(0xFFFFFFFF)                                /**< (AES_CTRR) Register Mask  */
+
+
+/* -------- AES_GCMHR : (AES Offset: 0x9c) (R/W 32) GCM H Word Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t H:32;                      /**< bit:  0..31  GCM H Word x                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AES_GCMHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_GCMHR_OFFSET                    (0x9C)                                        /**<  (AES_GCMHR) GCM H Word Register  Offset */
+
+#define AES_GCMHR_H_Pos                     0                                              /**< (AES_GCMHR) GCM H Word x Position */
+#define AES_GCMHR_H_Msk                     (_U_(0xFFFFFFFF) << AES_GCMHR_H_Pos)           /**< (AES_GCMHR) GCM H Word x Mask */
+#define AES_GCMHR_H(value)                  (AES_GCMHR_H_Msk & ((value) << AES_GCMHR_H_Pos))
+#define AES_GCMHR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (AES_GCMHR) Register MASK  (Use AES_GCMHR_Msk instead)  */
+#define AES_GCMHR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_GCMHR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief AES hardware registers */
+typedef struct {  
+  __O  uint32_t AES_CR;         /**< (AES Offset: 0x00) Control Register */
+  __IO uint32_t AES_MR;         /**< (AES Offset: 0x04) Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __O  uint32_t AES_IER;        /**< (AES Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t AES_IDR;        /**< (AES Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t AES_IMR;        /**< (AES Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t AES_ISR;        /**< (AES Offset: 0x1C) Interrupt Status Register */
+  __O  uint32_t AES_KEYWR[8];   /**< (AES Offset: 0x20) Key Word Register */
+  __O  uint32_t AES_IDATAR[4];  /**< (AES Offset: 0x40) Input Data Register */
+  __I  uint32_t AES_ODATAR[4];  /**< (AES Offset: 0x50) Output Data Register */
+  __O  uint32_t AES_IVR[4];     /**< (AES Offset: 0x60) Initialization Vector Register */
+  __IO uint32_t AES_AADLENR;    /**< (AES Offset: 0x70) Additional Authenticated Data Length Register */
+  __IO uint32_t AES_CLENR;      /**< (AES Offset: 0x74) Plaintext/Ciphertext Length Register */
+  __IO uint32_t AES_GHASHR[4];  /**< (AES Offset: 0x78) GCM Intermediate Hash Word Register */
+  __I  uint32_t AES_TAGR[4];    /**< (AES Offset: 0x88) GCM Authentication Tag Word Register */
+  __I  uint32_t AES_CTRR;       /**< (AES Offset: 0x98) GCM Encryption Counter Value Register */
+  __IO uint32_t AES_GCMHR[4];   /**< (AES Offset: 0x9C) GCM H Word Register */
+} Aes;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief AES hardware registers */
+typedef struct {  
+  __O  AES_CR_Type                    AES_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO AES_MR_Type                    AES_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __O  AES_IER_Type                   AES_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  AES_IDR_Type                   AES_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  AES_IMR_Type                   AES_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  AES_ISR_Type                   AES_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __O  AES_KEYWR_Type                 AES_KEYWR[8];   /**< Offset: 0x20 ( /W  32) Key Word Register */
+  __O  AES_IDATAR_Type                AES_IDATAR[4];  /**< Offset: 0x40 ( /W  32) Input Data Register */
+  __I  AES_ODATAR_Type                AES_ODATAR[4];  /**< Offset: 0x50 (R/   32) Output Data Register */
+  __O  AES_IVR_Type                   AES_IVR[4];     /**< Offset: 0x60 ( /W  32) Initialization Vector Register */
+  __IO AES_AADLENR_Type               AES_AADLENR;    /**< Offset: 0x70 (R/W  32) Additional Authenticated Data Length Register */
+  __IO AES_CLENR_Type                 AES_CLENR;      /**< Offset: 0x74 (R/W  32) Plaintext/Ciphertext Length Register */
+  __IO AES_GHASHR_Type                AES_GHASHR[4];  /**< Offset: 0x78 (R/W  32) GCM Intermediate Hash Word Register */
+  __I  AES_TAGR_Type                  AES_TAGR[4];    /**< Offset: 0x88 (R/   32) GCM Authentication Tag Word Register */
+  __I  AES_CTRR_Type                  AES_CTRR;       /**< Offset: 0x98 (R/   32) GCM Encryption Counter Value Register */
+  __IO AES_GCMHR_Type                 AES_GCMHR[4];   /**< Offset: 0x9C (R/W  32) GCM H Word Register */
+} Aes;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Advanced Encryption Standard */
+
+#endif /* _SAMV71_AES_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/afec.h
+++ b/asf/sam/include/samv71b/component/afec.h
@@ -1,0 +1,1710 @@
+/**
+ * \file
+ *
+ * \brief Component description for AFEC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_AFEC_COMPONENT_H_
+#define _SAMV71_AFEC_COMPONENT_H_
+#define _SAMV71_AFEC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Analog Front-End Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AFEC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define AFEC_11147                      /**< (AFEC) Module ID */
+#define REV_AFEC S                      /**< (AFEC) Module revision */
+
+/* -------- AFEC_CR : (AFEC Offset: 0x00) (/W 32) AFEC Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t START:1;                   /**< bit:      1  Start Conversion                         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CR_OFFSET                      (0x00)                                        /**<  (AFEC_CR) AFEC Control Register  Offset */
+
+#define AFEC_CR_SWRST_Pos                   0                                              /**< (AFEC_CR) Software Reset Position */
+#define AFEC_CR_SWRST_Msk                   (_U_(0x1) << AFEC_CR_SWRST_Pos)                /**< (AFEC_CR) Software Reset Mask */
+#define AFEC_CR_SWRST                       AFEC_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CR_SWRST_Msk instead */
+#define AFEC_CR_START_Pos                   1                                              /**< (AFEC_CR) Start Conversion Position */
+#define AFEC_CR_START_Msk                   (_U_(0x1) << AFEC_CR_START_Pos)                /**< (AFEC_CR) Start Conversion Mask */
+#define AFEC_CR_START                       AFEC_CR_START_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CR_START_Msk instead */
+#define AFEC_CR_MASK                        _U_(0x03)                                      /**< \deprecated (AFEC_CR) Register MASK  (Use AFEC_CR_Msk instead)  */
+#define AFEC_CR_Msk                         _U_(0x03)                                      /**< (AFEC_CR) Register Mask  */
+
+
+/* -------- AFEC_MR : (AFEC Offset: 0x04) (R/W 32) AFEC Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRGEN:1;                   /**< bit:      0  Trigger Enable                           */
+    uint32_t TRGSEL:3;                  /**< bit:   1..3  Trigger Selection                        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t SLEEP:1;                   /**< bit:      5  Sleep Mode                               */
+    uint32_t FWUP:1;                    /**< bit:      6  Fast Wake-up                             */
+    uint32_t FREERUN:1;                 /**< bit:      7  Free Run Mode                            */
+    uint32_t PRESCAL:8;                 /**< bit:  8..15  Prescaler Rate Selection                 */
+    uint32_t STARTUP:4;                 /**< bit: 16..19  Start-up Time                            */
+    uint32_t :3;                        /**< bit: 20..22  Reserved */
+    uint32_t ONE:1;                     /**< bit:     23  One                                      */
+    uint32_t TRACKTIM:4;                /**< bit: 24..27  Tracking Time                            */
+    uint32_t TRANSFER:2;                /**< bit: 28..29  Transfer Period                          */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t USEQ:1;                    /**< bit:     31  User Sequence Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_MR_OFFSET                      (0x04)                                        /**<  (AFEC_MR) AFEC Mode Register  Offset */
+
+#define AFEC_MR_TRGEN_Pos                   0                                              /**< (AFEC_MR) Trigger Enable Position */
+#define AFEC_MR_TRGEN_Msk                   (_U_(0x1) << AFEC_MR_TRGEN_Pos)                /**< (AFEC_MR) Trigger Enable Mask */
+#define AFEC_MR_TRGEN                       AFEC_MR_TRGEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_TRGEN_Msk instead */
+#define   AFEC_MR_TRGEN_DIS_Val             _U_(0x0)                                       /**< (AFEC_MR) Hardware triggers are disabled. Starting a conversion is only possible by software.  */
+#define   AFEC_MR_TRGEN_EN_Val              _U_(0x1)                                       /**< (AFEC_MR) Hardware trigger selected by TRGSEL field is enabled.  */
+#define AFEC_MR_TRGEN_DIS                   (AFEC_MR_TRGEN_DIS_Val << AFEC_MR_TRGEN_Pos)   /**< (AFEC_MR) Hardware triggers are disabled. Starting a conversion is only possible by software. Position  */
+#define AFEC_MR_TRGEN_EN                    (AFEC_MR_TRGEN_EN_Val << AFEC_MR_TRGEN_Pos)    /**< (AFEC_MR) Hardware trigger selected by TRGSEL field is enabled. Position  */
+#define AFEC_MR_TRGSEL_Pos                  1                                              /**< (AFEC_MR) Trigger Selection Position */
+#define AFEC_MR_TRGSEL_Msk                  (_U_(0x7) << AFEC_MR_TRGSEL_Pos)               /**< (AFEC_MR) Trigger Selection Mask */
+#define AFEC_MR_TRGSEL(value)               (AFEC_MR_TRGSEL_Msk & ((value) << AFEC_MR_TRGSEL_Pos))
+#define   AFEC_MR_TRGSEL_AFEC_TRIG0_Val     _U_(0x0)                                       /**< (AFEC_MR) AFE0_ADTRG for AFEC0 / AFE1_ADTRG for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG1_Val     _U_(0x1)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 0 for AFEC0/TIOA Output of the Timer Counter Channel 3 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG2_Val     _U_(0x2)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 1 for AFEC0/TIOA Output of the Timer Counter Channel 4 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG3_Val     _U_(0x3)                                       /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 2 for AFEC0/TIOA Output of the Timer Counter Channel 5 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG4_Val     _U_(0x4)                                       /**< (AFEC_MR) PWM0 event line 0 for AFEC0 / PWM1 event line 0 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG5_Val     _U_(0x5)                                       /**< (AFEC_MR) PWM0 event line 1 for AFEC0 / PWM1 event line 1 for AFEC1  */
+#define   AFEC_MR_TRGSEL_AFEC_TRIG6_Val     _U_(0x6)                                       /**< (AFEC_MR) Analog Comparator  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG0           (AFEC_MR_TRGSEL_AFEC_TRIG0_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) AFE0_ADTRG for AFEC0 / AFE1_ADTRG for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG1           (AFEC_MR_TRGSEL_AFEC_TRIG1_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 0 for AFEC0/TIOA Output of the Timer Counter Channel 3 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG2           (AFEC_MR_TRGSEL_AFEC_TRIG2_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 1 for AFEC0/TIOA Output of the Timer Counter Channel 4 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG3           (AFEC_MR_TRGSEL_AFEC_TRIG3_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) TIOA Output of the Timer Counter Channel 2 for AFEC0/TIOA Output of the Timer Counter Channel 5 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG4           (AFEC_MR_TRGSEL_AFEC_TRIG4_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) PWM0 event line 0 for AFEC0 / PWM1 event line 0 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG5           (AFEC_MR_TRGSEL_AFEC_TRIG5_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) PWM0 event line 1 for AFEC0 / PWM1 event line 1 for AFEC1 Position  */
+#define AFEC_MR_TRGSEL_AFEC_TRIG6           (AFEC_MR_TRGSEL_AFEC_TRIG6_Val << AFEC_MR_TRGSEL_Pos)  /**< (AFEC_MR) Analog Comparator Position  */
+#define AFEC_MR_SLEEP_Pos                   5                                              /**< (AFEC_MR) Sleep Mode Position */
+#define AFEC_MR_SLEEP_Msk                   (_U_(0x1) << AFEC_MR_SLEEP_Pos)                /**< (AFEC_MR) Sleep Mode Mask */
+#define AFEC_MR_SLEEP                       AFEC_MR_SLEEP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_SLEEP_Msk instead */
+#define   AFEC_MR_SLEEP_NORMAL_Val          _U_(0x0)                                       /**< (AFEC_MR) Normal mode: The AFE and reference voltage circuitry are kept ON between conversions.  */
+#define   AFEC_MR_SLEEP_SLEEP_Val           _U_(0x1)                                       /**< (AFEC_MR) Sleep mode: The AFE and reference voltage circuitry are OFF between conversions.  */
+#define AFEC_MR_SLEEP_NORMAL                (AFEC_MR_SLEEP_NORMAL_Val << AFEC_MR_SLEEP_Pos)  /**< (AFEC_MR) Normal mode: The AFE and reference voltage circuitry are kept ON between conversions. Position  */
+#define AFEC_MR_SLEEP_SLEEP                 (AFEC_MR_SLEEP_SLEEP_Val << AFEC_MR_SLEEP_Pos)  /**< (AFEC_MR) Sleep mode: The AFE and reference voltage circuitry are OFF between conversions. Position  */
+#define AFEC_MR_FWUP_Pos                    6                                              /**< (AFEC_MR) Fast Wake-up Position */
+#define AFEC_MR_FWUP_Msk                    (_U_(0x1) << AFEC_MR_FWUP_Pos)                 /**< (AFEC_MR) Fast Wake-up Mask */
+#define AFEC_MR_FWUP                        AFEC_MR_FWUP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_FWUP_Msk instead */
+#define   AFEC_MR_FWUP_OFF_Val              _U_(0x0)                                       /**< (AFEC_MR) Normal Sleep mode: The sleep mode is defined by the SLEEP bit.  */
+#define   AFEC_MR_FWUP_ON_Val               _U_(0x1)                                       /**< (AFEC_MR) Fast wake-up Sleep mode: The voltage reference is ON between conversions and AFE is OFF.  */
+#define AFEC_MR_FWUP_OFF                    (AFEC_MR_FWUP_OFF_Val << AFEC_MR_FWUP_Pos)     /**< (AFEC_MR) Normal Sleep mode: The sleep mode is defined by the SLEEP bit. Position  */
+#define AFEC_MR_FWUP_ON                     (AFEC_MR_FWUP_ON_Val << AFEC_MR_FWUP_Pos)      /**< (AFEC_MR) Fast wake-up Sleep mode: The voltage reference is ON between conversions and AFE is OFF. Position  */
+#define AFEC_MR_FREERUN_Pos                 7                                              /**< (AFEC_MR) Free Run Mode Position */
+#define AFEC_MR_FREERUN_Msk                 (_U_(0x1) << AFEC_MR_FREERUN_Pos)              /**< (AFEC_MR) Free Run Mode Mask */
+#define AFEC_MR_FREERUN                     AFEC_MR_FREERUN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_FREERUN_Msk instead */
+#define   AFEC_MR_FREERUN_OFF_Val           _U_(0x0)                                       /**< (AFEC_MR) Normal mode  */
+#define   AFEC_MR_FREERUN_ON_Val            _U_(0x1)                                       /**< (AFEC_MR) Free Run mode: Never wait for any trigger.  */
+#define AFEC_MR_FREERUN_OFF                 (AFEC_MR_FREERUN_OFF_Val << AFEC_MR_FREERUN_Pos)  /**< (AFEC_MR) Normal mode Position  */
+#define AFEC_MR_FREERUN_ON                  (AFEC_MR_FREERUN_ON_Val << AFEC_MR_FREERUN_Pos)  /**< (AFEC_MR) Free Run mode: Never wait for any trigger. Position  */
+#define AFEC_MR_PRESCAL_Pos                 8                                              /**< (AFEC_MR) Prescaler Rate Selection Position */
+#define AFEC_MR_PRESCAL_Msk                 (_U_(0xFF) << AFEC_MR_PRESCAL_Pos)             /**< (AFEC_MR) Prescaler Rate Selection Mask */
+#define AFEC_MR_PRESCAL(value)              (AFEC_MR_PRESCAL_Msk & ((value) << AFEC_MR_PRESCAL_Pos))
+#define AFEC_MR_STARTUP_Pos                 16                                             /**< (AFEC_MR) Start-up Time Position */
+#define AFEC_MR_STARTUP_Msk                 (_U_(0xF) << AFEC_MR_STARTUP_Pos)              /**< (AFEC_MR) Start-up Time Mask */
+#define AFEC_MR_STARTUP(value)              (AFEC_MR_STARTUP_Msk & ((value) << AFEC_MR_STARTUP_Pos))
+#define   AFEC_MR_STARTUP_SUT0_Val          _U_(0x0)                                       /**< (AFEC_MR) 0 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT8_Val          _U_(0x1)                                       /**< (AFEC_MR) 8 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT16_Val         _U_(0x2)                                       /**< (AFEC_MR) 16 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT24_Val         _U_(0x3)                                       /**< (AFEC_MR) 24 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT64_Val         _U_(0x4)                                       /**< (AFEC_MR) 64 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT80_Val         _U_(0x5)                                       /**< (AFEC_MR) 80 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT96_Val         _U_(0x6)                                       /**< (AFEC_MR) 96 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT112_Val        _U_(0x7)                                       /**< (AFEC_MR) 112 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT512_Val        _U_(0x8)                                       /**< (AFEC_MR) 512 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT576_Val        _U_(0x9)                                       /**< (AFEC_MR) 576 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT640_Val        _U_(0xA)                                       /**< (AFEC_MR) 640 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT704_Val        _U_(0xB)                                       /**< (AFEC_MR) 704 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT768_Val        _U_(0xC)                                       /**< (AFEC_MR) 768 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT832_Val        _U_(0xD)                                       /**< (AFEC_MR) 832 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT896_Val        _U_(0xE)                                       /**< (AFEC_MR) 896 periods of AFE clock  */
+#define   AFEC_MR_STARTUP_SUT960_Val        _U_(0xF)                                       /**< (AFEC_MR) 960 periods of AFE clock  */
+#define AFEC_MR_STARTUP_SUT0                (AFEC_MR_STARTUP_SUT0_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 0 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT8                (AFEC_MR_STARTUP_SUT8_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 8 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT16               (AFEC_MR_STARTUP_SUT16_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 16 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT24               (AFEC_MR_STARTUP_SUT24_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 24 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT64               (AFEC_MR_STARTUP_SUT64_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 64 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT80               (AFEC_MR_STARTUP_SUT80_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 80 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT96               (AFEC_MR_STARTUP_SUT96_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 96 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT112              (AFEC_MR_STARTUP_SUT112_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 112 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT512              (AFEC_MR_STARTUP_SUT512_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 512 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT576              (AFEC_MR_STARTUP_SUT576_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 576 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT640              (AFEC_MR_STARTUP_SUT640_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 640 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT704              (AFEC_MR_STARTUP_SUT704_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 704 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT768              (AFEC_MR_STARTUP_SUT768_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 768 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT832              (AFEC_MR_STARTUP_SUT832_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 832 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT896              (AFEC_MR_STARTUP_SUT896_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 896 periods of AFE clock Position  */
+#define AFEC_MR_STARTUP_SUT960              (AFEC_MR_STARTUP_SUT960_Val << AFEC_MR_STARTUP_Pos)  /**< (AFEC_MR) 960 periods of AFE clock Position  */
+#define AFEC_MR_ONE_Pos                     23                                             /**< (AFEC_MR) One Position */
+#define AFEC_MR_ONE_Msk                     (_U_(0x1) << AFEC_MR_ONE_Pos)                  /**< (AFEC_MR) One Mask */
+#define AFEC_MR_ONE                         AFEC_MR_ONE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_ONE_Msk instead */
+#define AFEC_MR_TRACKTIM_Pos                24                                             /**< (AFEC_MR) Tracking Time Position */
+#define AFEC_MR_TRACKTIM_Msk                (_U_(0xF) << AFEC_MR_TRACKTIM_Pos)             /**< (AFEC_MR) Tracking Time Mask */
+#define AFEC_MR_TRACKTIM(value)             (AFEC_MR_TRACKTIM_Msk & ((value) << AFEC_MR_TRACKTIM_Pos))
+#define AFEC_MR_TRANSFER_Pos                28                                             /**< (AFEC_MR) Transfer Period Position */
+#define AFEC_MR_TRANSFER_Msk                (_U_(0x3) << AFEC_MR_TRANSFER_Pos)             /**< (AFEC_MR) Transfer Period Mask */
+#define AFEC_MR_TRANSFER(value)             (AFEC_MR_TRANSFER_Msk & ((value) << AFEC_MR_TRANSFER_Pos))
+#define AFEC_MR_USEQ_Pos                    31                                             /**< (AFEC_MR) User Sequence Enable Position */
+#define AFEC_MR_USEQ_Msk                    (_U_(0x1) << AFEC_MR_USEQ_Pos)                 /**< (AFEC_MR) User Sequence Enable Mask */
+#define AFEC_MR_USEQ                        AFEC_MR_USEQ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_MR_USEQ_Msk instead */
+#define   AFEC_MR_USEQ_NUM_ORDER_Val        _U_(0x0)                                       /**< (AFEC_MR) Normal mode: The controller converts channels in a simple numeric order.  */
+#define   AFEC_MR_USEQ_REG_ORDER_Val        _U_(0x1)                                       /**< (AFEC_MR) User Sequence mode: The sequence respects what is defined in AFEC_SEQ1R and AFEC_SEQ1R.  */
+#define AFEC_MR_USEQ_NUM_ORDER              (AFEC_MR_USEQ_NUM_ORDER_Val << AFEC_MR_USEQ_Pos)  /**< (AFEC_MR) Normal mode: The controller converts channels in a simple numeric order. Position  */
+#define AFEC_MR_USEQ_REG_ORDER              (AFEC_MR_USEQ_REG_ORDER_Val << AFEC_MR_USEQ_Pos)  /**< (AFEC_MR) User Sequence mode: The sequence respects what is defined in AFEC_SEQ1R and AFEC_SEQ1R. Position  */
+#define AFEC_MR_MASK                        _U_(0xBF8FFFEF)                                /**< \deprecated (AFEC_MR) Register MASK  (Use AFEC_MR_Msk instead)  */
+#define AFEC_MR_Msk                         _U_(0xBF8FFFEF)                                /**< (AFEC_MR) Register Mask  */
+
+
+/* -------- AFEC_EMR : (AFEC Offset: 0x08) (R/W 32) AFEC Extended Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMPMODE:2;                 /**< bit:   0..1  Comparison Mode                          */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t CMPSEL:5;                  /**< bit:   3..7  Comparison Selected Channel              */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t CMPALL:1;                  /**< bit:      9  Compare All Channels                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t CMPFILTER:2;               /**< bit: 12..13  Compare Event Filtering                  */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RES:3;                     /**< bit: 16..18  Resolution                               */
+    uint32_t :5;                        /**< bit: 19..23  Reserved */
+    uint32_t TAG:1;                     /**< bit:     24  TAG of the AFEC_LDCR                     */
+    uint32_t STM:1;                     /**< bit:     25  Single Trigger Mode                      */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t SIGNMODE:2;                /**< bit: 28..29  Sign Mode                                */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_EMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_EMR_OFFSET                     (0x08)                                        /**<  (AFEC_EMR) AFEC Extended Mode Register  Offset */
+
+#define AFEC_EMR_CMPMODE_Pos                0                                              /**< (AFEC_EMR) Comparison Mode Position */
+#define AFEC_EMR_CMPMODE_Msk                (_U_(0x3) << AFEC_EMR_CMPMODE_Pos)             /**< (AFEC_EMR) Comparison Mode Mask */
+#define AFEC_EMR_CMPMODE(value)             (AFEC_EMR_CMPMODE_Msk & ((value) << AFEC_EMR_CMPMODE_Pos))
+#define   AFEC_EMR_CMPMODE_LOW_Val          _U_(0x0)                                       /**< (AFEC_EMR) Generates an event when the converted data is lower than the low threshold of the window.  */
+#define   AFEC_EMR_CMPMODE_HIGH_Val         _U_(0x1)                                       /**< (AFEC_EMR) Generates an event when the converted data is higher than the high threshold of the window.  */
+#define   AFEC_EMR_CMPMODE_IN_Val           _U_(0x2)                                       /**< (AFEC_EMR) Generates an event when the converted data is in the comparison window.  */
+#define   AFEC_EMR_CMPMODE_OUT_Val          _U_(0x3)                                       /**< (AFEC_EMR) Generates an event when the converted data is out of the comparison window.  */
+#define AFEC_EMR_CMPMODE_LOW                (AFEC_EMR_CMPMODE_LOW_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is lower than the low threshold of the window. Position  */
+#define AFEC_EMR_CMPMODE_HIGH               (AFEC_EMR_CMPMODE_HIGH_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is higher than the high threshold of the window. Position  */
+#define AFEC_EMR_CMPMODE_IN                 (AFEC_EMR_CMPMODE_IN_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is in the comparison window. Position  */
+#define AFEC_EMR_CMPMODE_OUT                (AFEC_EMR_CMPMODE_OUT_Val << AFEC_EMR_CMPMODE_Pos)  /**< (AFEC_EMR) Generates an event when the converted data is out of the comparison window. Position  */
+#define AFEC_EMR_CMPSEL_Pos                 3                                              /**< (AFEC_EMR) Comparison Selected Channel Position */
+#define AFEC_EMR_CMPSEL_Msk                 (_U_(0x1F) << AFEC_EMR_CMPSEL_Pos)             /**< (AFEC_EMR) Comparison Selected Channel Mask */
+#define AFEC_EMR_CMPSEL(value)              (AFEC_EMR_CMPSEL_Msk & ((value) << AFEC_EMR_CMPSEL_Pos))
+#define AFEC_EMR_CMPALL_Pos                 9                                              /**< (AFEC_EMR) Compare All Channels Position */
+#define AFEC_EMR_CMPALL_Msk                 (_U_(0x1) << AFEC_EMR_CMPALL_Pos)              /**< (AFEC_EMR) Compare All Channels Mask */
+#define AFEC_EMR_CMPALL                     AFEC_EMR_CMPALL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_CMPALL_Msk instead */
+#define AFEC_EMR_CMPFILTER_Pos              12                                             /**< (AFEC_EMR) Compare Event Filtering Position */
+#define AFEC_EMR_CMPFILTER_Msk              (_U_(0x3) << AFEC_EMR_CMPFILTER_Pos)           /**< (AFEC_EMR) Compare Event Filtering Mask */
+#define AFEC_EMR_CMPFILTER(value)           (AFEC_EMR_CMPFILTER_Msk & ((value) << AFEC_EMR_CMPFILTER_Pos))
+#define AFEC_EMR_RES_Pos                    16                                             /**< (AFEC_EMR) Resolution Position */
+#define AFEC_EMR_RES_Msk                    (_U_(0x7) << AFEC_EMR_RES_Pos)                 /**< (AFEC_EMR) Resolution Mask */
+#define AFEC_EMR_RES(value)                 (AFEC_EMR_RES_Msk & ((value) << AFEC_EMR_RES_Pos))
+#define   AFEC_EMR_RES_NO_AVERAGE_Val       _U_(0x0)                                       /**< (AFEC_EMR) 12-bit resolution, AFE sample rate is maximum (no averaging).  */
+#define   AFEC_EMR_RES_OSR4_Val             _U_(0x2)                                       /**< (AFEC_EMR) 13-bit resolution, AFE sample rate divided by 4 (averaging).  */
+#define   AFEC_EMR_RES_OSR16_Val            _U_(0x3)                                       /**< (AFEC_EMR) 14-bit resolution, AFE sample rate divided by 16 (averaging).  */
+#define   AFEC_EMR_RES_OSR64_Val            _U_(0x4)                                       /**< (AFEC_EMR) 15-bit resolution, AFE sample rate divided by 64 (averaging).  */
+#define   AFEC_EMR_RES_OSR256_Val           _U_(0x5)                                       /**< (AFEC_EMR) 16-bit resolution, AFE sample rate divided by 256 (averaging).  */
+#define AFEC_EMR_RES_NO_AVERAGE             (AFEC_EMR_RES_NO_AVERAGE_Val << AFEC_EMR_RES_Pos)  /**< (AFEC_EMR) 12-bit resolution, AFE sample rate is maximum (no averaging). Position  */
+#define AFEC_EMR_RES_OSR4                   (AFEC_EMR_RES_OSR4_Val << AFEC_EMR_RES_Pos)    /**< (AFEC_EMR) 13-bit resolution, AFE sample rate divided by 4 (averaging). Position  */
+#define AFEC_EMR_RES_OSR16                  (AFEC_EMR_RES_OSR16_Val << AFEC_EMR_RES_Pos)   /**< (AFEC_EMR) 14-bit resolution, AFE sample rate divided by 16 (averaging). Position  */
+#define AFEC_EMR_RES_OSR64                  (AFEC_EMR_RES_OSR64_Val << AFEC_EMR_RES_Pos)   /**< (AFEC_EMR) 15-bit resolution, AFE sample rate divided by 64 (averaging). Position  */
+#define AFEC_EMR_RES_OSR256                 (AFEC_EMR_RES_OSR256_Val << AFEC_EMR_RES_Pos)  /**< (AFEC_EMR) 16-bit resolution, AFE sample rate divided by 256 (averaging). Position  */
+#define AFEC_EMR_TAG_Pos                    24                                             /**< (AFEC_EMR) TAG of the AFEC_LDCR Position */
+#define AFEC_EMR_TAG_Msk                    (_U_(0x1) << AFEC_EMR_TAG_Pos)                 /**< (AFEC_EMR) TAG of the AFEC_LDCR Mask */
+#define AFEC_EMR_TAG                        AFEC_EMR_TAG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_TAG_Msk instead */
+#define AFEC_EMR_STM_Pos                    25                                             /**< (AFEC_EMR) Single Trigger Mode Position */
+#define AFEC_EMR_STM_Msk                    (_U_(0x1) << AFEC_EMR_STM_Pos)                 /**< (AFEC_EMR) Single Trigger Mode Mask */
+#define AFEC_EMR_STM                        AFEC_EMR_STM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_EMR_STM_Msk instead */
+#define AFEC_EMR_SIGNMODE_Pos               28                                             /**< (AFEC_EMR) Sign Mode Position */
+#define AFEC_EMR_SIGNMODE_Msk               (_U_(0x3) << AFEC_EMR_SIGNMODE_Pos)            /**< (AFEC_EMR) Sign Mode Mask */
+#define AFEC_EMR_SIGNMODE(value)            (AFEC_EMR_SIGNMODE_Msk & ((value) << AFEC_EMR_SIGNMODE_Pos))
+#define   AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN_Val _U_(0x0)                                       /**< (AFEC_EMR) Single-Ended channels: Unsigned conversions.Differential channels: Signed conversions.  */
+#define   AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG_Val _U_(0x1)                                       /**< (AFEC_EMR) Single-Ended channels: Signed conversions.Differential channels: Unsigned conversions.  */
+#define   AFEC_EMR_SIGNMODE_ALL_UNSIGNED_Val _U_(0x2)                                       /**< (AFEC_EMR) All channels: Unsigned conversions.  */
+#define   AFEC_EMR_SIGNMODE_ALL_SIGNED_Val  _U_(0x3)                                       /**< (AFEC_EMR) All channels: Signed conversions.  */
+#define AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN   (AFEC_EMR_SIGNMODE_SE_UNSG_DF_SIGN_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) Single-Ended channels: Unsigned conversions.Differential channels: Signed conversions. Position  */
+#define AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG   (AFEC_EMR_SIGNMODE_SE_SIGN_DF_UNSG_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) Single-Ended channels: Signed conversions.Differential channels: Unsigned conversions. Position  */
+#define AFEC_EMR_SIGNMODE_ALL_UNSIGNED      (AFEC_EMR_SIGNMODE_ALL_UNSIGNED_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) All channels: Unsigned conversions. Position  */
+#define AFEC_EMR_SIGNMODE_ALL_SIGNED        (AFEC_EMR_SIGNMODE_ALL_SIGNED_Val << AFEC_EMR_SIGNMODE_Pos)  /**< (AFEC_EMR) All channels: Signed conversions. Position  */
+#define AFEC_EMR_MASK                       _U_(0x330732FB)                                /**< \deprecated (AFEC_EMR) Register MASK  (Use AFEC_EMR_Msk instead)  */
+#define AFEC_EMR_Msk                        _U_(0x330732FB)                                /**< (AFEC_EMR) Register Mask  */
+
+
+/* -------- AFEC_SEQ1R : (AFEC Offset: 0x0c) (R/W 32) AFEC Channel Sequence 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USCH0:4;                   /**< bit:   0..3  User Sequence Number 0                   */
+    uint32_t USCH1:4;                   /**< bit:   4..7  User Sequence Number 1                   */
+    uint32_t USCH2:4;                   /**< bit:  8..11  User Sequence Number 2                   */
+    uint32_t USCH3:4;                   /**< bit: 12..15  User Sequence Number 3                   */
+    uint32_t USCH4:4;                   /**< bit: 16..19  User Sequence Number 4                   */
+    uint32_t USCH5:4;                   /**< bit: 20..23  User Sequence Number 5                   */
+    uint32_t USCH6:4;                   /**< bit: 24..27  User Sequence Number 6                   */
+    uint32_t USCH7:4;                   /**< bit: 28..31  User Sequence Number 7                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SEQ1R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SEQ1R_OFFSET                   (0x0C)                                        /**<  (AFEC_SEQ1R) AFEC Channel Sequence 1 Register  Offset */
+
+#define AFEC_SEQ1R_USCH0_Pos                0                                              /**< (AFEC_SEQ1R) User Sequence Number 0 Position */
+#define AFEC_SEQ1R_USCH0_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH0_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 0 Mask */
+#define AFEC_SEQ1R_USCH0(value)             (AFEC_SEQ1R_USCH0_Msk & ((value) << AFEC_SEQ1R_USCH0_Pos))
+#define AFEC_SEQ1R_USCH1_Pos                4                                              /**< (AFEC_SEQ1R) User Sequence Number 1 Position */
+#define AFEC_SEQ1R_USCH1_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH1_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 1 Mask */
+#define AFEC_SEQ1R_USCH1(value)             (AFEC_SEQ1R_USCH1_Msk & ((value) << AFEC_SEQ1R_USCH1_Pos))
+#define AFEC_SEQ1R_USCH2_Pos                8                                              /**< (AFEC_SEQ1R) User Sequence Number 2 Position */
+#define AFEC_SEQ1R_USCH2_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH2_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 2 Mask */
+#define AFEC_SEQ1R_USCH2(value)             (AFEC_SEQ1R_USCH2_Msk & ((value) << AFEC_SEQ1R_USCH2_Pos))
+#define AFEC_SEQ1R_USCH3_Pos                12                                             /**< (AFEC_SEQ1R) User Sequence Number 3 Position */
+#define AFEC_SEQ1R_USCH3_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH3_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 3 Mask */
+#define AFEC_SEQ1R_USCH3(value)             (AFEC_SEQ1R_USCH3_Msk & ((value) << AFEC_SEQ1R_USCH3_Pos))
+#define AFEC_SEQ1R_USCH4_Pos                16                                             /**< (AFEC_SEQ1R) User Sequence Number 4 Position */
+#define AFEC_SEQ1R_USCH4_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH4_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 4 Mask */
+#define AFEC_SEQ1R_USCH4(value)             (AFEC_SEQ1R_USCH4_Msk & ((value) << AFEC_SEQ1R_USCH4_Pos))
+#define AFEC_SEQ1R_USCH5_Pos                20                                             /**< (AFEC_SEQ1R) User Sequence Number 5 Position */
+#define AFEC_SEQ1R_USCH5_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH5_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 5 Mask */
+#define AFEC_SEQ1R_USCH5(value)             (AFEC_SEQ1R_USCH5_Msk & ((value) << AFEC_SEQ1R_USCH5_Pos))
+#define AFEC_SEQ1R_USCH6_Pos                24                                             /**< (AFEC_SEQ1R) User Sequence Number 6 Position */
+#define AFEC_SEQ1R_USCH6_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH6_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 6 Mask */
+#define AFEC_SEQ1R_USCH6(value)             (AFEC_SEQ1R_USCH6_Msk & ((value) << AFEC_SEQ1R_USCH6_Pos))
+#define AFEC_SEQ1R_USCH7_Pos                28                                             /**< (AFEC_SEQ1R) User Sequence Number 7 Position */
+#define AFEC_SEQ1R_USCH7_Msk                (_U_(0xF) << AFEC_SEQ1R_USCH7_Pos)             /**< (AFEC_SEQ1R) User Sequence Number 7 Mask */
+#define AFEC_SEQ1R_USCH7(value)             (AFEC_SEQ1R_USCH7_Msk & ((value) << AFEC_SEQ1R_USCH7_Pos))
+#define AFEC_SEQ1R_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_SEQ1R) Register MASK  (Use AFEC_SEQ1R_Msk instead)  */
+#define AFEC_SEQ1R_Msk                      _U_(0xFFFFFFFF)                                /**< (AFEC_SEQ1R) Register Mask  */
+
+
+/* -------- AFEC_SEQ2R : (AFEC Offset: 0x10) (R/W 32) AFEC Channel Sequence 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USCH8:4;                   /**< bit:   0..3  User Sequence Number 8                   */
+    uint32_t USCH9:4;                   /**< bit:   4..7  User Sequence Number 9                   */
+    uint32_t USCH10:4;                  /**< bit:  8..11  User Sequence Number 10                  */
+    uint32_t USCH11:4;                  /**< bit: 12..15  User Sequence Number 11                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SEQ2R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SEQ2R_OFFSET                   (0x10)                                        /**<  (AFEC_SEQ2R) AFEC Channel Sequence 2 Register  Offset */
+
+#define AFEC_SEQ2R_USCH8_Pos                0                                              /**< (AFEC_SEQ2R) User Sequence Number 8 Position */
+#define AFEC_SEQ2R_USCH8_Msk                (_U_(0xF) << AFEC_SEQ2R_USCH8_Pos)             /**< (AFEC_SEQ2R) User Sequence Number 8 Mask */
+#define AFEC_SEQ2R_USCH8(value)             (AFEC_SEQ2R_USCH8_Msk & ((value) << AFEC_SEQ2R_USCH8_Pos))
+#define AFEC_SEQ2R_USCH9_Pos                4                                              /**< (AFEC_SEQ2R) User Sequence Number 9 Position */
+#define AFEC_SEQ2R_USCH9_Msk                (_U_(0xF) << AFEC_SEQ2R_USCH9_Pos)             /**< (AFEC_SEQ2R) User Sequence Number 9 Mask */
+#define AFEC_SEQ2R_USCH9(value)             (AFEC_SEQ2R_USCH9_Msk & ((value) << AFEC_SEQ2R_USCH9_Pos))
+#define AFEC_SEQ2R_USCH10_Pos               8                                              /**< (AFEC_SEQ2R) User Sequence Number 10 Position */
+#define AFEC_SEQ2R_USCH10_Msk               (_U_(0xF) << AFEC_SEQ2R_USCH10_Pos)            /**< (AFEC_SEQ2R) User Sequence Number 10 Mask */
+#define AFEC_SEQ2R_USCH10(value)            (AFEC_SEQ2R_USCH10_Msk & ((value) << AFEC_SEQ2R_USCH10_Pos))
+#define AFEC_SEQ2R_USCH11_Pos               12                                             /**< (AFEC_SEQ2R) User Sequence Number 11 Position */
+#define AFEC_SEQ2R_USCH11_Msk               (_U_(0xF) << AFEC_SEQ2R_USCH11_Pos)            /**< (AFEC_SEQ2R) User Sequence Number 11 Mask */
+#define AFEC_SEQ2R_USCH11(value)            (AFEC_SEQ2R_USCH11_Msk & ((value) << AFEC_SEQ2R_USCH11_Pos))
+#define AFEC_SEQ2R_MASK                     _U_(0xFFFF)                                    /**< \deprecated (AFEC_SEQ2R) Register MASK  (Use AFEC_SEQ2R_Msk instead)  */
+#define AFEC_SEQ2R_Msk                      _U_(0xFFFF)                                    /**< (AFEC_SEQ2R) Register Mask  */
+
+
+/* -------- AFEC_CHER : (AFEC Offset: 0x14) (/W 32) AFEC Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Enable                         */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Enable                         */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Enable                         */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Enable                         */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Enable                         */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Enable                         */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Enable                         */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Enable                         */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Enable                         */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Enable                        */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Enable                        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Enable                        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHER_OFFSET                    (0x14)                                        /**<  (AFEC_CHER) AFEC Channel Enable Register  Offset */
+
+#define AFEC_CHER_CH0_Pos                   0                                              /**< (AFEC_CHER) Channel 0 Enable Position */
+#define AFEC_CHER_CH0_Msk                   (_U_(0x1) << AFEC_CHER_CH0_Pos)                /**< (AFEC_CHER) Channel 0 Enable Mask */
+#define AFEC_CHER_CH0                       AFEC_CHER_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH0_Msk instead */
+#define AFEC_CHER_CH1_Pos                   1                                              /**< (AFEC_CHER) Channel 1 Enable Position */
+#define AFEC_CHER_CH1_Msk                   (_U_(0x1) << AFEC_CHER_CH1_Pos)                /**< (AFEC_CHER) Channel 1 Enable Mask */
+#define AFEC_CHER_CH1                       AFEC_CHER_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH1_Msk instead */
+#define AFEC_CHER_CH2_Pos                   2                                              /**< (AFEC_CHER) Channel 2 Enable Position */
+#define AFEC_CHER_CH2_Msk                   (_U_(0x1) << AFEC_CHER_CH2_Pos)                /**< (AFEC_CHER) Channel 2 Enable Mask */
+#define AFEC_CHER_CH2                       AFEC_CHER_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH2_Msk instead */
+#define AFEC_CHER_CH3_Pos                   3                                              /**< (AFEC_CHER) Channel 3 Enable Position */
+#define AFEC_CHER_CH3_Msk                   (_U_(0x1) << AFEC_CHER_CH3_Pos)                /**< (AFEC_CHER) Channel 3 Enable Mask */
+#define AFEC_CHER_CH3                       AFEC_CHER_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH3_Msk instead */
+#define AFEC_CHER_CH4_Pos                   4                                              /**< (AFEC_CHER) Channel 4 Enable Position */
+#define AFEC_CHER_CH4_Msk                   (_U_(0x1) << AFEC_CHER_CH4_Pos)                /**< (AFEC_CHER) Channel 4 Enable Mask */
+#define AFEC_CHER_CH4                       AFEC_CHER_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH4_Msk instead */
+#define AFEC_CHER_CH5_Pos                   5                                              /**< (AFEC_CHER) Channel 5 Enable Position */
+#define AFEC_CHER_CH5_Msk                   (_U_(0x1) << AFEC_CHER_CH5_Pos)                /**< (AFEC_CHER) Channel 5 Enable Mask */
+#define AFEC_CHER_CH5                       AFEC_CHER_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH5_Msk instead */
+#define AFEC_CHER_CH6_Pos                   6                                              /**< (AFEC_CHER) Channel 6 Enable Position */
+#define AFEC_CHER_CH6_Msk                   (_U_(0x1) << AFEC_CHER_CH6_Pos)                /**< (AFEC_CHER) Channel 6 Enable Mask */
+#define AFEC_CHER_CH6                       AFEC_CHER_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH6_Msk instead */
+#define AFEC_CHER_CH7_Pos                   7                                              /**< (AFEC_CHER) Channel 7 Enable Position */
+#define AFEC_CHER_CH7_Msk                   (_U_(0x1) << AFEC_CHER_CH7_Pos)                /**< (AFEC_CHER) Channel 7 Enable Mask */
+#define AFEC_CHER_CH7                       AFEC_CHER_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH7_Msk instead */
+#define AFEC_CHER_CH8_Pos                   8                                              /**< (AFEC_CHER) Channel 8 Enable Position */
+#define AFEC_CHER_CH8_Msk                   (_U_(0x1) << AFEC_CHER_CH8_Pos)                /**< (AFEC_CHER) Channel 8 Enable Mask */
+#define AFEC_CHER_CH8                       AFEC_CHER_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH8_Msk instead */
+#define AFEC_CHER_CH9_Pos                   9                                              /**< (AFEC_CHER) Channel 9 Enable Position */
+#define AFEC_CHER_CH9_Msk                   (_U_(0x1) << AFEC_CHER_CH9_Pos)                /**< (AFEC_CHER) Channel 9 Enable Mask */
+#define AFEC_CHER_CH9                       AFEC_CHER_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH9_Msk instead */
+#define AFEC_CHER_CH10_Pos                  10                                             /**< (AFEC_CHER) Channel 10 Enable Position */
+#define AFEC_CHER_CH10_Msk                  (_U_(0x1) << AFEC_CHER_CH10_Pos)               /**< (AFEC_CHER) Channel 10 Enable Mask */
+#define AFEC_CHER_CH10                      AFEC_CHER_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH10_Msk instead */
+#define AFEC_CHER_CH11_Pos                  11                                             /**< (AFEC_CHER) Channel 11 Enable Position */
+#define AFEC_CHER_CH11_Msk                  (_U_(0x1) << AFEC_CHER_CH11_Pos)               /**< (AFEC_CHER) Channel 11 Enable Mask */
+#define AFEC_CHER_CH11                      AFEC_CHER_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHER_CH11_Msk instead */
+#define AFEC_CHER_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHER) Register MASK  (Use AFEC_CHER_Msk instead)  */
+#define AFEC_CHER_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHER) Register Mask  */
+
+#define AFEC_CHER_CH_Pos                    0                                              /**< (AFEC_CHER Position) Channel xx Enable */
+#define AFEC_CHER_CH_Msk                    (_U_(0xFFF) << AFEC_CHER_CH_Pos)               /**< (AFEC_CHER Mask) CH */
+#define AFEC_CHER_CH(value)                 (AFEC_CHER_CH_Msk & ((value) << AFEC_CHER_CH_Pos))  
+
+/* -------- AFEC_CHDR : (AFEC Offset: 0x18) (/W 32) AFEC Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Disable                        */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Disable                        */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Disable                        */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Disable                        */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Disable                        */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Disable                        */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Disable                        */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Disable                        */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Disable                        */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Disable                       */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Disable                       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Disable                       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHDR_OFFSET                    (0x18)                                        /**<  (AFEC_CHDR) AFEC Channel Disable Register  Offset */
+
+#define AFEC_CHDR_CH0_Pos                   0                                              /**< (AFEC_CHDR) Channel 0 Disable Position */
+#define AFEC_CHDR_CH0_Msk                   (_U_(0x1) << AFEC_CHDR_CH0_Pos)                /**< (AFEC_CHDR) Channel 0 Disable Mask */
+#define AFEC_CHDR_CH0                       AFEC_CHDR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH0_Msk instead */
+#define AFEC_CHDR_CH1_Pos                   1                                              /**< (AFEC_CHDR) Channel 1 Disable Position */
+#define AFEC_CHDR_CH1_Msk                   (_U_(0x1) << AFEC_CHDR_CH1_Pos)                /**< (AFEC_CHDR) Channel 1 Disable Mask */
+#define AFEC_CHDR_CH1                       AFEC_CHDR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH1_Msk instead */
+#define AFEC_CHDR_CH2_Pos                   2                                              /**< (AFEC_CHDR) Channel 2 Disable Position */
+#define AFEC_CHDR_CH2_Msk                   (_U_(0x1) << AFEC_CHDR_CH2_Pos)                /**< (AFEC_CHDR) Channel 2 Disable Mask */
+#define AFEC_CHDR_CH2                       AFEC_CHDR_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH2_Msk instead */
+#define AFEC_CHDR_CH3_Pos                   3                                              /**< (AFEC_CHDR) Channel 3 Disable Position */
+#define AFEC_CHDR_CH3_Msk                   (_U_(0x1) << AFEC_CHDR_CH3_Pos)                /**< (AFEC_CHDR) Channel 3 Disable Mask */
+#define AFEC_CHDR_CH3                       AFEC_CHDR_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH3_Msk instead */
+#define AFEC_CHDR_CH4_Pos                   4                                              /**< (AFEC_CHDR) Channel 4 Disable Position */
+#define AFEC_CHDR_CH4_Msk                   (_U_(0x1) << AFEC_CHDR_CH4_Pos)                /**< (AFEC_CHDR) Channel 4 Disable Mask */
+#define AFEC_CHDR_CH4                       AFEC_CHDR_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH4_Msk instead */
+#define AFEC_CHDR_CH5_Pos                   5                                              /**< (AFEC_CHDR) Channel 5 Disable Position */
+#define AFEC_CHDR_CH5_Msk                   (_U_(0x1) << AFEC_CHDR_CH5_Pos)                /**< (AFEC_CHDR) Channel 5 Disable Mask */
+#define AFEC_CHDR_CH5                       AFEC_CHDR_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH5_Msk instead */
+#define AFEC_CHDR_CH6_Pos                   6                                              /**< (AFEC_CHDR) Channel 6 Disable Position */
+#define AFEC_CHDR_CH6_Msk                   (_U_(0x1) << AFEC_CHDR_CH6_Pos)                /**< (AFEC_CHDR) Channel 6 Disable Mask */
+#define AFEC_CHDR_CH6                       AFEC_CHDR_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH6_Msk instead */
+#define AFEC_CHDR_CH7_Pos                   7                                              /**< (AFEC_CHDR) Channel 7 Disable Position */
+#define AFEC_CHDR_CH7_Msk                   (_U_(0x1) << AFEC_CHDR_CH7_Pos)                /**< (AFEC_CHDR) Channel 7 Disable Mask */
+#define AFEC_CHDR_CH7                       AFEC_CHDR_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH7_Msk instead */
+#define AFEC_CHDR_CH8_Pos                   8                                              /**< (AFEC_CHDR) Channel 8 Disable Position */
+#define AFEC_CHDR_CH8_Msk                   (_U_(0x1) << AFEC_CHDR_CH8_Pos)                /**< (AFEC_CHDR) Channel 8 Disable Mask */
+#define AFEC_CHDR_CH8                       AFEC_CHDR_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH8_Msk instead */
+#define AFEC_CHDR_CH9_Pos                   9                                              /**< (AFEC_CHDR) Channel 9 Disable Position */
+#define AFEC_CHDR_CH9_Msk                   (_U_(0x1) << AFEC_CHDR_CH9_Pos)                /**< (AFEC_CHDR) Channel 9 Disable Mask */
+#define AFEC_CHDR_CH9                       AFEC_CHDR_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH9_Msk instead */
+#define AFEC_CHDR_CH10_Pos                  10                                             /**< (AFEC_CHDR) Channel 10 Disable Position */
+#define AFEC_CHDR_CH10_Msk                  (_U_(0x1) << AFEC_CHDR_CH10_Pos)               /**< (AFEC_CHDR) Channel 10 Disable Mask */
+#define AFEC_CHDR_CH10                      AFEC_CHDR_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH10_Msk instead */
+#define AFEC_CHDR_CH11_Pos                  11                                             /**< (AFEC_CHDR) Channel 11 Disable Position */
+#define AFEC_CHDR_CH11_Msk                  (_U_(0x1) << AFEC_CHDR_CH11_Pos)               /**< (AFEC_CHDR) Channel 11 Disable Mask */
+#define AFEC_CHDR_CH11                      AFEC_CHDR_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHDR_CH11_Msk instead */
+#define AFEC_CHDR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHDR) Register MASK  (Use AFEC_CHDR_Msk instead)  */
+#define AFEC_CHDR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHDR) Register Mask  */
+
+#define AFEC_CHDR_CH_Pos                    0                                              /**< (AFEC_CHDR Position) Channel xx Disable */
+#define AFEC_CHDR_CH_Msk                    (_U_(0xFFF) << AFEC_CHDR_CH_Pos)               /**< (AFEC_CHDR Mask) CH */
+#define AFEC_CHDR_CH(value)                 (AFEC_CHDR_CH_Msk & ((value) << AFEC_CHDR_CH_Pos))  
+
+/* -------- AFEC_CHSR : (AFEC Offset: 0x1c) (R/ 32) AFEC Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Status                         */
+    uint32_t CH2:1;                     /**< bit:      2  Channel 2 Status                         */
+    uint32_t CH3:1;                     /**< bit:      3  Channel 3 Status                         */
+    uint32_t CH4:1;                     /**< bit:      4  Channel 4 Status                         */
+    uint32_t CH5:1;                     /**< bit:      5  Channel 5 Status                         */
+    uint32_t CH6:1;                     /**< bit:      6  Channel 6 Status                         */
+    uint32_t CH7:1;                     /**< bit:      7  Channel 7 Status                         */
+    uint32_t CH8:1;                     /**< bit:      8  Channel 8 Status                         */
+    uint32_t CH9:1;                     /**< bit:      9  Channel 9 Status                         */
+    uint32_t CH10:1;                    /**< bit:     10  Channel 10 Status                        */
+    uint32_t CH11:1;                    /**< bit:     11  Channel 11 Status                        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:12;                     /**< bit:  0..11  Channel xx Status                        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CHSR_OFFSET                    (0x1C)                                        /**<  (AFEC_CHSR) AFEC Channel Status Register  Offset */
+
+#define AFEC_CHSR_CH0_Pos                   0                                              /**< (AFEC_CHSR) Channel 0 Status Position */
+#define AFEC_CHSR_CH0_Msk                   (_U_(0x1) << AFEC_CHSR_CH0_Pos)                /**< (AFEC_CHSR) Channel 0 Status Mask */
+#define AFEC_CHSR_CH0                       AFEC_CHSR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH0_Msk instead */
+#define AFEC_CHSR_CH1_Pos                   1                                              /**< (AFEC_CHSR) Channel 1 Status Position */
+#define AFEC_CHSR_CH1_Msk                   (_U_(0x1) << AFEC_CHSR_CH1_Pos)                /**< (AFEC_CHSR) Channel 1 Status Mask */
+#define AFEC_CHSR_CH1                       AFEC_CHSR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH1_Msk instead */
+#define AFEC_CHSR_CH2_Pos                   2                                              /**< (AFEC_CHSR) Channel 2 Status Position */
+#define AFEC_CHSR_CH2_Msk                   (_U_(0x1) << AFEC_CHSR_CH2_Pos)                /**< (AFEC_CHSR) Channel 2 Status Mask */
+#define AFEC_CHSR_CH2                       AFEC_CHSR_CH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH2_Msk instead */
+#define AFEC_CHSR_CH3_Pos                   3                                              /**< (AFEC_CHSR) Channel 3 Status Position */
+#define AFEC_CHSR_CH3_Msk                   (_U_(0x1) << AFEC_CHSR_CH3_Pos)                /**< (AFEC_CHSR) Channel 3 Status Mask */
+#define AFEC_CHSR_CH3                       AFEC_CHSR_CH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH3_Msk instead */
+#define AFEC_CHSR_CH4_Pos                   4                                              /**< (AFEC_CHSR) Channel 4 Status Position */
+#define AFEC_CHSR_CH4_Msk                   (_U_(0x1) << AFEC_CHSR_CH4_Pos)                /**< (AFEC_CHSR) Channel 4 Status Mask */
+#define AFEC_CHSR_CH4                       AFEC_CHSR_CH4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH4_Msk instead */
+#define AFEC_CHSR_CH5_Pos                   5                                              /**< (AFEC_CHSR) Channel 5 Status Position */
+#define AFEC_CHSR_CH5_Msk                   (_U_(0x1) << AFEC_CHSR_CH5_Pos)                /**< (AFEC_CHSR) Channel 5 Status Mask */
+#define AFEC_CHSR_CH5                       AFEC_CHSR_CH5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH5_Msk instead */
+#define AFEC_CHSR_CH6_Pos                   6                                              /**< (AFEC_CHSR) Channel 6 Status Position */
+#define AFEC_CHSR_CH6_Msk                   (_U_(0x1) << AFEC_CHSR_CH6_Pos)                /**< (AFEC_CHSR) Channel 6 Status Mask */
+#define AFEC_CHSR_CH6                       AFEC_CHSR_CH6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH6_Msk instead */
+#define AFEC_CHSR_CH7_Pos                   7                                              /**< (AFEC_CHSR) Channel 7 Status Position */
+#define AFEC_CHSR_CH7_Msk                   (_U_(0x1) << AFEC_CHSR_CH7_Pos)                /**< (AFEC_CHSR) Channel 7 Status Mask */
+#define AFEC_CHSR_CH7                       AFEC_CHSR_CH7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH7_Msk instead */
+#define AFEC_CHSR_CH8_Pos                   8                                              /**< (AFEC_CHSR) Channel 8 Status Position */
+#define AFEC_CHSR_CH8_Msk                   (_U_(0x1) << AFEC_CHSR_CH8_Pos)                /**< (AFEC_CHSR) Channel 8 Status Mask */
+#define AFEC_CHSR_CH8                       AFEC_CHSR_CH8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH8_Msk instead */
+#define AFEC_CHSR_CH9_Pos                   9                                              /**< (AFEC_CHSR) Channel 9 Status Position */
+#define AFEC_CHSR_CH9_Msk                   (_U_(0x1) << AFEC_CHSR_CH9_Pos)                /**< (AFEC_CHSR) Channel 9 Status Mask */
+#define AFEC_CHSR_CH9                       AFEC_CHSR_CH9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH9_Msk instead */
+#define AFEC_CHSR_CH10_Pos                  10                                             /**< (AFEC_CHSR) Channel 10 Status Position */
+#define AFEC_CHSR_CH10_Msk                  (_U_(0x1) << AFEC_CHSR_CH10_Pos)               /**< (AFEC_CHSR) Channel 10 Status Mask */
+#define AFEC_CHSR_CH10                      AFEC_CHSR_CH10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH10_Msk instead */
+#define AFEC_CHSR_CH11_Pos                  11                                             /**< (AFEC_CHSR) Channel 11 Status Position */
+#define AFEC_CHSR_CH11_Msk                  (_U_(0x1) << AFEC_CHSR_CH11_Pos)               /**< (AFEC_CHSR) Channel 11 Status Mask */
+#define AFEC_CHSR_CH11                      AFEC_CHSR_CH11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CHSR_CH11_Msk instead */
+#define AFEC_CHSR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CHSR) Register MASK  (Use AFEC_CHSR_Msk instead)  */
+#define AFEC_CHSR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CHSR) Register Mask  */
+
+#define AFEC_CHSR_CH_Pos                    0                                              /**< (AFEC_CHSR Position) Channel xx Status */
+#define AFEC_CHSR_CH_Msk                    (_U_(0xFFF) << AFEC_CHSR_CH_Pos)               /**< (AFEC_CHSR Mask) CH */
+#define AFEC_CHSR_CH(value)                 (AFEC_CHSR_CH_Msk & ((value) << AFEC_CHSR_CH_Pos))  
+
+/* -------- AFEC_LCDR : (AFEC Offset: 0x20) (R/ 32) AFEC Last Converted Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LDATA:16;                  /**< bit:  0..15  Last Data Converted                      */
+    uint32_t :8;                        /**< bit: 16..23  Reserved */
+    uint32_t CHNB:4;                    /**< bit: 24..27  Channel Number                           */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_LCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_LCDR_OFFSET                    (0x20)                                        /**<  (AFEC_LCDR) AFEC Last Converted Data Register  Offset */
+
+#define AFEC_LCDR_LDATA_Pos                 0                                              /**< (AFEC_LCDR) Last Data Converted Position */
+#define AFEC_LCDR_LDATA_Msk                 (_U_(0xFFFF) << AFEC_LCDR_LDATA_Pos)           /**< (AFEC_LCDR) Last Data Converted Mask */
+#define AFEC_LCDR_LDATA(value)              (AFEC_LCDR_LDATA_Msk & ((value) << AFEC_LCDR_LDATA_Pos))
+#define AFEC_LCDR_CHNB_Pos                  24                                             /**< (AFEC_LCDR) Channel Number Position */
+#define AFEC_LCDR_CHNB_Msk                  (_U_(0xF) << AFEC_LCDR_CHNB_Pos)               /**< (AFEC_LCDR) Channel Number Mask */
+#define AFEC_LCDR_CHNB(value)               (AFEC_LCDR_CHNB_Msk & ((value) << AFEC_LCDR_CHNB_Pos))
+#define AFEC_LCDR_MASK                      _U_(0xF00FFFF)                                 /**< \deprecated (AFEC_LCDR) Register MASK  (Use AFEC_LCDR_Msk instead)  */
+#define AFEC_LCDR_Msk                       _U_(0xF00FFFF)                                 /**< (AFEC_LCDR) Register Mask  */
+
+
+/* -------- AFEC_IER : (AFEC Offset: 0x24) (/W 32) AFEC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Enable 0     */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Enable 1     */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Enable 2     */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Enable 3     */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Enable 4     */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Enable 5     */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Enable 6     */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Enable 7     */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Enable 8     */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Enable 9     */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Enable 10    */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Enable 11    */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Enable              */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Enable   */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Enable        */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Enable      */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Enable x     */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IER_OFFSET                     (0x24)                                        /**<  (AFEC_IER) AFEC Interrupt Enable Register  Offset */
+
+#define AFEC_IER_EOC0_Pos                   0                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 0 Position */
+#define AFEC_IER_EOC0_Msk                   (_U_(0x1) << AFEC_IER_EOC0_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 0 Mask */
+#define AFEC_IER_EOC0                       AFEC_IER_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC0_Msk instead */
+#define AFEC_IER_EOC1_Pos                   1                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 1 Position */
+#define AFEC_IER_EOC1_Msk                   (_U_(0x1) << AFEC_IER_EOC1_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 1 Mask */
+#define AFEC_IER_EOC1                       AFEC_IER_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC1_Msk instead */
+#define AFEC_IER_EOC2_Pos                   2                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 2 Position */
+#define AFEC_IER_EOC2_Msk                   (_U_(0x1) << AFEC_IER_EOC2_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 2 Mask */
+#define AFEC_IER_EOC2                       AFEC_IER_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC2_Msk instead */
+#define AFEC_IER_EOC3_Pos                   3                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 3 Position */
+#define AFEC_IER_EOC3_Msk                   (_U_(0x1) << AFEC_IER_EOC3_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 3 Mask */
+#define AFEC_IER_EOC3                       AFEC_IER_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC3_Msk instead */
+#define AFEC_IER_EOC4_Pos                   4                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 4 Position */
+#define AFEC_IER_EOC4_Msk                   (_U_(0x1) << AFEC_IER_EOC4_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 4 Mask */
+#define AFEC_IER_EOC4                       AFEC_IER_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC4_Msk instead */
+#define AFEC_IER_EOC5_Pos                   5                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 5 Position */
+#define AFEC_IER_EOC5_Msk                   (_U_(0x1) << AFEC_IER_EOC5_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 5 Mask */
+#define AFEC_IER_EOC5                       AFEC_IER_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC5_Msk instead */
+#define AFEC_IER_EOC6_Pos                   6                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 6 Position */
+#define AFEC_IER_EOC6_Msk                   (_U_(0x1) << AFEC_IER_EOC6_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 6 Mask */
+#define AFEC_IER_EOC6                       AFEC_IER_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC6_Msk instead */
+#define AFEC_IER_EOC7_Pos                   7                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 7 Position */
+#define AFEC_IER_EOC7_Msk                   (_U_(0x1) << AFEC_IER_EOC7_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 7 Mask */
+#define AFEC_IER_EOC7                       AFEC_IER_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC7_Msk instead */
+#define AFEC_IER_EOC8_Pos                   8                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 8 Position */
+#define AFEC_IER_EOC8_Msk                   (_U_(0x1) << AFEC_IER_EOC8_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 8 Mask */
+#define AFEC_IER_EOC8                       AFEC_IER_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC8_Msk instead */
+#define AFEC_IER_EOC9_Pos                   9                                              /**< (AFEC_IER) End of Conversion Interrupt Enable 9 Position */
+#define AFEC_IER_EOC9_Msk                   (_U_(0x1) << AFEC_IER_EOC9_Pos)                /**< (AFEC_IER) End of Conversion Interrupt Enable 9 Mask */
+#define AFEC_IER_EOC9                       AFEC_IER_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC9_Msk instead */
+#define AFEC_IER_EOC10_Pos                  10                                             /**< (AFEC_IER) End of Conversion Interrupt Enable 10 Position */
+#define AFEC_IER_EOC10_Msk                  (_U_(0x1) << AFEC_IER_EOC10_Pos)               /**< (AFEC_IER) End of Conversion Interrupt Enable 10 Mask */
+#define AFEC_IER_EOC10                      AFEC_IER_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC10_Msk instead */
+#define AFEC_IER_EOC11_Pos                  11                                             /**< (AFEC_IER) End of Conversion Interrupt Enable 11 Position */
+#define AFEC_IER_EOC11_Msk                  (_U_(0x1) << AFEC_IER_EOC11_Pos)               /**< (AFEC_IER) End of Conversion Interrupt Enable 11 Mask */
+#define AFEC_IER_EOC11                      AFEC_IER_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_EOC11_Msk instead */
+#define AFEC_IER_DRDY_Pos                   24                                             /**< (AFEC_IER) Data Ready Interrupt Enable Position */
+#define AFEC_IER_DRDY_Msk                   (_U_(0x1) << AFEC_IER_DRDY_Pos)                /**< (AFEC_IER) Data Ready Interrupt Enable Mask */
+#define AFEC_IER_DRDY                       AFEC_IER_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_DRDY_Msk instead */
+#define AFEC_IER_GOVRE_Pos                  25                                             /**< (AFEC_IER) General Overrun Error Interrupt Enable Position */
+#define AFEC_IER_GOVRE_Msk                  (_U_(0x1) << AFEC_IER_GOVRE_Pos)               /**< (AFEC_IER) General Overrun Error Interrupt Enable Mask */
+#define AFEC_IER_GOVRE                      AFEC_IER_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_GOVRE_Msk instead */
+#define AFEC_IER_COMPE_Pos                  26                                             /**< (AFEC_IER) Comparison Event Interrupt Enable Position */
+#define AFEC_IER_COMPE_Msk                  (_U_(0x1) << AFEC_IER_COMPE_Pos)               /**< (AFEC_IER) Comparison Event Interrupt Enable Mask */
+#define AFEC_IER_COMPE                      AFEC_IER_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_COMPE_Msk instead */
+#define AFEC_IER_TEMPCHG_Pos                30                                             /**< (AFEC_IER) Temperature Change Interrupt Enable Position */
+#define AFEC_IER_TEMPCHG_Msk                (_U_(0x1) << AFEC_IER_TEMPCHG_Pos)             /**< (AFEC_IER) Temperature Change Interrupt Enable Mask */
+#define AFEC_IER_TEMPCHG                    AFEC_IER_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IER_TEMPCHG_Msk instead */
+#define AFEC_IER_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IER) Register MASK  (Use AFEC_IER_Msk instead)  */
+#define AFEC_IER_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IER) Register Mask  */
+
+#define AFEC_IER_EOC_Pos                    0                                              /**< (AFEC_IER Position) End of Conversion Interrupt Enable x */
+#define AFEC_IER_EOC_Msk                    (_U_(0xFFF) << AFEC_IER_EOC_Pos)               /**< (AFEC_IER Mask) EOC */
+#define AFEC_IER_EOC(value)                 (AFEC_IER_EOC_Msk & ((value) << AFEC_IER_EOC_Pos))  
+
+/* -------- AFEC_IDR : (AFEC Offset: 0x28) (/W 32) AFEC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Disable 0    */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Disable 1    */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Disable 2    */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Disable 3    */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Disable 4    */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Disable 5    */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Disable 6    */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Disable 7    */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Disable 8    */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Disable 9    */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Disable 10   */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Disable 11   */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Disable             */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Disable  */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Disable       */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Disable     */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Disable x    */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IDR_OFFSET                     (0x28)                                        /**<  (AFEC_IDR) AFEC Interrupt Disable Register  Offset */
+
+#define AFEC_IDR_EOC0_Pos                   0                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 0 Position */
+#define AFEC_IDR_EOC0_Msk                   (_U_(0x1) << AFEC_IDR_EOC0_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 0 Mask */
+#define AFEC_IDR_EOC0                       AFEC_IDR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC0_Msk instead */
+#define AFEC_IDR_EOC1_Pos                   1                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 1 Position */
+#define AFEC_IDR_EOC1_Msk                   (_U_(0x1) << AFEC_IDR_EOC1_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 1 Mask */
+#define AFEC_IDR_EOC1                       AFEC_IDR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC1_Msk instead */
+#define AFEC_IDR_EOC2_Pos                   2                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 2 Position */
+#define AFEC_IDR_EOC2_Msk                   (_U_(0x1) << AFEC_IDR_EOC2_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 2 Mask */
+#define AFEC_IDR_EOC2                       AFEC_IDR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC2_Msk instead */
+#define AFEC_IDR_EOC3_Pos                   3                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 3 Position */
+#define AFEC_IDR_EOC3_Msk                   (_U_(0x1) << AFEC_IDR_EOC3_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 3 Mask */
+#define AFEC_IDR_EOC3                       AFEC_IDR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC3_Msk instead */
+#define AFEC_IDR_EOC4_Pos                   4                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 4 Position */
+#define AFEC_IDR_EOC4_Msk                   (_U_(0x1) << AFEC_IDR_EOC4_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 4 Mask */
+#define AFEC_IDR_EOC4                       AFEC_IDR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC4_Msk instead */
+#define AFEC_IDR_EOC5_Pos                   5                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 5 Position */
+#define AFEC_IDR_EOC5_Msk                   (_U_(0x1) << AFEC_IDR_EOC5_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 5 Mask */
+#define AFEC_IDR_EOC5                       AFEC_IDR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC5_Msk instead */
+#define AFEC_IDR_EOC6_Pos                   6                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 6 Position */
+#define AFEC_IDR_EOC6_Msk                   (_U_(0x1) << AFEC_IDR_EOC6_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 6 Mask */
+#define AFEC_IDR_EOC6                       AFEC_IDR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC6_Msk instead */
+#define AFEC_IDR_EOC7_Pos                   7                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 7 Position */
+#define AFEC_IDR_EOC7_Msk                   (_U_(0x1) << AFEC_IDR_EOC7_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 7 Mask */
+#define AFEC_IDR_EOC7                       AFEC_IDR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC7_Msk instead */
+#define AFEC_IDR_EOC8_Pos                   8                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 8 Position */
+#define AFEC_IDR_EOC8_Msk                   (_U_(0x1) << AFEC_IDR_EOC8_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 8 Mask */
+#define AFEC_IDR_EOC8                       AFEC_IDR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC8_Msk instead */
+#define AFEC_IDR_EOC9_Pos                   9                                              /**< (AFEC_IDR) End of Conversion Interrupt Disable 9 Position */
+#define AFEC_IDR_EOC9_Msk                   (_U_(0x1) << AFEC_IDR_EOC9_Pos)                /**< (AFEC_IDR) End of Conversion Interrupt Disable 9 Mask */
+#define AFEC_IDR_EOC9                       AFEC_IDR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC9_Msk instead */
+#define AFEC_IDR_EOC10_Pos                  10                                             /**< (AFEC_IDR) End of Conversion Interrupt Disable 10 Position */
+#define AFEC_IDR_EOC10_Msk                  (_U_(0x1) << AFEC_IDR_EOC10_Pos)               /**< (AFEC_IDR) End of Conversion Interrupt Disable 10 Mask */
+#define AFEC_IDR_EOC10                      AFEC_IDR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC10_Msk instead */
+#define AFEC_IDR_EOC11_Pos                  11                                             /**< (AFEC_IDR) End of Conversion Interrupt Disable 11 Position */
+#define AFEC_IDR_EOC11_Msk                  (_U_(0x1) << AFEC_IDR_EOC11_Pos)               /**< (AFEC_IDR) End of Conversion Interrupt Disable 11 Mask */
+#define AFEC_IDR_EOC11                      AFEC_IDR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_EOC11_Msk instead */
+#define AFEC_IDR_DRDY_Pos                   24                                             /**< (AFEC_IDR) Data Ready Interrupt Disable Position */
+#define AFEC_IDR_DRDY_Msk                   (_U_(0x1) << AFEC_IDR_DRDY_Pos)                /**< (AFEC_IDR) Data Ready Interrupt Disable Mask */
+#define AFEC_IDR_DRDY                       AFEC_IDR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_DRDY_Msk instead */
+#define AFEC_IDR_GOVRE_Pos                  25                                             /**< (AFEC_IDR) General Overrun Error Interrupt Disable Position */
+#define AFEC_IDR_GOVRE_Msk                  (_U_(0x1) << AFEC_IDR_GOVRE_Pos)               /**< (AFEC_IDR) General Overrun Error Interrupt Disable Mask */
+#define AFEC_IDR_GOVRE                      AFEC_IDR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_GOVRE_Msk instead */
+#define AFEC_IDR_COMPE_Pos                  26                                             /**< (AFEC_IDR) Comparison Event Interrupt Disable Position */
+#define AFEC_IDR_COMPE_Msk                  (_U_(0x1) << AFEC_IDR_COMPE_Pos)               /**< (AFEC_IDR) Comparison Event Interrupt Disable Mask */
+#define AFEC_IDR_COMPE                      AFEC_IDR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_COMPE_Msk instead */
+#define AFEC_IDR_TEMPCHG_Pos                30                                             /**< (AFEC_IDR) Temperature Change Interrupt Disable Position */
+#define AFEC_IDR_TEMPCHG_Msk                (_U_(0x1) << AFEC_IDR_TEMPCHG_Pos)             /**< (AFEC_IDR) Temperature Change Interrupt Disable Mask */
+#define AFEC_IDR_TEMPCHG                    AFEC_IDR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IDR_TEMPCHG_Msk instead */
+#define AFEC_IDR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IDR) Register MASK  (Use AFEC_IDR_Msk instead)  */
+#define AFEC_IDR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IDR) Register Mask  */
+
+#define AFEC_IDR_EOC_Pos                    0                                              /**< (AFEC_IDR Position) End of Conversion Interrupt Disable x */
+#define AFEC_IDR_EOC_Msk                    (_U_(0xFFF) << AFEC_IDR_EOC_Pos)               /**< (AFEC_IDR Mask) EOC */
+#define AFEC_IDR_EOC(value)                 (AFEC_IDR_EOC_Msk & ((value) << AFEC_IDR_EOC_Pos))  
+
+/* -------- AFEC_IMR : (AFEC Offset: 0x2c) (R/ 32) AFEC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Mask 0       */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion Interrupt Mask 1       */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion Interrupt Mask 2       */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion Interrupt Mask 3       */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion Interrupt Mask 4       */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion Interrupt Mask 5       */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion Interrupt Mask 6       */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion Interrupt Mask 7       */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion Interrupt Mask 8       */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion Interrupt Mask 9       */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion Interrupt Mask 10      */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion Interrupt Mask 11      */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready Interrupt Mask                */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error Interrupt Mask     */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Event Interrupt Mask          */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change Interrupt Mask        */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion Interrupt Mask x       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_IMR_OFFSET                     (0x2C)                                        /**<  (AFEC_IMR) AFEC Interrupt Mask Register  Offset */
+
+#define AFEC_IMR_EOC0_Pos                   0                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 0 Position */
+#define AFEC_IMR_EOC0_Msk                   (_U_(0x1) << AFEC_IMR_EOC0_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 0 Mask */
+#define AFEC_IMR_EOC0                       AFEC_IMR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC0_Msk instead */
+#define AFEC_IMR_EOC1_Pos                   1                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 1 Position */
+#define AFEC_IMR_EOC1_Msk                   (_U_(0x1) << AFEC_IMR_EOC1_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 1 Mask */
+#define AFEC_IMR_EOC1                       AFEC_IMR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC1_Msk instead */
+#define AFEC_IMR_EOC2_Pos                   2                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 2 Position */
+#define AFEC_IMR_EOC2_Msk                   (_U_(0x1) << AFEC_IMR_EOC2_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 2 Mask */
+#define AFEC_IMR_EOC2                       AFEC_IMR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC2_Msk instead */
+#define AFEC_IMR_EOC3_Pos                   3                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 3 Position */
+#define AFEC_IMR_EOC3_Msk                   (_U_(0x1) << AFEC_IMR_EOC3_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 3 Mask */
+#define AFEC_IMR_EOC3                       AFEC_IMR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC3_Msk instead */
+#define AFEC_IMR_EOC4_Pos                   4                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 4 Position */
+#define AFEC_IMR_EOC4_Msk                   (_U_(0x1) << AFEC_IMR_EOC4_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 4 Mask */
+#define AFEC_IMR_EOC4                       AFEC_IMR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC4_Msk instead */
+#define AFEC_IMR_EOC5_Pos                   5                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 5 Position */
+#define AFEC_IMR_EOC5_Msk                   (_U_(0x1) << AFEC_IMR_EOC5_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 5 Mask */
+#define AFEC_IMR_EOC5                       AFEC_IMR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC5_Msk instead */
+#define AFEC_IMR_EOC6_Pos                   6                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 6 Position */
+#define AFEC_IMR_EOC6_Msk                   (_U_(0x1) << AFEC_IMR_EOC6_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 6 Mask */
+#define AFEC_IMR_EOC6                       AFEC_IMR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC6_Msk instead */
+#define AFEC_IMR_EOC7_Pos                   7                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 7 Position */
+#define AFEC_IMR_EOC7_Msk                   (_U_(0x1) << AFEC_IMR_EOC7_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 7 Mask */
+#define AFEC_IMR_EOC7                       AFEC_IMR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC7_Msk instead */
+#define AFEC_IMR_EOC8_Pos                   8                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 8 Position */
+#define AFEC_IMR_EOC8_Msk                   (_U_(0x1) << AFEC_IMR_EOC8_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 8 Mask */
+#define AFEC_IMR_EOC8                       AFEC_IMR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC8_Msk instead */
+#define AFEC_IMR_EOC9_Pos                   9                                              /**< (AFEC_IMR) End of Conversion Interrupt Mask 9 Position */
+#define AFEC_IMR_EOC9_Msk                   (_U_(0x1) << AFEC_IMR_EOC9_Pos)                /**< (AFEC_IMR) End of Conversion Interrupt Mask 9 Mask */
+#define AFEC_IMR_EOC9                       AFEC_IMR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC9_Msk instead */
+#define AFEC_IMR_EOC10_Pos                  10                                             /**< (AFEC_IMR) End of Conversion Interrupt Mask 10 Position */
+#define AFEC_IMR_EOC10_Msk                  (_U_(0x1) << AFEC_IMR_EOC10_Pos)               /**< (AFEC_IMR) End of Conversion Interrupt Mask 10 Mask */
+#define AFEC_IMR_EOC10                      AFEC_IMR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC10_Msk instead */
+#define AFEC_IMR_EOC11_Pos                  11                                             /**< (AFEC_IMR) End of Conversion Interrupt Mask 11 Position */
+#define AFEC_IMR_EOC11_Msk                  (_U_(0x1) << AFEC_IMR_EOC11_Pos)               /**< (AFEC_IMR) End of Conversion Interrupt Mask 11 Mask */
+#define AFEC_IMR_EOC11                      AFEC_IMR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_EOC11_Msk instead */
+#define AFEC_IMR_DRDY_Pos                   24                                             /**< (AFEC_IMR) Data Ready Interrupt Mask Position */
+#define AFEC_IMR_DRDY_Msk                   (_U_(0x1) << AFEC_IMR_DRDY_Pos)                /**< (AFEC_IMR) Data Ready Interrupt Mask Mask */
+#define AFEC_IMR_DRDY                       AFEC_IMR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_DRDY_Msk instead */
+#define AFEC_IMR_GOVRE_Pos                  25                                             /**< (AFEC_IMR) General Overrun Error Interrupt Mask Position */
+#define AFEC_IMR_GOVRE_Msk                  (_U_(0x1) << AFEC_IMR_GOVRE_Pos)               /**< (AFEC_IMR) General Overrun Error Interrupt Mask Mask */
+#define AFEC_IMR_GOVRE                      AFEC_IMR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_GOVRE_Msk instead */
+#define AFEC_IMR_COMPE_Pos                  26                                             /**< (AFEC_IMR) Comparison Event Interrupt Mask Position */
+#define AFEC_IMR_COMPE_Msk                  (_U_(0x1) << AFEC_IMR_COMPE_Pos)               /**< (AFEC_IMR) Comparison Event Interrupt Mask Mask */
+#define AFEC_IMR_COMPE                      AFEC_IMR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_COMPE_Msk instead */
+#define AFEC_IMR_TEMPCHG_Pos                30                                             /**< (AFEC_IMR) Temperature Change Interrupt Mask Position */
+#define AFEC_IMR_TEMPCHG_Msk                (_U_(0x1) << AFEC_IMR_TEMPCHG_Pos)             /**< (AFEC_IMR) Temperature Change Interrupt Mask Mask */
+#define AFEC_IMR_TEMPCHG                    AFEC_IMR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_IMR_TEMPCHG_Msk instead */
+#define AFEC_IMR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_IMR) Register MASK  (Use AFEC_IMR_Msk instead)  */
+#define AFEC_IMR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_IMR) Register Mask  */
+
+#define AFEC_IMR_EOC_Pos                    0                                              /**< (AFEC_IMR Position) End of Conversion Interrupt Mask x */
+#define AFEC_IMR_EOC_Msk                    (_U_(0xFFF) << AFEC_IMR_EOC_Pos)               /**< (AFEC_IMR Mask) EOC */
+#define AFEC_IMR_EOC(value)                 (AFEC_IMR_EOC_Msk & ((value) << AFEC_IMR_EOC_Pos))  
+
+/* -------- AFEC_ISR : (AFEC Offset: 0x30) (R/ 32) AFEC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EOC0:1;                    /**< bit:      0  End of Conversion 0 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC1:1;                    /**< bit:      1  End of Conversion 1 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC2:1;                    /**< bit:      2  End of Conversion 2 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC3:1;                    /**< bit:      3  End of Conversion 3 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC4:1;                    /**< bit:      4  End of Conversion 4 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC5:1;                    /**< bit:      5  End of Conversion 5 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC6:1;                    /**< bit:      6  End of Conversion 6 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC7:1;                    /**< bit:      7  End of Conversion 7 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC8:1;                    /**< bit:      8  End of Conversion 8 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC9:1;                    /**< bit:      9  End of Conversion 9 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC10:1;                   /**< bit:     10  End of Conversion 10 (cleared by reading AFEC_CDRx) */
+    uint32_t EOC11:1;                   /**< bit:     11  End of Conversion 11 (cleared by reading AFEC_CDRx) */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t DRDY:1;                    /**< bit:     24  Data Ready (cleared by reading AFEC_LCDR) */
+    uint32_t GOVRE:1;                   /**< bit:     25  General Overrun Error (cleared by reading AFEC_ISR) */
+    uint32_t COMPE:1;                   /**< bit:     26  Comparison Error (cleared by reading AFEC_ISR) */
+    uint32_t :3;                        /**< bit: 27..29  Reserved */
+    uint32_t TEMPCHG:1;                 /**< bit:     30  Temperature Change (cleared on read)     */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EOC:12;                    /**< bit:  0..11  End of Conversion x (cleared by reading AFEC_CDRx) */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_ISR_OFFSET                     (0x30)                                        /**<  (AFEC_ISR) AFEC Interrupt Status Register  Offset */
+
+#define AFEC_ISR_EOC0_Pos                   0                                              /**< (AFEC_ISR) End of Conversion 0 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC0_Msk                   (_U_(0x1) << AFEC_ISR_EOC0_Pos)                /**< (AFEC_ISR) End of Conversion 0 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC0                       AFEC_ISR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC0_Msk instead */
+#define AFEC_ISR_EOC1_Pos                   1                                              /**< (AFEC_ISR) End of Conversion 1 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC1_Msk                   (_U_(0x1) << AFEC_ISR_EOC1_Pos)                /**< (AFEC_ISR) End of Conversion 1 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC1                       AFEC_ISR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC1_Msk instead */
+#define AFEC_ISR_EOC2_Pos                   2                                              /**< (AFEC_ISR) End of Conversion 2 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC2_Msk                   (_U_(0x1) << AFEC_ISR_EOC2_Pos)                /**< (AFEC_ISR) End of Conversion 2 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC2                       AFEC_ISR_EOC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC2_Msk instead */
+#define AFEC_ISR_EOC3_Pos                   3                                              /**< (AFEC_ISR) End of Conversion 3 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC3_Msk                   (_U_(0x1) << AFEC_ISR_EOC3_Pos)                /**< (AFEC_ISR) End of Conversion 3 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC3                       AFEC_ISR_EOC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC3_Msk instead */
+#define AFEC_ISR_EOC4_Pos                   4                                              /**< (AFEC_ISR) End of Conversion 4 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC4_Msk                   (_U_(0x1) << AFEC_ISR_EOC4_Pos)                /**< (AFEC_ISR) End of Conversion 4 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC4                       AFEC_ISR_EOC4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC4_Msk instead */
+#define AFEC_ISR_EOC5_Pos                   5                                              /**< (AFEC_ISR) End of Conversion 5 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC5_Msk                   (_U_(0x1) << AFEC_ISR_EOC5_Pos)                /**< (AFEC_ISR) End of Conversion 5 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC5                       AFEC_ISR_EOC5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC5_Msk instead */
+#define AFEC_ISR_EOC6_Pos                   6                                              /**< (AFEC_ISR) End of Conversion 6 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC6_Msk                   (_U_(0x1) << AFEC_ISR_EOC6_Pos)                /**< (AFEC_ISR) End of Conversion 6 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC6                       AFEC_ISR_EOC6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC6_Msk instead */
+#define AFEC_ISR_EOC7_Pos                   7                                              /**< (AFEC_ISR) End of Conversion 7 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC7_Msk                   (_U_(0x1) << AFEC_ISR_EOC7_Pos)                /**< (AFEC_ISR) End of Conversion 7 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC7                       AFEC_ISR_EOC7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC7_Msk instead */
+#define AFEC_ISR_EOC8_Pos                   8                                              /**< (AFEC_ISR) End of Conversion 8 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC8_Msk                   (_U_(0x1) << AFEC_ISR_EOC8_Pos)                /**< (AFEC_ISR) End of Conversion 8 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC8                       AFEC_ISR_EOC8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC8_Msk instead */
+#define AFEC_ISR_EOC9_Pos                   9                                              /**< (AFEC_ISR) End of Conversion 9 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC9_Msk                   (_U_(0x1) << AFEC_ISR_EOC9_Pos)                /**< (AFEC_ISR) End of Conversion 9 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC9                       AFEC_ISR_EOC9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC9_Msk instead */
+#define AFEC_ISR_EOC10_Pos                  10                                             /**< (AFEC_ISR) End of Conversion 10 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC10_Msk                  (_U_(0x1) << AFEC_ISR_EOC10_Pos)               /**< (AFEC_ISR) End of Conversion 10 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC10                      AFEC_ISR_EOC10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC10_Msk instead */
+#define AFEC_ISR_EOC11_Pos                  11                                             /**< (AFEC_ISR) End of Conversion 11 (cleared by reading AFEC_CDRx) Position */
+#define AFEC_ISR_EOC11_Msk                  (_U_(0x1) << AFEC_ISR_EOC11_Pos)               /**< (AFEC_ISR) End of Conversion 11 (cleared by reading AFEC_CDRx) Mask */
+#define AFEC_ISR_EOC11                      AFEC_ISR_EOC11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_EOC11_Msk instead */
+#define AFEC_ISR_DRDY_Pos                   24                                             /**< (AFEC_ISR) Data Ready (cleared by reading AFEC_LCDR) Position */
+#define AFEC_ISR_DRDY_Msk                   (_U_(0x1) << AFEC_ISR_DRDY_Pos)                /**< (AFEC_ISR) Data Ready (cleared by reading AFEC_LCDR) Mask */
+#define AFEC_ISR_DRDY                       AFEC_ISR_DRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_DRDY_Msk instead */
+#define AFEC_ISR_GOVRE_Pos                  25                                             /**< (AFEC_ISR) General Overrun Error (cleared by reading AFEC_ISR) Position */
+#define AFEC_ISR_GOVRE_Msk                  (_U_(0x1) << AFEC_ISR_GOVRE_Pos)               /**< (AFEC_ISR) General Overrun Error (cleared by reading AFEC_ISR) Mask */
+#define AFEC_ISR_GOVRE                      AFEC_ISR_GOVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_GOVRE_Msk instead */
+#define AFEC_ISR_COMPE_Pos                  26                                             /**< (AFEC_ISR) Comparison Error (cleared by reading AFEC_ISR) Position */
+#define AFEC_ISR_COMPE_Msk                  (_U_(0x1) << AFEC_ISR_COMPE_Pos)               /**< (AFEC_ISR) Comparison Error (cleared by reading AFEC_ISR) Mask */
+#define AFEC_ISR_COMPE                      AFEC_ISR_COMPE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_COMPE_Msk instead */
+#define AFEC_ISR_TEMPCHG_Pos                30                                             /**< (AFEC_ISR) Temperature Change (cleared on read) Position */
+#define AFEC_ISR_TEMPCHG_Msk                (_U_(0x1) << AFEC_ISR_TEMPCHG_Pos)             /**< (AFEC_ISR) Temperature Change (cleared on read) Mask */
+#define AFEC_ISR_TEMPCHG                    AFEC_ISR_TEMPCHG_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ISR_TEMPCHG_Msk instead */
+#define AFEC_ISR_MASK                       _U_(0x47000FFF)                                /**< \deprecated (AFEC_ISR) Register MASK  (Use AFEC_ISR_Msk instead)  */
+#define AFEC_ISR_Msk                        _U_(0x47000FFF)                                /**< (AFEC_ISR) Register Mask  */
+
+#define AFEC_ISR_EOC_Pos                    0                                              /**< (AFEC_ISR Position) End of Conversion x (cleared by reading AFEC_CDRx) */
+#define AFEC_ISR_EOC_Msk                    (_U_(0xFFF) << AFEC_ISR_EOC_Pos)               /**< (AFEC_ISR Mask) EOC */
+#define AFEC_ISR_EOC(value)                 (AFEC_ISR_EOC_Msk & ((value) << AFEC_ISR_EOC_Pos))  
+
+/* -------- AFEC_OVER : (AFEC Offset: 0x4c) (R/ 32) AFEC Overrun Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OVRE0:1;                   /**< bit:      0  Overrun Error 0                          */
+    uint32_t OVRE1:1;                   /**< bit:      1  Overrun Error 1                          */
+    uint32_t OVRE2:1;                   /**< bit:      2  Overrun Error 2                          */
+    uint32_t OVRE3:1;                   /**< bit:      3  Overrun Error 3                          */
+    uint32_t OVRE4:1;                   /**< bit:      4  Overrun Error 4                          */
+    uint32_t OVRE5:1;                   /**< bit:      5  Overrun Error 5                          */
+    uint32_t OVRE6:1;                   /**< bit:      6  Overrun Error 6                          */
+    uint32_t OVRE7:1;                   /**< bit:      7  Overrun Error 7                          */
+    uint32_t OVRE8:1;                   /**< bit:      8  Overrun Error 8                          */
+    uint32_t OVRE9:1;                   /**< bit:      9  Overrun Error 9                          */
+    uint32_t OVRE10:1;                  /**< bit:     10  Overrun Error 10                         */
+    uint32_t OVRE11:1;                  /**< bit:     11  Overrun Error 11                         */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OVRE:12;                   /**< bit:  0..11  Overrun Error xx                         */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_OVER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_OVER_OFFSET                    (0x4C)                                        /**<  (AFEC_OVER) AFEC Overrun Status Register  Offset */
+
+#define AFEC_OVER_OVRE0_Pos                 0                                              /**< (AFEC_OVER) Overrun Error 0 Position */
+#define AFEC_OVER_OVRE0_Msk                 (_U_(0x1) << AFEC_OVER_OVRE0_Pos)              /**< (AFEC_OVER) Overrun Error 0 Mask */
+#define AFEC_OVER_OVRE0                     AFEC_OVER_OVRE0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE0_Msk instead */
+#define AFEC_OVER_OVRE1_Pos                 1                                              /**< (AFEC_OVER) Overrun Error 1 Position */
+#define AFEC_OVER_OVRE1_Msk                 (_U_(0x1) << AFEC_OVER_OVRE1_Pos)              /**< (AFEC_OVER) Overrun Error 1 Mask */
+#define AFEC_OVER_OVRE1                     AFEC_OVER_OVRE1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE1_Msk instead */
+#define AFEC_OVER_OVRE2_Pos                 2                                              /**< (AFEC_OVER) Overrun Error 2 Position */
+#define AFEC_OVER_OVRE2_Msk                 (_U_(0x1) << AFEC_OVER_OVRE2_Pos)              /**< (AFEC_OVER) Overrun Error 2 Mask */
+#define AFEC_OVER_OVRE2                     AFEC_OVER_OVRE2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE2_Msk instead */
+#define AFEC_OVER_OVRE3_Pos                 3                                              /**< (AFEC_OVER) Overrun Error 3 Position */
+#define AFEC_OVER_OVRE3_Msk                 (_U_(0x1) << AFEC_OVER_OVRE3_Pos)              /**< (AFEC_OVER) Overrun Error 3 Mask */
+#define AFEC_OVER_OVRE3                     AFEC_OVER_OVRE3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE3_Msk instead */
+#define AFEC_OVER_OVRE4_Pos                 4                                              /**< (AFEC_OVER) Overrun Error 4 Position */
+#define AFEC_OVER_OVRE4_Msk                 (_U_(0x1) << AFEC_OVER_OVRE4_Pos)              /**< (AFEC_OVER) Overrun Error 4 Mask */
+#define AFEC_OVER_OVRE4                     AFEC_OVER_OVRE4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE4_Msk instead */
+#define AFEC_OVER_OVRE5_Pos                 5                                              /**< (AFEC_OVER) Overrun Error 5 Position */
+#define AFEC_OVER_OVRE5_Msk                 (_U_(0x1) << AFEC_OVER_OVRE5_Pos)              /**< (AFEC_OVER) Overrun Error 5 Mask */
+#define AFEC_OVER_OVRE5                     AFEC_OVER_OVRE5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE5_Msk instead */
+#define AFEC_OVER_OVRE6_Pos                 6                                              /**< (AFEC_OVER) Overrun Error 6 Position */
+#define AFEC_OVER_OVRE6_Msk                 (_U_(0x1) << AFEC_OVER_OVRE6_Pos)              /**< (AFEC_OVER) Overrun Error 6 Mask */
+#define AFEC_OVER_OVRE6                     AFEC_OVER_OVRE6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE6_Msk instead */
+#define AFEC_OVER_OVRE7_Pos                 7                                              /**< (AFEC_OVER) Overrun Error 7 Position */
+#define AFEC_OVER_OVRE7_Msk                 (_U_(0x1) << AFEC_OVER_OVRE7_Pos)              /**< (AFEC_OVER) Overrun Error 7 Mask */
+#define AFEC_OVER_OVRE7                     AFEC_OVER_OVRE7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE7_Msk instead */
+#define AFEC_OVER_OVRE8_Pos                 8                                              /**< (AFEC_OVER) Overrun Error 8 Position */
+#define AFEC_OVER_OVRE8_Msk                 (_U_(0x1) << AFEC_OVER_OVRE8_Pos)              /**< (AFEC_OVER) Overrun Error 8 Mask */
+#define AFEC_OVER_OVRE8                     AFEC_OVER_OVRE8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE8_Msk instead */
+#define AFEC_OVER_OVRE9_Pos                 9                                              /**< (AFEC_OVER) Overrun Error 9 Position */
+#define AFEC_OVER_OVRE9_Msk                 (_U_(0x1) << AFEC_OVER_OVRE9_Pos)              /**< (AFEC_OVER) Overrun Error 9 Mask */
+#define AFEC_OVER_OVRE9                     AFEC_OVER_OVRE9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE9_Msk instead */
+#define AFEC_OVER_OVRE10_Pos                10                                             /**< (AFEC_OVER) Overrun Error 10 Position */
+#define AFEC_OVER_OVRE10_Msk                (_U_(0x1) << AFEC_OVER_OVRE10_Pos)             /**< (AFEC_OVER) Overrun Error 10 Mask */
+#define AFEC_OVER_OVRE10                    AFEC_OVER_OVRE10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE10_Msk instead */
+#define AFEC_OVER_OVRE11_Pos                11                                             /**< (AFEC_OVER) Overrun Error 11 Position */
+#define AFEC_OVER_OVRE11_Msk                (_U_(0x1) << AFEC_OVER_OVRE11_Pos)             /**< (AFEC_OVER) Overrun Error 11 Mask */
+#define AFEC_OVER_OVRE11                    AFEC_OVER_OVRE11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_OVER_OVRE11_Msk instead */
+#define AFEC_OVER_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_OVER) Register MASK  (Use AFEC_OVER_Msk instead)  */
+#define AFEC_OVER_Msk                       _U_(0xFFF)                                     /**< (AFEC_OVER) Register Mask  */
+
+#define AFEC_OVER_OVRE_Pos                  0                                              /**< (AFEC_OVER Position) Overrun Error xx */
+#define AFEC_OVER_OVRE_Msk                  (_U_(0xFFF) << AFEC_OVER_OVRE_Pos)             /**< (AFEC_OVER Mask) OVRE */
+#define AFEC_OVER_OVRE(value)               (AFEC_OVER_OVRE_Msk & ((value) << AFEC_OVER_OVRE_Pos))  
+
+/* -------- AFEC_CWR : (AFEC Offset: 0x50) (R/W 32) AFEC Compare Window Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LOWTHRES:16;               /**< bit:  0..15  Low Threshold                            */
+    uint32_t HIGHTHRES:16;              /**< bit: 16..31  High Threshold                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CWR_OFFSET                     (0x50)                                        /**<  (AFEC_CWR) AFEC Compare Window Register  Offset */
+
+#define AFEC_CWR_LOWTHRES_Pos               0                                              /**< (AFEC_CWR) Low Threshold Position */
+#define AFEC_CWR_LOWTHRES_Msk               (_U_(0xFFFF) << AFEC_CWR_LOWTHRES_Pos)         /**< (AFEC_CWR) Low Threshold Mask */
+#define AFEC_CWR_LOWTHRES(value)            (AFEC_CWR_LOWTHRES_Msk & ((value) << AFEC_CWR_LOWTHRES_Pos))
+#define AFEC_CWR_HIGHTHRES_Pos              16                                             /**< (AFEC_CWR) High Threshold Position */
+#define AFEC_CWR_HIGHTHRES_Msk              (_U_(0xFFFF) << AFEC_CWR_HIGHTHRES_Pos)        /**< (AFEC_CWR) High Threshold Mask */
+#define AFEC_CWR_HIGHTHRES(value)           (AFEC_CWR_HIGHTHRES_Msk & ((value) << AFEC_CWR_HIGHTHRES_Pos))
+#define AFEC_CWR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_CWR) Register MASK  (Use AFEC_CWR_Msk instead)  */
+#define AFEC_CWR_Msk                        _U_(0xFFFFFFFF)                                /**< (AFEC_CWR) Register Mask  */
+
+
+/* -------- AFEC_CGR : (AFEC Offset: 0x54) (R/W 32) AFEC Channel Gain Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GAIN0:2;                   /**< bit:   0..1  Gain for Channel 0                       */
+    uint32_t GAIN1:2;                   /**< bit:   2..3  Gain for Channel 1                       */
+    uint32_t GAIN2:2;                   /**< bit:   4..5  Gain for Channel 2                       */
+    uint32_t GAIN3:2;                   /**< bit:   6..7  Gain for Channel 3                       */
+    uint32_t GAIN4:2;                   /**< bit:   8..9  Gain for Channel 4                       */
+    uint32_t GAIN5:2;                   /**< bit: 10..11  Gain for Channel 5                       */
+    uint32_t GAIN6:2;                   /**< bit: 12..13  Gain for Channel 6                       */
+    uint32_t GAIN7:2;                   /**< bit: 14..15  Gain for Channel 7                       */
+    uint32_t GAIN8:2;                   /**< bit: 16..17  Gain for Channel 8                       */
+    uint32_t GAIN9:2;                   /**< bit: 18..19  Gain for Channel 9                       */
+    uint32_t GAIN10:2;                  /**< bit: 20..21  Gain for Channel 10                      */
+    uint32_t GAIN11:2;                  /**< bit: 22..23  Gain for Channel 11                      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CGR_OFFSET                     (0x54)                                        /**<  (AFEC_CGR) AFEC Channel Gain Register  Offset */
+
+#define AFEC_CGR_GAIN0_Pos                  0                                              /**< (AFEC_CGR) Gain for Channel 0 Position */
+#define AFEC_CGR_GAIN0_Msk                  (_U_(0x3) << AFEC_CGR_GAIN0_Pos)               /**< (AFEC_CGR) Gain for Channel 0 Mask */
+#define AFEC_CGR_GAIN0(value)               (AFEC_CGR_GAIN0_Msk & ((value) << AFEC_CGR_GAIN0_Pos))
+#define AFEC_CGR_GAIN1_Pos                  2                                              /**< (AFEC_CGR) Gain for Channel 1 Position */
+#define AFEC_CGR_GAIN1_Msk                  (_U_(0x3) << AFEC_CGR_GAIN1_Pos)               /**< (AFEC_CGR) Gain for Channel 1 Mask */
+#define AFEC_CGR_GAIN1(value)               (AFEC_CGR_GAIN1_Msk & ((value) << AFEC_CGR_GAIN1_Pos))
+#define AFEC_CGR_GAIN2_Pos                  4                                              /**< (AFEC_CGR) Gain for Channel 2 Position */
+#define AFEC_CGR_GAIN2_Msk                  (_U_(0x3) << AFEC_CGR_GAIN2_Pos)               /**< (AFEC_CGR) Gain for Channel 2 Mask */
+#define AFEC_CGR_GAIN2(value)               (AFEC_CGR_GAIN2_Msk & ((value) << AFEC_CGR_GAIN2_Pos))
+#define AFEC_CGR_GAIN3_Pos                  6                                              /**< (AFEC_CGR) Gain for Channel 3 Position */
+#define AFEC_CGR_GAIN3_Msk                  (_U_(0x3) << AFEC_CGR_GAIN3_Pos)               /**< (AFEC_CGR) Gain for Channel 3 Mask */
+#define AFEC_CGR_GAIN3(value)               (AFEC_CGR_GAIN3_Msk & ((value) << AFEC_CGR_GAIN3_Pos))
+#define AFEC_CGR_GAIN4_Pos                  8                                              /**< (AFEC_CGR) Gain for Channel 4 Position */
+#define AFEC_CGR_GAIN4_Msk                  (_U_(0x3) << AFEC_CGR_GAIN4_Pos)               /**< (AFEC_CGR) Gain for Channel 4 Mask */
+#define AFEC_CGR_GAIN4(value)               (AFEC_CGR_GAIN4_Msk & ((value) << AFEC_CGR_GAIN4_Pos))
+#define AFEC_CGR_GAIN5_Pos                  10                                             /**< (AFEC_CGR) Gain for Channel 5 Position */
+#define AFEC_CGR_GAIN5_Msk                  (_U_(0x3) << AFEC_CGR_GAIN5_Pos)               /**< (AFEC_CGR) Gain for Channel 5 Mask */
+#define AFEC_CGR_GAIN5(value)               (AFEC_CGR_GAIN5_Msk & ((value) << AFEC_CGR_GAIN5_Pos))
+#define AFEC_CGR_GAIN6_Pos                  12                                             /**< (AFEC_CGR) Gain for Channel 6 Position */
+#define AFEC_CGR_GAIN6_Msk                  (_U_(0x3) << AFEC_CGR_GAIN6_Pos)               /**< (AFEC_CGR) Gain for Channel 6 Mask */
+#define AFEC_CGR_GAIN6(value)               (AFEC_CGR_GAIN6_Msk & ((value) << AFEC_CGR_GAIN6_Pos))
+#define AFEC_CGR_GAIN7_Pos                  14                                             /**< (AFEC_CGR) Gain for Channel 7 Position */
+#define AFEC_CGR_GAIN7_Msk                  (_U_(0x3) << AFEC_CGR_GAIN7_Pos)               /**< (AFEC_CGR) Gain for Channel 7 Mask */
+#define AFEC_CGR_GAIN7(value)               (AFEC_CGR_GAIN7_Msk & ((value) << AFEC_CGR_GAIN7_Pos))
+#define AFEC_CGR_GAIN8_Pos                  16                                             /**< (AFEC_CGR) Gain for Channel 8 Position */
+#define AFEC_CGR_GAIN8_Msk                  (_U_(0x3) << AFEC_CGR_GAIN8_Pos)               /**< (AFEC_CGR) Gain for Channel 8 Mask */
+#define AFEC_CGR_GAIN8(value)               (AFEC_CGR_GAIN8_Msk & ((value) << AFEC_CGR_GAIN8_Pos))
+#define AFEC_CGR_GAIN9_Pos                  18                                             /**< (AFEC_CGR) Gain for Channel 9 Position */
+#define AFEC_CGR_GAIN9_Msk                  (_U_(0x3) << AFEC_CGR_GAIN9_Pos)               /**< (AFEC_CGR) Gain for Channel 9 Mask */
+#define AFEC_CGR_GAIN9(value)               (AFEC_CGR_GAIN9_Msk & ((value) << AFEC_CGR_GAIN9_Pos))
+#define AFEC_CGR_GAIN10_Pos                 20                                             /**< (AFEC_CGR) Gain for Channel 10 Position */
+#define AFEC_CGR_GAIN10_Msk                 (_U_(0x3) << AFEC_CGR_GAIN10_Pos)              /**< (AFEC_CGR) Gain for Channel 10 Mask */
+#define AFEC_CGR_GAIN10(value)              (AFEC_CGR_GAIN10_Msk & ((value) << AFEC_CGR_GAIN10_Pos))
+#define AFEC_CGR_GAIN11_Pos                 22                                             /**< (AFEC_CGR) Gain for Channel 11 Position */
+#define AFEC_CGR_GAIN11_Msk                 (_U_(0x3) << AFEC_CGR_GAIN11_Pos)              /**< (AFEC_CGR) Gain for Channel 11 Mask */
+#define AFEC_CGR_GAIN11(value)              (AFEC_CGR_GAIN11_Msk & ((value) << AFEC_CGR_GAIN11_Pos))
+#define AFEC_CGR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (AFEC_CGR) Register MASK  (Use AFEC_CGR_Msk instead)  */
+#define AFEC_CGR_Msk                        _U_(0xFFFFFF)                                  /**< (AFEC_CGR) Register Mask  */
+
+
+/* -------- AFEC_DIFFR : (AFEC Offset: 0x60) (R/W 32) AFEC Channel Differential Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIFF0:1;                   /**< bit:      0  Differential inputs for channel 0        */
+    uint32_t DIFF1:1;                   /**< bit:      1  Differential inputs for channel 1        */
+    uint32_t DIFF2:1;                   /**< bit:      2  Differential inputs for channel 2        */
+    uint32_t DIFF3:1;                   /**< bit:      3  Differential inputs for channel 3        */
+    uint32_t DIFF4:1;                   /**< bit:      4  Differential inputs for channel 4        */
+    uint32_t DIFF5:1;                   /**< bit:      5  Differential inputs for channel 5        */
+    uint32_t DIFF6:1;                   /**< bit:      6  Differential inputs for channel 6        */
+    uint32_t DIFF7:1;                   /**< bit:      7  Differential inputs for channel 7        */
+    uint32_t DIFF8:1;                   /**< bit:      8  Differential inputs for channel 8        */
+    uint32_t DIFF9:1;                   /**< bit:      9  Differential inputs for channel 9        */
+    uint32_t DIFF10:1;                  /**< bit:     10  Differential inputs for channel 10       */
+    uint32_t DIFF11:1;                  /**< bit:     11  Differential inputs for channel 11       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DIFF:12;                   /**< bit:  0..11  Differential inputs for channel xx       */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_DIFFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_DIFFR_OFFSET                   (0x60)                                        /**<  (AFEC_DIFFR) AFEC Channel Differential Register  Offset */
+
+#define AFEC_DIFFR_DIFF0_Pos                0                                              /**< (AFEC_DIFFR) Differential inputs for channel 0 Position */
+#define AFEC_DIFFR_DIFF0_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF0_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 0 Mask */
+#define AFEC_DIFFR_DIFF0                    AFEC_DIFFR_DIFF0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF0_Msk instead */
+#define AFEC_DIFFR_DIFF1_Pos                1                                              /**< (AFEC_DIFFR) Differential inputs for channel 1 Position */
+#define AFEC_DIFFR_DIFF1_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF1_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 1 Mask */
+#define AFEC_DIFFR_DIFF1                    AFEC_DIFFR_DIFF1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF1_Msk instead */
+#define AFEC_DIFFR_DIFF2_Pos                2                                              /**< (AFEC_DIFFR) Differential inputs for channel 2 Position */
+#define AFEC_DIFFR_DIFF2_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF2_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 2 Mask */
+#define AFEC_DIFFR_DIFF2                    AFEC_DIFFR_DIFF2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF2_Msk instead */
+#define AFEC_DIFFR_DIFF3_Pos                3                                              /**< (AFEC_DIFFR) Differential inputs for channel 3 Position */
+#define AFEC_DIFFR_DIFF3_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF3_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 3 Mask */
+#define AFEC_DIFFR_DIFF3                    AFEC_DIFFR_DIFF3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF3_Msk instead */
+#define AFEC_DIFFR_DIFF4_Pos                4                                              /**< (AFEC_DIFFR) Differential inputs for channel 4 Position */
+#define AFEC_DIFFR_DIFF4_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF4_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 4 Mask */
+#define AFEC_DIFFR_DIFF4                    AFEC_DIFFR_DIFF4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF4_Msk instead */
+#define AFEC_DIFFR_DIFF5_Pos                5                                              /**< (AFEC_DIFFR) Differential inputs for channel 5 Position */
+#define AFEC_DIFFR_DIFF5_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF5_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 5 Mask */
+#define AFEC_DIFFR_DIFF5                    AFEC_DIFFR_DIFF5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF5_Msk instead */
+#define AFEC_DIFFR_DIFF6_Pos                6                                              /**< (AFEC_DIFFR) Differential inputs for channel 6 Position */
+#define AFEC_DIFFR_DIFF6_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF6_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 6 Mask */
+#define AFEC_DIFFR_DIFF6                    AFEC_DIFFR_DIFF6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF6_Msk instead */
+#define AFEC_DIFFR_DIFF7_Pos                7                                              /**< (AFEC_DIFFR) Differential inputs for channel 7 Position */
+#define AFEC_DIFFR_DIFF7_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF7_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 7 Mask */
+#define AFEC_DIFFR_DIFF7                    AFEC_DIFFR_DIFF7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF7_Msk instead */
+#define AFEC_DIFFR_DIFF8_Pos                8                                              /**< (AFEC_DIFFR) Differential inputs for channel 8 Position */
+#define AFEC_DIFFR_DIFF8_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF8_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 8 Mask */
+#define AFEC_DIFFR_DIFF8                    AFEC_DIFFR_DIFF8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF8_Msk instead */
+#define AFEC_DIFFR_DIFF9_Pos                9                                              /**< (AFEC_DIFFR) Differential inputs for channel 9 Position */
+#define AFEC_DIFFR_DIFF9_Msk                (_U_(0x1) << AFEC_DIFFR_DIFF9_Pos)             /**< (AFEC_DIFFR) Differential inputs for channel 9 Mask */
+#define AFEC_DIFFR_DIFF9                    AFEC_DIFFR_DIFF9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF9_Msk instead */
+#define AFEC_DIFFR_DIFF10_Pos               10                                             /**< (AFEC_DIFFR) Differential inputs for channel 10 Position */
+#define AFEC_DIFFR_DIFF10_Msk               (_U_(0x1) << AFEC_DIFFR_DIFF10_Pos)            /**< (AFEC_DIFFR) Differential inputs for channel 10 Mask */
+#define AFEC_DIFFR_DIFF10                   AFEC_DIFFR_DIFF10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF10_Msk instead */
+#define AFEC_DIFFR_DIFF11_Pos               11                                             /**< (AFEC_DIFFR) Differential inputs for channel 11 Position */
+#define AFEC_DIFFR_DIFF11_Msk               (_U_(0x1) << AFEC_DIFFR_DIFF11_Pos)            /**< (AFEC_DIFFR) Differential inputs for channel 11 Mask */
+#define AFEC_DIFFR_DIFF11                   AFEC_DIFFR_DIFF11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_DIFFR_DIFF11_Msk instead */
+#define AFEC_DIFFR_MASK                     _U_(0xFFF)                                     /**< \deprecated (AFEC_DIFFR) Register MASK  (Use AFEC_DIFFR_Msk instead)  */
+#define AFEC_DIFFR_Msk                      _U_(0xFFF)                                     /**< (AFEC_DIFFR) Register Mask  */
+
+#define AFEC_DIFFR_DIFF_Pos                 0                                              /**< (AFEC_DIFFR Position) Differential inputs for channel xx */
+#define AFEC_DIFFR_DIFF_Msk                 (_U_(0xFFF) << AFEC_DIFFR_DIFF_Pos)            /**< (AFEC_DIFFR Mask) DIFF */
+#define AFEC_DIFFR_DIFF(value)              (AFEC_DIFFR_DIFF_Msk & ((value) << AFEC_DIFFR_DIFF_Pos))  
+
+/* -------- AFEC_CSELR : (AFEC Offset: 0x64) (R/W 32) AFEC Channel Selection Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL:4;                    /**< bit:   0..3  Channel Selection                        */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CSELR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CSELR_OFFSET                   (0x64)                                        /**<  (AFEC_CSELR) AFEC Channel Selection Register  Offset */
+
+#define AFEC_CSELR_CSEL_Pos                 0                                              /**< (AFEC_CSELR) Channel Selection Position */
+#define AFEC_CSELR_CSEL_Msk                 (_U_(0xF) << AFEC_CSELR_CSEL_Pos)              /**< (AFEC_CSELR) Channel Selection Mask */
+#define AFEC_CSELR_CSEL(value)              (AFEC_CSELR_CSEL_Msk & ((value) << AFEC_CSELR_CSEL_Pos))
+#define AFEC_CSELR_MASK                     _U_(0x0F)                                      /**< \deprecated (AFEC_CSELR) Register MASK  (Use AFEC_CSELR_Msk instead)  */
+#define AFEC_CSELR_Msk                      _U_(0x0F)                                      /**< (AFEC_CSELR) Register Mask  */
+
+
+/* -------- AFEC_CDR : (AFEC Offset: 0x68) (R/ 32) AFEC Channel Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:16;                   /**< bit:  0..15  Converted Data                           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CDR_OFFSET                     (0x68)                                        /**<  (AFEC_CDR) AFEC Channel Data Register  Offset */
+
+#define AFEC_CDR_DATA_Pos                   0                                              /**< (AFEC_CDR) Converted Data Position */
+#define AFEC_CDR_DATA_Msk                   (_U_(0xFFFF) << AFEC_CDR_DATA_Pos)             /**< (AFEC_CDR) Converted Data Mask */
+#define AFEC_CDR_DATA(value)                (AFEC_CDR_DATA_Msk & ((value) << AFEC_CDR_DATA_Pos))
+#define AFEC_CDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (AFEC_CDR) Register MASK  (Use AFEC_CDR_Msk instead)  */
+#define AFEC_CDR_Msk                        _U_(0xFFFF)                                    /**< (AFEC_CDR) Register Mask  */
+
+
+/* -------- AFEC_COCR : (AFEC Offset: 0x6c) (R/W 32) AFEC Channel Offset Compensation Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AOFF:10;                   /**< bit:   0..9  Analog Offset                            */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_COCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_COCR_OFFSET                    (0x6C)                                        /**<  (AFEC_COCR) AFEC Channel Offset Compensation Register  Offset */
+
+#define AFEC_COCR_AOFF_Pos                  0                                              /**< (AFEC_COCR) Analog Offset Position */
+#define AFEC_COCR_AOFF_Msk                  (_U_(0x3FF) << AFEC_COCR_AOFF_Pos)             /**< (AFEC_COCR) Analog Offset Mask */
+#define AFEC_COCR_AOFF(value)               (AFEC_COCR_AOFF_Msk & ((value) << AFEC_COCR_AOFF_Pos))
+#define AFEC_COCR_MASK                      _U_(0x3FF)                                     /**< \deprecated (AFEC_COCR) Register MASK  (Use AFEC_COCR_Msk instead)  */
+#define AFEC_COCR_Msk                       _U_(0x3FF)                                     /**< (AFEC_COCR) Register Mask  */
+
+
+/* -------- AFEC_TEMPMR : (AFEC Offset: 0x70) (R/W 32) AFEC Temperature Sensor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RTCT:1;                    /**< bit:      0  Temperature Sensor RTC Trigger Mode      */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t TEMPCMPMOD:2;              /**< bit:   4..5  Temperature Comparison Mode              */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_TEMPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_TEMPMR_OFFSET                  (0x70)                                        /**<  (AFEC_TEMPMR) AFEC Temperature Sensor Mode Register  Offset */
+
+#define AFEC_TEMPMR_RTCT_Pos                0                                              /**< (AFEC_TEMPMR) Temperature Sensor RTC Trigger Mode Position */
+#define AFEC_TEMPMR_RTCT_Msk                (_U_(0x1) << AFEC_TEMPMR_RTCT_Pos)             /**< (AFEC_TEMPMR) Temperature Sensor RTC Trigger Mode Mask */
+#define AFEC_TEMPMR_RTCT                    AFEC_TEMPMR_RTCT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_TEMPMR_RTCT_Msk instead */
+#define AFEC_TEMPMR_TEMPCMPMOD_Pos          4                                              /**< (AFEC_TEMPMR) Temperature Comparison Mode Position */
+#define AFEC_TEMPMR_TEMPCMPMOD_Msk          (_U_(0x3) << AFEC_TEMPMR_TEMPCMPMOD_Pos)       /**< (AFEC_TEMPMR) Temperature Comparison Mode Mask */
+#define AFEC_TEMPMR_TEMPCMPMOD(value)       (AFEC_TEMPMR_TEMPCMPMOD_Msk & ((value) << AFEC_TEMPMR_TEMPCMPMOD_Pos))
+#define   AFEC_TEMPMR_TEMPCMPMOD_LOW_Val    _U_(0x0)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is lower than the low threshold of the window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_HIGH_Val   _U_(0x1)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is higher than the high threshold of the window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_IN_Val     _U_(0x2)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is in the comparison window.  */
+#define   AFEC_TEMPMR_TEMPCMPMOD_OUT_Val    _U_(0x3)                                       /**< (AFEC_TEMPMR) Generates an event when the converted data is out of the comparison window.  */
+#define AFEC_TEMPMR_TEMPCMPMOD_LOW          (AFEC_TEMPMR_TEMPCMPMOD_LOW_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is lower than the low threshold of the window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_HIGH         (AFEC_TEMPMR_TEMPCMPMOD_HIGH_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is higher than the high threshold of the window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_IN           (AFEC_TEMPMR_TEMPCMPMOD_IN_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is in the comparison window. Position  */
+#define AFEC_TEMPMR_TEMPCMPMOD_OUT          (AFEC_TEMPMR_TEMPCMPMOD_OUT_Val << AFEC_TEMPMR_TEMPCMPMOD_Pos)  /**< (AFEC_TEMPMR) Generates an event when the converted data is out of the comparison window. Position  */
+#define AFEC_TEMPMR_MASK                    _U_(0x31)                                      /**< \deprecated (AFEC_TEMPMR) Register MASK  (Use AFEC_TEMPMR_Msk instead)  */
+#define AFEC_TEMPMR_Msk                     _U_(0x31)                                      /**< (AFEC_TEMPMR) Register Mask  */
+
+
+/* -------- AFEC_TEMPCWR : (AFEC Offset: 0x74) (R/W 32) AFEC Temperature Compare Window Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TLOWTHRES:16;              /**< bit:  0..15  Temperature Low Threshold                */
+    uint32_t THIGHTHRES:16;             /**< bit: 16..31  Temperature High Threshold               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_TEMPCWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_TEMPCWR_OFFSET                 (0x74)                                        /**<  (AFEC_TEMPCWR) AFEC Temperature Compare Window Register  Offset */
+
+#define AFEC_TEMPCWR_TLOWTHRES_Pos          0                                              /**< (AFEC_TEMPCWR) Temperature Low Threshold Position */
+#define AFEC_TEMPCWR_TLOWTHRES_Msk          (_U_(0xFFFF) << AFEC_TEMPCWR_TLOWTHRES_Pos)    /**< (AFEC_TEMPCWR) Temperature Low Threshold Mask */
+#define AFEC_TEMPCWR_TLOWTHRES(value)       (AFEC_TEMPCWR_TLOWTHRES_Msk & ((value) << AFEC_TEMPCWR_TLOWTHRES_Pos))
+#define AFEC_TEMPCWR_THIGHTHRES_Pos         16                                             /**< (AFEC_TEMPCWR) Temperature High Threshold Position */
+#define AFEC_TEMPCWR_THIGHTHRES_Msk         (_U_(0xFFFF) << AFEC_TEMPCWR_THIGHTHRES_Pos)   /**< (AFEC_TEMPCWR) Temperature High Threshold Mask */
+#define AFEC_TEMPCWR_THIGHTHRES(value)      (AFEC_TEMPCWR_THIGHTHRES_Msk & ((value) << AFEC_TEMPCWR_THIGHTHRES_Pos))
+#define AFEC_TEMPCWR_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_TEMPCWR) Register MASK  (Use AFEC_TEMPCWR_Msk instead)  */
+#define AFEC_TEMPCWR_Msk                    _U_(0xFFFFFFFF)                                /**< (AFEC_TEMPCWR) Register Mask  */
+
+
+/* -------- AFEC_ACR : (AFEC Offset: 0x94) (R/W 32) AFEC Analog Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t PGA0EN:1;                  /**< bit:      2  PGA0 Enable                              */
+    uint32_t PGA1EN:1;                  /**< bit:      3  PGA1 Enable                              */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t IBCTL:2;                   /**< bit:   8..9  AFE Bias Current Control                 */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_ACR_OFFSET                     (0x94)                                        /**<  (AFEC_ACR) AFEC Analog Control Register  Offset */
+
+#define AFEC_ACR_PGA0EN_Pos                 2                                              /**< (AFEC_ACR) PGA0 Enable Position */
+#define AFEC_ACR_PGA0EN_Msk                 (_U_(0x1) << AFEC_ACR_PGA0EN_Pos)              /**< (AFEC_ACR) PGA0 Enable Mask */
+#define AFEC_ACR_PGA0EN                     AFEC_ACR_PGA0EN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ACR_PGA0EN_Msk instead */
+#define AFEC_ACR_PGA1EN_Pos                 3                                              /**< (AFEC_ACR) PGA1 Enable Position */
+#define AFEC_ACR_PGA1EN_Msk                 (_U_(0x1) << AFEC_ACR_PGA1EN_Pos)              /**< (AFEC_ACR) PGA1 Enable Mask */
+#define AFEC_ACR_PGA1EN                     AFEC_ACR_PGA1EN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_ACR_PGA1EN_Msk instead */
+#define AFEC_ACR_IBCTL_Pos                  8                                              /**< (AFEC_ACR) AFE Bias Current Control Position */
+#define AFEC_ACR_IBCTL_Msk                  (_U_(0x3) << AFEC_ACR_IBCTL_Pos)               /**< (AFEC_ACR) AFE Bias Current Control Mask */
+#define AFEC_ACR_IBCTL(value)               (AFEC_ACR_IBCTL_Msk & ((value) << AFEC_ACR_IBCTL_Pos))
+#define AFEC_ACR_MASK                       _U_(0x30C)                                     /**< \deprecated (AFEC_ACR) Register MASK  (Use AFEC_ACR_Msk instead)  */
+#define AFEC_ACR_Msk                        _U_(0x30C)                                     /**< (AFEC_ACR) Register Mask  */
+
+
+/* -------- AFEC_SHMR : (AFEC Offset: 0xa0) (R/W 32) AFEC Sample & Hold Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DUAL0:1;                   /**< bit:      0  Dual Sample & Hold for channel 0         */
+    uint32_t DUAL1:1;                   /**< bit:      1  Dual Sample & Hold for channel 1         */
+    uint32_t DUAL2:1;                   /**< bit:      2  Dual Sample & Hold for channel 2         */
+    uint32_t DUAL3:1;                   /**< bit:      3  Dual Sample & Hold for channel 3         */
+    uint32_t DUAL4:1;                   /**< bit:      4  Dual Sample & Hold for channel 4         */
+    uint32_t DUAL5:1;                   /**< bit:      5  Dual Sample & Hold for channel 5         */
+    uint32_t DUAL6:1;                   /**< bit:      6  Dual Sample & Hold for channel 6         */
+    uint32_t DUAL7:1;                   /**< bit:      7  Dual Sample & Hold for channel 7         */
+    uint32_t DUAL8:1;                   /**< bit:      8  Dual Sample & Hold for channel 8         */
+    uint32_t DUAL9:1;                   /**< bit:      9  Dual Sample & Hold for channel 9         */
+    uint32_t DUAL10:1;                  /**< bit:     10  Dual Sample & Hold for channel 10        */
+    uint32_t DUAL11:1;                  /**< bit:     11  Dual Sample & Hold for channel 11        */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DUAL:12;                   /**< bit:  0..11  Dual Sample & Hold for channel xx        */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_SHMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_SHMR_OFFSET                    (0xA0)                                        /**<  (AFEC_SHMR) AFEC Sample & Hold Mode Register  Offset */
+
+#define AFEC_SHMR_DUAL0_Pos                 0                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 0 Position */
+#define AFEC_SHMR_DUAL0_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL0_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 0 Mask */
+#define AFEC_SHMR_DUAL0                     AFEC_SHMR_DUAL0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL0_Msk instead */
+#define AFEC_SHMR_DUAL1_Pos                 1                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 1 Position */
+#define AFEC_SHMR_DUAL1_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL1_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 1 Mask */
+#define AFEC_SHMR_DUAL1                     AFEC_SHMR_DUAL1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL1_Msk instead */
+#define AFEC_SHMR_DUAL2_Pos                 2                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 2 Position */
+#define AFEC_SHMR_DUAL2_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL2_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 2 Mask */
+#define AFEC_SHMR_DUAL2                     AFEC_SHMR_DUAL2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL2_Msk instead */
+#define AFEC_SHMR_DUAL3_Pos                 3                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 3 Position */
+#define AFEC_SHMR_DUAL3_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL3_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 3 Mask */
+#define AFEC_SHMR_DUAL3                     AFEC_SHMR_DUAL3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL3_Msk instead */
+#define AFEC_SHMR_DUAL4_Pos                 4                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 4 Position */
+#define AFEC_SHMR_DUAL4_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL4_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 4 Mask */
+#define AFEC_SHMR_DUAL4                     AFEC_SHMR_DUAL4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL4_Msk instead */
+#define AFEC_SHMR_DUAL5_Pos                 5                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 5 Position */
+#define AFEC_SHMR_DUAL5_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL5_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 5 Mask */
+#define AFEC_SHMR_DUAL5                     AFEC_SHMR_DUAL5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL5_Msk instead */
+#define AFEC_SHMR_DUAL6_Pos                 6                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 6 Position */
+#define AFEC_SHMR_DUAL6_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL6_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 6 Mask */
+#define AFEC_SHMR_DUAL6                     AFEC_SHMR_DUAL6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL6_Msk instead */
+#define AFEC_SHMR_DUAL7_Pos                 7                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 7 Position */
+#define AFEC_SHMR_DUAL7_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL7_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 7 Mask */
+#define AFEC_SHMR_DUAL7                     AFEC_SHMR_DUAL7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL7_Msk instead */
+#define AFEC_SHMR_DUAL8_Pos                 8                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 8 Position */
+#define AFEC_SHMR_DUAL8_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL8_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 8 Mask */
+#define AFEC_SHMR_DUAL8                     AFEC_SHMR_DUAL8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL8_Msk instead */
+#define AFEC_SHMR_DUAL9_Pos                 9                                              /**< (AFEC_SHMR) Dual Sample & Hold for channel 9 Position */
+#define AFEC_SHMR_DUAL9_Msk                 (_U_(0x1) << AFEC_SHMR_DUAL9_Pos)              /**< (AFEC_SHMR) Dual Sample & Hold for channel 9 Mask */
+#define AFEC_SHMR_DUAL9                     AFEC_SHMR_DUAL9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL9_Msk instead */
+#define AFEC_SHMR_DUAL10_Pos                10                                             /**< (AFEC_SHMR) Dual Sample & Hold for channel 10 Position */
+#define AFEC_SHMR_DUAL10_Msk                (_U_(0x1) << AFEC_SHMR_DUAL10_Pos)             /**< (AFEC_SHMR) Dual Sample & Hold for channel 10 Mask */
+#define AFEC_SHMR_DUAL10                    AFEC_SHMR_DUAL10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL10_Msk instead */
+#define AFEC_SHMR_DUAL11_Pos                11                                             /**< (AFEC_SHMR) Dual Sample & Hold for channel 11 Position */
+#define AFEC_SHMR_DUAL11_Msk                (_U_(0x1) << AFEC_SHMR_DUAL11_Pos)             /**< (AFEC_SHMR) Dual Sample & Hold for channel 11 Mask */
+#define AFEC_SHMR_DUAL11                    AFEC_SHMR_DUAL11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_SHMR_DUAL11_Msk instead */
+#define AFEC_SHMR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_SHMR) Register MASK  (Use AFEC_SHMR_Msk instead)  */
+#define AFEC_SHMR_Msk                       _U_(0xFFF)                                     /**< (AFEC_SHMR) Register Mask  */
+
+#define AFEC_SHMR_DUAL_Pos                  0                                              /**< (AFEC_SHMR Position) Dual Sample & Hold for channel xx */
+#define AFEC_SHMR_DUAL_Msk                  (_U_(0xFFF) << AFEC_SHMR_DUAL_Pos)             /**< (AFEC_SHMR Mask) DUAL */
+#define AFEC_SHMR_DUAL(value)               (AFEC_SHMR_DUAL_Msk & ((value) << AFEC_SHMR_DUAL_Pos))  
+
+/* -------- AFEC_COSR : (AFEC Offset: 0xd0) (R/W 32) AFEC Correction Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL:1;                    /**< bit:      0  Sample & Hold unit Correction Select     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_COSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_COSR_OFFSET                    (0xD0)                                        /**<  (AFEC_COSR) AFEC Correction Select Register  Offset */
+
+#define AFEC_COSR_CSEL_Pos                  0                                              /**< (AFEC_COSR) Sample & Hold unit Correction Select Position */
+#define AFEC_COSR_CSEL_Msk                  (_U_(0x1) << AFEC_COSR_CSEL_Pos)               /**< (AFEC_COSR) Sample & Hold unit Correction Select Mask */
+#define AFEC_COSR_CSEL                      AFEC_COSR_CSEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_COSR_CSEL_Msk instead */
+#define AFEC_COSR_MASK                      _U_(0x01)                                      /**< \deprecated (AFEC_COSR) Register MASK  (Use AFEC_COSR_Msk instead)  */
+#define AFEC_COSR_Msk                       _U_(0x01)                                      /**< (AFEC_COSR) Register Mask  */
+
+
+/* -------- AFEC_CVR : (AFEC Offset: 0xd4) (R/W 32) AFEC Correction Values Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSETCORR:16;             /**< bit:  0..15  Offset Correction                        */
+    uint32_t GAINCORR:16;               /**< bit: 16..31  Gain Correction                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CVR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CVR_OFFSET                     (0xD4)                                        /**<  (AFEC_CVR) AFEC Correction Values Register  Offset */
+
+#define AFEC_CVR_OFFSETCORR_Pos             0                                              /**< (AFEC_CVR) Offset Correction Position */
+#define AFEC_CVR_OFFSETCORR_Msk             (_U_(0xFFFF) << AFEC_CVR_OFFSETCORR_Pos)       /**< (AFEC_CVR) Offset Correction Mask */
+#define AFEC_CVR_OFFSETCORR(value)          (AFEC_CVR_OFFSETCORR_Msk & ((value) << AFEC_CVR_OFFSETCORR_Pos))
+#define AFEC_CVR_GAINCORR_Pos               16                                             /**< (AFEC_CVR) Gain Correction Position */
+#define AFEC_CVR_GAINCORR_Msk               (_U_(0xFFFF) << AFEC_CVR_GAINCORR_Pos)         /**< (AFEC_CVR) Gain Correction Mask */
+#define AFEC_CVR_GAINCORR(value)            (AFEC_CVR_GAINCORR_Msk & ((value) << AFEC_CVR_GAINCORR_Pos))
+#define AFEC_CVR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (AFEC_CVR) Register MASK  (Use AFEC_CVR_Msk instead)  */
+#define AFEC_CVR_Msk                        _U_(0xFFFFFFFF)                                /**< (AFEC_CVR) Register Mask  */
+
+
+/* -------- AFEC_CECR : (AFEC Offset: 0xd8) (R/W 32) AFEC Channel Error Correction Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ECORR0:1;                  /**< bit:      0  Error Correction Enable for channel 0    */
+    uint32_t ECORR1:1;                  /**< bit:      1  Error Correction Enable for channel 1    */
+    uint32_t ECORR2:1;                  /**< bit:      2  Error Correction Enable for channel 2    */
+    uint32_t ECORR3:1;                  /**< bit:      3  Error Correction Enable for channel 3    */
+    uint32_t ECORR4:1;                  /**< bit:      4  Error Correction Enable for channel 4    */
+    uint32_t ECORR5:1;                  /**< bit:      5  Error Correction Enable for channel 5    */
+    uint32_t ECORR6:1;                  /**< bit:      6  Error Correction Enable for channel 6    */
+    uint32_t ECORR7:1;                  /**< bit:      7  Error Correction Enable for channel 7    */
+    uint32_t ECORR8:1;                  /**< bit:      8  Error Correction Enable for channel 8    */
+    uint32_t ECORR9:1;                  /**< bit:      9  Error Correction Enable for channel 9    */
+    uint32_t ECORR10:1;                 /**< bit:     10  Error Correction Enable for channel 10   */
+    uint32_t ECORR11:1;                 /**< bit:     11  Error Correction Enable for channel 11   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ECORR:12;                  /**< bit:  0..11  Error Correction Enable for channel xx   */
+    uint32_t :20;                       /**< bit: 12..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_CECR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_CECR_OFFSET                    (0xD8)                                        /**<  (AFEC_CECR) AFEC Channel Error Correction Register  Offset */
+
+#define AFEC_CECR_ECORR0_Pos                0                                              /**< (AFEC_CECR) Error Correction Enable for channel 0 Position */
+#define AFEC_CECR_ECORR0_Msk                (_U_(0x1) << AFEC_CECR_ECORR0_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 0 Mask */
+#define AFEC_CECR_ECORR0                    AFEC_CECR_ECORR0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR0_Msk instead */
+#define AFEC_CECR_ECORR1_Pos                1                                              /**< (AFEC_CECR) Error Correction Enable for channel 1 Position */
+#define AFEC_CECR_ECORR1_Msk                (_U_(0x1) << AFEC_CECR_ECORR1_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 1 Mask */
+#define AFEC_CECR_ECORR1                    AFEC_CECR_ECORR1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR1_Msk instead */
+#define AFEC_CECR_ECORR2_Pos                2                                              /**< (AFEC_CECR) Error Correction Enable for channel 2 Position */
+#define AFEC_CECR_ECORR2_Msk                (_U_(0x1) << AFEC_CECR_ECORR2_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 2 Mask */
+#define AFEC_CECR_ECORR2                    AFEC_CECR_ECORR2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR2_Msk instead */
+#define AFEC_CECR_ECORR3_Pos                3                                              /**< (AFEC_CECR) Error Correction Enable for channel 3 Position */
+#define AFEC_CECR_ECORR3_Msk                (_U_(0x1) << AFEC_CECR_ECORR3_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 3 Mask */
+#define AFEC_CECR_ECORR3                    AFEC_CECR_ECORR3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR3_Msk instead */
+#define AFEC_CECR_ECORR4_Pos                4                                              /**< (AFEC_CECR) Error Correction Enable for channel 4 Position */
+#define AFEC_CECR_ECORR4_Msk                (_U_(0x1) << AFEC_CECR_ECORR4_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 4 Mask */
+#define AFEC_CECR_ECORR4                    AFEC_CECR_ECORR4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR4_Msk instead */
+#define AFEC_CECR_ECORR5_Pos                5                                              /**< (AFEC_CECR) Error Correction Enable for channel 5 Position */
+#define AFEC_CECR_ECORR5_Msk                (_U_(0x1) << AFEC_CECR_ECORR5_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 5 Mask */
+#define AFEC_CECR_ECORR5                    AFEC_CECR_ECORR5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR5_Msk instead */
+#define AFEC_CECR_ECORR6_Pos                6                                              /**< (AFEC_CECR) Error Correction Enable for channel 6 Position */
+#define AFEC_CECR_ECORR6_Msk                (_U_(0x1) << AFEC_CECR_ECORR6_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 6 Mask */
+#define AFEC_CECR_ECORR6                    AFEC_CECR_ECORR6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR6_Msk instead */
+#define AFEC_CECR_ECORR7_Pos                7                                              /**< (AFEC_CECR) Error Correction Enable for channel 7 Position */
+#define AFEC_CECR_ECORR7_Msk                (_U_(0x1) << AFEC_CECR_ECORR7_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 7 Mask */
+#define AFEC_CECR_ECORR7                    AFEC_CECR_ECORR7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR7_Msk instead */
+#define AFEC_CECR_ECORR8_Pos                8                                              /**< (AFEC_CECR) Error Correction Enable for channel 8 Position */
+#define AFEC_CECR_ECORR8_Msk                (_U_(0x1) << AFEC_CECR_ECORR8_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 8 Mask */
+#define AFEC_CECR_ECORR8                    AFEC_CECR_ECORR8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR8_Msk instead */
+#define AFEC_CECR_ECORR9_Pos                9                                              /**< (AFEC_CECR) Error Correction Enable for channel 9 Position */
+#define AFEC_CECR_ECORR9_Msk                (_U_(0x1) << AFEC_CECR_ECORR9_Pos)             /**< (AFEC_CECR) Error Correction Enable for channel 9 Mask */
+#define AFEC_CECR_ECORR9                    AFEC_CECR_ECORR9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR9_Msk instead */
+#define AFEC_CECR_ECORR10_Pos               10                                             /**< (AFEC_CECR) Error Correction Enable for channel 10 Position */
+#define AFEC_CECR_ECORR10_Msk               (_U_(0x1) << AFEC_CECR_ECORR10_Pos)            /**< (AFEC_CECR) Error Correction Enable for channel 10 Mask */
+#define AFEC_CECR_ECORR10                   AFEC_CECR_ECORR10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR10_Msk instead */
+#define AFEC_CECR_ECORR11_Pos               11                                             /**< (AFEC_CECR) Error Correction Enable for channel 11 Position */
+#define AFEC_CECR_ECORR11_Msk               (_U_(0x1) << AFEC_CECR_ECORR11_Pos)            /**< (AFEC_CECR) Error Correction Enable for channel 11 Mask */
+#define AFEC_CECR_ECORR11                   AFEC_CECR_ECORR11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_CECR_ECORR11_Msk instead */
+#define AFEC_CECR_MASK                      _U_(0xFFF)                                     /**< \deprecated (AFEC_CECR) Register MASK  (Use AFEC_CECR_Msk instead)  */
+#define AFEC_CECR_Msk                       _U_(0xFFF)                                     /**< (AFEC_CECR) Register Mask  */
+
+#define AFEC_CECR_ECORR_Pos                 0                                              /**< (AFEC_CECR Position) Error Correction Enable for channel xx */
+#define AFEC_CECR_ECORR_Msk                 (_U_(0xFFF) << AFEC_CECR_ECORR_Pos)            /**< (AFEC_CECR Mask) ECORR */
+#define AFEC_CECR_ECORR(value)              (AFEC_CECR_ECORR_Msk & ((value) << AFEC_CECR_ECORR_Pos))  
+
+/* -------- AFEC_WPMR : (AFEC Offset: 0xe4) (R/W 32) AFEC Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect KEY                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_WPMR_OFFSET                    (0xE4)                                        /**<  (AFEC_WPMR) AFEC Write Protection Mode Register  Offset */
+
+#define AFEC_WPMR_WPEN_Pos                  0                                              /**< (AFEC_WPMR) Write Protection Enable Position */
+#define AFEC_WPMR_WPEN_Msk                  (_U_(0x1) << AFEC_WPMR_WPEN_Pos)               /**< (AFEC_WPMR) Write Protection Enable Mask */
+#define AFEC_WPMR_WPEN                      AFEC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_WPMR_WPEN_Msk instead */
+#define AFEC_WPMR_WPKEY_Pos                 8                                              /**< (AFEC_WPMR) Write Protect KEY Position */
+#define AFEC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << AFEC_WPMR_WPKEY_Pos)         /**< (AFEC_WPMR) Write Protect KEY Mask */
+#define AFEC_WPMR_WPKEY(value)              (AFEC_WPMR_WPKEY_Msk & ((value) << AFEC_WPMR_WPKEY_Pos))
+#define   AFEC_WPMR_WPKEY_PASSWD_Val        _U_(0x414443)                                  /**< (AFEC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define AFEC_WPMR_WPKEY_PASSWD              (AFEC_WPMR_WPKEY_PASSWD_Val << AFEC_WPMR_WPKEY_Pos)  /**< (AFEC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define AFEC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (AFEC_WPMR) Register MASK  (Use AFEC_WPMR_Msk instead)  */
+#define AFEC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (AFEC_WPMR) Register Mask  */
+
+
+/* -------- AFEC_WPSR : (AFEC Offset: 0xe8) (R/ 32) AFEC Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protect Violation Status           */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protect Violation Source           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} AFEC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AFEC_WPSR_OFFSET                    (0xE8)                                        /**<  (AFEC_WPSR) AFEC Write Protection Status Register  Offset */
+
+#define AFEC_WPSR_WPVS_Pos                  0                                              /**< (AFEC_WPSR) Write Protect Violation Status Position */
+#define AFEC_WPSR_WPVS_Msk                  (_U_(0x1) << AFEC_WPSR_WPVS_Pos)               /**< (AFEC_WPSR) Write Protect Violation Status Mask */
+#define AFEC_WPSR_WPVS                      AFEC_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use AFEC_WPSR_WPVS_Msk instead */
+#define AFEC_WPSR_WPVSRC_Pos                8                                              /**< (AFEC_WPSR) Write Protect Violation Source Position */
+#define AFEC_WPSR_WPVSRC_Msk                (_U_(0xFFFF) << AFEC_WPSR_WPVSRC_Pos)          /**< (AFEC_WPSR) Write Protect Violation Source Mask */
+#define AFEC_WPSR_WPVSRC(value)             (AFEC_WPSR_WPVSRC_Msk & ((value) << AFEC_WPSR_WPVSRC_Pos))
+#define AFEC_WPSR_MASK                      _U_(0xFFFF01)                                  /**< \deprecated (AFEC_WPSR) Register MASK  (Use AFEC_WPSR_Msk instead)  */
+#define AFEC_WPSR_Msk                       _U_(0xFFFF01)                                  /**< (AFEC_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief AFEC hardware registers */
+typedef struct {  
+  __O  uint32_t AFEC_CR;        /**< (AFEC Offset: 0x00) AFEC Control Register */
+  __IO uint32_t AFEC_MR;        /**< (AFEC Offset: 0x04) AFEC Mode Register */
+  __IO uint32_t AFEC_EMR;       /**< (AFEC Offset: 0x08) AFEC Extended Mode Register */
+  __IO uint32_t AFEC_SEQ1R;     /**< (AFEC Offset: 0x0C) AFEC Channel Sequence 1 Register */
+  __IO uint32_t AFEC_SEQ2R;     /**< (AFEC Offset: 0x10) AFEC Channel Sequence 2 Register */
+  __O  uint32_t AFEC_CHER;      /**< (AFEC Offset: 0x14) AFEC Channel Enable Register */
+  __O  uint32_t AFEC_CHDR;      /**< (AFEC Offset: 0x18) AFEC Channel Disable Register */
+  __I  uint32_t AFEC_CHSR;      /**< (AFEC Offset: 0x1C) AFEC Channel Status Register */
+  __I  uint32_t AFEC_LCDR;      /**< (AFEC Offset: 0x20) AFEC Last Converted Data Register */
+  __O  uint32_t AFEC_IER;       /**< (AFEC Offset: 0x24) AFEC Interrupt Enable Register */
+  __O  uint32_t AFEC_IDR;       /**< (AFEC Offset: 0x28) AFEC Interrupt Disable Register */
+  __I  uint32_t AFEC_IMR;       /**< (AFEC Offset: 0x2C) AFEC Interrupt Mask Register */
+  __I  uint32_t AFEC_ISR;       /**< (AFEC Offset: 0x30) AFEC Interrupt Status Register */
+  __I  uint8_t                        Reserved1[24];
+  __I  uint32_t AFEC_OVER;      /**< (AFEC Offset: 0x4C) AFEC Overrun Status Register */
+  __IO uint32_t AFEC_CWR;       /**< (AFEC Offset: 0x50) AFEC Compare Window Register */
+  __IO uint32_t AFEC_CGR;       /**< (AFEC Offset: 0x54) AFEC Channel Gain Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO uint32_t AFEC_DIFFR;     /**< (AFEC Offset: 0x60) AFEC Channel Differential Register */
+  __IO uint32_t AFEC_CSELR;     /**< (AFEC Offset: 0x64) AFEC Channel Selection Register */
+  __I  uint32_t AFEC_CDR;       /**< (AFEC Offset: 0x68) AFEC Channel Data Register */
+  __IO uint32_t AFEC_COCR;      /**< (AFEC Offset: 0x6C) AFEC Channel Offset Compensation Register */
+  __IO uint32_t AFEC_TEMPMR;    /**< (AFEC Offset: 0x70) AFEC Temperature Sensor Mode Register */
+  __IO uint32_t AFEC_TEMPCWR;   /**< (AFEC Offset: 0x74) AFEC Temperature Compare Window Register */
+  __I  uint8_t                        Reserved3[28];
+  __IO uint32_t AFEC_ACR;       /**< (AFEC Offset: 0x94) AFEC Analog Control Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO uint32_t AFEC_SHMR;      /**< (AFEC Offset: 0xA0) AFEC Sample & Hold Mode Register */
+  __I  uint8_t                        Reserved5[44];
+  __IO uint32_t AFEC_COSR;      /**< (AFEC Offset: 0xD0) AFEC Correction Select Register */
+  __IO uint32_t AFEC_CVR;       /**< (AFEC Offset: 0xD4) AFEC Correction Values Register */
+  __IO uint32_t AFEC_CECR;      /**< (AFEC Offset: 0xD8) AFEC Channel Error Correction Register */
+  __I  uint8_t                        Reserved6[8];
+  __IO uint32_t AFEC_WPMR;      /**< (AFEC Offset: 0xE4) AFEC Write Protection Mode Register */
+  __I  uint32_t AFEC_WPSR;      /**< (AFEC Offset: 0xE8) AFEC Write Protection Status Register */
+} Afec;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief AFEC hardware registers */
+typedef struct {  
+  __O  AFEC_CR_Type                   AFEC_CR;        /**< Offset: 0x00 ( /W  32) AFEC Control Register */
+  __IO AFEC_MR_Type                   AFEC_MR;        /**< Offset: 0x04 (R/W  32) AFEC Mode Register */
+  __IO AFEC_EMR_Type                  AFEC_EMR;       /**< Offset: 0x08 (R/W  32) AFEC Extended Mode Register */
+  __IO AFEC_SEQ1R_Type                AFEC_SEQ1R;     /**< Offset: 0x0C (R/W  32) AFEC Channel Sequence 1 Register */
+  __IO AFEC_SEQ2R_Type                AFEC_SEQ2R;     /**< Offset: 0x10 (R/W  32) AFEC Channel Sequence 2 Register */
+  __O  AFEC_CHER_Type                 AFEC_CHER;      /**< Offset: 0x14 ( /W  32) AFEC Channel Enable Register */
+  __O  AFEC_CHDR_Type                 AFEC_CHDR;      /**< Offset: 0x18 ( /W  32) AFEC Channel Disable Register */
+  __I  AFEC_CHSR_Type                 AFEC_CHSR;      /**< Offset: 0x1C (R/   32) AFEC Channel Status Register */
+  __I  AFEC_LCDR_Type                 AFEC_LCDR;      /**< Offset: 0x20 (R/   32) AFEC Last Converted Data Register */
+  __O  AFEC_IER_Type                  AFEC_IER;       /**< Offset: 0x24 ( /W  32) AFEC Interrupt Enable Register */
+  __O  AFEC_IDR_Type                  AFEC_IDR;       /**< Offset: 0x28 ( /W  32) AFEC Interrupt Disable Register */
+  __I  AFEC_IMR_Type                  AFEC_IMR;       /**< Offset: 0x2C (R/   32) AFEC Interrupt Mask Register */
+  __I  AFEC_ISR_Type                  AFEC_ISR;       /**< Offset: 0x30 (R/   32) AFEC Interrupt Status Register */
+  __I  uint8_t                        Reserved1[24];
+  __I  AFEC_OVER_Type                 AFEC_OVER;      /**< Offset: 0x4C (R/   32) AFEC Overrun Status Register */
+  __IO AFEC_CWR_Type                  AFEC_CWR;       /**< Offset: 0x50 (R/W  32) AFEC Compare Window Register */
+  __IO AFEC_CGR_Type                  AFEC_CGR;       /**< Offset: 0x54 (R/W  32) AFEC Channel Gain Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO AFEC_DIFFR_Type                AFEC_DIFFR;     /**< Offset: 0x60 (R/W  32) AFEC Channel Differential Register */
+  __IO AFEC_CSELR_Type                AFEC_CSELR;     /**< Offset: 0x64 (R/W  32) AFEC Channel Selection Register */
+  __I  AFEC_CDR_Type                  AFEC_CDR;       /**< Offset: 0x68 (R/   32) AFEC Channel Data Register */
+  __IO AFEC_COCR_Type                 AFEC_COCR;      /**< Offset: 0x6C (R/W  32) AFEC Channel Offset Compensation Register */
+  __IO AFEC_TEMPMR_Type               AFEC_TEMPMR;    /**< Offset: 0x70 (R/W  32) AFEC Temperature Sensor Mode Register */
+  __IO AFEC_TEMPCWR_Type              AFEC_TEMPCWR;   /**< Offset: 0x74 (R/W  32) AFEC Temperature Compare Window Register */
+  __I  uint8_t                        Reserved3[28];
+  __IO AFEC_ACR_Type                  AFEC_ACR;       /**< Offset: 0x94 (R/W  32) AFEC Analog Control Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO AFEC_SHMR_Type                 AFEC_SHMR;      /**< Offset: 0xA0 (R/W  32) AFEC Sample & Hold Mode Register */
+  __I  uint8_t                        Reserved5[44];
+  __IO AFEC_COSR_Type                 AFEC_COSR;      /**< Offset: 0xD0 (R/W  32) AFEC Correction Select Register */
+  __IO AFEC_CVR_Type                  AFEC_CVR;       /**< Offset: 0xD4 (R/W  32) AFEC Correction Values Register */
+  __IO AFEC_CECR_Type                 AFEC_CECR;      /**< Offset: 0xD8 (R/W  32) AFEC Channel Error Correction Register */
+  __I  uint8_t                        Reserved6[8];
+  __IO AFEC_WPMR_Type                 AFEC_WPMR;      /**< Offset: 0xE4 (R/W  32) AFEC Write Protection Mode Register */
+  __I  AFEC_WPSR_Type                 AFEC_WPSR;      /**< Offset: 0xE8 (R/   32) AFEC Write Protection Status Register */
+} Afec;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Analog Front-End Controller */
+
+#endif /* _SAMV71_AFEC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/chipid.h
+++ b/asf/sam/include/samv71b/component/chipid.h
@@ -1,0 +1,248 @@
+/**
+ * \file
+ *
+ * \brief Component description for CHIPID
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_CHIPID_COMPONENT_H_
+#define _SAMV71_CHIPID_COMPONENT_H_
+#define _SAMV71_CHIPID_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Chip Identifier
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CHIPID */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define CHIPID_6417                       /**< (CHIPID) Module ID */
+#define REV_CHIPID ZK                     /**< (CHIPID) Module revision */
+
+/* -------- CHIPID_CIDR : (CHIPID Offset: 0x00) (R/ 32) Chip ID Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VERSION:5;                 /**< bit:   0..4  Version of the Device                    */
+    uint32_t EPROC:3;                   /**< bit:   5..7  Embedded Processor                       */
+    uint32_t NVPSIZ:4;                  /**< bit:  8..11  Nonvolatile Program Memory Size          */
+    uint32_t NVPSIZ2:4;                 /**< bit: 12..15  Second Nonvolatile Program Memory Size   */
+    uint32_t SRAMSIZ:4;                 /**< bit: 16..19  Internal SRAM Size                       */
+    uint32_t ARCH:8;                    /**< bit: 20..27  Architecture Identifier                  */
+    uint32_t NVPTYP:3;                  /**< bit: 28..30  Nonvolatile Program Memory Type          */
+    uint32_t EXT:1;                     /**< bit:     31  Extension Flag                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CHIPID_CIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_CIDR_OFFSET                  (0x00)                                        /**<  (CHIPID_CIDR) Chip ID Register  Offset */
+
+#define CHIPID_CIDR_VERSION_Pos             0                                              /**< (CHIPID_CIDR) Version of the Device Position */
+#define CHIPID_CIDR_VERSION_Msk             (_U_(0x1F) << CHIPID_CIDR_VERSION_Pos)         /**< (CHIPID_CIDR) Version of the Device Mask */
+#define CHIPID_CIDR_VERSION(value)          (CHIPID_CIDR_VERSION_Msk & ((value) << CHIPID_CIDR_VERSION_Pos))
+#define CHIPID_CIDR_EPROC_Pos               5                                              /**< (CHIPID_CIDR) Embedded Processor Position */
+#define CHIPID_CIDR_EPROC_Msk               (_U_(0x7) << CHIPID_CIDR_EPROC_Pos)            /**< (CHIPID_CIDR) Embedded Processor Mask */
+#define CHIPID_CIDR_EPROC(value)            (CHIPID_CIDR_EPROC_Msk & ((value) << CHIPID_CIDR_EPROC_Pos))
+#define   CHIPID_CIDR_EPROC_SAMx7_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) Cortex-M7  */
+#define   CHIPID_CIDR_EPROC_ARM946ES_Val    _U_(0x1)                                       /**< (CHIPID_CIDR) ARM946ES  */
+#define   CHIPID_CIDR_EPROC_ARM7TDMI_Val    _U_(0x2)                                       /**< (CHIPID_CIDR) ARM7TDMI  */
+#define   CHIPID_CIDR_EPROC_CM3_Val         _U_(0x3)                                       /**< (CHIPID_CIDR) Cortex-M3  */
+#define   CHIPID_CIDR_EPROC_ARM920T_Val     _U_(0x4)                                       /**< (CHIPID_CIDR) ARM920T  */
+#define   CHIPID_CIDR_EPROC_ARM926EJS_Val   _U_(0x5)                                       /**< (CHIPID_CIDR) ARM926EJS  */
+#define   CHIPID_CIDR_EPROC_CA5_Val         _U_(0x6)                                       /**< (CHIPID_CIDR) Cortex-A5  */
+#define   CHIPID_CIDR_EPROC_CM4_Val         _U_(0x7)                                       /**< (CHIPID_CIDR) Cortex-M4  */
+#define CHIPID_CIDR_EPROC_SAMx7             (CHIPID_CIDR_EPROC_SAMx7_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M7 Position  */
+#define CHIPID_CIDR_EPROC_ARM946ES          (CHIPID_CIDR_EPROC_ARM946ES_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM946ES Position  */
+#define CHIPID_CIDR_EPROC_ARM7TDMI          (CHIPID_CIDR_EPROC_ARM7TDMI_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM7TDMI Position  */
+#define CHIPID_CIDR_EPROC_CM3               (CHIPID_CIDR_EPROC_CM3_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M3 Position  */
+#define CHIPID_CIDR_EPROC_ARM920T           (CHIPID_CIDR_EPROC_ARM920T_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM920T Position  */
+#define CHIPID_CIDR_EPROC_ARM926EJS         (CHIPID_CIDR_EPROC_ARM926EJS_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) ARM926EJS Position  */
+#define CHIPID_CIDR_EPROC_CA5               (CHIPID_CIDR_EPROC_CA5_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-A5 Position  */
+#define CHIPID_CIDR_EPROC_CM4               (CHIPID_CIDR_EPROC_CM4_Val << CHIPID_CIDR_EPROC_Pos)  /**< (CHIPID_CIDR) Cortex-M4 Position  */
+#define CHIPID_CIDR_NVPSIZ_Pos              8                                              /**< (CHIPID_CIDR) Nonvolatile Program Memory Size Position */
+#define CHIPID_CIDR_NVPSIZ_Msk              (_U_(0xF) << CHIPID_CIDR_NVPSIZ_Pos)           /**< (CHIPID_CIDR) Nonvolatile Program Memory Size Mask */
+#define CHIPID_CIDR_NVPSIZ(value)           (CHIPID_CIDR_NVPSIZ_Msk & ((value) << CHIPID_CIDR_NVPSIZ_Pos))
+#define   CHIPID_CIDR_NVPSIZ_NONE_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) None  */
+#define   CHIPID_CIDR_NVPSIZ_8K_Val         _U_(0x1)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_16K_Val        _U_(0x2)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_32K_Val        _U_(0x3)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_64K_Val        _U_(0x5)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_128K_Val       _U_(0x7)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_160K_Val       _U_(0x8)                                       /**< (CHIPID_CIDR) 160 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_256K_Val       _U_(0x9)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_512K_Val       _U_(0xA)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_1024K_Val      _U_(0xC)                                       /**< (CHIPID_CIDR) 1024 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ_2048K_Val      _U_(0xE)                                       /**< (CHIPID_CIDR) 2048 Kbytes  */
+#define CHIPID_CIDR_NVPSIZ_NONE             (CHIPID_CIDR_NVPSIZ_NONE_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) None Position  */
+#define CHIPID_CIDR_NVPSIZ_8K               (CHIPID_CIDR_NVPSIZ_8K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_16K              (CHIPID_CIDR_NVPSIZ_16K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_32K              (CHIPID_CIDR_NVPSIZ_32K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_64K              (CHIPID_CIDR_NVPSIZ_64K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_128K             (CHIPID_CIDR_NVPSIZ_128K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_160K             (CHIPID_CIDR_NVPSIZ_160K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 160 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_256K             (CHIPID_CIDR_NVPSIZ_256K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_512K             (CHIPID_CIDR_NVPSIZ_512K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_1024K            (CHIPID_CIDR_NVPSIZ_1024K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 1024 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ_2048K            (CHIPID_CIDR_NVPSIZ_2048K_Val << CHIPID_CIDR_NVPSIZ_Pos)  /**< (CHIPID_CIDR) 2048 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_Pos             12                                             /**< (CHIPID_CIDR) Second Nonvolatile Program Memory Size Position */
+#define CHIPID_CIDR_NVPSIZ2_Msk             (_U_(0xF) << CHIPID_CIDR_NVPSIZ2_Pos)          /**< (CHIPID_CIDR) Second Nonvolatile Program Memory Size Mask */
+#define CHIPID_CIDR_NVPSIZ2(value)          (CHIPID_CIDR_NVPSIZ2_Msk & ((value) << CHIPID_CIDR_NVPSIZ2_Pos))
+#define   CHIPID_CIDR_NVPSIZ2_NONE_Val      _U_(0x0)                                       /**< (CHIPID_CIDR) None  */
+#define   CHIPID_CIDR_NVPSIZ2_8K_Val        _U_(0x1)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_16K_Val       _U_(0x2)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_32K_Val       _U_(0x3)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_64K_Val       _U_(0x5)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_128K_Val      _U_(0x7)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_256K_Val      _U_(0x9)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_512K_Val      _U_(0xA)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_1024K_Val     _U_(0xC)                                       /**< (CHIPID_CIDR) 1024 Kbytes  */
+#define   CHIPID_CIDR_NVPSIZ2_2048K_Val     _U_(0xE)                                       /**< (CHIPID_CIDR) 2048 Kbytes  */
+#define CHIPID_CIDR_NVPSIZ2_NONE            (CHIPID_CIDR_NVPSIZ2_NONE_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) None Position  */
+#define CHIPID_CIDR_NVPSIZ2_8K              (CHIPID_CIDR_NVPSIZ2_8K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_16K             (CHIPID_CIDR_NVPSIZ2_16K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_32K             (CHIPID_CIDR_NVPSIZ2_32K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_64K             (CHIPID_CIDR_NVPSIZ2_64K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_128K            (CHIPID_CIDR_NVPSIZ2_128K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_256K            (CHIPID_CIDR_NVPSIZ2_256K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_512K            (CHIPID_CIDR_NVPSIZ2_512K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_1024K           (CHIPID_CIDR_NVPSIZ2_1024K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 1024 Kbytes Position  */
+#define CHIPID_CIDR_NVPSIZ2_2048K           (CHIPID_CIDR_NVPSIZ2_2048K_Val << CHIPID_CIDR_NVPSIZ2_Pos)  /**< (CHIPID_CIDR) 2048 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_Pos             16                                             /**< (CHIPID_CIDR) Internal SRAM Size Position */
+#define CHIPID_CIDR_SRAMSIZ_Msk             (_U_(0xF) << CHIPID_CIDR_SRAMSIZ_Pos)          /**< (CHIPID_CIDR) Internal SRAM Size Mask */
+#define CHIPID_CIDR_SRAMSIZ(value)          (CHIPID_CIDR_SRAMSIZ_Msk & ((value) << CHIPID_CIDR_SRAMSIZ_Pos))
+#define   CHIPID_CIDR_SRAMSIZ_48K_Val       _U_(0x0)                                       /**< (CHIPID_CIDR) 48 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_192K_Val      _U_(0x1)                                       /**< (CHIPID_CIDR) 192 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_384K_Val      _U_(0x2)                                       /**< (CHIPID_CIDR) 384 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_6K_Val        _U_(0x3)                                       /**< (CHIPID_CIDR) 6 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_24K_Val       _U_(0x4)                                       /**< (CHIPID_CIDR) 24 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_4K_Val        _U_(0x5)                                       /**< (CHIPID_CIDR) 4 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_80K_Val       _U_(0x6)                                       /**< (CHIPID_CIDR) 80 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_160K_Val      _U_(0x7)                                       /**< (CHIPID_CIDR) 160 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_8K_Val        _U_(0x8)                                       /**< (CHIPID_CIDR) 8 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_16K_Val       _U_(0x9)                                       /**< (CHIPID_CIDR) 16 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_32K_Val       _U_(0xA)                                       /**< (CHIPID_CIDR) 32 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_64K_Val       _U_(0xB)                                       /**< (CHIPID_CIDR) 64 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_128K_Val      _U_(0xC)                                       /**< (CHIPID_CIDR) 128 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_256K_Val      _U_(0xD)                                       /**< (CHIPID_CIDR) 256 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_96K_Val       _U_(0xE)                                       /**< (CHIPID_CIDR) 96 Kbytes  */
+#define   CHIPID_CIDR_SRAMSIZ_512K_Val      _U_(0xF)                                       /**< (CHIPID_CIDR) 512 Kbytes  */
+#define CHIPID_CIDR_SRAMSIZ_48K             (CHIPID_CIDR_SRAMSIZ_48K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 48 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_192K            (CHIPID_CIDR_SRAMSIZ_192K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 192 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_384K            (CHIPID_CIDR_SRAMSIZ_384K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 384 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_6K              (CHIPID_CIDR_SRAMSIZ_6K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 6 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_24K             (CHIPID_CIDR_SRAMSIZ_24K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 24 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_4K              (CHIPID_CIDR_SRAMSIZ_4K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 4 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_80K             (CHIPID_CIDR_SRAMSIZ_80K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 80 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_160K            (CHIPID_CIDR_SRAMSIZ_160K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 160 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_8K              (CHIPID_CIDR_SRAMSIZ_8K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 8 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_16K             (CHIPID_CIDR_SRAMSIZ_16K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 16 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_32K             (CHIPID_CIDR_SRAMSIZ_32K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 32 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_64K             (CHIPID_CIDR_SRAMSIZ_64K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 64 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_128K            (CHIPID_CIDR_SRAMSIZ_128K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 128 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_256K            (CHIPID_CIDR_SRAMSIZ_256K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 256 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_96K             (CHIPID_CIDR_SRAMSIZ_96K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 96 Kbytes Position  */
+#define CHIPID_CIDR_SRAMSIZ_512K            (CHIPID_CIDR_SRAMSIZ_512K_Val << CHIPID_CIDR_SRAMSIZ_Pos)  /**< (CHIPID_CIDR) 512 Kbytes Position  */
+#define CHIPID_CIDR_ARCH_Pos                20                                             /**< (CHIPID_CIDR) Architecture Identifier Position */
+#define CHIPID_CIDR_ARCH_Msk                (_U_(0xFF) << CHIPID_CIDR_ARCH_Pos)            /**< (CHIPID_CIDR) Architecture Identifier Mask */
+#define CHIPID_CIDR_ARCH(value)             (CHIPID_CIDR_ARCH_Msk & ((value) << CHIPID_CIDR_ARCH_Pos))
+#define   CHIPID_CIDR_ARCH_SAME70_Val       _U_(0x10)                                      /**< (CHIPID_CIDR) SAM E70  */
+#define   CHIPID_CIDR_ARCH_SAMS70_Val       _U_(0x11)                                      /**< (CHIPID_CIDR) SAM S70  */
+#define   CHIPID_CIDR_ARCH_SAMV71_Val       _U_(0x12)                                      /**< (CHIPID_CIDR) SAM V71  */
+#define   CHIPID_CIDR_ARCH_SAMV70_Val       _U_(0x13)                                      /**< (CHIPID_CIDR) SAM V70  */
+#define CHIPID_CIDR_ARCH_SAME70             (CHIPID_CIDR_ARCH_SAME70_Val << CHIPID_CIDR_ARCH_Pos)  /**< (CHIPID_CIDR) SAM E70 Position  */
+#define CHIPID_CIDR_ARCH_SAMS70             (CHIPID_CIDR_ARCH_SAMS70_Val << CHIPID_CIDR_ARCH_Pos)  /**< (CHIPID_CIDR) SAM S70 Position  */
+#define CHIPID_CIDR_ARCH_SAMV71             (CHIPID_CIDR_ARCH_SAMV71_Val << CHIPID_CIDR_ARCH_Pos)  /**< (CHIPID_CIDR) SAM V71 Position  */
+#define CHIPID_CIDR_ARCH_SAMV70             (CHIPID_CIDR_ARCH_SAMV70_Val << CHIPID_CIDR_ARCH_Pos)  /**< (CHIPID_CIDR) SAM V70 Position  */
+#define CHIPID_CIDR_NVPTYP_Pos              28                                             /**< (CHIPID_CIDR) Nonvolatile Program Memory Type Position */
+#define CHIPID_CIDR_NVPTYP_Msk              (_U_(0x7) << CHIPID_CIDR_NVPTYP_Pos)           /**< (CHIPID_CIDR) Nonvolatile Program Memory Type Mask */
+#define CHIPID_CIDR_NVPTYP(value)           (CHIPID_CIDR_NVPTYP_Msk & ((value) << CHIPID_CIDR_NVPTYP_Pos))
+#define   CHIPID_CIDR_NVPTYP_ROM_Val        _U_(0x0)                                       /**< (CHIPID_CIDR) ROM  */
+#define   CHIPID_CIDR_NVPTYP_ROMLESS_Val    _U_(0x1)                                       /**< (CHIPID_CIDR) ROMless or on-chip Flash  */
+#define   CHIPID_CIDR_NVPTYP_FLASH_Val      _U_(0x2)                                       /**< (CHIPID_CIDR) Embedded Flash Memory  */
+#define   CHIPID_CIDR_NVPTYP_ROM_FLASH_Val  _U_(0x3)                                       /**< (CHIPID_CIDR) ROM and Embedded Flash Memory- NVPSIZ is ROM size- NVPSIZ2 is Flash size  */
+#define   CHIPID_CIDR_NVPTYP_SRAM_Val       _U_(0x4)                                       /**< (CHIPID_CIDR) SRAM emulating ROM  */
+#define CHIPID_CIDR_NVPTYP_ROM              (CHIPID_CIDR_NVPTYP_ROM_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROM Position  */
+#define CHIPID_CIDR_NVPTYP_ROMLESS          (CHIPID_CIDR_NVPTYP_ROMLESS_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROMless or on-chip Flash Position  */
+#define CHIPID_CIDR_NVPTYP_FLASH            (CHIPID_CIDR_NVPTYP_FLASH_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) Embedded Flash Memory Position  */
+#define CHIPID_CIDR_NVPTYP_ROM_FLASH        (CHIPID_CIDR_NVPTYP_ROM_FLASH_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) ROM and Embedded Flash Memory- NVPSIZ is ROM size- NVPSIZ2 is Flash size Position  */
+#define CHIPID_CIDR_NVPTYP_SRAM             (CHIPID_CIDR_NVPTYP_SRAM_Val << CHIPID_CIDR_NVPTYP_Pos)  /**< (CHIPID_CIDR) SRAM emulating ROM Position  */
+#define CHIPID_CIDR_EXT_Pos                 31                                             /**< (CHIPID_CIDR) Extension Flag Position */
+#define CHIPID_CIDR_EXT_Msk                 (_U_(0x1) << CHIPID_CIDR_EXT_Pos)              /**< (CHIPID_CIDR) Extension Flag Mask */
+#define CHIPID_CIDR_EXT                     CHIPID_CIDR_EXT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use CHIPID_CIDR_EXT_Msk instead */
+#define CHIPID_CIDR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (CHIPID_CIDR) Register MASK  (Use CHIPID_CIDR_Msk instead)  */
+#define CHIPID_CIDR_Msk                     _U_(0xFFFFFFFF)                                /**< (CHIPID_CIDR) Register Mask  */
+
+
+/* -------- CHIPID_EXID : (CHIPID Offset: 0x04) (R/ 32) Chip ID Extension Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EXID:32;                   /**< bit:  0..31  Chip ID Extension                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CHIPID_EXID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_EXID_OFFSET                  (0x04)                                        /**<  (CHIPID_EXID) Chip ID Extension Register  Offset */
+
+#define CHIPID_EXID_EXID_Pos                0                                              /**< (CHIPID_EXID) Chip ID Extension Position */
+#define CHIPID_EXID_EXID_Msk                (_U_(0xFFFFFFFF) << CHIPID_EXID_EXID_Pos)      /**< (CHIPID_EXID) Chip ID Extension Mask */
+#define CHIPID_EXID_EXID(value)             (CHIPID_EXID_EXID_Msk & ((value) << CHIPID_EXID_EXID_Pos))
+#define CHIPID_EXID_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (CHIPID_EXID) Register MASK  (Use CHIPID_EXID_Msk instead)  */
+#define CHIPID_EXID_Msk                     _U_(0xFFFFFFFF)                                /**< (CHIPID_EXID) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief CHIPID hardware registers */
+typedef struct {  
+  __I  uint32_t CHIPID_CIDR;    /**< (CHIPID Offset: 0x00) Chip ID Register */
+  __I  uint32_t CHIPID_EXID;    /**< (CHIPID Offset: 0x04) Chip ID Extension Register */
+} Chipid;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief CHIPID hardware registers */
+typedef struct {  
+  __I  CHIPID_CIDR_Type               CHIPID_CIDR;    /**< Offset: 0x00 (R/   32) Chip ID Register */
+  __I  CHIPID_EXID_Type               CHIPID_EXID;    /**< Offset: 0x04 (R/   32) Chip ID Extension Register */
+} Chipid;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Chip Identifier */
+
+#endif /* _SAMV71_CHIPID_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/dacc.h
+++ b/asf/sam/include/samv71b/component/dacc.h
@@ -1,0 +1,713 @@
+/**
+ * \file
+ *
+ * \brief Component description for DACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_DACC_COMPONENT_H_
+#define _SAMV71_DACC_COMPONENT_H_
+#define _SAMV71_DACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Digital-to-Analog Converter Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DACC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define DACC_11246                      /**< (DACC) Module ID */
+#define REV_DACC E                      /**< (DACC) Module revision */
+
+/* -------- DACC_CR : (DACC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CR_OFFSET                      (0x00)                                        /**<  (DACC_CR) Control Register  Offset */
+
+#define DACC_CR_SWRST_Pos                   0                                              /**< (DACC_CR) Software Reset Position */
+#define DACC_CR_SWRST_Msk                   (_U_(0x1) << DACC_CR_SWRST_Pos)                /**< (DACC_CR) Software Reset Mask */
+#define DACC_CR_SWRST                       DACC_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CR_SWRST_Msk instead */
+#define DACC_CR_MASK                        _U_(0x01)                                      /**< \deprecated (DACC_CR) Register MASK  (Use DACC_CR_Msk instead)  */
+#define DACC_CR_Msk                         _U_(0x01)                                      /**< (DACC_CR) Register Mask  */
+
+
+/* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXS0:1;                   /**< bit:      0  Max Speed Mode for Channel 0             */
+    uint32_t MAXS1:1;                   /**< bit:      1  Max Speed Mode for Channel 1             */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t WORD:1;                    /**< bit:      4  Word Transfer Mode                       */
+    uint32_t ZERO:1;                    /**< bit:      5  Must always be written to 0.             */
+    uint32_t :17;                       /**< bit:  6..22  Reserved */
+    uint32_t DIFF:1;                    /**< bit:     23  Differential Mode                        */
+    uint32_t PRESCALER:4;               /**< bit: 24..27  Peripheral Clock to DAC Clock Ratio      */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t MAXS:2;                    /**< bit:   0..1  Max Speed Mode for Channel x             */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_MR_OFFSET                      (0x04)                                        /**<  (DACC_MR) Mode Register  Offset */
+
+#define DACC_MR_MAXS0_Pos                   0                                              /**< (DACC_MR) Max Speed Mode for Channel 0 Position */
+#define DACC_MR_MAXS0_Msk                   (_U_(0x1) << DACC_MR_MAXS0_Pos)                /**< (DACC_MR) Max Speed Mode for Channel 0 Mask */
+#define DACC_MR_MAXS0                       DACC_MR_MAXS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_MAXS0_Msk instead */
+#define   DACC_MR_MAXS0_TRIG_EVENT_Val      _U_(0x0)                                       /**< (DACC_MR) External trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.)  */
+#define   DACC_MR_MAXS0_MAXIMUM_Val         _U_(0x1)                                       /**< (DACC_MR) Max speed mode enabled.  */
+#define DACC_MR_MAXS0_TRIG_EVENT            (DACC_MR_MAXS0_TRIG_EVENT_Val << DACC_MR_MAXS0_Pos)  /**< (DACC_MR) External trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.) Position  */
+#define DACC_MR_MAXS0_MAXIMUM               (DACC_MR_MAXS0_MAXIMUM_Val << DACC_MR_MAXS0_Pos)  /**< (DACC_MR) Max speed mode enabled. Position  */
+#define DACC_MR_MAXS1_Pos                   1                                              /**< (DACC_MR) Max Speed Mode for Channel 1 Position */
+#define DACC_MR_MAXS1_Msk                   (_U_(0x1) << DACC_MR_MAXS1_Pos)                /**< (DACC_MR) Max Speed Mode for Channel 1 Mask */
+#define DACC_MR_MAXS1                       DACC_MR_MAXS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_MAXS1_Msk instead */
+#define   DACC_MR_MAXS1_TRIG_EVENT_Val      _U_(0x0)                                       /**< (DACC_MR) External trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.)  */
+#define   DACC_MR_MAXS1_MAXIMUM_Val         _U_(0x1)                                       /**< (DACC_MR) Max speed mode enabled.  */
+#define DACC_MR_MAXS1_TRIG_EVENT            (DACC_MR_MAXS1_TRIG_EVENT_Val << DACC_MR_MAXS1_Pos)  /**< (DACC_MR) External trigger mode or Free-running mode enabled. (See TRGENx.DACC_TRIGR.) Position  */
+#define DACC_MR_MAXS1_MAXIMUM               (DACC_MR_MAXS1_MAXIMUM_Val << DACC_MR_MAXS1_Pos)  /**< (DACC_MR) Max speed mode enabled. Position  */
+#define DACC_MR_WORD_Pos                    4                                              /**< (DACC_MR) Word Transfer Mode Position */
+#define DACC_MR_WORD_Msk                    (_U_(0x1) << DACC_MR_WORD_Pos)                 /**< (DACC_MR) Word Transfer Mode Mask */
+#define DACC_MR_WORD                        DACC_MR_WORD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_WORD_Msk instead */
+#define   DACC_MR_WORD_DISABLED_Val         _U_(0x0)                                       /**< (DACC_MR) One data to convert is written to the FIFO per access to DACC.  */
+#define   DACC_MR_WORD_ENABLED_Val          _U_(0x1)                                       /**< (DACC_MR) Two data to convert are written to the FIFO per access to DACC (reduces the number of requests to DMA and the number of system bus accesses).  */
+#define DACC_MR_WORD_DISABLED               (DACC_MR_WORD_DISABLED_Val << DACC_MR_WORD_Pos)  /**< (DACC_MR) One data to convert is written to the FIFO per access to DACC. Position  */
+#define DACC_MR_WORD_ENABLED                (DACC_MR_WORD_ENABLED_Val << DACC_MR_WORD_Pos)  /**< (DACC_MR) Two data to convert are written to the FIFO per access to DACC (reduces the number of requests to DMA and the number of system bus accesses). Position  */
+#define DACC_MR_ZERO_Pos                    5                                              /**< (DACC_MR) Must always be written to 0. Position */
+#define DACC_MR_ZERO_Msk                    (_U_(0x1) << DACC_MR_ZERO_Pos)                 /**< (DACC_MR) Must always be written to 0. Mask */
+#define DACC_MR_ZERO                        DACC_MR_ZERO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_ZERO_Msk instead */
+#define DACC_MR_DIFF_Pos                    23                                             /**< (DACC_MR) Differential Mode Position */
+#define DACC_MR_DIFF_Msk                    (_U_(0x1) << DACC_MR_DIFF_Pos)                 /**< (DACC_MR) Differential Mode Mask */
+#define DACC_MR_DIFF                        DACC_MR_DIFF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_MR_DIFF_Msk instead */
+#define   DACC_MR_DIFF_DISABLED_Val         _U_(0x0)                                       /**< (DACC_MR) DAC0 and DAC1 are single-ended outputs.  */
+#define   DACC_MR_DIFF_ENABLED_Val          _U_(0x1)                                       /**< (DACC_MR) DACP and DACN are differential outputs. The differential level is configured by the channel 0 value.  */
+#define DACC_MR_DIFF_DISABLED               (DACC_MR_DIFF_DISABLED_Val << DACC_MR_DIFF_Pos)  /**< (DACC_MR) DAC0 and DAC1 are single-ended outputs. Position  */
+#define DACC_MR_DIFF_ENABLED                (DACC_MR_DIFF_ENABLED_Val << DACC_MR_DIFF_Pos)  /**< (DACC_MR) DACP and DACN are differential outputs. The differential level is configured by the channel 0 value. Position  */
+#define DACC_MR_PRESCALER_Pos               24                                             /**< (DACC_MR) Peripheral Clock to DAC Clock Ratio Position */
+#define DACC_MR_PRESCALER_Msk               (_U_(0xF) << DACC_MR_PRESCALER_Pos)            /**< (DACC_MR) Peripheral Clock to DAC Clock Ratio Mask */
+#define DACC_MR_PRESCALER(value)            (DACC_MR_PRESCALER_Msk & ((value) << DACC_MR_PRESCALER_Pos))
+#define DACC_MR_MASK                        _U_(0xF800033)                                 /**< \deprecated (DACC_MR) Register MASK  (Use DACC_MR_Msk instead)  */
+#define DACC_MR_Msk                         _U_(0xF800033)                                 /**< (DACC_MR) Register Mask  */
+
+#define DACC_MR_MAXS_Pos                    0                                              /**< (DACC_MR Position) Max Speed Mode for Channel x */
+#define DACC_MR_MAXS_Msk                    (_U_(0x3) << DACC_MR_MAXS_Pos)                 /**< (DACC_MR Mask) MAXS */
+#define DACC_MR_MAXS(value)                 (DACC_MR_MAXS_Msk & ((value) << DACC_MR_MAXS_Pos))  
+
+/* -------- DACC_TRIGR : (DACC Offset: 0x08) (R/W 32) Trigger Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRGEN0:1;                  /**< bit:      0  Trigger Enable of Channel 0              */
+    uint32_t TRGEN1:1;                  /**< bit:      1  Trigger Enable of Channel 1              */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t TRGSEL0:3;                 /**< bit:   4..6  Trigger Selection of Channel 0           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TRGSEL1:3;                 /**< bit:  8..10  Trigger Selection of Channel 1           */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t OSR0:3;                    /**< bit: 16..18  Over Sampling Ratio of Channel 0         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t OSR1:3;                    /**< bit: 20..22  Over Sampling Ratio of Channel 1         */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TRGEN:2;                   /**< bit:   0..1  Trigger Enable of Channel x              */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_TRIGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_TRIGR_OFFSET                   (0x08)                                        /**<  (DACC_TRIGR) Trigger Register  Offset */
+
+#define DACC_TRIGR_TRGEN0_Pos               0                                              /**< (DACC_TRIGR) Trigger Enable of Channel 0 Position */
+#define DACC_TRIGR_TRGEN0_Msk               (_U_(0x1) << DACC_TRIGR_TRGEN0_Pos)            /**< (DACC_TRIGR) Trigger Enable of Channel 0 Mask */
+#define DACC_TRIGR_TRGEN0                   DACC_TRIGR_TRGEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_TRIGR_TRGEN0_Msk instead */
+#define   DACC_TRIGR_TRGEN0_DIS_Val         _U_(0x0)                                       /**< (DACC_TRIGR) External trigger mode disabled. DACC is in Free-running mode or Max speed mode.  */
+#define   DACC_TRIGR_TRGEN0_EN_Val          _U_(0x1)                                       /**< (DACC_TRIGR) External trigger mode enabled.  */
+#define DACC_TRIGR_TRGEN0_DIS               (DACC_TRIGR_TRGEN0_DIS_Val << DACC_TRIGR_TRGEN0_Pos)  /**< (DACC_TRIGR) External trigger mode disabled. DACC is in Free-running mode or Max speed mode. Position  */
+#define DACC_TRIGR_TRGEN0_EN                (DACC_TRIGR_TRGEN0_EN_Val << DACC_TRIGR_TRGEN0_Pos)  /**< (DACC_TRIGR) External trigger mode enabled. Position  */
+#define DACC_TRIGR_TRGEN1_Pos               1                                              /**< (DACC_TRIGR) Trigger Enable of Channel 1 Position */
+#define DACC_TRIGR_TRGEN1_Msk               (_U_(0x1) << DACC_TRIGR_TRGEN1_Pos)            /**< (DACC_TRIGR) Trigger Enable of Channel 1 Mask */
+#define DACC_TRIGR_TRGEN1                   DACC_TRIGR_TRGEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_TRIGR_TRGEN1_Msk instead */
+#define   DACC_TRIGR_TRGEN1_DIS_Val         _U_(0x0)                                       /**< (DACC_TRIGR) External trigger mode disabled. DACC is in Free-running mode or Max speed mode.  */
+#define   DACC_TRIGR_TRGEN1_EN_Val          _U_(0x1)                                       /**< (DACC_TRIGR) External trigger mode enabled.  */
+#define DACC_TRIGR_TRGEN1_DIS               (DACC_TRIGR_TRGEN1_DIS_Val << DACC_TRIGR_TRGEN1_Pos)  /**< (DACC_TRIGR) External trigger mode disabled. DACC is in Free-running mode or Max speed mode. Position  */
+#define DACC_TRIGR_TRGEN1_EN                (DACC_TRIGR_TRGEN1_EN_Val << DACC_TRIGR_TRGEN1_Pos)  /**< (DACC_TRIGR) External trigger mode enabled. Position  */
+#define DACC_TRIGR_TRGSEL0_Pos              4                                              /**< (DACC_TRIGR) Trigger Selection of Channel 0 Position */
+#define DACC_TRIGR_TRGSEL0_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL0_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 0 Mask */
+#define DACC_TRIGR_TRGSEL0(value)           (DACC_TRIGR_TRGSEL0_Msk & ((value) << DACC_TRIGR_TRGSEL0_Pos))
+#define   DACC_TRIGR_TRGSEL0_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DAC External Trigger Input (DATRG)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 Event Line 1  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 Event Line 1  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL0          (DACC_TRIGR_TRGSEL0_TRGSEL0_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) DAC External Trigger Input (DATRG) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL1          (DACC_TRIGR_TRGSEL0_TRGSEL1_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL2          (DACC_TRIGR_TRGSEL0_TRGSEL2_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL3          (DACC_TRIGR_TRGSEL0_TRGSEL3_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL4          (DACC_TRIGR_TRGSEL0_TRGSEL4_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL5          (DACC_TRIGR_TRGSEL0_TRGSEL5_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 1 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL6          (DACC_TRIGR_TRGSEL0_TRGSEL6_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL7          (DACC_TRIGR_TRGSEL0_TRGSEL7_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 1 Position  */
+#define DACC_TRIGR_TRGSEL1_Pos              8                                              /**< (DACC_TRIGR) Trigger Selection of Channel 1 Position */
+#define DACC_TRIGR_TRGSEL1_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL1_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 1 Mask */
+#define DACC_TRIGR_TRGSEL1(value)           (DACC_TRIGR_TRGSEL1_Msk & ((value) << DACC_TRIGR_TRGSEL1_Pos))
+#define   DACC_TRIGR_TRGSEL1_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DAC External Trigger Input (DATRG)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 Event Line 1  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 Event Line 1  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL0          (DACC_TRIGR_TRGSEL1_TRGSEL0_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) DAC External Trigger Input (DATRG) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL1          (DACC_TRIGR_TRGSEL1_TRGSEL1_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL2          (DACC_TRIGR_TRGSEL1_TRGSEL2_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL3          (DACC_TRIGR_TRGSEL1_TRGSEL3_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL4          (DACC_TRIGR_TRGSEL1_TRGSEL4_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL5          (DACC_TRIGR_TRGSEL1_TRGSEL5_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 1 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL6          (DACC_TRIGR_TRGSEL1_TRGSEL6_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL7          (DACC_TRIGR_TRGSEL1_TRGSEL7_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 1 Position  */
+#define DACC_TRIGR_OSR0_Pos                 16                                             /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Position */
+#define DACC_TRIGR_OSR0_Msk                 (_U_(0x7) << DACC_TRIGR_OSR0_Pos)              /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Mask */
+#define DACC_TRIGR_OSR0(value)              (DACC_TRIGR_OSR0_Msk & ((value) << DACC_TRIGR_OSR0_Pos))
+#define   DACC_TRIGR_OSR0_OSR_1_Val         _U_(0x0)                                       /**< (DACC_TRIGR) OSR = 1  */
+#define   DACC_TRIGR_OSR0_OSR_2_Val         _U_(0x1)                                       /**< (DACC_TRIGR) OSR = 2  */
+#define   DACC_TRIGR_OSR0_OSR_4_Val         _U_(0x2)                                       /**< (DACC_TRIGR) OSR = 4  */
+#define   DACC_TRIGR_OSR0_OSR_8_Val         _U_(0x3)                                       /**< (DACC_TRIGR) OSR = 8  */
+#define   DACC_TRIGR_OSR0_OSR_16_Val        _U_(0x4)                                       /**< (DACC_TRIGR) OSR = 16  */
+#define   DACC_TRIGR_OSR0_OSR_32_Val        _U_(0x5)                                       /**< (DACC_TRIGR) OSR = 32  */
+#define DACC_TRIGR_OSR0_OSR_1               (DACC_TRIGR_OSR0_OSR_1_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 1 Position  */
+#define DACC_TRIGR_OSR0_OSR_2               (DACC_TRIGR_OSR0_OSR_2_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 2 Position  */
+#define DACC_TRIGR_OSR0_OSR_4               (DACC_TRIGR_OSR0_OSR_4_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 4 Position  */
+#define DACC_TRIGR_OSR0_OSR_8               (DACC_TRIGR_OSR0_OSR_8_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 8 Position  */
+#define DACC_TRIGR_OSR0_OSR_16              (DACC_TRIGR_OSR0_OSR_16_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 16 Position  */
+#define DACC_TRIGR_OSR0_OSR_32              (DACC_TRIGR_OSR0_OSR_32_Val << DACC_TRIGR_OSR0_Pos)  /**< (DACC_TRIGR) OSR = 32 Position  */
+#define DACC_TRIGR_OSR1_Pos                 20                                             /**< (DACC_TRIGR) Over Sampling Ratio of Channel 1 Position */
+#define DACC_TRIGR_OSR1_Msk                 (_U_(0x7) << DACC_TRIGR_OSR1_Pos)              /**< (DACC_TRIGR) Over Sampling Ratio of Channel 1 Mask */
+#define DACC_TRIGR_OSR1(value)              (DACC_TRIGR_OSR1_Msk & ((value) << DACC_TRIGR_OSR1_Pos))
+#define   DACC_TRIGR_OSR1_OSR_1_Val         _U_(0x0)                                       /**< (DACC_TRIGR) OSR = 1  */
+#define   DACC_TRIGR_OSR1_OSR_2_Val         _U_(0x1)                                       /**< (DACC_TRIGR) OSR = 2  */
+#define   DACC_TRIGR_OSR1_OSR_4_Val         _U_(0x2)                                       /**< (DACC_TRIGR) OSR = 4  */
+#define   DACC_TRIGR_OSR1_OSR_8_Val         _U_(0x3)                                       /**< (DACC_TRIGR) OSR = 8  */
+#define   DACC_TRIGR_OSR1_OSR_16_Val        _U_(0x4)                                       /**< (DACC_TRIGR) OSR = 16  */
+#define   DACC_TRIGR_OSR1_OSR_32_Val        _U_(0x5)                                       /**< (DACC_TRIGR) OSR = 32  */
+#define DACC_TRIGR_OSR1_OSR_1               (DACC_TRIGR_OSR1_OSR_1_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 1 Position  */
+#define DACC_TRIGR_OSR1_OSR_2               (DACC_TRIGR_OSR1_OSR_2_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 2 Position  */
+#define DACC_TRIGR_OSR1_OSR_4               (DACC_TRIGR_OSR1_OSR_4_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 4 Position  */
+#define DACC_TRIGR_OSR1_OSR_8               (DACC_TRIGR_OSR1_OSR_8_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 8 Position  */
+#define DACC_TRIGR_OSR1_OSR_16              (DACC_TRIGR_OSR1_OSR_16_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 16 Position  */
+#define DACC_TRIGR_OSR1_OSR_32              (DACC_TRIGR_OSR1_OSR_32_Val << DACC_TRIGR_OSR1_Pos)  /**< (DACC_TRIGR) OSR = 32 Position  */
+#define DACC_TRIGR_MASK                     _U_(0x770773)                                  /**< \deprecated (DACC_TRIGR) Register MASK  (Use DACC_TRIGR_Msk instead)  */
+#define DACC_TRIGR_Msk                      _U_(0x770773)                                  /**< (DACC_TRIGR) Register Mask  */
+
+#define DACC_TRIGR_TRGEN_Pos                0                                              /**< (DACC_TRIGR Position) Trigger Enable of Channel x */
+#define DACC_TRIGR_TRGEN_Msk                (_U_(0x3) << DACC_TRIGR_TRGEN_Pos)             /**< (DACC_TRIGR Mask) TRGEN */
+#define DACC_TRIGR_TRGEN(value)             (DACC_TRIGR_TRGEN_Msk & ((value) << DACC_TRIGR_TRGEN_Pos))  
+
+/* -------- DACC_CHER : (DACC Offset: 0x10) (/W 32) Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Enable                         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Enable                         */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHER_OFFSET                    (0x10)                                        /**<  (DACC_CHER) Channel Enable Register  Offset */
+
+#define DACC_CHER_CH0_Pos                   0                                              /**< (DACC_CHER) Channel 0 Enable Position */
+#define DACC_CHER_CH0_Msk                   (_U_(0x1) << DACC_CHER_CH0_Pos)                /**< (DACC_CHER) Channel 0 Enable Mask */
+#define DACC_CHER_CH0                       DACC_CHER_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHER_CH0_Msk instead */
+#define DACC_CHER_CH1_Pos                   1                                              /**< (DACC_CHER) Channel 1 Enable Position */
+#define DACC_CHER_CH1_Msk                   (_U_(0x1) << DACC_CHER_CH1_Pos)                /**< (DACC_CHER) Channel 1 Enable Mask */
+#define DACC_CHER_CH1                       DACC_CHER_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHER_CH1_Msk instead */
+#define DACC_CHER_MASK                      _U_(0x03)                                      /**< \deprecated (DACC_CHER) Register MASK  (Use DACC_CHER_Msk instead)  */
+#define DACC_CHER_Msk                       _U_(0x03)                                      /**< (DACC_CHER) Register Mask  */
+
+#define DACC_CHER_CH_Pos                    0                                              /**< (DACC_CHER Position) Channel x Enable */
+#define DACC_CHER_CH_Msk                    (_U_(0x3) << DACC_CHER_CH_Pos)                 /**< (DACC_CHER Mask) CH */
+#define DACC_CHER_CH(value)                 (DACC_CHER_CH_Msk & ((value) << DACC_CHER_CH_Pos))  
+
+/* -------- DACC_CHDR : (DACC Offset: 0x14) (/W 32) Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Disable                        */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Disable                        */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHDR_OFFSET                    (0x14)                                        /**<  (DACC_CHDR) Channel Disable Register  Offset */
+
+#define DACC_CHDR_CH0_Pos                   0                                              /**< (DACC_CHDR) Channel 0 Disable Position */
+#define DACC_CHDR_CH0_Msk                   (_U_(0x1) << DACC_CHDR_CH0_Pos)                /**< (DACC_CHDR) Channel 0 Disable Mask */
+#define DACC_CHDR_CH0                       DACC_CHDR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHDR_CH0_Msk instead */
+#define DACC_CHDR_CH1_Pos                   1                                              /**< (DACC_CHDR) Channel 1 Disable Position */
+#define DACC_CHDR_CH1_Msk                   (_U_(0x1) << DACC_CHDR_CH1_Pos)                /**< (DACC_CHDR) Channel 1 Disable Mask */
+#define DACC_CHDR_CH1                       DACC_CHDR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHDR_CH1_Msk instead */
+#define DACC_CHDR_MASK                      _U_(0x03)                                      /**< \deprecated (DACC_CHDR) Register MASK  (Use DACC_CHDR_Msk instead)  */
+#define DACC_CHDR_Msk                       _U_(0x03)                                      /**< (DACC_CHDR) Register Mask  */
+
+#define DACC_CHDR_CH_Pos                    0                                              /**< (DACC_CHDR Position) Channel x Disable */
+#define DACC_CHDR_CH_Msk                    (_U_(0x3) << DACC_CHDR_CH_Pos)                 /**< (DACC_CHDR Mask) CH */
+#define DACC_CHDR_CH(value)                 (DACC_CHDR_CH_Msk & ((value) << DACC_CHDR_CH_Pos))  
+
+/* -------- DACC_CHSR : (DACC Offset: 0x18) (R/ 32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
+    uint32_t CH1:1;                     /**< bit:      1  Channel 1 Status                         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t DACRDY0:1;                 /**< bit:      8  DAC Ready Flag                           */
+    uint32_t DACRDY1:1;                 /**< bit:      9  DAC Ready Flag                           */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CH:2;                      /**< bit:   0..1  Channel x Status                         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t DACRDY:2;                  /**< bit:   8..9  DAC Ready Flag                           */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CHSR_OFFSET                    (0x18)                                        /**<  (DACC_CHSR) Channel Status Register  Offset */
+
+#define DACC_CHSR_CH0_Pos                   0                                              /**< (DACC_CHSR) Channel 0 Status Position */
+#define DACC_CHSR_CH0_Msk                   (_U_(0x1) << DACC_CHSR_CH0_Pos)                /**< (DACC_CHSR) Channel 0 Status Mask */
+#define DACC_CHSR_CH0                       DACC_CHSR_CH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_CH0_Msk instead */
+#define DACC_CHSR_CH1_Pos                   1                                              /**< (DACC_CHSR) Channel 1 Status Position */
+#define DACC_CHSR_CH1_Msk                   (_U_(0x1) << DACC_CHSR_CH1_Pos)                /**< (DACC_CHSR) Channel 1 Status Mask */
+#define DACC_CHSR_CH1                       DACC_CHSR_CH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_CH1_Msk instead */
+#define DACC_CHSR_DACRDY0_Pos               8                                              /**< (DACC_CHSR) DAC Ready Flag Position */
+#define DACC_CHSR_DACRDY0_Msk               (_U_(0x1) << DACC_CHSR_DACRDY0_Pos)            /**< (DACC_CHSR) DAC Ready Flag Mask */
+#define DACC_CHSR_DACRDY0                   DACC_CHSR_DACRDY0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_DACRDY0_Msk instead */
+#define DACC_CHSR_DACRDY1_Pos               9                                              /**< (DACC_CHSR) DAC Ready Flag Position */
+#define DACC_CHSR_DACRDY1_Msk               (_U_(0x1) << DACC_CHSR_DACRDY1_Pos)            /**< (DACC_CHSR) DAC Ready Flag Mask */
+#define DACC_CHSR_DACRDY1                   DACC_CHSR_DACRDY1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_CHSR_DACRDY1_Msk instead */
+#define DACC_CHSR_MASK                      _U_(0x303)                                     /**< \deprecated (DACC_CHSR) Register MASK  (Use DACC_CHSR_Msk instead)  */
+#define DACC_CHSR_Msk                       _U_(0x303)                                     /**< (DACC_CHSR) Register Mask  */
+
+#define DACC_CHSR_CH_Pos                    0                                              /**< (DACC_CHSR Position) Channel x Status */
+#define DACC_CHSR_CH_Msk                    (_U_(0x3) << DACC_CHSR_CH_Pos)                 /**< (DACC_CHSR Mask) CH */
+#define DACC_CHSR_CH(value)                 (DACC_CHSR_CH_Msk & ((value) << DACC_CHSR_CH_Pos))  
+#define DACC_CHSR_DACRDY_Pos                8                                              /**< (DACC_CHSR Position) DAC Ready Flag */
+#define DACC_CHSR_DACRDY_Msk                (_U_(0x3) << DACC_CHSR_DACRDY_Pos)             /**< (DACC_CHSR Mask) DACRDY */
+#define DACC_CHSR_DACRDY(value)             (DACC_CHSR_DACRDY_Msk & ((value) << DACC_CHSR_DACRDY_Pos))  
+
+/* -------- DACC_CDR : (DACC Offset: 0x1c) (/W 32) Conversion Data Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA0:16;                  /**< bit:  0..15  Data to Convert for channel 0            */
+    uint32_t DATA1:16;                  /**< bit: 16..31  Data to Convert for channel 1            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_CDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CDR_OFFSET                     (0x1C)                                        /**<  (DACC_CDR) Conversion Data Register 0  Offset */
+
+#define DACC_CDR_DATA0_Pos                  0                                              /**< (DACC_CDR) Data to Convert for channel 0 Position */
+#define DACC_CDR_DATA0_Msk                  (_U_(0xFFFF) << DACC_CDR_DATA0_Pos)            /**< (DACC_CDR) Data to Convert for channel 0 Mask */
+#define DACC_CDR_DATA0(value)               (DACC_CDR_DATA0_Msk & ((value) << DACC_CDR_DATA0_Pos))
+#define DACC_CDR_DATA1_Pos                  16                                             /**< (DACC_CDR) Data to Convert for channel 1 Position */
+#define DACC_CDR_DATA1_Msk                  (_U_(0xFFFF) << DACC_CDR_DATA1_Pos)            /**< (DACC_CDR) Data to Convert for channel 1 Mask */
+#define DACC_CDR_DATA1(value)               (DACC_CDR_DATA1_Msk & ((value) << DACC_CDR_DATA1_Pos))
+#define DACC_CDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (DACC_CDR) Register MASK  (Use DACC_CDR_Msk instead)  */
+#define DACC_CDR_Msk                        _U_(0xFFFFFFFF)                                /**< (DACC_CDR) Register Mask  */
+
+
+/* -------- DACC_IER : (DACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Enable of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Enable of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Enable of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Enable of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Enable of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Enable of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IER_OFFSET                     (0x24)                                        /**<  (DACC_IER) Interrupt Enable Register  Offset */
+
+#define DACC_IER_TXRDY0_Pos                 0                                              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 0 Position */
+#define DACC_IER_TXRDY0_Msk                 (_U_(0x1) << DACC_IER_TXRDY0_Pos)              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 0 Mask */
+#define DACC_IER_TXRDY0                     DACC_IER_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_TXRDY0_Msk instead */
+#define DACC_IER_TXRDY1_Pos                 1                                              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 1 Position */
+#define DACC_IER_TXRDY1_Msk                 (_U_(0x1) << DACC_IER_TXRDY1_Pos)              /**< (DACC_IER) Transmit Ready Interrupt Enable of channel 1 Mask */
+#define DACC_IER_TXRDY1                     DACC_IER_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_TXRDY1_Msk instead */
+#define DACC_IER_EOC0_Pos                   4                                              /**< (DACC_IER) End of Conversion Interrupt Enable of channel 0 Position */
+#define DACC_IER_EOC0_Msk                   (_U_(0x1) << DACC_IER_EOC0_Pos)                /**< (DACC_IER) End of Conversion Interrupt Enable of channel 0 Mask */
+#define DACC_IER_EOC0                       DACC_IER_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_EOC0_Msk instead */
+#define DACC_IER_EOC1_Pos                   5                                              /**< (DACC_IER) End of Conversion Interrupt Enable of channel 1 Position */
+#define DACC_IER_EOC1_Msk                   (_U_(0x1) << DACC_IER_EOC1_Pos)                /**< (DACC_IER) End of Conversion Interrupt Enable of channel 1 Mask */
+#define DACC_IER_EOC1                       DACC_IER_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IER_EOC1_Msk instead */
+#define DACC_IER_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IER) Register MASK  (Use DACC_IER_Msk instead)  */
+#define DACC_IER_Msk                        _U_(0x33)                                      /**< (DACC_IER) Register Mask  */
+
+#define DACC_IER_TXRDY_Pos                  0                                              /**< (DACC_IER Position) Transmit Ready Interrupt Enable of channel x */
+#define DACC_IER_TXRDY_Msk                  (_U_(0x3) << DACC_IER_TXRDY_Pos)               /**< (DACC_IER Mask) TXRDY */
+#define DACC_IER_TXRDY(value)               (DACC_IER_TXRDY_Msk & ((value) << DACC_IER_TXRDY_Pos))  
+#define DACC_IER_EOC_Pos                    4                                              /**< (DACC_IER Position) End of Conversion Interrupt Enable of channel x */
+#define DACC_IER_EOC_Msk                    (_U_(0x3) << DACC_IER_EOC_Pos)                 /**< (DACC_IER Mask) EOC */
+#define DACC_IER_EOC(value)                 (DACC_IER_EOC_Msk & ((value) << DACC_IER_EOC_Pos))  
+
+/* -------- DACC_IDR : (DACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Disable of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Disable of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Disable of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Disable of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Disable of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Disable of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IDR_OFFSET                     (0x28)                                        /**<  (DACC_IDR) Interrupt Disable Register  Offset */
+
+#define DACC_IDR_TXRDY0_Pos                 0                                              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 0 Position */
+#define DACC_IDR_TXRDY0_Msk                 (_U_(0x1) << DACC_IDR_TXRDY0_Pos)              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 0 Mask */
+#define DACC_IDR_TXRDY0                     DACC_IDR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_TXRDY0_Msk instead */
+#define DACC_IDR_TXRDY1_Pos                 1                                              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 1 Position */
+#define DACC_IDR_TXRDY1_Msk                 (_U_(0x1) << DACC_IDR_TXRDY1_Pos)              /**< (DACC_IDR) Transmit Ready Interrupt Disable of channel 1 Mask */
+#define DACC_IDR_TXRDY1                     DACC_IDR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_TXRDY1_Msk instead */
+#define DACC_IDR_EOC0_Pos                   4                                              /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 0 Position */
+#define DACC_IDR_EOC0_Msk                   (_U_(0x1) << DACC_IDR_EOC0_Pos)                /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 0 Mask */
+#define DACC_IDR_EOC0                       DACC_IDR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_EOC0_Msk instead */
+#define DACC_IDR_EOC1_Pos                   5                                              /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 1 Position */
+#define DACC_IDR_EOC1_Msk                   (_U_(0x1) << DACC_IDR_EOC1_Pos)                /**< (DACC_IDR) End of Conversion Interrupt Disable of channel 1 Mask */
+#define DACC_IDR_EOC1                       DACC_IDR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IDR_EOC1_Msk instead */
+#define DACC_IDR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IDR) Register MASK  (Use DACC_IDR_Msk instead)  */
+#define DACC_IDR_Msk                        _U_(0x33)                                      /**< (DACC_IDR) Register Mask  */
+
+#define DACC_IDR_TXRDY_Pos                  0                                              /**< (DACC_IDR Position) Transmit Ready Interrupt Disable of channel x */
+#define DACC_IDR_TXRDY_Msk                  (_U_(0x3) << DACC_IDR_TXRDY_Pos)               /**< (DACC_IDR Mask) TXRDY */
+#define DACC_IDR_TXRDY(value)               (DACC_IDR_TXRDY_Msk & ((value) << DACC_IDR_TXRDY_Pos))  
+#define DACC_IDR_EOC_Pos                    4                                              /**< (DACC_IDR Position) End of Conversion Interrupt Disable of channel x */
+#define DACC_IDR_EOC_Msk                    (_U_(0x3) << DACC_IDR_EOC_Pos)                 /**< (DACC_IDR Mask) EOC */
+#define DACC_IDR_EOC(value)                 (DACC_IDR_EOC_Msk & ((value) << DACC_IDR_EOC_Pos))  
+
+/* -------- DACC_IMR : (DACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Mask of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Mask of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Mask of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Mask of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Mask of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Mask of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IMR_OFFSET                     (0x2C)                                        /**<  (DACC_IMR) Interrupt Mask Register  Offset */
+
+#define DACC_IMR_TXRDY0_Pos                 0                                              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 0 Position */
+#define DACC_IMR_TXRDY0_Msk                 (_U_(0x1) << DACC_IMR_TXRDY0_Pos)              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 0 Mask */
+#define DACC_IMR_TXRDY0                     DACC_IMR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_TXRDY0_Msk instead */
+#define DACC_IMR_TXRDY1_Pos                 1                                              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 1 Position */
+#define DACC_IMR_TXRDY1_Msk                 (_U_(0x1) << DACC_IMR_TXRDY1_Pos)              /**< (DACC_IMR) Transmit Ready Interrupt Mask of channel 1 Mask */
+#define DACC_IMR_TXRDY1                     DACC_IMR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_TXRDY1_Msk instead */
+#define DACC_IMR_EOC0_Pos                   4                                              /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 0 Position */
+#define DACC_IMR_EOC0_Msk                   (_U_(0x1) << DACC_IMR_EOC0_Pos)                /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 0 Mask */
+#define DACC_IMR_EOC0                       DACC_IMR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_EOC0_Msk instead */
+#define DACC_IMR_EOC1_Pos                   5                                              /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 1 Position */
+#define DACC_IMR_EOC1_Msk                   (_U_(0x1) << DACC_IMR_EOC1_Pos)                /**< (DACC_IMR) End of Conversion Interrupt Mask of channel 1 Mask */
+#define DACC_IMR_EOC1                       DACC_IMR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_IMR_EOC1_Msk instead */
+#define DACC_IMR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_IMR) Register MASK  (Use DACC_IMR_Msk instead)  */
+#define DACC_IMR_Msk                        _U_(0x33)                                      /**< (DACC_IMR) Register Mask  */
+
+#define DACC_IMR_TXRDY_Pos                  0                                              /**< (DACC_IMR Position) Transmit Ready Interrupt Mask of channel x */
+#define DACC_IMR_TXRDY_Msk                  (_U_(0x3) << DACC_IMR_TXRDY_Pos)               /**< (DACC_IMR Mask) TXRDY */
+#define DACC_IMR_TXRDY(value)               (DACC_IMR_TXRDY_Msk & ((value) << DACC_IMR_TXRDY_Pos))  
+#define DACC_IMR_EOC_Pos                    4                                              /**< (DACC_IMR Position) End of Conversion Interrupt Mask of channel x */
+#define DACC_IMR_EOC_Msk                    (_U_(0x3) << DACC_IMR_EOC_Pos)                 /**< (DACC_IMR Mask) EOC */
+#define DACC_IMR_EOC(value)                 (DACC_IMR_EOC_Msk & ((value) << DACC_IMR_EOC_Pos))  
+
+/* -------- DACC_ISR : (DACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Flag of channel 0 */
+    uint32_t TXRDY1:1;                  /**< bit:      1  Transmit Ready Interrupt Flag of channel 1 */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC0:1;                    /**< bit:      4  End of Conversion Interrupt Flag of channel 0 */
+    uint32_t EOC1:1;                    /**< bit:      5  End of Conversion Interrupt Flag of channel 1 */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TXRDY:2;                   /**< bit:   0..1  Transmit Ready Interrupt Flag of channel x */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EOC:2;                     /**< bit:   4..5  End of Conversion Interrupt Flag of channel x */
+    uint32_t :26;                       /**< bit:  6..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_ISR_OFFSET                     (0x30)                                        /**<  (DACC_ISR) Interrupt Status Register  Offset */
+
+#define DACC_ISR_TXRDY0_Pos                 0                                              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 0 Position */
+#define DACC_ISR_TXRDY0_Msk                 (_U_(0x1) << DACC_ISR_TXRDY0_Pos)              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 0 Mask */
+#define DACC_ISR_TXRDY0                     DACC_ISR_TXRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_TXRDY0_Msk instead */
+#define DACC_ISR_TXRDY1_Pos                 1                                              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 1 Position */
+#define DACC_ISR_TXRDY1_Msk                 (_U_(0x1) << DACC_ISR_TXRDY1_Pos)              /**< (DACC_ISR) Transmit Ready Interrupt Flag of channel 1 Mask */
+#define DACC_ISR_TXRDY1                     DACC_ISR_TXRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_TXRDY1_Msk instead */
+#define DACC_ISR_EOC0_Pos                   4                                              /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 0 Position */
+#define DACC_ISR_EOC0_Msk                   (_U_(0x1) << DACC_ISR_EOC0_Pos)                /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 0 Mask */
+#define DACC_ISR_EOC0                       DACC_ISR_EOC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_EOC0_Msk instead */
+#define DACC_ISR_EOC1_Pos                   5                                              /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 1 Position */
+#define DACC_ISR_EOC1_Msk                   (_U_(0x1) << DACC_ISR_EOC1_Pos)                /**< (DACC_ISR) End of Conversion Interrupt Flag of channel 1 Mask */
+#define DACC_ISR_EOC1                       DACC_ISR_EOC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_ISR_EOC1_Msk instead */
+#define DACC_ISR_MASK                       _U_(0x33)                                      /**< \deprecated (DACC_ISR) Register MASK  (Use DACC_ISR_Msk instead)  */
+#define DACC_ISR_Msk                        _U_(0x33)                                      /**< (DACC_ISR) Register Mask  */
+
+#define DACC_ISR_TXRDY_Pos                  0                                              /**< (DACC_ISR Position) Transmit Ready Interrupt Flag of channel x */
+#define DACC_ISR_TXRDY_Msk                  (_U_(0x3) << DACC_ISR_TXRDY_Pos)               /**< (DACC_ISR Mask) TXRDY */
+#define DACC_ISR_TXRDY(value)               (DACC_ISR_TXRDY_Msk & ((value) << DACC_ISR_TXRDY_Pos))  
+#define DACC_ISR_EOC_Pos                    4                                              /**< (DACC_ISR Position) End of Conversion Interrupt Flag of channel x */
+#define DACC_ISR_EOC_Msk                    (_U_(0x3) << DACC_ISR_EOC_Pos)                 /**< (DACC_ISR Mask) EOC */
+#define DACC_ISR_EOC(value)                 (DACC_ISR_EOC_Msk & ((value) << DACC_ISR_EOC_Pos))  
+
+/* -------- DACC_ACR : (DACC Offset: 0x94) (R/W 32) Analog Current Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IBCTLCH0:2;                /**< bit:   0..1  Analog Output Current Control            */
+    uint32_t IBCTLCH1:2;                /**< bit:   2..3  Analog Output Current Control            */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_ACR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_ACR_OFFSET                     (0x94)                                        /**<  (DACC_ACR) Analog Current Register  Offset */
+
+#define DACC_ACR_IBCTLCH0_Pos               0                                              /**< (DACC_ACR) Analog Output Current Control Position */
+#define DACC_ACR_IBCTLCH0_Msk               (_U_(0x3) << DACC_ACR_IBCTLCH0_Pos)            /**< (DACC_ACR) Analog Output Current Control Mask */
+#define DACC_ACR_IBCTLCH0(value)            (DACC_ACR_IBCTLCH0_Msk & ((value) << DACC_ACR_IBCTLCH0_Pos))
+#define DACC_ACR_IBCTLCH1_Pos               2                                              /**< (DACC_ACR) Analog Output Current Control Position */
+#define DACC_ACR_IBCTLCH1_Msk               (_U_(0x3) << DACC_ACR_IBCTLCH1_Pos)            /**< (DACC_ACR) Analog Output Current Control Mask */
+#define DACC_ACR_IBCTLCH1(value)            (DACC_ACR_IBCTLCH1_Msk & ((value) << DACC_ACR_IBCTLCH1_Pos))
+#define DACC_ACR_MASK                       _U_(0x0F)                                      /**< \deprecated (DACC_ACR) Register MASK  (Use DACC_ACR_Msk instead)  */
+#define DACC_ACR_Msk                        _U_(0x0F)                                      /**< (DACC_ACR) Register Mask  */
+
+
+/* -------- DACC_WPMR : (DACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect Key                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPMR_OFFSET                    (0xE4)                                        /**<  (DACC_WPMR) Write Protection Mode Register  Offset */
+
+#define DACC_WPMR_WPEN_Pos                  0                                              /**< (DACC_WPMR) Write Protection Enable Position */
+#define DACC_WPMR_WPEN_Msk                  (_U_(0x1) << DACC_WPMR_WPEN_Pos)               /**< (DACC_WPMR) Write Protection Enable Mask */
+#define DACC_WPMR_WPEN                      DACC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_WPMR_WPEN_Msk instead */
+#define DACC_WPMR_WPKEY_Pos                 8                                              /**< (DACC_WPMR) Write Protect Key Position */
+#define DACC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << DACC_WPMR_WPKEY_Pos)         /**< (DACC_WPMR) Write Protect Key Mask */
+#define DACC_WPMR_WPKEY(value)              (DACC_WPMR_WPKEY_Msk & ((value) << DACC_WPMR_WPKEY_Pos))
+#define   DACC_WPMR_WPKEY_PASSWD_Val        _U_(0x444143)                                  /**< (DACC_WPMR) Writing any other value in this field aborts the write operation of bit WPEN.Always reads as 0.  */
+#define DACC_WPMR_WPKEY_PASSWD              (DACC_WPMR_WPKEY_PASSWD_Val << DACC_WPMR_WPKEY_Pos)  /**< (DACC_WPMR) Writing any other value in this field aborts the write operation of bit WPEN.Always reads as 0. Position  */
+#define DACC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (DACC_WPMR) Register MASK  (Use DACC_WPMR_Msk instead)  */
+#define DACC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (DACC_WPMR) Register Mask  */
+
+
+/* -------- DACC_WPSR : (DACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} DACC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPSR_OFFSET                    (0xE8)                                        /**<  (DACC_WPSR) Write Protection Status Register  Offset */
+
+#define DACC_WPSR_WPVS_Pos                  0                                              /**< (DACC_WPSR) Write Protection Violation Status Position */
+#define DACC_WPSR_WPVS_Msk                  (_U_(0x1) << DACC_WPSR_WPVS_Pos)               /**< (DACC_WPSR) Write Protection Violation Status Mask */
+#define DACC_WPSR_WPVS                      DACC_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use DACC_WPSR_WPVS_Msk instead */
+#define DACC_WPSR_WPVSRC_Pos                8                                              /**< (DACC_WPSR) Write Protection Violation Source Position */
+#define DACC_WPSR_WPVSRC_Msk                (_U_(0xFF) << DACC_WPSR_WPVSRC_Pos)            /**< (DACC_WPSR) Write Protection Violation Source Mask */
+#define DACC_WPSR_WPVSRC(value)             (DACC_WPSR_WPVSRC_Msk & ((value) << DACC_WPSR_WPVSRC_Pos))
+#define DACC_WPSR_MASK                      _U_(0xFF01)                                    /**< \deprecated (DACC_WPSR) Register MASK  (Use DACC_WPSR_Msk instead)  */
+#define DACC_WPSR_Msk                       _U_(0xFF01)                                    /**< (DACC_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief DACC hardware registers */
+typedef struct {  
+  __O  uint32_t DACC_CR;        /**< (DACC Offset: 0x00) Control Register */
+  __IO uint32_t DACC_MR;        /**< (DACC Offset: 0x04) Mode Register */
+  __IO uint32_t DACC_TRIGR;     /**< (DACC Offset: 0x08) Trigger Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t DACC_CHER;      /**< (DACC Offset: 0x10) Channel Enable Register */
+  __O  uint32_t DACC_CHDR;      /**< (DACC Offset: 0x14) Channel Disable Register */
+  __I  uint32_t DACC_CHSR;      /**< (DACC Offset: 0x18) Channel Status Register */
+  __O  uint32_t DACC_CDR[2];    /**< (DACC Offset: 0x1C) Conversion Data Register 0 */
+  __O  uint32_t DACC_IER;       /**< (DACC Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t DACC_IDR;       /**< (DACC Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t DACC_IMR;       /**< (DACC Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t DACC_ISR;       /**< (DACC Offset: 0x30) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO uint32_t DACC_ACR;       /**< (DACC Offset: 0x94) Analog Current Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO uint32_t DACC_WPMR;      /**< (DACC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t DACC_WPSR;      /**< (DACC Offset: 0xE8) Write Protection Status Register */
+} Dacc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief DACC hardware registers */
+typedef struct {  
+  __O  DACC_CR_Type                   DACC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO DACC_MR_Type                   DACC_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO DACC_TRIGR_Type                DACC_TRIGR;     /**< Offset: 0x08 (R/W  32) Trigger Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  DACC_CHER_Type                 DACC_CHER;      /**< Offset: 0x10 ( /W  32) Channel Enable Register */
+  __O  DACC_CHDR_Type                 DACC_CHDR;      /**< Offset: 0x14 ( /W  32) Channel Disable Register */
+  __I  DACC_CHSR_Type                 DACC_CHSR;      /**< Offset: 0x18 (R/   32) Channel Status Register */
+  __O  DACC_CDR_Type                  DACC_CDR[2];    /**< Offset: 0x1C ( /W  32) Conversion Data Register 0 */
+  __O  DACC_IER_Type                  DACC_IER;       /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  DACC_IDR_Type                  DACC_IDR;       /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  DACC_IMR_Type                  DACC_IMR;       /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  DACC_ISR_Type                  DACC_ISR;       /**< Offset: 0x30 (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[96];
+  __IO DACC_ACR_Type                  DACC_ACR;       /**< Offset: 0x94 (R/W  32) Analog Current Register */
+  __I  uint8_t                        Reserved3[76];
+  __IO DACC_WPMR_Type                 DACC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  DACC_WPSR_Type                 DACC_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Dacc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Digital-to-Analog Converter Controller */
+
+#endif /* _SAMV71_DACC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/efc.h
+++ b/asf/sam/include/samv71b/component/efc.h
@@ -1,0 +1,288 @@
+/**
+ * \file
+ *
+ * \brief Component description for EFC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_EFC_COMPONENT_H_
+#define _SAMV71_EFC_COMPONENT_H_
+#define _SAMV71_EFC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Embedded Flash Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EFC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define EFC_6450                       /**< (EFC) Module ID */
+#define REV_EFC Y                      /**< (EFC) Module revision */
+
+/* -------- EEFC_FMR : (EFC Offset: 0x00) (R/W 32) EEFC Flash Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Interrupt Enable             */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t FWS:4;                     /**< bit:  8..11  Flash Wait State                         */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t SCOD:1;                    /**< bit:     16  Sequential Code Optimization Disable     */
+    uint32_t :9;                        /**< bit: 17..25  Reserved */
+    uint32_t CLOE:1;                    /**< bit:     26  Code Loop Optimization Enable            */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FMR_OFFSET                     (0x00)                                        /**<  (EEFC_FMR) EEFC Flash Mode Register  Offset */
+
+#define EEFC_FMR_FRDY_Pos                   0                                              /**< (EEFC_FMR) Flash Ready Interrupt Enable Position */
+#define EEFC_FMR_FRDY_Msk                   (_U_(0x1) << EEFC_FMR_FRDY_Pos)                /**< (EEFC_FMR) Flash Ready Interrupt Enable Mask */
+#define EEFC_FMR_FRDY                       EEFC_FMR_FRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_FRDY_Msk instead */
+#define EEFC_FMR_FWS_Pos                    8                                              /**< (EEFC_FMR) Flash Wait State Position */
+#define EEFC_FMR_FWS_Msk                    (_U_(0xF) << EEFC_FMR_FWS_Pos)                 /**< (EEFC_FMR) Flash Wait State Mask */
+#define EEFC_FMR_FWS(value)                 (EEFC_FMR_FWS_Msk & ((value) << EEFC_FMR_FWS_Pos))
+#define EEFC_FMR_SCOD_Pos                   16                                             /**< (EEFC_FMR) Sequential Code Optimization Disable Position */
+#define EEFC_FMR_SCOD_Msk                   (_U_(0x1) << EEFC_FMR_SCOD_Pos)                /**< (EEFC_FMR) Sequential Code Optimization Disable Mask */
+#define EEFC_FMR_SCOD                       EEFC_FMR_SCOD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_SCOD_Msk instead */
+#define EEFC_FMR_CLOE_Pos                   26                                             /**< (EEFC_FMR) Code Loop Optimization Enable Position */
+#define EEFC_FMR_CLOE_Msk                   (_U_(0x1) << EEFC_FMR_CLOE_Pos)                /**< (EEFC_FMR) Code Loop Optimization Enable Mask */
+#define EEFC_FMR_CLOE                       EEFC_FMR_CLOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FMR_CLOE_Msk instead */
+#define EEFC_FMR_MASK                       _U_(0x4010F01)                                 /**< \deprecated (EEFC_FMR) Register MASK  (Use EEFC_FMR_Msk instead)  */
+#define EEFC_FMR_Msk                        _U_(0x4010F01)                                 /**< (EEFC_FMR) Register Mask  */
+
+
+/* -------- EEFC_FCR : (EFC Offset: 0x04) (/W 32) EEFC Flash Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCMD:8;                    /**< bit:   0..7  Flash Command                            */
+    uint32_t FARG:16;                   /**< bit:  8..23  Flash Command Argument                   */
+    uint32_t FKEY:8;                    /**< bit: 24..31  Flash Writing Protection Key             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FCR_OFFSET                     (0x04)                                        /**<  (EEFC_FCR) EEFC Flash Command Register  Offset */
+
+#define EEFC_FCR_FCMD_Pos                   0                                              /**< (EEFC_FCR) Flash Command Position */
+#define EEFC_FCR_FCMD_Msk                   (_U_(0xFF) << EEFC_FCR_FCMD_Pos)               /**< (EEFC_FCR) Flash Command Mask */
+#define EEFC_FCR_FCMD(value)                (EEFC_FCR_FCMD_Msk & ((value) << EEFC_FCR_FCMD_Pos))
+#define   EEFC_FCR_FCMD_GETD_Val            _U_(0x0)                                       /**< (EEFC_FCR) Get Flash descriptor  */
+#define   EEFC_FCR_FCMD_WP_Val              _U_(0x1)                                       /**< (EEFC_FCR) Write page  */
+#define   EEFC_FCR_FCMD_WPL_Val             _U_(0x2)                                       /**< (EEFC_FCR) Write page and lock  */
+#define   EEFC_FCR_FCMD_EWP_Val             _U_(0x3)                                       /**< (EEFC_FCR) Erase page and write page  */
+#define   EEFC_FCR_FCMD_EWPL_Val            _U_(0x4)                                       /**< (EEFC_FCR) Erase page and write page then lock  */
+#define   EEFC_FCR_FCMD_EA_Val              _U_(0x5)                                       /**< (EEFC_FCR) Erase all  */
+#define   EEFC_FCR_FCMD_EPA_Val             _U_(0x7)                                       /**< (EEFC_FCR) Erase pages  */
+#define   EEFC_FCR_FCMD_SLB_Val             _U_(0x8)                                       /**< (EEFC_FCR) Set lock bit  */
+#define   EEFC_FCR_FCMD_CLB_Val             _U_(0x9)                                       /**< (EEFC_FCR) Clear lock bit  */
+#define   EEFC_FCR_FCMD_GLB_Val             _U_(0xA)                                       /**< (EEFC_FCR) Get lock bit  */
+#define   EEFC_FCR_FCMD_SGPB_Val            _U_(0xB)                                       /**< (EEFC_FCR) Set GPNVM bit  */
+#define   EEFC_FCR_FCMD_CGPB_Val            _U_(0xC)                                       /**< (EEFC_FCR) Clear GPNVM bit  */
+#define   EEFC_FCR_FCMD_GGPB_Val            _U_(0xD)                                       /**< (EEFC_FCR) Get GPNVM bit  */
+#define   EEFC_FCR_FCMD_STUI_Val            _U_(0xE)                                       /**< (EEFC_FCR) Start read unique identifier  */
+#define   EEFC_FCR_FCMD_SPUI_Val            _U_(0xF)                                       /**< (EEFC_FCR) Stop read unique identifier  */
+#define   EEFC_FCR_FCMD_GCALB_Val           _U_(0x10)                                      /**< (EEFC_FCR) Get CALIB bit  */
+#define   EEFC_FCR_FCMD_ES_Val              _U_(0x11)                                      /**< (EEFC_FCR) Erase sector  */
+#define   EEFC_FCR_FCMD_WUS_Val             _U_(0x12)                                      /**< (EEFC_FCR) Write user signature  */
+#define   EEFC_FCR_FCMD_EUS_Val             _U_(0x13)                                      /**< (EEFC_FCR) Erase user signature  */
+#define   EEFC_FCR_FCMD_STUS_Val            _U_(0x14)                                      /**< (EEFC_FCR) Start read user signature  */
+#define   EEFC_FCR_FCMD_SPUS_Val            _U_(0x15)                                      /**< (EEFC_FCR) Stop read user signature  */
+#define EEFC_FCR_FCMD_GETD                  (EEFC_FCR_FCMD_GETD_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get Flash descriptor Position  */
+#define EEFC_FCR_FCMD_WP                    (EEFC_FCR_FCMD_WP_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Write page Position  */
+#define EEFC_FCR_FCMD_WPL                   (EEFC_FCR_FCMD_WPL_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Write page and lock Position  */
+#define EEFC_FCR_FCMD_EWP                   (EEFC_FCR_FCMD_EWP_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase page and write page Position  */
+#define EEFC_FCR_FCMD_EWPL                  (EEFC_FCR_FCMD_EWPL_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Erase page and write page then lock Position  */
+#define EEFC_FCR_FCMD_EA                    (EEFC_FCR_FCMD_EA_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Erase all Position  */
+#define EEFC_FCR_FCMD_EPA                   (EEFC_FCR_FCMD_EPA_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase pages Position  */
+#define EEFC_FCR_FCMD_SLB                   (EEFC_FCR_FCMD_SLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Set lock bit Position  */
+#define EEFC_FCR_FCMD_CLB                   (EEFC_FCR_FCMD_CLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Clear lock bit Position  */
+#define EEFC_FCR_FCMD_GLB                   (EEFC_FCR_FCMD_GLB_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Get lock bit Position  */
+#define EEFC_FCR_FCMD_SGPB                  (EEFC_FCR_FCMD_SGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Set GPNVM bit Position  */
+#define EEFC_FCR_FCMD_CGPB                  (EEFC_FCR_FCMD_CGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Clear GPNVM bit Position  */
+#define EEFC_FCR_FCMD_GGPB                  (EEFC_FCR_FCMD_GGPB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get GPNVM bit Position  */
+#define EEFC_FCR_FCMD_STUI                  (EEFC_FCR_FCMD_STUI_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Start read unique identifier Position  */
+#define EEFC_FCR_FCMD_SPUI                  (EEFC_FCR_FCMD_SPUI_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Stop read unique identifier Position  */
+#define EEFC_FCR_FCMD_GCALB                 (EEFC_FCR_FCMD_GCALB_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Get CALIB bit Position  */
+#define EEFC_FCR_FCMD_ES                    (EEFC_FCR_FCMD_ES_Val << EEFC_FCR_FCMD_Pos)    /**< (EEFC_FCR) Erase sector Position  */
+#define EEFC_FCR_FCMD_WUS                   (EEFC_FCR_FCMD_WUS_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Write user signature Position  */
+#define EEFC_FCR_FCMD_EUS                   (EEFC_FCR_FCMD_EUS_Val << EEFC_FCR_FCMD_Pos)   /**< (EEFC_FCR) Erase user signature Position  */
+#define EEFC_FCR_FCMD_STUS                  (EEFC_FCR_FCMD_STUS_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Start read user signature Position  */
+#define EEFC_FCR_FCMD_SPUS                  (EEFC_FCR_FCMD_SPUS_Val << EEFC_FCR_FCMD_Pos)  /**< (EEFC_FCR) Stop read user signature Position  */
+#define EEFC_FCR_FARG_Pos                   8                                              /**< (EEFC_FCR) Flash Command Argument Position */
+#define EEFC_FCR_FARG_Msk                   (_U_(0xFFFF) << EEFC_FCR_FARG_Pos)             /**< (EEFC_FCR) Flash Command Argument Mask */
+#define EEFC_FCR_FARG(value)                (EEFC_FCR_FARG_Msk & ((value) << EEFC_FCR_FARG_Pos))
+#define EEFC_FCR_FKEY_Pos                   24                                             /**< (EEFC_FCR) Flash Writing Protection Key Position */
+#define EEFC_FCR_FKEY_Msk                   (_U_(0xFF) << EEFC_FCR_FKEY_Pos)               /**< (EEFC_FCR) Flash Writing Protection Key Mask */
+#define EEFC_FCR_FKEY(value)                (EEFC_FCR_FKEY_Msk & ((value) << EEFC_FCR_FKEY_Pos))
+#define   EEFC_FCR_FKEY_PASSWD_Val          _U_(0x5A)                                      /**< (EEFC_FCR) The 0x5A value enables the command defined by the bits of the register. If the field is written with a different value, the write is not performed and no action is started.  */
+#define EEFC_FCR_FKEY_PASSWD                (EEFC_FCR_FKEY_PASSWD_Val << EEFC_FCR_FKEY_Pos)  /**< (EEFC_FCR) The 0x5A value enables the command defined by the bits of the register. If the field is written with a different value, the write is not performed and no action is started. Position  */
+#define EEFC_FCR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (EEFC_FCR) Register MASK  (Use EEFC_FCR_Msk instead)  */
+#define EEFC_FCR_Msk                        _U_(0xFFFFFFFF)                                /**< (EEFC_FCR) Register Mask  */
+
+
+/* -------- EEFC_FSR : (EFC Offset: 0x08) (R/ 32) EEFC Flash Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Status (cleared when Flash is busy) */
+    uint32_t FCMDE:1;                   /**< bit:      1  Flash Command Error Status (cleared on read or by writing EEFC_FCR) */
+    uint32_t FLOCKE:1;                  /**< bit:      2  Flash Lock Error Status (cleared on read) */
+    uint32_t FLERR:1;                   /**< bit:      3  Flash Error Status (cleared when a programming operation starts) */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t UECCELSB:1;                /**< bit:     16  Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t MECCELSB:1;                /**< bit:     17  Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t UECCEMSB:1;                /**< bit:     18  Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t MECCEMSB:1;                /**< bit:     19  Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FSR_OFFSET                     (0x08)                                        /**<  (EEFC_FSR) EEFC Flash Status Register  Offset */
+
+#define EEFC_FSR_FRDY_Pos                   0                                              /**< (EEFC_FSR) Flash Ready Status (cleared when Flash is busy) Position */
+#define EEFC_FSR_FRDY_Msk                   (_U_(0x1) << EEFC_FSR_FRDY_Pos)                /**< (EEFC_FSR) Flash Ready Status (cleared when Flash is busy) Mask */
+#define EEFC_FSR_FRDY                       EEFC_FSR_FRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FRDY_Msk instead */
+#define EEFC_FSR_FCMDE_Pos                  1                                              /**< (EEFC_FSR) Flash Command Error Status (cleared on read or by writing EEFC_FCR) Position */
+#define EEFC_FSR_FCMDE_Msk                  (_U_(0x1) << EEFC_FSR_FCMDE_Pos)               /**< (EEFC_FSR) Flash Command Error Status (cleared on read or by writing EEFC_FCR) Mask */
+#define EEFC_FSR_FCMDE                      EEFC_FSR_FCMDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FCMDE_Msk instead */
+#define EEFC_FSR_FLOCKE_Pos                 2                                              /**< (EEFC_FSR) Flash Lock Error Status (cleared on read) Position */
+#define EEFC_FSR_FLOCKE_Msk                 (_U_(0x1) << EEFC_FSR_FLOCKE_Pos)              /**< (EEFC_FSR) Flash Lock Error Status (cleared on read) Mask */
+#define EEFC_FSR_FLOCKE                     EEFC_FSR_FLOCKE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FLOCKE_Msk instead */
+#define EEFC_FSR_FLERR_Pos                  3                                              /**< (EEFC_FSR) Flash Error Status (cleared when a programming operation starts) Position */
+#define EEFC_FSR_FLERR_Msk                  (_U_(0x1) << EEFC_FSR_FLERR_Pos)               /**< (EEFC_FSR) Flash Error Status (cleared when a programming operation starts) Mask */
+#define EEFC_FSR_FLERR                      EEFC_FSR_FLERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_FLERR_Msk instead */
+#define EEFC_FSR_UECCELSB_Pos               16                                             /**< (EEFC_FSR) Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_UECCELSB_Msk               (_U_(0x1) << EEFC_FSR_UECCELSB_Pos)            /**< (EEFC_FSR) Unique ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_UECCELSB                   EEFC_FSR_UECCELSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_UECCELSB_Msk instead */
+#define EEFC_FSR_MECCELSB_Pos               17                                             /**< (EEFC_FSR) Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_MECCELSB_Msk               (_U_(0x1) << EEFC_FSR_MECCELSB_Pos)            /**< (EEFC_FSR) Multiple ECC Error on LSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_MECCELSB                   EEFC_FSR_MECCELSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_MECCELSB_Msk instead */
+#define EEFC_FSR_UECCEMSB_Pos               18                                             /**< (EEFC_FSR) Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_UECCEMSB_Msk               (_U_(0x1) << EEFC_FSR_UECCEMSB_Pos)            /**< (EEFC_FSR) Unique ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_UECCEMSB                   EEFC_FSR_UECCEMSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_UECCEMSB_Msk instead */
+#define EEFC_FSR_MECCEMSB_Pos               19                                             /**< (EEFC_FSR) Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Position */
+#define EEFC_FSR_MECCEMSB_Msk               (_U_(0x1) << EEFC_FSR_MECCEMSB_Pos)            /**< (EEFC_FSR) Multiple ECC Error on MSB Part of the Memory Flash Data Bus (cleared on read) Mask */
+#define EEFC_FSR_MECCEMSB                   EEFC_FSR_MECCEMSB_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_FSR_MECCEMSB_Msk instead */
+#define EEFC_FSR_MASK                       _U_(0xF000F)                                   /**< \deprecated (EEFC_FSR) Register MASK  (Use EEFC_FSR_Msk instead)  */
+#define EEFC_FSR_Msk                        _U_(0xF000F)                                   /**< (EEFC_FSR) Register Mask  */
+
+
+/* -------- EEFC_FRR : (EFC Offset: 0x0c) (R/ 32) EEFC Flash Result Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FVALUE:32;                 /**< bit:  0..31  Flash Result Value                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_FRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_FRR_OFFSET                     (0x0C)                                        /**<  (EEFC_FRR) EEFC Flash Result Register  Offset */
+
+#define EEFC_FRR_FVALUE_Pos                 0                                              /**< (EEFC_FRR) Flash Result Value Position */
+#define EEFC_FRR_FVALUE_Msk                 (_U_(0xFFFFFFFF) << EEFC_FRR_FVALUE_Pos)       /**< (EEFC_FRR) Flash Result Value Mask */
+#define EEFC_FRR_FVALUE(value)              (EEFC_FRR_FVALUE_Msk & ((value) << EEFC_FRR_FVALUE_Pos))
+#define EEFC_FRR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (EEFC_FRR) Register MASK  (Use EEFC_FRR_Msk instead)  */
+#define EEFC_FRR_Msk                        _U_(0xFFFFFFFF)                                /**< (EEFC_FRR) Register Mask  */
+
+
+/* -------- EEFC_WPMR : (EFC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} EEFC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EEFC_WPMR_OFFSET                    (0xE4)                                        /**<  (EEFC_WPMR) Write Protection Mode Register  Offset */
+
+#define EEFC_WPMR_WPEN_Pos                  0                                              /**< (EEFC_WPMR) Write Protection Enable Position */
+#define EEFC_WPMR_WPEN_Msk                  (_U_(0x1) << EEFC_WPMR_WPEN_Pos)               /**< (EEFC_WPMR) Write Protection Enable Mask */
+#define EEFC_WPMR_WPEN                      EEFC_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use EEFC_WPMR_WPEN_Msk instead */
+#define EEFC_WPMR_WPKEY_Pos                 8                                              /**< (EEFC_WPMR) Write Protection Key Position */
+#define EEFC_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << EEFC_WPMR_WPKEY_Pos)         /**< (EEFC_WPMR) Write Protection Key Mask */
+#define EEFC_WPMR_WPKEY(value)              (EEFC_WPMR_WPKEY_Msk & ((value) << EEFC_WPMR_WPKEY_Pos))
+#define   EEFC_WPMR_WPKEY_PASSWD_Val        _U_(0x454643)                                  /**< (EEFC_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define EEFC_WPMR_WPKEY_PASSWD              (EEFC_WPMR_WPKEY_PASSWD_Val << EEFC_WPMR_WPKEY_Pos)  /**< (EEFC_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define EEFC_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (EEFC_WPMR) Register MASK  (Use EEFC_WPMR_Msk instead)  */
+#define EEFC_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (EEFC_WPMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief EFC hardware registers */
+typedef struct {  
+  __IO uint32_t EEFC_FMR;       /**< (EFC Offset: 0x00) EEFC Flash Mode Register */
+  __O  uint32_t EEFC_FCR;       /**< (EFC Offset: 0x04) EEFC Flash Command Register */
+  __I  uint32_t EEFC_FSR;       /**< (EFC Offset: 0x08) EEFC Flash Status Register */
+  __I  uint32_t EEFC_FRR;       /**< (EFC Offset: 0x0C) EEFC Flash Result Register */
+  __I  uint8_t                        Reserved1[212];
+  __IO uint32_t EEFC_WPMR;      /**< (EFC Offset: 0xE4) Write Protection Mode Register */
+} Efc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief EFC hardware registers */
+typedef struct {  
+  __IO EEFC_FMR_Type                  EEFC_FMR;       /**< Offset: 0x00 (R/W  32) EEFC Flash Mode Register */
+  __O  EEFC_FCR_Type                  EEFC_FCR;       /**< Offset: 0x04 ( /W  32) EEFC Flash Command Register */
+  __I  EEFC_FSR_Type                  EEFC_FSR;       /**< Offset: 0x08 (R/   32) EEFC Flash Status Register */
+  __I  EEFC_FRR_Type                  EEFC_FRR;       /**< Offset: 0x0C (R/   32) EEFC Flash Result Register */
+  __I  uint8_t                        Reserved1[212];
+  __IO EEFC_WPMR_Type                 EEFC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+} Efc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Embedded Flash Controller */
+
+#endif /* _SAMV71_EFC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/gmac.h
+++ b/asf/sam/include/samv71b/component/gmac.h
@@ -1,0 +1,3891 @@
+/**
+ * \file
+ *
+ * \brief Component description for GMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_GMAC_COMPONENT_H_
+#define _SAMV71_GMAC_COMPONENT_H_
+#define _SAMV71_GMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Gigabit Ethernet MAC
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GMAC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define GMAC_11046                      /**< (GMAC) Module ID */
+#define REV_GMAC S                      /**< (GMAC) Module revision */
+
+/* -------- GMAC_SAB : (GMAC Offset: 0x00) (R/W 32) Specific Address 1 Bottom Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAB_OFFSET                     (0x00)                                        /**<  (GMAC_SAB) Specific Address 1 Bottom Register  Offset */
+
+#define GMAC_SAB_ADDR_Pos                   0                                              /**< (GMAC_SAB) Specific Address 1 Position */
+#define GMAC_SAB_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_SAB_ADDR_Pos)         /**< (GMAC_SAB) Specific Address 1 Mask */
+#define GMAC_SAB_ADDR(value)                (GMAC_SAB_ADDR_Msk & ((value) << GMAC_SAB_ADDR_Pos))
+#define GMAC_SAB_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SAB) Register MASK  (Use GMAC_SAB_Msk instead)  */
+#define GMAC_SAB_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_SAB) Register Mask  */
+
+
+/* -------- GMAC_SAT : (GMAC Offset: 0x04) (R/W 32) Specific Address 1 Top Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1                       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAT_OFFSET                     (0x04)                                        /**<  (GMAC_SAT) Specific Address 1 Top Register  Offset */
+
+#define GMAC_SAT_ADDR_Pos                   0                                              /**< (GMAC_SAT) Specific Address 1 Position */
+#define GMAC_SAT_ADDR_Msk                   (_U_(0xFFFF) << GMAC_SAT_ADDR_Pos)             /**< (GMAC_SAT) Specific Address 1 Mask */
+#define GMAC_SAT_ADDR(value)                (GMAC_SAT_ADDR_Msk & ((value) << GMAC_SAT_ADDR_Pos))
+#define GMAC_SAT_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_SAT) Register MASK  (Use GMAC_SAT_Msk instead)  */
+#define GMAC_SAT_Msk                        _U_(0xFFFF)                                    /**< (GMAC_SAT) Register Mask  */
+
+
+/* -------- GMAC_ST2CW0 : (GMAC Offset: 0x00) (R/W 32) Screening Type 2 Compare Word 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW0_OFFSET                  (0x00)                                        /**<  (GMAC_ST2CW0) Screening Type 2 Compare Word 0 Register  Offset */
+
+#define GMAC_ST2CW0_MASKVAL_Pos             0                                              /**< (GMAC_ST2CW0) Mask Value Position */
+#define GMAC_ST2CW0_MASKVAL_Msk             (_U_(0xFFFF) << GMAC_ST2CW0_MASKVAL_Pos)       /**< (GMAC_ST2CW0) Mask Value Mask */
+#define GMAC_ST2CW0_MASKVAL(value)          (GMAC_ST2CW0_MASKVAL_Msk & ((value) << GMAC_ST2CW0_MASKVAL_Pos))
+#define GMAC_ST2CW0_COMPVAL_Pos             16                                             /**< (GMAC_ST2CW0) Compare Value Position */
+#define GMAC_ST2CW0_COMPVAL_Msk             (_U_(0xFFFF) << GMAC_ST2CW0_COMPVAL_Pos)       /**< (GMAC_ST2CW0) Compare Value Mask */
+#define GMAC_ST2CW0_COMPVAL(value)          (GMAC_ST2CW0_COMPVAL_Msk & ((value) << GMAC_ST2CW0_COMPVAL_Pos))
+#define GMAC_ST2CW0_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW0) Register Mask  */
+
+
+/* -------- GMAC_ST2CW1 : (GMAC Offset: 0x04) (R/W 32) Screening Type 2 Compare Word 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW1_OFFSET                  (0x04)                                        /**<  (GMAC_ST2CW1) Screening Type 2 Compare Word 1 Register  Offset */
+
+#define GMAC_ST2CW1_OFFSVAL_Pos             0                                              /**< (GMAC_ST2CW1) Offset Value in Bytes Position */
+#define GMAC_ST2CW1_OFFSVAL_Msk             (_U_(0x7F) << GMAC_ST2CW1_OFFSVAL_Pos)         /**< (GMAC_ST2CW1) Offset Value in Bytes Mask */
+#define GMAC_ST2CW1_OFFSVAL(value)          (GMAC_ST2CW1_OFFSVAL_Msk & ((value) << GMAC_ST2CW1_OFFSVAL_Pos))
+#define GMAC_ST2CW1_OFFSSTRT_Pos            7                                              /**< (GMAC_ST2CW1) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW1_OFFSSTRT_Msk            (_U_(0x3) << GMAC_ST2CW1_OFFSSTRT_Pos)         /**< (GMAC_ST2CW1) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW1_OFFSSTRT(value)         (GMAC_ST2CW1_OFFSSTRT_Msk & ((value) << GMAC_ST2CW1_OFFSSTRT_Pos))
+#define   GMAC_ST2CW1_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW1) Offset from the start of the frame  */
+#define   GMAC_ST2CW1_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW1) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW1_OFFSSTRT_IP_Val       _U_(0x2)                                       /**< (GMAC_ST2CW1) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW1_OFFSSTRT_TCP_UDP_Val  _U_(0x3)                                       /**< (GMAC_ST2CW1) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW1_OFFSSTRT_FRAMESTART     (GMAC_ST2CW1_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the start of the frame Position  */
+#define GMAC_ST2CW1_OFFSSTRT_ETHERTYPE      (GMAC_ST2CW1_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW1_OFFSSTRT_IP             (GMAC_ST2CW1_OFFSSTRT_IP_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW1_OFFSSTRT_TCP_UDP        (GMAC_ST2CW1_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW1_MASK                    _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW1) Register MASK  (Use GMAC_ST2CW1_Msk instead)  */
+#define GMAC_ST2CW1_Msk                     _U_(0x1FF)                                     /**< (GMAC_ST2CW1) Register Mask  */
+
+
+/* -------- GMAC_NCR : (GMAC Offset: 0x00) (R/W 32) Network Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t LBL:1;                     /**< bit:      1  Loop Back Local                          */
+    uint32_t RXEN:1;                    /**< bit:      2  Receive Enable                           */
+    uint32_t TXEN:1;                    /**< bit:      3  Transmit Enable                          */
+    uint32_t MPE:1;                     /**< bit:      4  Management Port Enable                   */
+    uint32_t CLRSTAT:1;                 /**< bit:      5  Clear Statistics Registers               */
+    uint32_t INCSTAT:1;                 /**< bit:      6  Increment Statistics Registers           */
+    uint32_t WESTAT:1;                  /**< bit:      7  Write Enable for Statistics Registers    */
+    uint32_t BP:1;                      /**< bit:      8  Back pressure                            */
+    uint32_t TSTART:1;                  /**< bit:      9  Start Transmission                       */
+    uint32_t THALT:1;                   /**< bit:     10  Transmit Halt                            */
+    uint32_t TXPF:1;                    /**< bit:     11  Transmit Pause Frame                     */
+    uint32_t TXZQPF:1;                  /**< bit:     12  Transmit Zero Quantum Pause Frame        */
+    uint32_t :2;                        /**< bit: 13..14  Reserved */
+    uint32_t SRTSM:1;                   /**< bit:     15  Store Receive Time Stamp to Memory       */
+    uint32_t ENPBPR:1;                  /**< bit:     16  Enable PFC Priority-based Pause Reception */
+    uint32_t TXPBPF:1;                  /**< bit:     17  Transmit PFC Priority-based Pause Frame  */
+    uint32_t FNP:1;                     /**< bit:     18  Flush Next Packet                        */
+    uint32_t TXLPIEN:1;                 /**< bit:     19  Enable LPI Transmission                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NCR_OFFSET                     (0x00)                                        /**<  (GMAC_NCR) Network Control Register  Offset */
+
+#define GMAC_NCR_LBL_Pos                    1                                              /**< (GMAC_NCR) Loop Back Local Position */
+#define GMAC_NCR_LBL_Msk                    (_U_(0x1) << GMAC_NCR_LBL_Pos)                 /**< (GMAC_NCR) Loop Back Local Mask */
+#define GMAC_NCR_LBL                        GMAC_NCR_LBL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_LBL_Msk instead */
+#define GMAC_NCR_RXEN_Pos                   2                                              /**< (GMAC_NCR) Receive Enable Position */
+#define GMAC_NCR_RXEN_Msk                   (_U_(0x1) << GMAC_NCR_RXEN_Pos)                /**< (GMAC_NCR) Receive Enable Mask */
+#define GMAC_NCR_RXEN                       GMAC_NCR_RXEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_RXEN_Msk instead */
+#define GMAC_NCR_TXEN_Pos                   3                                              /**< (GMAC_NCR) Transmit Enable Position */
+#define GMAC_NCR_TXEN_Msk                   (_U_(0x1) << GMAC_NCR_TXEN_Pos)                /**< (GMAC_NCR) Transmit Enable Mask */
+#define GMAC_NCR_TXEN                       GMAC_NCR_TXEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXEN_Msk instead */
+#define GMAC_NCR_MPE_Pos                    4                                              /**< (GMAC_NCR) Management Port Enable Position */
+#define GMAC_NCR_MPE_Msk                    (_U_(0x1) << GMAC_NCR_MPE_Pos)                 /**< (GMAC_NCR) Management Port Enable Mask */
+#define GMAC_NCR_MPE                        GMAC_NCR_MPE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_MPE_Msk instead */
+#define GMAC_NCR_CLRSTAT_Pos                5                                              /**< (GMAC_NCR) Clear Statistics Registers Position */
+#define GMAC_NCR_CLRSTAT_Msk                (_U_(0x1) << GMAC_NCR_CLRSTAT_Pos)             /**< (GMAC_NCR) Clear Statistics Registers Mask */
+#define GMAC_NCR_CLRSTAT                    GMAC_NCR_CLRSTAT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_CLRSTAT_Msk instead */
+#define GMAC_NCR_INCSTAT_Pos                6                                              /**< (GMAC_NCR) Increment Statistics Registers Position */
+#define GMAC_NCR_INCSTAT_Msk                (_U_(0x1) << GMAC_NCR_INCSTAT_Pos)             /**< (GMAC_NCR) Increment Statistics Registers Mask */
+#define GMAC_NCR_INCSTAT                    GMAC_NCR_INCSTAT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_INCSTAT_Msk instead */
+#define GMAC_NCR_WESTAT_Pos                 7                                              /**< (GMAC_NCR) Write Enable for Statistics Registers Position */
+#define GMAC_NCR_WESTAT_Msk                 (_U_(0x1) << GMAC_NCR_WESTAT_Pos)              /**< (GMAC_NCR) Write Enable for Statistics Registers Mask */
+#define GMAC_NCR_WESTAT                     GMAC_NCR_WESTAT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_WESTAT_Msk instead */
+#define GMAC_NCR_BP_Pos                     8                                              /**< (GMAC_NCR) Back pressure Position */
+#define GMAC_NCR_BP_Msk                     (_U_(0x1) << GMAC_NCR_BP_Pos)                  /**< (GMAC_NCR) Back pressure Mask */
+#define GMAC_NCR_BP                         GMAC_NCR_BP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_BP_Msk instead */
+#define GMAC_NCR_TSTART_Pos                 9                                              /**< (GMAC_NCR) Start Transmission Position */
+#define GMAC_NCR_TSTART_Msk                 (_U_(0x1) << GMAC_NCR_TSTART_Pos)              /**< (GMAC_NCR) Start Transmission Mask */
+#define GMAC_NCR_TSTART                     GMAC_NCR_TSTART_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TSTART_Msk instead */
+#define GMAC_NCR_THALT_Pos                  10                                             /**< (GMAC_NCR) Transmit Halt Position */
+#define GMAC_NCR_THALT_Msk                  (_U_(0x1) << GMAC_NCR_THALT_Pos)               /**< (GMAC_NCR) Transmit Halt Mask */
+#define GMAC_NCR_THALT                      GMAC_NCR_THALT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_THALT_Msk instead */
+#define GMAC_NCR_TXPF_Pos                   11                                             /**< (GMAC_NCR) Transmit Pause Frame Position */
+#define GMAC_NCR_TXPF_Msk                   (_U_(0x1) << GMAC_NCR_TXPF_Pos)                /**< (GMAC_NCR) Transmit Pause Frame Mask */
+#define GMAC_NCR_TXPF                       GMAC_NCR_TXPF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXPF_Msk instead */
+#define GMAC_NCR_TXZQPF_Pos                 12                                             /**< (GMAC_NCR) Transmit Zero Quantum Pause Frame Position */
+#define GMAC_NCR_TXZQPF_Msk                 (_U_(0x1) << GMAC_NCR_TXZQPF_Pos)              /**< (GMAC_NCR) Transmit Zero Quantum Pause Frame Mask */
+#define GMAC_NCR_TXZQPF                     GMAC_NCR_TXZQPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXZQPF_Msk instead */
+#define GMAC_NCR_SRTSM_Pos                  15                                             /**< (GMAC_NCR) Store Receive Time Stamp to Memory Position */
+#define GMAC_NCR_SRTSM_Msk                  (_U_(0x1) << GMAC_NCR_SRTSM_Pos)               /**< (GMAC_NCR) Store Receive Time Stamp to Memory Mask */
+#define GMAC_NCR_SRTSM                      GMAC_NCR_SRTSM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_SRTSM_Msk instead */
+#define GMAC_NCR_ENPBPR_Pos                 16                                             /**< (GMAC_NCR) Enable PFC Priority-based Pause Reception Position */
+#define GMAC_NCR_ENPBPR_Msk                 (_U_(0x1) << GMAC_NCR_ENPBPR_Pos)              /**< (GMAC_NCR) Enable PFC Priority-based Pause Reception Mask */
+#define GMAC_NCR_ENPBPR                     GMAC_NCR_ENPBPR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_ENPBPR_Msk instead */
+#define GMAC_NCR_TXPBPF_Pos                 17                                             /**< (GMAC_NCR) Transmit PFC Priority-based Pause Frame Position */
+#define GMAC_NCR_TXPBPF_Msk                 (_U_(0x1) << GMAC_NCR_TXPBPF_Pos)              /**< (GMAC_NCR) Transmit PFC Priority-based Pause Frame Mask */
+#define GMAC_NCR_TXPBPF                     GMAC_NCR_TXPBPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXPBPF_Msk instead */
+#define GMAC_NCR_FNP_Pos                    18                                             /**< (GMAC_NCR) Flush Next Packet Position */
+#define GMAC_NCR_FNP_Msk                    (_U_(0x1) << GMAC_NCR_FNP_Pos)                 /**< (GMAC_NCR) Flush Next Packet Mask */
+#define GMAC_NCR_FNP                        GMAC_NCR_FNP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_FNP_Msk instead */
+#define GMAC_NCR_TXLPIEN_Pos                19                                             /**< (GMAC_NCR) Enable LPI Transmission Position */
+#define GMAC_NCR_TXLPIEN_Msk                (_U_(0x1) << GMAC_NCR_TXLPIEN_Pos)             /**< (GMAC_NCR) Enable LPI Transmission Mask */
+#define GMAC_NCR_TXLPIEN                    GMAC_NCR_TXLPIEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXLPIEN_Msk instead */
+#define GMAC_NCR_MASK                       _U_(0xF9FFE)                                   /**< \deprecated (GMAC_NCR) Register MASK  (Use GMAC_NCR_Msk instead)  */
+#define GMAC_NCR_Msk                        _U_(0xF9FFE)                                   /**< (GMAC_NCR) Register Mask  */
+
+
+/* -------- GMAC_NCFGR : (GMAC Offset: 0x04) (R/W 32) Network Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPD:1;                     /**< bit:      0  Speed                                    */
+    uint32_t FD:1;                      /**< bit:      1  Full Duplex                              */
+    uint32_t DNVLAN:1;                  /**< bit:      2  Discard Non-VLAN FRAMES                  */
+    uint32_t JFRAME:1;                  /**< bit:      3  Jumbo Frame Size                         */
+    uint32_t CAF:1;                     /**< bit:      4  Copy All Frames                          */
+    uint32_t NBC:1;                     /**< bit:      5  No Broadcast                             */
+    uint32_t MTIHEN:1;                  /**< bit:      6  Multicast Hash Enable                    */
+    uint32_t UNIHEN:1;                  /**< bit:      7  Unicast Hash Enable                      */
+    uint32_t MAXFS:1;                   /**< bit:      8  1536 Maximum Frame Size                  */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t RTY:1;                     /**< bit:     12  Retry Test                               */
+    uint32_t PEN:1;                     /**< bit:     13  Pause Enable                             */
+    uint32_t RXBUFO:2;                  /**< bit: 14..15  Receive Buffer Offset                    */
+    uint32_t LFERD:1;                   /**< bit:     16  Length Field Error Frame Discard         */
+    uint32_t RFCS:1;                    /**< bit:     17  Remove FCS                               */
+    uint32_t CLK:3;                     /**< bit: 18..20  MDC CLock Division                       */
+    uint32_t DBW:2;                     /**< bit: 21..22  Data Bus Width                           */
+    uint32_t DCPF:1;                    /**< bit:     23  Disable Copy of Pause Frames             */
+    uint32_t RXCOEN:1;                  /**< bit:     24  Receive Checksum Offload Enable          */
+    uint32_t EFRHD:1;                   /**< bit:     25  Enable Frames Received in Half Duplex    */
+    uint32_t IRXFCS:1;                  /**< bit:     26  Ignore RX FCS                            */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t IPGSEN:1;                  /**< bit:     28  IP Stretch Enable                        */
+    uint32_t RXBP:1;                    /**< bit:     29  Receive Bad Preamble                     */
+    uint32_t IRXER:1;                   /**< bit:     30  Ignore IPG GRXER                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NCFGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NCFGR_OFFSET                   (0x04)                                        /**<  (GMAC_NCFGR) Network Configuration Register  Offset */
+
+#define GMAC_NCFGR_SPD_Pos                  0                                              /**< (GMAC_NCFGR) Speed Position */
+#define GMAC_NCFGR_SPD_Msk                  (_U_(0x1) << GMAC_NCFGR_SPD_Pos)               /**< (GMAC_NCFGR) Speed Mask */
+#define GMAC_NCFGR_SPD                      GMAC_NCFGR_SPD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_SPD_Msk instead */
+#define GMAC_NCFGR_FD_Pos                   1                                              /**< (GMAC_NCFGR) Full Duplex Position */
+#define GMAC_NCFGR_FD_Msk                   (_U_(0x1) << GMAC_NCFGR_FD_Pos)                /**< (GMAC_NCFGR) Full Duplex Mask */
+#define GMAC_NCFGR_FD                       GMAC_NCFGR_FD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_FD_Msk instead */
+#define GMAC_NCFGR_DNVLAN_Pos               2                                              /**< (GMAC_NCFGR) Discard Non-VLAN FRAMES Position */
+#define GMAC_NCFGR_DNVLAN_Msk               (_U_(0x1) << GMAC_NCFGR_DNVLAN_Pos)            /**< (GMAC_NCFGR) Discard Non-VLAN FRAMES Mask */
+#define GMAC_NCFGR_DNVLAN                   GMAC_NCFGR_DNVLAN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_DNVLAN_Msk instead */
+#define GMAC_NCFGR_JFRAME_Pos               3                                              /**< (GMAC_NCFGR) Jumbo Frame Size Position */
+#define GMAC_NCFGR_JFRAME_Msk               (_U_(0x1) << GMAC_NCFGR_JFRAME_Pos)            /**< (GMAC_NCFGR) Jumbo Frame Size Mask */
+#define GMAC_NCFGR_JFRAME                   GMAC_NCFGR_JFRAME_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_JFRAME_Msk instead */
+#define GMAC_NCFGR_CAF_Pos                  4                                              /**< (GMAC_NCFGR) Copy All Frames Position */
+#define GMAC_NCFGR_CAF_Msk                  (_U_(0x1) << GMAC_NCFGR_CAF_Pos)               /**< (GMAC_NCFGR) Copy All Frames Mask */
+#define GMAC_NCFGR_CAF                      GMAC_NCFGR_CAF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_CAF_Msk instead */
+#define GMAC_NCFGR_NBC_Pos                  5                                              /**< (GMAC_NCFGR) No Broadcast Position */
+#define GMAC_NCFGR_NBC_Msk                  (_U_(0x1) << GMAC_NCFGR_NBC_Pos)               /**< (GMAC_NCFGR) No Broadcast Mask */
+#define GMAC_NCFGR_NBC                      GMAC_NCFGR_NBC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_NBC_Msk instead */
+#define GMAC_NCFGR_MTIHEN_Pos               6                                              /**< (GMAC_NCFGR) Multicast Hash Enable Position */
+#define GMAC_NCFGR_MTIHEN_Msk               (_U_(0x1) << GMAC_NCFGR_MTIHEN_Pos)            /**< (GMAC_NCFGR) Multicast Hash Enable Mask */
+#define GMAC_NCFGR_MTIHEN                   GMAC_NCFGR_MTIHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_MTIHEN_Msk instead */
+#define GMAC_NCFGR_UNIHEN_Pos               7                                              /**< (GMAC_NCFGR) Unicast Hash Enable Position */
+#define GMAC_NCFGR_UNIHEN_Msk               (_U_(0x1) << GMAC_NCFGR_UNIHEN_Pos)            /**< (GMAC_NCFGR) Unicast Hash Enable Mask */
+#define GMAC_NCFGR_UNIHEN                   GMAC_NCFGR_UNIHEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_UNIHEN_Msk instead */
+#define GMAC_NCFGR_MAXFS_Pos                8                                              /**< (GMAC_NCFGR) 1536 Maximum Frame Size Position */
+#define GMAC_NCFGR_MAXFS_Msk                (_U_(0x1) << GMAC_NCFGR_MAXFS_Pos)             /**< (GMAC_NCFGR) 1536 Maximum Frame Size Mask */
+#define GMAC_NCFGR_MAXFS                    GMAC_NCFGR_MAXFS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_MAXFS_Msk instead */
+#define GMAC_NCFGR_RTY_Pos                  12                                             /**< (GMAC_NCFGR) Retry Test Position */
+#define GMAC_NCFGR_RTY_Msk                  (_U_(0x1) << GMAC_NCFGR_RTY_Pos)               /**< (GMAC_NCFGR) Retry Test Mask */
+#define GMAC_NCFGR_RTY                      GMAC_NCFGR_RTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RTY_Msk instead */
+#define GMAC_NCFGR_PEN_Pos                  13                                             /**< (GMAC_NCFGR) Pause Enable Position */
+#define GMAC_NCFGR_PEN_Msk                  (_U_(0x1) << GMAC_NCFGR_PEN_Pos)               /**< (GMAC_NCFGR) Pause Enable Mask */
+#define GMAC_NCFGR_PEN                      GMAC_NCFGR_PEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_PEN_Msk instead */
+#define GMAC_NCFGR_RXBUFO_Pos               14                                             /**< (GMAC_NCFGR) Receive Buffer Offset Position */
+#define GMAC_NCFGR_RXBUFO_Msk               (_U_(0x3) << GMAC_NCFGR_RXBUFO_Pos)            /**< (GMAC_NCFGR) Receive Buffer Offset Mask */
+#define GMAC_NCFGR_RXBUFO(value)            (GMAC_NCFGR_RXBUFO_Msk & ((value) << GMAC_NCFGR_RXBUFO_Pos))
+#define GMAC_NCFGR_LFERD_Pos                16                                             /**< (GMAC_NCFGR) Length Field Error Frame Discard Position */
+#define GMAC_NCFGR_LFERD_Msk                (_U_(0x1) << GMAC_NCFGR_LFERD_Pos)             /**< (GMAC_NCFGR) Length Field Error Frame Discard Mask */
+#define GMAC_NCFGR_LFERD                    GMAC_NCFGR_LFERD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_LFERD_Msk instead */
+#define GMAC_NCFGR_RFCS_Pos                 17                                             /**< (GMAC_NCFGR) Remove FCS Position */
+#define GMAC_NCFGR_RFCS_Msk                 (_U_(0x1) << GMAC_NCFGR_RFCS_Pos)              /**< (GMAC_NCFGR) Remove FCS Mask */
+#define GMAC_NCFGR_RFCS                     GMAC_NCFGR_RFCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RFCS_Msk instead */
+#define GMAC_NCFGR_CLK_Pos                  18                                             /**< (GMAC_NCFGR) MDC CLock Division Position */
+#define GMAC_NCFGR_CLK_Msk                  (_U_(0x7) << GMAC_NCFGR_CLK_Pos)               /**< (GMAC_NCFGR) MDC CLock Division Mask */
+#define GMAC_NCFGR_CLK(value)               (GMAC_NCFGR_CLK_Msk & ((value) << GMAC_NCFGR_CLK_Pos))
+#define   GMAC_NCFGR_CLK_MCK_8_Val          _U_(0x0)                                       /**< (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_16_Val         _U_(0x1)                                       /**< (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_32_Val         _U_(0x2)                                       /**< (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_48_Val         _U_(0x3)                                       /**< (GMAC_NCFGR) MCK divided by 48 (MCK up to 120 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_64_Val         _U_(0x4)                                       /**< (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz)  */
+#define   GMAC_NCFGR_CLK_MCK_96_Val         _U_(0x5)                                       /**< (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz)  */
+#define GMAC_NCFGR_CLK_MCK_8                (GMAC_NCFGR_CLK_MCK_8_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_16               (GMAC_NCFGR_CLK_MCK_16_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_32               (GMAC_NCFGR_CLK_MCK_32_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_48               (GMAC_NCFGR_CLK_MCK_48_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 48 (MCK up to 120 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_64               (GMAC_NCFGR_CLK_MCK_64_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz) Position  */
+#define GMAC_NCFGR_CLK_MCK_96               (GMAC_NCFGR_CLK_MCK_96_Val << GMAC_NCFGR_CLK_Pos)  /**< (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz) Position  */
+#define GMAC_NCFGR_DBW_Pos                  21                                             /**< (GMAC_NCFGR) Data Bus Width Position */
+#define GMAC_NCFGR_DBW_Msk                  (_U_(0x3) << GMAC_NCFGR_DBW_Pos)               /**< (GMAC_NCFGR) Data Bus Width Mask */
+#define GMAC_NCFGR_DBW(value)               (GMAC_NCFGR_DBW_Msk & ((value) << GMAC_NCFGR_DBW_Pos))
+#define GMAC_NCFGR_DCPF_Pos                 23                                             /**< (GMAC_NCFGR) Disable Copy of Pause Frames Position */
+#define GMAC_NCFGR_DCPF_Msk                 (_U_(0x1) << GMAC_NCFGR_DCPF_Pos)              /**< (GMAC_NCFGR) Disable Copy of Pause Frames Mask */
+#define GMAC_NCFGR_DCPF                     GMAC_NCFGR_DCPF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_DCPF_Msk instead */
+#define GMAC_NCFGR_RXCOEN_Pos               24                                             /**< (GMAC_NCFGR) Receive Checksum Offload Enable Position */
+#define GMAC_NCFGR_RXCOEN_Msk               (_U_(0x1) << GMAC_NCFGR_RXCOEN_Pos)            /**< (GMAC_NCFGR) Receive Checksum Offload Enable Mask */
+#define GMAC_NCFGR_RXCOEN                   GMAC_NCFGR_RXCOEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RXCOEN_Msk instead */
+#define GMAC_NCFGR_EFRHD_Pos                25                                             /**< (GMAC_NCFGR) Enable Frames Received in Half Duplex Position */
+#define GMAC_NCFGR_EFRHD_Msk                (_U_(0x1) << GMAC_NCFGR_EFRHD_Pos)             /**< (GMAC_NCFGR) Enable Frames Received in Half Duplex Mask */
+#define GMAC_NCFGR_EFRHD                    GMAC_NCFGR_EFRHD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_EFRHD_Msk instead */
+#define GMAC_NCFGR_IRXFCS_Pos               26                                             /**< (GMAC_NCFGR) Ignore RX FCS Position */
+#define GMAC_NCFGR_IRXFCS_Msk               (_U_(0x1) << GMAC_NCFGR_IRXFCS_Pos)            /**< (GMAC_NCFGR) Ignore RX FCS Mask */
+#define GMAC_NCFGR_IRXFCS                   GMAC_NCFGR_IRXFCS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IRXFCS_Msk instead */
+#define GMAC_NCFGR_IPGSEN_Pos               28                                             /**< (GMAC_NCFGR) IP Stretch Enable Position */
+#define GMAC_NCFGR_IPGSEN_Msk               (_U_(0x1) << GMAC_NCFGR_IPGSEN_Pos)            /**< (GMAC_NCFGR) IP Stretch Enable Mask */
+#define GMAC_NCFGR_IPGSEN                   GMAC_NCFGR_IPGSEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IPGSEN_Msk instead */
+#define GMAC_NCFGR_RXBP_Pos                 29                                             /**< (GMAC_NCFGR) Receive Bad Preamble Position */
+#define GMAC_NCFGR_RXBP_Msk                 (_U_(0x1) << GMAC_NCFGR_RXBP_Pos)              /**< (GMAC_NCFGR) Receive Bad Preamble Mask */
+#define GMAC_NCFGR_RXBP                     GMAC_NCFGR_RXBP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_RXBP_Msk instead */
+#define GMAC_NCFGR_IRXER_Pos                30                                             /**< (GMAC_NCFGR) Ignore IPG GRXER Position */
+#define GMAC_NCFGR_IRXER_Msk                (_U_(0x1) << GMAC_NCFGR_IRXER_Pos)             /**< (GMAC_NCFGR) Ignore IPG GRXER Mask */
+#define GMAC_NCFGR_IRXER                    GMAC_NCFGR_IRXER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCFGR_IRXER_Msk instead */
+#define GMAC_NCFGR_MASK                     _U_(0x77FFF1FF)                                /**< \deprecated (GMAC_NCFGR) Register MASK  (Use GMAC_NCFGR_Msk instead)  */
+#define GMAC_NCFGR_Msk                      _U_(0x77FFF1FF)                                /**< (GMAC_NCFGR) Register Mask  */
+
+
+/* -------- GMAC_NSR : (GMAC Offset: 0x08) (R/ 32) Network Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t MDIO:1;                    /**< bit:      1  MDIO Input Status                        */
+    uint32_t IDLE:1;                    /**< bit:      2  PHY Management Logic Idle                */
+    uint32_t :4;                        /**< bit:   3..6  Reserved */
+    uint32_t RXLPIS:1;                  /**< bit:      7  LPI Indication                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NSR_OFFSET                     (0x08)                                        /**<  (GMAC_NSR) Network Status Register  Offset */
+
+#define GMAC_NSR_MDIO_Pos                   1                                              /**< (GMAC_NSR) MDIO Input Status Position */
+#define GMAC_NSR_MDIO_Msk                   (_U_(0x1) << GMAC_NSR_MDIO_Pos)                /**< (GMAC_NSR) MDIO Input Status Mask */
+#define GMAC_NSR_MDIO                       GMAC_NSR_MDIO_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_MDIO_Msk instead */
+#define GMAC_NSR_IDLE_Pos                   2                                              /**< (GMAC_NSR) PHY Management Logic Idle Position */
+#define GMAC_NSR_IDLE_Msk                   (_U_(0x1) << GMAC_NSR_IDLE_Pos)                /**< (GMAC_NSR) PHY Management Logic Idle Mask */
+#define GMAC_NSR_IDLE                       GMAC_NSR_IDLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_IDLE_Msk instead */
+#define GMAC_NSR_RXLPIS_Pos                 7                                              /**< (GMAC_NSR) LPI Indication Position */
+#define GMAC_NSR_RXLPIS_Msk                 (_U_(0x1) << GMAC_NSR_RXLPIS_Pos)              /**< (GMAC_NSR) LPI Indication Mask */
+#define GMAC_NSR_RXLPIS                     GMAC_NSR_RXLPIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_RXLPIS_Msk instead */
+#define GMAC_NSR_MASK                       _U_(0x86)                                      /**< \deprecated (GMAC_NSR) Register MASK  (Use GMAC_NSR_Msk instead)  */
+#define GMAC_NSR_Msk                        _U_(0x86)                                      /**< (GMAC_NSR) Register Mask  */
+
+
+/* -------- GMAC_UR : (GMAC Offset: 0x0c) (R/W 32) User Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RMII:1;                    /**< bit:      0  Reduced MII Mode                         */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UR_OFFSET                      (0x0C)                                        /**<  (GMAC_UR) User Register  Offset */
+
+#define GMAC_UR_RMII_Pos                    0                                              /**< (GMAC_UR) Reduced MII Mode Position */
+#define GMAC_UR_RMII_Msk                    (_U_(0x1) << GMAC_UR_RMII_Pos)                 /**< (GMAC_UR) Reduced MII Mode Mask */
+#define GMAC_UR_RMII                        GMAC_UR_RMII_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_UR_RMII_Msk instead */
+#define GMAC_UR_MASK                        _U_(0x01)                                      /**< \deprecated (GMAC_UR) Register MASK  (Use GMAC_UR_Msk instead)  */
+#define GMAC_UR_Msk                         _U_(0x01)                                      /**< (GMAC_UR) Register Mask  */
+
+
+/* -------- GMAC_DCFGR : (GMAC Offset: 0x10) (R/W 32) DMA Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FBLDO:5;                   /**< bit:   0..4  Fixed Burst Length for DMA Data Operations: */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t ESMA:1;                    /**< bit:      6  Endian Swap Mode Enable for Management Descriptor Accesses */
+    uint32_t ESPA:1;                    /**< bit:      7  Endian Swap Mode Enable for Packet Data Accesses */
+    uint32_t RXBMS:2;                   /**< bit:   8..9  Receiver Packet Buffer Memory Size Select */
+    uint32_t TXPBMS:1;                  /**< bit:     10  Transmitter Packet Buffer Memory Size Select */
+    uint32_t TXCOEN:1;                  /**< bit:     11  Transmitter Checksum Generation Offload Enable */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DRBS:8;                    /**< bit: 16..23  DMA Receive Buffer Size                  */
+    uint32_t DDRP:1;                    /**< bit:     24  DMA Discard Receive Packets              */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_DCFGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_DCFGR_OFFSET                   (0x10)                                        /**<  (GMAC_DCFGR) DMA Configuration Register  Offset */
+
+#define GMAC_DCFGR_FBLDO_Pos                0                                              /**< (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: Position */
+#define GMAC_DCFGR_FBLDO_Msk                (_U_(0x1F) << GMAC_DCFGR_FBLDO_Pos)            /**< (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: Mask */
+#define GMAC_DCFGR_FBLDO(value)             (GMAC_DCFGR_FBLDO_Msk & ((value) << GMAC_DCFGR_FBLDO_Pos))
+#define   GMAC_DCFGR_FBLDO_SINGLE_Val       _U_(0x1)                                       /**< (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts  */
+#define   GMAC_DCFGR_FBLDO_INCR4_Val        _U_(0x4)                                       /**< (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default)  */
+#define   GMAC_DCFGR_FBLDO_INCR8_Val        _U_(0x8)                                       /**< (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts  */
+#define   GMAC_DCFGR_FBLDO_INCR16_Val       _U_(0x10)                                      /**< (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts  */
+#define GMAC_DCFGR_FBLDO_SINGLE             (GMAC_DCFGR_FBLDO_SINGLE_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts Position  */
+#define GMAC_DCFGR_FBLDO_INCR4              (GMAC_DCFGR_FBLDO_INCR4_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default) Position  */
+#define GMAC_DCFGR_FBLDO_INCR8              (GMAC_DCFGR_FBLDO_INCR8_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts Position  */
+#define GMAC_DCFGR_FBLDO_INCR16             (GMAC_DCFGR_FBLDO_INCR16_Val << GMAC_DCFGR_FBLDO_Pos)  /**< (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts Position  */
+#define GMAC_DCFGR_ESMA_Pos                 6                                              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses Position */
+#define GMAC_DCFGR_ESMA_Msk                 (_U_(0x1) << GMAC_DCFGR_ESMA_Pos)              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses Mask */
+#define GMAC_DCFGR_ESMA                     GMAC_DCFGR_ESMA_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_ESMA_Msk instead */
+#define GMAC_DCFGR_ESPA_Pos                 7                                              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses Position */
+#define GMAC_DCFGR_ESPA_Msk                 (_U_(0x1) << GMAC_DCFGR_ESPA_Pos)              /**< (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses Mask */
+#define GMAC_DCFGR_ESPA                     GMAC_DCFGR_ESPA_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_ESPA_Msk instead */
+#define GMAC_DCFGR_RXBMS_Pos                8                                              /**< (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select Position */
+#define GMAC_DCFGR_RXBMS_Msk                (_U_(0x3) << GMAC_DCFGR_RXBMS_Pos)             /**< (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select Mask */
+#define GMAC_DCFGR_RXBMS(value)             (GMAC_DCFGR_RXBMS_Msk & ((value) << GMAC_DCFGR_RXBMS_Pos))
+#define   GMAC_DCFGR_RXBMS_EIGHTH_Val       _U_(0x0)                                       /**< (GMAC_DCFGR) 4/8 Kbyte Memory Size  */
+#define   GMAC_DCFGR_RXBMS_QUARTER_Val      _U_(0x1)                                       /**< (GMAC_DCFGR) 4/4 Kbytes Memory Size  */
+#define   GMAC_DCFGR_RXBMS_HALF_Val         _U_(0x2)                                       /**< (GMAC_DCFGR) 4/2 Kbytes Memory Size  */
+#define   GMAC_DCFGR_RXBMS_FULL_Val         _U_(0x3)                                       /**< (GMAC_DCFGR) 4 Kbytes Memory Size  */
+#define GMAC_DCFGR_RXBMS_EIGHTH             (GMAC_DCFGR_RXBMS_EIGHTH_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/8 Kbyte Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_QUARTER            (GMAC_DCFGR_RXBMS_QUARTER_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/4 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_HALF               (GMAC_DCFGR_RXBMS_HALF_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4/2 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_RXBMS_FULL               (GMAC_DCFGR_RXBMS_FULL_Val << GMAC_DCFGR_RXBMS_Pos)  /**< (GMAC_DCFGR) 4 Kbytes Memory Size Position  */
+#define GMAC_DCFGR_TXPBMS_Pos               10                                             /**< (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select Position */
+#define GMAC_DCFGR_TXPBMS_Msk               (_U_(0x1) << GMAC_DCFGR_TXPBMS_Pos)            /**< (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select Mask */
+#define GMAC_DCFGR_TXPBMS                   GMAC_DCFGR_TXPBMS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_TXPBMS_Msk instead */
+#define GMAC_DCFGR_TXCOEN_Pos               11                                             /**< (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable Position */
+#define GMAC_DCFGR_TXCOEN_Msk               (_U_(0x1) << GMAC_DCFGR_TXCOEN_Pos)            /**< (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable Mask */
+#define GMAC_DCFGR_TXCOEN                   GMAC_DCFGR_TXCOEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_TXCOEN_Msk instead */
+#define GMAC_DCFGR_DRBS_Pos                 16                                             /**< (GMAC_DCFGR) DMA Receive Buffer Size Position */
+#define GMAC_DCFGR_DRBS_Msk                 (_U_(0xFF) << GMAC_DCFGR_DRBS_Pos)             /**< (GMAC_DCFGR) DMA Receive Buffer Size Mask */
+#define GMAC_DCFGR_DRBS(value)              (GMAC_DCFGR_DRBS_Msk & ((value) << GMAC_DCFGR_DRBS_Pos))
+#define GMAC_DCFGR_DDRP_Pos                 24                                             /**< (GMAC_DCFGR) DMA Discard Receive Packets Position */
+#define GMAC_DCFGR_DDRP_Msk                 (_U_(0x1) << GMAC_DCFGR_DDRP_Pos)              /**< (GMAC_DCFGR) DMA Discard Receive Packets Mask */
+#define GMAC_DCFGR_DDRP                     GMAC_DCFGR_DDRP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_DCFGR_DDRP_Msk instead */
+#define GMAC_DCFGR_MASK                     _U_(0x1FF0FDF)                                 /**< \deprecated (GMAC_DCFGR) Register MASK  (Use GMAC_DCFGR_Msk instead)  */
+#define GMAC_DCFGR_Msk                      _U_(0x1FF0FDF)                                 /**< (GMAC_DCFGR) Register Mask  */
+
+
+/* -------- GMAC_TSR : (GMAC Offset: 0x14) (R/W 32) Transmit Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UBR:1;                     /**< bit:      0  Used Bit Read                            */
+    uint32_t COL:1;                     /**< bit:      1  Collision Occurred                       */
+    uint32_t RLE:1;                     /**< bit:      2  Retry Limit Exceeded                     */
+    uint32_t TXGO:1;                    /**< bit:      3  Transmit Go                              */
+    uint32_t TFC:1;                     /**< bit:      4  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TXCOMP:1;                  /**< bit:      5  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t HRESP:1;                   /**< bit:      8  HRESP Not OK                             */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSR_OFFSET                     (0x14)                                        /**<  (GMAC_TSR) Transmit Status Register  Offset */
+
+#define GMAC_TSR_UBR_Pos                    0                                              /**< (GMAC_TSR) Used Bit Read Position */
+#define GMAC_TSR_UBR_Msk                    (_U_(0x1) << GMAC_TSR_UBR_Pos)                 /**< (GMAC_TSR) Used Bit Read Mask */
+#define GMAC_TSR_UBR                        GMAC_TSR_UBR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_UBR_Msk instead */
+#define GMAC_TSR_COL_Pos                    1                                              /**< (GMAC_TSR) Collision Occurred Position */
+#define GMAC_TSR_COL_Msk                    (_U_(0x1) << GMAC_TSR_COL_Pos)                 /**< (GMAC_TSR) Collision Occurred Mask */
+#define GMAC_TSR_COL                        GMAC_TSR_COL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_COL_Msk instead */
+#define GMAC_TSR_RLE_Pos                    2                                              /**< (GMAC_TSR) Retry Limit Exceeded Position */
+#define GMAC_TSR_RLE_Msk                    (_U_(0x1) << GMAC_TSR_RLE_Pos)                 /**< (GMAC_TSR) Retry Limit Exceeded Mask */
+#define GMAC_TSR_RLE                        GMAC_TSR_RLE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_RLE_Msk instead */
+#define GMAC_TSR_TXGO_Pos                   3                                              /**< (GMAC_TSR) Transmit Go Position */
+#define GMAC_TSR_TXGO_Msk                   (_U_(0x1) << GMAC_TSR_TXGO_Pos)                /**< (GMAC_TSR) Transmit Go Mask */
+#define GMAC_TSR_TXGO                       GMAC_TSR_TXGO_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TXGO_Msk instead */
+#define GMAC_TSR_TFC_Pos                    4                                              /**< (GMAC_TSR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_TSR_TFC_Msk                    (_U_(0x1) << GMAC_TSR_TFC_Pos)                 /**< (GMAC_TSR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_TSR_TFC                        GMAC_TSR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TFC_Msk instead */
+#define GMAC_TSR_TXCOMP_Pos                 5                                              /**< (GMAC_TSR) Transmit Complete Position */
+#define GMAC_TSR_TXCOMP_Msk                 (_U_(0x1) << GMAC_TSR_TXCOMP_Pos)              /**< (GMAC_TSR) Transmit Complete Mask */
+#define GMAC_TSR_TXCOMP                     GMAC_TSR_TXCOMP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_TXCOMP_Msk instead */
+#define GMAC_TSR_HRESP_Pos                  8                                              /**< (GMAC_TSR) HRESP Not OK Position */
+#define GMAC_TSR_HRESP_Msk                  (_U_(0x1) << GMAC_TSR_HRESP_Pos)               /**< (GMAC_TSR) HRESP Not OK Mask */
+#define GMAC_TSR_HRESP                      GMAC_TSR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TSR_HRESP_Msk instead */
+#define GMAC_TSR_MASK                       _U_(0x13F)                                     /**< \deprecated (GMAC_TSR) Register MASK  (Use GMAC_TSR_Msk instead)  */
+#define GMAC_TSR_Msk                        _U_(0x13F)                                     /**< (GMAC_TSR) Register Mask  */
+
+
+/* -------- GMAC_RBQB : (GMAC Offset: 0x18) (R/W 32) Receive Buffer Queue Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Receive Buffer Queue Base Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBQB_OFFSET                    (0x18)                                        /**<  (GMAC_RBQB) Receive Buffer Queue Base Address Register  Offset */
+
+#define GMAC_RBQB_ADDR_Pos                  2                                              /**< (GMAC_RBQB) Receive Buffer Queue Base Address Position */
+#define GMAC_RBQB_ADDR_Msk                  (_U_(0x3FFFFFFF) << GMAC_RBQB_ADDR_Pos)        /**< (GMAC_RBQB) Receive Buffer Queue Base Address Mask */
+#define GMAC_RBQB_ADDR(value)               (GMAC_RBQB_ADDR_Msk & ((value) << GMAC_RBQB_ADDR_Pos))
+#define GMAC_RBQB_MASK                      _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_RBQB) Register MASK  (Use GMAC_RBQB_Msk instead)  */
+#define GMAC_RBQB_Msk                       _U_(0xFFFFFFFC)                                /**< (GMAC_RBQB) Register Mask  */
+
+
+/* -------- GMAC_TBQB : (GMAC Offset: 0x1c) (R/W 32) Transmit Buffer Queue Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t ADDR:30;                   /**< bit:  2..31  Transmit Buffer Queue Base Address       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBQB_OFFSET                    (0x1C)                                        /**<  (GMAC_TBQB) Transmit Buffer Queue Base Address Register  Offset */
+
+#define GMAC_TBQB_ADDR_Pos                  2                                              /**< (GMAC_TBQB) Transmit Buffer Queue Base Address Position */
+#define GMAC_TBQB_ADDR_Msk                  (_U_(0x3FFFFFFF) << GMAC_TBQB_ADDR_Pos)        /**< (GMAC_TBQB) Transmit Buffer Queue Base Address Mask */
+#define GMAC_TBQB_ADDR(value)               (GMAC_TBQB_ADDR_Msk & ((value) << GMAC_TBQB_ADDR_Pos))
+#define GMAC_TBQB_MASK                      _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_TBQB) Register MASK  (Use GMAC_TBQB_Msk instead)  */
+#define GMAC_TBQB_Msk                       _U_(0xFFFFFFFC)                                /**< (GMAC_TBQB) Register Mask  */
+
+
+/* -------- GMAC_RSR : (GMAC Offset: 0x20) (R/W 32) Receive Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BNA:1;                     /**< bit:      0  Buffer Not Available                     */
+    uint32_t REC:1;                     /**< bit:      1  Frame Received                           */
+    uint32_t RXOVR:1;                   /**< bit:      2  Receive Overrun                          */
+    uint32_t HNO:1;                     /**< bit:      3  HRESP Not OK                             */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RSR_OFFSET                     (0x20)                                        /**<  (GMAC_RSR) Receive Status Register  Offset */
+
+#define GMAC_RSR_BNA_Pos                    0                                              /**< (GMAC_RSR) Buffer Not Available Position */
+#define GMAC_RSR_BNA_Msk                    (_U_(0x1) << GMAC_RSR_BNA_Pos)                 /**< (GMAC_RSR) Buffer Not Available Mask */
+#define GMAC_RSR_BNA                        GMAC_RSR_BNA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_BNA_Msk instead */
+#define GMAC_RSR_REC_Pos                    1                                              /**< (GMAC_RSR) Frame Received Position */
+#define GMAC_RSR_REC_Msk                    (_U_(0x1) << GMAC_RSR_REC_Pos)                 /**< (GMAC_RSR) Frame Received Mask */
+#define GMAC_RSR_REC                        GMAC_RSR_REC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_REC_Msk instead */
+#define GMAC_RSR_RXOVR_Pos                  2                                              /**< (GMAC_RSR) Receive Overrun Position */
+#define GMAC_RSR_RXOVR_Msk                  (_U_(0x1) << GMAC_RSR_RXOVR_Pos)               /**< (GMAC_RSR) Receive Overrun Mask */
+#define GMAC_RSR_RXOVR                      GMAC_RSR_RXOVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_RXOVR_Msk instead */
+#define GMAC_RSR_HNO_Pos                    3                                              /**< (GMAC_RSR) HRESP Not OK Position */
+#define GMAC_RSR_HNO_Msk                    (_U_(0x1) << GMAC_RSR_HNO_Pos)                 /**< (GMAC_RSR) HRESP Not OK Mask */
+#define GMAC_RSR_HNO                        GMAC_RSR_HNO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RSR_HNO_Msk instead */
+#define GMAC_RSR_MASK                       _U_(0x0F)                                      /**< \deprecated (GMAC_RSR) Register MASK  (Use GMAC_RSR_Msk instead)  */
+#define GMAC_RSR_Msk                        _U_(0x0F)                                      /**< (GMAC_RSR) Register Mask  */
+
+
+/* -------- GMAC_ISR : (GMAC Offset: 0x24) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded                     */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t :3;                        /**< bit: 15..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Receive LPI indication Status Bit Change */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ISR_OFFSET                     (0x24)                                        /**<  (GMAC_ISR) Interrupt Status Register  Offset */
+
+#define GMAC_ISR_MFS_Pos                    0                                              /**< (GMAC_ISR) Management Frame Sent Position */
+#define GMAC_ISR_MFS_Msk                    (_U_(0x1) << GMAC_ISR_MFS_Pos)                 /**< (GMAC_ISR) Management Frame Sent Mask */
+#define GMAC_ISR_MFS                        GMAC_ISR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_MFS_Msk instead */
+#define GMAC_ISR_RCOMP_Pos                  1                                              /**< (GMAC_ISR) Receive Complete Position */
+#define GMAC_ISR_RCOMP_Msk                  (_U_(0x1) << GMAC_ISR_RCOMP_Pos)               /**< (GMAC_ISR) Receive Complete Mask */
+#define GMAC_ISR_RCOMP                      GMAC_ISR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RCOMP_Msk instead */
+#define GMAC_ISR_RXUBR_Pos                  2                                              /**< (GMAC_ISR) RX Used Bit Read Position */
+#define GMAC_ISR_RXUBR_Msk                  (_U_(0x1) << GMAC_ISR_RXUBR_Pos)               /**< (GMAC_ISR) RX Used Bit Read Mask */
+#define GMAC_ISR_RXUBR                      GMAC_ISR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RXUBR_Msk instead */
+#define GMAC_ISR_TXUBR_Pos                  3                                              /**< (GMAC_ISR) TX Used Bit Read Position */
+#define GMAC_ISR_TXUBR_Msk                  (_U_(0x1) << GMAC_ISR_TXUBR_Pos)               /**< (GMAC_ISR) TX Used Bit Read Mask */
+#define GMAC_ISR_TXUBR                      GMAC_ISR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TXUBR_Msk instead */
+#define GMAC_ISR_TUR_Pos                    4                                              /**< (GMAC_ISR) Transmit Underrun Position */
+#define GMAC_ISR_TUR_Msk                    (_U_(0x1) << GMAC_ISR_TUR_Pos)                 /**< (GMAC_ISR) Transmit Underrun Mask */
+#define GMAC_ISR_TUR                        GMAC_ISR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TUR_Msk instead */
+#define GMAC_ISR_RLEX_Pos                   5                                              /**< (GMAC_ISR) Retry Limit Exceeded Position */
+#define GMAC_ISR_RLEX_Msk                   (_U_(0x1) << GMAC_ISR_RLEX_Pos)                /**< (GMAC_ISR) Retry Limit Exceeded Mask */
+#define GMAC_ISR_RLEX                       GMAC_ISR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RLEX_Msk instead */
+#define GMAC_ISR_TFC_Pos                    6                                              /**< (GMAC_ISR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_ISR_TFC_Msk                    (_U_(0x1) << GMAC_ISR_TFC_Pos)                 /**< (GMAC_ISR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_ISR_TFC                        GMAC_ISR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TFC_Msk instead */
+#define GMAC_ISR_TCOMP_Pos                  7                                              /**< (GMAC_ISR) Transmit Complete Position */
+#define GMAC_ISR_TCOMP_Msk                  (_U_(0x1) << GMAC_ISR_TCOMP_Pos)               /**< (GMAC_ISR) Transmit Complete Mask */
+#define GMAC_ISR_TCOMP                      GMAC_ISR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TCOMP_Msk instead */
+#define GMAC_ISR_ROVR_Pos                   10                                             /**< (GMAC_ISR) Receive Overrun Position */
+#define GMAC_ISR_ROVR_Msk                   (_U_(0x1) << GMAC_ISR_ROVR_Pos)                /**< (GMAC_ISR) Receive Overrun Mask */
+#define GMAC_ISR_ROVR                       GMAC_ISR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_ROVR_Msk instead */
+#define GMAC_ISR_HRESP_Pos                  11                                             /**< (GMAC_ISR) HRESP Not OK Position */
+#define GMAC_ISR_HRESP_Msk                  (_U_(0x1) << GMAC_ISR_HRESP_Pos)               /**< (GMAC_ISR) HRESP Not OK Mask */
+#define GMAC_ISR_HRESP                      GMAC_ISR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_HRESP_Msk instead */
+#define GMAC_ISR_PFNZ_Pos                   12                                             /**< (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_ISR_PFNZ_Msk                   (_U_(0x1) << GMAC_ISR_PFNZ_Pos)                /**< (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_ISR_PFNZ                       GMAC_ISR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PFNZ_Msk instead */
+#define GMAC_ISR_PTZ_Pos                    13                                             /**< (GMAC_ISR) Pause Time Zero Position */
+#define GMAC_ISR_PTZ_Msk                    (_U_(0x1) << GMAC_ISR_PTZ_Pos)                 /**< (GMAC_ISR) Pause Time Zero Mask */
+#define GMAC_ISR_PTZ                        GMAC_ISR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PTZ_Msk instead */
+#define GMAC_ISR_PFTR_Pos                   14                                             /**< (GMAC_ISR) Pause Frame Transmitted Position */
+#define GMAC_ISR_PFTR_Msk                   (_U_(0x1) << GMAC_ISR_PFTR_Pos)                /**< (GMAC_ISR) Pause Frame Transmitted Mask */
+#define GMAC_ISR_PFTR                       GMAC_ISR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PFTR_Msk instead */
+#define GMAC_ISR_DRQFR_Pos                  18                                             /**< (GMAC_ISR) PTP Delay Request Frame Received Position */
+#define GMAC_ISR_DRQFR_Msk                  (_U_(0x1) << GMAC_ISR_DRQFR_Pos)               /**< (GMAC_ISR) PTP Delay Request Frame Received Mask */
+#define GMAC_ISR_DRQFR                      GMAC_ISR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_DRQFR_Msk instead */
+#define GMAC_ISR_SFR_Pos                    19                                             /**< (GMAC_ISR) PTP Sync Frame Received Position */
+#define GMAC_ISR_SFR_Msk                    (_U_(0x1) << GMAC_ISR_SFR_Pos)                 /**< (GMAC_ISR) PTP Sync Frame Received Mask */
+#define GMAC_ISR_SFR                        GMAC_ISR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SFR_Msk instead */
+#define GMAC_ISR_DRQFT_Pos                  20                                             /**< (GMAC_ISR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_ISR_DRQFT_Msk                  (_U_(0x1) << GMAC_ISR_DRQFT_Pos)               /**< (GMAC_ISR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_ISR_DRQFT                      GMAC_ISR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_DRQFT_Msk instead */
+#define GMAC_ISR_SFT_Pos                    21                                             /**< (GMAC_ISR) PTP Sync Frame Transmitted Position */
+#define GMAC_ISR_SFT_Msk                    (_U_(0x1) << GMAC_ISR_SFT_Pos)                 /**< (GMAC_ISR) PTP Sync Frame Transmitted Mask */
+#define GMAC_ISR_SFT                        GMAC_ISR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SFT_Msk instead */
+#define GMAC_ISR_PDRQFR_Pos                 22                                             /**< (GMAC_ISR) PDelay Request Frame Received Position */
+#define GMAC_ISR_PDRQFR_Msk                 (_U_(0x1) << GMAC_ISR_PDRQFR_Pos)              /**< (GMAC_ISR) PDelay Request Frame Received Mask */
+#define GMAC_ISR_PDRQFR                     GMAC_ISR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRQFR_Msk instead */
+#define GMAC_ISR_PDRSFR_Pos                 23                                             /**< (GMAC_ISR) PDelay Response Frame Received Position */
+#define GMAC_ISR_PDRSFR_Msk                 (_U_(0x1) << GMAC_ISR_PDRSFR_Pos)              /**< (GMAC_ISR) PDelay Response Frame Received Mask */
+#define GMAC_ISR_PDRSFR                     GMAC_ISR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRSFR_Msk instead */
+#define GMAC_ISR_PDRQFT_Pos                 24                                             /**< (GMAC_ISR) PDelay Request Frame Transmitted Position */
+#define GMAC_ISR_PDRQFT_Msk                 (_U_(0x1) << GMAC_ISR_PDRQFT_Pos)              /**< (GMAC_ISR) PDelay Request Frame Transmitted Mask */
+#define GMAC_ISR_PDRQFT                     GMAC_ISR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRQFT_Msk instead */
+#define GMAC_ISR_PDRSFT_Pos                 25                                             /**< (GMAC_ISR) PDelay Response Frame Transmitted Position */
+#define GMAC_ISR_PDRSFT_Msk                 (_U_(0x1) << GMAC_ISR_PDRSFT_Pos)              /**< (GMAC_ISR) PDelay Response Frame Transmitted Mask */
+#define GMAC_ISR_PDRSFT                     GMAC_ISR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_PDRSFT_Msk instead */
+#define GMAC_ISR_SRI_Pos                    26                                             /**< (GMAC_ISR) TSU Seconds Register Increment Position */
+#define GMAC_ISR_SRI_Msk                    (_U_(0x1) << GMAC_ISR_SRI_Pos)                 /**< (GMAC_ISR) TSU Seconds Register Increment Mask */
+#define GMAC_ISR_SRI                        GMAC_ISR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SRI_Msk instead */
+#define GMAC_ISR_RXLPISBC_Pos               27                                             /**< (GMAC_ISR) Receive LPI indication Status Bit Change Position */
+#define GMAC_ISR_RXLPISBC_Msk               (_U_(0x1) << GMAC_ISR_RXLPISBC_Pos)            /**< (GMAC_ISR) Receive LPI indication Status Bit Change Mask */
+#define GMAC_ISR_RXLPISBC                   GMAC_ISR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RXLPISBC_Msk instead */
+#define GMAC_ISR_WOL_Pos                    28                                             /**< (GMAC_ISR) Wake On LAN Position */
+#define GMAC_ISR_WOL_Msk                    (_U_(0x1) << GMAC_ISR_WOL_Pos)                 /**< (GMAC_ISR) Wake On LAN Mask */
+#define GMAC_ISR_WOL                        GMAC_ISR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_WOL_Msk instead */
+#define GMAC_ISR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_ISR) TSU Timer Comparison Position */
+#define GMAC_ISR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_ISR_TSUTIMCOMP_Pos)          /**< (GMAC_ISR) TSU Timer Comparison Mask */
+#define GMAC_ISR_TSUTIMCOMP                 GMAC_ISR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TSUTIMCOMP_Msk instead */
+#define GMAC_ISR_MASK                       _U_(0x3FFC7CFF)                                /**< \deprecated (GMAC_ISR) Register MASK  (Use GMAC_ISR_Msk instead)  */
+#define GMAC_ISR_Msk                        _U_(0x3FFC7CFF)                                /**< (GMAC_ISR) Register Mask  */
+
+
+/* -------- GMAC_IER : (GMAC Offset: 0x28) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IER_OFFSET                     (0x28)                                        /**<  (GMAC_IER) Interrupt Enable Register  Offset */
+
+#define GMAC_IER_MFS_Pos                    0                                              /**< (GMAC_IER) Management Frame Sent Position */
+#define GMAC_IER_MFS_Msk                    (_U_(0x1) << GMAC_IER_MFS_Pos)                 /**< (GMAC_IER) Management Frame Sent Mask */
+#define GMAC_IER_MFS                        GMAC_IER_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_MFS_Msk instead */
+#define GMAC_IER_RCOMP_Pos                  1                                              /**< (GMAC_IER) Receive Complete Position */
+#define GMAC_IER_RCOMP_Msk                  (_U_(0x1) << GMAC_IER_RCOMP_Pos)               /**< (GMAC_IER) Receive Complete Mask */
+#define GMAC_IER_RCOMP                      GMAC_IER_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RCOMP_Msk instead */
+#define GMAC_IER_RXUBR_Pos                  2                                              /**< (GMAC_IER) RX Used Bit Read Position */
+#define GMAC_IER_RXUBR_Msk                  (_U_(0x1) << GMAC_IER_RXUBR_Pos)               /**< (GMAC_IER) RX Used Bit Read Mask */
+#define GMAC_IER_RXUBR                      GMAC_IER_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RXUBR_Msk instead */
+#define GMAC_IER_TXUBR_Pos                  3                                              /**< (GMAC_IER) TX Used Bit Read Position */
+#define GMAC_IER_TXUBR_Msk                  (_U_(0x1) << GMAC_IER_TXUBR_Pos)               /**< (GMAC_IER) TX Used Bit Read Mask */
+#define GMAC_IER_TXUBR                      GMAC_IER_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TXUBR_Msk instead */
+#define GMAC_IER_TUR_Pos                    4                                              /**< (GMAC_IER) Transmit Underrun Position */
+#define GMAC_IER_TUR_Msk                    (_U_(0x1) << GMAC_IER_TUR_Pos)                 /**< (GMAC_IER) Transmit Underrun Mask */
+#define GMAC_IER_TUR                        GMAC_IER_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TUR_Msk instead */
+#define GMAC_IER_RLEX_Pos                   5                                              /**< (GMAC_IER) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IER_RLEX_Msk                   (_U_(0x1) << GMAC_IER_RLEX_Pos)                /**< (GMAC_IER) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IER_RLEX                       GMAC_IER_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RLEX_Msk instead */
+#define GMAC_IER_TFC_Pos                    6                                              /**< (GMAC_IER) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IER_TFC_Msk                    (_U_(0x1) << GMAC_IER_TFC_Pos)                 /**< (GMAC_IER) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IER_TFC                        GMAC_IER_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TFC_Msk instead */
+#define GMAC_IER_TCOMP_Pos                  7                                              /**< (GMAC_IER) Transmit Complete Position */
+#define GMAC_IER_TCOMP_Msk                  (_U_(0x1) << GMAC_IER_TCOMP_Pos)               /**< (GMAC_IER) Transmit Complete Mask */
+#define GMAC_IER_TCOMP                      GMAC_IER_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TCOMP_Msk instead */
+#define GMAC_IER_ROVR_Pos                   10                                             /**< (GMAC_IER) Receive Overrun Position */
+#define GMAC_IER_ROVR_Msk                   (_U_(0x1) << GMAC_IER_ROVR_Pos)                /**< (GMAC_IER) Receive Overrun Mask */
+#define GMAC_IER_ROVR                       GMAC_IER_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_ROVR_Msk instead */
+#define GMAC_IER_HRESP_Pos                  11                                             /**< (GMAC_IER) HRESP Not OK Position */
+#define GMAC_IER_HRESP_Msk                  (_U_(0x1) << GMAC_IER_HRESP_Pos)               /**< (GMAC_IER) HRESP Not OK Mask */
+#define GMAC_IER_HRESP                      GMAC_IER_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_HRESP_Msk instead */
+#define GMAC_IER_PFNZ_Pos                   12                                             /**< (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IER_PFNZ_Msk                   (_U_(0x1) << GMAC_IER_PFNZ_Pos)                /**< (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IER_PFNZ                       GMAC_IER_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PFNZ_Msk instead */
+#define GMAC_IER_PTZ_Pos                    13                                             /**< (GMAC_IER) Pause Time Zero Position */
+#define GMAC_IER_PTZ_Msk                    (_U_(0x1) << GMAC_IER_PTZ_Pos)                 /**< (GMAC_IER) Pause Time Zero Mask */
+#define GMAC_IER_PTZ                        GMAC_IER_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PTZ_Msk instead */
+#define GMAC_IER_PFTR_Pos                   14                                             /**< (GMAC_IER) Pause Frame Transmitted Position */
+#define GMAC_IER_PFTR_Msk                   (_U_(0x1) << GMAC_IER_PFTR_Pos)                /**< (GMAC_IER) Pause Frame Transmitted Mask */
+#define GMAC_IER_PFTR                       GMAC_IER_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PFTR_Msk instead */
+#define GMAC_IER_EXINT_Pos                  15                                             /**< (GMAC_IER) External Interrupt Position */
+#define GMAC_IER_EXINT_Msk                  (_U_(0x1) << GMAC_IER_EXINT_Pos)               /**< (GMAC_IER) External Interrupt Mask */
+#define GMAC_IER_EXINT                      GMAC_IER_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_EXINT_Msk instead */
+#define GMAC_IER_DRQFR_Pos                  18                                             /**< (GMAC_IER) PTP Delay Request Frame Received Position */
+#define GMAC_IER_DRQFR_Msk                  (_U_(0x1) << GMAC_IER_DRQFR_Pos)               /**< (GMAC_IER) PTP Delay Request Frame Received Mask */
+#define GMAC_IER_DRQFR                      GMAC_IER_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_DRQFR_Msk instead */
+#define GMAC_IER_SFR_Pos                    19                                             /**< (GMAC_IER) PTP Sync Frame Received Position */
+#define GMAC_IER_SFR_Msk                    (_U_(0x1) << GMAC_IER_SFR_Pos)                 /**< (GMAC_IER) PTP Sync Frame Received Mask */
+#define GMAC_IER_SFR                        GMAC_IER_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SFR_Msk instead */
+#define GMAC_IER_DRQFT_Pos                  20                                             /**< (GMAC_IER) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IER_DRQFT_Msk                  (_U_(0x1) << GMAC_IER_DRQFT_Pos)               /**< (GMAC_IER) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IER_DRQFT                      GMAC_IER_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_DRQFT_Msk instead */
+#define GMAC_IER_SFT_Pos                    21                                             /**< (GMAC_IER) PTP Sync Frame Transmitted Position */
+#define GMAC_IER_SFT_Msk                    (_U_(0x1) << GMAC_IER_SFT_Pos)                 /**< (GMAC_IER) PTP Sync Frame Transmitted Mask */
+#define GMAC_IER_SFT                        GMAC_IER_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SFT_Msk instead */
+#define GMAC_IER_PDRQFR_Pos                 22                                             /**< (GMAC_IER) PDelay Request Frame Received Position */
+#define GMAC_IER_PDRQFR_Msk                 (_U_(0x1) << GMAC_IER_PDRQFR_Pos)              /**< (GMAC_IER) PDelay Request Frame Received Mask */
+#define GMAC_IER_PDRQFR                     GMAC_IER_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRQFR_Msk instead */
+#define GMAC_IER_PDRSFR_Pos                 23                                             /**< (GMAC_IER) PDelay Response Frame Received Position */
+#define GMAC_IER_PDRSFR_Msk                 (_U_(0x1) << GMAC_IER_PDRSFR_Pos)              /**< (GMAC_IER) PDelay Response Frame Received Mask */
+#define GMAC_IER_PDRSFR                     GMAC_IER_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRSFR_Msk instead */
+#define GMAC_IER_PDRQFT_Pos                 24                                             /**< (GMAC_IER) PDelay Request Frame Transmitted Position */
+#define GMAC_IER_PDRQFT_Msk                 (_U_(0x1) << GMAC_IER_PDRQFT_Pos)              /**< (GMAC_IER) PDelay Request Frame Transmitted Mask */
+#define GMAC_IER_PDRQFT                     GMAC_IER_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRQFT_Msk instead */
+#define GMAC_IER_PDRSFT_Pos                 25                                             /**< (GMAC_IER) PDelay Response Frame Transmitted Position */
+#define GMAC_IER_PDRSFT_Msk                 (_U_(0x1) << GMAC_IER_PDRSFT_Pos)              /**< (GMAC_IER) PDelay Response Frame Transmitted Mask */
+#define GMAC_IER_PDRSFT                     GMAC_IER_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_PDRSFT_Msk instead */
+#define GMAC_IER_SRI_Pos                    26                                             /**< (GMAC_IER) TSU Seconds Register Increment Position */
+#define GMAC_IER_SRI_Msk                    (_U_(0x1) << GMAC_IER_SRI_Pos)                 /**< (GMAC_IER) TSU Seconds Register Increment Mask */
+#define GMAC_IER_SRI                        GMAC_IER_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SRI_Msk instead */
+#define GMAC_IER_RXLPISBC_Pos               27                                             /**< (GMAC_IER) Enable RX LPI Indication Position */
+#define GMAC_IER_RXLPISBC_Msk               (_U_(0x1) << GMAC_IER_RXLPISBC_Pos)            /**< (GMAC_IER) Enable RX LPI Indication Mask */
+#define GMAC_IER_RXLPISBC                   GMAC_IER_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RXLPISBC_Msk instead */
+#define GMAC_IER_WOL_Pos                    28                                             /**< (GMAC_IER) Wake On LAN Position */
+#define GMAC_IER_WOL_Msk                    (_U_(0x1) << GMAC_IER_WOL_Pos)                 /**< (GMAC_IER) Wake On LAN Mask */
+#define GMAC_IER_WOL                        GMAC_IER_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_WOL_Msk instead */
+#define GMAC_IER_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IER) TSU Timer Comparison Position */
+#define GMAC_IER_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IER_TSUTIMCOMP_Pos)          /**< (GMAC_IER) TSU Timer Comparison Mask */
+#define GMAC_IER_TSUTIMCOMP                 GMAC_IER_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TSUTIMCOMP_Msk instead */
+#define GMAC_IER_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IER) Register MASK  (Use GMAC_IER_Msk instead)  */
+#define GMAC_IER_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IER) Register Mask  */
+
+
+/* -------- GMAC_IDR : (GMAC Offset: 0x2c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IDR_OFFSET                     (0x2C)                                        /**<  (GMAC_IDR) Interrupt Disable Register  Offset */
+
+#define GMAC_IDR_MFS_Pos                    0                                              /**< (GMAC_IDR) Management Frame Sent Position */
+#define GMAC_IDR_MFS_Msk                    (_U_(0x1) << GMAC_IDR_MFS_Pos)                 /**< (GMAC_IDR) Management Frame Sent Mask */
+#define GMAC_IDR_MFS                        GMAC_IDR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_MFS_Msk instead */
+#define GMAC_IDR_RCOMP_Pos                  1                                              /**< (GMAC_IDR) Receive Complete Position */
+#define GMAC_IDR_RCOMP_Msk                  (_U_(0x1) << GMAC_IDR_RCOMP_Pos)               /**< (GMAC_IDR) Receive Complete Mask */
+#define GMAC_IDR_RCOMP                      GMAC_IDR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RCOMP_Msk instead */
+#define GMAC_IDR_RXUBR_Pos                  2                                              /**< (GMAC_IDR) RX Used Bit Read Position */
+#define GMAC_IDR_RXUBR_Msk                  (_U_(0x1) << GMAC_IDR_RXUBR_Pos)               /**< (GMAC_IDR) RX Used Bit Read Mask */
+#define GMAC_IDR_RXUBR                      GMAC_IDR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RXUBR_Msk instead */
+#define GMAC_IDR_TXUBR_Pos                  3                                              /**< (GMAC_IDR) TX Used Bit Read Position */
+#define GMAC_IDR_TXUBR_Msk                  (_U_(0x1) << GMAC_IDR_TXUBR_Pos)               /**< (GMAC_IDR) TX Used Bit Read Mask */
+#define GMAC_IDR_TXUBR                      GMAC_IDR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TXUBR_Msk instead */
+#define GMAC_IDR_TUR_Pos                    4                                              /**< (GMAC_IDR) Transmit Underrun Position */
+#define GMAC_IDR_TUR_Msk                    (_U_(0x1) << GMAC_IDR_TUR_Pos)                 /**< (GMAC_IDR) Transmit Underrun Mask */
+#define GMAC_IDR_TUR                        GMAC_IDR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TUR_Msk instead */
+#define GMAC_IDR_RLEX_Pos                   5                                              /**< (GMAC_IDR) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IDR_RLEX_Msk                   (_U_(0x1) << GMAC_IDR_RLEX_Pos)                /**< (GMAC_IDR) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IDR_RLEX                       GMAC_IDR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RLEX_Msk instead */
+#define GMAC_IDR_TFC_Pos                    6                                              /**< (GMAC_IDR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IDR_TFC_Msk                    (_U_(0x1) << GMAC_IDR_TFC_Pos)                 /**< (GMAC_IDR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IDR_TFC                        GMAC_IDR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TFC_Msk instead */
+#define GMAC_IDR_TCOMP_Pos                  7                                              /**< (GMAC_IDR) Transmit Complete Position */
+#define GMAC_IDR_TCOMP_Msk                  (_U_(0x1) << GMAC_IDR_TCOMP_Pos)               /**< (GMAC_IDR) Transmit Complete Mask */
+#define GMAC_IDR_TCOMP                      GMAC_IDR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TCOMP_Msk instead */
+#define GMAC_IDR_ROVR_Pos                   10                                             /**< (GMAC_IDR) Receive Overrun Position */
+#define GMAC_IDR_ROVR_Msk                   (_U_(0x1) << GMAC_IDR_ROVR_Pos)                /**< (GMAC_IDR) Receive Overrun Mask */
+#define GMAC_IDR_ROVR                       GMAC_IDR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_ROVR_Msk instead */
+#define GMAC_IDR_HRESP_Pos                  11                                             /**< (GMAC_IDR) HRESP Not OK Position */
+#define GMAC_IDR_HRESP_Msk                  (_U_(0x1) << GMAC_IDR_HRESP_Pos)               /**< (GMAC_IDR) HRESP Not OK Mask */
+#define GMAC_IDR_HRESP                      GMAC_IDR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_HRESP_Msk instead */
+#define GMAC_IDR_PFNZ_Pos                   12                                             /**< (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IDR_PFNZ_Msk                   (_U_(0x1) << GMAC_IDR_PFNZ_Pos)                /**< (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IDR_PFNZ                       GMAC_IDR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PFNZ_Msk instead */
+#define GMAC_IDR_PTZ_Pos                    13                                             /**< (GMAC_IDR) Pause Time Zero Position */
+#define GMAC_IDR_PTZ_Msk                    (_U_(0x1) << GMAC_IDR_PTZ_Pos)                 /**< (GMAC_IDR) Pause Time Zero Mask */
+#define GMAC_IDR_PTZ                        GMAC_IDR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PTZ_Msk instead */
+#define GMAC_IDR_PFTR_Pos                   14                                             /**< (GMAC_IDR) Pause Frame Transmitted Position */
+#define GMAC_IDR_PFTR_Msk                   (_U_(0x1) << GMAC_IDR_PFTR_Pos)                /**< (GMAC_IDR) Pause Frame Transmitted Mask */
+#define GMAC_IDR_PFTR                       GMAC_IDR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PFTR_Msk instead */
+#define GMAC_IDR_EXINT_Pos                  15                                             /**< (GMAC_IDR) External Interrupt Position */
+#define GMAC_IDR_EXINT_Msk                  (_U_(0x1) << GMAC_IDR_EXINT_Pos)               /**< (GMAC_IDR) External Interrupt Mask */
+#define GMAC_IDR_EXINT                      GMAC_IDR_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_EXINT_Msk instead */
+#define GMAC_IDR_DRQFR_Pos                  18                                             /**< (GMAC_IDR) PTP Delay Request Frame Received Position */
+#define GMAC_IDR_DRQFR_Msk                  (_U_(0x1) << GMAC_IDR_DRQFR_Pos)               /**< (GMAC_IDR) PTP Delay Request Frame Received Mask */
+#define GMAC_IDR_DRQFR                      GMAC_IDR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_DRQFR_Msk instead */
+#define GMAC_IDR_SFR_Pos                    19                                             /**< (GMAC_IDR) PTP Sync Frame Received Position */
+#define GMAC_IDR_SFR_Msk                    (_U_(0x1) << GMAC_IDR_SFR_Pos)                 /**< (GMAC_IDR) PTP Sync Frame Received Mask */
+#define GMAC_IDR_SFR                        GMAC_IDR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SFR_Msk instead */
+#define GMAC_IDR_DRQFT_Pos                  20                                             /**< (GMAC_IDR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IDR_DRQFT_Msk                  (_U_(0x1) << GMAC_IDR_DRQFT_Pos)               /**< (GMAC_IDR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IDR_DRQFT                      GMAC_IDR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_DRQFT_Msk instead */
+#define GMAC_IDR_SFT_Pos                    21                                             /**< (GMAC_IDR) PTP Sync Frame Transmitted Position */
+#define GMAC_IDR_SFT_Msk                    (_U_(0x1) << GMAC_IDR_SFT_Pos)                 /**< (GMAC_IDR) PTP Sync Frame Transmitted Mask */
+#define GMAC_IDR_SFT                        GMAC_IDR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SFT_Msk instead */
+#define GMAC_IDR_PDRQFR_Pos                 22                                             /**< (GMAC_IDR) PDelay Request Frame Received Position */
+#define GMAC_IDR_PDRQFR_Msk                 (_U_(0x1) << GMAC_IDR_PDRQFR_Pos)              /**< (GMAC_IDR) PDelay Request Frame Received Mask */
+#define GMAC_IDR_PDRQFR                     GMAC_IDR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRQFR_Msk instead */
+#define GMAC_IDR_PDRSFR_Pos                 23                                             /**< (GMAC_IDR) PDelay Response Frame Received Position */
+#define GMAC_IDR_PDRSFR_Msk                 (_U_(0x1) << GMAC_IDR_PDRSFR_Pos)              /**< (GMAC_IDR) PDelay Response Frame Received Mask */
+#define GMAC_IDR_PDRSFR                     GMAC_IDR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRSFR_Msk instead */
+#define GMAC_IDR_PDRQFT_Pos                 24                                             /**< (GMAC_IDR) PDelay Request Frame Transmitted Position */
+#define GMAC_IDR_PDRQFT_Msk                 (_U_(0x1) << GMAC_IDR_PDRQFT_Pos)              /**< (GMAC_IDR) PDelay Request Frame Transmitted Mask */
+#define GMAC_IDR_PDRQFT                     GMAC_IDR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRQFT_Msk instead */
+#define GMAC_IDR_PDRSFT_Pos                 25                                             /**< (GMAC_IDR) PDelay Response Frame Transmitted Position */
+#define GMAC_IDR_PDRSFT_Msk                 (_U_(0x1) << GMAC_IDR_PDRSFT_Pos)              /**< (GMAC_IDR) PDelay Response Frame Transmitted Mask */
+#define GMAC_IDR_PDRSFT                     GMAC_IDR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_PDRSFT_Msk instead */
+#define GMAC_IDR_SRI_Pos                    26                                             /**< (GMAC_IDR) TSU Seconds Register Increment Position */
+#define GMAC_IDR_SRI_Msk                    (_U_(0x1) << GMAC_IDR_SRI_Pos)                 /**< (GMAC_IDR) TSU Seconds Register Increment Mask */
+#define GMAC_IDR_SRI                        GMAC_IDR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SRI_Msk instead */
+#define GMAC_IDR_RXLPISBC_Pos               27                                             /**< (GMAC_IDR) Enable RX LPI Indication Position */
+#define GMAC_IDR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IDR_RXLPISBC_Pos)            /**< (GMAC_IDR) Enable RX LPI Indication Mask */
+#define GMAC_IDR_RXLPISBC                   GMAC_IDR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RXLPISBC_Msk instead */
+#define GMAC_IDR_WOL_Pos                    28                                             /**< (GMAC_IDR) Wake On LAN Position */
+#define GMAC_IDR_WOL_Msk                    (_U_(0x1) << GMAC_IDR_WOL_Pos)                 /**< (GMAC_IDR) Wake On LAN Mask */
+#define GMAC_IDR_WOL                        GMAC_IDR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_WOL_Msk instead */
+#define GMAC_IDR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IDR) TSU Timer Comparison Position */
+#define GMAC_IDR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IDR_TSUTIMCOMP_Pos)          /**< (GMAC_IDR) TSU Timer Comparison Mask */
+#define GMAC_IDR_TSUTIMCOMP                 GMAC_IDR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TSUTIMCOMP_Msk instead */
+#define GMAC_IDR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IDR) Register MASK  (Use GMAC_IDR_Msk instead)  */
+#define GMAC_IDR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IDR) Register Mask  */
+
+
+/* -------- GMAC_IMR : (GMAC Offset: 0x30) (R/W 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t TXUBR:1;                   /**< bit:      3  TX Used Bit Read                         */
+    uint32_t TUR:1;                     /**< bit:      4  Transmit Underrun                        */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded                     */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t PFNZ:1;                    /**< bit:     12  Pause Frame with Non-zero Pause Quantum Received */
+    uint32_t PTZ:1;                     /**< bit:     13  Pause Time Zero                          */
+    uint32_t PFTR:1;                    /**< bit:     14  Pause Frame Transmitted                  */
+    uint32_t EXINT:1;                   /**< bit:     15  External Interrupt                       */
+    uint32_t :2;                        /**< bit: 16..17  Reserved */
+    uint32_t DRQFR:1;                   /**< bit:     18  PTP Delay Request Frame Received         */
+    uint32_t SFR:1;                     /**< bit:     19  PTP Sync Frame Received                  */
+    uint32_t DRQFT:1;                   /**< bit:     20  PTP Delay Request Frame Transmitted      */
+    uint32_t SFT:1;                     /**< bit:     21  PTP Sync Frame Transmitted               */
+    uint32_t PDRQFR:1;                  /**< bit:     22  PDelay Request Frame Received            */
+    uint32_t PDRSFR:1;                  /**< bit:     23  PDelay Response Frame Received           */
+    uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
+    uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
+    uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
+    uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IMR_OFFSET                     (0x30)                                        /**<  (GMAC_IMR) Interrupt Mask Register  Offset */
+
+#define GMAC_IMR_MFS_Pos                    0                                              /**< (GMAC_IMR) Management Frame Sent Position */
+#define GMAC_IMR_MFS_Msk                    (_U_(0x1) << GMAC_IMR_MFS_Pos)                 /**< (GMAC_IMR) Management Frame Sent Mask */
+#define GMAC_IMR_MFS                        GMAC_IMR_MFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_MFS_Msk instead */
+#define GMAC_IMR_RCOMP_Pos                  1                                              /**< (GMAC_IMR) Receive Complete Position */
+#define GMAC_IMR_RCOMP_Msk                  (_U_(0x1) << GMAC_IMR_RCOMP_Pos)               /**< (GMAC_IMR) Receive Complete Mask */
+#define GMAC_IMR_RCOMP                      GMAC_IMR_RCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RCOMP_Msk instead */
+#define GMAC_IMR_RXUBR_Pos                  2                                              /**< (GMAC_IMR) RX Used Bit Read Position */
+#define GMAC_IMR_RXUBR_Msk                  (_U_(0x1) << GMAC_IMR_RXUBR_Pos)               /**< (GMAC_IMR) RX Used Bit Read Mask */
+#define GMAC_IMR_RXUBR                      GMAC_IMR_RXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RXUBR_Msk instead */
+#define GMAC_IMR_TXUBR_Pos                  3                                              /**< (GMAC_IMR) TX Used Bit Read Position */
+#define GMAC_IMR_TXUBR_Msk                  (_U_(0x1) << GMAC_IMR_TXUBR_Pos)               /**< (GMAC_IMR) TX Used Bit Read Mask */
+#define GMAC_IMR_TXUBR                      GMAC_IMR_TXUBR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TXUBR_Msk instead */
+#define GMAC_IMR_TUR_Pos                    4                                              /**< (GMAC_IMR) Transmit Underrun Position */
+#define GMAC_IMR_TUR_Msk                    (_U_(0x1) << GMAC_IMR_TUR_Pos)                 /**< (GMAC_IMR) Transmit Underrun Mask */
+#define GMAC_IMR_TUR                        GMAC_IMR_TUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TUR_Msk instead */
+#define GMAC_IMR_RLEX_Pos                   5                                              /**< (GMAC_IMR) Retry Limit Exceeded Position */
+#define GMAC_IMR_RLEX_Msk                   (_U_(0x1) << GMAC_IMR_RLEX_Pos)                /**< (GMAC_IMR) Retry Limit Exceeded Mask */
+#define GMAC_IMR_RLEX                       GMAC_IMR_RLEX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RLEX_Msk instead */
+#define GMAC_IMR_TFC_Pos                    6                                              /**< (GMAC_IMR) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IMR_TFC_Msk                    (_U_(0x1) << GMAC_IMR_TFC_Pos)                 /**< (GMAC_IMR) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IMR_TFC                        GMAC_IMR_TFC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TFC_Msk instead */
+#define GMAC_IMR_TCOMP_Pos                  7                                              /**< (GMAC_IMR) Transmit Complete Position */
+#define GMAC_IMR_TCOMP_Msk                  (_U_(0x1) << GMAC_IMR_TCOMP_Pos)               /**< (GMAC_IMR) Transmit Complete Mask */
+#define GMAC_IMR_TCOMP                      GMAC_IMR_TCOMP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TCOMP_Msk instead */
+#define GMAC_IMR_ROVR_Pos                   10                                             /**< (GMAC_IMR) Receive Overrun Position */
+#define GMAC_IMR_ROVR_Msk                   (_U_(0x1) << GMAC_IMR_ROVR_Pos)                /**< (GMAC_IMR) Receive Overrun Mask */
+#define GMAC_IMR_ROVR                       GMAC_IMR_ROVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_ROVR_Msk instead */
+#define GMAC_IMR_HRESP_Pos                  11                                             /**< (GMAC_IMR) HRESP Not OK Position */
+#define GMAC_IMR_HRESP_Msk                  (_U_(0x1) << GMAC_IMR_HRESP_Pos)               /**< (GMAC_IMR) HRESP Not OK Mask */
+#define GMAC_IMR_HRESP                      GMAC_IMR_HRESP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_HRESP_Msk instead */
+#define GMAC_IMR_PFNZ_Pos                   12                                             /**< (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received Position */
+#define GMAC_IMR_PFNZ_Msk                   (_U_(0x1) << GMAC_IMR_PFNZ_Pos)                /**< (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received Mask */
+#define GMAC_IMR_PFNZ                       GMAC_IMR_PFNZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PFNZ_Msk instead */
+#define GMAC_IMR_PTZ_Pos                    13                                             /**< (GMAC_IMR) Pause Time Zero Position */
+#define GMAC_IMR_PTZ_Msk                    (_U_(0x1) << GMAC_IMR_PTZ_Pos)                 /**< (GMAC_IMR) Pause Time Zero Mask */
+#define GMAC_IMR_PTZ                        GMAC_IMR_PTZ_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PTZ_Msk instead */
+#define GMAC_IMR_PFTR_Pos                   14                                             /**< (GMAC_IMR) Pause Frame Transmitted Position */
+#define GMAC_IMR_PFTR_Msk                   (_U_(0x1) << GMAC_IMR_PFTR_Pos)                /**< (GMAC_IMR) Pause Frame Transmitted Mask */
+#define GMAC_IMR_PFTR                       GMAC_IMR_PFTR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PFTR_Msk instead */
+#define GMAC_IMR_EXINT_Pos                  15                                             /**< (GMAC_IMR) External Interrupt Position */
+#define GMAC_IMR_EXINT_Msk                  (_U_(0x1) << GMAC_IMR_EXINT_Pos)               /**< (GMAC_IMR) External Interrupt Mask */
+#define GMAC_IMR_EXINT                      GMAC_IMR_EXINT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_EXINT_Msk instead */
+#define GMAC_IMR_DRQFR_Pos                  18                                             /**< (GMAC_IMR) PTP Delay Request Frame Received Position */
+#define GMAC_IMR_DRQFR_Msk                  (_U_(0x1) << GMAC_IMR_DRQFR_Pos)               /**< (GMAC_IMR) PTP Delay Request Frame Received Mask */
+#define GMAC_IMR_DRQFR                      GMAC_IMR_DRQFR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_DRQFR_Msk instead */
+#define GMAC_IMR_SFR_Pos                    19                                             /**< (GMAC_IMR) PTP Sync Frame Received Position */
+#define GMAC_IMR_SFR_Msk                    (_U_(0x1) << GMAC_IMR_SFR_Pos)                 /**< (GMAC_IMR) PTP Sync Frame Received Mask */
+#define GMAC_IMR_SFR                        GMAC_IMR_SFR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SFR_Msk instead */
+#define GMAC_IMR_DRQFT_Pos                  20                                             /**< (GMAC_IMR) PTP Delay Request Frame Transmitted Position */
+#define GMAC_IMR_DRQFT_Msk                  (_U_(0x1) << GMAC_IMR_DRQFT_Pos)               /**< (GMAC_IMR) PTP Delay Request Frame Transmitted Mask */
+#define GMAC_IMR_DRQFT                      GMAC_IMR_DRQFT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_DRQFT_Msk instead */
+#define GMAC_IMR_SFT_Pos                    21                                             /**< (GMAC_IMR) PTP Sync Frame Transmitted Position */
+#define GMAC_IMR_SFT_Msk                    (_U_(0x1) << GMAC_IMR_SFT_Pos)                 /**< (GMAC_IMR) PTP Sync Frame Transmitted Mask */
+#define GMAC_IMR_SFT                        GMAC_IMR_SFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SFT_Msk instead */
+#define GMAC_IMR_PDRQFR_Pos                 22                                             /**< (GMAC_IMR) PDelay Request Frame Received Position */
+#define GMAC_IMR_PDRQFR_Msk                 (_U_(0x1) << GMAC_IMR_PDRQFR_Pos)              /**< (GMAC_IMR) PDelay Request Frame Received Mask */
+#define GMAC_IMR_PDRQFR                     GMAC_IMR_PDRQFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRQFR_Msk instead */
+#define GMAC_IMR_PDRSFR_Pos                 23                                             /**< (GMAC_IMR) PDelay Response Frame Received Position */
+#define GMAC_IMR_PDRSFR_Msk                 (_U_(0x1) << GMAC_IMR_PDRSFR_Pos)              /**< (GMAC_IMR) PDelay Response Frame Received Mask */
+#define GMAC_IMR_PDRSFR                     GMAC_IMR_PDRSFR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRSFR_Msk instead */
+#define GMAC_IMR_PDRQFT_Pos                 24                                             /**< (GMAC_IMR) PDelay Request Frame Transmitted Position */
+#define GMAC_IMR_PDRQFT_Msk                 (_U_(0x1) << GMAC_IMR_PDRQFT_Pos)              /**< (GMAC_IMR) PDelay Request Frame Transmitted Mask */
+#define GMAC_IMR_PDRQFT                     GMAC_IMR_PDRQFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRQFT_Msk instead */
+#define GMAC_IMR_PDRSFT_Pos                 25                                             /**< (GMAC_IMR) PDelay Response Frame Transmitted Position */
+#define GMAC_IMR_PDRSFT_Msk                 (_U_(0x1) << GMAC_IMR_PDRSFT_Pos)              /**< (GMAC_IMR) PDelay Response Frame Transmitted Mask */
+#define GMAC_IMR_PDRSFT                     GMAC_IMR_PDRSFT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_PDRSFT_Msk instead */
+#define GMAC_IMR_SRI_Pos                    26                                             /**< (GMAC_IMR) TSU Seconds Register Increment Position */
+#define GMAC_IMR_SRI_Msk                    (_U_(0x1) << GMAC_IMR_SRI_Pos)                 /**< (GMAC_IMR) TSU Seconds Register Increment Mask */
+#define GMAC_IMR_SRI                        GMAC_IMR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SRI_Msk instead */
+#define GMAC_IMR_RXLPISBC_Pos               27                                             /**< (GMAC_IMR) Enable RX LPI Indication Position */
+#define GMAC_IMR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IMR_RXLPISBC_Pos)            /**< (GMAC_IMR) Enable RX LPI Indication Mask */
+#define GMAC_IMR_RXLPISBC                   GMAC_IMR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RXLPISBC_Msk instead */
+#define GMAC_IMR_WOL_Pos                    28                                             /**< (GMAC_IMR) Wake On LAN Position */
+#define GMAC_IMR_WOL_Msk                    (_U_(0x1) << GMAC_IMR_WOL_Pos)                 /**< (GMAC_IMR) Wake On LAN Mask */
+#define GMAC_IMR_WOL                        GMAC_IMR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_WOL_Msk instead */
+#define GMAC_IMR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IMR) TSU Timer Comparison Position */
+#define GMAC_IMR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IMR_TSUTIMCOMP_Pos)          /**< (GMAC_IMR) TSU Timer Comparison Mask */
+#define GMAC_IMR_TSUTIMCOMP                 GMAC_IMR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TSUTIMCOMP_Msk instead */
+#define GMAC_IMR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IMR) Register MASK  (Use GMAC_IMR_Msk instead)  */
+#define GMAC_IMR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IMR) Register Mask  */
+
+
+/* -------- GMAC_MAN : (GMAC Offset: 0x34) (R/W 32) PHY Maintenance Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:16;                   /**< bit:  0..15  PHY Data                                 */
+    uint32_t WTN:2;                     /**< bit: 16..17  Write Ten                                */
+    uint32_t REGA:5;                    /**< bit: 18..22  Register Address                         */
+    uint32_t PHYA:5;                    /**< bit: 23..27  PHY Address                              */
+    uint32_t OP:2;                      /**< bit: 28..29  Operation                                */
+    uint32_t CLTTO:1;                   /**< bit:     30  Clause 22 Operation                      */
+    uint32_t WZO:1;                     /**< bit:     31  Write ZERO                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MAN_OFFSET                     (0x34)                                        /**<  (GMAC_MAN) PHY Maintenance Register  Offset */
+
+#define GMAC_MAN_DATA_Pos                   0                                              /**< (GMAC_MAN) PHY Data Position */
+#define GMAC_MAN_DATA_Msk                   (_U_(0xFFFF) << GMAC_MAN_DATA_Pos)             /**< (GMAC_MAN) PHY Data Mask */
+#define GMAC_MAN_DATA(value)                (GMAC_MAN_DATA_Msk & ((value) << GMAC_MAN_DATA_Pos))
+#define GMAC_MAN_WTN_Pos                    16                                             /**< (GMAC_MAN) Write Ten Position */
+#define GMAC_MAN_WTN_Msk                    (_U_(0x3) << GMAC_MAN_WTN_Pos)                 /**< (GMAC_MAN) Write Ten Mask */
+#define GMAC_MAN_WTN(value)                 (GMAC_MAN_WTN_Msk & ((value) << GMAC_MAN_WTN_Pos))
+#define GMAC_MAN_REGA_Pos                   18                                             /**< (GMAC_MAN) Register Address Position */
+#define GMAC_MAN_REGA_Msk                   (_U_(0x1F) << GMAC_MAN_REGA_Pos)               /**< (GMAC_MAN) Register Address Mask */
+#define GMAC_MAN_REGA(value)                (GMAC_MAN_REGA_Msk & ((value) << GMAC_MAN_REGA_Pos))
+#define GMAC_MAN_PHYA_Pos                   23                                             /**< (GMAC_MAN) PHY Address Position */
+#define GMAC_MAN_PHYA_Msk                   (_U_(0x1F) << GMAC_MAN_PHYA_Pos)               /**< (GMAC_MAN) PHY Address Mask */
+#define GMAC_MAN_PHYA(value)                (GMAC_MAN_PHYA_Msk & ((value) << GMAC_MAN_PHYA_Pos))
+#define GMAC_MAN_OP_Pos                     28                                             /**< (GMAC_MAN) Operation Position */
+#define GMAC_MAN_OP_Msk                     (_U_(0x3) << GMAC_MAN_OP_Pos)                  /**< (GMAC_MAN) Operation Mask */
+#define GMAC_MAN_OP(value)                  (GMAC_MAN_OP_Msk & ((value) << GMAC_MAN_OP_Pos))
+#define GMAC_MAN_CLTTO_Pos                  30                                             /**< (GMAC_MAN) Clause 22 Operation Position */
+#define GMAC_MAN_CLTTO_Msk                  (_U_(0x1) << GMAC_MAN_CLTTO_Pos)               /**< (GMAC_MAN) Clause 22 Operation Mask */
+#define GMAC_MAN_CLTTO                      GMAC_MAN_CLTTO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_MAN_CLTTO_Msk instead */
+#define GMAC_MAN_WZO_Pos                    31                                             /**< (GMAC_MAN) Write ZERO Position */
+#define GMAC_MAN_WZO_Msk                    (_U_(0x1) << GMAC_MAN_WZO_Pos)                 /**< (GMAC_MAN) Write ZERO Mask */
+#define GMAC_MAN_WZO                        GMAC_MAN_WZO_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_MAN_WZO_Msk instead */
+#define GMAC_MAN_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MAN) Register MASK  (Use GMAC_MAN_Msk instead)  */
+#define GMAC_MAN_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MAN) Register Mask  */
+
+
+/* -------- GMAC_RPQ : (GMAC Offset: 0x38) (R/ 32) Received Pause Quantum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RPQ:16;                    /**< bit:  0..15  Received Pause Quantum                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RPQ_OFFSET                     (0x38)                                        /**<  (GMAC_RPQ) Received Pause Quantum Register  Offset */
+
+#define GMAC_RPQ_RPQ_Pos                    0                                              /**< (GMAC_RPQ) Received Pause Quantum Position */
+#define GMAC_RPQ_RPQ_Msk                    (_U_(0xFFFF) << GMAC_RPQ_RPQ_Pos)              /**< (GMAC_RPQ) Received Pause Quantum Mask */
+#define GMAC_RPQ_RPQ(value)                 (GMAC_RPQ_RPQ_Msk & ((value) << GMAC_RPQ_RPQ_Pos))
+#define GMAC_RPQ_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_RPQ) Register MASK  (Use GMAC_RPQ_Msk instead)  */
+#define GMAC_RPQ_Msk                        _U_(0xFFFF)                                    /**< (GMAC_RPQ) Register Mask  */
+
+
+/* -------- GMAC_TPQ : (GMAC Offset: 0x3c) (R/W 32) Transmit Pause Quantum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TPQ:16;                    /**< bit:  0..15  Transmit Pause Quantum                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPQ_OFFSET                     (0x3C)                                        /**<  (GMAC_TPQ) Transmit Pause Quantum Register  Offset */
+
+#define GMAC_TPQ_TPQ_Pos                    0                                              /**< (GMAC_TPQ) Transmit Pause Quantum Position */
+#define GMAC_TPQ_TPQ_Msk                    (_U_(0xFFFF) << GMAC_TPQ_TPQ_Pos)              /**< (GMAC_TPQ) Transmit Pause Quantum Mask */
+#define GMAC_TPQ_TPQ(value)                 (GMAC_TPQ_TPQ_Msk & ((value) << GMAC_TPQ_TPQ_Pos))
+#define GMAC_TPQ_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_TPQ) Register MASK  (Use GMAC_TPQ_Msk instead)  */
+#define GMAC_TPQ_Msk                        _U_(0xFFFF)                                    /**< (GMAC_TPQ) Register Mask  */
+
+
+/* -------- GMAC_TPSF : (GMAC Offset: 0x40) (R/W 32) TX Partial Store and Forward Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TPB1ADR:12;                /**< bit:  0..11  Transmit Partial Store and Forward Address */
+    uint32_t :19;                       /**< bit: 12..30  Reserved */
+    uint32_t ENTXP:1;                   /**< bit:     31  Enable TX Partial Store and Forward Operation */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPSF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPSF_OFFSET                    (0x40)                                        /**<  (GMAC_TPSF) TX Partial Store and Forward Register  Offset */
+
+#define GMAC_TPSF_TPB1ADR_Pos               0                                              /**< (GMAC_TPSF) Transmit Partial Store and Forward Address Position */
+#define GMAC_TPSF_TPB1ADR_Msk               (_U_(0xFFF) << GMAC_TPSF_TPB1ADR_Pos)          /**< (GMAC_TPSF) Transmit Partial Store and Forward Address Mask */
+#define GMAC_TPSF_TPB1ADR(value)            (GMAC_TPSF_TPB1ADR_Msk & ((value) << GMAC_TPSF_TPB1ADR_Pos))
+#define GMAC_TPSF_ENTXP_Pos                 31                                             /**< (GMAC_TPSF) Enable TX Partial Store and Forward Operation Position */
+#define GMAC_TPSF_ENTXP_Msk                 (_U_(0x1) << GMAC_TPSF_ENTXP_Pos)              /**< (GMAC_TPSF) Enable TX Partial Store and Forward Operation Mask */
+#define GMAC_TPSF_ENTXP                     GMAC_TPSF_ENTXP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TPSF_ENTXP_Msk instead */
+#define GMAC_TPSF_MASK                      _U_(0x80000FFF)                                /**< \deprecated (GMAC_TPSF) Register MASK  (Use GMAC_TPSF_Msk instead)  */
+#define GMAC_TPSF_Msk                       _U_(0x80000FFF)                                /**< (GMAC_TPSF) Register Mask  */
+
+
+/* -------- GMAC_RPSF : (GMAC Offset: 0x44) (R/W 32) RX Partial Store and Forward Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RPB1ADR:12;                /**< bit:  0..11  Receive Partial Store and Forward Address */
+    uint32_t :19;                       /**< bit: 12..30  Reserved */
+    uint32_t ENRXP:1;                   /**< bit:     31  Enable RX Partial Store and Forward Operation */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RPSF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RPSF_OFFSET                    (0x44)                                        /**<  (GMAC_RPSF) RX Partial Store and Forward Register  Offset */
+
+#define GMAC_RPSF_RPB1ADR_Pos               0                                              /**< (GMAC_RPSF) Receive Partial Store and Forward Address Position */
+#define GMAC_RPSF_RPB1ADR_Msk               (_U_(0xFFF) << GMAC_RPSF_RPB1ADR_Pos)          /**< (GMAC_RPSF) Receive Partial Store and Forward Address Mask */
+#define GMAC_RPSF_RPB1ADR(value)            (GMAC_RPSF_RPB1ADR_Msk & ((value) << GMAC_RPSF_RPB1ADR_Pos))
+#define GMAC_RPSF_ENRXP_Pos                 31                                             /**< (GMAC_RPSF) Enable RX Partial Store and Forward Operation Position */
+#define GMAC_RPSF_ENRXP_Msk                 (_U_(0x1) << GMAC_RPSF_ENRXP_Pos)              /**< (GMAC_RPSF) Enable RX Partial Store and Forward Operation Mask */
+#define GMAC_RPSF_ENRXP                     GMAC_RPSF_ENRXP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_RPSF_ENRXP_Msk instead */
+#define GMAC_RPSF_MASK                      _U_(0x80000FFF)                                /**< \deprecated (GMAC_RPSF) Register MASK  (Use GMAC_RPSF_Msk instead)  */
+#define GMAC_RPSF_Msk                       _U_(0x80000FFF)                                /**< (GMAC_RPSF) Register Mask  */
+
+
+/* -------- GMAC_RJFML : (GMAC Offset: 0x48) (R/W 32) RX Jumbo Frame Max Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FML:14;                    /**< bit:  0..13  Frame Max Length                         */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RJFML_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RJFML_OFFSET                   (0x48)                                        /**<  (GMAC_RJFML) RX Jumbo Frame Max Length Register  Offset */
+
+#define GMAC_RJFML_FML_Pos                  0                                              /**< (GMAC_RJFML) Frame Max Length Position */
+#define GMAC_RJFML_FML_Msk                  (_U_(0x3FFF) << GMAC_RJFML_FML_Pos)            /**< (GMAC_RJFML) Frame Max Length Mask */
+#define GMAC_RJFML_FML(value)               (GMAC_RJFML_FML_Msk & ((value) << GMAC_RJFML_FML_Pos))
+#define GMAC_RJFML_MASK                     _U_(0x3FFF)                                    /**< \deprecated (GMAC_RJFML) Register MASK  (Use GMAC_RJFML_Msk instead)  */
+#define GMAC_RJFML_Msk                      _U_(0x3FFF)                                    /**< (GMAC_RJFML) Register Mask  */
+
+
+/* -------- GMAC_HRB : (GMAC Offset: 0x80) (R/W 32) Hash Register Bottom -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_HRB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_HRB_OFFSET                     (0x80)                                        /**<  (GMAC_HRB) Hash Register Bottom  Offset */
+
+#define GMAC_HRB_ADDR_Pos                   0                                              /**< (GMAC_HRB) Hash Address Position */
+#define GMAC_HRB_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_HRB_ADDR_Pos)         /**< (GMAC_HRB) Hash Address Mask */
+#define GMAC_HRB_ADDR(value)                (GMAC_HRB_ADDR_Msk & ((value) << GMAC_HRB_ADDR_Pos))
+#define GMAC_HRB_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_HRB) Register MASK  (Use GMAC_HRB_Msk instead)  */
+#define GMAC_HRB_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_HRB) Register Mask  */
+
+
+/* -------- GMAC_HRT : (GMAC Offset: 0x84) (R/W 32) Hash Register Top -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_HRT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_HRT_OFFSET                     (0x84)                                        /**<  (GMAC_HRT) Hash Register Top  Offset */
+
+#define GMAC_HRT_ADDR_Pos                   0                                              /**< (GMAC_HRT) Hash Address Position */
+#define GMAC_HRT_ADDR_Msk                   (_U_(0xFFFFFFFF) << GMAC_HRT_ADDR_Pos)         /**< (GMAC_HRT) Hash Address Mask */
+#define GMAC_HRT_ADDR(value)                (GMAC_HRT_ADDR_Msk & ((value) << GMAC_HRT_ADDR_Pos))
+#define GMAC_HRT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_HRT) Register MASK  (Use GMAC_HRT_Msk instead)  */
+#define GMAC_HRT_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_HRT) Register Mask  */
+
+
+/* -------- GMAC_TIDM1 : (GMAC Offset: 0xa8) (R/W 32) Type ID Match 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 1                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID1:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM1_OFFSET                   (0xA8)                                        /**<  (GMAC_TIDM1) Type ID Match 1 Register  Offset */
+
+#define GMAC_TIDM1_TID_Pos                  0                                              /**< (GMAC_TIDM1) Type ID Match 1 Position */
+#define GMAC_TIDM1_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM1_TID_Pos)            /**< (GMAC_TIDM1) Type ID Match 1 Mask */
+#define GMAC_TIDM1_TID(value)               (GMAC_TIDM1_TID_Msk & ((value) << GMAC_TIDM1_TID_Pos))
+#define GMAC_TIDM1_ENID1_Pos                31                                             /**< (GMAC_TIDM1) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM1_ENID1_Msk                (_U_(0x1) << GMAC_TIDM1_ENID1_Pos)             /**< (GMAC_TIDM1) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM1_ENID1                    GMAC_TIDM1_ENID1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM1_ENID1_Msk instead */
+#define GMAC_TIDM1_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM1) Register MASK  (Use GMAC_TIDM1_Msk instead)  */
+#define GMAC_TIDM1_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM1) Register Mask  */
+
+#define GMAC_TIDM1_ENID_Pos                 31                                             /**< (GMAC_TIDM1 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM1_ENID_Msk                 (_U_(0x1) << GMAC_TIDM1_ENID_Pos)              /**< (GMAC_TIDM1 Mask) ENID */
+#define GMAC_TIDM1_ENID(value)              (GMAC_TIDM1_ENID_Msk & ((value) << GMAC_TIDM1_ENID_Pos))  
+
+/* -------- GMAC_TIDM2 : (GMAC Offset: 0xac) (R/W 32) Type ID Match 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 2                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID2:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM2_OFFSET                   (0xAC)                                        /**<  (GMAC_TIDM2) Type ID Match 2 Register  Offset */
+
+#define GMAC_TIDM2_TID_Pos                  0                                              /**< (GMAC_TIDM2) Type ID Match 2 Position */
+#define GMAC_TIDM2_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM2_TID_Pos)            /**< (GMAC_TIDM2) Type ID Match 2 Mask */
+#define GMAC_TIDM2_TID(value)               (GMAC_TIDM2_TID_Msk & ((value) << GMAC_TIDM2_TID_Pos))
+#define GMAC_TIDM2_ENID2_Pos                31                                             /**< (GMAC_TIDM2) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM2_ENID2_Msk                (_U_(0x1) << GMAC_TIDM2_ENID2_Pos)             /**< (GMAC_TIDM2) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM2_ENID2                    GMAC_TIDM2_ENID2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM2_ENID2_Msk instead */
+#define GMAC_TIDM2_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM2) Register MASK  (Use GMAC_TIDM2_Msk instead)  */
+#define GMAC_TIDM2_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM2) Register Mask  */
+
+#define GMAC_TIDM2_ENID_Pos                 31                                             /**< (GMAC_TIDM2 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM2_ENID_Msk                 (_U_(0x1) << GMAC_TIDM2_ENID_Pos)              /**< (GMAC_TIDM2 Mask) ENID */
+#define GMAC_TIDM2_ENID(value)              (GMAC_TIDM2_ENID_Msk & ((value) << GMAC_TIDM2_ENID_Pos))  
+
+/* -------- GMAC_TIDM3 : (GMAC Offset: 0xb0) (R/W 32) Type ID Match 3 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 3                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID3:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM3_OFFSET                   (0xB0)                                        /**<  (GMAC_TIDM3) Type ID Match 3 Register  Offset */
+
+#define GMAC_TIDM3_TID_Pos                  0                                              /**< (GMAC_TIDM3) Type ID Match 3 Position */
+#define GMAC_TIDM3_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM3_TID_Pos)            /**< (GMAC_TIDM3) Type ID Match 3 Mask */
+#define GMAC_TIDM3_TID(value)               (GMAC_TIDM3_TID_Msk & ((value) << GMAC_TIDM3_TID_Pos))
+#define GMAC_TIDM3_ENID3_Pos                31                                             /**< (GMAC_TIDM3) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM3_ENID3_Msk                (_U_(0x1) << GMAC_TIDM3_ENID3_Pos)             /**< (GMAC_TIDM3) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM3_ENID3                    GMAC_TIDM3_ENID3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM3_ENID3_Msk instead */
+#define GMAC_TIDM3_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM3) Register MASK  (Use GMAC_TIDM3_Msk instead)  */
+#define GMAC_TIDM3_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM3) Register Mask  */
+
+#define GMAC_TIDM3_ENID_Pos                 31                                             /**< (GMAC_TIDM3 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM3_ENID_Msk                 (_U_(0x1) << GMAC_TIDM3_ENID_Pos)              /**< (GMAC_TIDM3 Mask) ENID */
+#define GMAC_TIDM3_ENID(value)              (GMAC_TIDM3_ENID_Msk & ((value) << GMAC_TIDM3_ENID_Pos))  
+
+/* -------- GMAC_TIDM4 : (GMAC Offset: 0xb4) (R/W 32) Type ID Match 4 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 4                          */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ENID4:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TIDM4_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TIDM4_OFFSET                   (0xB4)                                        /**<  (GMAC_TIDM4) Type ID Match 4 Register  Offset */
+
+#define GMAC_TIDM4_TID_Pos                  0                                              /**< (GMAC_TIDM4) Type ID Match 4 Position */
+#define GMAC_TIDM4_TID_Msk                  (_U_(0xFFFF) << GMAC_TIDM4_TID_Pos)            /**< (GMAC_TIDM4) Type ID Match 4 Mask */
+#define GMAC_TIDM4_TID(value)               (GMAC_TIDM4_TID_Msk & ((value) << GMAC_TIDM4_TID_Pos))
+#define GMAC_TIDM4_ENID4_Pos                31                                             /**< (GMAC_TIDM4) Enable Copying of TID Matched Frames Position */
+#define GMAC_TIDM4_ENID4_Msk                (_U_(0x1) << GMAC_TIDM4_ENID4_Pos)             /**< (GMAC_TIDM4) Enable Copying of TID Matched Frames Mask */
+#define GMAC_TIDM4_ENID4                    GMAC_TIDM4_ENID4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TIDM4_ENID4_Msk instead */
+#define GMAC_TIDM4_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM4) Register MASK  (Use GMAC_TIDM4_Msk instead)  */
+#define GMAC_TIDM4_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM4) Register Mask  */
+
+#define GMAC_TIDM4_ENID_Pos                 31                                             /**< (GMAC_TIDM4 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM4_ENID_Msk                 (_U_(0x1) << GMAC_TIDM4_ENID_Pos)              /**< (GMAC_TIDM4 Mask) ENID */
+#define GMAC_TIDM4_ENID(value)              (GMAC_TIDM4_ENID_Msk & ((value) << GMAC_TIDM4_ENID_Pos))  
+
+/* -------- GMAC_WOL : (GMAC Offset: 0xb8) (R/W 32) Wake on LAN Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IP:16;                     /**< bit:  0..15  ARP Request IP Address                   */
+    uint32_t MAG:1;                     /**< bit:     16  Magic Packet Event Enable                */
+    uint32_t ARP:1;                     /**< bit:     17  ARP Request IP Address                   */
+    uint32_t SA1:1;                     /**< bit:     18  Specific Address Register 1 Event Enable */
+    uint32_t MTI:1;                     /**< bit:     19  Multicast Hash Event Enable              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t SA:1;                      /**< bit:     18  Specific Address Register x Event Enable */
+    uint32_t :13;                       /**< bit: 19..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_WOL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_WOL_OFFSET                     (0xB8)                                        /**<  (GMAC_WOL) Wake on LAN Register  Offset */
+
+#define GMAC_WOL_IP_Pos                     0                                              /**< (GMAC_WOL) ARP Request IP Address Position */
+#define GMAC_WOL_IP_Msk                     (_U_(0xFFFF) << GMAC_WOL_IP_Pos)               /**< (GMAC_WOL) ARP Request IP Address Mask */
+#define GMAC_WOL_IP(value)                  (GMAC_WOL_IP_Msk & ((value) << GMAC_WOL_IP_Pos))
+#define GMAC_WOL_MAG_Pos                    16                                             /**< (GMAC_WOL) Magic Packet Event Enable Position */
+#define GMAC_WOL_MAG_Msk                    (_U_(0x1) << GMAC_WOL_MAG_Pos)                 /**< (GMAC_WOL) Magic Packet Event Enable Mask */
+#define GMAC_WOL_MAG                        GMAC_WOL_MAG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_MAG_Msk instead */
+#define GMAC_WOL_ARP_Pos                    17                                             /**< (GMAC_WOL) ARP Request IP Address Position */
+#define GMAC_WOL_ARP_Msk                    (_U_(0x1) << GMAC_WOL_ARP_Pos)                 /**< (GMAC_WOL) ARP Request IP Address Mask */
+#define GMAC_WOL_ARP                        GMAC_WOL_ARP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_ARP_Msk instead */
+#define GMAC_WOL_SA1_Pos                    18                                             /**< (GMAC_WOL) Specific Address Register 1 Event Enable Position */
+#define GMAC_WOL_SA1_Msk                    (_U_(0x1) << GMAC_WOL_SA1_Pos)                 /**< (GMAC_WOL) Specific Address Register 1 Event Enable Mask */
+#define GMAC_WOL_SA1                        GMAC_WOL_SA1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_SA1_Msk instead */
+#define GMAC_WOL_MTI_Pos                    19                                             /**< (GMAC_WOL) Multicast Hash Event Enable Position */
+#define GMAC_WOL_MTI_Msk                    (_U_(0x1) << GMAC_WOL_MTI_Pos)                 /**< (GMAC_WOL) Multicast Hash Event Enable Mask */
+#define GMAC_WOL_MTI                        GMAC_WOL_MTI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_WOL_MTI_Msk instead */
+#define GMAC_WOL_MASK                       _U_(0xFFFFF)                                   /**< \deprecated (GMAC_WOL) Register MASK  (Use GMAC_WOL_Msk instead)  */
+#define GMAC_WOL_Msk                        _U_(0xFFFFF)                                   /**< (GMAC_WOL) Register Mask  */
+
+#define GMAC_WOL_SA_Pos                     18                                             /**< (GMAC_WOL Position) Specific Address Register x Event Enable */
+#define GMAC_WOL_SA_Msk                     (_U_(0x1) << GMAC_WOL_SA_Pos)                  /**< (GMAC_WOL Mask) SA */
+#define GMAC_WOL_SA(value)                  (GMAC_WOL_SA_Msk & ((value) << GMAC_WOL_SA_Pos))  
+
+/* -------- GMAC_IPGS : (GMAC Offset: 0xbc) (R/W 32) IPG Stretch Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FL:16;                     /**< bit:  0..15  Frame Length                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IPGS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IPGS_OFFSET                    (0xBC)                                        /**<  (GMAC_IPGS) IPG Stretch Register  Offset */
+
+#define GMAC_IPGS_FL_Pos                    0                                              /**< (GMAC_IPGS) Frame Length Position */
+#define GMAC_IPGS_FL_Msk                    (_U_(0xFFFF) << GMAC_IPGS_FL_Pos)              /**< (GMAC_IPGS) Frame Length Mask */
+#define GMAC_IPGS_FL(value)                 (GMAC_IPGS_FL_Msk & ((value) << GMAC_IPGS_FL_Pos))
+#define GMAC_IPGS_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_IPGS) Register MASK  (Use GMAC_IPGS_Msk instead)  */
+#define GMAC_IPGS_Msk                       _U_(0xFFFF)                                    /**< (GMAC_IPGS) Register Mask  */
+
+
+/* -------- GMAC_SVLAN : (GMAC Offset: 0xc0) (R/W 32) Stacked VLAN Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VLAN_TYPE:16;              /**< bit:  0..15  User Defined VLAN_TYPE Field             */
+    uint32_t :15;                       /**< bit: 16..30  Reserved */
+    uint32_t ESVLAN:1;                  /**< bit:     31  Enable Stacked VLAN Processing Mode      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SVLAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SVLAN_OFFSET                   (0xC0)                                        /**<  (GMAC_SVLAN) Stacked VLAN Register  Offset */
+
+#define GMAC_SVLAN_VLAN_TYPE_Pos            0                                              /**< (GMAC_SVLAN) User Defined VLAN_TYPE Field Position */
+#define GMAC_SVLAN_VLAN_TYPE_Msk            (_U_(0xFFFF) << GMAC_SVLAN_VLAN_TYPE_Pos)      /**< (GMAC_SVLAN) User Defined VLAN_TYPE Field Mask */
+#define GMAC_SVLAN_VLAN_TYPE(value)         (GMAC_SVLAN_VLAN_TYPE_Msk & ((value) << GMAC_SVLAN_VLAN_TYPE_Pos))
+#define GMAC_SVLAN_ESVLAN_Pos               31                                             /**< (GMAC_SVLAN) Enable Stacked VLAN Processing Mode Position */
+#define GMAC_SVLAN_ESVLAN_Msk               (_U_(0x1) << GMAC_SVLAN_ESVLAN_Pos)            /**< (GMAC_SVLAN) Enable Stacked VLAN Processing Mode Mask */
+#define GMAC_SVLAN_ESVLAN                   GMAC_SVLAN_ESVLAN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_SVLAN_ESVLAN_Msk instead */
+#define GMAC_SVLAN_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_SVLAN) Register MASK  (Use GMAC_SVLAN_Msk instead)  */
+#define GMAC_SVLAN_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_SVLAN) Register Mask  */
+
+
+/* -------- GMAC_TPFCP : (GMAC Offset: 0xc4) (R/W 32) Transmit PFC Pause Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PEV:8;                     /**< bit:   0..7  Priority Enable Vector                   */
+    uint32_t PQ:8;                      /**< bit:  8..15  Pause Quantum                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TPFCP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TPFCP_OFFSET                   (0xC4)                                        /**<  (GMAC_TPFCP) Transmit PFC Pause Register  Offset */
+
+#define GMAC_TPFCP_PEV_Pos                  0                                              /**< (GMAC_TPFCP) Priority Enable Vector Position */
+#define GMAC_TPFCP_PEV_Msk                  (_U_(0xFF) << GMAC_TPFCP_PEV_Pos)              /**< (GMAC_TPFCP) Priority Enable Vector Mask */
+#define GMAC_TPFCP_PEV(value)               (GMAC_TPFCP_PEV_Msk & ((value) << GMAC_TPFCP_PEV_Pos))
+#define GMAC_TPFCP_PQ_Pos                   8                                              /**< (GMAC_TPFCP) Pause Quantum Position */
+#define GMAC_TPFCP_PQ_Msk                   (_U_(0xFF) << GMAC_TPFCP_PQ_Pos)               /**< (GMAC_TPFCP) Pause Quantum Mask */
+#define GMAC_TPFCP_PQ(value)                (GMAC_TPFCP_PQ_Msk & ((value) << GMAC_TPFCP_PQ_Pos))
+#define GMAC_TPFCP_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_TPFCP) Register MASK  (Use GMAC_TPFCP_Msk instead)  */
+#define GMAC_TPFCP_Msk                      _U_(0xFFFF)                                    /**< (GMAC_TPFCP) Register Mask  */
+
+
+/* -------- GMAC_SAMB1 : (GMAC Offset: 0xc8) (R/W 32) Specific Address 1 Mask Bottom Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1 Mask                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAMB1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAMB1_OFFSET                   (0xC8)                                        /**<  (GMAC_SAMB1) Specific Address 1 Mask Bottom Register  Offset */
+
+#define GMAC_SAMB1_ADDR_Pos                 0                                              /**< (GMAC_SAMB1) Specific Address 1 Mask Position */
+#define GMAC_SAMB1_ADDR_Msk                 (_U_(0xFFFFFFFF) << GMAC_SAMB1_ADDR_Pos)       /**< (GMAC_SAMB1) Specific Address 1 Mask Mask */
+#define GMAC_SAMB1_ADDR(value)              (GMAC_SAMB1_ADDR_Msk & ((value) << GMAC_SAMB1_ADDR_Pos))
+#define GMAC_SAMB1_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SAMB1) Register MASK  (Use GMAC_SAMB1_Msk instead)  */
+#define GMAC_SAMB1_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_SAMB1) Register Mask  */
+
+
+/* -------- GMAC_SAMT1 : (GMAC Offset: 0xcc) (R/W 32) Specific Address 1 Mask Top Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1 Mask                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SAMT1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SAMT1_OFFSET                   (0xCC)                                        /**<  (GMAC_SAMT1) Specific Address 1 Mask Top Register  Offset */
+
+#define GMAC_SAMT1_ADDR_Pos                 0                                              /**< (GMAC_SAMT1) Specific Address 1 Mask Position */
+#define GMAC_SAMT1_ADDR_Msk                 (_U_(0xFFFF) << GMAC_SAMT1_ADDR_Pos)           /**< (GMAC_SAMT1) Specific Address 1 Mask Mask */
+#define GMAC_SAMT1_ADDR(value)              (GMAC_SAMT1_ADDR_Msk & ((value) << GMAC_SAMT1_ADDR_Pos))
+#define GMAC_SAMT1_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_SAMT1) Register MASK  (Use GMAC_SAMT1_Msk instead)  */
+#define GMAC_SAMT1_Msk                      _U_(0xFFFF)                                    /**< (GMAC_SAMT1) Register Mask  */
+
+
+/* -------- GMAC_NSC : (GMAC Offset: 0xdc) (R/W 32) 1588 Timer Nanosecond Comparison Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NANOSEC:22;                /**< bit:  0..21  1588 Timer Nanosecond Comparison Value   */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_NSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_NSC_OFFSET                     (0xDC)                                        /**<  (GMAC_NSC) 1588 Timer Nanosecond Comparison Register  Offset */
+
+#define GMAC_NSC_NANOSEC_Pos                0                                              /**< (GMAC_NSC) 1588 Timer Nanosecond Comparison Value Position */
+#define GMAC_NSC_NANOSEC_Msk                (_U_(0x3FFFFF) << GMAC_NSC_NANOSEC_Pos)        /**< (GMAC_NSC) 1588 Timer Nanosecond Comparison Value Mask */
+#define GMAC_NSC_NANOSEC(value)             (GMAC_NSC_NANOSEC_Msk & ((value) << GMAC_NSC_NANOSEC_Pos))
+#define GMAC_NSC_MASK                       _U_(0x3FFFFF)                                  /**< \deprecated (GMAC_NSC) Register MASK  (Use GMAC_NSC_Msk instead)  */
+#define GMAC_NSC_Msk                        _U_(0x3FFFFF)                                  /**< (GMAC_NSC) Register Mask  */
+
+
+/* -------- GMAC_SCL : (GMAC Offset: 0xe0) (R/W 32) 1588 Timer Second Comparison Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:32;                    /**< bit:  0..31  1588 Timer Second Comparison Value       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCL_OFFSET                     (0xE0)                                        /**<  (GMAC_SCL) 1588 Timer Second Comparison Low Register  Offset */
+
+#define GMAC_SCL_SEC_Pos                    0                                              /**< (GMAC_SCL) 1588 Timer Second Comparison Value Position */
+#define GMAC_SCL_SEC_Msk                    (_U_(0xFFFFFFFF) << GMAC_SCL_SEC_Pos)          /**< (GMAC_SCL) 1588 Timer Second Comparison Value Mask */
+#define GMAC_SCL_SEC(value)                 (GMAC_SCL_SEC_Msk & ((value) << GMAC_SCL_SEC_Pos))
+#define GMAC_SCL_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_SCL) Register MASK  (Use GMAC_SCL_Msk instead)  */
+#define GMAC_SCL_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_SCL) Register Mask  */
+
+
+/* -------- GMAC_SCH : (GMAC Offset: 0xe4) (R/W 32) 1588 Timer Second Comparison High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:16;                    /**< bit:  0..15  1588 Timer Second Comparison Value       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCH_OFFSET                     (0xE4)                                        /**<  (GMAC_SCH) 1588 Timer Second Comparison High Register  Offset */
+
+#define GMAC_SCH_SEC_Pos                    0                                              /**< (GMAC_SCH) 1588 Timer Second Comparison Value Position */
+#define GMAC_SCH_SEC_Msk                    (_U_(0xFFFF) << GMAC_SCH_SEC_Pos)              /**< (GMAC_SCH) 1588 Timer Second Comparison Value Mask */
+#define GMAC_SCH_SEC(value)                 (GMAC_SCH_SEC_Msk & ((value) << GMAC_SCH_SEC_Pos))
+#define GMAC_SCH_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_SCH) Register MASK  (Use GMAC_SCH_Msk instead)  */
+#define GMAC_SCH_Msk                        _U_(0xFFFF)                                    /**< (GMAC_SCH) Register Mask  */
+
+
+/* -------- GMAC_EFTSH : (GMAC Offset: 0xe8) (R/ 32) PTP Event Frame Transmitted Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTSH_OFFSET                   (0xE8)                                        /**<  (GMAC_EFTSH) PTP Event Frame Transmitted Seconds High Register  Offset */
+
+#define GMAC_EFTSH_RUD_Pos                  0                                              /**< (GMAC_EFTSH) Register Update Position */
+#define GMAC_EFTSH_RUD_Msk                  (_U_(0xFFFF) << GMAC_EFTSH_RUD_Pos)            /**< (GMAC_EFTSH) Register Update Mask */
+#define GMAC_EFTSH_RUD(value)               (GMAC_EFTSH_RUD_Msk & ((value) << GMAC_EFTSH_RUD_Pos))
+#define GMAC_EFTSH_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_EFTSH) Register MASK  (Use GMAC_EFTSH_Msk instead)  */
+#define GMAC_EFTSH_Msk                      _U_(0xFFFF)                                    /**< (GMAC_EFTSH) Register Mask  */
+
+
+/* -------- GMAC_EFRSH : (GMAC Offset: 0xec) (R/ 32) PTP Event Frame Received Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRSH_OFFSET                   (0xEC)                                        /**<  (GMAC_EFRSH) PTP Event Frame Received Seconds High Register  Offset */
+
+#define GMAC_EFRSH_RUD_Pos                  0                                              /**< (GMAC_EFRSH) Register Update Position */
+#define GMAC_EFRSH_RUD_Msk                  (_U_(0xFFFF) << GMAC_EFRSH_RUD_Pos)            /**< (GMAC_EFRSH) Register Update Mask */
+#define GMAC_EFRSH_RUD(value)               (GMAC_EFRSH_RUD_Msk & ((value) << GMAC_EFRSH_RUD_Pos))
+#define GMAC_EFRSH_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_EFRSH) Register MASK  (Use GMAC_EFRSH_Msk instead)  */
+#define GMAC_EFRSH_Msk                      _U_(0xFFFF)                                    /**< (GMAC_EFRSH) Register Mask  */
+
+
+/* -------- GMAC_PEFTSH : (GMAC Offset: 0xf0) (R/ 32) PTP Peer Event Frame Transmitted Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTSH_OFFSET                  (0xF0)                                        /**<  (GMAC_PEFTSH) PTP Peer Event Frame Transmitted Seconds High Register  Offset */
+
+#define GMAC_PEFTSH_RUD_Pos                 0                                              /**< (GMAC_PEFTSH) Register Update Position */
+#define GMAC_PEFTSH_RUD_Msk                 (_U_(0xFFFF) << GMAC_PEFTSH_RUD_Pos)           /**< (GMAC_PEFTSH) Register Update Mask */
+#define GMAC_PEFTSH_RUD(value)              (GMAC_PEFTSH_RUD_Msk & ((value) << GMAC_PEFTSH_RUD_Pos))
+#define GMAC_PEFTSH_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_PEFTSH) Register MASK  (Use GMAC_PEFTSH_Msk instead)  */
+#define GMAC_PEFTSH_Msk                     _U_(0xFFFF)                                    /**< (GMAC_PEFTSH) Register Mask  */
+
+
+/* -------- GMAC_PEFRSH : (GMAC Offset: 0xf4) (R/ 32) PTP Peer Event Frame Received Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRSH_OFFSET                  (0xF4)                                        /**<  (GMAC_PEFRSH) PTP Peer Event Frame Received Seconds High Register  Offset */
+
+#define GMAC_PEFRSH_RUD_Pos                 0                                              /**< (GMAC_PEFRSH) Register Update Position */
+#define GMAC_PEFRSH_RUD_Msk                 (_U_(0xFFFF) << GMAC_PEFRSH_RUD_Pos)           /**< (GMAC_PEFRSH) Register Update Mask */
+#define GMAC_PEFRSH_RUD(value)              (GMAC_PEFRSH_RUD_Msk & ((value) << GMAC_PEFRSH_RUD_Pos))
+#define GMAC_PEFRSH_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_PEFRSH) Register MASK  (Use GMAC_PEFRSH_Msk instead)  */
+#define GMAC_PEFRSH_Msk                     _U_(0xFFFF)                                    /**< (GMAC_PEFRSH) Register Mask  */
+
+
+/* -------- GMAC_OTLO : (GMAC Offset: 0x100) (R/ 32) Octets Transmitted Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXO:32;                    /**< bit:  0..31  Transmitted Octets                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OTLO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OTLO_OFFSET                    (0x100)                                       /**<  (GMAC_OTLO) Octets Transmitted Low Register  Offset */
+
+#define GMAC_OTLO_TXO_Pos                   0                                              /**< (GMAC_OTLO) Transmitted Octets Position */
+#define GMAC_OTLO_TXO_Msk                   (_U_(0xFFFFFFFF) << GMAC_OTLO_TXO_Pos)         /**< (GMAC_OTLO) Transmitted Octets Mask */
+#define GMAC_OTLO_TXO(value)                (GMAC_OTLO_TXO_Msk & ((value) << GMAC_OTLO_TXO_Pos))
+#define GMAC_OTLO_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_OTLO) Register MASK  (Use GMAC_OTLO_Msk instead)  */
+#define GMAC_OTLO_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_OTLO) Register Mask  */
+
+
+/* -------- GMAC_OTHI : (GMAC Offset: 0x104) (R/ 32) Octets Transmitted High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXO:16;                    /**< bit:  0..15  Transmitted Octets                       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OTHI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OTHI_OFFSET                    (0x104)                                       /**<  (GMAC_OTHI) Octets Transmitted High Register  Offset */
+
+#define GMAC_OTHI_TXO_Pos                   0                                              /**< (GMAC_OTHI) Transmitted Octets Position */
+#define GMAC_OTHI_TXO_Msk                   (_U_(0xFFFF) << GMAC_OTHI_TXO_Pos)             /**< (GMAC_OTHI) Transmitted Octets Mask */
+#define GMAC_OTHI_TXO(value)                (GMAC_OTHI_TXO_Msk & ((value) << GMAC_OTHI_TXO_Pos))
+#define GMAC_OTHI_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_OTHI) Register MASK  (Use GMAC_OTHI_Msk instead)  */
+#define GMAC_OTHI_Msk                       _U_(0xFFFF)                                    /**< (GMAC_OTHI) Register Mask  */
+
+
+/* -------- GMAC_FT : (GMAC Offset: 0x108) (R/ 32) Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FTX:32;                    /**< bit:  0..31  Frames Transmitted without Error         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FT_OFFSET                      (0x108)                                       /**<  (GMAC_FT) Frames Transmitted Register  Offset */
+
+#define GMAC_FT_FTX_Pos                     0                                              /**< (GMAC_FT) Frames Transmitted without Error Position */
+#define GMAC_FT_FTX_Msk                     (_U_(0xFFFFFFFF) << GMAC_FT_FTX_Pos)           /**< (GMAC_FT) Frames Transmitted without Error Mask */
+#define GMAC_FT_FTX(value)                  (GMAC_FT_FTX_Msk & ((value) << GMAC_FT_FTX_Pos))
+#define GMAC_FT_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_FT) Register MASK  (Use GMAC_FT_Msk instead)  */
+#define GMAC_FT_Msk                         _U_(0xFFFFFFFF)                                /**< (GMAC_FT) Register Mask  */
+
+
+/* -------- GMAC_BCFT : (GMAC Offset: 0x10c) (R/ 32) Broadcast Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BFTX:32;                   /**< bit:  0..31  Broadcast Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BCFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BCFT_OFFSET                    (0x10C)                                       /**<  (GMAC_BCFT) Broadcast Frames Transmitted Register  Offset */
+
+#define GMAC_BCFT_BFTX_Pos                  0                                              /**< (GMAC_BCFT) Broadcast Frames Transmitted without Error Position */
+#define GMAC_BCFT_BFTX_Msk                  (_U_(0xFFFFFFFF) << GMAC_BCFT_BFTX_Pos)        /**< (GMAC_BCFT) Broadcast Frames Transmitted without Error Mask */
+#define GMAC_BCFT_BFTX(value)               (GMAC_BCFT_BFTX_Msk & ((value) << GMAC_BCFT_BFTX_Pos))
+#define GMAC_BCFT_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BCFT) Register MASK  (Use GMAC_BCFT_Msk instead)  */
+#define GMAC_BCFT_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_BCFT) Register Mask  */
+
+
+/* -------- GMAC_MFT : (GMAC Offset: 0x110) (R/ 32) Multicast Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFTX:32;                   /**< bit:  0..31  Multicast Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MFT_OFFSET                     (0x110)                                       /**<  (GMAC_MFT) Multicast Frames Transmitted Register  Offset */
+
+#define GMAC_MFT_MFTX_Pos                   0                                              /**< (GMAC_MFT) Multicast Frames Transmitted without Error Position */
+#define GMAC_MFT_MFTX_Msk                   (_U_(0xFFFFFFFF) << GMAC_MFT_MFTX_Pos)         /**< (GMAC_MFT) Multicast Frames Transmitted without Error Mask */
+#define GMAC_MFT_MFTX(value)                (GMAC_MFT_MFTX_Msk & ((value) << GMAC_MFT_MFTX_Pos))
+#define GMAC_MFT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MFT) Register MASK  (Use GMAC_MFT_Msk instead)  */
+#define GMAC_MFT_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MFT) Register Mask  */
+
+
+/* -------- GMAC_PFT : (GMAC Offset: 0x114) (R/ 32) Pause Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PFTX:16;                   /**< bit:  0..15  Pause Frames Transmitted Register        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PFT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PFT_OFFSET                     (0x114)                                       /**<  (GMAC_PFT) Pause Frames Transmitted Register  Offset */
+
+#define GMAC_PFT_PFTX_Pos                   0                                              /**< (GMAC_PFT) Pause Frames Transmitted Register Position */
+#define GMAC_PFT_PFTX_Msk                   (_U_(0xFFFF) << GMAC_PFT_PFTX_Pos)             /**< (GMAC_PFT) Pause Frames Transmitted Register Mask */
+#define GMAC_PFT_PFTX(value)                (GMAC_PFT_PFTX_Msk & ((value) << GMAC_PFT_PFTX_Pos))
+#define GMAC_PFT_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_PFT) Register MASK  (Use GMAC_PFT_Msk instead)  */
+#define GMAC_PFT_Msk                        _U_(0xFFFF)                                    /**< (GMAC_PFT) Register Mask  */
+
+
+/* -------- GMAC_BFT64 : (GMAC Offset: 0x118) (R/ 32) 64 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  64 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BFT64_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BFT64_OFFSET                   (0x118)                                       /**<  (GMAC_BFT64) 64 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_BFT64_NFTX_Pos                 0                                              /**< (GMAC_BFT64) 64 Byte Frames Transmitted without Error Position */
+#define GMAC_BFT64_NFTX_Msk                 (_U_(0xFFFFFFFF) << GMAC_BFT64_NFTX_Pos)       /**< (GMAC_BFT64) 64 Byte Frames Transmitted without Error Mask */
+#define GMAC_BFT64_NFTX(value)              (GMAC_BFT64_NFTX_Msk & ((value) << GMAC_BFT64_NFTX_Pos))
+#define GMAC_BFT64_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BFT64) Register MASK  (Use GMAC_BFT64_Msk instead)  */
+#define GMAC_BFT64_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_BFT64) Register Mask  */
+
+
+/* -------- GMAC_TBFT127 : (GMAC Offset: 0x11c) (R/ 32) 65 to 127 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT127_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT127_OFFSET                 (0x11C)                                       /**<  (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT127_NFTX_Pos               0                                              /**< (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT127_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT127_NFTX_Pos)     /**< (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT127_NFTX(value)            (GMAC_TBFT127_NFTX_Msk & ((value) << GMAC_TBFT127_NFTX_Pos))
+#define GMAC_TBFT127_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT127) Register MASK  (Use GMAC_TBFT127_Msk instead)  */
+#define GMAC_TBFT127_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT127) Register Mask  */
+
+
+/* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) (R/ 32) 128 to 255 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT255_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT255_OFFSET                 (0x120)                                       /**<  (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT255_NFTX_Pos               0                                              /**< (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT255_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT255_NFTX_Pos)     /**< (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT255_NFTX(value)            (GMAC_TBFT255_NFTX_Msk & ((value) << GMAC_TBFT255_NFTX_Pos))
+#define GMAC_TBFT255_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT255) Register MASK  (Use GMAC_TBFT255_Msk instead)  */
+#define GMAC_TBFT255_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT255) Register Mask  */
+
+
+/* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) (R/ 32) 256 to 511 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT511_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT511_OFFSET                 (0x124)                                       /**<  (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT511_NFTX_Pos               0                                              /**< (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT511_NFTX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFT511_NFTX_Pos)     /**< (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT511_NFTX(value)            (GMAC_TBFT511_NFTX_Msk & ((value) << GMAC_TBFT511_NFTX_Pos))
+#define GMAC_TBFT511_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT511) Register MASK  (Use GMAC_TBFT511_Msk instead)  */
+#define GMAC_TBFT511_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT511) Register Mask  */
+
+
+/* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) (R/ 32) 512 to 1023 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT1023_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT1023_OFFSET                (0x128)                                       /**<  (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT1023_NFTX_Pos              0                                              /**< (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT1023_NFTX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFT1023_NFTX_Pos)    /**< (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT1023_NFTX(value)           (GMAC_TBFT1023_NFTX_Msk & ((value) << GMAC_TBFT1023_NFTX_Pos))
+#define GMAC_TBFT1023_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT1023) Register MASK  (Use GMAC_TBFT1023_Msk instead)  */
+#define GMAC_TBFT1023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT1023) Register Mask  */
+
+
+/* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12c) (R/ 32) 1024 to 1518 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFT1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFT1518_OFFSET                (0x12C)                                       /**<  (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_TBFT1518_NFTX_Pos              0                                              /**< (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error Position */
+#define GMAC_TBFT1518_NFTX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFT1518_NFTX_Pos)    /**< (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error Mask */
+#define GMAC_TBFT1518_NFTX(value)           (GMAC_TBFT1518_NFTX_Msk & ((value) << GMAC_TBFT1518_NFTX_Pos))
+#define GMAC_TBFT1518_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFT1518) Register MASK  (Use GMAC_TBFT1518_Msk instead)  */
+#define GMAC_TBFT1518_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFT1518) Register Mask  */
+
+
+/* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) (R/ 32) Greater Than 1518 Byte Frames Transmitted Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFTX:32;                   /**< bit:  0..31  Greater than 1518 Byte Frames Transmitted without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_GTBFT1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_GTBFT1518_OFFSET               (0x130)                                       /**<  (GMAC_GTBFT1518) Greater Than 1518 Byte Frames Transmitted Register  Offset */
+
+#define GMAC_GTBFT1518_NFTX_Pos             0                                              /**< (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error Position */
+#define GMAC_GTBFT1518_NFTX_Msk             (_U_(0xFFFFFFFF) << GMAC_GTBFT1518_NFTX_Pos)   /**< (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error Mask */
+#define GMAC_GTBFT1518_NFTX(value)          (GMAC_GTBFT1518_NFTX_Msk & ((value) << GMAC_GTBFT1518_NFTX_Pos))
+#define GMAC_GTBFT1518_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_GTBFT1518) Register MASK  (Use GMAC_GTBFT1518_Msk instead)  */
+#define GMAC_GTBFT1518_Msk                  _U_(0xFFFFFFFF)                                /**< (GMAC_GTBFT1518) Register Mask  */
+
+
+/* -------- GMAC_TUR : (GMAC Offset: 0x134) (R/ 32) Transmit Underruns Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXUNR:10;                  /**< bit:   0..9  Transmit Underruns                       */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TUR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TUR_OFFSET                     (0x134)                                       /**<  (GMAC_TUR) Transmit Underruns Register  Offset */
+
+#define GMAC_TUR_TXUNR_Pos                  0                                              /**< (GMAC_TUR) Transmit Underruns Position */
+#define GMAC_TUR_TXUNR_Msk                  (_U_(0x3FF) << GMAC_TUR_TXUNR_Pos)             /**< (GMAC_TUR) Transmit Underruns Mask */
+#define GMAC_TUR_TXUNR(value)               (GMAC_TUR_TXUNR_Msk & ((value) << GMAC_TUR_TXUNR_Pos))
+#define GMAC_TUR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_TUR) Register MASK  (Use GMAC_TUR_Msk instead)  */
+#define GMAC_TUR_Msk                        _U_(0x3FF)                                     /**< (GMAC_TUR) Register Mask  */
+
+
+/* -------- GMAC_SCF : (GMAC Offset: 0x138) (R/ 32) Single Collision Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCOL:18;                   /**< bit:  0..17  Single Collision                         */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_SCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_SCF_OFFSET                     (0x138)                                       /**<  (GMAC_SCF) Single Collision Frames Register  Offset */
+
+#define GMAC_SCF_SCOL_Pos                   0                                              /**< (GMAC_SCF) Single Collision Position */
+#define GMAC_SCF_SCOL_Msk                   (_U_(0x3FFFF) << GMAC_SCF_SCOL_Pos)            /**< (GMAC_SCF) Single Collision Mask */
+#define GMAC_SCF_SCOL(value)                (GMAC_SCF_SCOL_Msk & ((value) << GMAC_SCF_SCOL_Pos))
+#define GMAC_SCF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_SCF) Register MASK  (Use GMAC_SCF_Msk instead)  */
+#define GMAC_SCF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_SCF) Register Mask  */
+
+
+/* -------- GMAC_MCF : (GMAC Offset: 0x13c) (R/ 32) Multiple Collision Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCOL:18;                   /**< bit:  0..17  Multiple Collision                       */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MCF_OFFSET                     (0x13C)                                       /**<  (GMAC_MCF) Multiple Collision Frames Register  Offset */
+
+#define GMAC_MCF_MCOL_Pos                   0                                              /**< (GMAC_MCF) Multiple Collision Position */
+#define GMAC_MCF_MCOL_Msk                   (_U_(0x3FFFF) << GMAC_MCF_MCOL_Pos)            /**< (GMAC_MCF) Multiple Collision Mask */
+#define GMAC_MCF_MCOL(value)                (GMAC_MCF_MCOL_Msk & ((value) << GMAC_MCF_MCOL_Pos))
+#define GMAC_MCF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_MCF) Register MASK  (Use GMAC_MCF_Msk instead)  */
+#define GMAC_MCF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_MCF) Register Mask  */
+
+
+/* -------- GMAC_EC : (GMAC Offset: 0x140) (R/ 32) Excessive Collisions Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t XCOL:10;                   /**< bit:   0..9  Excessive Collisions                     */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EC_OFFSET                      (0x140)                                       /**<  (GMAC_EC) Excessive Collisions Register  Offset */
+
+#define GMAC_EC_XCOL_Pos                    0                                              /**< (GMAC_EC) Excessive Collisions Position */
+#define GMAC_EC_XCOL_Msk                    (_U_(0x3FF) << GMAC_EC_XCOL_Pos)               /**< (GMAC_EC) Excessive Collisions Mask */
+#define GMAC_EC_XCOL(value)                 (GMAC_EC_XCOL_Msk & ((value) << GMAC_EC_XCOL_Pos))
+#define GMAC_EC_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_EC) Register MASK  (Use GMAC_EC_Msk instead)  */
+#define GMAC_EC_Msk                         _U_(0x3FF)                                     /**< (GMAC_EC) Register Mask  */
+
+
+/* -------- GMAC_LC : (GMAC Offset: 0x144) (R/ 32) Late Collisions Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LCOL:10;                   /**< bit:   0..9  Late Collisions                          */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_LC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_LC_OFFSET                      (0x144)                                       /**<  (GMAC_LC) Late Collisions Register  Offset */
+
+#define GMAC_LC_LCOL_Pos                    0                                              /**< (GMAC_LC) Late Collisions Position */
+#define GMAC_LC_LCOL_Msk                    (_U_(0x3FF) << GMAC_LC_LCOL_Pos)               /**< (GMAC_LC) Late Collisions Mask */
+#define GMAC_LC_LCOL(value)                 (GMAC_LC_LCOL_Msk & ((value) << GMAC_LC_LCOL_Pos))
+#define GMAC_LC_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_LC) Register MASK  (Use GMAC_LC_Msk instead)  */
+#define GMAC_LC_Msk                         _U_(0x3FF)                                     /**< (GMAC_LC) Register Mask  */
+
+
+/* -------- GMAC_DTF : (GMAC Offset: 0x148) (R/ 32) Deferred Transmission Frames Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DEFT:18;                   /**< bit:  0..17  Deferred Transmission                    */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_DTF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_DTF_OFFSET                     (0x148)                                       /**<  (GMAC_DTF) Deferred Transmission Frames Register  Offset */
+
+#define GMAC_DTF_DEFT_Pos                   0                                              /**< (GMAC_DTF) Deferred Transmission Position */
+#define GMAC_DTF_DEFT_Msk                   (_U_(0x3FFFF) << GMAC_DTF_DEFT_Pos)            /**< (GMAC_DTF) Deferred Transmission Mask */
+#define GMAC_DTF_DEFT(value)                (GMAC_DTF_DEFT_Msk & ((value) << GMAC_DTF_DEFT_Pos))
+#define GMAC_DTF_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_DTF) Register MASK  (Use GMAC_DTF_Msk instead)  */
+#define GMAC_DTF_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_DTF) Register Mask  */
+
+
+/* -------- GMAC_CSE : (GMAC Offset: 0x14c) (R/ 32) Carrier Sense Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSR:10;                    /**< bit:   0..9  Carrier Sense Error                      */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CSE_OFFSET                     (0x14C)                                       /**<  (GMAC_CSE) Carrier Sense Errors Register  Offset */
+
+#define GMAC_CSE_CSR_Pos                    0                                              /**< (GMAC_CSE) Carrier Sense Error Position */
+#define GMAC_CSE_CSR_Msk                    (_U_(0x3FF) << GMAC_CSE_CSR_Pos)               /**< (GMAC_CSE) Carrier Sense Error Mask */
+#define GMAC_CSE_CSR(value)                 (GMAC_CSE_CSR_Msk & ((value) << GMAC_CSE_CSR_Pos))
+#define GMAC_CSE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_CSE) Register MASK  (Use GMAC_CSE_Msk instead)  */
+#define GMAC_CSE_Msk                        _U_(0x3FF)                                     /**< (GMAC_CSE) Register Mask  */
+
+
+/* -------- GMAC_ORLO : (GMAC Offset: 0x150) (R/ 32) Octets Received Low Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXO:32;                    /**< bit:  0..31  Received Octets                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ORLO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ORLO_OFFSET                    (0x150)                                       /**<  (GMAC_ORLO) Octets Received Low Received Register  Offset */
+
+#define GMAC_ORLO_RXO_Pos                   0                                              /**< (GMAC_ORLO) Received Octets Position */
+#define GMAC_ORLO_RXO_Msk                   (_U_(0xFFFFFFFF) << GMAC_ORLO_RXO_Pos)         /**< (GMAC_ORLO) Received Octets Mask */
+#define GMAC_ORLO_RXO(value)                (GMAC_ORLO_RXO_Msk & ((value) << GMAC_ORLO_RXO_Pos))
+#define GMAC_ORLO_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_ORLO) Register MASK  (Use GMAC_ORLO_Msk instead)  */
+#define GMAC_ORLO_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_ORLO) Register Mask  */
+
+
+/* -------- GMAC_ORHI : (GMAC Offset: 0x154) (R/ 32) Octets Received High Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXO:16;                    /**< bit:  0..15  Received Octets                          */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ORHI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ORHI_OFFSET                    (0x154)                                       /**<  (GMAC_ORHI) Octets Received High Received Register  Offset */
+
+#define GMAC_ORHI_RXO_Pos                   0                                              /**< (GMAC_ORHI) Received Octets Position */
+#define GMAC_ORHI_RXO_Msk                   (_U_(0xFFFF) << GMAC_ORHI_RXO_Pos)             /**< (GMAC_ORHI) Received Octets Mask */
+#define GMAC_ORHI_RXO(value)                (GMAC_ORHI_RXO_Msk & ((value) << GMAC_ORHI_RXO_Pos))
+#define GMAC_ORHI_MASK                      _U_(0xFFFF)                                    /**< \deprecated (GMAC_ORHI) Register MASK  (Use GMAC_ORHI_Msk instead)  */
+#define GMAC_ORHI_Msk                       _U_(0xFFFF)                                    /**< (GMAC_ORHI) Register Mask  */
+
+
+/* -------- GMAC_FR : (GMAC Offset: 0x158) (R/ 32) Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FRX:32;                    /**< bit:  0..31  Frames Received without Error            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FR_OFFSET                      (0x158)                                       /**<  (GMAC_FR) Frames Received Register  Offset */
+
+#define GMAC_FR_FRX_Pos                     0                                              /**< (GMAC_FR) Frames Received without Error Position */
+#define GMAC_FR_FRX_Msk                     (_U_(0xFFFFFFFF) << GMAC_FR_FRX_Pos)           /**< (GMAC_FR) Frames Received without Error Mask */
+#define GMAC_FR_FRX(value)                  (GMAC_FR_FRX_Msk & ((value) << GMAC_FR_FRX_Pos))
+#define GMAC_FR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_FR) Register MASK  (Use GMAC_FR_Msk instead)  */
+#define GMAC_FR_Msk                         _U_(0xFFFFFFFF)                                /**< (GMAC_FR) Register Mask  */
+
+
+/* -------- GMAC_BCFR : (GMAC Offset: 0x15c) (R/ 32) Broadcast Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BFRX:32;                   /**< bit:  0..31  Broadcast Frames Received without Error  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BCFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BCFR_OFFSET                    (0x15C)                                       /**<  (GMAC_BCFR) Broadcast Frames Received Register  Offset */
+
+#define GMAC_BCFR_BFRX_Pos                  0                                              /**< (GMAC_BCFR) Broadcast Frames Received without Error Position */
+#define GMAC_BCFR_BFRX_Msk                  (_U_(0xFFFFFFFF) << GMAC_BCFR_BFRX_Pos)        /**< (GMAC_BCFR) Broadcast Frames Received without Error Mask */
+#define GMAC_BCFR_BFRX(value)               (GMAC_BCFR_BFRX_Msk & ((value) << GMAC_BCFR_BFRX_Pos))
+#define GMAC_BCFR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BCFR) Register MASK  (Use GMAC_BCFR_Msk instead)  */
+#define GMAC_BCFR_Msk                       _U_(0xFFFFFFFF)                                /**< (GMAC_BCFR) Register Mask  */
+
+
+/* -------- GMAC_MFR : (GMAC Offset: 0x160) (R/ 32) Multicast Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFRX:32;                   /**< bit:  0..31  Multicast Frames Received without Error  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_MFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_MFR_OFFSET                     (0x160)                                       /**<  (GMAC_MFR) Multicast Frames Received Register  Offset */
+
+#define GMAC_MFR_MFRX_Pos                   0                                              /**< (GMAC_MFR) Multicast Frames Received without Error Position */
+#define GMAC_MFR_MFRX_Msk                   (_U_(0xFFFFFFFF) << GMAC_MFR_MFRX_Pos)         /**< (GMAC_MFR) Multicast Frames Received without Error Mask */
+#define GMAC_MFR_MFRX(value)                (GMAC_MFR_MFRX_Msk & ((value) << GMAC_MFR_MFRX_Pos))
+#define GMAC_MFR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_MFR) Register MASK  (Use GMAC_MFR_Msk instead)  */
+#define GMAC_MFR_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_MFR) Register Mask  */
+
+
+/* -------- GMAC_PFR : (GMAC Offset: 0x164) (R/ 32) Pause Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PFRX:16;                   /**< bit:  0..15  Pause Frames Received Register           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PFR_OFFSET                     (0x164)                                       /**<  (GMAC_PFR) Pause Frames Received Register  Offset */
+
+#define GMAC_PFR_PFRX_Pos                   0                                              /**< (GMAC_PFR) Pause Frames Received Register Position */
+#define GMAC_PFR_PFRX_Msk                   (_U_(0xFFFF) << GMAC_PFR_PFRX_Pos)             /**< (GMAC_PFR) Pause Frames Received Register Mask */
+#define GMAC_PFR_PFRX(value)                (GMAC_PFR_PFRX_Msk & ((value) << GMAC_PFR_PFRX_Pos))
+#define GMAC_PFR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_PFR) Register MASK  (Use GMAC_PFR_Msk instead)  */
+#define GMAC_PFR_Msk                        _U_(0xFFFF)                                    /**< (GMAC_PFR) Register Mask  */
+
+
+/* -------- GMAC_BFR64 : (GMAC Offset: 0x168) (R/ 32) 64 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  64 Byte Frames Received without Error    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_BFR64_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_BFR64_OFFSET                   (0x168)                                       /**<  (GMAC_BFR64) 64 Byte Frames Received Register  Offset */
+
+#define GMAC_BFR64_NFRX_Pos                 0                                              /**< (GMAC_BFR64) 64 Byte Frames Received without Error Position */
+#define GMAC_BFR64_NFRX_Msk                 (_U_(0xFFFFFFFF) << GMAC_BFR64_NFRX_Pos)       /**< (GMAC_BFR64) 64 Byte Frames Received without Error Mask */
+#define GMAC_BFR64_NFRX(value)              (GMAC_BFR64_NFRX_Msk & ((value) << GMAC_BFR64_NFRX_Pos))
+#define GMAC_BFR64_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_BFR64) Register MASK  (Use GMAC_BFR64_Msk instead)  */
+#define GMAC_BFR64_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_BFR64) Register Mask  */
+
+
+/* -------- GMAC_TBFR127 : (GMAC Offset: 0x16c) (R/ 32) 65 to 127 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR127_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR127_OFFSET                 (0x16C)                                       /**<  (GMAC_TBFR127) 65 to 127 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR127_NFRX_Pos               0                                              /**< (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error Position */
+#define GMAC_TBFR127_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR127_NFRX_Pos)     /**< (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error Mask */
+#define GMAC_TBFR127_NFRX(value)            (GMAC_TBFR127_NFRX_Msk & ((value) << GMAC_TBFR127_NFRX_Pos))
+#define GMAC_TBFR127_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR127) Register MASK  (Use GMAC_TBFR127_Msk instead)  */
+#define GMAC_TBFR127_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR127) Register Mask  */
+
+
+/* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) (R/ 32) 128 to 255 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR255_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR255_OFFSET                 (0x170)                                       /**<  (GMAC_TBFR255) 128 to 255 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR255_NFRX_Pos               0                                              /**< (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error Position */
+#define GMAC_TBFR255_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR255_NFRX_Pos)     /**< (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error Mask */
+#define GMAC_TBFR255_NFRX(value)            (GMAC_TBFR255_NFRX_Msk & ((value) << GMAC_TBFR255_NFRX_Pos))
+#define GMAC_TBFR255_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR255) Register MASK  (Use GMAC_TBFR255_Msk instead)  */
+#define GMAC_TBFR255_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR255) Register Mask  */
+
+
+/* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) (R/ 32) 256 to 511 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR511_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR511_OFFSET                 (0x174)                                       /**<  (GMAC_TBFR511) 256 to 511 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR511_NFRX_Pos               0                                              /**< (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error Position */
+#define GMAC_TBFR511_NFRX_Msk               (_U_(0xFFFFFFFF) << GMAC_TBFR511_NFRX_Pos)     /**< (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error Mask */
+#define GMAC_TBFR511_NFRX(value)            (GMAC_TBFR511_NFRX_Msk & ((value) << GMAC_TBFR511_NFRX_Pos))
+#define GMAC_TBFR511_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR511) Register MASK  (Use GMAC_TBFR511_Msk instead)  */
+#define GMAC_TBFR511_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR511) Register Mask  */
+
+
+/* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) (R/ 32) 512 to 1023 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR1023_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR1023_OFFSET                (0x178)                                       /**<  (GMAC_TBFR1023) 512 to 1023 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR1023_NFRX_Pos              0                                              /**< (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error Position */
+#define GMAC_TBFR1023_NFRX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFR1023_NFRX_Pos)    /**< (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error Mask */
+#define GMAC_TBFR1023_NFRX(value)           (GMAC_TBFR1023_NFRX_Msk & ((value) << GMAC_TBFR1023_NFRX_Pos))
+#define GMAC_TBFR1023_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR1023) Register MASK  (Use GMAC_TBFR1023_Msk instead)  */
+#define GMAC_TBFR1023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR1023) Register Mask  */
+
+
+/* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17c) (R/ 32) 1024 to 1518 Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBFR1518_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBFR1518_OFFSET                (0x17C)                                       /**<  (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received Register  Offset */
+
+#define GMAC_TBFR1518_NFRX_Pos              0                                              /**< (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error Position */
+#define GMAC_TBFR1518_NFRX_Msk              (_U_(0xFFFFFFFF) << GMAC_TBFR1518_NFRX_Pos)    /**< (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error Mask */
+#define GMAC_TBFR1518_NFRX(value)           (GMAC_TBFR1518_NFRX_Msk & ((value) << GMAC_TBFR1518_NFRX_Pos))
+#define GMAC_TBFR1518_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TBFR1518) Register MASK  (Use GMAC_TBFR1518_Msk instead)  */
+#define GMAC_TBFR1518_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_TBFR1518) Register Mask  */
+
+
+/* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) (R/ 32) 1519 to Maximum Byte Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NFRX:32;                   /**< bit:  0..31  1519 to Maximum Byte Frames Received without Error */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TMXBFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TMXBFR_OFFSET                  (0x180)                                       /**<  (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received Register  Offset */
+
+#define GMAC_TMXBFR_NFRX_Pos                0                                              /**< (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error Position */
+#define GMAC_TMXBFR_NFRX_Msk                (_U_(0xFFFFFFFF) << GMAC_TMXBFR_NFRX_Pos)      /**< (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error Mask */
+#define GMAC_TMXBFR_NFRX(value)             (GMAC_TMXBFR_NFRX_Msk & ((value) << GMAC_TMXBFR_NFRX_Pos))
+#define GMAC_TMXBFR_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TMXBFR) Register MASK  (Use GMAC_TMXBFR_Msk instead)  */
+#define GMAC_TMXBFR_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_TMXBFR) Register Mask  */
+
+
+/* -------- GMAC_UFR : (GMAC Offset: 0x184) (R/ 32) Undersize Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UFRX:10;                   /**< bit:   0..9  Undersize Frames Received                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UFR_OFFSET                     (0x184)                                       /**<  (GMAC_UFR) Undersize Frames Received Register  Offset */
+
+#define GMAC_UFR_UFRX_Pos                   0                                              /**< (GMAC_UFR) Undersize Frames Received Position */
+#define GMAC_UFR_UFRX_Msk                   (_U_(0x3FF) << GMAC_UFR_UFRX_Pos)              /**< (GMAC_UFR) Undersize Frames Received Mask */
+#define GMAC_UFR_UFRX(value)                (GMAC_UFR_UFRX_Msk & ((value) << GMAC_UFR_UFRX_Pos))
+#define GMAC_UFR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_UFR) Register MASK  (Use GMAC_UFR_Msk instead)  */
+#define GMAC_UFR_Msk                        _U_(0x3FF)                                     /**< (GMAC_UFR) Register Mask  */
+
+
+/* -------- GMAC_OFR : (GMAC Offset: 0x188) (R/ 32) Oversize Frames Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFRX:10;                   /**< bit:   0..9  Oversized Frames Received                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_OFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_OFR_OFFSET                     (0x188)                                       /**<  (GMAC_OFR) Oversize Frames Received Register  Offset */
+
+#define GMAC_OFR_OFRX_Pos                   0                                              /**< (GMAC_OFR) Oversized Frames Received Position */
+#define GMAC_OFR_OFRX_Msk                   (_U_(0x3FF) << GMAC_OFR_OFRX_Pos)              /**< (GMAC_OFR) Oversized Frames Received Mask */
+#define GMAC_OFR_OFRX(value)                (GMAC_OFR_OFRX_Msk & ((value) << GMAC_OFR_OFRX_Pos))
+#define GMAC_OFR_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_OFR) Register MASK  (Use GMAC_OFR_Msk instead)  */
+#define GMAC_OFR_Msk                        _U_(0x3FF)                                     /**< (GMAC_OFR) Register Mask  */
+
+
+/* -------- GMAC_JR : (GMAC Offset: 0x18c) (R/ 32) Jabbers Received Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t JRX:10;                    /**< bit:   0..9  Jabbers Received                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_JR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_JR_OFFSET                      (0x18C)                                       /**<  (GMAC_JR) Jabbers Received Register  Offset */
+
+#define GMAC_JR_JRX_Pos                     0                                              /**< (GMAC_JR) Jabbers Received Position */
+#define GMAC_JR_JRX_Msk                     (_U_(0x3FF) << GMAC_JR_JRX_Pos)                /**< (GMAC_JR) Jabbers Received Mask */
+#define GMAC_JR_JRX(value)                  (GMAC_JR_JRX_Msk & ((value) << GMAC_JR_JRX_Pos))
+#define GMAC_JR_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_JR) Register MASK  (Use GMAC_JR_Msk instead)  */
+#define GMAC_JR_Msk                         _U_(0x3FF)                                     /**< (GMAC_JR) Register Mask  */
+
+
+/* -------- GMAC_FCSE : (GMAC Offset: 0x190) (R/ 32) Frame Check Sequence Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCKR:10;                   /**< bit:   0..9  Frame Check Sequence Errors              */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_FCSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_FCSE_OFFSET                    (0x190)                                       /**<  (GMAC_FCSE) Frame Check Sequence Errors Register  Offset */
+
+#define GMAC_FCSE_FCKR_Pos                  0                                              /**< (GMAC_FCSE) Frame Check Sequence Errors Position */
+#define GMAC_FCSE_FCKR_Msk                  (_U_(0x3FF) << GMAC_FCSE_FCKR_Pos)             /**< (GMAC_FCSE) Frame Check Sequence Errors Mask */
+#define GMAC_FCSE_FCKR(value)               (GMAC_FCSE_FCKR_Msk & ((value) << GMAC_FCSE_FCKR_Pos))
+#define GMAC_FCSE_MASK                      _U_(0x3FF)                                     /**< \deprecated (GMAC_FCSE) Register MASK  (Use GMAC_FCSE_Msk instead)  */
+#define GMAC_FCSE_Msk                       _U_(0x3FF)                                     /**< (GMAC_FCSE) Register Mask  */
+
+
+/* -------- GMAC_LFFE : (GMAC Offset: 0x194) (R/ 32) Length Field Frame Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LFER:10;                   /**< bit:   0..9  Length Field Frame Errors                */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_LFFE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_LFFE_OFFSET                    (0x194)                                       /**<  (GMAC_LFFE) Length Field Frame Errors Register  Offset */
+
+#define GMAC_LFFE_LFER_Pos                  0                                              /**< (GMAC_LFFE) Length Field Frame Errors Position */
+#define GMAC_LFFE_LFER_Msk                  (_U_(0x3FF) << GMAC_LFFE_LFER_Pos)             /**< (GMAC_LFFE) Length Field Frame Errors Mask */
+#define GMAC_LFFE_LFER(value)               (GMAC_LFFE_LFER_Msk & ((value) << GMAC_LFFE_LFER_Pos))
+#define GMAC_LFFE_MASK                      _U_(0x3FF)                                     /**< \deprecated (GMAC_LFFE) Register MASK  (Use GMAC_LFFE_Msk instead)  */
+#define GMAC_LFFE_Msk                       _U_(0x3FF)                                     /**< (GMAC_LFFE) Register Mask  */
+
+
+/* -------- GMAC_RSE : (GMAC Offset: 0x198) (R/ 32) Receive Symbol Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXSE:10;                   /**< bit:   0..9  Receive Symbol Errors                    */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RSE_OFFSET                     (0x198)                                       /**<  (GMAC_RSE) Receive Symbol Errors Register  Offset */
+
+#define GMAC_RSE_RXSE_Pos                   0                                              /**< (GMAC_RSE) Receive Symbol Errors Position */
+#define GMAC_RSE_RXSE_Msk                   (_U_(0x3FF) << GMAC_RSE_RXSE_Pos)              /**< (GMAC_RSE) Receive Symbol Errors Mask */
+#define GMAC_RSE_RXSE(value)                (GMAC_RSE_RXSE_Msk & ((value) << GMAC_RSE_RXSE_Pos))
+#define GMAC_RSE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_RSE) Register MASK  (Use GMAC_RSE_Msk instead)  */
+#define GMAC_RSE_Msk                        _U_(0x3FF)                                     /**< (GMAC_RSE) Register Mask  */
+
+
+/* -------- GMAC_AE : (GMAC Offset: 0x19c) (R/ 32) Alignment Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AER:10;                    /**< bit:   0..9  Alignment Errors                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_AE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_AE_OFFSET                      (0x19C)                                       /**<  (GMAC_AE) Alignment Errors Register  Offset */
+
+#define GMAC_AE_AER_Pos                     0                                              /**< (GMAC_AE) Alignment Errors Position */
+#define GMAC_AE_AER_Msk                     (_U_(0x3FF) << GMAC_AE_AER_Pos)                /**< (GMAC_AE) Alignment Errors Mask */
+#define GMAC_AE_AER(value)                  (GMAC_AE_AER_Msk & ((value) << GMAC_AE_AER_Pos))
+#define GMAC_AE_MASK                        _U_(0x3FF)                                     /**< \deprecated (GMAC_AE) Register MASK  (Use GMAC_AE_Msk instead)  */
+#define GMAC_AE_Msk                         _U_(0x3FF)                                     /**< (GMAC_AE) Register Mask  */
+
+
+/* -------- GMAC_RRE : (GMAC Offset: 0x1a0) (R/ 32) Receive Resource Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRER:18;                  /**< bit:  0..17  Receive Resource Errors                  */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RRE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RRE_OFFSET                     (0x1A0)                                       /**<  (GMAC_RRE) Receive Resource Errors Register  Offset */
+
+#define GMAC_RRE_RXRER_Pos                  0                                              /**< (GMAC_RRE) Receive Resource Errors Position */
+#define GMAC_RRE_RXRER_Msk                  (_U_(0x3FFFF) << GMAC_RRE_RXRER_Pos)           /**< (GMAC_RRE) Receive Resource Errors Mask */
+#define GMAC_RRE_RXRER(value)               (GMAC_RRE_RXRER_Msk & ((value) << GMAC_RRE_RXRER_Pos))
+#define GMAC_RRE_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (GMAC_RRE) Register MASK  (Use GMAC_RRE_Msk instead)  */
+#define GMAC_RRE_Msk                        _U_(0x3FFFF)                                   /**< (GMAC_RRE) Register Mask  */
+
+
+/* -------- GMAC_ROE : (GMAC Offset: 0x1a4) (R/ 32) Receive Overrun Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXOVR:10;                  /**< bit:   0..9  Receive Overruns                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ROE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ROE_OFFSET                     (0x1A4)                                       /**<  (GMAC_ROE) Receive Overrun Register  Offset */
+
+#define GMAC_ROE_RXOVR_Pos                  0                                              /**< (GMAC_ROE) Receive Overruns Position */
+#define GMAC_ROE_RXOVR_Msk                  (_U_(0x3FF) << GMAC_ROE_RXOVR_Pos)             /**< (GMAC_ROE) Receive Overruns Mask */
+#define GMAC_ROE_RXOVR(value)               (GMAC_ROE_RXOVR_Msk & ((value) << GMAC_ROE_RXOVR_Pos))
+#define GMAC_ROE_MASK                       _U_(0x3FF)                                     /**< \deprecated (GMAC_ROE) Register MASK  (Use GMAC_ROE_Msk instead)  */
+#define GMAC_ROE_Msk                        _U_(0x3FF)                                     /**< (GMAC_ROE) Register Mask  */
+
+
+/* -------- GMAC_IHCE : (GMAC Offset: 0x1a8) (R/ 32) IP Header Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HCKER:8;                   /**< bit:   0..7  IP Header Checksum Errors                */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IHCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IHCE_OFFSET                    (0x1A8)                                       /**<  (GMAC_IHCE) IP Header Checksum Errors Register  Offset */
+
+#define GMAC_IHCE_HCKER_Pos                 0                                              /**< (GMAC_IHCE) IP Header Checksum Errors Position */
+#define GMAC_IHCE_HCKER_Msk                 (_U_(0xFF) << GMAC_IHCE_HCKER_Pos)             /**< (GMAC_IHCE) IP Header Checksum Errors Mask */
+#define GMAC_IHCE_HCKER(value)              (GMAC_IHCE_HCKER_Msk & ((value) << GMAC_IHCE_HCKER_Pos))
+#define GMAC_IHCE_MASK                      _U_(0xFF)                                      /**< \deprecated (GMAC_IHCE) Register MASK  (Use GMAC_IHCE_Msk instead)  */
+#define GMAC_IHCE_Msk                       _U_(0xFF)                                      /**< (GMAC_IHCE) Register Mask  */
+
+
+/* -------- GMAC_TCE : (GMAC Offset: 0x1ac) (R/ 32) TCP Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCKER:8;                   /**< bit:   0..7  TCP Checksum Errors                      */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TCE_OFFSET                     (0x1AC)                                       /**<  (GMAC_TCE) TCP Checksum Errors Register  Offset */
+
+#define GMAC_TCE_TCKER_Pos                  0                                              /**< (GMAC_TCE) TCP Checksum Errors Position */
+#define GMAC_TCE_TCKER_Msk                  (_U_(0xFF) << GMAC_TCE_TCKER_Pos)              /**< (GMAC_TCE) TCP Checksum Errors Mask */
+#define GMAC_TCE_TCKER(value)               (GMAC_TCE_TCKER_Msk & ((value) << GMAC_TCE_TCKER_Pos))
+#define GMAC_TCE_MASK                       _U_(0xFF)                                      /**< \deprecated (GMAC_TCE) Register MASK  (Use GMAC_TCE_Msk instead)  */
+#define GMAC_TCE_Msk                        _U_(0xFF)                                      /**< (GMAC_TCE) Register Mask  */
+
+
+/* -------- GMAC_UCE : (GMAC Offset: 0x1b0) (R/ 32) UDP Checksum Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UCKER:8;                   /**< bit:   0..7  UDP Checksum Errors                      */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_UCE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_UCE_OFFSET                     (0x1B0)                                       /**<  (GMAC_UCE) UDP Checksum Errors Register  Offset */
+
+#define GMAC_UCE_UCKER_Pos                  0                                              /**< (GMAC_UCE) UDP Checksum Errors Position */
+#define GMAC_UCE_UCKER_Msk                  (_U_(0xFF) << GMAC_UCE_UCKER_Pos)              /**< (GMAC_UCE) UDP Checksum Errors Mask */
+#define GMAC_UCE_UCKER(value)               (GMAC_UCE_UCKER_Msk & ((value) << GMAC_UCE_UCKER_Pos))
+#define GMAC_UCE_MASK                       _U_(0xFF)                                      /**< \deprecated (GMAC_UCE) Register MASK  (Use GMAC_UCE_Msk instead)  */
+#define GMAC_UCE_Msk                        _U_(0xFF)                                      /**< (GMAC_UCE) Register Mask  */
+
+
+/* -------- GMAC_TISUBN : (GMAC Offset: 0x1bc) (R/W 32) 1588 Timer Increment Sub-nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LSBTIR:16;                 /**< bit:  0..15  Lower Significant Bits of Timer Increment Register */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TISUBN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TISUBN_OFFSET                  (0x1BC)                                       /**<  (GMAC_TISUBN) 1588 Timer Increment Sub-nanoseconds Register  Offset */
+
+#define GMAC_TISUBN_LSBTIR_Pos              0                                              /**< (GMAC_TISUBN) Lower Significant Bits of Timer Increment Register Position */
+#define GMAC_TISUBN_LSBTIR_Msk              (_U_(0xFFFF) << GMAC_TISUBN_LSBTIR_Pos)        /**< (GMAC_TISUBN) Lower Significant Bits of Timer Increment Register Mask */
+#define GMAC_TISUBN_LSBTIR(value)           (GMAC_TISUBN_LSBTIR_Msk & ((value) << GMAC_TISUBN_LSBTIR_Pos))
+#define GMAC_TISUBN_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_TISUBN) Register MASK  (Use GMAC_TISUBN_Msk instead)  */
+#define GMAC_TISUBN_Msk                     _U_(0xFFFF)                                    /**< (GMAC_TISUBN) Register Mask  */
+
+
+/* -------- GMAC_TSH : (GMAC Offset: 0x1c0) (R/W 32) 1588 Timer Seconds High Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCS:16;                    /**< bit:  0..15  Timer Count in Seconds                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSH_OFFSET                     (0x1C0)                                       /**<  (GMAC_TSH) 1588 Timer Seconds High Register  Offset */
+
+#define GMAC_TSH_TCS_Pos                    0                                              /**< (GMAC_TSH) Timer Count in Seconds Position */
+#define GMAC_TSH_TCS_Msk                    (_U_(0xFFFF) << GMAC_TSH_TCS_Pos)              /**< (GMAC_TSH) Timer Count in Seconds Mask */
+#define GMAC_TSH_TCS(value)                 (GMAC_TSH_TCS_Msk & ((value) << GMAC_TSH_TCS_Pos))
+#define GMAC_TSH_MASK                       _U_(0xFFFF)                                    /**< \deprecated (GMAC_TSH) Register MASK  (Use GMAC_TSH_Msk instead)  */
+#define GMAC_TSH_Msk                        _U_(0xFFFF)                                    /**< (GMAC_TSH) Register Mask  */
+
+
+/* -------- GMAC_TSL : (GMAC Offset: 0x1d0) (R/W 32) 1588 Timer Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCS:32;                    /**< bit:  0..31  Timer Count in Seconds                   */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TSL_OFFSET                     (0x1D0)                                       /**<  (GMAC_TSL) 1588 Timer Seconds Low Register  Offset */
+
+#define GMAC_TSL_TCS_Pos                    0                                              /**< (GMAC_TSL) Timer Count in Seconds Position */
+#define GMAC_TSL_TCS_Msk                    (_U_(0xFFFFFFFF) << GMAC_TSL_TCS_Pos)          /**< (GMAC_TSL) Timer Count in Seconds Mask */
+#define GMAC_TSL_TCS(value)                 (GMAC_TSL_TCS_Msk & ((value) << GMAC_TSL_TCS_Pos))
+#define GMAC_TSL_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_TSL) Register MASK  (Use GMAC_TSL_Msk instead)  */
+#define GMAC_TSL_Msk                        _U_(0xFFFFFFFF)                                /**< (GMAC_TSL) Register Mask  */
+
+
+/* -------- GMAC_TN : (GMAC Offset: 0x1d4) (R/W 32) 1588 Timer Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TNS:30;                    /**< bit:  0..29  Timer Count in Nanoseconds               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TN_OFFSET                      (0x1D4)                                       /**<  (GMAC_TN) 1588 Timer Nanoseconds Register  Offset */
+
+#define GMAC_TN_TNS_Pos                     0                                              /**< (GMAC_TN) Timer Count in Nanoseconds Position */
+#define GMAC_TN_TNS_Msk                     (_U_(0x3FFFFFFF) << GMAC_TN_TNS_Pos)           /**< (GMAC_TN) Timer Count in Nanoseconds Mask */
+#define GMAC_TN_TNS(value)                  (GMAC_TN_TNS_Msk & ((value) << GMAC_TN_TNS_Pos))
+#define GMAC_TN_MASK                        _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_TN) Register MASK  (Use GMAC_TN_Msk instead)  */
+#define GMAC_TN_Msk                         _U_(0x3FFFFFFF)                                /**< (GMAC_TN) Register Mask  */
+
+
+/* -------- GMAC_TA : (GMAC Offset: 0x1d8) (/W 32) 1588 Timer Adjust Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ITDT:30;                   /**< bit:  0..29  Increment/Decrement                      */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t ADJ:1;                     /**< bit:     31  Adjust 1588 Timer                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TA_OFFSET                      (0x1D8)                                       /**<  (GMAC_TA) 1588 Timer Adjust Register  Offset */
+
+#define GMAC_TA_ITDT_Pos                    0                                              /**< (GMAC_TA) Increment/Decrement Position */
+#define GMAC_TA_ITDT_Msk                    (_U_(0x3FFFFFFF) << GMAC_TA_ITDT_Pos)          /**< (GMAC_TA) Increment/Decrement Mask */
+#define GMAC_TA_ITDT(value)                 (GMAC_TA_ITDT_Msk & ((value) << GMAC_TA_ITDT_Pos))
+#define GMAC_TA_ADJ_Pos                     31                                             /**< (GMAC_TA) Adjust 1588 Timer Position */
+#define GMAC_TA_ADJ_Msk                     (_U_(0x1) << GMAC_TA_ADJ_Pos)                  /**< (GMAC_TA) Adjust 1588 Timer Mask */
+#define GMAC_TA_ADJ                         GMAC_TA_ADJ_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_TA_ADJ_Msk instead */
+#define GMAC_TA_MASK                        _U_(0xBFFFFFFF)                                /**< \deprecated (GMAC_TA) Register MASK  (Use GMAC_TA_Msk instead)  */
+#define GMAC_TA_Msk                         _U_(0xBFFFFFFF)                                /**< (GMAC_TA) Register Mask  */
+
+
+/* -------- GMAC_TI : (GMAC Offset: 0x1dc) (R/W 32) 1588 Timer Increment Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CNS:8;                     /**< bit:   0..7  Count Nanoseconds                        */
+    uint32_t ACNS:8;                    /**< bit:  8..15  Alternative Count Nanoseconds            */
+    uint32_t NIT:8;                     /**< bit: 16..23  Number of Increments                     */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TI_OFFSET                      (0x1DC)                                       /**<  (GMAC_TI) 1588 Timer Increment Register  Offset */
+
+#define GMAC_TI_CNS_Pos                     0                                              /**< (GMAC_TI) Count Nanoseconds Position */
+#define GMAC_TI_CNS_Msk                     (_U_(0xFF) << GMAC_TI_CNS_Pos)                 /**< (GMAC_TI) Count Nanoseconds Mask */
+#define GMAC_TI_CNS(value)                  (GMAC_TI_CNS_Msk & ((value) << GMAC_TI_CNS_Pos))
+#define GMAC_TI_ACNS_Pos                    8                                              /**< (GMAC_TI) Alternative Count Nanoseconds Position */
+#define GMAC_TI_ACNS_Msk                    (_U_(0xFF) << GMAC_TI_ACNS_Pos)                /**< (GMAC_TI) Alternative Count Nanoseconds Mask */
+#define GMAC_TI_ACNS(value)                 (GMAC_TI_ACNS_Msk & ((value) << GMAC_TI_ACNS_Pos))
+#define GMAC_TI_NIT_Pos                     16                                             /**< (GMAC_TI) Number of Increments Position */
+#define GMAC_TI_NIT_Msk                     (_U_(0xFF) << GMAC_TI_NIT_Pos)                 /**< (GMAC_TI) Number of Increments Mask */
+#define GMAC_TI_NIT(value)                  (GMAC_TI_NIT_Msk & ((value) << GMAC_TI_NIT_Pos))
+#define GMAC_TI_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (GMAC_TI) Register MASK  (Use GMAC_TI_Msk instead)  */
+#define GMAC_TI_Msk                         _U_(0xFFFFFF)                                  /**< (GMAC_TI) Register Mask  */
+
+
+/* -------- GMAC_EFTSL : (GMAC Offset: 0x1e0) (R/ 32) PTP Event Frame Transmitted Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTSL_OFFSET                   (0x1E0)                                       /**<  (GMAC_EFTSL) PTP Event Frame Transmitted Seconds Low Register  Offset */
+
+#define GMAC_EFTSL_RUD_Pos                  0                                              /**< (GMAC_EFTSL) Register Update Position */
+#define GMAC_EFTSL_RUD_Msk                  (_U_(0xFFFFFFFF) << GMAC_EFTSL_RUD_Pos)        /**< (GMAC_EFTSL) Register Update Mask */
+#define GMAC_EFTSL_RUD(value)               (GMAC_EFTSL_RUD_Msk & ((value) << GMAC_EFTSL_RUD_Pos))
+#define GMAC_EFTSL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_EFTSL) Register MASK  (Use GMAC_EFTSL_Msk instead)  */
+#define GMAC_EFTSL_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_EFTSL) Register Mask  */
+
+
+/* -------- GMAC_EFTN : (GMAC Offset: 0x1e4) (R/ 32) PTP Event Frame Transmitted Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFTN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFTN_OFFSET                    (0x1E4)                                       /**<  (GMAC_EFTN) PTP Event Frame Transmitted Nanoseconds Register  Offset */
+
+#define GMAC_EFTN_RUD_Pos                   0                                              /**< (GMAC_EFTN) Register Update Position */
+#define GMAC_EFTN_RUD_Msk                   (_U_(0x3FFFFFFF) << GMAC_EFTN_RUD_Pos)         /**< (GMAC_EFTN) Register Update Mask */
+#define GMAC_EFTN_RUD(value)                (GMAC_EFTN_RUD_Msk & ((value) << GMAC_EFTN_RUD_Pos))
+#define GMAC_EFTN_MASK                      _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_EFTN) Register MASK  (Use GMAC_EFTN_Msk instead)  */
+#define GMAC_EFTN_Msk                       _U_(0x3FFFFFFF)                                /**< (GMAC_EFTN) Register Mask  */
+
+
+/* -------- GMAC_EFRSL : (GMAC Offset: 0x1e8) (R/ 32) PTP Event Frame Received Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRSL_OFFSET                   (0x1E8)                                       /**<  (GMAC_EFRSL) PTP Event Frame Received Seconds Low Register  Offset */
+
+#define GMAC_EFRSL_RUD_Pos                  0                                              /**< (GMAC_EFRSL) Register Update Position */
+#define GMAC_EFRSL_RUD_Msk                  (_U_(0xFFFFFFFF) << GMAC_EFRSL_RUD_Pos)        /**< (GMAC_EFRSL) Register Update Mask */
+#define GMAC_EFRSL_RUD(value)               (GMAC_EFRSL_RUD_Msk & ((value) << GMAC_EFRSL_RUD_Pos))
+#define GMAC_EFRSL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_EFRSL) Register MASK  (Use GMAC_EFRSL_Msk instead)  */
+#define GMAC_EFRSL_Msk                      _U_(0xFFFFFFFF)                                /**< (GMAC_EFRSL) Register Mask  */
+
+
+/* -------- GMAC_EFRN : (GMAC Offset: 0x1ec) (R/ 32) PTP Event Frame Received Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_EFRN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_EFRN_OFFSET                    (0x1EC)                                       /**<  (GMAC_EFRN) PTP Event Frame Received Nanoseconds Register  Offset */
+
+#define GMAC_EFRN_RUD_Pos                   0                                              /**< (GMAC_EFRN) Register Update Position */
+#define GMAC_EFRN_RUD_Msk                   (_U_(0x3FFFFFFF) << GMAC_EFRN_RUD_Pos)         /**< (GMAC_EFRN) Register Update Mask */
+#define GMAC_EFRN_RUD(value)                (GMAC_EFRN_RUD_Msk & ((value) << GMAC_EFRN_RUD_Pos))
+#define GMAC_EFRN_MASK                      _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_EFRN) Register MASK  (Use GMAC_EFRN_Msk instead)  */
+#define GMAC_EFRN_Msk                       _U_(0x3FFFFFFF)                                /**< (GMAC_EFRN) Register Mask  */
+
+
+/* -------- GMAC_PEFTSL : (GMAC Offset: 0x1f0) (R/ 32) PTP Peer Event Frame Transmitted Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTSL_OFFSET                  (0x1F0)                                       /**<  (GMAC_PEFTSL) PTP Peer Event Frame Transmitted Seconds Low Register  Offset */
+
+#define GMAC_PEFTSL_RUD_Pos                 0                                              /**< (GMAC_PEFTSL) Register Update Position */
+#define GMAC_PEFTSL_RUD_Msk                 (_U_(0xFFFFFFFF) << GMAC_PEFTSL_RUD_Pos)       /**< (GMAC_PEFTSL) Register Update Mask */
+#define GMAC_PEFTSL_RUD(value)              (GMAC_PEFTSL_RUD_Msk & ((value) << GMAC_PEFTSL_RUD_Pos))
+#define GMAC_PEFTSL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_PEFTSL) Register MASK  (Use GMAC_PEFTSL_Msk instead)  */
+#define GMAC_PEFTSL_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_PEFTSL) Register Mask  */
+
+
+/* -------- GMAC_PEFTN : (GMAC Offset: 0x1f4) (R/ 32) PTP Peer Event Frame Transmitted Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFTN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFTN_OFFSET                   (0x1F4)                                       /**<  (GMAC_PEFTN) PTP Peer Event Frame Transmitted Nanoseconds Register  Offset */
+
+#define GMAC_PEFTN_RUD_Pos                  0                                              /**< (GMAC_PEFTN) Register Update Position */
+#define GMAC_PEFTN_RUD_Msk                  (_U_(0x3FFFFFFF) << GMAC_PEFTN_RUD_Pos)        /**< (GMAC_PEFTN) Register Update Mask */
+#define GMAC_PEFTN_RUD(value)               (GMAC_PEFTN_RUD_Msk & ((value) << GMAC_PEFTN_RUD_Pos))
+#define GMAC_PEFTN_MASK                     _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_PEFTN) Register MASK  (Use GMAC_PEFTN_Msk instead)  */
+#define GMAC_PEFTN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFTN) Register Mask  */
+
+
+/* -------- GMAC_PEFRSL : (GMAC Offset: 0x1f8) (R/ 32) PTP Peer Event Frame Received Seconds Low Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRSL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRSL_OFFSET                  (0x1F8)                                       /**<  (GMAC_PEFRSL) PTP Peer Event Frame Received Seconds Low Register  Offset */
+
+#define GMAC_PEFRSL_RUD_Pos                 0                                              /**< (GMAC_PEFRSL) Register Update Position */
+#define GMAC_PEFRSL_RUD_Msk                 (_U_(0xFFFFFFFF) << GMAC_PEFRSL_RUD_Pos)       /**< (GMAC_PEFRSL) Register Update Mask */
+#define GMAC_PEFRSL_RUD(value)              (GMAC_PEFRSL_RUD_Msk & ((value) << GMAC_PEFRSL_RUD_Pos))
+#define GMAC_PEFRSL_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_PEFRSL) Register MASK  (Use GMAC_PEFRSL_Msk instead)  */
+#define GMAC_PEFRSL_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_PEFRSL) Register Mask  */
+
+
+/* -------- GMAC_PEFRN : (GMAC Offset: 0x1fc) (R/ 32) PTP Peer Event Frame Received Nanoseconds Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_PEFRN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_PEFRN_OFFSET                   (0x1FC)                                       /**<  (GMAC_PEFRN) PTP Peer Event Frame Received Nanoseconds Register  Offset */
+
+#define GMAC_PEFRN_RUD_Pos                  0                                              /**< (GMAC_PEFRN) Register Update Position */
+#define GMAC_PEFRN_RUD_Msk                  (_U_(0x3FFFFFFF) << GMAC_PEFRN_RUD_Pos)        /**< (GMAC_PEFRN) Register Update Mask */
+#define GMAC_PEFRN_RUD(value)               (GMAC_PEFRN_RUD_Msk & ((value) << GMAC_PEFRN_RUD_Pos))
+#define GMAC_PEFRN_MASK                     _U_(0x3FFFFFFF)                                /**< \deprecated (GMAC_PEFRN) Register MASK  (Use GMAC_PEFRN_Msk instead)  */
+#define GMAC_PEFRN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFRN) Register Mask  */
+
+
+/* -------- GMAC_RXLPI : (GMAC Offset: 0x270) (R/ 32) Received LPI Transitions -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COUNT:16;                  /**< bit:  0..15  Count of RX LPI transitions (cleared on read) */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RXLPI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RXLPI_OFFSET                   (0x270)                                       /**<  (GMAC_RXLPI) Received LPI Transitions  Offset */
+
+#define GMAC_RXLPI_COUNT_Pos                0                                              /**< (GMAC_RXLPI) Count of RX LPI transitions (cleared on read) Position */
+#define GMAC_RXLPI_COUNT_Msk                (_U_(0xFFFF) << GMAC_RXLPI_COUNT_Pos)          /**< (GMAC_RXLPI) Count of RX LPI transitions (cleared on read) Mask */
+#define GMAC_RXLPI_COUNT(value)             (GMAC_RXLPI_COUNT_Msk & ((value) << GMAC_RXLPI_COUNT_Pos))
+#define GMAC_RXLPI_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_RXLPI) Register MASK  (Use GMAC_RXLPI_Msk instead)  */
+#define GMAC_RXLPI_Msk                      _U_(0xFFFF)                                    /**< (GMAC_RXLPI) Register Mask  */
+
+
+/* -------- GMAC_RXLPITIME : (GMAC Offset: 0x274) (R/ 32) Received LPI Time -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LPITIME:24;                /**< bit:  0..23  Time in LPI (cleared on read)            */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RXLPITIME_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RXLPITIME_OFFSET               (0x274)                                       /**<  (GMAC_RXLPITIME) Received LPI Time  Offset */
+
+#define GMAC_RXLPITIME_LPITIME_Pos          0                                              /**< (GMAC_RXLPITIME) Time in LPI (cleared on read) Position */
+#define GMAC_RXLPITIME_LPITIME_Msk          (_U_(0xFFFFFF) << GMAC_RXLPITIME_LPITIME_Pos)  /**< (GMAC_RXLPITIME) Time in LPI (cleared on read) Mask */
+#define GMAC_RXLPITIME_LPITIME(value)       (GMAC_RXLPITIME_LPITIME_Msk & ((value) << GMAC_RXLPITIME_LPITIME_Pos))
+#define GMAC_RXLPITIME_MASK                 _U_(0xFFFFFF)                                  /**< \deprecated (GMAC_RXLPITIME) Register MASK  (Use GMAC_RXLPITIME_Msk instead)  */
+#define GMAC_RXLPITIME_Msk                  _U_(0xFFFFFF)                                  /**< (GMAC_RXLPITIME) Register Mask  */
+
+
+/* -------- GMAC_TXLPI : (GMAC Offset: 0x278) (R/ 32) Transmit LPI Transitions -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COUNT:16;                  /**< bit:  0..15  Count of LPI transitions (cleared on read) */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TXLPI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TXLPI_OFFSET                   (0x278)                                       /**<  (GMAC_TXLPI) Transmit LPI Transitions  Offset */
+
+#define GMAC_TXLPI_COUNT_Pos                0                                              /**< (GMAC_TXLPI) Count of LPI transitions (cleared on read) Position */
+#define GMAC_TXLPI_COUNT_Msk                (_U_(0xFFFF) << GMAC_TXLPI_COUNT_Pos)          /**< (GMAC_TXLPI) Count of LPI transitions (cleared on read) Mask */
+#define GMAC_TXLPI_COUNT(value)             (GMAC_TXLPI_COUNT_Msk & ((value) << GMAC_TXLPI_COUNT_Pos))
+#define GMAC_TXLPI_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_TXLPI) Register MASK  (Use GMAC_TXLPI_Msk instead)  */
+#define GMAC_TXLPI_Msk                      _U_(0xFFFF)                                    /**< (GMAC_TXLPI) Register Mask  */
+
+
+/* -------- GMAC_TXLPITIME : (GMAC Offset: 0x27c) (R/ 32) Transmit LPI Time -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LPITIME:24;                /**< bit:  0..23  Time in LPI (cleared on read)            */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TXLPITIME_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TXLPITIME_OFFSET               (0x27C)                                       /**<  (GMAC_TXLPITIME) Transmit LPI Time  Offset */
+
+#define GMAC_TXLPITIME_LPITIME_Pos          0                                              /**< (GMAC_TXLPITIME) Time in LPI (cleared on read) Position */
+#define GMAC_TXLPITIME_LPITIME_Msk          (_U_(0xFFFFFF) << GMAC_TXLPITIME_LPITIME_Pos)  /**< (GMAC_TXLPITIME) Time in LPI (cleared on read) Mask */
+#define GMAC_TXLPITIME_LPITIME(value)       (GMAC_TXLPITIME_LPITIME_Msk & ((value) << GMAC_TXLPITIME_LPITIME_Pos))
+#define GMAC_TXLPITIME_MASK                 _U_(0xFFFFFF)                                  /**< \deprecated (GMAC_TXLPITIME) Register MASK  (Use GMAC_TXLPITIME_Msk instead)  */
+#define GMAC_TXLPITIME_Msk                  _U_(0xFFFFFF)                                  /**< (GMAC_TXLPITIME) Register Mask  */
+
+
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ISRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (1..5)  Offset */
+
+#define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
+#define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
+#define GMAC_ISRPQ_RCOMP                    GMAC_ISRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RCOMP_Msk instead */
+#define GMAC_ISRPQ_RXUBR_Pos                2                                              /**< (GMAC_ISRPQ) RX Used Bit Read Position */
+#define GMAC_ISRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_ISRPQ_RXUBR_Pos)             /**< (GMAC_ISRPQ) RX Used Bit Read Mask */
+#define GMAC_ISRPQ_RXUBR                    GMAC_ISRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RXUBR_Msk instead */
+#define GMAC_ISRPQ_RLEX_Pos                 5                                              /**< (GMAC_ISRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_ISRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_ISRPQ_RLEX_Pos)              /**< (GMAC_ISRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_ISRPQ_RLEX                     GMAC_ISRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_RLEX_Msk instead */
+#define GMAC_ISRPQ_TFC_Pos                  6                                              /**< (GMAC_ISRPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_ISRPQ_TFC_Msk                  (_U_(0x1) << GMAC_ISRPQ_TFC_Pos)               /**< (GMAC_ISRPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_ISRPQ_TFC                      GMAC_ISRPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_TFC_Msk instead */
+#define GMAC_ISRPQ_TCOMP_Pos                7                                              /**< (GMAC_ISRPQ) Transmit Complete Position */
+#define GMAC_ISRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_TCOMP_Pos)             /**< (GMAC_ISRPQ) Transmit Complete Mask */
+#define GMAC_ISRPQ_TCOMP                    GMAC_ISRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_TCOMP_Msk instead */
+#define GMAC_ISRPQ_ROVR_Pos                 10                                             /**< (GMAC_ISRPQ) Receive Overrun Position */
+#define GMAC_ISRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_ISRPQ_ROVR_Pos)              /**< (GMAC_ISRPQ) Receive Overrun Mask */
+#define GMAC_ISRPQ_ROVR                     GMAC_ISRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_ROVR_Msk instead */
+#define GMAC_ISRPQ_HRESP_Pos                11                                             /**< (GMAC_ISRPQ) HRESP Not OK Position */
+#define GMAC_ISRPQ_HRESP_Msk                (_U_(0x1) << GMAC_ISRPQ_HRESP_Pos)             /**< (GMAC_ISRPQ) HRESP Not OK Mask */
+#define GMAC_ISRPQ_HRESP                    GMAC_ISRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISRPQ_HRESP_Msk instead */
+#define GMAC_ISRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_ISRPQ) Register MASK  (Use GMAC_ISRPQ_Msk instead)  */
+#define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
+
+
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXBQBA:30;                 /**< bit:  2..31  Transmit Buffer Queue Base Address       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_TBQBAPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (1..5)  Offset */
+
+#define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
+#define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
+#define GMAC_TBQBAPQ_TXBQBA(value)          (GMAC_TBQBAPQ_TXBQBA_Msk & ((value) << GMAC_TBQBAPQ_TXBQBA_Pos))
+#define GMAC_TBQBAPQ_MASK                   _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_TBQBAPQ) Register MASK  (Use GMAC_TBQBAPQ_Msk instead)  */
+#define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
+
+
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBQBA:30;                 /**< bit:  2..31  Receive Buffer Queue Base Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBQBAPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (1..5)  Offset */
+
+#define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
+#define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
+#define GMAC_RBQBAPQ_RXBQBA(value)          (GMAC_RBQBAPQ_RXBQBA_Msk & ((value) << GMAC_RBQBAPQ_RXBQBA_Pos))
+#define GMAC_RBQBAPQ_MASK                   _U_(0xFFFFFFFC)                                /**< \deprecated (GMAC_RBQBAPQ) Register MASK  (Use GMAC_RBQBAPQ_Msk instead)  */
+#define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
+
+
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RBS:16;                    /**< bit:  0..15  Receive Buffer Size                      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_RBSRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (1..5)  Offset */
+
+#define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
+#define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
+#define GMAC_RBSRPQ_RBS(value)              (GMAC_RBSRPQ_RBS_Msk & ((value) << GMAC_RBSRPQ_RBS_Pos))
+#define GMAC_RBSRPQ_MASK                    _U_(0xFFFF)                                    /**< \deprecated (GMAC_RBSRPQ) Register MASK  (Use GMAC_RBSRPQ_Msk instead)  */
+#define GMAC_RBSRPQ_Msk                     _U_(0xFFFF)                                    /**< (GMAC_RBSRPQ) Register Mask  */
+
+
+/* -------- GMAC_CBSCR : (GMAC Offset: 0x4bc) (R/W 32) Credit-Based Shaping Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QBE:1;                     /**< bit:      0  Queue B CBS Enable                       */
+    uint32_t QAE:1;                     /**< bit:      1  Queue A CBS Enable                       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSCR_OFFSET                   (0x4BC)                                       /**<  (GMAC_CBSCR) Credit-Based Shaping Control Register  Offset */
+
+#define GMAC_CBSCR_QBE_Pos                  0                                              /**< (GMAC_CBSCR) Queue B CBS Enable Position */
+#define GMAC_CBSCR_QBE_Msk                  (_U_(0x1) << GMAC_CBSCR_QBE_Pos)               /**< (GMAC_CBSCR) Queue B CBS Enable Mask */
+#define GMAC_CBSCR_QBE                      GMAC_CBSCR_QBE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_CBSCR_QBE_Msk instead */
+#define GMAC_CBSCR_QAE_Pos                  1                                              /**< (GMAC_CBSCR) Queue A CBS Enable Position */
+#define GMAC_CBSCR_QAE_Msk                  (_U_(0x1) << GMAC_CBSCR_QAE_Pos)               /**< (GMAC_CBSCR) Queue A CBS Enable Mask */
+#define GMAC_CBSCR_QAE                      GMAC_CBSCR_QAE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_CBSCR_QAE_Msk instead */
+#define GMAC_CBSCR_MASK                     _U_(0x03)                                      /**< \deprecated (GMAC_CBSCR) Register MASK  (Use GMAC_CBSCR_Msk instead)  */
+#define GMAC_CBSCR_Msk                      _U_(0x03)                                      /**< (GMAC_CBSCR) Register Mask  */
+
+
+/* -------- GMAC_CBSISQA : (GMAC Offset: 0x4c0) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue A -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSISQA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSISQA_OFFSET                 (0x4C0)                                       /**<  (GMAC_CBSISQA) Credit-Based Shaping IdleSlope Register for Queue A  Offset */
+
+#define GMAC_CBSISQA_IS_Pos                 0                                              /**< (GMAC_CBSISQA) IdleSlope Position */
+#define GMAC_CBSISQA_IS_Msk                 (_U_(0xFFFFFFFF) << GMAC_CBSISQA_IS_Pos)       /**< (GMAC_CBSISQA) IdleSlope Mask */
+#define GMAC_CBSISQA_IS(value)              (GMAC_CBSISQA_IS_Msk & ((value) << GMAC_CBSISQA_IS_Pos))
+#define GMAC_CBSISQA_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_CBSISQA) Register MASK  (Use GMAC_CBSISQA_Msk instead)  */
+#define GMAC_CBSISQA_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_CBSISQA) Register Mask  */
+
+
+/* -------- GMAC_CBSISQB : (GMAC Offset: 0x4c4) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue B -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_CBSISQB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_CBSISQB_OFFSET                 (0x4C4)                                       /**<  (GMAC_CBSISQB) Credit-Based Shaping IdleSlope Register for Queue B  Offset */
+
+#define GMAC_CBSISQB_IS_Pos                 0                                              /**< (GMAC_CBSISQB) IdleSlope Position */
+#define GMAC_CBSISQB_IS_Msk                 (_U_(0xFFFFFFFF) << GMAC_CBSISQB_IS_Pos)       /**< (GMAC_CBSISQB) IdleSlope Mask */
+#define GMAC_CBSISQB_IS(value)              (GMAC_CBSISQB_IS_Msk & ((value) << GMAC_CBSISQB_IS_Pos))
+#define GMAC_CBSISQB_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (GMAC_CBSISQB) Register MASK  (Use GMAC_CBSISQB_Msk instead)  */
+#define GMAC_CBSISQB_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_CBSISQB) Register Mask  */
+
+
+/* -------- GMAC_ST1RPQ : (GMAC Offset: 0x500) (R/W 32) Screening Type 1 Register Priority Queue -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-5)                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t DSTCM:8;                   /**< bit:  4..11  Differentiated Services or Traffic Class Match */
+    uint32_t UDPM:16;                   /**< bit: 12..27  UDP Port Match                           */
+    uint32_t DSTCE:1;                   /**< bit:     28  Differentiated Services or Traffic Class Match Enable */
+    uint32_t UDPE:1;                    /**< bit:     29  UDP Port Match Enable                    */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST1RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST1RPQ_OFFSET                  (0x500)                                       /**<  (GMAC_ST1RPQ) Screening Type 1 Register Priority Queue  Offset */
+
+#define GMAC_ST1RPQ_QNB_Pos                 0                                              /**< (GMAC_ST1RPQ) Queue Number (0-5) Position */
+#define GMAC_ST1RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST1RPQ_QNB_Pos)              /**< (GMAC_ST1RPQ) Queue Number (0-5) Mask */
+#define GMAC_ST1RPQ_QNB(value)              (GMAC_ST1RPQ_QNB_Msk & ((value) << GMAC_ST1RPQ_QNB_Pos))
+#define GMAC_ST1RPQ_DSTCM_Pos               4                                              /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Position */
+#define GMAC_ST1RPQ_DSTCM_Msk               (_U_(0xFF) << GMAC_ST1RPQ_DSTCM_Pos)           /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Mask */
+#define GMAC_ST1RPQ_DSTCM(value)            (GMAC_ST1RPQ_DSTCM_Msk & ((value) << GMAC_ST1RPQ_DSTCM_Pos))
+#define GMAC_ST1RPQ_UDPM_Pos                12                                             /**< (GMAC_ST1RPQ) UDP Port Match Position */
+#define GMAC_ST1RPQ_UDPM_Msk                (_U_(0xFFFF) << GMAC_ST1RPQ_UDPM_Pos)          /**< (GMAC_ST1RPQ) UDP Port Match Mask */
+#define GMAC_ST1RPQ_UDPM(value)             (GMAC_ST1RPQ_UDPM_Msk & ((value) << GMAC_ST1RPQ_UDPM_Pos))
+#define GMAC_ST1RPQ_DSTCE_Pos               28                                             /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Enable Position */
+#define GMAC_ST1RPQ_DSTCE_Msk               (_U_(0x1) << GMAC_ST1RPQ_DSTCE_Pos)            /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Enable Mask */
+#define GMAC_ST1RPQ_DSTCE                   GMAC_ST1RPQ_DSTCE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST1RPQ_DSTCE_Msk instead */
+#define GMAC_ST1RPQ_UDPE_Pos                29                                             /**< (GMAC_ST1RPQ) UDP Port Match Enable Position */
+#define GMAC_ST1RPQ_UDPE_Msk                (_U_(0x1) << GMAC_ST1RPQ_UDPE_Pos)             /**< (GMAC_ST1RPQ) UDP Port Match Enable Mask */
+#define GMAC_ST1RPQ_UDPE                    GMAC_ST1RPQ_UDPE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST1RPQ_UDPE_Msk instead */
+#define GMAC_ST1RPQ_MASK                    _U_(0x3FFFFFF7)                                /**< \deprecated (GMAC_ST1RPQ) Register MASK  (Use GMAC_ST1RPQ_Msk instead)  */
+#define GMAC_ST1RPQ_Msk                     _U_(0x3FFFFFF7)                                /**< (GMAC_ST1RPQ) Register Mask  */
+
+
+/* -------- GMAC_ST2RPQ : (GMAC Offset: 0x540) (R/W 32) Screening Type 2 Register Priority Queue -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-5)                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t VLANP:3;                   /**< bit:   4..6  VLAN Priority                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t VLANE:1;                   /**< bit:      8  VLAN Enable                              */
+    uint32_t I2ETH:3;                   /**< bit:  9..11  Index of Screening Type 2 EtherType register x */
+    uint32_t ETHE:1;                    /**< bit:     12  EtherType Enable                         */
+    uint32_t COMPA:5;                   /**< bit: 13..17  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPAE:1;                  /**< bit:     18  Compare A Enable                         */
+    uint32_t COMPB:5;                   /**< bit: 19..23  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPBE:1;                  /**< bit:     24  Compare B Enable                         */
+    uint32_t COMPC:5;                   /**< bit: 25..29  Index of Screening Type 2 Compare Word 0/Word 1 register x */
+    uint32_t COMPCE:1;                  /**< bit:     30  Compare C Enable                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2RPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2RPQ_OFFSET                  (0x540)                                       /**<  (GMAC_ST2RPQ) Screening Type 2 Register Priority Queue  Offset */
+
+#define GMAC_ST2RPQ_QNB_Pos                 0                                              /**< (GMAC_ST2RPQ) Queue Number (0-5) Position */
+#define GMAC_ST2RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST2RPQ_QNB_Pos)              /**< (GMAC_ST2RPQ) Queue Number (0-5) Mask */
+#define GMAC_ST2RPQ_QNB(value)              (GMAC_ST2RPQ_QNB_Msk & ((value) << GMAC_ST2RPQ_QNB_Pos))
+#define GMAC_ST2RPQ_VLANP_Pos               4                                              /**< (GMAC_ST2RPQ) VLAN Priority Position */
+#define GMAC_ST2RPQ_VLANP_Msk               (_U_(0x7) << GMAC_ST2RPQ_VLANP_Pos)            /**< (GMAC_ST2RPQ) VLAN Priority Mask */
+#define GMAC_ST2RPQ_VLANP(value)            (GMAC_ST2RPQ_VLANP_Msk & ((value) << GMAC_ST2RPQ_VLANP_Pos))
+#define GMAC_ST2RPQ_VLANE_Pos               8                                              /**< (GMAC_ST2RPQ) VLAN Enable Position */
+#define GMAC_ST2RPQ_VLANE_Msk               (_U_(0x1) << GMAC_ST2RPQ_VLANE_Pos)            /**< (GMAC_ST2RPQ) VLAN Enable Mask */
+#define GMAC_ST2RPQ_VLANE                   GMAC_ST2RPQ_VLANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_VLANE_Msk instead */
+#define GMAC_ST2RPQ_I2ETH_Pos               9                                              /**< (GMAC_ST2RPQ) Index of Screening Type 2 EtherType register x Position */
+#define GMAC_ST2RPQ_I2ETH_Msk               (_U_(0x7) << GMAC_ST2RPQ_I2ETH_Pos)            /**< (GMAC_ST2RPQ) Index of Screening Type 2 EtherType register x Mask */
+#define GMAC_ST2RPQ_I2ETH(value)            (GMAC_ST2RPQ_I2ETH_Msk & ((value) << GMAC_ST2RPQ_I2ETH_Pos))
+#define GMAC_ST2RPQ_ETHE_Pos                12                                             /**< (GMAC_ST2RPQ) EtherType Enable Position */
+#define GMAC_ST2RPQ_ETHE_Msk                (_U_(0x1) << GMAC_ST2RPQ_ETHE_Pos)             /**< (GMAC_ST2RPQ) EtherType Enable Mask */
+#define GMAC_ST2RPQ_ETHE                    GMAC_ST2RPQ_ETHE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_ETHE_Msk instead */
+#define GMAC_ST2RPQ_COMPA_Pos               13                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPA_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPA_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPA(value)            (GMAC_ST2RPQ_COMPA_Msk & ((value) << GMAC_ST2RPQ_COMPA_Pos))
+#define GMAC_ST2RPQ_COMPAE_Pos              18                                             /**< (GMAC_ST2RPQ) Compare A Enable Position */
+#define GMAC_ST2RPQ_COMPAE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPAE_Pos)           /**< (GMAC_ST2RPQ) Compare A Enable Mask */
+#define GMAC_ST2RPQ_COMPAE                  GMAC_ST2RPQ_COMPAE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPAE_Msk instead */
+#define GMAC_ST2RPQ_COMPB_Pos               19                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPB_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPB_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPB(value)            (GMAC_ST2RPQ_COMPB_Msk & ((value) << GMAC_ST2RPQ_COMPB_Pos))
+#define GMAC_ST2RPQ_COMPBE_Pos              24                                             /**< (GMAC_ST2RPQ) Compare B Enable Position */
+#define GMAC_ST2RPQ_COMPBE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPBE_Pos)           /**< (GMAC_ST2RPQ) Compare B Enable Mask */
+#define GMAC_ST2RPQ_COMPBE                  GMAC_ST2RPQ_COMPBE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPBE_Msk instead */
+#define GMAC_ST2RPQ_COMPC_Pos               25                                             /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Position */
+#define GMAC_ST2RPQ_COMPC_Msk               (_U_(0x1F) << GMAC_ST2RPQ_COMPC_Pos)           /**< (GMAC_ST2RPQ) Index of Screening Type 2 Compare Word 0/Word 1 register x Mask */
+#define GMAC_ST2RPQ_COMPC(value)            (GMAC_ST2RPQ_COMPC_Msk & ((value) << GMAC_ST2RPQ_COMPC_Pos))
+#define GMAC_ST2RPQ_COMPCE_Pos              30                                             /**< (GMAC_ST2RPQ) Compare C Enable Position */
+#define GMAC_ST2RPQ_COMPCE_Msk              (_U_(0x1) << GMAC_ST2RPQ_COMPCE_Pos)           /**< (GMAC_ST2RPQ) Compare C Enable Mask */
+#define GMAC_ST2RPQ_COMPCE                  GMAC_ST2RPQ_COMPCE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ST2RPQ_COMPCE_Msk instead */
+#define GMAC_ST2RPQ_MASK                    _U_(0x7FFFFF77)                                /**< \deprecated (GMAC_ST2RPQ) Register MASK  (Use GMAC_ST2RPQ_Msk instead)  */
+#define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
+
+
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IERPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (1..5)  Offset */
+
+#define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
+#define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
+#define GMAC_IERPQ_RCOMP                    GMAC_IERPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RCOMP_Msk instead */
+#define GMAC_IERPQ_RXUBR_Pos                2                                              /**< (GMAC_IERPQ) RX Used Bit Read Position */
+#define GMAC_IERPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IERPQ_RXUBR_Pos)             /**< (GMAC_IERPQ) RX Used Bit Read Mask */
+#define GMAC_IERPQ_RXUBR                    GMAC_IERPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RXUBR_Msk instead */
+#define GMAC_IERPQ_RLEX_Pos                 5                                              /**< (GMAC_IERPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IERPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IERPQ_RLEX_Pos)              /**< (GMAC_IERPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IERPQ_RLEX                     GMAC_IERPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_RLEX_Msk instead */
+#define GMAC_IERPQ_TFC_Pos                  6                                              /**< (GMAC_IERPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IERPQ_TFC_Msk                  (_U_(0x1) << GMAC_IERPQ_TFC_Pos)               /**< (GMAC_IERPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IERPQ_TFC                      GMAC_IERPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_TFC_Msk instead */
+#define GMAC_IERPQ_TCOMP_Pos                7                                              /**< (GMAC_IERPQ) Transmit Complete Position */
+#define GMAC_IERPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_TCOMP_Pos)             /**< (GMAC_IERPQ) Transmit Complete Mask */
+#define GMAC_IERPQ_TCOMP                    GMAC_IERPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_TCOMP_Msk instead */
+#define GMAC_IERPQ_ROVR_Pos                 10                                             /**< (GMAC_IERPQ) Receive Overrun Position */
+#define GMAC_IERPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IERPQ_ROVR_Pos)              /**< (GMAC_IERPQ) Receive Overrun Mask */
+#define GMAC_IERPQ_ROVR                     GMAC_IERPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_ROVR_Msk instead */
+#define GMAC_IERPQ_HRESP_Pos                11                                             /**< (GMAC_IERPQ) HRESP Not OK Position */
+#define GMAC_IERPQ_HRESP_Msk                (_U_(0x1) << GMAC_IERPQ_HRESP_Pos)             /**< (GMAC_IERPQ) HRESP Not OK Mask */
+#define GMAC_IERPQ_HRESP                    GMAC_IERPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IERPQ_HRESP_Msk instead */
+#define GMAC_IERPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IERPQ) Register MASK  (Use GMAC_IERPQ_Msk instead)  */
+#define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
+
+
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t TFC:1;                     /**< bit:      6  Transmit Frame Corruption Due to AHB Error */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IDRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (1..5)  Offset */
+
+#define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
+#define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
+#define GMAC_IDRPQ_RCOMP                    GMAC_IDRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RCOMP_Msk instead */
+#define GMAC_IDRPQ_RXUBR_Pos                2                                              /**< (GMAC_IDRPQ) RX Used Bit Read Position */
+#define GMAC_IDRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IDRPQ_RXUBR_Pos)             /**< (GMAC_IDRPQ) RX Used Bit Read Mask */
+#define GMAC_IDRPQ_RXUBR                    GMAC_IDRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RXUBR_Msk instead */
+#define GMAC_IDRPQ_RLEX_Pos                 5                                              /**< (GMAC_IDRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IDRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IDRPQ_RLEX_Pos)              /**< (GMAC_IDRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IDRPQ_RLEX                     GMAC_IDRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_RLEX_Msk instead */
+#define GMAC_IDRPQ_TFC_Pos                  6                                              /**< (GMAC_IDRPQ) Transmit Frame Corruption Due to AHB Error Position */
+#define GMAC_IDRPQ_TFC_Msk                  (_U_(0x1) << GMAC_IDRPQ_TFC_Pos)               /**< (GMAC_IDRPQ) Transmit Frame Corruption Due to AHB Error Mask */
+#define GMAC_IDRPQ_TFC                      GMAC_IDRPQ_TFC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_TFC_Msk instead */
+#define GMAC_IDRPQ_TCOMP_Pos                7                                              /**< (GMAC_IDRPQ) Transmit Complete Position */
+#define GMAC_IDRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_TCOMP_Pos)             /**< (GMAC_IDRPQ) Transmit Complete Mask */
+#define GMAC_IDRPQ_TCOMP                    GMAC_IDRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_TCOMP_Msk instead */
+#define GMAC_IDRPQ_ROVR_Pos                 10                                             /**< (GMAC_IDRPQ) Receive Overrun Position */
+#define GMAC_IDRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IDRPQ_ROVR_Pos)              /**< (GMAC_IDRPQ) Receive Overrun Mask */
+#define GMAC_IDRPQ_ROVR                     GMAC_IDRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_ROVR_Msk instead */
+#define GMAC_IDRPQ_HRESP_Pos                11                                             /**< (GMAC_IDRPQ) HRESP Not OK Position */
+#define GMAC_IDRPQ_HRESP_Msk                (_U_(0x1) << GMAC_IDRPQ_HRESP_Pos)             /**< (GMAC_IDRPQ) HRESP Not OK Mask */
+#define GMAC_IDRPQ_HRESP                    GMAC_IDRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDRPQ_HRESP_Msk instead */
+#define GMAC_IDRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IDRPQ) Register MASK  (Use GMAC_IDRPQ_Msk instead)  */
+#define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
+
+
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (1..5) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RCOMP:1;                   /**< bit:      1  Receive Complete                         */
+    uint32_t RXUBR:1;                   /**< bit:      2  RX Used Bit Read                         */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t RLEX:1;                    /**< bit:      5  Retry Limit Exceeded or Late Collision   */
+    uint32_t AHB:1;                     /**< bit:      6  AHB Error                                */
+    uint32_t TCOMP:1;                   /**< bit:      7  Transmit Complete                        */
+    uint32_t :2;                        /**< bit:   8..9  Reserved */
+    uint32_t ROVR:1;                    /**< bit:     10  Receive Overrun                          */
+    uint32_t HRESP:1;                   /**< bit:     11  HRESP Not OK                             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_IMRPQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (1..5)  Offset */
+
+#define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
+#define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */
+#define GMAC_IMRPQ_RCOMP                    GMAC_IMRPQ_RCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RCOMP_Msk instead */
+#define GMAC_IMRPQ_RXUBR_Pos                2                                              /**< (GMAC_IMRPQ) RX Used Bit Read Position */
+#define GMAC_IMRPQ_RXUBR_Msk                (_U_(0x1) << GMAC_IMRPQ_RXUBR_Pos)             /**< (GMAC_IMRPQ) RX Used Bit Read Mask */
+#define GMAC_IMRPQ_RXUBR                    GMAC_IMRPQ_RXUBR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RXUBR_Msk instead */
+#define GMAC_IMRPQ_RLEX_Pos                 5                                              /**< (GMAC_IMRPQ) Retry Limit Exceeded or Late Collision Position */
+#define GMAC_IMRPQ_RLEX_Msk                 (_U_(0x1) << GMAC_IMRPQ_RLEX_Pos)              /**< (GMAC_IMRPQ) Retry Limit Exceeded or Late Collision Mask */
+#define GMAC_IMRPQ_RLEX                     GMAC_IMRPQ_RLEX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_RLEX_Msk instead */
+#define GMAC_IMRPQ_AHB_Pos                  6                                              /**< (GMAC_IMRPQ) AHB Error Position */
+#define GMAC_IMRPQ_AHB_Msk                  (_U_(0x1) << GMAC_IMRPQ_AHB_Pos)               /**< (GMAC_IMRPQ) AHB Error Mask */
+#define GMAC_IMRPQ_AHB                      GMAC_IMRPQ_AHB_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_AHB_Msk instead */
+#define GMAC_IMRPQ_TCOMP_Pos                7                                              /**< (GMAC_IMRPQ) Transmit Complete Position */
+#define GMAC_IMRPQ_TCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_TCOMP_Pos)             /**< (GMAC_IMRPQ) Transmit Complete Mask */
+#define GMAC_IMRPQ_TCOMP                    GMAC_IMRPQ_TCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_TCOMP_Msk instead */
+#define GMAC_IMRPQ_ROVR_Pos                 10                                             /**< (GMAC_IMRPQ) Receive Overrun Position */
+#define GMAC_IMRPQ_ROVR_Msk                 (_U_(0x1) << GMAC_IMRPQ_ROVR_Pos)              /**< (GMAC_IMRPQ) Receive Overrun Mask */
+#define GMAC_IMRPQ_ROVR                     GMAC_IMRPQ_ROVR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_ROVR_Msk instead */
+#define GMAC_IMRPQ_HRESP_Pos                11                                             /**< (GMAC_IMRPQ) HRESP Not OK Position */
+#define GMAC_IMRPQ_HRESP_Msk                (_U_(0x1) << GMAC_IMRPQ_HRESP_Pos)             /**< (GMAC_IMRPQ) HRESP Not OK Mask */
+#define GMAC_IMRPQ_HRESP                    GMAC_IMRPQ_HRESP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMRPQ_HRESP_Msk instead */
+#define GMAC_IMRPQ_MASK                     _U_(0xCE6)                                     /**< \deprecated (GMAC_IMRPQ) Register MASK  (Use GMAC_IMRPQ_Msk instead)  */
+#define GMAC_IMRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IMRPQ) Register Mask  */
+
+
+/* -------- GMAC_ST2ER : (GMAC Offset: 0x6e0) (R/W 32) Screening Type 2 Ethertype Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COMPVAL:16;                /**< bit:  0..15  Ethertype Compare Value                  */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2ER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2ER_OFFSET                   (0x6E0)                                       /**<  (GMAC_ST2ER) Screening Type 2 Ethertype Register  Offset */
+
+#define GMAC_ST2ER_COMPVAL_Pos              0                                              /**< (GMAC_ST2ER) Ethertype Compare Value Position */
+#define GMAC_ST2ER_COMPVAL_Msk              (_U_(0xFFFF) << GMAC_ST2ER_COMPVAL_Pos)        /**< (GMAC_ST2ER) Ethertype Compare Value Mask */
+#define GMAC_ST2ER_COMPVAL(value)           (GMAC_ST2ER_COMPVAL_Msk & ((value) << GMAC_ST2ER_COMPVAL_Pos))
+#define GMAC_ST2ER_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_ST2ER) Register MASK  (Use GMAC_ST2ER_Msk instead)  */
+#define GMAC_ST2ER_Msk                      _U_(0xFFFF)                                    /**< (GMAC_ST2ER) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief GMAC_SA hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_SAB;       /**< (GMAC_SA Offset: 0x00) Specific Address 1 Bottom Register */
+  __IO uint32_t GMAC_SAT;       /**< (GMAC_SA Offset: 0x04) Specific Address 1 Top Register */
+} GmacSa;
+
+/** \brief GMAC_ST2CW hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_ST2CW0;    /**< (GMAC_ST2CW Offset: 0x00) Screening Type 2 Compare Word 0 Register */
+  __IO uint32_t GMAC_ST2CW1;    /**< (GMAC_ST2CW Offset: 0x04) Screening Type 2 Compare Word 1 Register */
+} GmacSt2cw;
+
+#define GMACSA_NUMBER 4
+#define GMACST2CW_NUMBER 24
+/** \brief GMAC hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_NCR;       /**< (GMAC Offset: 0x00) Network Control Register */
+  __IO uint32_t GMAC_NCFGR;     /**< (GMAC Offset: 0x04) Network Configuration Register */
+  __I  uint32_t GMAC_NSR;       /**< (GMAC Offset: 0x08) Network Status Register */
+  __IO uint32_t GMAC_UR;        /**< (GMAC Offset: 0x0C) User Register */
+  __IO uint32_t GMAC_DCFGR;     /**< (GMAC Offset: 0x10) DMA Configuration Register */
+  __IO uint32_t GMAC_TSR;       /**< (GMAC Offset: 0x14) Transmit Status Register */
+  __IO uint32_t GMAC_RBQB;      /**< (GMAC Offset: 0x18) Receive Buffer Queue Base Address Register */
+  __IO uint32_t GMAC_TBQB;      /**< (GMAC Offset: 0x1C) Transmit Buffer Queue Base Address Register */
+  __IO uint32_t GMAC_RSR;       /**< (GMAC Offset: 0x20) Receive Status Register */
+  __I  uint32_t GMAC_ISR;       /**< (GMAC Offset: 0x24) Interrupt Status Register */
+  __O  uint32_t GMAC_IER;       /**< (GMAC Offset: 0x28) Interrupt Enable Register */
+  __O  uint32_t GMAC_IDR;       /**< (GMAC Offset: 0x2C) Interrupt Disable Register */
+  __IO uint32_t GMAC_IMR;       /**< (GMAC Offset: 0x30) Interrupt Mask Register */
+  __IO uint32_t GMAC_MAN;       /**< (GMAC Offset: 0x34) PHY Maintenance Register */
+  __I  uint32_t GMAC_RPQ;       /**< (GMAC Offset: 0x38) Received Pause Quantum Register */
+  __IO uint32_t GMAC_TPQ;       /**< (GMAC Offset: 0x3C) Transmit Pause Quantum Register */
+  __IO uint32_t GMAC_TPSF;      /**< (GMAC Offset: 0x40) TX Partial Store and Forward Register */
+  __IO uint32_t GMAC_RPSF;      /**< (GMAC Offset: 0x44) RX Partial Store and Forward Register */
+  __IO uint32_t GMAC_RJFML;     /**< (GMAC Offset: 0x48) RX Jumbo Frame Max Length Register */
+  __I  uint8_t                        Reserved1[52];
+  __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
+  __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
+       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+  __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
+  __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
+  __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
+  __IO uint32_t GMAC_TIDM4;     /**< (GMAC Offset: 0xB4) Type ID Match 4 Register */
+  __IO uint32_t GMAC_WOL;       /**< (GMAC Offset: 0xB8) Wake on LAN Register */
+  __IO uint32_t GMAC_IPGS;      /**< (GMAC Offset: 0xBC) IPG Stretch Register */
+  __IO uint32_t GMAC_SVLAN;     /**< (GMAC Offset: 0xC0) Stacked VLAN Register */
+  __IO uint32_t GMAC_TPFCP;     /**< (GMAC Offset: 0xC4) Transmit PFC Pause Register */
+  __IO uint32_t GMAC_SAMB1;     /**< (GMAC Offset: 0xC8) Specific Address 1 Mask Bottom Register */
+  __IO uint32_t GMAC_SAMT1;     /**< (GMAC Offset: 0xCC) Specific Address 1 Mask Top Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO uint32_t GMAC_NSC;       /**< (GMAC Offset: 0xDC) 1588 Timer Nanosecond Comparison Register */
+  __IO uint32_t GMAC_SCL;       /**< (GMAC Offset: 0xE0) 1588 Timer Second Comparison Low Register */
+  __IO uint32_t GMAC_SCH;       /**< (GMAC Offset: 0xE4) 1588 Timer Second Comparison High Register */
+  __I  uint32_t GMAC_EFTSH;     /**< (GMAC Offset: 0xE8) PTP Event Frame Transmitted Seconds High Register */
+  __I  uint32_t GMAC_EFRSH;     /**< (GMAC Offset: 0xEC) PTP Event Frame Received Seconds High Register */
+  __I  uint32_t GMAC_PEFTSH;    /**< (GMAC Offset: 0xF0) PTP Peer Event Frame Transmitted Seconds High Register */
+  __I  uint32_t GMAC_PEFRSH;    /**< (GMAC Offset: 0xF4) PTP Peer Event Frame Received Seconds High Register */
+  __I  uint8_t                        Reserved3[8];
+  __I  uint32_t GMAC_OTLO;      /**< (GMAC Offset: 0x100) Octets Transmitted Low Register */
+  __I  uint32_t GMAC_OTHI;      /**< (GMAC Offset: 0x104) Octets Transmitted High Register */
+  __I  uint32_t GMAC_FT;        /**< (GMAC Offset: 0x108) Frames Transmitted Register */
+  __I  uint32_t GMAC_BCFT;      /**< (GMAC Offset: 0x10C) Broadcast Frames Transmitted Register */
+  __I  uint32_t GMAC_MFT;       /**< (GMAC Offset: 0x110) Multicast Frames Transmitted Register */
+  __I  uint32_t GMAC_PFT;       /**< (GMAC Offset: 0x114) Pause Frames Transmitted Register */
+  __I  uint32_t GMAC_BFT64;     /**< (GMAC Offset: 0x118) 64 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT127;   /**< (GMAC Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT255;   /**< (GMAC Offset: 0x120) 128 to 255 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT511;   /**< (GMAC Offset: 0x124) 256 to 511 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT1023;  /**< (GMAC Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TBFT1518;  /**< (GMAC Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_GTBFT1518; /**< (GMAC Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register */
+  __I  uint32_t GMAC_TUR;       /**< (GMAC Offset: 0x134) Transmit Underruns Register */
+  __I  uint32_t GMAC_SCF;       /**< (GMAC Offset: 0x138) Single Collision Frames Register */
+  __I  uint32_t GMAC_MCF;       /**< (GMAC Offset: 0x13C) Multiple Collision Frames Register */
+  __I  uint32_t GMAC_EC;        /**< (GMAC Offset: 0x140) Excessive Collisions Register */
+  __I  uint32_t GMAC_LC;        /**< (GMAC Offset: 0x144) Late Collisions Register */
+  __I  uint32_t GMAC_DTF;       /**< (GMAC Offset: 0x148) Deferred Transmission Frames Register */
+  __I  uint32_t GMAC_CSE;       /**< (GMAC Offset: 0x14C) Carrier Sense Errors Register */
+  __I  uint32_t GMAC_ORLO;      /**< (GMAC Offset: 0x150) Octets Received Low Received Register */
+  __I  uint32_t GMAC_ORHI;      /**< (GMAC Offset: 0x154) Octets Received High Received Register */
+  __I  uint32_t GMAC_FR;        /**< (GMAC Offset: 0x158) Frames Received Register */
+  __I  uint32_t GMAC_BCFR;      /**< (GMAC Offset: 0x15C) Broadcast Frames Received Register */
+  __I  uint32_t GMAC_MFR;       /**< (GMAC Offset: 0x160) Multicast Frames Received Register */
+  __I  uint32_t GMAC_PFR;       /**< (GMAC Offset: 0x164) Pause Frames Received Register */
+  __I  uint32_t GMAC_BFR64;     /**< (GMAC Offset: 0x168) 64 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR127;   /**< (GMAC Offset: 0x16C) 65 to 127 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR255;   /**< (GMAC Offset: 0x170) 128 to 255 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR511;   /**< (GMAC Offset: 0x174) 256 to 511 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR1023;  /**< (GMAC Offset: 0x178) 512 to 1023 Byte Frames Received Register */
+  __I  uint32_t GMAC_TBFR1518;  /**< (GMAC Offset: 0x17C) 1024 to 1518 Byte Frames Received Register */
+  __I  uint32_t GMAC_TMXBFR;    /**< (GMAC Offset: 0x180) 1519 to Maximum Byte Frames Received Register */
+  __I  uint32_t GMAC_UFR;       /**< (GMAC Offset: 0x184) Undersize Frames Received Register */
+  __I  uint32_t GMAC_OFR;       /**< (GMAC Offset: 0x188) Oversize Frames Received Register */
+  __I  uint32_t GMAC_JR;        /**< (GMAC Offset: 0x18C) Jabbers Received Register */
+  __I  uint32_t GMAC_FCSE;      /**< (GMAC Offset: 0x190) Frame Check Sequence Errors Register */
+  __I  uint32_t GMAC_LFFE;      /**< (GMAC Offset: 0x194) Length Field Frame Errors Register */
+  __I  uint32_t GMAC_RSE;       /**< (GMAC Offset: 0x198) Receive Symbol Errors Register */
+  __I  uint32_t GMAC_AE;        /**< (GMAC Offset: 0x19C) Alignment Errors Register */
+  __I  uint32_t GMAC_RRE;       /**< (GMAC Offset: 0x1A0) Receive Resource Errors Register */
+  __I  uint32_t GMAC_ROE;       /**< (GMAC Offset: 0x1A4) Receive Overrun Register */
+  __I  uint32_t GMAC_IHCE;      /**< (GMAC Offset: 0x1A8) IP Header Checksum Errors Register */
+  __I  uint32_t GMAC_TCE;       /**< (GMAC Offset: 0x1AC) TCP Checksum Errors Register */
+  __I  uint32_t GMAC_UCE;       /**< (GMAC Offset: 0x1B0) UDP Checksum Errors Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO uint32_t GMAC_TISUBN;    /**< (GMAC Offset: 0x1BC) 1588 Timer Increment Sub-nanoseconds Register */
+  __IO uint32_t GMAC_TSH;       /**< (GMAC Offset: 0x1C0) 1588 Timer Seconds High Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO uint32_t GMAC_TSL;       /**< (GMAC Offset: 0x1D0) 1588 Timer Seconds Low Register */
+  __IO uint32_t GMAC_TN;        /**< (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register */
+  __O  uint32_t GMAC_TA;        /**< (GMAC Offset: 0x1D8) 1588 Timer Adjust Register */
+  __IO uint32_t GMAC_TI;        /**< (GMAC Offset: 0x1DC) 1588 Timer Increment Register */
+  __I  uint32_t GMAC_EFTSL;     /**< (GMAC Offset: 0x1E0) PTP Event Frame Transmitted Seconds Low Register */
+  __I  uint32_t GMAC_EFTN;      /**< (GMAC Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds Register */
+  __I  uint32_t GMAC_EFRSL;     /**< (GMAC Offset: 0x1E8) PTP Event Frame Received Seconds Low Register */
+  __I  uint32_t GMAC_EFRN;      /**< (GMAC Offset: 0x1EC) PTP Event Frame Received Nanoseconds Register */
+  __I  uint32_t GMAC_PEFTSL;    /**< (GMAC Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds Low Register */
+  __I  uint32_t GMAC_PEFTN;     /**< (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds Register */
+  __I  uint32_t GMAC_PEFRSL;    /**< (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds Low Register */
+  __I  uint32_t GMAC_PEFRN;     /**< (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds Register */
+  __I  uint8_t                        Reserved6[112];
+  __I  uint32_t GMAC_RXLPI;     /**< (GMAC Offset: 0x270) Received LPI Transitions */
+  __I  uint32_t GMAC_RXLPITIME; /**< (GMAC Offset: 0x274) Received LPI Time */
+  __I  uint32_t GMAC_TXLPI;     /**< (GMAC Offset: 0x278) Transmit LPI Transitions */
+  __I  uint32_t GMAC_TXLPITIME; /**< (GMAC Offset: 0x27C) Transmit LPI Time */
+  __I  uint8_t                        Reserved7[384];
+  __I  uint32_t GMAC_ISRPQ[5];  /**< (GMAC Offset: 0x400) Interrupt Status Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved8[44];
+  __IO uint32_t GMAC_TBQBAPQ[5]; /**< (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved9[44];
+  __IO uint32_t GMAC_RBQBAPQ[5]; /**< (GMAC Offset: 0x480) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved10[12];
+  __IO uint32_t GMAC_RBSRPQ[5]; /**< (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved11[8];
+  __IO uint32_t GMAC_CBSCR;     /**< (GMAC Offset: 0x4BC) Credit-Based Shaping Control Register */
+  __IO uint32_t GMAC_CBSISQA;   /**< (GMAC Offset: 0x4C0) Credit-Based Shaping IdleSlope Register for Queue A */
+  __IO uint32_t GMAC_CBSISQB;   /**< (GMAC Offset: 0x4C4) Credit-Based Shaping IdleSlope Register for Queue B */
+  __I  uint8_t                        Reserved12[56];
+  __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue */
+  __I  uint8_t                        Reserved13[48];
+  __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue */
+  __I  uint8_t                        Reserved14[160];
+  __O  uint32_t GMAC_IERPQ[5];  /**< (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved15[12];
+  __O  uint32_t GMAC_IDRPQ[5];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved16[12];
+  __IO uint32_t GMAC_IMRPQ[5];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved17[140];
+  __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register */
+  __I  uint8_t                        Reserved18[16];
+       GmacSt2cw GmacSt2cw[GMACST2CW_NUMBER]; /**< Offset: 0x700 Screening Type 2 Compare Word 0 Register */
+} Gmac;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief GMAC_SA hardware registers */
+typedef struct {  
+  __IO GMAC_SAB_Type                  GMAC_SAB;       /**< Offset: 0x00 (R/W  32) Specific Address 1 Bottom Register */
+  __IO GMAC_SAT_Type                  GMAC_SAT;       /**< Offset: 0x04 (R/W  32) Specific Address 1 Top Register */
+} GmacSa;
+
+/** \brief GMAC_ST2CW hardware registers */
+typedef struct {  
+  __IO GMAC_ST2CW0_Type               GMAC_ST2CW0;    /**< Offset: 0x00 (R/W  32) Screening Type 2 Compare Word 0 Register */
+  __IO GMAC_ST2CW1_Type               GMAC_ST2CW1;    /**< Offset: 0x04 (R/W  32) Screening Type 2 Compare Word 1 Register */
+} GmacSt2cw;
+
+/** \brief GMAC hardware registers */
+typedef struct {  
+  __IO GMAC_NCR_Type                  GMAC_NCR;       /**< Offset: 0x00 (R/W  32) Network Control Register */
+  __IO GMAC_NCFGR_Type                GMAC_NCFGR;     /**< Offset: 0x04 (R/W  32) Network Configuration Register */
+  __I  GMAC_NSR_Type                  GMAC_NSR;       /**< Offset: 0x08 (R/   32) Network Status Register */
+  __IO GMAC_UR_Type                   GMAC_UR;        /**< Offset: 0x0C (R/W  32) User Register */
+  __IO GMAC_DCFGR_Type                GMAC_DCFGR;     /**< Offset: 0x10 (R/W  32) DMA Configuration Register */
+  __IO GMAC_TSR_Type                  GMAC_TSR;       /**< Offset: 0x14 (R/W  32) Transmit Status Register */
+  __IO GMAC_RBQB_Type                 GMAC_RBQB;      /**< Offset: 0x18 (R/W  32) Receive Buffer Queue Base Address Register */
+  __IO GMAC_TBQB_Type                 GMAC_TBQB;      /**< Offset: 0x1C (R/W  32) Transmit Buffer Queue Base Address Register */
+  __IO GMAC_RSR_Type                  GMAC_RSR;       /**< Offset: 0x20 (R/W  32) Receive Status Register */
+  __I  GMAC_ISR_Type                  GMAC_ISR;       /**< Offset: 0x24 (R/   32) Interrupt Status Register */
+  __O  GMAC_IER_Type                  GMAC_IER;       /**< Offset: 0x28 ( /W  32) Interrupt Enable Register */
+  __O  GMAC_IDR_Type                  GMAC_IDR;       /**< Offset: 0x2C ( /W  32) Interrupt Disable Register */
+  __IO GMAC_IMR_Type                  GMAC_IMR;       /**< Offset: 0x30 (R/W  32) Interrupt Mask Register */
+  __IO GMAC_MAN_Type                  GMAC_MAN;       /**< Offset: 0x34 (R/W  32) PHY Maintenance Register */
+  __I  GMAC_RPQ_Type                  GMAC_RPQ;       /**< Offset: 0x38 (R/   32) Received Pause Quantum Register */
+  __IO GMAC_TPQ_Type                  GMAC_TPQ;       /**< Offset: 0x3C (R/W  32) Transmit Pause Quantum Register */
+  __IO GMAC_TPSF_Type                 GMAC_TPSF;      /**< Offset: 0x40 (R/W  32) TX Partial Store and Forward Register */
+  __IO GMAC_RPSF_Type                 GMAC_RPSF;      /**< Offset: 0x44 (R/W  32) RX Partial Store and Forward Register */
+  __IO GMAC_RJFML_Type                GMAC_RJFML;     /**< Offset: 0x48 (R/W  32) RX Jumbo Frame Max Length Register */
+  __I  uint8_t                        Reserved1[52];
+  __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
+  __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
+       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+  __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
+  __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
+  __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */
+  __IO GMAC_TIDM4_Type                GMAC_TIDM4;     /**< Offset: 0xB4 (R/W  32) Type ID Match 4 Register */
+  __IO GMAC_WOL_Type                  GMAC_WOL;       /**< Offset: 0xB8 (R/W  32) Wake on LAN Register */
+  __IO GMAC_IPGS_Type                 GMAC_IPGS;      /**< Offset: 0xBC (R/W  32) IPG Stretch Register */
+  __IO GMAC_SVLAN_Type                GMAC_SVLAN;     /**< Offset: 0xC0 (R/W  32) Stacked VLAN Register */
+  __IO GMAC_TPFCP_Type                GMAC_TPFCP;     /**< Offset: 0xC4 (R/W  32) Transmit PFC Pause Register */
+  __IO GMAC_SAMB1_Type                GMAC_SAMB1;     /**< Offset: 0xC8 (R/W  32) Specific Address 1 Mask Bottom Register */
+  __IO GMAC_SAMT1_Type                GMAC_SAMT1;     /**< Offset: 0xCC (R/W  32) Specific Address 1 Mask Top Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO GMAC_NSC_Type                  GMAC_NSC;       /**< Offset: 0xDC (R/W  32) 1588 Timer Nanosecond Comparison Register */
+  __IO GMAC_SCL_Type                  GMAC_SCL;       /**< Offset: 0xE0 (R/W  32) 1588 Timer Second Comparison Low Register */
+  __IO GMAC_SCH_Type                  GMAC_SCH;       /**< Offset: 0xE4 (R/W  32) 1588 Timer Second Comparison High Register */
+  __I  GMAC_EFTSH_Type                GMAC_EFTSH;     /**< Offset: 0xE8 (R/   32) PTP Event Frame Transmitted Seconds High Register */
+  __I  GMAC_EFRSH_Type                GMAC_EFRSH;     /**< Offset: 0xEC (R/   32) PTP Event Frame Received Seconds High Register */
+  __I  GMAC_PEFTSH_Type               GMAC_PEFTSH;    /**< Offset: 0xF0 (R/   32) PTP Peer Event Frame Transmitted Seconds High Register */
+  __I  GMAC_PEFRSH_Type               GMAC_PEFRSH;    /**< Offset: 0xF4 (R/   32) PTP Peer Event Frame Received Seconds High Register */
+  __I  uint8_t                        Reserved3[8];
+  __I  GMAC_OTLO_Type                 GMAC_OTLO;      /**< Offset: 0x100 (R/   32) Octets Transmitted Low Register */
+  __I  GMAC_OTHI_Type                 GMAC_OTHI;      /**< Offset: 0x104 (R/   32) Octets Transmitted High Register */
+  __I  GMAC_FT_Type                   GMAC_FT;        /**< Offset: 0x108 (R/   32) Frames Transmitted Register */
+  __I  GMAC_BCFT_Type                 GMAC_BCFT;      /**< Offset: 0x10C (R/   32) Broadcast Frames Transmitted Register */
+  __I  GMAC_MFT_Type                  GMAC_MFT;       /**< Offset: 0x110 (R/   32) Multicast Frames Transmitted Register */
+  __I  GMAC_PFT_Type                  GMAC_PFT;       /**< Offset: 0x114 (R/   32) Pause Frames Transmitted Register */
+  __I  GMAC_BFT64_Type                GMAC_BFT64;     /**< Offset: 0x118 (R/   32) 64 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT127_Type              GMAC_TBFT127;   /**< Offset: 0x11C (R/   32) 65 to 127 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT255_Type              GMAC_TBFT255;   /**< Offset: 0x120 (R/   32) 128 to 255 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT511_Type              GMAC_TBFT511;   /**< Offset: 0x124 (R/   32) 256 to 511 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT1023_Type             GMAC_TBFT1023;  /**< Offset: 0x128 (R/   32) 512 to 1023 Byte Frames Transmitted Register */
+  __I  GMAC_TBFT1518_Type             GMAC_TBFT1518;  /**< Offset: 0x12C (R/   32) 1024 to 1518 Byte Frames Transmitted Register */
+  __I  GMAC_GTBFT1518_Type            GMAC_GTBFT1518; /**< Offset: 0x130 (R/   32) Greater Than 1518 Byte Frames Transmitted Register */
+  __I  GMAC_TUR_Type                  GMAC_TUR;       /**< Offset: 0x134 (R/   32) Transmit Underruns Register */
+  __I  GMAC_SCF_Type                  GMAC_SCF;       /**< Offset: 0x138 (R/   32) Single Collision Frames Register */
+  __I  GMAC_MCF_Type                  GMAC_MCF;       /**< Offset: 0x13C (R/   32) Multiple Collision Frames Register */
+  __I  GMAC_EC_Type                   GMAC_EC;        /**< Offset: 0x140 (R/   32) Excessive Collisions Register */
+  __I  GMAC_LC_Type                   GMAC_LC;        /**< Offset: 0x144 (R/   32) Late Collisions Register */
+  __I  GMAC_DTF_Type                  GMAC_DTF;       /**< Offset: 0x148 (R/   32) Deferred Transmission Frames Register */
+  __I  GMAC_CSE_Type                  GMAC_CSE;       /**< Offset: 0x14C (R/   32) Carrier Sense Errors Register */
+  __I  GMAC_ORLO_Type                 GMAC_ORLO;      /**< Offset: 0x150 (R/   32) Octets Received Low Received Register */
+  __I  GMAC_ORHI_Type                 GMAC_ORHI;      /**< Offset: 0x154 (R/   32) Octets Received High Received Register */
+  __I  GMAC_FR_Type                   GMAC_FR;        /**< Offset: 0x158 (R/   32) Frames Received Register */
+  __I  GMAC_BCFR_Type                 GMAC_BCFR;      /**< Offset: 0x15C (R/   32) Broadcast Frames Received Register */
+  __I  GMAC_MFR_Type                  GMAC_MFR;       /**< Offset: 0x160 (R/   32) Multicast Frames Received Register */
+  __I  GMAC_PFR_Type                  GMAC_PFR;       /**< Offset: 0x164 (R/   32) Pause Frames Received Register */
+  __I  GMAC_BFR64_Type                GMAC_BFR64;     /**< Offset: 0x168 (R/   32) 64 Byte Frames Received Register */
+  __I  GMAC_TBFR127_Type              GMAC_TBFR127;   /**< Offset: 0x16C (R/   32) 65 to 127 Byte Frames Received Register */
+  __I  GMAC_TBFR255_Type              GMAC_TBFR255;   /**< Offset: 0x170 (R/   32) 128 to 255 Byte Frames Received Register */
+  __I  GMAC_TBFR511_Type              GMAC_TBFR511;   /**< Offset: 0x174 (R/   32) 256 to 511 Byte Frames Received Register */
+  __I  GMAC_TBFR1023_Type             GMAC_TBFR1023;  /**< Offset: 0x178 (R/   32) 512 to 1023 Byte Frames Received Register */
+  __I  GMAC_TBFR1518_Type             GMAC_TBFR1518;  /**< Offset: 0x17C (R/   32) 1024 to 1518 Byte Frames Received Register */
+  __I  GMAC_TMXBFR_Type               GMAC_TMXBFR;    /**< Offset: 0x180 (R/   32) 1519 to Maximum Byte Frames Received Register */
+  __I  GMAC_UFR_Type                  GMAC_UFR;       /**< Offset: 0x184 (R/   32) Undersize Frames Received Register */
+  __I  GMAC_OFR_Type                  GMAC_OFR;       /**< Offset: 0x188 (R/   32) Oversize Frames Received Register */
+  __I  GMAC_JR_Type                   GMAC_JR;        /**< Offset: 0x18C (R/   32) Jabbers Received Register */
+  __I  GMAC_FCSE_Type                 GMAC_FCSE;      /**< Offset: 0x190 (R/   32) Frame Check Sequence Errors Register */
+  __I  GMAC_LFFE_Type                 GMAC_LFFE;      /**< Offset: 0x194 (R/   32) Length Field Frame Errors Register */
+  __I  GMAC_RSE_Type                  GMAC_RSE;       /**< Offset: 0x198 (R/   32) Receive Symbol Errors Register */
+  __I  GMAC_AE_Type                   GMAC_AE;        /**< Offset: 0x19C (R/   32) Alignment Errors Register */
+  __I  GMAC_RRE_Type                  GMAC_RRE;       /**< Offset: 0x1A0 (R/   32) Receive Resource Errors Register */
+  __I  GMAC_ROE_Type                  GMAC_ROE;       /**< Offset: 0x1A4 (R/   32) Receive Overrun Register */
+  __I  GMAC_IHCE_Type                 GMAC_IHCE;      /**< Offset: 0x1A8 (R/   32) IP Header Checksum Errors Register */
+  __I  GMAC_TCE_Type                  GMAC_TCE;       /**< Offset: 0x1AC (R/   32) TCP Checksum Errors Register */
+  __I  GMAC_UCE_Type                  GMAC_UCE;       /**< Offset: 0x1B0 (R/   32) UDP Checksum Errors Register */
+  __I  uint8_t                        Reserved4[8];
+  __IO GMAC_TISUBN_Type               GMAC_TISUBN;    /**< Offset: 0x1BC (R/W  32) 1588 Timer Increment Sub-nanoseconds Register */
+  __IO GMAC_TSH_Type                  GMAC_TSH;       /**< Offset: 0x1C0 (R/W  32) 1588 Timer Seconds High Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO GMAC_TSL_Type                  GMAC_TSL;       /**< Offset: 0x1D0 (R/W  32) 1588 Timer Seconds Low Register */
+  __IO GMAC_TN_Type                   GMAC_TN;        /**< Offset: 0x1D4 (R/W  32) 1588 Timer Nanoseconds Register */
+  __O  GMAC_TA_Type                   GMAC_TA;        /**< Offset: 0x1D8 ( /W  32) 1588 Timer Adjust Register */
+  __IO GMAC_TI_Type                   GMAC_TI;        /**< Offset: 0x1DC (R/W  32) 1588 Timer Increment Register */
+  __I  GMAC_EFTSL_Type                GMAC_EFTSL;     /**< Offset: 0x1E0 (R/   32) PTP Event Frame Transmitted Seconds Low Register */
+  __I  GMAC_EFTN_Type                 GMAC_EFTN;      /**< Offset: 0x1E4 (R/   32) PTP Event Frame Transmitted Nanoseconds Register */
+  __I  GMAC_EFRSL_Type                GMAC_EFRSL;     /**< Offset: 0x1E8 (R/   32) PTP Event Frame Received Seconds Low Register */
+  __I  GMAC_EFRN_Type                 GMAC_EFRN;      /**< Offset: 0x1EC (R/   32) PTP Event Frame Received Nanoseconds Register */
+  __I  GMAC_PEFTSL_Type               GMAC_PEFTSL;    /**< Offset: 0x1F0 (R/   32) PTP Peer Event Frame Transmitted Seconds Low Register */
+  __I  GMAC_PEFTN_Type                GMAC_PEFTN;     /**< Offset: 0x1F4 (R/   32) PTP Peer Event Frame Transmitted Nanoseconds Register */
+  __I  GMAC_PEFRSL_Type               GMAC_PEFRSL;    /**< Offset: 0x1F8 (R/   32) PTP Peer Event Frame Received Seconds Low Register */
+  __I  GMAC_PEFRN_Type                GMAC_PEFRN;     /**< Offset: 0x1FC (R/   32) PTP Peer Event Frame Received Nanoseconds Register */
+  __I  uint8_t                        Reserved6[112];
+  __I  GMAC_RXLPI_Type                GMAC_RXLPI;     /**< Offset: 0x270 (R/   32) Received LPI Transitions */
+  __I  GMAC_RXLPITIME_Type            GMAC_RXLPITIME; /**< Offset: 0x274 (R/   32) Received LPI Time */
+  __I  GMAC_TXLPI_Type                GMAC_TXLPI;     /**< Offset: 0x278 (R/   32) Transmit LPI Transitions */
+  __I  GMAC_TXLPITIME_Type            GMAC_TXLPITIME; /**< Offset: 0x27C (R/   32) Transmit LPI Time */
+  __I  uint8_t                        Reserved7[384];
+  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[5];  /**< Offset: 0x400 (R/   32) Interrupt Status Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved8[44];
+  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[5]; /**< Offset: 0x440 (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved9[44];
+  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[5]; /**< Offset: 0x480 (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved10[12];
+  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[5]; /**< Offset: 0x4A0 (R/W  32) Receive Buffer Size Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved11[8];
+  __IO GMAC_CBSCR_Type                GMAC_CBSCR;     /**< Offset: 0x4BC (R/W  32) Credit-Based Shaping Control Register */
+  __IO GMAC_CBSISQA_Type              GMAC_CBSISQA;   /**< Offset: 0x4C0 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue A */
+  __IO GMAC_CBSISQB_Type              GMAC_CBSISQB;   /**< Offset: 0x4C4 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue B */
+  __I  uint8_t                        Reserved12[56];
+  __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue */
+  __I  uint8_t                        Reserved13[48];
+  __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue */
+  __I  uint8_t                        Reserved14[160];
+  __O  GMAC_IERPQ_Type                GMAC_IERPQ[5];  /**< Offset: 0x600 ( /W  32) Interrupt Enable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved15[12];
+  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[5];  /**< Offset: 0x620 ( /W  32) Interrupt Disable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved16[12];
+  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[5];  /**< Offset: 0x640 (R/W  32) Interrupt Mask Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved17[140];
+  __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register */
+  __I  uint8_t                        Reserved18[16];
+       GmacSt2cw                      GmacSt2cw[24];  /**< Offset: 0x700 Screening Type 2 Compare Word 0 Register */
+} Gmac;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Gigabit Ethernet MAC */
+
+#endif /* _SAMV71_GMAC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/gmac.h
+++ b/asf/sam/include/samv71b/component/gmac.h
@@ -3616,7 +3616,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -3767,7 +3767,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GMAC_SA[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */

--- a/asf/sam/include/samv71b/component/gpbr.h
+++ b/asf/sam/include/samv71b/component/gpbr.h
@@ -1,0 +1,89 @@
+/**
+ * \file
+ *
+ * \brief Component description for GPBR
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_GPBR_COMPONENT_H_
+#define _SAMV71_GPBR_COMPONENT_H_
+#define _SAMV71_GPBR_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 General Purpose Backup Registers
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GPBR */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define GPBR_6378                       /**< (GPBR) Module ID */
+#define REV_GPBR J                      /**< (GPBR) Module revision */
+
+/* -------- GPBR_SYS_GPBR : (GPBR Offset: 0x00) (R/W 32) General Purpose Backup Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GPBR_VALUE:32;             /**< bit:  0..31  Value of GPBR x                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GPBR_SYS_GPBR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPBR_SYS_GPBR_OFFSET                (0x00)                                        /**<  (GPBR_SYS_GPBR) General Purpose Backup Register 0  Offset */
+
+#define GPBR_SYS_GPBR_GPBR_VALUE_Pos        0                                              /**< (GPBR_SYS_GPBR) Value of GPBR x Position */
+#define GPBR_SYS_GPBR_GPBR_VALUE_Msk        (_U_(0xFFFFFFFF) << GPBR_SYS_GPBR_GPBR_VALUE_Pos)  /**< (GPBR_SYS_GPBR) Value of GPBR x Mask */
+#define GPBR_SYS_GPBR_GPBR_VALUE(value)     (GPBR_SYS_GPBR_GPBR_VALUE_Msk & ((value) << GPBR_SYS_GPBR_GPBR_VALUE_Pos))
+#define GPBR_SYS_GPBR_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (GPBR_SYS_GPBR) Register MASK  (Use GPBR_SYS_GPBR_Msk instead)  */
+#define GPBR_SYS_GPBR_Msk                   _U_(0xFFFFFFFF)                                /**< (GPBR_SYS_GPBR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief GPBR hardware registers */
+typedef struct {  
+  __IO uint32_t SYS_GPBR[8];    /**< (GPBR Offset: 0x00) General Purpose Backup Register 0 */
+} Gpbr;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief GPBR hardware registers */
+typedef struct {  
+  __IO GPBR_SYS_GPBR_Type             SYS_GPBR[8];    /**< Offset: 0x00 (R/W  32) General Purpose Backup Register 0 */
+} Gpbr;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of General Purpose Backup Registers */
+
+#endif /* _SAMV71_GPBR_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/hsmci.h
+++ b/asf/sam/include/samv71b/component/hsmci.h
@@ -1,0 +1,1171 @@
+/**
+ * \file
+ *
+ * \brief Component description for HSMCI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_HSMCI_COMPONENT_H_
+#define _SAMV71_HSMCI_COMPONENT_H_
+#define _SAMV71_HSMCI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 High Speed MultiMedia Card Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR HSMCI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define HSMCI_6449                       /**< (HSMCI) Module ID */
+#define REV_HSMCI R                      /**< (HSMCI) Module revision */
+
+/* -------- HSMCI_CR : (HSMCI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCIEN:1;                   /**< bit:      0  Multi-Media Interface Enable             */
+    uint32_t MCIDIS:1;                  /**< bit:      1  Multi-Media Interface Disable            */
+    uint32_t PWSEN:1;                   /**< bit:      2  Power Save Mode Enable                   */
+    uint32_t PWSDIS:1;                  /**< bit:      3  Power Save Mode Disable                  */
+    uint32_t :3;                        /**< bit:   4..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  Software Reset                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CR_OFFSET                     (0x00)                                        /**<  (HSMCI_CR) Control Register  Offset */
+
+#define HSMCI_CR_MCIEN_Pos                  0                                              /**< (HSMCI_CR) Multi-Media Interface Enable Position */
+#define HSMCI_CR_MCIEN_Msk                  (_U_(0x1) << HSMCI_CR_MCIEN_Pos)               /**< (HSMCI_CR) Multi-Media Interface Enable Mask */
+#define HSMCI_CR_MCIEN                      HSMCI_CR_MCIEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_MCIEN_Msk instead */
+#define HSMCI_CR_MCIDIS_Pos                 1                                              /**< (HSMCI_CR) Multi-Media Interface Disable Position */
+#define HSMCI_CR_MCIDIS_Msk                 (_U_(0x1) << HSMCI_CR_MCIDIS_Pos)              /**< (HSMCI_CR) Multi-Media Interface Disable Mask */
+#define HSMCI_CR_MCIDIS                     HSMCI_CR_MCIDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_MCIDIS_Msk instead */
+#define HSMCI_CR_PWSEN_Pos                  2                                              /**< (HSMCI_CR) Power Save Mode Enable Position */
+#define HSMCI_CR_PWSEN_Msk                  (_U_(0x1) << HSMCI_CR_PWSEN_Pos)               /**< (HSMCI_CR) Power Save Mode Enable Mask */
+#define HSMCI_CR_PWSEN                      HSMCI_CR_PWSEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_PWSEN_Msk instead */
+#define HSMCI_CR_PWSDIS_Pos                 3                                              /**< (HSMCI_CR) Power Save Mode Disable Position */
+#define HSMCI_CR_PWSDIS_Msk                 (_U_(0x1) << HSMCI_CR_PWSDIS_Pos)              /**< (HSMCI_CR) Power Save Mode Disable Mask */
+#define HSMCI_CR_PWSDIS                     HSMCI_CR_PWSDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_PWSDIS_Msk instead */
+#define HSMCI_CR_SWRST_Pos                  7                                              /**< (HSMCI_CR) Software Reset Position */
+#define HSMCI_CR_SWRST_Msk                  (_U_(0x1) << HSMCI_CR_SWRST_Pos)               /**< (HSMCI_CR) Software Reset Mask */
+#define HSMCI_CR_SWRST                      HSMCI_CR_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CR_SWRST_Msk instead */
+#define HSMCI_CR_MASK                       _U_(0x8F)                                      /**< \deprecated (HSMCI_CR) Register MASK  (Use HSMCI_CR_Msk instead)  */
+#define HSMCI_CR_Msk                        _U_(0x8F)                                      /**< (HSMCI_CR) Register Mask  */
+
+
+/* -------- HSMCI_MR : (HSMCI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLKDIV:8;                  /**< bit:   0..7  Clock Divider                            */
+    uint32_t PWSDIV:3;                  /**< bit:  8..10  Power Saving Divider                     */
+    uint32_t RDPROOF:1;                 /**< bit:     11  Read Proof Enable                        */
+    uint32_t WRPROOF:1;                 /**< bit:     12  Write Proof Enable                       */
+    uint32_t FBYTE:1;                   /**< bit:     13  Force Byte Transfer                      */
+    uint32_t PADV:1;                    /**< bit:     14  Padding Value                            */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t CLKODD:1;                  /**< bit:     16  Clock divider is odd                     */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_MR_OFFSET                     (0x04)                                        /**<  (HSMCI_MR) Mode Register  Offset */
+
+#define HSMCI_MR_CLKDIV_Pos                 0                                              /**< (HSMCI_MR) Clock Divider Position */
+#define HSMCI_MR_CLKDIV_Msk                 (_U_(0xFF) << HSMCI_MR_CLKDIV_Pos)             /**< (HSMCI_MR) Clock Divider Mask */
+#define HSMCI_MR_CLKDIV(value)              (HSMCI_MR_CLKDIV_Msk & ((value) << HSMCI_MR_CLKDIV_Pos))
+#define HSMCI_MR_PWSDIV_Pos                 8                                              /**< (HSMCI_MR) Power Saving Divider Position */
+#define HSMCI_MR_PWSDIV_Msk                 (_U_(0x7) << HSMCI_MR_PWSDIV_Pos)              /**< (HSMCI_MR) Power Saving Divider Mask */
+#define HSMCI_MR_PWSDIV(value)              (HSMCI_MR_PWSDIV_Msk & ((value) << HSMCI_MR_PWSDIV_Pos))
+#define HSMCI_MR_RDPROOF_Pos                11                                             /**< (HSMCI_MR) Read Proof Enable Position */
+#define HSMCI_MR_RDPROOF_Msk                (_U_(0x1) << HSMCI_MR_RDPROOF_Pos)             /**< (HSMCI_MR) Read Proof Enable Mask */
+#define HSMCI_MR_RDPROOF                    HSMCI_MR_RDPROOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_RDPROOF_Msk instead */
+#define HSMCI_MR_WRPROOF_Pos                12                                             /**< (HSMCI_MR) Write Proof Enable Position */
+#define HSMCI_MR_WRPROOF_Msk                (_U_(0x1) << HSMCI_MR_WRPROOF_Pos)             /**< (HSMCI_MR) Write Proof Enable Mask */
+#define HSMCI_MR_WRPROOF                    HSMCI_MR_WRPROOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_WRPROOF_Msk instead */
+#define HSMCI_MR_FBYTE_Pos                  13                                             /**< (HSMCI_MR) Force Byte Transfer Position */
+#define HSMCI_MR_FBYTE_Msk                  (_U_(0x1) << HSMCI_MR_FBYTE_Pos)               /**< (HSMCI_MR) Force Byte Transfer Mask */
+#define HSMCI_MR_FBYTE                      HSMCI_MR_FBYTE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_FBYTE_Msk instead */
+#define HSMCI_MR_PADV_Pos                   14                                             /**< (HSMCI_MR) Padding Value Position */
+#define HSMCI_MR_PADV_Msk                   (_U_(0x1) << HSMCI_MR_PADV_Pos)                /**< (HSMCI_MR) Padding Value Mask */
+#define HSMCI_MR_PADV                       HSMCI_MR_PADV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_PADV_Msk instead */
+#define HSMCI_MR_CLKODD_Pos                 16                                             /**< (HSMCI_MR) Clock divider is odd Position */
+#define HSMCI_MR_CLKODD_Msk                 (_U_(0x1) << HSMCI_MR_CLKODD_Pos)              /**< (HSMCI_MR) Clock divider is odd Mask */
+#define HSMCI_MR_CLKODD                     HSMCI_MR_CLKODD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_MR_CLKODD_Msk instead */
+#define HSMCI_MR_MASK                       _U_(0x17FFF)                                   /**< \deprecated (HSMCI_MR) Register MASK  (Use HSMCI_MR_Msk instead)  */
+#define HSMCI_MR_Msk                        _U_(0x17FFF)                                   /**< (HSMCI_MR) Register Mask  */
+
+
+/* -------- HSMCI_DTOR : (HSMCI Offset: 0x08) (R/W 32) Data Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTOCYC:4;                  /**< bit:   0..3  Data Timeout Cycle Number                */
+    uint32_t DTOMUL:3;                  /**< bit:   4..6  Data Timeout Multiplier                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_DTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_DTOR_OFFSET                   (0x08)                                        /**<  (HSMCI_DTOR) Data Timeout Register  Offset */
+
+#define HSMCI_DTOR_DTOCYC_Pos               0                                              /**< (HSMCI_DTOR) Data Timeout Cycle Number Position */
+#define HSMCI_DTOR_DTOCYC_Msk               (_U_(0xF) << HSMCI_DTOR_DTOCYC_Pos)            /**< (HSMCI_DTOR) Data Timeout Cycle Number Mask */
+#define HSMCI_DTOR_DTOCYC(value)            (HSMCI_DTOR_DTOCYC_Msk & ((value) << HSMCI_DTOR_DTOCYC_Pos))
+#define HSMCI_DTOR_DTOMUL_Pos               4                                              /**< (HSMCI_DTOR) Data Timeout Multiplier Position */
+#define HSMCI_DTOR_DTOMUL_Msk               (_U_(0x7) << HSMCI_DTOR_DTOMUL_Pos)            /**< (HSMCI_DTOR) Data Timeout Multiplier Mask */
+#define HSMCI_DTOR_DTOMUL(value)            (HSMCI_DTOR_DTOMUL_Msk & ((value) << HSMCI_DTOR_DTOMUL_Pos))
+#define   HSMCI_DTOR_DTOMUL_1_Val           _U_(0x0)                                       /**< (HSMCI_DTOR) DTOCYC  */
+#define   HSMCI_DTOR_DTOMUL_16_Val          _U_(0x1)                                       /**< (HSMCI_DTOR) DTOCYC x 16  */
+#define   HSMCI_DTOR_DTOMUL_128_Val         _U_(0x2)                                       /**< (HSMCI_DTOR) DTOCYC x 128  */
+#define   HSMCI_DTOR_DTOMUL_256_Val         _U_(0x3)                                       /**< (HSMCI_DTOR) DTOCYC x 256  */
+#define   HSMCI_DTOR_DTOMUL_1024_Val        _U_(0x4)                                       /**< (HSMCI_DTOR) DTOCYC x 1024  */
+#define   HSMCI_DTOR_DTOMUL_4096_Val        _U_(0x5)                                       /**< (HSMCI_DTOR) DTOCYC x 4096  */
+#define   HSMCI_DTOR_DTOMUL_65536_Val       _U_(0x6)                                       /**< (HSMCI_DTOR) DTOCYC x 65536  */
+#define   HSMCI_DTOR_DTOMUL_1048576_Val     _U_(0x7)                                       /**< (HSMCI_DTOR) DTOCYC x 1048576  */
+#define HSMCI_DTOR_DTOMUL_1                 (HSMCI_DTOR_DTOMUL_1_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC Position  */
+#define HSMCI_DTOR_DTOMUL_16                (HSMCI_DTOR_DTOMUL_16_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 16 Position  */
+#define HSMCI_DTOR_DTOMUL_128               (HSMCI_DTOR_DTOMUL_128_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 128 Position  */
+#define HSMCI_DTOR_DTOMUL_256               (HSMCI_DTOR_DTOMUL_256_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 256 Position  */
+#define HSMCI_DTOR_DTOMUL_1024              (HSMCI_DTOR_DTOMUL_1024_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 1024 Position  */
+#define HSMCI_DTOR_DTOMUL_4096              (HSMCI_DTOR_DTOMUL_4096_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 4096 Position  */
+#define HSMCI_DTOR_DTOMUL_65536             (HSMCI_DTOR_DTOMUL_65536_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 65536 Position  */
+#define HSMCI_DTOR_DTOMUL_1048576           (HSMCI_DTOR_DTOMUL_1048576_Val << HSMCI_DTOR_DTOMUL_Pos)  /**< (HSMCI_DTOR) DTOCYC x 1048576 Position  */
+#define HSMCI_DTOR_MASK                     _U_(0x7F)                                      /**< \deprecated (HSMCI_DTOR) Register MASK  (Use HSMCI_DTOR_Msk instead)  */
+#define HSMCI_DTOR_Msk                      _U_(0x7F)                                      /**< (HSMCI_DTOR) Register Mask  */
+
+
+/* -------- HSMCI_SDCR : (HSMCI Offset: 0x0c) (R/W 32) SD/SDIO Card Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDCSEL:2;                  /**< bit:   0..1  SDCard/SDIO Slot                         */
+    uint32_t :4;                        /**< bit:   2..5  Reserved */
+    uint32_t SDCBUS:2;                  /**< bit:   6..7  SDCard/SDIO Bus Width                    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_SDCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_SDCR_OFFSET                   (0x0C)                                        /**<  (HSMCI_SDCR) SD/SDIO Card Register  Offset */
+
+#define HSMCI_SDCR_SDCSEL_Pos               0                                              /**< (HSMCI_SDCR) SDCard/SDIO Slot Position */
+#define HSMCI_SDCR_SDCSEL_Msk               (_U_(0x3) << HSMCI_SDCR_SDCSEL_Pos)            /**< (HSMCI_SDCR) SDCard/SDIO Slot Mask */
+#define HSMCI_SDCR_SDCSEL(value)            (HSMCI_SDCR_SDCSEL_Msk & ((value) << HSMCI_SDCR_SDCSEL_Pos))
+#define   HSMCI_SDCR_SDCSEL_SLOTA_Val       _U_(0x0)                                       /**< (HSMCI_SDCR) Slot A is selected.  */
+#define HSMCI_SDCR_SDCSEL_SLOTA             (HSMCI_SDCR_SDCSEL_SLOTA_Val << HSMCI_SDCR_SDCSEL_Pos)  /**< (HSMCI_SDCR) Slot A is selected. Position  */
+#define HSMCI_SDCR_SDCBUS_Pos               6                                              /**< (HSMCI_SDCR) SDCard/SDIO Bus Width Position */
+#define HSMCI_SDCR_SDCBUS_Msk               (_U_(0x3) << HSMCI_SDCR_SDCBUS_Pos)            /**< (HSMCI_SDCR) SDCard/SDIO Bus Width Mask */
+#define HSMCI_SDCR_SDCBUS(value)            (HSMCI_SDCR_SDCBUS_Msk & ((value) << HSMCI_SDCR_SDCBUS_Pos))
+#define   HSMCI_SDCR_SDCBUS_1_Val           _U_(0x0)                                       /**< (HSMCI_SDCR) 1 bit  */
+#define   HSMCI_SDCR_SDCBUS_4_Val           _U_(0x2)                                       /**< (HSMCI_SDCR) 4 bits  */
+#define   HSMCI_SDCR_SDCBUS_8_Val           _U_(0x3)                                       /**< (HSMCI_SDCR) 8 bits  */
+#define HSMCI_SDCR_SDCBUS_1                 (HSMCI_SDCR_SDCBUS_1_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 1 bit Position  */
+#define HSMCI_SDCR_SDCBUS_4                 (HSMCI_SDCR_SDCBUS_4_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 4 bits Position  */
+#define HSMCI_SDCR_SDCBUS_8                 (HSMCI_SDCR_SDCBUS_8_Val << HSMCI_SDCR_SDCBUS_Pos)  /**< (HSMCI_SDCR) 8 bits Position  */
+#define HSMCI_SDCR_MASK                     _U_(0xC3)                                      /**< \deprecated (HSMCI_SDCR) Register MASK  (Use HSMCI_SDCR_Msk instead)  */
+#define HSMCI_SDCR_Msk                      _U_(0xC3)                                      /**< (HSMCI_SDCR) Register Mask  */
+
+
+/* -------- HSMCI_ARGR : (HSMCI Offset: 0x10) (R/W 32) Argument Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ARG:32;                    /**< bit:  0..31  Command Argument                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_ARGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_ARGR_OFFSET                   (0x10)                                        /**<  (HSMCI_ARGR) Argument Register  Offset */
+
+#define HSMCI_ARGR_ARG_Pos                  0                                              /**< (HSMCI_ARGR) Command Argument Position */
+#define HSMCI_ARGR_ARG_Msk                  (_U_(0xFFFFFFFF) << HSMCI_ARGR_ARG_Pos)        /**< (HSMCI_ARGR) Command Argument Mask */
+#define HSMCI_ARGR_ARG(value)               (HSMCI_ARGR_ARG_Msk & ((value) << HSMCI_ARGR_ARG_Pos))
+#define HSMCI_ARGR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_ARGR) Register MASK  (Use HSMCI_ARGR_Msk instead)  */
+#define HSMCI_ARGR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_ARGR) Register Mask  */
+
+
+/* -------- HSMCI_CMDR : (HSMCI Offset: 0x14) (/W 32) Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDNB:6;                   /**< bit:   0..5  Command Number                           */
+    uint32_t RSPTYP:2;                  /**< bit:   6..7  Response Type                            */
+    uint32_t SPCMD:3;                   /**< bit:  8..10  Special Command                          */
+    uint32_t OPDCMD:1;                  /**< bit:     11  Open Drain Command                       */
+    uint32_t MAXLAT:1;                  /**< bit:     12  Max Latency for Command to Response      */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TRCMD:2;                   /**< bit: 16..17  Transfer Command                         */
+    uint32_t TRDIR:1;                   /**< bit:     18  Transfer Direction                       */
+    uint32_t TRTYP:3;                   /**< bit: 19..21  Transfer Type                            */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t IOSPCMD:2;                 /**< bit: 24..25  SDIO Special Command                     */
+    uint32_t ATACS:1;                   /**< bit:     26  ATA with Command Completion Signal       */
+    uint32_t BOOT_ACK:1;                /**< bit:     27  Boot Operation Acknowledge               */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CMDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CMDR_OFFSET                   (0x14)                                        /**<  (HSMCI_CMDR) Command Register  Offset */
+
+#define HSMCI_CMDR_CMDNB_Pos                0                                              /**< (HSMCI_CMDR) Command Number Position */
+#define HSMCI_CMDR_CMDNB_Msk                (_U_(0x3F) << HSMCI_CMDR_CMDNB_Pos)            /**< (HSMCI_CMDR) Command Number Mask */
+#define HSMCI_CMDR_CMDNB(value)             (HSMCI_CMDR_CMDNB_Msk & ((value) << HSMCI_CMDR_CMDNB_Pos))
+#define HSMCI_CMDR_RSPTYP_Pos               6                                              /**< (HSMCI_CMDR) Response Type Position */
+#define HSMCI_CMDR_RSPTYP_Msk               (_U_(0x3) << HSMCI_CMDR_RSPTYP_Pos)            /**< (HSMCI_CMDR) Response Type Mask */
+#define HSMCI_CMDR_RSPTYP(value)            (HSMCI_CMDR_RSPTYP_Msk & ((value) << HSMCI_CMDR_RSPTYP_Pos))
+#define   HSMCI_CMDR_RSPTYP_NORESP_Val      _U_(0x0)                                       /**< (HSMCI_CMDR) No response  */
+#define   HSMCI_CMDR_RSPTYP_48_BIT_Val      _U_(0x1)                                       /**< (HSMCI_CMDR) 48-bit response  */
+#define   HSMCI_CMDR_RSPTYP_136_BIT_Val     _U_(0x2)                                       /**< (HSMCI_CMDR) 136-bit response  */
+#define   HSMCI_CMDR_RSPTYP_R1B_Val         _U_(0x3)                                       /**< (HSMCI_CMDR) R1b response type  */
+#define HSMCI_CMDR_RSPTYP_NORESP            (HSMCI_CMDR_RSPTYP_NORESP_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) No response Position  */
+#define HSMCI_CMDR_RSPTYP_48_BIT            (HSMCI_CMDR_RSPTYP_48_BIT_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) 48-bit response Position  */
+#define HSMCI_CMDR_RSPTYP_136_BIT           (HSMCI_CMDR_RSPTYP_136_BIT_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) 136-bit response Position  */
+#define HSMCI_CMDR_RSPTYP_R1B               (HSMCI_CMDR_RSPTYP_R1B_Val << HSMCI_CMDR_RSPTYP_Pos)  /**< (HSMCI_CMDR) R1b response type Position  */
+#define HSMCI_CMDR_SPCMD_Pos                8                                              /**< (HSMCI_CMDR) Special Command Position */
+#define HSMCI_CMDR_SPCMD_Msk                (_U_(0x7) << HSMCI_CMDR_SPCMD_Pos)             /**< (HSMCI_CMDR) Special Command Mask */
+#define HSMCI_CMDR_SPCMD(value)             (HSMCI_CMDR_SPCMD_Msk & ((value) << HSMCI_CMDR_SPCMD_Pos))
+#define   HSMCI_CMDR_SPCMD_STD_Val          _U_(0x0)                                       /**< (HSMCI_CMDR) Not a special CMD.  */
+#define   HSMCI_CMDR_SPCMD_INIT_Val         _U_(0x1)                                       /**< (HSMCI_CMDR) Initialization CMD: 74 clock cycles for initialization sequence.  */
+#define   HSMCI_CMDR_SPCMD_SYNC_Val         _U_(0x2)                                       /**< (HSMCI_CMDR) Synchronized CMD: Wait for the end of the current data block transfer before sending the pending command.  */
+#define   HSMCI_CMDR_SPCMD_CE_ATA_Val       _U_(0x3)                                       /**< (HSMCI_CMDR) CE-ATA Completion Signal disable Command. The host cancels the ability for the device to return a command completion signal on the command line.  */
+#define   HSMCI_CMDR_SPCMD_IT_CMD_Val       _U_(0x4)                                       /**< (HSMCI_CMDR) Interrupt command: Corresponds to the Interrupt Mode (CMD40).  */
+#define   HSMCI_CMDR_SPCMD_IT_RESP_Val      _U_(0x5)                                       /**< (HSMCI_CMDR) Interrupt response: Corresponds to the Interrupt Mode (CMD40).  */
+#define   HSMCI_CMDR_SPCMD_BOR_Val          _U_(0x6)                                       /**< (HSMCI_CMDR) Boot Operation Request. Start a boot operation mode, the host processor can read boot data from the MMC device directly.  */
+#define   HSMCI_CMDR_SPCMD_EBO_Val          _U_(0x7)                                       /**< (HSMCI_CMDR) End Boot Operation. This command allows the host processor to terminate the boot operation mode.  */
+#define HSMCI_CMDR_SPCMD_STD                (HSMCI_CMDR_SPCMD_STD_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Not a special CMD. Position  */
+#define HSMCI_CMDR_SPCMD_INIT               (HSMCI_CMDR_SPCMD_INIT_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Initialization CMD: 74 clock cycles for initialization sequence. Position  */
+#define HSMCI_CMDR_SPCMD_SYNC               (HSMCI_CMDR_SPCMD_SYNC_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Synchronized CMD: Wait for the end of the current data block transfer before sending the pending command. Position  */
+#define HSMCI_CMDR_SPCMD_CE_ATA             (HSMCI_CMDR_SPCMD_CE_ATA_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) CE-ATA Completion Signal disable Command. The host cancels the ability for the device to return a command completion signal on the command line. Position  */
+#define HSMCI_CMDR_SPCMD_IT_CMD             (HSMCI_CMDR_SPCMD_IT_CMD_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Interrupt command: Corresponds to the Interrupt Mode (CMD40). Position  */
+#define HSMCI_CMDR_SPCMD_IT_RESP            (HSMCI_CMDR_SPCMD_IT_RESP_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Interrupt response: Corresponds to the Interrupt Mode (CMD40). Position  */
+#define HSMCI_CMDR_SPCMD_BOR                (HSMCI_CMDR_SPCMD_BOR_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) Boot Operation Request. Start a boot operation mode, the host processor can read boot data from the MMC device directly. Position  */
+#define HSMCI_CMDR_SPCMD_EBO                (HSMCI_CMDR_SPCMD_EBO_Val << HSMCI_CMDR_SPCMD_Pos)  /**< (HSMCI_CMDR) End Boot Operation. This command allows the host processor to terminate the boot operation mode. Position  */
+#define HSMCI_CMDR_OPDCMD_Pos               11                                             /**< (HSMCI_CMDR) Open Drain Command Position */
+#define HSMCI_CMDR_OPDCMD_Msk               (_U_(0x1) << HSMCI_CMDR_OPDCMD_Pos)            /**< (HSMCI_CMDR) Open Drain Command Mask */
+#define HSMCI_CMDR_OPDCMD                   HSMCI_CMDR_OPDCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_OPDCMD_Msk instead */
+#define   HSMCI_CMDR_OPDCMD_PUSHPULL_Val    _U_(0x0)                                       /**< (HSMCI_CMDR) Push pull command.  */
+#define   HSMCI_CMDR_OPDCMD_OPENDRAIN_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) Open drain command.  */
+#define HSMCI_CMDR_OPDCMD_PUSHPULL          (HSMCI_CMDR_OPDCMD_PUSHPULL_Val << HSMCI_CMDR_OPDCMD_Pos)  /**< (HSMCI_CMDR) Push pull command. Position  */
+#define HSMCI_CMDR_OPDCMD_OPENDRAIN         (HSMCI_CMDR_OPDCMD_OPENDRAIN_Val << HSMCI_CMDR_OPDCMD_Pos)  /**< (HSMCI_CMDR) Open drain command. Position  */
+#define HSMCI_CMDR_MAXLAT_Pos               12                                             /**< (HSMCI_CMDR) Max Latency for Command to Response Position */
+#define HSMCI_CMDR_MAXLAT_Msk               (_U_(0x1) << HSMCI_CMDR_MAXLAT_Pos)            /**< (HSMCI_CMDR) Max Latency for Command to Response Mask */
+#define HSMCI_CMDR_MAXLAT                   HSMCI_CMDR_MAXLAT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_MAXLAT_Msk instead */
+#define   HSMCI_CMDR_MAXLAT_5_Val           _U_(0x0)                                       /**< (HSMCI_CMDR) 5-cycle max latency.  */
+#define   HSMCI_CMDR_MAXLAT_64_Val          _U_(0x1)                                       /**< (HSMCI_CMDR) 64-cycle max latency.  */
+#define HSMCI_CMDR_MAXLAT_5                 (HSMCI_CMDR_MAXLAT_5_Val << HSMCI_CMDR_MAXLAT_Pos)  /**< (HSMCI_CMDR) 5-cycle max latency. Position  */
+#define HSMCI_CMDR_MAXLAT_64                (HSMCI_CMDR_MAXLAT_64_Val << HSMCI_CMDR_MAXLAT_Pos)  /**< (HSMCI_CMDR) 64-cycle max latency. Position  */
+#define HSMCI_CMDR_TRCMD_Pos                16                                             /**< (HSMCI_CMDR) Transfer Command Position */
+#define HSMCI_CMDR_TRCMD_Msk                (_U_(0x3) << HSMCI_CMDR_TRCMD_Pos)             /**< (HSMCI_CMDR) Transfer Command Mask */
+#define HSMCI_CMDR_TRCMD(value)             (HSMCI_CMDR_TRCMD_Msk & ((value) << HSMCI_CMDR_TRCMD_Pos))
+#define   HSMCI_CMDR_TRCMD_NO_DATA_Val      _U_(0x0)                                       /**< (HSMCI_CMDR) No data transfer  */
+#define   HSMCI_CMDR_TRCMD_START_DATA_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) Start data transfer  */
+#define   HSMCI_CMDR_TRCMD_STOP_DATA_Val    _U_(0x2)                                       /**< (HSMCI_CMDR) Stop data transfer  */
+#define HSMCI_CMDR_TRCMD_NO_DATA            (HSMCI_CMDR_TRCMD_NO_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) No data transfer Position  */
+#define HSMCI_CMDR_TRCMD_START_DATA         (HSMCI_CMDR_TRCMD_START_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) Start data transfer Position  */
+#define HSMCI_CMDR_TRCMD_STOP_DATA          (HSMCI_CMDR_TRCMD_STOP_DATA_Val << HSMCI_CMDR_TRCMD_Pos)  /**< (HSMCI_CMDR) Stop data transfer Position  */
+#define HSMCI_CMDR_TRDIR_Pos                18                                             /**< (HSMCI_CMDR) Transfer Direction Position */
+#define HSMCI_CMDR_TRDIR_Msk                (_U_(0x1) << HSMCI_CMDR_TRDIR_Pos)             /**< (HSMCI_CMDR) Transfer Direction Mask */
+#define HSMCI_CMDR_TRDIR                    HSMCI_CMDR_TRDIR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_TRDIR_Msk instead */
+#define   HSMCI_CMDR_TRDIR_WRITE_Val        _U_(0x0)                                       /**< (HSMCI_CMDR) Write.  */
+#define   HSMCI_CMDR_TRDIR_READ_Val         _U_(0x1)                                       /**< (HSMCI_CMDR) Read.  */
+#define HSMCI_CMDR_TRDIR_WRITE              (HSMCI_CMDR_TRDIR_WRITE_Val << HSMCI_CMDR_TRDIR_Pos)  /**< (HSMCI_CMDR) Write. Position  */
+#define HSMCI_CMDR_TRDIR_READ               (HSMCI_CMDR_TRDIR_READ_Val << HSMCI_CMDR_TRDIR_Pos)  /**< (HSMCI_CMDR) Read. Position  */
+#define HSMCI_CMDR_TRTYP_Pos                19                                             /**< (HSMCI_CMDR) Transfer Type Position */
+#define HSMCI_CMDR_TRTYP_Msk                (_U_(0x7) << HSMCI_CMDR_TRTYP_Pos)             /**< (HSMCI_CMDR) Transfer Type Mask */
+#define HSMCI_CMDR_TRTYP(value)             (HSMCI_CMDR_TRTYP_Msk & ((value) << HSMCI_CMDR_TRTYP_Pos))
+#define   HSMCI_CMDR_TRTYP_SINGLE_Val       _U_(0x0)                                       /**< (HSMCI_CMDR) MMC/SD Card Single Block  */
+#define   HSMCI_CMDR_TRTYP_MULTIPLE_Val     _U_(0x1)                                       /**< (HSMCI_CMDR) MMC/SD Card Multiple Block  */
+#define   HSMCI_CMDR_TRTYP_STREAM_Val       _U_(0x2)                                       /**< (HSMCI_CMDR) MMC Stream  */
+#define   HSMCI_CMDR_TRTYP_BYTE_Val         _U_(0x4)                                       /**< (HSMCI_CMDR) SDIO Byte  */
+#define   HSMCI_CMDR_TRTYP_BLOCK_Val        _U_(0x5)                                       /**< (HSMCI_CMDR) SDIO Block  */
+#define HSMCI_CMDR_TRTYP_SINGLE             (HSMCI_CMDR_TRTYP_SINGLE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC/SD Card Single Block Position  */
+#define HSMCI_CMDR_TRTYP_MULTIPLE           (HSMCI_CMDR_TRTYP_MULTIPLE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC/SD Card Multiple Block Position  */
+#define HSMCI_CMDR_TRTYP_STREAM             (HSMCI_CMDR_TRTYP_STREAM_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) MMC Stream Position  */
+#define HSMCI_CMDR_TRTYP_BYTE               (HSMCI_CMDR_TRTYP_BYTE_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) SDIO Byte Position  */
+#define HSMCI_CMDR_TRTYP_BLOCK              (HSMCI_CMDR_TRTYP_BLOCK_Val << HSMCI_CMDR_TRTYP_Pos)  /**< (HSMCI_CMDR) SDIO Block Position  */
+#define HSMCI_CMDR_IOSPCMD_Pos              24                                             /**< (HSMCI_CMDR) SDIO Special Command Position */
+#define HSMCI_CMDR_IOSPCMD_Msk              (_U_(0x3) << HSMCI_CMDR_IOSPCMD_Pos)           /**< (HSMCI_CMDR) SDIO Special Command Mask */
+#define HSMCI_CMDR_IOSPCMD(value)           (HSMCI_CMDR_IOSPCMD_Msk & ((value) << HSMCI_CMDR_IOSPCMD_Pos))
+#define   HSMCI_CMDR_IOSPCMD_STD_Val        _U_(0x0)                                       /**< (HSMCI_CMDR) Not an SDIO Special Command  */
+#define   HSMCI_CMDR_IOSPCMD_SUSPEND_Val    _U_(0x1)                                       /**< (HSMCI_CMDR) SDIO Suspend Command  */
+#define   HSMCI_CMDR_IOSPCMD_RESUME_Val     _U_(0x2)                                       /**< (HSMCI_CMDR) SDIO Resume Command  */
+#define HSMCI_CMDR_IOSPCMD_STD              (HSMCI_CMDR_IOSPCMD_STD_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) Not an SDIO Special Command Position  */
+#define HSMCI_CMDR_IOSPCMD_SUSPEND          (HSMCI_CMDR_IOSPCMD_SUSPEND_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) SDIO Suspend Command Position  */
+#define HSMCI_CMDR_IOSPCMD_RESUME           (HSMCI_CMDR_IOSPCMD_RESUME_Val << HSMCI_CMDR_IOSPCMD_Pos)  /**< (HSMCI_CMDR) SDIO Resume Command Position  */
+#define HSMCI_CMDR_ATACS_Pos                26                                             /**< (HSMCI_CMDR) ATA with Command Completion Signal Position */
+#define HSMCI_CMDR_ATACS_Msk                (_U_(0x1) << HSMCI_CMDR_ATACS_Pos)             /**< (HSMCI_CMDR) ATA with Command Completion Signal Mask */
+#define HSMCI_CMDR_ATACS                    HSMCI_CMDR_ATACS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_ATACS_Msk instead */
+#define   HSMCI_CMDR_ATACS_NORMAL_Val       _U_(0x0)                                       /**< (HSMCI_CMDR) Normal operation mode.  */
+#define   HSMCI_CMDR_ATACS_COMPLETION_Val   _U_(0x1)                                       /**< (HSMCI_CMDR) This bit indicates that a completion signal is expected within a programmed amount of time (HSMCI_CSTOR).  */
+#define HSMCI_CMDR_ATACS_NORMAL             (HSMCI_CMDR_ATACS_NORMAL_Val << HSMCI_CMDR_ATACS_Pos)  /**< (HSMCI_CMDR) Normal operation mode. Position  */
+#define HSMCI_CMDR_ATACS_COMPLETION         (HSMCI_CMDR_ATACS_COMPLETION_Val << HSMCI_CMDR_ATACS_Pos)  /**< (HSMCI_CMDR) This bit indicates that a completion signal is expected within a programmed amount of time (HSMCI_CSTOR). Position  */
+#define HSMCI_CMDR_BOOT_ACK_Pos             27                                             /**< (HSMCI_CMDR) Boot Operation Acknowledge Position */
+#define HSMCI_CMDR_BOOT_ACK_Msk             (_U_(0x1) << HSMCI_CMDR_BOOT_ACK_Pos)          /**< (HSMCI_CMDR) Boot Operation Acknowledge Mask */
+#define HSMCI_CMDR_BOOT_ACK                 HSMCI_CMDR_BOOT_ACK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CMDR_BOOT_ACK_Msk instead */
+#define HSMCI_CMDR_MASK                     _U_(0xF3F1FFF)                                 /**< \deprecated (HSMCI_CMDR) Register MASK  (Use HSMCI_CMDR_Msk instead)  */
+#define HSMCI_CMDR_Msk                      _U_(0xF3F1FFF)                                 /**< (HSMCI_CMDR) Register Mask  */
+
+
+/* -------- HSMCI_BLKR : (HSMCI Offset: 0x18) (R/W 32) Block Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BCNT:16;                   /**< bit:  0..15  MMC/SDIO Block Count - SDIO Byte Count   */
+    uint32_t BLKLEN:16;                 /**< bit: 16..31  Data Block Length                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_BLKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_BLKR_OFFSET                   (0x18)                                        /**<  (HSMCI_BLKR) Block Register  Offset */
+
+#define HSMCI_BLKR_BCNT_Pos                 0                                              /**< (HSMCI_BLKR) MMC/SDIO Block Count - SDIO Byte Count Position */
+#define HSMCI_BLKR_BCNT_Msk                 (_U_(0xFFFF) << HSMCI_BLKR_BCNT_Pos)           /**< (HSMCI_BLKR) MMC/SDIO Block Count - SDIO Byte Count Mask */
+#define HSMCI_BLKR_BCNT(value)              (HSMCI_BLKR_BCNT_Msk & ((value) << HSMCI_BLKR_BCNT_Pos))
+#define HSMCI_BLKR_BLKLEN_Pos               16                                             /**< (HSMCI_BLKR) Data Block Length Position */
+#define HSMCI_BLKR_BLKLEN_Msk               (_U_(0xFFFF) << HSMCI_BLKR_BLKLEN_Pos)         /**< (HSMCI_BLKR) Data Block Length Mask */
+#define HSMCI_BLKR_BLKLEN(value)            (HSMCI_BLKR_BLKLEN_Msk & ((value) << HSMCI_BLKR_BLKLEN_Pos))
+#define HSMCI_BLKR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_BLKR) Register MASK  (Use HSMCI_BLKR_Msk instead)  */
+#define HSMCI_BLKR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_BLKR) Register Mask  */
+
+
+/* -------- HSMCI_CSTOR : (HSMCI Offset: 0x1c) (R/W 32) Completion Signal Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSTOCYC:4;                 /**< bit:   0..3  Completion Signal Timeout Cycle Number   */
+    uint32_t CSTOMUL:3;                 /**< bit:   4..6  Completion Signal Timeout Multiplier     */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CSTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CSTOR_OFFSET                  (0x1C)                                        /**<  (HSMCI_CSTOR) Completion Signal Timeout Register  Offset */
+
+#define HSMCI_CSTOR_CSTOCYC_Pos             0                                              /**< (HSMCI_CSTOR) Completion Signal Timeout Cycle Number Position */
+#define HSMCI_CSTOR_CSTOCYC_Msk             (_U_(0xF) << HSMCI_CSTOR_CSTOCYC_Pos)          /**< (HSMCI_CSTOR) Completion Signal Timeout Cycle Number Mask */
+#define HSMCI_CSTOR_CSTOCYC(value)          (HSMCI_CSTOR_CSTOCYC_Msk & ((value) << HSMCI_CSTOR_CSTOCYC_Pos))
+#define HSMCI_CSTOR_CSTOMUL_Pos             4                                              /**< (HSMCI_CSTOR) Completion Signal Timeout Multiplier Position */
+#define HSMCI_CSTOR_CSTOMUL_Msk             (_U_(0x7) << HSMCI_CSTOR_CSTOMUL_Pos)          /**< (HSMCI_CSTOR) Completion Signal Timeout Multiplier Mask */
+#define HSMCI_CSTOR_CSTOMUL(value)          (HSMCI_CSTOR_CSTOMUL_Msk & ((value) << HSMCI_CSTOR_CSTOMUL_Pos))
+#define   HSMCI_CSTOR_CSTOMUL_1_Val         _U_(0x0)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1  */
+#define   HSMCI_CSTOR_CSTOMUL_16_Val        _U_(0x1)                                       /**< (HSMCI_CSTOR) CSTOCYC x 16  */
+#define   HSMCI_CSTOR_CSTOMUL_128_Val       _U_(0x2)                                       /**< (HSMCI_CSTOR) CSTOCYC x 128  */
+#define   HSMCI_CSTOR_CSTOMUL_256_Val       _U_(0x3)                                       /**< (HSMCI_CSTOR) CSTOCYC x 256  */
+#define   HSMCI_CSTOR_CSTOMUL_1024_Val      _U_(0x4)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1024  */
+#define   HSMCI_CSTOR_CSTOMUL_4096_Val      _U_(0x5)                                       /**< (HSMCI_CSTOR) CSTOCYC x 4096  */
+#define   HSMCI_CSTOR_CSTOMUL_65536_Val     _U_(0x6)                                       /**< (HSMCI_CSTOR) CSTOCYC x 65536  */
+#define   HSMCI_CSTOR_CSTOMUL_1048576_Val   _U_(0x7)                                       /**< (HSMCI_CSTOR) CSTOCYC x 1048576  */
+#define HSMCI_CSTOR_CSTOMUL_1               (HSMCI_CSTOR_CSTOMUL_1_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1 Position  */
+#define HSMCI_CSTOR_CSTOMUL_16              (HSMCI_CSTOR_CSTOMUL_16_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 16 Position  */
+#define HSMCI_CSTOR_CSTOMUL_128             (HSMCI_CSTOR_CSTOMUL_128_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 128 Position  */
+#define HSMCI_CSTOR_CSTOMUL_256             (HSMCI_CSTOR_CSTOMUL_256_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 256 Position  */
+#define HSMCI_CSTOR_CSTOMUL_1024            (HSMCI_CSTOR_CSTOMUL_1024_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1024 Position  */
+#define HSMCI_CSTOR_CSTOMUL_4096            (HSMCI_CSTOR_CSTOMUL_4096_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 4096 Position  */
+#define HSMCI_CSTOR_CSTOMUL_65536           (HSMCI_CSTOR_CSTOMUL_65536_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 65536 Position  */
+#define HSMCI_CSTOR_CSTOMUL_1048576         (HSMCI_CSTOR_CSTOMUL_1048576_Val << HSMCI_CSTOR_CSTOMUL_Pos)  /**< (HSMCI_CSTOR) CSTOCYC x 1048576 Position  */
+#define HSMCI_CSTOR_MASK                    _U_(0x7F)                                      /**< \deprecated (HSMCI_CSTOR) Register MASK  (Use HSMCI_CSTOR_Msk instead)  */
+#define HSMCI_CSTOR_Msk                     _U_(0x7F)                                      /**< (HSMCI_CSTOR) Register Mask  */
+
+
+/* -------- HSMCI_RSPR : (HSMCI Offset: 0x20) (R/ 32) Response Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSP:32;                    /**< bit:  0..31  Response                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_RSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_RSPR_OFFSET                   (0x20)                                        /**<  (HSMCI_RSPR) Response Register 0  Offset */
+
+#define HSMCI_RSPR_RSP_Pos                  0                                              /**< (HSMCI_RSPR) Response Position */
+#define HSMCI_RSPR_RSP_Msk                  (_U_(0xFFFFFFFF) << HSMCI_RSPR_RSP_Pos)        /**< (HSMCI_RSPR) Response Mask */
+#define HSMCI_RSPR_RSP(value)               (HSMCI_RSPR_RSP_Msk & ((value) << HSMCI_RSPR_RSP_Pos))
+#define HSMCI_RSPR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_RSPR) Register MASK  (Use HSMCI_RSPR_Msk instead)  */
+#define HSMCI_RSPR_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_RSPR) Register Mask  */
+
+
+/* -------- HSMCI_RDR : (HSMCI Offset: 0x30) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Read                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_RDR_OFFSET                    (0x30)                                        /**<  (HSMCI_RDR) Receive Data Register  Offset */
+
+#define HSMCI_RDR_DATA_Pos                  0                                              /**< (HSMCI_RDR) Data to Read Position */
+#define HSMCI_RDR_DATA_Msk                  (_U_(0xFFFFFFFF) << HSMCI_RDR_DATA_Pos)        /**< (HSMCI_RDR) Data to Read Mask */
+#define HSMCI_RDR_DATA(value)               (HSMCI_RDR_DATA_Msk & ((value) << HSMCI_RDR_DATA_Pos))
+#define HSMCI_RDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_RDR) Register MASK  (Use HSMCI_RDR_Msk instead)  */
+#define HSMCI_RDR_Msk                       _U_(0xFFFFFFFF)                                /**< (HSMCI_RDR) Register Mask  */
+
+
+/* -------- HSMCI_TDR : (HSMCI Offset: 0x34) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Write                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_TDR_OFFSET                    (0x34)                                        /**<  (HSMCI_TDR) Transmit Data Register  Offset */
+
+#define HSMCI_TDR_DATA_Pos                  0                                              /**< (HSMCI_TDR) Data to Write Position */
+#define HSMCI_TDR_DATA_Msk                  (_U_(0xFFFFFFFF) << HSMCI_TDR_DATA_Pos)        /**< (HSMCI_TDR) Data to Write Mask */
+#define HSMCI_TDR_DATA(value)               (HSMCI_TDR_DATA_Msk & ((value) << HSMCI_TDR_DATA_Pos))
+#define HSMCI_TDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_TDR) Register MASK  (Use HSMCI_TDR_Msk instead)  */
+#define HSMCI_TDR_Msk                       _U_(0xFFFFFFFF)                                /**< (HSMCI_TDR) Register Mask  */
+
+
+/* -------- HSMCI_SR : (HSMCI Offset: 0x40) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready (cleared by writing in HSMCI_CMDR) */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready (cleared by reading HSMCI_RDR) */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready (cleared by writing in HSMCI_TDR) */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended (cleared on read)       */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress (cleared at the end of CRC16 calculation) */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  HSMCI Not Busy                           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A (cleared on read) */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status          */
+    uint32_t CSRCV:1;                   /**< bit:     13  CE-ATA Completion Signal Received (cleared on read) */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error (cleared by writing in HSMCI_CMDR) */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error (cleared on read)         */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error (cleared on read)    */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time-out Error (cleared on read) */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error (cleared on read) */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty flag                          */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done flag                       */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Operation Acknowledge Received (cleared on read) */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Operation Acknowledge Error (cleared on read) */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_SR_OFFSET                     (0x40)                                        /**<  (HSMCI_SR) Status Register  Offset */
+
+#define HSMCI_SR_CMDRDY_Pos                 0                                              /**< (HSMCI_SR) Command Ready (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_CMDRDY_Msk                 (_U_(0x1) << HSMCI_SR_CMDRDY_Pos)              /**< (HSMCI_SR) Command Ready (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_CMDRDY                     HSMCI_SR_CMDRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CMDRDY_Msk instead */
+#define HSMCI_SR_RXRDY_Pos                  1                                              /**< (HSMCI_SR) Receiver Ready (cleared by reading HSMCI_RDR) Position */
+#define HSMCI_SR_RXRDY_Msk                  (_U_(0x1) << HSMCI_SR_RXRDY_Pos)               /**< (HSMCI_SR) Receiver Ready (cleared by reading HSMCI_RDR) Mask */
+#define HSMCI_SR_RXRDY                      HSMCI_SR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RXRDY_Msk instead */
+#define HSMCI_SR_TXRDY_Pos                  2                                              /**< (HSMCI_SR) Transmit Ready (cleared by writing in HSMCI_TDR) Position */
+#define HSMCI_SR_TXRDY_Msk                  (_U_(0x1) << HSMCI_SR_TXRDY_Pos)               /**< (HSMCI_SR) Transmit Ready (cleared by writing in HSMCI_TDR) Mask */
+#define HSMCI_SR_TXRDY                      HSMCI_SR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_TXRDY_Msk instead */
+#define HSMCI_SR_BLKE_Pos                   3                                              /**< (HSMCI_SR) Data Block Ended (cleared on read) Position */
+#define HSMCI_SR_BLKE_Msk                   (_U_(0x1) << HSMCI_SR_BLKE_Pos)                /**< (HSMCI_SR) Data Block Ended (cleared on read) Mask */
+#define HSMCI_SR_BLKE                       HSMCI_SR_BLKE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_BLKE_Msk instead */
+#define HSMCI_SR_DTIP_Pos                   4                                              /**< (HSMCI_SR) Data Transfer in Progress (cleared at the end of CRC16 calculation) Position */
+#define HSMCI_SR_DTIP_Msk                   (_U_(0x1) << HSMCI_SR_DTIP_Pos)                /**< (HSMCI_SR) Data Transfer in Progress (cleared at the end of CRC16 calculation) Mask */
+#define HSMCI_SR_DTIP                       HSMCI_SR_DTIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DTIP_Msk instead */
+#define HSMCI_SR_NOTBUSY_Pos                5                                              /**< (HSMCI_SR) HSMCI Not Busy Position */
+#define HSMCI_SR_NOTBUSY_Msk                (_U_(0x1) << HSMCI_SR_NOTBUSY_Pos)             /**< (HSMCI_SR) HSMCI Not Busy Mask */
+#define HSMCI_SR_NOTBUSY                    HSMCI_SR_NOTBUSY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_NOTBUSY_Msk instead */
+#define HSMCI_SR_SDIOIRQA_Pos               8                                              /**< (HSMCI_SR) SDIO Interrupt for Slot A (cleared on read) Position */
+#define HSMCI_SR_SDIOIRQA_Msk               (_U_(0x1) << HSMCI_SR_SDIOIRQA_Pos)            /**< (HSMCI_SR) SDIO Interrupt for Slot A (cleared on read) Mask */
+#define HSMCI_SR_SDIOIRQA                   HSMCI_SR_SDIOIRQA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_SDIOIRQA_Msk instead */
+#define HSMCI_SR_SDIOWAIT_Pos               12                                             /**< (HSMCI_SR) SDIO Read Wait Operation Status Position */
+#define HSMCI_SR_SDIOWAIT_Msk               (_U_(0x1) << HSMCI_SR_SDIOWAIT_Pos)            /**< (HSMCI_SR) SDIO Read Wait Operation Status Mask */
+#define HSMCI_SR_SDIOWAIT                   HSMCI_SR_SDIOWAIT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_SDIOWAIT_Msk instead */
+#define HSMCI_SR_CSRCV_Pos                  13                                             /**< (HSMCI_SR) CE-ATA Completion Signal Received (cleared on read) Position */
+#define HSMCI_SR_CSRCV_Msk                  (_U_(0x1) << HSMCI_SR_CSRCV_Pos)               /**< (HSMCI_SR) CE-ATA Completion Signal Received (cleared on read) Mask */
+#define HSMCI_SR_CSRCV                      HSMCI_SR_CSRCV_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CSRCV_Msk instead */
+#define HSMCI_SR_RINDE_Pos                  16                                             /**< (HSMCI_SR) Response Index Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RINDE_Msk                  (_U_(0x1) << HSMCI_SR_RINDE_Pos)               /**< (HSMCI_SR) Response Index Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RINDE                      HSMCI_SR_RINDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RINDE_Msk instead */
+#define HSMCI_SR_RDIRE_Pos                  17                                             /**< (HSMCI_SR) Response Direction Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RDIRE_Msk                  (_U_(0x1) << HSMCI_SR_RDIRE_Pos)               /**< (HSMCI_SR) Response Direction Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RDIRE                      HSMCI_SR_RDIRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RDIRE_Msk instead */
+#define HSMCI_SR_RCRCE_Pos                  18                                             /**< (HSMCI_SR) Response CRC Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RCRCE_Msk                  (_U_(0x1) << HSMCI_SR_RCRCE_Pos)               /**< (HSMCI_SR) Response CRC Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RCRCE                      HSMCI_SR_RCRCE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RCRCE_Msk instead */
+#define HSMCI_SR_RENDE_Pos                  19                                             /**< (HSMCI_SR) Response End Bit Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RENDE_Msk                  (_U_(0x1) << HSMCI_SR_RENDE_Pos)               /**< (HSMCI_SR) Response End Bit Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RENDE                      HSMCI_SR_RENDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RENDE_Msk instead */
+#define HSMCI_SR_RTOE_Pos                   20                                             /**< (HSMCI_SR) Response Time-out Error (cleared by writing in HSMCI_CMDR) Position */
+#define HSMCI_SR_RTOE_Msk                   (_U_(0x1) << HSMCI_SR_RTOE_Pos)                /**< (HSMCI_SR) Response Time-out Error (cleared by writing in HSMCI_CMDR) Mask */
+#define HSMCI_SR_RTOE                       HSMCI_SR_RTOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_RTOE_Msk instead */
+#define HSMCI_SR_DCRCE_Pos                  21                                             /**< (HSMCI_SR) Data CRC Error (cleared on read) Position */
+#define HSMCI_SR_DCRCE_Msk                  (_U_(0x1) << HSMCI_SR_DCRCE_Pos)               /**< (HSMCI_SR) Data CRC Error (cleared on read) Mask */
+#define HSMCI_SR_DCRCE                      HSMCI_SR_DCRCE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DCRCE_Msk instead */
+#define HSMCI_SR_DTOE_Pos                   22                                             /**< (HSMCI_SR) Data Time-out Error (cleared on read) Position */
+#define HSMCI_SR_DTOE_Msk                   (_U_(0x1) << HSMCI_SR_DTOE_Pos)                /**< (HSMCI_SR) Data Time-out Error (cleared on read) Mask */
+#define HSMCI_SR_DTOE                       HSMCI_SR_DTOE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_DTOE_Msk instead */
+#define HSMCI_SR_CSTOE_Pos                  23                                             /**< (HSMCI_SR) Completion Signal Time-out Error (cleared on read) Position */
+#define HSMCI_SR_CSTOE_Msk                  (_U_(0x1) << HSMCI_SR_CSTOE_Pos)               /**< (HSMCI_SR) Completion Signal Time-out Error (cleared on read) Mask */
+#define HSMCI_SR_CSTOE                      HSMCI_SR_CSTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_CSTOE_Msk instead */
+#define HSMCI_SR_BLKOVRE_Pos                24                                             /**< (HSMCI_SR) DMA Block Overrun Error (cleared on read) Position */
+#define HSMCI_SR_BLKOVRE_Msk                (_U_(0x1) << HSMCI_SR_BLKOVRE_Pos)             /**< (HSMCI_SR) DMA Block Overrun Error (cleared on read) Mask */
+#define HSMCI_SR_BLKOVRE                    HSMCI_SR_BLKOVRE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_BLKOVRE_Msk instead */
+#define HSMCI_SR_FIFOEMPTY_Pos              26                                             /**< (HSMCI_SR) FIFO empty flag Position */
+#define HSMCI_SR_FIFOEMPTY_Msk              (_U_(0x1) << HSMCI_SR_FIFOEMPTY_Pos)           /**< (HSMCI_SR) FIFO empty flag Mask */
+#define HSMCI_SR_FIFOEMPTY                  HSMCI_SR_FIFOEMPTY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_FIFOEMPTY_Msk instead */
+#define HSMCI_SR_XFRDONE_Pos                27                                             /**< (HSMCI_SR) Transfer Done flag Position */
+#define HSMCI_SR_XFRDONE_Msk                (_U_(0x1) << HSMCI_SR_XFRDONE_Pos)             /**< (HSMCI_SR) Transfer Done flag Mask */
+#define HSMCI_SR_XFRDONE                    HSMCI_SR_XFRDONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_XFRDONE_Msk instead */
+#define HSMCI_SR_ACKRCV_Pos                 28                                             /**< (HSMCI_SR) Boot Operation Acknowledge Received (cleared on read) Position */
+#define HSMCI_SR_ACKRCV_Msk                 (_U_(0x1) << HSMCI_SR_ACKRCV_Pos)              /**< (HSMCI_SR) Boot Operation Acknowledge Received (cleared on read) Mask */
+#define HSMCI_SR_ACKRCV                     HSMCI_SR_ACKRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_ACKRCV_Msk instead */
+#define HSMCI_SR_ACKRCVE_Pos                29                                             /**< (HSMCI_SR) Boot Operation Acknowledge Error (cleared on read) Position */
+#define HSMCI_SR_ACKRCVE_Msk                (_U_(0x1) << HSMCI_SR_ACKRCVE_Pos)             /**< (HSMCI_SR) Boot Operation Acknowledge Error (cleared on read) Mask */
+#define HSMCI_SR_ACKRCVE                    HSMCI_SR_ACKRCVE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_ACKRCVE_Msk instead */
+#define HSMCI_SR_OVRE_Pos                   30                                             /**< (HSMCI_SR) Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Position */
+#define HSMCI_SR_OVRE_Msk                   (_U_(0x1) << HSMCI_SR_OVRE_Pos)                /**< (HSMCI_SR) Overrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Mask */
+#define HSMCI_SR_OVRE                       HSMCI_SR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_OVRE_Msk instead */
+#define HSMCI_SR_UNRE_Pos                   31                                             /**< (HSMCI_SR) Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Position */
+#define HSMCI_SR_UNRE_Msk                   (_U_(0x1) << HSMCI_SR_UNRE_Pos)                /**< (HSMCI_SR) Underrun (if FERRCTRL = 1, cleared by writing in HSMCI_CMDR or cleared on read if FERRCTRL = 0) Mask */
+#define HSMCI_SR_UNRE                       HSMCI_SR_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_SR_UNRE_Msk instead */
+#define HSMCI_SR_MASK                       _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_SR) Register MASK  (Use HSMCI_SR_Msk instead)  */
+#define HSMCI_SR_Msk                        _U_(0xFDFF313F)                                /**< (HSMCI_SR) Register Mask  */
+
+
+/* -------- HSMCI_IER : (HSMCI Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Enable           */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Enable          */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Enable          */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Enable        */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Enable */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Enable           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Enable */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Enable */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal Received Interrupt Enable */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Enable    */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Enable */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Enable      */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Enable  */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Enable */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Enable          */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Enable     */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Timeout Error Interrupt Enable */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Enable */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty Interrupt enable              */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt enable           */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Acknowledge Interrupt Enable        */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Acknowledge Error Interrupt Enable  */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Enable                 */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Enable                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IER_OFFSET                    (0x44)                                        /**<  (HSMCI_IER) Interrupt Enable Register  Offset */
+
+#define HSMCI_IER_CMDRDY_Pos                0                                              /**< (HSMCI_IER) Command Ready Interrupt Enable Position */
+#define HSMCI_IER_CMDRDY_Msk                (_U_(0x1) << HSMCI_IER_CMDRDY_Pos)             /**< (HSMCI_IER) Command Ready Interrupt Enable Mask */
+#define HSMCI_IER_CMDRDY                    HSMCI_IER_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CMDRDY_Msk instead */
+#define HSMCI_IER_RXRDY_Pos                 1                                              /**< (HSMCI_IER) Receiver Ready Interrupt Enable Position */
+#define HSMCI_IER_RXRDY_Msk                 (_U_(0x1) << HSMCI_IER_RXRDY_Pos)              /**< (HSMCI_IER) Receiver Ready Interrupt Enable Mask */
+#define HSMCI_IER_RXRDY                     HSMCI_IER_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RXRDY_Msk instead */
+#define HSMCI_IER_TXRDY_Pos                 2                                              /**< (HSMCI_IER) Transmit Ready Interrupt Enable Position */
+#define HSMCI_IER_TXRDY_Msk                 (_U_(0x1) << HSMCI_IER_TXRDY_Pos)              /**< (HSMCI_IER) Transmit Ready Interrupt Enable Mask */
+#define HSMCI_IER_TXRDY                     HSMCI_IER_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_TXRDY_Msk instead */
+#define HSMCI_IER_BLKE_Pos                  3                                              /**< (HSMCI_IER) Data Block Ended Interrupt Enable Position */
+#define HSMCI_IER_BLKE_Msk                  (_U_(0x1) << HSMCI_IER_BLKE_Pos)               /**< (HSMCI_IER) Data Block Ended Interrupt Enable Mask */
+#define HSMCI_IER_BLKE                      HSMCI_IER_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_BLKE_Msk instead */
+#define HSMCI_IER_DTIP_Pos                  4                                              /**< (HSMCI_IER) Data Transfer in Progress Interrupt Enable Position */
+#define HSMCI_IER_DTIP_Msk                  (_U_(0x1) << HSMCI_IER_DTIP_Pos)               /**< (HSMCI_IER) Data Transfer in Progress Interrupt Enable Mask */
+#define HSMCI_IER_DTIP                      HSMCI_IER_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DTIP_Msk instead */
+#define HSMCI_IER_NOTBUSY_Pos               5                                              /**< (HSMCI_IER) Data Not Busy Interrupt Enable Position */
+#define HSMCI_IER_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IER_NOTBUSY_Pos)            /**< (HSMCI_IER) Data Not Busy Interrupt Enable Mask */
+#define HSMCI_IER_NOTBUSY                   HSMCI_IER_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_NOTBUSY_Msk instead */
+#define HSMCI_IER_SDIOIRQA_Pos              8                                              /**< (HSMCI_IER) SDIO Interrupt for Slot A Interrupt Enable Position */
+#define HSMCI_IER_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IER_SDIOIRQA_Pos)           /**< (HSMCI_IER) SDIO Interrupt for Slot A Interrupt Enable Mask */
+#define HSMCI_IER_SDIOIRQA                  HSMCI_IER_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_SDIOIRQA_Msk instead */
+#define HSMCI_IER_SDIOWAIT_Pos              12                                             /**< (HSMCI_IER) SDIO Read Wait Operation Status Interrupt Enable Position */
+#define HSMCI_IER_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IER_SDIOWAIT_Pos)           /**< (HSMCI_IER) SDIO Read Wait Operation Status Interrupt Enable Mask */
+#define HSMCI_IER_SDIOWAIT                  HSMCI_IER_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_SDIOWAIT_Msk instead */
+#define HSMCI_IER_CSRCV_Pos                 13                                             /**< (HSMCI_IER) Completion Signal Received Interrupt Enable Position */
+#define HSMCI_IER_CSRCV_Msk                 (_U_(0x1) << HSMCI_IER_CSRCV_Pos)              /**< (HSMCI_IER) Completion Signal Received Interrupt Enable Mask */
+#define HSMCI_IER_CSRCV                     HSMCI_IER_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CSRCV_Msk instead */
+#define HSMCI_IER_RINDE_Pos                 16                                             /**< (HSMCI_IER) Response Index Error Interrupt Enable Position */
+#define HSMCI_IER_RINDE_Msk                 (_U_(0x1) << HSMCI_IER_RINDE_Pos)              /**< (HSMCI_IER) Response Index Error Interrupt Enable Mask */
+#define HSMCI_IER_RINDE                     HSMCI_IER_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RINDE_Msk instead */
+#define HSMCI_IER_RDIRE_Pos                 17                                             /**< (HSMCI_IER) Response Direction Error Interrupt Enable Position */
+#define HSMCI_IER_RDIRE_Msk                 (_U_(0x1) << HSMCI_IER_RDIRE_Pos)              /**< (HSMCI_IER) Response Direction Error Interrupt Enable Mask */
+#define HSMCI_IER_RDIRE                     HSMCI_IER_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RDIRE_Msk instead */
+#define HSMCI_IER_RCRCE_Pos                 18                                             /**< (HSMCI_IER) Response CRC Error Interrupt Enable Position */
+#define HSMCI_IER_RCRCE_Msk                 (_U_(0x1) << HSMCI_IER_RCRCE_Pos)              /**< (HSMCI_IER) Response CRC Error Interrupt Enable Mask */
+#define HSMCI_IER_RCRCE                     HSMCI_IER_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RCRCE_Msk instead */
+#define HSMCI_IER_RENDE_Pos                 19                                             /**< (HSMCI_IER) Response End Bit Error Interrupt Enable Position */
+#define HSMCI_IER_RENDE_Msk                 (_U_(0x1) << HSMCI_IER_RENDE_Pos)              /**< (HSMCI_IER) Response End Bit Error Interrupt Enable Mask */
+#define HSMCI_IER_RENDE                     HSMCI_IER_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RENDE_Msk instead */
+#define HSMCI_IER_RTOE_Pos                  20                                             /**< (HSMCI_IER) Response Time-out Error Interrupt Enable Position */
+#define HSMCI_IER_RTOE_Msk                  (_U_(0x1) << HSMCI_IER_RTOE_Pos)               /**< (HSMCI_IER) Response Time-out Error Interrupt Enable Mask */
+#define HSMCI_IER_RTOE                      HSMCI_IER_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_RTOE_Msk instead */
+#define HSMCI_IER_DCRCE_Pos                 21                                             /**< (HSMCI_IER) Data CRC Error Interrupt Enable Position */
+#define HSMCI_IER_DCRCE_Msk                 (_U_(0x1) << HSMCI_IER_DCRCE_Pos)              /**< (HSMCI_IER) Data CRC Error Interrupt Enable Mask */
+#define HSMCI_IER_DCRCE                     HSMCI_IER_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DCRCE_Msk instead */
+#define HSMCI_IER_DTOE_Pos                  22                                             /**< (HSMCI_IER) Data Time-out Error Interrupt Enable Position */
+#define HSMCI_IER_DTOE_Msk                  (_U_(0x1) << HSMCI_IER_DTOE_Pos)               /**< (HSMCI_IER) Data Time-out Error Interrupt Enable Mask */
+#define HSMCI_IER_DTOE                      HSMCI_IER_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_DTOE_Msk instead */
+#define HSMCI_IER_CSTOE_Pos                 23                                             /**< (HSMCI_IER) Completion Signal Timeout Error Interrupt Enable Position */
+#define HSMCI_IER_CSTOE_Msk                 (_U_(0x1) << HSMCI_IER_CSTOE_Pos)              /**< (HSMCI_IER) Completion Signal Timeout Error Interrupt Enable Mask */
+#define HSMCI_IER_CSTOE                     HSMCI_IER_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_CSTOE_Msk instead */
+#define HSMCI_IER_BLKOVRE_Pos               24                                             /**< (HSMCI_IER) DMA Block Overrun Error Interrupt Enable Position */
+#define HSMCI_IER_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IER_BLKOVRE_Pos)            /**< (HSMCI_IER) DMA Block Overrun Error Interrupt Enable Mask */
+#define HSMCI_IER_BLKOVRE                   HSMCI_IER_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_BLKOVRE_Msk instead */
+#define HSMCI_IER_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IER) FIFO empty Interrupt enable Position */
+#define HSMCI_IER_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IER_FIFOEMPTY_Pos)          /**< (HSMCI_IER) FIFO empty Interrupt enable Mask */
+#define HSMCI_IER_FIFOEMPTY                 HSMCI_IER_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_FIFOEMPTY_Msk instead */
+#define HSMCI_IER_XFRDONE_Pos               27                                             /**< (HSMCI_IER) Transfer Done Interrupt enable Position */
+#define HSMCI_IER_XFRDONE_Msk               (_U_(0x1) << HSMCI_IER_XFRDONE_Pos)            /**< (HSMCI_IER) Transfer Done Interrupt enable Mask */
+#define HSMCI_IER_XFRDONE                   HSMCI_IER_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_XFRDONE_Msk instead */
+#define HSMCI_IER_ACKRCV_Pos                28                                             /**< (HSMCI_IER) Boot Acknowledge Interrupt Enable Position */
+#define HSMCI_IER_ACKRCV_Msk                (_U_(0x1) << HSMCI_IER_ACKRCV_Pos)             /**< (HSMCI_IER) Boot Acknowledge Interrupt Enable Mask */
+#define HSMCI_IER_ACKRCV                    HSMCI_IER_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_ACKRCV_Msk instead */
+#define HSMCI_IER_ACKRCVE_Pos               29                                             /**< (HSMCI_IER) Boot Acknowledge Error Interrupt Enable Position */
+#define HSMCI_IER_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IER_ACKRCVE_Pos)            /**< (HSMCI_IER) Boot Acknowledge Error Interrupt Enable Mask */
+#define HSMCI_IER_ACKRCVE                   HSMCI_IER_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_ACKRCVE_Msk instead */
+#define HSMCI_IER_OVRE_Pos                  30                                             /**< (HSMCI_IER) Overrun Interrupt Enable Position */
+#define HSMCI_IER_OVRE_Msk                  (_U_(0x1) << HSMCI_IER_OVRE_Pos)               /**< (HSMCI_IER) Overrun Interrupt Enable Mask */
+#define HSMCI_IER_OVRE                      HSMCI_IER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_OVRE_Msk instead */
+#define HSMCI_IER_UNRE_Pos                  31                                             /**< (HSMCI_IER) Underrun Interrupt Enable Position */
+#define HSMCI_IER_UNRE_Msk                  (_U_(0x1) << HSMCI_IER_UNRE_Pos)               /**< (HSMCI_IER) Underrun Interrupt Enable Mask */
+#define HSMCI_IER_UNRE                      HSMCI_IER_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IER_UNRE_Msk instead */
+#define HSMCI_IER_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IER) Register MASK  (Use HSMCI_IER_Msk instead)  */
+#define HSMCI_IER_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IER) Register Mask  */
+
+
+/* -------- HSMCI_IDR : (HSMCI Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Disable          */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Disable         */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Disable         */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Disable       */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Disable */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Disable          */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Disable */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Disable */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal received interrupt Disable */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Disable   */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Disable */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Disable     */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Disable */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Disable */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Disable         */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Disable    */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time out Error Interrupt Disable */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Disable */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO empty Interrupt Disable             */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt Disable          */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Acknowledge Interrupt Disable       */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Acknowledge Error Interrupt Disable */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Disable                */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Disable               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IDR_OFFSET                    (0x48)                                        /**<  (HSMCI_IDR) Interrupt Disable Register  Offset */
+
+#define HSMCI_IDR_CMDRDY_Pos                0                                              /**< (HSMCI_IDR) Command Ready Interrupt Disable Position */
+#define HSMCI_IDR_CMDRDY_Msk                (_U_(0x1) << HSMCI_IDR_CMDRDY_Pos)             /**< (HSMCI_IDR) Command Ready Interrupt Disable Mask */
+#define HSMCI_IDR_CMDRDY                    HSMCI_IDR_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CMDRDY_Msk instead */
+#define HSMCI_IDR_RXRDY_Pos                 1                                              /**< (HSMCI_IDR) Receiver Ready Interrupt Disable Position */
+#define HSMCI_IDR_RXRDY_Msk                 (_U_(0x1) << HSMCI_IDR_RXRDY_Pos)              /**< (HSMCI_IDR) Receiver Ready Interrupt Disable Mask */
+#define HSMCI_IDR_RXRDY                     HSMCI_IDR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RXRDY_Msk instead */
+#define HSMCI_IDR_TXRDY_Pos                 2                                              /**< (HSMCI_IDR) Transmit Ready Interrupt Disable Position */
+#define HSMCI_IDR_TXRDY_Msk                 (_U_(0x1) << HSMCI_IDR_TXRDY_Pos)              /**< (HSMCI_IDR) Transmit Ready Interrupt Disable Mask */
+#define HSMCI_IDR_TXRDY                     HSMCI_IDR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_TXRDY_Msk instead */
+#define HSMCI_IDR_BLKE_Pos                  3                                              /**< (HSMCI_IDR) Data Block Ended Interrupt Disable Position */
+#define HSMCI_IDR_BLKE_Msk                  (_U_(0x1) << HSMCI_IDR_BLKE_Pos)               /**< (HSMCI_IDR) Data Block Ended Interrupt Disable Mask */
+#define HSMCI_IDR_BLKE                      HSMCI_IDR_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_BLKE_Msk instead */
+#define HSMCI_IDR_DTIP_Pos                  4                                              /**< (HSMCI_IDR) Data Transfer in Progress Interrupt Disable Position */
+#define HSMCI_IDR_DTIP_Msk                  (_U_(0x1) << HSMCI_IDR_DTIP_Pos)               /**< (HSMCI_IDR) Data Transfer in Progress Interrupt Disable Mask */
+#define HSMCI_IDR_DTIP                      HSMCI_IDR_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DTIP_Msk instead */
+#define HSMCI_IDR_NOTBUSY_Pos               5                                              /**< (HSMCI_IDR) Data Not Busy Interrupt Disable Position */
+#define HSMCI_IDR_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IDR_NOTBUSY_Pos)            /**< (HSMCI_IDR) Data Not Busy Interrupt Disable Mask */
+#define HSMCI_IDR_NOTBUSY                   HSMCI_IDR_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_NOTBUSY_Msk instead */
+#define HSMCI_IDR_SDIOIRQA_Pos              8                                              /**< (HSMCI_IDR) SDIO Interrupt for Slot A Interrupt Disable Position */
+#define HSMCI_IDR_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IDR_SDIOIRQA_Pos)           /**< (HSMCI_IDR) SDIO Interrupt for Slot A Interrupt Disable Mask */
+#define HSMCI_IDR_SDIOIRQA                  HSMCI_IDR_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_SDIOIRQA_Msk instead */
+#define HSMCI_IDR_SDIOWAIT_Pos              12                                             /**< (HSMCI_IDR) SDIO Read Wait Operation Status Interrupt Disable Position */
+#define HSMCI_IDR_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IDR_SDIOWAIT_Pos)           /**< (HSMCI_IDR) SDIO Read Wait Operation Status Interrupt Disable Mask */
+#define HSMCI_IDR_SDIOWAIT                  HSMCI_IDR_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_SDIOWAIT_Msk instead */
+#define HSMCI_IDR_CSRCV_Pos                 13                                             /**< (HSMCI_IDR) Completion Signal received interrupt Disable Position */
+#define HSMCI_IDR_CSRCV_Msk                 (_U_(0x1) << HSMCI_IDR_CSRCV_Pos)              /**< (HSMCI_IDR) Completion Signal received interrupt Disable Mask */
+#define HSMCI_IDR_CSRCV                     HSMCI_IDR_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CSRCV_Msk instead */
+#define HSMCI_IDR_RINDE_Pos                 16                                             /**< (HSMCI_IDR) Response Index Error Interrupt Disable Position */
+#define HSMCI_IDR_RINDE_Msk                 (_U_(0x1) << HSMCI_IDR_RINDE_Pos)              /**< (HSMCI_IDR) Response Index Error Interrupt Disable Mask */
+#define HSMCI_IDR_RINDE                     HSMCI_IDR_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RINDE_Msk instead */
+#define HSMCI_IDR_RDIRE_Pos                 17                                             /**< (HSMCI_IDR) Response Direction Error Interrupt Disable Position */
+#define HSMCI_IDR_RDIRE_Msk                 (_U_(0x1) << HSMCI_IDR_RDIRE_Pos)              /**< (HSMCI_IDR) Response Direction Error Interrupt Disable Mask */
+#define HSMCI_IDR_RDIRE                     HSMCI_IDR_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RDIRE_Msk instead */
+#define HSMCI_IDR_RCRCE_Pos                 18                                             /**< (HSMCI_IDR) Response CRC Error Interrupt Disable Position */
+#define HSMCI_IDR_RCRCE_Msk                 (_U_(0x1) << HSMCI_IDR_RCRCE_Pos)              /**< (HSMCI_IDR) Response CRC Error Interrupt Disable Mask */
+#define HSMCI_IDR_RCRCE                     HSMCI_IDR_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RCRCE_Msk instead */
+#define HSMCI_IDR_RENDE_Pos                 19                                             /**< (HSMCI_IDR) Response End Bit Error Interrupt Disable Position */
+#define HSMCI_IDR_RENDE_Msk                 (_U_(0x1) << HSMCI_IDR_RENDE_Pos)              /**< (HSMCI_IDR) Response End Bit Error Interrupt Disable Mask */
+#define HSMCI_IDR_RENDE                     HSMCI_IDR_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RENDE_Msk instead */
+#define HSMCI_IDR_RTOE_Pos                  20                                             /**< (HSMCI_IDR) Response Time-out Error Interrupt Disable Position */
+#define HSMCI_IDR_RTOE_Msk                  (_U_(0x1) << HSMCI_IDR_RTOE_Pos)               /**< (HSMCI_IDR) Response Time-out Error Interrupt Disable Mask */
+#define HSMCI_IDR_RTOE                      HSMCI_IDR_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_RTOE_Msk instead */
+#define HSMCI_IDR_DCRCE_Pos                 21                                             /**< (HSMCI_IDR) Data CRC Error Interrupt Disable Position */
+#define HSMCI_IDR_DCRCE_Msk                 (_U_(0x1) << HSMCI_IDR_DCRCE_Pos)              /**< (HSMCI_IDR) Data CRC Error Interrupt Disable Mask */
+#define HSMCI_IDR_DCRCE                     HSMCI_IDR_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DCRCE_Msk instead */
+#define HSMCI_IDR_DTOE_Pos                  22                                             /**< (HSMCI_IDR) Data Time-out Error Interrupt Disable Position */
+#define HSMCI_IDR_DTOE_Msk                  (_U_(0x1) << HSMCI_IDR_DTOE_Pos)               /**< (HSMCI_IDR) Data Time-out Error Interrupt Disable Mask */
+#define HSMCI_IDR_DTOE                      HSMCI_IDR_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_DTOE_Msk instead */
+#define HSMCI_IDR_CSTOE_Pos                 23                                             /**< (HSMCI_IDR) Completion Signal Time out Error Interrupt Disable Position */
+#define HSMCI_IDR_CSTOE_Msk                 (_U_(0x1) << HSMCI_IDR_CSTOE_Pos)              /**< (HSMCI_IDR) Completion Signal Time out Error Interrupt Disable Mask */
+#define HSMCI_IDR_CSTOE                     HSMCI_IDR_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_CSTOE_Msk instead */
+#define HSMCI_IDR_BLKOVRE_Pos               24                                             /**< (HSMCI_IDR) DMA Block Overrun Error Interrupt Disable Position */
+#define HSMCI_IDR_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IDR_BLKOVRE_Pos)            /**< (HSMCI_IDR) DMA Block Overrun Error Interrupt Disable Mask */
+#define HSMCI_IDR_BLKOVRE                   HSMCI_IDR_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_BLKOVRE_Msk instead */
+#define HSMCI_IDR_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IDR) FIFO empty Interrupt Disable Position */
+#define HSMCI_IDR_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IDR_FIFOEMPTY_Pos)          /**< (HSMCI_IDR) FIFO empty Interrupt Disable Mask */
+#define HSMCI_IDR_FIFOEMPTY                 HSMCI_IDR_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_FIFOEMPTY_Msk instead */
+#define HSMCI_IDR_XFRDONE_Pos               27                                             /**< (HSMCI_IDR) Transfer Done Interrupt Disable Position */
+#define HSMCI_IDR_XFRDONE_Msk               (_U_(0x1) << HSMCI_IDR_XFRDONE_Pos)            /**< (HSMCI_IDR) Transfer Done Interrupt Disable Mask */
+#define HSMCI_IDR_XFRDONE                   HSMCI_IDR_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_XFRDONE_Msk instead */
+#define HSMCI_IDR_ACKRCV_Pos                28                                             /**< (HSMCI_IDR) Boot Acknowledge Interrupt Disable Position */
+#define HSMCI_IDR_ACKRCV_Msk                (_U_(0x1) << HSMCI_IDR_ACKRCV_Pos)             /**< (HSMCI_IDR) Boot Acknowledge Interrupt Disable Mask */
+#define HSMCI_IDR_ACKRCV                    HSMCI_IDR_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_ACKRCV_Msk instead */
+#define HSMCI_IDR_ACKRCVE_Pos               29                                             /**< (HSMCI_IDR) Boot Acknowledge Error Interrupt Disable Position */
+#define HSMCI_IDR_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IDR_ACKRCVE_Pos)            /**< (HSMCI_IDR) Boot Acknowledge Error Interrupt Disable Mask */
+#define HSMCI_IDR_ACKRCVE                   HSMCI_IDR_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_ACKRCVE_Msk instead */
+#define HSMCI_IDR_OVRE_Pos                  30                                             /**< (HSMCI_IDR) Overrun Interrupt Disable Position */
+#define HSMCI_IDR_OVRE_Msk                  (_U_(0x1) << HSMCI_IDR_OVRE_Pos)               /**< (HSMCI_IDR) Overrun Interrupt Disable Mask */
+#define HSMCI_IDR_OVRE                      HSMCI_IDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_OVRE_Msk instead */
+#define HSMCI_IDR_UNRE_Pos                  31                                             /**< (HSMCI_IDR) Underrun Interrupt Disable Position */
+#define HSMCI_IDR_UNRE_Msk                  (_U_(0x1) << HSMCI_IDR_UNRE_Pos)               /**< (HSMCI_IDR) Underrun Interrupt Disable Mask */
+#define HSMCI_IDR_UNRE                      HSMCI_IDR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IDR_UNRE_Msk instead */
+#define HSMCI_IDR_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IDR) Register MASK  (Use HSMCI_IDR_Msk instead)  */
+#define HSMCI_IDR_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IDR) Register Mask  */
+
+
+/* -------- HSMCI_IMR : (HSMCI Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Mask             */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Mask            */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Ready Interrupt Mask            */
+    uint32_t BLKE:1;                    /**< bit:      3  Data Block Ended Interrupt Mask          */
+    uint32_t DTIP:1;                    /**< bit:      4  Data Transfer in Progress Interrupt Mask */
+    uint32_t NOTBUSY:1;                 /**< bit:      5  Data Not Busy Interrupt Mask             */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t SDIOIRQA:1;                /**< bit:      8  SDIO Interrupt for Slot A Interrupt Mask */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t SDIOWAIT:1;                /**< bit:     12  SDIO Read Wait Operation Status Interrupt Mask */
+    uint32_t CSRCV:1;                   /**< bit:     13  Completion Signal Received Interrupt Mask */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RINDE:1;                   /**< bit:     16  Response Index Error Interrupt Mask      */
+    uint32_t RDIRE:1;                   /**< bit:     17  Response Direction Error Interrupt Mask  */
+    uint32_t RCRCE:1;                   /**< bit:     18  Response CRC Error Interrupt Mask        */
+    uint32_t RENDE:1;                   /**< bit:     19  Response End Bit Error Interrupt Mask    */
+    uint32_t RTOE:1;                    /**< bit:     20  Response Time-out Error Interrupt Mask   */
+    uint32_t DCRCE:1;                   /**< bit:     21  Data CRC Error Interrupt Mask            */
+    uint32_t DTOE:1;                    /**< bit:     22  Data Time-out Error Interrupt Mask       */
+    uint32_t CSTOE:1;                   /**< bit:     23  Completion Signal Time-out Error Interrupt Mask */
+    uint32_t BLKOVRE:1;                 /**< bit:     24  DMA Block Overrun Error Interrupt Mask   */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t FIFOEMPTY:1;               /**< bit:     26  FIFO Empty Interrupt Mask                */
+    uint32_t XFRDONE:1;                 /**< bit:     27  Transfer Done Interrupt Mask             */
+    uint32_t ACKRCV:1;                  /**< bit:     28  Boot Operation Acknowledge Received Interrupt Mask */
+    uint32_t ACKRCVE:1;                 /**< bit:     29  Boot Operation Acknowledge Error Interrupt Mask */
+    uint32_t OVRE:1;                    /**< bit:     30  Overrun Interrupt Mask                   */
+    uint32_t UNRE:1;                    /**< bit:     31  Underrun Interrupt Mask                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_IMR_OFFSET                    (0x4C)                                        /**<  (HSMCI_IMR) Interrupt Mask Register  Offset */
+
+#define HSMCI_IMR_CMDRDY_Pos                0                                              /**< (HSMCI_IMR) Command Ready Interrupt Mask Position */
+#define HSMCI_IMR_CMDRDY_Msk                (_U_(0x1) << HSMCI_IMR_CMDRDY_Pos)             /**< (HSMCI_IMR) Command Ready Interrupt Mask Mask */
+#define HSMCI_IMR_CMDRDY                    HSMCI_IMR_CMDRDY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CMDRDY_Msk instead */
+#define HSMCI_IMR_RXRDY_Pos                 1                                              /**< (HSMCI_IMR) Receiver Ready Interrupt Mask Position */
+#define HSMCI_IMR_RXRDY_Msk                 (_U_(0x1) << HSMCI_IMR_RXRDY_Pos)              /**< (HSMCI_IMR) Receiver Ready Interrupt Mask Mask */
+#define HSMCI_IMR_RXRDY                     HSMCI_IMR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RXRDY_Msk instead */
+#define HSMCI_IMR_TXRDY_Pos                 2                                              /**< (HSMCI_IMR) Transmit Ready Interrupt Mask Position */
+#define HSMCI_IMR_TXRDY_Msk                 (_U_(0x1) << HSMCI_IMR_TXRDY_Pos)              /**< (HSMCI_IMR) Transmit Ready Interrupt Mask Mask */
+#define HSMCI_IMR_TXRDY                     HSMCI_IMR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_TXRDY_Msk instead */
+#define HSMCI_IMR_BLKE_Pos                  3                                              /**< (HSMCI_IMR) Data Block Ended Interrupt Mask Position */
+#define HSMCI_IMR_BLKE_Msk                  (_U_(0x1) << HSMCI_IMR_BLKE_Pos)               /**< (HSMCI_IMR) Data Block Ended Interrupt Mask Mask */
+#define HSMCI_IMR_BLKE                      HSMCI_IMR_BLKE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_BLKE_Msk instead */
+#define HSMCI_IMR_DTIP_Pos                  4                                              /**< (HSMCI_IMR) Data Transfer in Progress Interrupt Mask Position */
+#define HSMCI_IMR_DTIP_Msk                  (_U_(0x1) << HSMCI_IMR_DTIP_Pos)               /**< (HSMCI_IMR) Data Transfer in Progress Interrupt Mask Mask */
+#define HSMCI_IMR_DTIP                      HSMCI_IMR_DTIP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DTIP_Msk instead */
+#define HSMCI_IMR_NOTBUSY_Pos               5                                              /**< (HSMCI_IMR) Data Not Busy Interrupt Mask Position */
+#define HSMCI_IMR_NOTBUSY_Msk               (_U_(0x1) << HSMCI_IMR_NOTBUSY_Pos)            /**< (HSMCI_IMR) Data Not Busy Interrupt Mask Mask */
+#define HSMCI_IMR_NOTBUSY                   HSMCI_IMR_NOTBUSY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_NOTBUSY_Msk instead */
+#define HSMCI_IMR_SDIOIRQA_Pos              8                                              /**< (HSMCI_IMR) SDIO Interrupt for Slot A Interrupt Mask Position */
+#define HSMCI_IMR_SDIOIRQA_Msk              (_U_(0x1) << HSMCI_IMR_SDIOIRQA_Pos)           /**< (HSMCI_IMR) SDIO Interrupt for Slot A Interrupt Mask Mask */
+#define HSMCI_IMR_SDIOIRQA                  HSMCI_IMR_SDIOIRQA_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_SDIOIRQA_Msk instead */
+#define HSMCI_IMR_SDIOWAIT_Pos              12                                             /**< (HSMCI_IMR) SDIO Read Wait Operation Status Interrupt Mask Position */
+#define HSMCI_IMR_SDIOWAIT_Msk              (_U_(0x1) << HSMCI_IMR_SDIOWAIT_Pos)           /**< (HSMCI_IMR) SDIO Read Wait Operation Status Interrupt Mask Mask */
+#define HSMCI_IMR_SDIOWAIT                  HSMCI_IMR_SDIOWAIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_SDIOWAIT_Msk instead */
+#define HSMCI_IMR_CSRCV_Pos                 13                                             /**< (HSMCI_IMR) Completion Signal Received Interrupt Mask Position */
+#define HSMCI_IMR_CSRCV_Msk                 (_U_(0x1) << HSMCI_IMR_CSRCV_Pos)              /**< (HSMCI_IMR) Completion Signal Received Interrupt Mask Mask */
+#define HSMCI_IMR_CSRCV                     HSMCI_IMR_CSRCV_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CSRCV_Msk instead */
+#define HSMCI_IMR_RINDE_Pos                 16                                             /**< (HSMCI_IMR) Response Index Error Interrupt Mask Position */
+#define HSMCI_IMR_RINDE_Msk                 (_U_(0x1) << HSMCI_IMR_RINDE_Pos)              /**< (HSMCI_IMR) Response Index Error Interrupt Mask Mask */
+#define HSMCI_IMR_RINDE                     HSMCI_IMR_RINDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RINDE_Msk instead */
+#define HSMCI_IMR_RDIRE_Pos                 17                                             /**< (HSMCI_IMR) Response Direction Error Interrupt Mask Position */
+#define HSMCI_IMR_RDIRE_Msk                 (_U_(0x1) << HSMCI_IMR_RDIRE_Pos)              /**< (HSMCI_IMR) Response Direction Error Interrupt Mask Mask */
+#define HSMCI_IMR_RDIRE                     HSMCI_IMR_RDIRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RDIRE_Msk instead */
+#define HSMCI_IMR_RCRCE_Pos                 18                                             /**< (HSMCI_IMR) Response CRC Error Interrupt Mask Position */
+#define HSMCI_IMR_RCRCE_Msk                 (_U_(0x1) << HSMCI_IMR_RCRCE_Pos)              /**< (HSMCI_IMR) Response CRC Error Interrupt Mask Mask */
+#define HSMCI_IMR_RCRCE                     HSMCI_IMR_RCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RCRCE_Msk instead */
+#define HSMCI_IMR_RENDE_Pos                 19                                             /**< (HSMCI_IMR) Response End Bit Error Interrupt Mask Position */
+#define HSMCI_IMR_RENDE_Msk                 (_U_(0x1) << HSMCI_IMR_RENDE_Pos)              /**< (HSMCI_IMR) Response End Bit Error Interrupt Mask Mask */
+#define HSMCI_IMR_RENDE                     HSMCI_IMR_RENDE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RENDE_Msk instead */
+#define HSMCI_IMR_RTOE_Pos                  20                                             /**< (HSMCI_IMR) Response Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_RTOE_Msk                  (_U_(0x1) << HSMCI_IMR_RTOE_Pos)               /**< (HSMCI_IMR) Response Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_RTOE                      HSMCI_IMR_RTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_RTOE_Msk instead */
+#define HSMCI_IMR_DCRCE_Pos                 21                                             /**< (HSMCI_IMR) Data CRC Error Interrupt Mask Position */
+#define HSMCI_IMR_DCRCE_Msk                 (_U_(0x1) << HSMCI_IMR_DCRCE_Pos)              /**< (HSMCI_IMR) Data CRC Error Interrupt Mask Mask */
+#define HSMCI_IMR_DCRCE                     HSMCI_IMR_DCRCE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DCRCE_Msk instead */
+#define HSMCI_IMR_DTOE_Pos                  22                                             /**< (HSMCI_IMR) Data Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_DTOE_Msk                  (_U_(0x1) << HSMCI_IMR_DTOE_Pos)               /**< (HSMCI_IMR) Data Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_DTOE                      HSMCI_IMR_DTOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_DTOE_Msk instead */
+#define HSMCI_IMR_CSTOE_Pos                 23                                             /**< (HSMCI_IMR) Completion Signal Time-out Error Interrupt Mask Position */
+#define HSMCI_IMR_CSTOE_Msk                 (_U_(0x1) << HSMCI_IMR_CSTOE_Pos)              /**< (HSMCI_IMR) Completion Signal Time-out Error Interrupt Mask Mask */
+#define HSMCI_IMR_CSTOE                     HSMCI_IMR_CSTOE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_CSTOE_Msk instead */
+#define HSMCI_IMR_BLKOVRE_Pos               24                                             /**< (HSMCI_IMR) DMA Block Overrun Error Interrupt Mask Position */
+#define HSMCI_IMR_BLKOVRE_Msk               (_U_(0x1) << HSMCI_IMR_BLKOVRE_Pos)            /**< (HSMCI_IMR) DMA Block Overrun Error Interrupt Mask Mask */
+#define HSMCI_IMR_BLKOVRE                   HSMCI_IMR_BLKOVRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_BLKOVRE_Msk instead */
+#define HSMCI_IMR_FIFOEMPTY_Pos             26                                             /**< (HSMCI_IMR) FIFO Empty Interrupt Mask Position */
+#define HSMCI_IMR_FIFOEMPTY_Msk             (_U_(0x1) << HSMCI_IMR_FIFOEMPTY_Pos)          /**< (HSMCI_IMR) FIFO Empty Interrupt Mask Mask */
+#define HSMCI_IMR_FIFOEMPTY                 HSMCI_IMR_FIFOEMPTY_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_FIFOEMPTY_Msk instead */
+#define HSMCI_IMR_XFRDONE_Pos               27                                             /**< (HSMCI_IMR) Transfer Done Interrupt Mask Position */
+#define HSMCI_IMR_XFRDONE_Msk               (_U_(0x1) << HSMCI_IMR_XFRDONE_Pos)            /**< (HSMCI_IMR) Transfer Done Interrupt Mask Mask */
+#define HSMCI_IMR_XFRDONE                   HSMCI_IMR_XFRDONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_XFRDONE_Msk instead */
+#define HSMCI_IMR_ACKRCV_Pos                28                                             /**< (HSMCI_IMR) Boot Operation Acknowledge Received Interrupt Mask Position */
+#define HSMCI_IMR_ACKRCV_Msk                (_U_(0x1) << HSMCI_IMR_ACKRCV_Pos)             /**< (HSMCI_IMR) Boot Operation Acknowledge Received Interrupt Mask Mask */
+#define HSMCI_IMR_ACKRCV                    HSMCI_IMR_ACKRCV_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_ACKRCV_Msk instead */
+#define HSMCI_IMR_ACKRCVE_Pos               29                                             /**< (HSMCI_IMR) Boot Operation Acknowledge Error Interrupt Mask Position */
+#define HSMCI_IMR_ACKRCVE_Msk               (_U_(0x1) << HSMCI_IMR_ACKRCVE_Pos)            /**< (HSMCI_IMR) Boot Operation Acknowledge Error Interrupt Mask Mask */
+#define HSMCI_IMR_ACKRCVE                   HSMCI_IMR_ACKRCVE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_ACKRCVE_Msk instead */
+#define HSMCI_IMR_OVRE_Pos                  30                                             /**< (HSMCI_IMR) Overrun Interrupt Mask Position */
+#define HSMCI_IMR_OVRE_Msk                  (_U_(0x1) << HSMCI_IMR_OVRE_Pos)               /**< (HSMCI_IMR) Overrun Interrupt Mask Mask */
+#define HSMCI_IMR_OVRE                      HSMCI_IMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_OVRE_Msk instead */
+#define HSMCI_IMR_UNRE_Pos                  31                                             /**< (HSMCI_IMR) Underrun Interrupt Mask Position */
+#define HSMCI_IMR_UNRE_Msk                  (_U_(0x1) << HSMCI_IMR_UNRE_Pos)               /**< (HSMCI_IMR) Underrun Interrupt Mask Mask */
+#define HSMCI_IMR_UNRE                      HSMCI_IMR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_IMR_UNRE_Msk instead */
+#define HSMCI_IMR_MASK                      _U_(0xFDFF313F)                                /**< \deprecated (HSMCI_IMR) Register MASK  (Use HSMCI_IMR_Msk instead)  */
+#define HSMCI_IMR_Msk                       _U_(0xFDFF313F)                                /**< (HSMCI_IMR) Register Mask  */
+
+
+/* -------- HSMCI_DMA : (HSMCI Offset: 0x50) (R/W 32) DMA Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CHKSIZE:3;                 /**< bit:   4..6  DMA Channel Read and Write Chunk Size    */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t DMAEN:1;                   /**< bit:      8  DMA Hardware Handshaking Enable          */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_DMA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_DMA_OFFSET                    (0x50)                                        /**<  (HSMCI_DMA) DMA Configuration Register  Offset */
+
+#define HSMCI_DMA_CHKSIZE_Pos               4                                              /**< (HSMCI_DMA) DMA Channel Read and Write Chunk Size Position */
+#define HSMCI_DMA_CHKSIZE_Msk               (_U_(0x7) << HSMCI_DMA_CHKSIZE_Pos)            /**< (HSMCI_DMA) DMA Channel Read and Write Chunk Size Mask */
+#define HSMCI_DMA_CHKSIZE(value)            (HSMCI_DMA_CHKSIZE_Msk & ((value) << HSMCI_DMA_CHKSIZE_Pos))
+#define   HSMCI_DMA_CHKSIZE_1_Val           _U_(0x0)                                       /**< (HSMCI_DMA) 1 data available  */
+#define   HSMCI_DMA_CHKSIZE_2_Val           _U_(0x1)                                       /**< (HSMCI_DMA) 2 data available  */
+#define   HSMCI_DMA_CHKSIZE_4_Val           _U_(0x2)                                       /**< (HSMCI_DMA) 4 data available  */
+#define   HSMCI_DMA_CHKSIZE_8_Val           _U_(0x3)                                       /**< (HSMCI_DMA) 8 data available  */
+#define   HSMCI_DMA_CHKSIZE_16_Val          _U_(0x4)                                       /**< (HSMCI_DMA) 16 data available  */
+#define HSMCI_DMA_CHKSIZE_1                 (HSMCI_DMA_CHKSIZE_1_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 1 data available Position  */
+#define HSMCI_DMA_CHKSIZE_2                 (HSMCI_DMA_CHKSIZE_2_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 2 data available Position  */
+#define HSMCI_DMA_CHKSIZE_4                 (HSMCI_DMA_CHKSIZE_4_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 4 data available Position  */
+#define HSMCI_DMA_CHKSIZE_8                 (HSMCI_DMA_CHKSIZE_8_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 8 data available Position  */
+#define HSMCI_DMA_CHKSIZE_16                (HSMCI_DMA_CHKSIZE_16_Val << HSMCI_DMA_CHKSIZE_Pos)  /**< (HSMCI_DMA) 16 data available Position  */
+#define HSMCI_DMA_DMAEN_Pos                 8                                              /**< (HSMCI_DMA) DMA Hardware Handshaking Enable Position */
+#define HSMCI_DMA_DMAEN_Msk                 (_U_(0x1) << HSMCI_DMA_DMAEN_Pos)              /**< (HSMCI_DMA) DMA Hardware Handshaking Enable Mask */
+#define HSMCI_DMA_DMAEN                     HSMCI_DMA_DMAEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_DMA_DMAEN_Msk instead */
+#define HSMCI_DMA_MASK                      _U_(0x170)                                     /**< \deprecated (HSMCI_DMA) Register MASK  (Use HSMCI_DMA_Msk instead)  */
+#define HSMCI_DMA_Msk                       _U_(0x170)                                     /**< (HSMCI_DMA) Register Mask  */
+
+
+/* -------- HSMCI_CFG : (HSMCI Offset: 0x54) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FIFOMODE:1;                /**< bit:      0  HSMCI Internal FIFO control mode         */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t FERRCTRL:1;                /**< bit:      4  Flow Error flag reset control mode       */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t HSMODE:1;                  /**< bit:      8  High Speed Mode                          */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t LSYNC:1;                   /**< bit:     12  Synchronize on the last block            */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_CFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_CFG_OFFSET                    (0x54)                                        /**<  (HSMCI_CFG) Configuration Register  Offset */
+
+#define HSMCI_CFG_FIFOMODE_Pos              0                                              /**< (HSMCI_CFG) HSMCI Internal FIFO control mode Position */
+#define HSMCI_CFG_FIFOMODE_Msk              (_U_(0x1) << HSMCI_CFG_FIFOMODE_Pos)           /**< (HSMCI_CFG) HSMCI Internal FIFO control mode Mask */
+#define HSMCI_CFG_FIFOMODE                  HSMCI_CFG_FIFOMODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_FIFOMODE_Msk instead */
+#define HSMCI_CFG_FERRCTRL_Pos              4                                              /**< (HSMCI_CFG) Flow Error flag reset control mode Position */
+#define HSMCI_CFG_FERRCTRL_Msk              (_U_(0x1) << HSMCI_CFG_FERRCTRL_Pos)           /**< (HSMCI_CFG) Flow Error flag reset control mode Mask */
+#define HSMCI_CFG_FERRCTRL                  HSMCI_CFG_FERRCTRL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_FERRCTRL_Msk instead */
+#define HSMCI_CFG_HSMODE_Pos                8                                              /**< (HSMCI_CFG) High Speed Mode Position */
+#define HSMCI_CFG_HSMODE_Msk                (_U_(0x1) << HSMCI_CFG_HSMODE_Pos)             /**< (HSMCI_CFG) High Speed Mode Mask */
+#define HSMCI_CFG_HSMODE                    HSMCI_CFG_HSMODE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_HSMODE_Msk instead */
+#define HSMCI_CFG_LSYNC_Pos                 12                                             /**< (HSMCI_CFG) Synchronize on the last block Position */
+#define HSMCI_CFG_LSYNC_Msk                 (_U_(0x1) << HSMCI_CFG_LSYNC_Pos)              /**< (HSMCI_CFG) Synchronize on the last block Mask */
+#define HSMCI_CFG_LSYNC                     HSMCI_CFG_LSYNC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_CFG_LSYNC_Msk instead */
+#define HSMCI_CFG_MASK                      _U_(0x1111)                                    /**< \deprecated (HSMCI_CFG) Register MASK  (Use HSMCI_CFG_Msk instead)  */
+#define HSMCI_CFG_Msk                       _U_(0x1111)                                    /**< (HSMCI_CFG) Register Mask  */
+
+
+/* -------- HSMCI_WPMR : (HSMCI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protect Key                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_WPMR_OFFSET                   (0xE4)                                        /**<  (HSMCI_WPMR) Write Protection Mode Register  Offset */
+
+#define HSMCI_WPMR_WPEN_Pos                 0                                              /**< (HSMCI_WPMR) Write Protect Enable Position */
+#define HSMCI_WPMR_WPEN_Msk                 (_U_(0x1) << HSMCI_WPMR_WPEN_Pos)              /**< (HSMCI_WPMR) Write Protect Enable Mask */
+#define HSMCI_WPMR_WPEN                     HSMCI_WPMR_WPEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_WPMR_WPEN_Msk instead */
+#define HSMCI_WPMR_WPKEY_Pos                8                                              /**< (HSMCI_WPMR) Write Protect Key Position */
+#define HSMCI_WPMR_WPKEY_Msk                (_U_(0xFFFFFF) << HSMCI_WPMR_WPKEY_Pos)        /**< (HSMCI_WPMR) Write Protect Key Mask */
+#define HSMCI_WPMR_WPKEY(value)             (HSMCI_WPMR_WPKEY_Msk & ((value) << HSMCI_WPMR_WPKEY_Pos))
+#define   HSMCI_WPMR_WPKEY_PASSWD_Val       _U_(0x4D4349)                                  /**< (HSMCI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define HSMCI_WPMR_WPKEY_PASSWD             (HSMCI_WPMR_WPKEY_PASSWD_Val << HSMCI_WPMR_WPKEY_Pos)  /**< (HSMCI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define HSMCI_WPMR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (HSMCI_WPMR) Register MASK  (Use HSMCI_WPMR_Msk instead)  */
+#define HSMCI_WPMR_Msk                      _U_(0xFFFFFF01)                                /**< (HSMCI_WPMR) Register Mask  */
+
+
+/* -------- HSMCI_WPSR : (HSMCI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_WPSR_OFFSET                   (0xE8)                                        /**<  (HSMCI_WPSR) Write Protection Status Register  Offset */
+
+#define HSMCI_WPSR_WPVS_Pos                 0                                              /**< (HSMCI_WPSR) Write Protection Violation Status Position */
+#define HSMCI_WPSR_WPVS_Msk                 (_U_(0x1) << HSMCI_WPSR_WPVS_Pos)              /**< (HSMCI_WPSR) Write Protection Violation Status Mask */
+#define HSMCI_WPSR_WPVS                     HSMCI_WPSR_WPVS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use HSMCI_WPSR_WPVS_Msk instead */
+#define HSMCI_WPSR_WPVSRC_Pos               8                                              /**< (HSMCI_WPSR) Write Protection Violation Source Position */
+#define HSMCI_WPSR_WPVSRC_Msk               (_U_(0xFFFF) << HSMCI_WPSR_WPVSRC_Pos)         /**< (HSMCI_WPSR) Write Protection Violation Source Mask */
+#define HSMCI_WPSR_WPVSRC(value)            (HSMCI_WPSR_WPVSRC_Msk & ((value) << HSMCI_WPSR_WPVSRC_Pos))
+#define HSMCI_WPSR_MASK                     _U_(0xFFFF01)                                  /**< \deprecated (HSMCI_WPSR) Register MASK  (Use HSMCI_WPSR_Msk instead)  */
+#define HSMCI_WPSR_Msk                      _U_(0xFFFF01)                                  /**< (HSMCI_WPSR) Register Mask  */
+
+
+/* -------- HSMCI_FIFO : (HSMCI Offset: 0x200) (R/W 32) FIFO Memory Aperture0 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  Data to Read or Data to Write            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} HSMCI_FIFO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HSMCI_FIFO_OFFSET                   (0x200)                                       /**<  (HSMCI_FIFO) FIFO Memory Aperture0 0  Offset */
+
+#define HSMCI_FIFO_DATA_Pos                 0                                              /**< (HSMCI_FIFO) Data to Read or Data to Write Position */
+#define HSMCI_FIFO_DATA_Msk                 (_U_(0xFFFFFFFF) << HSMCI_FIFO_DATA_Pos)       /**< (HSMCI_FIFO) Data to Read or Data to Write Mask */
+#define HSMCI_FIFO_DATA(value)              (HSMCI_FIFO_DATA_Msk & ((value) << HSMCI_FIFO_DATA_Pos))
+#define HSMCI_FIFO_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (HSMCI_FIFO) Register MASK  (Use HSMCI_FIFO_Msk instead)  */
+#define HSMCI_FIFO_Msk                      _U_(0xFFFFFFFF)                                /**< (HSMCI_FIFO) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief HSMCI hardware registers */
+typedef struct {  
+  __O  uint32_t HSMCI_CR;       /**< (HSMCI Offset: 0x00) Control Register */
+  __IO uint32_t HSMCI_MR;       /**< (HSMCI Offset: 0x04) Mode Register */
+  __IO uint32_t HSMCI_DTOR;     /**< (HSMCI Offset: 0x08) Data Timeout Register */
+  __IO uint32_t HSMCI_SDCR;     /**< (HSMCI Offset: 0x0C) SD/SDIO Card Register */
+  __IO uint32_t HSMCI_ARGR;     /**< (HSMCI Offset: 0x10) Argument Register */
+  __O  uint32_t HSMCI_CMDR;     /**< (HSMCI Offset: 0x14) Command Register */
+  __IO uint32_t HSMCI_BLKR;     /**< (HSMCI Offset: 0x18) Block Register */
+  __IO uint32_t HSMCI_CSTOR;    /**< (HSMCI Offset: 0x1C) Completion Signal Timeout Register */
+  __I  uint32_t HSMCI_RSPR[4];  /**< (HSMCI Offset: 0x20) Response Register 0 */
+  __I  uint32_t HSMCI_RDR;      /**< (HSMCI Offset: 0x30) Receive Data Register */
+  __O  uint32_t HSMCI_TDR;      /**< (HSMCI Offset: 0x34) Transmit Data Register */
+  __I  uint8_t                        Reserved1[8];
+  __I  uint32_t HSMCI_SR;       /**< (HSMCI Offset: 0x40) Status Register */
+  __O  uint32_t HSMCI_IER;      /**< (HSMCI Offset: 0x44) Interrupt Enable Register */
+  __O  uint32_t HSMCI_IDR;      /**< (HSMCI Offset: 0x48) Interrupt Disable Register */
+  __I  uint32_t HSMCI_IMR;      /**< (HSMCI Offset: 0x4C) Interrupt Mask Register */
+  __IO uint32_t HSMCI_DMA;      /**< (HSMCI Offset: 0x50) DMA Configuration Register */
+  __IO uint32_t HSMCI_CFG;      /**< (HSMCI Offset: 0x54) Configuration Register */
+  __I  uint8_t                        Reserved2[140];
+  __IO uint32_t HSMCI_WPMR;     /**< (HSMCI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t HSMCI_WPSR;     /**< (HSMCI Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[276];
+  __IO uint32_t HSMCI_FIFO[256]; /**< (HSMCI Offset: 0x200) FIFO Memory Aperture0 0 */
+} Hsmci;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief HSMCI hardware registers */
+typedef struct {  
+  __O  HSMCI_CR_Type                  HSMCI_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO HSMCI_MR_Type                  HSMCI_MR;       /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO HSMCI_DTOR_Type                HSMCI_DTOR;     /**< Offset: 0x08 (R/W  32) Data Timeout Register */
+  __IO HSMCI_SDCR_Type                HSMCI_SDCR;     /**< Offset: 0x0C (R/W  32) SD/SDIO Card Register */
+  __IO HSMCI_ARGR_Type                HSMCI_ARGR;     /**< Offset: 0x10 (R/W  32) Argument Register */
+  __O  HSMCI_CMDR_Type                HSMCI_CMDR;     /**< Offset: 0x14 ( /W  32) Command Register */
+  __IO HSMCI_BLKR_Type                HSMCI_BLKR;     /**< Offset: 0x18 (R/W  32) Block Register */
+  __IO HSMCI_CSTOR_Type               HSMCI_CSTOR;    /**< Offset: 0x1C (R/W  32) Completion Signal Timeout Register */
+  __I  HSMCI_RSPR_Type                HSMCI_RSPR[4];  /**< Offset: 0x20 (R/   32) Response Register 0 */
+  __I  HSMCI_RDR_Type                 HSMCI_RDR;      /**< Offset: 0x30 (R/   32) Receive Data Register */
+  __O  HSMCI_TDR_Type                 HSMCI_TDR;      /**< Offset: 0x34 ( /W  32) Transmit Data Register */
+  __I  uint8_t                        Reserved1[8];
+  __I  HSMCI_SR_Type                  HSMCI_SR;       /**< Offset: 0x40 (R/   32) Status Register */
+  __O  HSMCI_IER_Type                 HSMCI_IER;      /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
+  __O  HSMCI_IDR_Type                 HSMCI_IDR;      /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
+  __I  HSMCI_IMR_Type                 HSMCI_IMR;      /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
+  __IO HSMCI_DMA_Type                 HSMCI_DMA;      /**< Offset: 0x50 (R/W  32) DMA Configuration Register */
+  __IO HSMCI_CFG_Type                 HSMCI_CFG;      /**< Offset: 0x54 (R/W  32) Configuration Register */
+  __I  uint8_t                        Reserved2[140];
+  __IO HSMCI_WPMR_Type                HSMCI_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  HSMCI_WPSR_Type                HSMCI_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved3[276];
+  __IO HSMCI_FIFO_Type                HSMCI_FIFO[256]; /**< Offset: 0x200 (R/W  32) FIFO Memory Aperture0 0 */
+} Hsmci;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of High Speed MultiMedia Card Interface */
+
+#endif /* _SAMV71_HSMCI_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/i2sc.h
+++ b/asf/sam/include/samv71b/component/i2sc.h
@@ -1,0 +1,526 @@
+/**
+ * \file
+ *
+ * \brief Component description for I2SC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_I2SC_COMPONENT_H_
+#define _SAMV71_I2SC_COMPONENT_H_
+#define _SAMV71_I2SC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Inter-IC Sound Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR I2SC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define I2SC_11241                      /**< (I2SC) Module ID */
+#define REV_I2SC N                      /**< (I2SC) Module revision */
+
+/* -------- I2SC_CR : (I2SC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXEN:1;                    /**< bit:      0  Receiver Enable                          */
+    uint32_t RXDIS:1;                   /**< bit:      1  Receiver Disable                         */
+    uint32_t CKEN:1;                    /**< bit:      2  Clocks Enable                            */
+    uint32_t CKDIS:1;                   /**< bit:      3  Clocks Disable                           */
+    uint32_t TXEN:1;                    /**< bit:      4  Transmitter Enable                       */
+    uint32_t TXDIS:1;                   /**< bit:      5  Transmitter Disable                      */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  Software Reset                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_CR_OFFSET                      (0x00)                                        /**<  (I2SC_CR) Control Register  Offset */
+
+#define I2SC_CR_RXEN_Pos                    0                                              /**< (I2SC_CR) Receiver Enable Position */
+#define I2SC_CR_RXEN_Msk                    (_U_(0x1) << I2SC_CR_RXEN_Pos)                 /**< (I2SC_CR) Receiver Enable Mask */
+#define I2SC_CR_RXEN                        I2SC_CR_RXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_RXEN_Msk instead */
+#define I2SC_CR_RXDIS_Pos                   1                                              /**< (I2SC_CR) Receiver Disable Position */
+#define I2SC_CR_RXDIS_Msk                   (_U_(0x1) << I2SC_CR_RXDIS_Pos)                /**< (I2SC_CR) Receiver Disable Mask */
+#define I2SC_CR_RXDIS                       I2SC_CR_RXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_RXDIS_Msk instead */
+#define I2SC_CR_CKEN_Pos                    2                                              /**< (I2SC_CR) Clocks Enable Position */
+#define I2SC_CR_CKEN_Msk                    (_U_(0x1) << I2SC_CR_CKEN_Pos)                 /**< (I2SC_CR) Clocks Enable Mask */
+#define I2SC_CR_CKEN                        I2SC_CR_CKEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_CKEN_Msk instead */
+#define I2SC_CR_CKDIS_Pos                   3                                              /**< (I2SC_CR) Clocks Disable Position */
+#define I2SC_CR_CKDIS_Msk                   (_U_(0x1) << I2SC_CR_CKDIS_Pos)                /**< (I2SC_CR) Clocks Disable Mask */
+#define I2SC_CR_CKDIS                       I2SC_CR_CKDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_CKDIS_Msk instead */
+#define I2SC_CR_TXEN_Pos                    4                                              /**< (I2SC_CR) Transmitter Enable Position */
+#define I2SC_CR_TXEN_Msk                    (_U_(0x1) << I2SC_CR_TXEN_Pos)                 /**< (I2SC_CR) Transmitter Enable Mask */
+#define I2SC_CR_TXEN                        I2SC_CR_TXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_TXEN_Msk instead */
+#define I2SC_CR_TXDIS_Pos                   5                                              /**< (I2SC_CR) Transmitter Disable Position */
+#define I2SC_CR_TXDIS_Msk                   (_U_(0x1) << I2SC_CR_TXDIS_Pos)                /**< (I2SC_CR) Transmitter Disable Mask */
+#define I2SC_CR_TXDIS                       I2SC_CR_TXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_TXDIS_Msk instead */
+#define I2SC_CR_SWRST_Pos                   7                                              /**< (I2SC_CR) Software Reset Position */
+#define I2SC_CR_SWRST_Msk                   (_U_(0x1) << I2SC_CR_SWRST_Pos)                /**< (I2SC_CR) Software Reset Mask */
+#define I2SC_CR_SWRST                       I2SC_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_CR_SWRST_Msk instead */
+#define I2SC_CR_MASK                        _U_(0xBF)                                      /**< \deprecated (I2SC_CR) Register MASK  (Use I2SC_CR_Msk instead)  */
+#define I2SC_CR_Msk                         _U_(0xBF)                                      /**< (I2SC_CR) Register Mask  */
+
+
+/* -------- I2SC_MR : (I2SC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MODE:1;                    /**< bit:      0  Inter-IC Sound Controller Mode           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t DATALENGTH:3;              /**< bit:   2..4  Data Word Length                         */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t RXMONO:1;                  /**< bit:      8  Receive Mono                             */
+    uint32_t RXDMA:1;                   /**< bit:      9  Single or Multiple DMA Controller Channels for Receiver */
+    uint32_t RXLOOP:1;                  /**< bit:     10  Loopback Test Mode                       */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t TXMONO:1;                  /**< bit:     12  Transmit Mono                            */
+    uint32_t TXDMA:1;                   /**< bit:     13  Single or Multiple DMA Controller Channels for Transmitter */
+    uint32_t TXSAME:1;                  /**< bit:     14  Transmit Data when Underrun              */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t IMCKDIV:6;                 /**< bit: 16..21  Selected Clock to I2SC Master Clock Ratio */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t IMCKFS:6;                  /**< bit: 24..29  Master Clock to fs Ratio                 */
+    uint32_t IMCKMODE:1;                /**< bit:     30  Master Clock Mode                        */
+    uint32_t IWS:1;                     /**< bit:     31  I2SC_WS Slot Width                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_MR_OFFSET                      (0x04)                                        /**<  (I2SC_MR) Mode Register  Offset */
+
+#define I2SC_MR_MODE_Pos                    0                                              /**< (I2SC_MR) Inter-IC Sound Controller Mode Position */
+#define I2SC_MR_MODE_Msk                    (_U_(0x1) << I2SC_MR_MODE_Pos)                 /**< (I2SC_MR) Inter-IC Sound Controller Mode Mask */
+#define I2SC_MR_MODE                        I2SC_MR_MODE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_MODE_Msk instead */
+#define   I2SC_MR_MODE_SLAVE_Val            _U_(0x0)                                       /**< (I2SC_MR) I2SC_CK and I2SC_WS pin inputs used as bit clock and word select/frame synchronization.  */
+#define   I2SC_MR_MODE_MASTER_Val           _U_(0x1)                                       /**< (I2SC_MR) Bit clock and word select/frame synchronization generated by I2SC from MCK and output to I2SC_CK and I2SC_WS pins. Peripheral clock or GCLK is output as master clock on I2SC_MCK if I2SC_MR.IMCKMODE is set.  */
+#define I2SC_MR_MODE_SLAVE                  (I2SC_MR_MODE_SLAVE_Val << I2SC_MR_MODE_Pos)   /**< (I2SC_MR) I2SC_CK and I2SC_WS pin inputs used as bit clock and word select/frame synchronization. Position  */
+#define I2SC_MR_MODE_MASTER                 (I2SC_MR_MODE_MASTER_Val << I2SC_MR_MODE_Pos)  /**< (I2SC_MR) Bit clock and word select/frame synchronization generated by I2SC from MCK and output to I2SC_CK and I2SC_WS pins. Peripheral clock or GCLK is output as master clock on I2SC_MCK if I2SC_MR.IMCKMODE is set. Position  */
+#define I2SC_MR_DATALENGTH_Pos              2                                              /**< (I2SC_MR) Data Word Length Position */
+#define I2SC_MR_DATALENGTH_Msk              (_U_(0x7) << I2SC_MR_DATALENGTH_Pos)           /**< (I2SC_MR) Data Word Length Mask */
+#define I2SC_MR_DATALENGTH(value)           (I2SC_MR_DATALENGTH_Msk & ((value) << I2SC_MR_DATALENGTH_Pos))
+#define   I2SC_MR_DATALENGTH_32_BITS_Val    _U_(0x0)                                       /**< (I2SC_MR) Data length is set to 32 bits  */
+#define   I2SC_MR_DATALENGTH_24_BITS_Val    _U_(0x1)                                       /**< (I2SC_MR) Data length is set to 24 bits  */
+#define   I2SC_MR_DATALENGTH_20_BITS_Val    _U_(0x2)                                       /**< (I2SC_MR) Data length is set to 20 bits  */
+#define   I2SC_MR_DATALENGTH_18_BITS_Val    _U_(0x3)                                       /**< (I2SC_MR) Data length is set to 18 bits  */
+#define   I2SC_MR_DATALENGTH_16_BITS_Val    _U_(0x4)                                       /**< (I2SC_MR) Data length is set to 16 bits  */
+#define   I2SC_MR_DATALENGTH_16_BITS_COMPACT_Val _U_(0x5)                                       /**< (I2SC_MR) Data length is set to 16-bit compact stereo. Left sample in bits 15:0 and right sample in bits 31:16 of same word.  */
+#define   I2SC_MR_DATALENGTH_8_BITS_Val     _U_(0x6)                                       /**< (I2SC_MR) Data length is set to 8 bits  */
+#define   I2SC_MR_DATALENGTH_8_BITS_COMPACT_Val _U_(0x7)                                       /**< (I2SC_MR) Data length is set to 8-bit compact stereo. Left sample in bits 7:0 and right sample in bits 15:8 of the same word.  */
+#define I2SC_MR_DATALENGTH_32_BITS          (I2SC_MR_DATALENGTH_32_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 32 bits Position  */
+#define I2SC_MR_DATALENGTH_24_BITS          (I2SC_MR_DATALENGTH_24_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 24 bits Position  */
+#define I2SC_MR_DATALENGTH_20_BITS          (I2SC_MR_DATALENGTH_20_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 20 bits Position  */
+#define I2SC_MR_DATALENGTH_18_BITS          (I2SC_MR_DATALENGTH_18_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 18 bits Position  */
+#define I2SC_MR_DATALENGTH_16_BITS          (I2SC_MR_DATALENGTH_16_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 16 bits Position  */
+#define I2SC_MR_DATALENGTH_16_BITS_COMPACT  (I2SC_MR_DATALENGTH_16_BITS_COMPACT_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 16-bit compact stereo. Left sample in bits 15:0 and right sample in bits 31:16 of same word. Position  */
+#define I2SC_MR_DATALENGTH_8_BITS           (I2SC_MR_DATALENGTH_8_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 8 bits Position  */
+#define I2SC_MR_DATALENGTH_8_BITS_COMPACT   (I2SC_MR_DATALENGTH_8_BITS_COMPACT_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 8-bit compact stereo. Left sample in bits 7:0 and right sample in bits 15:8 of the same word. Position  */
+#define I2SC_MR_RXMONO_Pos                  8                                              /**< (I2SC_MR) Receive Mono Position */
+#define I2SC_MR_RXMONO_Msk                  (_U_(0x1) << I2SC_MR_RXMONO_Pos)               /**< (I2SC_MR) Receive Mono Mask */
+#define I2SC_MR_RXMONO                      I2SC_MR_RXMONO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_RXMONO_Msk instead */
+#define I2SC_MR_RXDMA_Pos                   9                                              /**< (I2SC_MR) Single or Multiple DMA Controller Channels for Receiver Position */
+#define I2SC_MR_RXDMA_Msk                   (_U_(0x1) << I2SC_MR_RXDMA_Pos)                /**< (I2SC_MR) Single or Multiple DMA Controller Channels for Receiver Mask */
+#define I2SC_MR_RXDMA                       I2SC_MR_RXDMA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_RXDMA_Msk instead */
+#define I2SC_MR_RXLOOP_Pos                  10                                             /**< (I2SC_MR) Loopback Test Mode Position */
+#define I2SC_MR_RXLOOP_Msk                  (_U_(0x1) << I2SC_MR_RXLOOP_Pos)               /**< (I2SC_MR) Loopback Test Mode Mask */
+#define I2SC_MR_RXLOOP                      I2SC_MR_RXLOOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_RXLOOP_Msk instead */
+#define I2SC_MR_TXMONO_Pos                  12                                             /**< (I2SC_MR) Transmit Mono Position */
+#define I2SC_MR_TXMONO_Msk                  (_U_(0x1) << I2SC_MR_TXMONO_Pos)               /**< (I2SC_MR) Transmit Mono Mask */
+#define I2SC_MR_TXMONO                      I2SC_MR_TXMONO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_TXMONO_Msk instead */
+#define I2SC_MR_TXDMA_Pos                   13                                             /**< (I2SC_MR) Single or Multiple DMA Controller Channels for Transmitter Position */
+#define I2SC_MR_TXDMA_Msk                   (_U_(0x1) << I2SC_MR_TXDMA_Pos)                /**< (I2SC_MR) Single or Multiple DMA Controller Channels for Transmitter Mask */
+#define I2SC_MR_TXDMA                       I2SC_MR_TXDMA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_TXDMA_Msk instead */
+#define I2SC_MR_TXSAME_Pos                  14                                             /**< (I2SC_MR) Transmit Data when Underrun Position */
+#define I2SC_MR_TXSAME_Msk                  (_U_(0x1) << I2SC_MR_TXSAME_Pos)               /**< (I2SC_MR) Transmit Data when Underrun Mask */
+#define I2SC_MR_TXSAME                      I2SC_MR_TXSAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_TXSAME_Msk instead */
+#define I2SC_MR_IMCKDIV_Pos                 16                                             /**< (I2SC_MR) Selected Clock to I2SC Master Clock Ratio Position */
+#define I2SC_MR_IMCKDIV_Msk                 (_U_(0x3F) << I2SC_MR_IMCKDIV_Pos)             /**< (I2SC_MR) Selected Clock to I2SC Master Clock Ratio Mask */
+#define I2SC_MR_IMCKDIV(value)              (I2SC_MR_IMCKDIV_Msk & ((value) << I2SC_MR_IMCKDIV_Pos))
+#define I2SC_MR_IMCKFS_Pos                  24                                             /**< (I2SC_MR) Master Clock to fs Ratio Position */
+#define I2SC_MR_IMCKFS_Msk                  (_U_(0x3F) << I2SC_MR_IMCKFS_Pos)              /**< (I2SC_MR) Master Clock to fs Ratio Mask */
+#define I2SC_MR_IMCKFS(value)               (I2SC_MR_IMCKFS_Msk & ((value) << I2SC_MR_IMCKFS_Pos))
+#define   I2SC_MR_IMCKFS_M2SF32_Val         _U_(0x0)                                       /**< (I2SC_MR) Sample frequency ratio set to 32  */
+#define   I2SC_MR_IMCKFS_M2SF64_Val         _U_(0x1)                                       /**< (I2SC_MR) Sample frequency ratio set to 64  */
+#define   I2SC_MR_IMCKFS_M2SF96_Val         _U_(0x2)                                       /**< (I2SC_MR) Sample frequency ratio set to 96  */
+#define   I2SC_MR_IMCKFS_M2SF128_Val        _U_(0x3)                                       /**< (I2SC_MR) Sample frequency ratio set to 128  */
+#define   I2SC_MR_IMCKFS_M2SF192_Val        _U_(0x5)                                       /**< (I2SC_MR) Sample frequency ratio set to 192  */
+#define   I2SC_MR_IMCKFS_M2SF256_Val        _U_(0x7)                                       /**< (I2SC_MR) Sample frequency ratio set to 256  */
+#define   I2SC_MR_IMCKFS_M2SF384_Val        _U_(0xB)                                       /**< (I2SC_MR) Sample frequency ratio set to 384  */
+#define   I2SC_MR_IMCKFS_M2SF512_Val        _U_(0xF)                                       /**< (I2SC_MR) Sample frequency ratio set to 512  */
+#define   I2SC_MR_IMCKFS_M2SF768_Val        _U_(0x17)                                      /**< (I2SC_MR) Sample frequency ratio set to 768  */
+#define   I2SC_MR_IMCKFS_M2SF1024_Val       _U_(0x1F)                                      /**< (I2SC_MR) Sample frequency ratio set to 1024  */
+#define   I2SC_MR_IMCKFS_M2SF1536_Val       _U_(0x2F)                                      /**< (I2SC_MR) Sample frequency ratio set to 1536  */
+#define   I2SC_MR_IMCKFS_M2SF2048_Val       _U_(0x3F)                                      /**< (I2SC_MR) Sample frequency ratio set to 2048  */
+#define I2SC_MR_IMCKFS_M2SF32               (I2SC_MR_IMCKFS_M2SF32_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 32 Position  */
+#define I2SC_MR_IMCKFS_M2SF64               (I2SC_MR_IMCKFS_M2SF64_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 64 Position  */
+#define I2SC_MR_IMCKFS_M2SF96               (I2SC_MR_IMCKFS_M2SF96_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 96 Position  */
+#define I2SC_MR_IMCKFS_M2SF128              (I2SC_MR_IMCKFS_M2SF128_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 128 Position  */
+#define I2SC_MR_IMCKFS_M2SF192              (I2SC_MR_IMCKFS_M2SF192_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 192 Position  */
+#define I2SC_MR_IMCKFS_M2SF256              (I2SC_MR_IMCKFS_M2SF256_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 256 Position  */
+#define I2SC_MR_IMCKFS_M2SF384              (I2SC_MR_IMCKFS_M2SF384_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 384 Position  */
+#define I2SC_MR_IMCKFS_M2SF512              (I2SC_MR_IMCKFS_M2SF512_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 512 Position  */
+#define I2SC_MR_IMCKFS_M2SF768              (I2SC_MR_IMCKFS_M2SF768_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 768 Position  */
+#define I2SC_MR_IMCKFS_M2SF1024             (I2SC_MR_IMCKFS_M2SF1024_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 1024 Position  */
+#define I2SC_MR_IMCKFS_M2SF1536             (I2SC_MR_IMCKFS_M2SF1536_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 1536 Position  */
+#define I2SC_MR_IMCKFS_M2SF2048             (I2SC_MR_IMCKFS_M2SF2048_Val << I2SC_MR_IMCKFS_Pos)  /**< (I2SC_MR) Sample frequency ratio set to 2048 Position  */
+#define I2SC_MR_IMCKMODE_Pos                30                                             /**< (I2SC_MR) Master Clock Mode Position */
+#define I2SC_MR_IMCKMODE_Msk                (_U_(0x1) << I2SC_MR_IMCKMODE_Pos)             /**< (I2SC_MR) Master Clock Mode Mask */
+#define I2SC_MR_IMCKMODE                    I2SC_MR_IMCKMODE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_IMCKMODE_Msk instead */
+#define I2SC_MR_IWS_Pos                     31                                             /**< (I2SC_MR) I2SC_WS Slot Width Position */
+#define I2SC_MR_IWS_Msk                     (_U_(0x1) << I2SC_MR_IWS_Pos)                  /**< (I2SC_MR) I2SC_WS Slot Width Mask */
+#define I2SC_MR_IWS                         I2SC_MR_IWS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_IWS_Msk instead */
+#define I2SC_MR_MASK                        _U_(0xFF3F771D)                                /**< \deprecated (I2SC_MR) Register MASK  (Use I2SC_MR_Msk instead)  */
+#define I2SC_MR_Msk                         _U_(0xFF3F771D)                                /**< (I2SC_MR) Register Mask  */
+
+
+/* -------- I2SC_SR : (I2SC Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXEN:1;                    /**< bit:      0  Receiver Enabled                         */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Ready                            */
+    uint32_t RXOR:1;                    /**< bit:      2  Receive Overrun                          */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t TXEN:1;                    /**< bit:      4  Transmitter Enabled                      */
+    uint32_t TXRDY:1;                   /**< bit:      5  Transmit Ready                           */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underrun                        */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t RXORCH:2;                  /**< bit:   8..9  Receive Overrun Channel                  */
+    uint32_t :10;                       /**< bit: 10..19  Reserved */
+    uint32_t TXURCH:2;                  /**< bit: 20..21  Transmit Underrun Channel                */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_SR_OFFSET                      (0x08)                                        /**<  (I2SC_SR) Status Register  Offset */
+
+#define I2SC_SR_RXEN_Pos                    0                                              /**< (I2SC_SR) Receiver Enabled Position */
+#define I2SC_SR_RXEN_Msk                    (_U_(0x1) << I2SC_SR_RXEN_Pos)                 /**< (I2SC_SR) Receiver Enabled Mask */
+#define I2SC_SR_RXEN                        I2SC_SR_RXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_RXEN_Msk instead */
+#define I2SC_SR_RXRDY_Pos                   1                                              /**< (I2SC_SR) Receive Ready Position */
+#define I2SC_SR_RXRDY_Msk                   (_U_(0x1) << I2SC_SR_RXRDY_Pos)                /**< (I2SC_SR) Receive Ready Mask */
+#define I2SC_SR_RXRDY                       I2SC_SR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_RXRDY_Msk instead */
+#define I2SC_SR_RXOR_Pos                    2                                              /**< (I2SC_SR) Receive Overrun Position */
+#define I2SC_SR_RXOR_Msk                    (_U_(0x1) << I2SC_SR_RXOR_Pos)                 /**< (I2SC_SR) Receive Overrun Mask */
+#define I2SC_SR_RXOR                        I2SC_SR_RXOR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_RXOR_Msk instead */
+#define I2SC_SR_TXEN_Pos                    4                                              /**< (I2SC_SR) Transmitter Enabled Position */
+#define I2SC_SR_TXEN_Msk                    (_U_(0x1) << I2SC_SR_TXEN_Pos)                 /**< (I2SC_SR) Transmitter Enabled Mask */
+#define I2SC_SR_TXEN                        I2SC_SR_TXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_TXEN_Msk instead */
+#define I2SC_SR_TXRDY_Pos                   5                                              /**< (I2SC_SR) Transmit Ready Position */
+#define I2SC_SR_TXRDY_Msk                   (_U_(0x1) << I2SC_SR_TXRDY_Pos)                /**< (I2SC_SR) Transmit Ready Mask */
+#define I2SC_SR_TXRDY                       I2SC_SR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_TXRDY_Msk instead */
+#define I2SC_SR_TXUR_Pos                    6                                              /**< (I2SC_SR) Transmit Underrun Position */
+#define I2SC_SR_TXUR_Msk                    (_U_(0x1) << I2SC_SR_TXUR_Pos)                 /**< (I2SC_SR) Transmit Underrun Mask */
+#define I2SC_SR_TXUR                        I2SC_SR_TXUR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SR_TXUR_Msk instead */
+#define I2SC_SR_RXORCH_Pos                  8                                              /**< (I2SC_SR) Receive Overrun Channel Position */
+#define I2SC_SR_RXORCH_Msk                  (_U_(0x3) << I2SC_SR_RXORCH_Pos)               /**< (I2SC_SR) Receive Overrun Channel Mask */
+#define I2SC_SR_RXORCH(value)               (I2SC_SR_RXORCH_Msk & ((value) << I2SC_SR_RXORCH_Pos))
+#define I2SC_SR_TXURCH_Pos                  20                                             /**< (I2SC_SR) Transmit Underrun Channel Position */
+#define I2SC_SR_TXURCH_Msk                  (_U_(0x3) << I2SC_SR_TXURCH_Pos)               /**< (I2SC_SR) Transmit Underrun Channel Mask */
+#define I2SC_SR_TXURCH(value)               (I2SC_SR_TXURCH_Msk & ((value) << I2SC_SR_TXURCH_Pos))
+#define I2SC_SR_MASK                        _U_(0x300377)                                  /**< \deprecated (I2SC_SR) Register MASK  (Use I2SC_SR_Msk instead)  */
+#define I2SC_SR_Msk                         _U_(0x300377)                                  /**< (I2SC_SR) Register Mask  */
+
+
+/* -------- I2SC_SCR : (I2SC Offset: 0x0c) (/W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXOR:1;                    /**< bit:      2  Receive Overrun Status Clear             */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underrun Status Clear           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t RXORCH:2;                  /**< bit:   8..9  Receive Overrun Per Channel Status Clear */
+    uint32_t :10;                       /**< bit: 10..19  Reserved */
+    uint32_t TXURCH:2;                  /**< bit: 20..21  Transmit Underrun Per Channel Status Clear */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_SCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_SCR_OFFSET                     (0x0C)                                        /**<  (I2SC_SCR) Status Clear Register  Offset */
+
+#define I2SC_SCR_RXOR_Pos                   2                                              /**< (I2SC_SCR) Receive Overrun Status Clear Position */
+#define I2SC_SCR_RXOR_Msk                   (_U_(0x1) << I2SC_SCR_RXOR_Pos)                /**< (I2SC_SCR) Receive Overrun Status Clear Mask */
+#define I2SC_SCR_RXOR                       I2SC_SCR_RXOR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SCR_RXOR_Msk instead */
+#define I2SC_SCR_TXUR_Pos                   6                                              /**< (I2SC_SCR) Transmit Underrun Status Clear Position */
+#define I2SC_SCR_TXUR_Msk                   (_U_(0x1) << I2SC_SCR_TXUR_Pos)                /**< (I2SC_SCR) Transmit Underrun Status Clear Mask */
+#define I2SC_SCR_TXUR                       I2SC_SCR_TXUR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SCR_TXUR_Msk instead */
+#define I2SC_SCR_RXORCH_Pos                 8                                              /**< (I2SC_SCR) Receive Overrun Per Channel Status Clear Position */
+#define I2SC_SCR_RXORCH_Msk                 (_U_(0x3) << I2SC_SCR_RXORCH_Pos)              /**< (I2SC_SCR) Receive Overrun Per Channel Status Clear Mask */
+#define I2SC_SCR_RXORCH(value)              (I2SC_SCR_RXORCH_Msk & ((value) << I2SC_SCR_RXORCH_Pos))
+#define I2SC_SCR_TXURCH_Pos                 20                                             /**< (I2SC_SCR) Transmit Underrun Per Channel Status Clear Position */
+#define I2SC_SCR_TXURCH_Msk                 (_U_(0x3) << I2SC_SCR_TXURCH_Pos)              /**< (I2SC_SCR) Transmit Underrun Per Channel Status Clear Mask */
+#define I2SC_SCR_TXURCH(value)              (I2SC_SCR_TXURCH_Msk & ((value) << I2SC_SCR_TXURCH_Pos))
+#define I2SC_SCR_MASK                       _U_(0x300344)                                  /**< \deprecated (I2SC_SCR) Register MASK  (Use I2SC_SCR_Msk instead)  */
+#define I2SC_SCR_Msk                        _U_(0x300344)                                  /**< (I2SC_SCR) Register Mask  */
+
+
+/* -------- I2SC_SSR : (I2SC Offset: 0x10) (/W 32) Status Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXOR:1;                    /**< bit:      2  Receive Overrun Status Set               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underrun Status Set             */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t RXORCH:2;                  /**< bit:   8..9  Receive Overrun Per Channel Status Set   */
+    uint32_t :10;                       /**< bit: 10..19  Reserved */
+    uint32_t TXURCH:2;                  /**< bit: 20..21  Transmit Underrun Per Channel Status Set */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_SSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_SSR_OFFSET                     (0x10)                                        /**<  (I2SC_SSR) Status Set Register  Offset */
+
+#define I2SC_SSR_RXOR_Pos                   2                                              /**< (I2SC_SSR) Receive Overrun Status Set Position */
+#define I2SC_SSR_RXOR_Msk                   (_U_(0x1) << I2SC_SSR_RXOR_Pos)                /**< (I2SC_SSR) Receive Overrun Status Set Mask */
+#define I2SC_SSR_RXOR                       I2SC_SSR_RXOR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SSR_RXOR_Msk instead */
+#define I2SC_SSR_TXUR_Pos                   6                                              /**< (I2SC_SSR) Transmit Underrun Status Set Position */
+#define I2SC_SSR_TXUR_Msk                   (_U_(0x1) << I2SC_SSR_TXUR_Pos)                /**< (I2SC_SSR) Transmit Underrun Status Set Mask */
+#define I2SC_SSR_TXUR                       I2SC_SSR_TXUR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_SSR_TXUR_Msk instead */
+#define I2SC_SSR_RXORCH_Pos                 8                                              /**< (I2SC_SSR) Receive Overrun Per Channel Status Set Position */
+#define I2SC_SSR_RXORCH_Msk                 (_U_(0x3) << I2SC_SSR_RXORCH_Pos)              /**< (I2SC_SSR) Receive Overrun Per Channel Status Set Mask */
+#define I2SC_SSR_RXORCH(value)              (I2SC_SSR_RXORCH_Msk & ((value) << I2SC_SSR_RXORCH_Pos))
+#define I2SC_SSR_TXURCH_Pos                 20                                             /**< (I2SC_SSR) Transmit Underrun Per Channel Status Set Position */
+#define I2SC_SSR_TXURCH_Msk                 (_U_(0x3) << I2SC_SSR_TXURCH_Pos)              /**< (I2SC_SSR) Transmit Underrun Per Channel Status Set Mask */
+#define I2SC_SSR_TXURCH(value)              (I2SC_SSR_TXURCH_Msk & ((value) << I2SC_SSR_TXURCH_Pos))
+#define I2SC_SSR_MASK                       _U_(0x300344)                                  /**< \deprecated (I2SC_SSR) Register MASK  (Use I2SC_SSR_Msk instead)  */
+#define I2SC_SSR_Msk                        _U_(0x300344)                                  /**< (I2SC_SSR) Register Mask  */
+
+
+/* -------- I2SC_IER : (I2SC Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Enable          */
+    uint32_t RXOR:1;                    /**< bit:      2  Receiver Overrun Interrupt Enable        */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t TXRDY:1;                   /**< bit:      5  Transmit Ready Interrupt Enable          */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underflow Interrupt Enable      */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_IER_OFFSET                     (0x14)                                        /**<  (I2SC_IER) Interrupt Enable Register  Offset */
+
+#define I2SC_IER_RXRDY_Pos                  1                                              /**< (I2SC_IER) Receiver Ready Interrupt Enable Position */
+#define I2SC_IER_RXRDY_Msk                  (_U_(0x1) << I2SC_IER_RXRDY_Pos)               /**< (I2SC_IER) Receiver Ready Interrupt Enable Mask */
+#define I2SC_IER_RXRDY                      I2SC_IER_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IER_RXRDY_Msk instead */
+#define I2SC_IER_RXOR_Pos                   2                                              /**< (I2SC_IER) Receiver Overrun Interrupt Enable Position */
+#define I2SC_IER_RXOR_Msk                   (_U_(0x1) << I2SC_IER_RXOR_Pos)                /**< (I2SC_IER) Receiver Overrun Interrupt Enable Mask */
+#define I2SC_IER_RXOR                       I2SC_IER_RXOR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IER_RXOR_Msk instead */
+#define I2SC_IER_TXRDY_Pos                  5                                              /**< (I2SC_IER) Transmit Ready Interrupt Enable Position */
+#define I2SC_IER_TXRDY_Msk                  (_U_(0x1) << I2SC_IER_TXRDY_Pos)               /**< (I2SC_IER) Transmit Ready Interrupt Enable Mask */
+#define I2SC_IER_TXRDY                      I2SC_IER_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IER_TXRDY_Msk instead */
+#define I2SC_IER_TXUR_Pos                   6                                              /**< (I2SC_IER) Transmit Underflow Interrupt Enable Position */
+#define I2SC_IER_TXUR_Msk                   (_U_(0x1) << I2SC_IER_TXUR_Pos)                /**< (I2SC_IER) Transmit Underflow Interrupt Enable Mask */
+#define I2SC_IER_TXUR                       I2SC_IER_TXUR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IER_TXUR_Msk instead */
+#define I2SC_IER_MASK                       _U_(0x66)                                      /**< \deprecated (I2SC_IER) Register MASK  (Use I2SC_IER_Msk instead)  */
+#define I2SC_IER_Msk                        _U_(0x66)                                      /**< (I2SC_IER) Register Mask  */
+
+
+/* -------- I2SC_IDR : (I2SC Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Disable         */
+    uint32_t RXOR:1;                    /**< bit:      2  Receiver Overrun Interrupt Disable       */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t TXRDY:1;                   /**< bit:      5  Transmit Ready Interrupt Disable         */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underflow Interrupt Disable     */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_IDR_OFFSET                     (0x18)                                        /**<  (I2SC_IDR) Interrupt Disable Register  Offset */
+
+#define I2SC_IDR_RXRDY_Pos                  1                                              /**< (I2SC_IDR) Receiver Ready Interrupt Disable Position */
+#define I2SC_IDR_RXRDY_Msk                  (_U_(0x1) << I2SC_IDR_RXRDY_Pos)               /**< (I2SC_IDR) Receiver Ready Interrupt Disable Mask */
+#define I2SC_IDR_RXRDY                      I2SC_IDR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IDR_RXRDY_Msk instead */
+#define I2SC_IDR_RXOR_Pos                   2                                              /**< (I2SC_IDR) Receiver Overrun Interrupt Disable Position */
+#define I2SC_IDR_RXOR_Msk                   (_U_(0x1) << I2SC_IDR_RXOR_Pos)                /**< (I2SC_IDR) Receiver Overrun Interrupt Disable Mask */
+#define I2SC_IDR_RXOR                       I2SC_IDR_RXOR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IDR_RXOR_Msk instead */
+#define I2SC_IDR_TXRDY_Pos                  5                                              /**< (I2SC_IDR) Transmit Ready Interrupt Disable Position */
+#define I2SC_IDR_TXRDY_Msk                  (_U_(0x1) << I2SC_IDR_TXRDY_Pos)               /**< (I2SC_IDR) Transmit Ready Interrupt Disable Mask */
+#define I2SC_IDR_TXRDY                      I2SC_IDR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IDR_TXRDY_Msk instead */
+#define I2SC_IDR_TXUR_Pos                   6                                              /**< (I2SC_IDR) Transmit Underflow Interrupt Disable Position */
+#define I2SC_IDR_TXUR_Msk                   (_U_(0x1) << I2SC_IDR_TXUR_Pos)                /**< (I2SC_IDR) Transmit Underflow Interrupt Disable Mask */
+#define I2SC_IDR_TXUR                       I2SC_IDR_TXUR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IDR_TXUR_Msk instead */
+#define I2SC_IDR_MASK                       _U_(0x66)                                      /**< \deprecated (I2SC_IDR) Register MASK  (Use I2SC_IDR_Msk instead)  */
+#define I2SC_IDR_Msk                        _U_(0x66)                                      /**< (I2SC_IDR) Register Mask  */
+
+
+/* -------- I2SC_IMR : (I2SC Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receiver Ready Interrupt Disable         */
+    uint32_t RXOR:1;                    /**< bit:      2  Receiver Overrun Interrupt Disable       */
+    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t TXRDY:1;                   /**< bit:      5  Transmit Ready Interrupt Disable         */
+    uint32_t TXUR:1;                    /**< bit:      6  Transmit Underflow Interrupt Disable     */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_IMR_OFFSET                     (0x1C)                                        /**<  (I2SC_IMR) Interrupt Mask Register  Offset */
+
+#define I2SC_IMR_RXRDY_Pos                  1                                              /**< (I2SC_IMR) Receiver Ready Interrupt Disable Position */
+#define I2SC_IMR_RXRDY_Msk                  (_U_(0x1) << I2SC_IMR_RXRDY_Pos)               /**< (I2SC_IMR) Receiver Ready Interrupt Disable Mask */
+#define I2SC_IMR_RXRDY                      I2SC_IMR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IMR_RXRDY_Msk instead */
+#define I2SC_IMR_RXOR_Pos                   2                                              /**< (I2SC_IMR) Receiver Overrun Interrupt Disable Position */
+#define I2SC_IMR_RXOR_Msk                   (_U_(0x1) << I2SC_IMR_RXOR_Pos)                /**< (I2SC_IMR) Receiver Overrun Interrupt Disable Mask */
+#define I2SC_IMR_RXOR                       I2SC_IMR_RXOR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IMR_RXOR_Msk instead */
+#define I2SC_IMR_TXRDY_Pos                  5                                              /**< (I2SC_IMR) Transmit Ready Interrupt Disable Position */
+#define I2SC_IMR_TXRDY_Msk                  (_U_(0x1) << I2SC_IMR_TXRDY_Pos)               /**< (I2SC_IMR) Transmit Ready Interrupt Disable Mask */
+#define I2SC_IMR_TXRDY                      I2SC_IMR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IMR_TXRDY_Msk instead */
+#define I2SC_IMR_TXUR_Pos                   6                                              /**< (I2SC_IMR) Transmit Underflow Interrupt Disable Position */
+#define I2SC_IMR_TXUR_Msk                   (_U_(0x1) << I2SC_IMR_TXUR_Pos)                /**< (I2SC_IMR) Transmit Underflow Interrupt Disable Mask */
+#define I2SC_IMR_TXUR                       I2SC_IMR_TXUR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_IMR_TXUR_Msk instead */
+#define I2SC_IMR_MASK                       _U_(0x66)                                      /**< \deprecated (I2SC_IMR) Register MASK  (Use I2SC_IMR_Msk instead)  */
+#define I2SC_IMR_Msk                        _U_(0x66)                                      /**< (I2SC_IMR) Register Mask  */
+
+
+/* -------- I2SC_RHR : (I2SC Offset: 0x20) (R/ 32) Receiver Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHR:32;                    /**< bit:  0..31  Receiver Holding Register                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_RHR_OFFSET                     (0x20)                                        /**<  (I2SC_RHR) Receiver Holding Register  Offset */
+
+#define I2SC_RHR_RHR_Pos                    0                                              /**< (I2SC_RHR) Receiver Holding Register Position */
+#define I2SC_RHR_RHR_Msk                    (_U_(0xFFFFFFFF) << I2SC_RHR_RHR_Pos)          /**< (I2SC_RHR) Receiver Holding Register Mask */
+#define I2SC_RHR_RHR(value)                 (I2SC_RHR_RHR_Msk & ((value) << I2SC_RHR_RHR_Pos))
+#define I2SC_RHR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (I2SC_RHR) Register MASK  (Use I2SC_RHR_Msk instead)  */
+#define I2SC_RHR_Msk                        _U_(0xFFFFFFFF)                                /**< (I2SC_RHR) Register Mask  */
+
+
+/* -------- I2SC_THR : (I2SC Offset: 0x24) (/W 32) Transmitter Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t THR:32;                    /**< bit:  0..31  Transmitter Holding Register             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} I2SC_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define I2SC_THR_OFFSET                     (0x24)                                        /**<  (I2SC_THR) Transmitter Holding Register  Offset */
+
+#define I2SC_THR_THR_Pos                    0                                              /**< (I2SC_THR) Transmitter Holding Register Position */
+#define I2SC_THR_THR_Msk                    (_U_(0xFFFFFFFF) << I2SC_THR_THR_Pos)          /**< (I2SC_THR) Transmitter Holding Register Mask */
+#define I2SC_THR_THR(value)                 (I2SC_THR_THR_Msk & ((value) << I2SC_THR_THR_Pos))
+#define I2SC_THR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (I2SC_THR) Register MASK  (Use I2SC_THR_Msk instead)  */
+#define I2SC_THR_Msk                        _U_(0xFFFFFFFF)                                /**< (I2SC_THR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief I2SC hardware registers */
+typedef struct {  
+  __O  uint32_t I2SC_CR;        /**< (I2SC Offset: 0x00) Control Register */
+  __IO uint32_t I2SC_MR;        /**< (I2SC Offset: 0x04) Mode Register */
+  __I  uint32_t I2SC_SR;        /**< (I2SC Offset: 0x08) Status Register */
+  __O  uint32_t I2SC_SCR;       /**< (I2SC Offset: 0x0C) Status Clear Register */
+  __O  uint32_t I2SC_SSR;       /**< (I2SC Offset: 0x10) Status Set Register */
+  __O  uint32_t I2SC_IER;       /**< (I2SC Offset: 0x14) Interrupt Enable Register */
+  __O  uint32_t I2SC_IDR;       /**< (I2SC Offset: 0x18) Interrupt Disable Register */
+  __I  uint32_t I2SC_IMR;       /**< (I2SC Offset: 0x1C) Interrupt Mask Register */
+  __I  uint32_t I2SC_RHR;       /**< (I2SC Offset: 0x20) Receiver Holding Register */
+  __O  uint32_t I2SC_THR;       /**< (I2SC Offset: 0x24) Transmitter Holding Register */
+} I2sc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief I2SC hardware registers */
+typedef struct {  
+  __O  I2SC_CR_Type                   I2SC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO I2SC_MR_Type                   I2SC_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  I2SC_SR_Type                   I2SC_SR;        /**< Offset: 0x08 (R/   32) Status Register */
+  __O  I2SC_SCR_Type                  I2SC_SCR;       /**< Offset: 0x0C ( /W  32) Status Clear Register */
+  __O  I2SC_SSR_Type                  I2SC_SSR;       /**< Offset: 0x10 ( /W  32) Status Set Register */
+  __O  I2SC_IER_Type                  I2SC_IER;       /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
+  __O  I2SC_IDR_Type                  I2SC_IDR;       /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
+  __I  I2SC_IMR_Type                  I2SC_IMR;       /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
+  __I  I2SC_RHR_Type                  I2SC_RHR;       /**< Offset: 0x20 (R/   32) Receiver Holding Register */
+  __O  I2SC_THR_Type                  I2SC_THR;       /**< Offset: 0x24 ( /W  32) Transmitter Holding Register */
+} I2sc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Inter-IC Sound Controller */
+
+#endif /* _SAMV71_I2SC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/icm.h
+++ b/asf/sam/include/samv71b/component/icm.h
@@ -1,0 +1,505 @@
+/**
+ * \file
+ *
+ * \brief Component description for ICM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ICM_COMPONENT_H_
+#define _SAMV71_ICM_COMPONENT_H_
+#define _SAMV71_ICM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Integrity Check Monitor
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ICM */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ICM_11105                      /**< (ICM) Module ID */
+#define REV_ICM H                      /**< (ICM) Module revision */
+
+/* -------- ICM_CFG : (ICM Offset: 0x00) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WBDIS:1;                   /**< bit:      0  Write Back Disable                       */
+    uint32_t EOMDIS:1;                  /**< bit:      1  End of Monitoring Disable                */
+    uint32_t SLBDIS:1;                  /**< bit:      2  Secondary List Branching Disable         */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t BBC:4;                     /**< bit:   4..7  Bus Burden Control                       */
+    uint32_t ASCD:1;                    /**< bit:      8  Automatic Switch To Compare Digest       */
+    uint32_t DUALBUFF:1;                /**< bit:      9  Dual Input Buffer                        */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t UIHASH:1;                  /**< bit:     12  User Initial Hash Value                  */
+    uint32_t UALGO:3;                   /**< bit: 13..15  User SHA Algorithm                       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_CFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_CFG_OFFSET                      (0x00)                                        /**<  (ICM_CFG) Configuration Register  Offset */
+
+#define ICM_CFG_WBDIS_Pos                   0                                              /**< (ICM_CFG) Write Back Disable Position */
+#define ICM_CFG_WBDIS_Msk                   (_U_(0x1) << ICM_CFG_WBDIS_Pos)                /**< (ICM_CFG) Write Back Disable Mask */
+#define ICM_CFG_WBDIS                       ICM_CFG_WBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_WBDIS_Msk instead */
+#define ICM_CFG_EOMDIS_Pos                  1                                              /**< (ICM_CFG) End of Monitoring Disable Position */
+#define ICM_CFG_EOMDIS_Msk                  (_U_(0x1) << ICM_CFG_EOMDIS_Pos)               /**< (ICM_CFG) End of Monitoring Disable Mask */
+#define ICM_CFG_EOMDIS                      ICM_CFG_EOMDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_EOMDIS_Msk instead */
+#define ICM_CFG_SLBDIS_Pos                  2                                              /**< (ICM_CFG) Secondary List Branching Disable Position */
+#define ICM_CFG_SLBDIS_Msk                  (_U_(0x1) << ICM_CFG_SLBDIS_Pos)               /**< (ICM_CFG) Secondary List Branching Disable Mask */
+#define ICM_CFG_SLBDIS                      ICM_CFG_SLBDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_SLBDIS_Msk instead */
+#define ICM_CFG_BBC_Pos                     4                                              /**< (ICM_CFG) Bus Burden Control Position */
+#define ICM_CFG_BBC_Msk                     (_U_(0xF) << ICM_CFG_BBC_Pos)                  /**< (ICM_CFG) Bus Burden Control Mask */
+#define ICM_CFG_BBC(value)                  (ICM_CFG_BBC_Msk & ((value) << ICM_CFG_BBC_Pos))
+#define ICM_CFG_ASCD_Pos                    8                                              /**< (ICM_CFG) Automatic Switch To Compare Digest Position */
+#define ICM_CFG_ASCD_Msk                    (_U_(0x1) << ICM_CFG_ASCD_Pos)                 /**< (ICM_CFG) Automatic Switch To Compare Digest Mask */
+#define ICM_CFG_ASCD                        ICM_CFG_ASCD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_ASCD_Msk instead */
+#define ICM_CFG_DUALBUFF_Pos                9                                              /**< (ICM_CFG) Dual Input Buffer Position */
+#define ICM_CFG_DUALBUFF_Msk                (_U_(0x1) << ICM_CFG_DUALBUFF_Pos)             /**< (ICM_CFG) Dual Input Buffer Mask */
+#define ICM_CFG_DUALBUFF                    ICM_CFG_DUALBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_DUALBUFF_Msk instead */
+#define ICM_CFG_UIHASH_Pos                  12                                             /**< (ICM_CFG) User Initial Hash Value Position */
+#define ICM_CFG_UIHASH_Msk                  (_U_(0x1) << ICM_CFG_UIHASH_Pos)               /**< (ICM_CFG) User Initial Hash Value Mask */
+#define ICM_CFG_UIHASH                      ICM_CFG_UIHASH_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CFG_UIHASH_Msk instead */
+#define ICM_CFG_UALGO_Pos                   13                                             /**< (ICM_CFG) User SHA Algorithm Position */
+#define ICM_CFG_UALGO_Msk                   (_U_(0x7) << ICM_CFG_UALGO_Pos)                /**< (ICM_CFG) User SHA Algorithm Mask */
+#define ICM_CFG_UALGO(value)                (ICM_CFG_UALGO_Msk & ((value) << ICM_CFG_UALGO_Pos))
+#define   ICM_CFG_UALGO_SHA1_Val            _U_(0x0)                                       /**< (ICM_CFG) SHA1 algorithm processed  */
+#define   ICM_CFG_UALGO_SHA256_Val          _U_(0x1)                                       /**< (ICM_CFG) SHA256 algorithm processed  */
+#define   ICM_CFG_UALGO_SHA224_Val          _U_(0x4)                                       /**< (ICM_CFG) SHA224 algorithm processed  */
+#define ICM_CFG_UALGO_SHA1                  (ICM_CFG_UALGO_SHA1_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA1 algorithm processed Position  */
+#define ICM_CFG_UALGO_SHA256                (ICM_CFG_UALGO_SHA256_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA256 algorithm processed Position  */
+#define ICM_CFG_UALGO_SHA224                (ICM_CFG_UALGO_SHA224_Val << ICM_CFG_UALGO_Pos)  /**< (ICM_CFG) SHA224 algorithm processed Position  */
+#define ICM_CFG_MASK                        _U_(0xF3F7)                                    /**< \deprecated (ICM_CFG) Register MASK  (Use ICM_CFG_Msk instead)  */
+#define ICM_CFG_Msk                         _U_(0xF3F7)                                    /**< (ICM_CFG) Register Mask  */
+
+
+/* -------- ICM_CTRL : (ICM Offset: 0x04) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  ICM Enable                               */
+    uint32_t DISABLE:1;                 /**< bit:      1  ICM Disable Register                     */
+    uint32_t SWRST:1;                   /**< bit:      2  Software Reset                           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t REHASH:4;                  /**< bit:   4..7  Recompute Internal Hash                  */
+    uint32_t RMDIS:4;                   /**< bit:  8..11  Region Monitoring Disable                */
+    uint32_t RMEN:4;                    /**< bit: 12..15  Region Monitoring Enable                 */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_CTRL_OFFSET                     (0x04)                                        /**<  (ICM_CTRL) Control Register  Offset */
+
+#define ICM_CTRL_ENABLE_Pos                 0                                              /**< (ICM_CTRL) ICM Enable Position */
+#define ICM_CTRL_ENABLE_Msk                 (_U_(0x1) << ICM_CTRL_ENABLE_Pos)              /**< (ICM_CTRL) ICM Enable Mask */
+#define ICM_CTRL_ENABLE                     ICM_CTRL_ENABLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_ENABLE_Msk instead */
+#define ICM_CTRL_DISABLE_Pos                1                                              /**< (ICM_CTRL) ICM Disable Register Position */
+#define ICM_CTRL_DISABLE_Msk                (_U_(0x1) << ICM_CTRL_DISABLE_Pos)             /**< (ICM_CTRL) ICM Disable Register Mask */
+#define ICM_CTRL_DISABLE                    ICM_CTRL_DISABLE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_DISABLE_Msk instead */
+#define ICM_CTRL_SWRST_Pos                  2                                              /**< (ICM_CTRL) Software Reset Position */
+#define ICM_CTRL_SWRST_Msk                  (_U_(0x1) << ICM_CTRL_SWRST_Pos)               /**< (ICM_CTRL) Software Reset Mask */
+#define ICM_CTRL_SWRST                      ICM_CTRL_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_CTRL_SWRST_Msk instead */
+#define ICM_CTRL_REHASH_Pos                 4                                              /**< (ICM_CTRL) Recompute Internal Hash Position */
+#define ICM_CTRL_REHASH_Msk                 (_U_(0xF) << ICM_CTRL_REHASH_Pos)              /**< (ICM_CTRL) Recompute Internal Hash Mask */
+#define ICM_CTRL_REHASH(value)              (ICM_CTRL_REHASH_Msk & ((value) << ICM_CTRL_REHASH_Pos))
+#define ICM_CTRL_RMDIS_Pos                  8                                              /**< (ICM_CTRL) Region Monitoring Disable Position */
+#define ICM_CTRL_RMDIS_Msk                  (_U_(0xF) << ICM_CTRL_RMDIS_Pos)               /**< (ICM_CTRL) Region Monitoring Disable Mask */
+#define ICM_CTRL_RMDIS(value)               (ICM_CTRL_RMDIS_Msk & ((value) << ICM_CTRL_RMDIS_Pos))
+#define ICM_CTRL_RMEN_Pos                   12                                             /**< (ICM_CTRL) Region Monitoring Enable Position */
+#define ICM_CTRL_RMEN_Msk                   (_U_(0xF) << ICM_CTRL_RMEN_Pos)                /**< (ICM_CTRL) Region Monitoring Enable Mask */
+#define ICM_CTRL_RMEN(value)                (ICM_CTRL_RMEN_Msk & ((value) << ICM_CTRL_RMEN_Pos))
+#define ICM_CTRL_MASK                       _U_(0xFFF7)                                    /**< \deprecated (ICM_CTRL) Register MASK  (Use ICM_CTRL_Msk instead)  */
+#define ICM_CTRL_Msk                        _U_(0xFFF7)                                    /**< (ICM_CTRL) Register Mask  */
+
+
+/* -------- ICM_SR : (ICM Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  ICM Controller Enable Register           */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t RAWRMDIS:4;                /**< bit:  8..11  Region Monitoring Disabled Raw Status    */
+    uint32_t RMDIS:4;                   /**< bit: 12..15  Region Monitoring Disabled Status        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_SR_OFFSET                       (0x08)                                        /**<  (ICM_SR) Status Register  Offset */
+
+#define ICM_SR_ENABLE_Pos                   0                                              /**< (ICM_SR) ICM Controller Enable Register Position */
+#define ICM_SR_ENABLE_Msk                   (_U_(0x1) << ICM_SR_ENABLE_Pos)                /**< (ICM_SR) ICM Controller Enable Register Mask */
+#define ICM_SR_ENABLE                       ICM_SR_ENABLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_SR_ENABLE_Msk instead */
+#define ICM_SR_RAWRMDIS_Pos                 8                                              /**< (ICM_SR) Region Monitoring Disabled Raw Status Position */
+#define ICM_SR_RAWRMDIS_Msk                 (_U_(0xF) << ICM_SR_RAWRMDIS_Pos)              /**< (ICM_SR) Region Monitoring Disabled Raw Status Mask */
+#define ICM_SR_RAWRMDIS(value)              (ICM_SR_RAWRMDIS_Msk & ((value) << ICM_SR_RAWRMDIS_Pos))
+#define ICM_SR_RMDIS_Pos                    12                                             /**< (ICM_SR) Region Monitoring Disabled Status Position */
+#define ICM_SR_RMDIS_Msk                    (_U_(0xF) << ICM_SR_RMDIS_Pos)                 /**< (ICM_SR) Region Monitoring Disabled Status Mask */
+#define ICM_SR_RMDIS(value)                 (ICM_SR_RMDIS_Msk & ((value) << ICM_SR_RMDIS_Pos))
+#define ICM_SR_MASK                         _U_(0xFF01)                                    /**< \deprecated (ICM_SR) Register MASK  (Use ICM_SR_Msk instead)  */
+#define ICM_SR_Msk                          _U_(0xFF01)                                    /**< (ICM_SR) Register Mask  */
+
+
+/* -------- ICM_IER : (ICM Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Enable   */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Enable  */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Enable        */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition detected Interrupt Enable */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected Interrupt Enable */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Disable  */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Enable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IER_OFFSET                      (0x10)                                        /**<  (ICM_IER) Interrupt Enable Register  Offset */
+
+#define ICM_IER_RHC_Pos                     0                                              /**< (ICM_IER) Region Hash Completed Interrupt Enable Position */
+#define ICM_IER_RHC_Msk                     (_U_(0xF) << ICM_IER_RHC_Pos)                  /**< (ICM_IER) Region Hash Completed Interrupt Enable Mask */
+#define ICM_IER_RHC(value)                  (ICM_IER_RHC_Msk & ((value) << ICM_IER_RHC_Pos))
+#define ICM_IER_RDM_Pos                     4                                              /**< (ICM_IER) Region Digest Mismatch Interrupt Enable Position */
+#define ICM_IER_RDM_Msk                     (_U_(0xF) << ICM_IER_RDM_Pos)                  /**< (ICM_IER) Region Digest Mismatch Interrupt Enable Mask */
+#define ICM_IER_RDM(value)                  (ICM_IER_RDM_Msk & ((value) << ICM_IER_RDM_Pos))
+#define ICM_IER_RBE_Pos                     8                                              /**< (ICM_IER) Region Bus Error Interrupt Enable Position */
+#define ICM_IER_RBE_Msk                     (_U_(0xF) << ICM_IER_RBE_Pos)                  /**< (ICM_IER) Region Bus Error Interrupt Enable Mask */
+#define ICM_IER_RBE(value)                  (ICM_IER_RBE_Msk & ((value) << ICM_IER_RBE_Pos))
+#define ICM_IER_RWC_Pos                     12                                             /**< (ICM_IER) Region Wrap Condition detected Interrupt Enable Position */
+#define ICM_IER_RWC_Msk                     (_U_(0xF) << ICM_IER_RWC_Pos)                  /**< (ICM_IER) Region Wrap Condition detected Interrupt Enable Mask */
+#define ICM_IER_RWC(value)                  (ICM_IER_RWC_Msk & ((value) << ICM_IER_RWC_Pos))
+#define ICM_IER_REC_Pos                     16                                             /**< (ICM_IER) Region End bit Condition Detected Interrupt Enable Position */
+#define ICM_IER_REC_Msk                     (_U_(0xF) << ICM_IER_REC_Pos)                  /**< (ICM_IER) Region End bit Condition Detected Interrupt Enable Mask */
+#define ICM_IER_REC(value)                  (ICM_IER_REC_Msk & ((value) << ICM_IER_REC_Pos))
+#define ICM_IER_RSU_Pos                     20                                             /**< (ICM_IER) Region Status Updated Interrupt Disable Position */
+#define ICM_IER_RSU_Msk                     (_U_(0xF) << ICM_IER_RSU_Pos)                  /**< (ICM_IER) Region Status Updated Interrupt Disable Mask */
+#define ICM_IER_RSU(value)                  (ICM_IER_RSU_Msk & ((value) << ICM_IER_RSU_Pos))
+#define ICM_IER_URAD_Pos                    24                                             /**< (ICM_IER) Undefined Register Access Detection Interrupt Enable Position */
+#define ICM_IER_URAD_Msk                    (_U_(0x1) << ICM_IER_URAD_Pos)                 /**< (ICM_IER) Undefined Register Access Detection Interrupt Enable Mask */
+#define ICM_IER_URAD                        ICM_IER_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IER_URAD_Msk instead */
+#define ICM_IER_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IER) Register MASK  (Use ICM_IER_Msk instead)  */
+#define ICM_IER_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IER) Register Mask  */
+
+
+/* -------- ICM_IDR : (ICM Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Disable  */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Disable */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Disable       */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected Interrupt Disable */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition detected Interrupt Disable */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Disable  */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Disable */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IDR_OFFSET                      (0x14)                                        /**<  (ICM_IDR) Interrupt Disable Register  Offset */
+
+#define ICM_IDR_RHC_Pos                     0                                              /**< (ICM_IDR) Region Hash Completed Interrupt Disable Position */
+#define ICM_IDR_RHC_Msk                     (_U_(0xF) << ICM_IDR_RHC_Pos)                  /**< (ICM_IDR) Region Hash Completed Interrupt Disable Mask */
+#define ICM_IDR_RHC(value)                  (ICM_IDR_RHC_Msk & ((value) << ICM_IDR_RHC_Pos))
+#define ICM_IDR_RDM_Pos                     4                                              /**< (ICM_IDR) Region Digest Mismatch Interrupt Disable Position */
+#define ICM_IDR_RDM_Msk                     (_U_(0xF) << ICM_IDR_RDM_Pos)                  /**< (ICM_IDR) Region Digest Mismatch Interrupt Disable Mask */
+#define ICM_IDR_RDM(value)                  (ICM_IDR_RDM_Msk & ((value) << ICM_IDR_RDM_Pos))
+#define ICM_IDR_RBE_Pos                     8                                              /**< (ICM_IDR) Region Bus Error Interrupt Disable Position */
+#define ICM_IDR_RBE_Msk                     (_U_(0xF) << ICM_IDR_RBE_Pos)                  /**< (ICM_IDR) Region Bus Error Interrupt Disable Mask */
+#define ICM_IDR_RBE(value)                  (ICM_IDR_RBE_Msk & ((value) << ICM_IDR_RBE_Pos))
+#define ICM_IDR_RWC_Pos                     12                                             /**< (ICM_IDR) Region Wrap Condition Detected Interrupt Disable Position */
+#define ICM_IDR_RWC_Msk                     (_U_(0xF) << ICM_IDR_RWC_Pos)                  /**< (ICM_IDR) Region Wrap Condition Detected Interrupt Disable Mask */
+#define ICM_IDR_RWC(value)                  (ICM_IDR_RWC_Msk & ((value) << ICM_IDR_RWC_Pos))
+#define ICM_IDR_REC_Pos                     16                                             /**< (ICM_IDR) Region End bit Condition detected Interrupt Disable Position */
+#define ICM_IDR_REC_Msk                     (_U_(0xF) << ICM_IDR_REC_Pos)                  /**< (ICM_IDR) Region End bit Condition detected Interrupt Disable Mask */
+#define ICM_IDR_REC(value)                  (ICM_IDR_REC_Msk & ((value) << ICM_IDR_REC_Pos))
+#define ICM_IDR_RSU_Pos                     20                                             /**< (ICM_IDR) Region Status Updated Interrupt Disable Position */
+#define ICM_IDR_RSU_Msk                     (_U_(0xF) << ICM_IDR_RSU_Pos)                  /**< (ICM_IDR) Region Status Updated Interrupt Disable Mask */
+#define ICM_IDR_RSU(value)                  (ICM_IDR_RSU_Msk & ((value) << ICM_IDR_RSU_Pos))
+#define ICM_IDR_URAD_Pos                    24                                             /**< (ICM_IDR) Undefined Register Access Detection Interrupt Disable Position */
+#define ICM_IDR_URAD_Msk                    (_U_(0x1) << ICM_IDR_URAD_Pos)                 /**< (ICM_IDR) Undefined Register Access Detection Interrupt Disable Mask */
+#define ICM_IDR_URAD                        ICM_IDR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IDR_URAD_Msk instead */
+#define ICM_IDR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IDR) Register MASK  (Use ICM_IDR_Msk instead)  */
+#define ICM_IDR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IDR) Register Mask  */
+
+
+/* -------- ICM_IMR : (ICM Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Mask     */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch Interrupt Mask    */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error Interrupt Mask          */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected Interrupt Mask */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected Interrupt Mask */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Interrupt Mask     */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Interrupt Mask */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_IMR_OFFSET                      (0x18)                                        /**<  (ICM_IMR) Interrupt Mask Register  Offset */
+
+#define ICM_IMR_RHC_Pos                     0                                              /**< (ICM_IMR) Region Hash Completed Interrupt Mask Position */
+#define ICM_IMR_RHC_Msk                     (_U_(0xF) << ICM_IMR_RHC_Pos)                  /**< (ICM_IMR) Region Hash Completed Interrupt Mask Mask */
+#define ICM_IMR_RHC(value)                  (ICM_IMR_RHC_Msk & ((value) << ICM_IMR_RHC_Pos))
+#define ICM_IMR_RDM_Pos                     4                                              /**< (ICM_IMR) Region Digest Mismatch Interrupt Mask Position */
+#define ICM_IMR_RDM_Msk                     (_U_(0xF) << ICM_IMR_RDM_Pos)                  /**< (ICM_IMR) Region Digest Mismatch Interrupt Mask Mask */
+#define ICM_IMR_RDM(value)                  (ICM_IMR_RDM_Msk & ((value) << ICM_IMR_RDM_Pos))
+#define ICM_IMR_RBE_Pos                     8                                              /**< (ICM_IMR) Region Bus Error Interrupt Mask Position */
+#define ICM_IMR_RBE_Msk                     (_U_(0xF) << ICM_IMR_RBE_Pos)                  /**< (ICM_IMR) Region Bus Error Interrupt Mask Mask */
+#define ICM_IMR_RBE(value)                  (ICM_IMR_RBE_Msk & ((value) << ICM_IMR_RBE_Pos))
+#define ICM_IMR_RWC_Pos                     12                                             /**< (ICM_IMR) Region Wrap Condition Detected Interrupt Mask Position */
+#define ICM_IMR_RWC_Msk                     (_U_(0xF) << ICM_IMR_RWC_Pos)                  /**< (ICM_IMR) Region Wrap Condition Detected Interrupt Mask Mask */
+#define ICM_IMR_RWC(value)                  (ICM_IMR_RWC_Msk & ((value) << ICM_IMR_RWC_Pos))
+#define ICM_IMR_REC_Pos                     16                                             /**< (ICM_IMR) Region End bit Condition Detected Interrupt Mask Position */
+#define ICM_IMR_REC_Msk                     (_U_(0xF) << ICM_IMR_REC_Pos)                  /**< (ICM_IMR) Region End bit Condition Detected Interrupt Mask Mask */
+#define ICM_IMR_REC(value)                  (ICM_IMR_REC_Msk & ((value) << ICM_IMR_REC_Pos))
+#define ICM_IMR_RSU_Pos                     20                                             /**< (ICM_IMR) Region Status Updated Interrupt Mask Position */
+#define ICM_IMR_RSU_Msk                     (_U_(0xF) << ICM_IMR_RSU_Pos)                  /**< (ICM_IMR) Region Status Updated Interrupt Mask Mask */
+#define ICM_IMR_RSU(value)                  (ICM_IMR_RSU_Msk & ((value) << ICM_IMR_RSU_Pos))
+#define ICM_IMR_URAD_Pos                    24                                             /**< (ICM_IMR) Undefined Register Access Detection Interrupt Mask Position */
+#define ICM_IMR_URAD_Msk                    (_U_(0x1) << ICM_IMR_URAD_Pos)                 /**< (ICM_IMR) Undefined Register Access Detection Interrupt Mask Mask */
+#define ICM_IMR_URAD                        ICM_IMR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_IMR_URAD_Msk instead */
+#define ICM_IMR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_IMR) Register MASK  (Use ICM_IMR_Msk instead)  */
+#define ICM_IMR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_IMR) Register Mask  */
+
+
+/* -------- ICM_ISR : (ICM Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed                    */
+    uint32_t RDM:4;                     /**< bit:   4..7  Region Digest Mismatch                   */
+    uint32_t RBE:4;                     /**< bit:  8..11  Region Bus Error                         */
+    uint32_t RWC:4;                     /**< bit: 12..15  Region Wrap Condition Detected           */
+    uint32_t REC:4;                     /**< bit: 16..19  Region End bit Condition Detected        */
+    uint32_t RSU:4;                     /**< bit: 20..23  Region Status Updated Detected           */
+    uint32_t URAD:1;                    /**< bit:     24  Undefined Register Access Detection Status */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_ISR_OFFSET                      (0x1C)                                        /**<  (ICM_ISR) Interrupt Status Register  Offset */
+
+#define ICM_ISR_RHC_Pos                     0                                              /**< (ICM_ISR) Region Hash Completed Position */
+#define ICM_ISR_RHC_Msk                     (_U_(0xF) << ICM_ISR_RHC_Pos)                  /**< (ICM_ISR) Region Hash Completed Mask */
+#define ICM_ISR_RHC(value)                  (ICM_ISR_RHC_Msk & ((value) << ICM_ISR_RHC_Pos))
+#define ICM_ISR_RDM_Pos                     4                                              /**< (ICM_ISR) Region Digest Mismatch Position */
+#define ICM_ISR_RDM_Msk                     (_U_(0xF) << ICM_ISR_RDM_Pos)                  /**< (ICM_ISR) Region Digest Mismatch Mask */
+#define ICM_ISR_RDM(value)                  (ICM_ISR_RDM_Msk & ((value) << ICM_ISR_RDM_Pos))
+#define ICM_ISR_RBE_Pos                     8                                              /**< (ICM_ISR) Region Bus Error Position */
+#define ICM_ISR_RBE_Msk                     (_U_(0xF) << ICM_ISR_RBE_Pos)                  /**< (ICM_ISR) Region Bus Error Mask */
+#define ICM_ISR_RBE(value)                  (ICM_ISR_RBE_Msk & ((value) << ICM_ISR_RBE_Pos))
+#define ICM_ISR_RWC_Pos                     12                                             /**< (ICM_ISR) Region Wrap Condition Detected Position */
+#define ICM_ISR_RWC_Msk                     (_U_(0xF) << ICM_ISR_RWC_Pos)                  /**< (ICM_ISR) Region Wrap Condition Detected Mask */
+#define ICM_ISR_RWC(value)                  (ICM_ISR_RWC_Msk & ((value) << ICM_ISR_RWC_Pos))
+#define ICM_ISR_REC_Pos                     16                                             /**< (ICM_ISR) Region End bit Condition Detected Position */
+#define ICM_ISR_REC_Msk                     (_U_(0xF) << ICM_ISR_REC_Pos)                  /**< (ICM_ISR) Region End bit Condition Detected Mask */
+#define ICM_ISR_REC(value)                  (ICM_ISR_REC_Msk & ((value) << ICM_ISR_REC_Pos))
+#define ICM_ISR_RSU_Pos                     20                                             /**< (ICM_ISR) Region Status Updated Detected Position */
+#define ICM_ISR_RSU_Msk                     (_U_(0xF) << ICM_ISR_RSU_Pos)                  /**< (ICM_ISR) Region Status Updated Detected Mask */
+#define ICM_ISR_RSU(value)                  (ICM_ISR_RSU_Msk & ((value) << ICM_ISR_RSU_Pos))
+#define ICM_ISR_URAD_Pos                    24                                             /**< (ICM_ISR) Undefined Register Access Detection Status Position */
+#define ICM_ISR_URAD_Msk                    (_U_(0x1) << ICM_ISR_URAD_Pos)                 /**< (ICM_ISR) Undefined Register Access Detection Status Mask */
+#define ICM_ISR_URAD                        ICM_ISR_URAD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ICM_ISR_URAD_Msk instead */
+#define ICM_ISR_MASK                        _U_(0x1FFFFFF)                                 /**< \deprecated (ICM_ISR) Register MASK  (Use ICM_ISR_Msk instead)  */
+#define ICM_ISR_Msk                         _U_(0x1FFFFFF)                                 /**< (ICM_ISR) Register Mask  */
+
+
+/* -------- ICM_UASR : (ICM Offset: 0x20) (R/ 32) Undefined Access Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URAT:3;                    /**< bit:   0..2  Undefined Register Access Trace          */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_UASR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_UASR_OFFSET                     (0x20)                                        /**<  (ICM_UASR) Undefined Access Status Register  Offset */
+
+#define ICM_UASR_URAT_Pos                   0                                              /**< (ICM_UASR) Undefined Register Access Trace Position */
+#define ICM_UASR_URAT_Msk                   (_U_(0x7) << ICM_UASR_URAT_Pos)                /**< (ICM_UASR) Undefined Register Access Trace Mask */
+#define ICM_UASR_URAT(value)                (ICM_UASR_URAT_Msk & ((value) << ICM_UASR_URAT_Pos))
+#define   ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER_Val _U_(0x0)                                       /**< (ICM_UASR) Unspecified structure member set to one detected when the descriptor is loaded.  */
+#define   ICM_UASR_URAT_ICM_CFG_MODIFIED_Val _U_(0x1)                                       /**< (ICM_UASR) ICM_CFG modified during active monitoring.  */
+#define   ICM_UASR_URAT_ICM_DSCR_MODIFIED_Val _U_(0x2)                                       /**< (ICM_UASR) ICM_DSCR modified during active monitoring.  */
+#define   ICM_UASR_URAT_ICM_HASH_MODIFIED_Val _U_(0x3)                                       /**< (ICM_UASR) ICM_HASH modified during active monitoring  */
+#define   ICM_UASR_URAT_READ_ACCESS_Val     _U_(0x4)                                       /**< (ICM_UASR) Write-only register read access  */
+#define ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER  (ICM_UASR_URAT_UNSPEC_STRUCT_MEMBER_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) Unspecified structure member set to one detected when the descriptor is loaded. Position  */
+#define ICM_UASR_URAT_ICM_CFG_MODIFIED      (ICM_UASR_URAT_ICM_CFG_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_CFG modified during active monitoring. Position  */
+#define ICM_UASR_URAT_ICM_DSCR_MODIFIED     (ICM_UASR_URAT_ICM_DSCR_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_DSCR modified during active monitoring. Position  */
+#define ICM_UASR_URAT_ICM_HASH_MODIFIED     (ICM_UASR_URAT_ICM_HASH_MODIFIED_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) ICM_HASH modified during active monitoring Position  */
+#define ICM_UASR_URAT_READ_ACCESS           (ICM_UASR_URAT_READ_ACCESS_Val << ICM_UASR_URAT_Pos)  /**< (ICM_UASR) Write-only register read access Position  */
+#define ICM_UASR_MASK                       _U_(0x07)                                      /**< \deprecated (ICM_UASR) Register MASK  (Use ICM_UASR_Msk instead)  */
+#define ICM_UASR_Msk                        _U_(0x07)                                      /**< (ICM_UASR) Register Mask  */
+
+
+/* -------- ICM_DSCR : (ICM Offset: 0x30) (R/W 32) Region Descriptor Area Start Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t DASA:26;                   /**< bit:  6..31  Descriptor Area Start Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_DSCR_OFFSET                     (0x30)                                        /**<  (ICM_DSCR) Region Descriptor Area Start Address Register  Offset */
+
+#define ICM_DSCR_DASA_Pos                   6                                              /**< (ICM_DSCR) Descriptor Area Start Address Position */
+#define ICM_DSCR_DASA_Msk                   (_U_(0x3FFFFFF) << ICM_DSCR_DASA_Pos)          /**< (ICM_DSCR) Descriptor Area Start Address Mask */
+#define ICM_DSCR_DASA(value)                (ICM_DSCR_DASA_Msk & ((value) << ICM_DSCR_DASA_Pos))
+#define ICM_DSCR_MASK                       _U_(0xFFFFFFC0)                                /**< \deprecated (ICM_DSCR) Register MASK  (Use ICM_DSCR_Msk instead)  */
+#define ICM_DSCR_Msk                        _U_(0xFFFFFFC0)                                /**< (ICM_DSCR) Register Mask  */
+
+
+/* -------- ICM_HASH : (ICM Offset: 0x34) (R/W 32) Region Hash Area Start Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t HASA:25;                   /**< bit:  7..31  Hash Area Start Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_HASH_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_HASH_OFFSET                     (0x34)                                        /**<  (ICM_HASH) Region Hash Area Start Address Register  Offset */
+
+#define ICM_HASH_HASA_Pos                   7                                              /**< (ICM_HASH) Hash Area Start Address Position */
+#define ICM_HASH_HASA_Msk                   (_U_(0x1FFFFFF) << ICM_HASH_HASA_Pos)          /**< (ICM_HASH) Hash Area Start Address Mask */
+#define ICM_HASH_HASA(value)                (ICM_HASH_HASA_Msk & ((value) << ICM_HASH_HASA_Pos))
+#define ICM_HASH_MASK                       _U_(0xFFFFFF80)                                /**< \deprecated (ICM_HASH) Register MASK  (Use ICM_HASH_Msk instead)  */
+#define ICM_HASH_Msk                        _U_(0xFFFFFF80)                                /**< (ICM_HASH) Register Mask  */
+
+
+/* -------- ICM_UIHVAL : (ICM Offset: 0x38) (/W 32) User Initial Hash Value 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VAL:32;                    /**< bit:  0..31  Initial Hash Value                       */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ICM_UIHVAL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ICM_UIHVAL_OFFSET                   (0x38)                                        /**<  (ICM_UIHVAL) User Initial Hash Value 0 Register 0  Offset */
+
+#define ICM_UIHVAL_VAL_Pos                  0                                              /**< (ICM_UIHVAL) Initial Hash Value Position */
+#define ICM_UIHVAL_VAL_Msk                  (_U_(0xFFFFFFFF) << ICM_UIHVAL_VAL_Pos)        /**< (ICM_UIHVAL) Initial Hash Value Mask */
+#define ICM_UIHVAL_VAL(value)               (ICM_UIHVAL_VAL_Msk & ((value) << ICM_UIHVAL_VAL_Pos))
+#define ICM_UIHVAL_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (ICM_UIHVAL) Register MASK  (Use ICM_UIHVAL_Msk instead)  */
+#define ICM_UIHVAL_Msk                      _U_(0xFFFFFFFF)                                /**< (ICM_UIHVAL) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ICM hardware registers */
+typedef struct {  
+  __IO uint32_t ICM_CFG;        /**< (ICM Offset: 0x00) Configuration Register */
+  __O  uint32_t ICM_CTRL;       /**< (ICM Offset: 0x04) Control Register */
+  __I  uint32_t ICM_SR;         /**< (ICM Offset: 0x08) Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t ICM_IER;        /**< (ICM Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t ICM_IDR;        /**< (ICM Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t ICM_IMR;        /**< (ICM Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t ICM_ISR;        /**< (ICM Offset: 0x1C) Interrupt Status Register */
+  __I  uint32_t ICM_UASR;       /**< (ICM Offset: 0x20) Undefined Access Status Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO uint32_t ICM_DSCR;       /**< (ICM Offset: 0x30) Region Descriptor Area Start Address Register */
+  __IO uint32_t ICM_HASH;       /**< (ICM Offset: 0x34) Region Hash Area Start Address Register */
+  __O  uint32_t ICM_UIHVAL[8];  /**< (ICM Offset: 0x38) User Initial Hash Value 0 Register 0 */
+} Icm;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ICM hardware registers */
+typedef struct {  
+  __IO ICM_CFG_Type                   ICM_CFG;        /**< Offset: 0x00 (R/W  32) Configuration Register */
+  __O  ICM_CTRL_Type                  ICM_CTRL;       /**< Offset: 0x04 ( /W  32) Control Register */
+  __I  ICM_SR_Type                    ICM_SR;         /**< Offset: 0x08 (R/   32) Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  ICM_IER_Type                   ICM_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  ICM_IDR_Type                   ICM_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  ICM_IMR_Type                   ICM_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  ICM_ISR_Type                   ICM_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __I  ICM_UASR_Type                  ICM_UASR;       /**< Offset: 0x20 (R/   32) Undefined Access Status Register */
+  __I  uint8_t                        Reserved2[12];
+  __IO ICM_DSCR_Type                  ICM_DSCR;       /**< Offset: 0x30 (R/W  32) Region Descriptor Area Start Address Register */
+  __IO ICM_HASH_Type                  ICM_HASH;       /**< Offset: 0x34 (R/W  32) Region Hash Area Start Address Register */
+  __O  ICM_UIHVAL_Type                ICM_UIHVAL[8];  /**< Offset: 0x38 ( /W  32) User Initial Hash Value 0 Register 0 */
+} Icm;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Integrity Check Monitor */
+
+#endif /* _SAMV71_ICM_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/isi.h
+++ b/asf/sam/include/samv71b/component/isi.h
@@ -1,0 +1,1057 @@
+/**
+ * \file
+ *
+ * \brief Component description for ISI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ISI_COMPONENT_H_
+#define _SAMV71_ISI_COMPONENT_H_
+#define _SAMV71_ISI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Image Sensor Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ISI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define ISI_6350                       /**< (ISI) Module ID */
+#define REV_ISI K                      /**< (ISI) Module revision */
+
+/* -------- ISI_CFG1 : (ISI Offset: 0x00) (R/W 32) ISI Configuration 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t HSYNC_POL:1;               /**< bit:      2  Horizontal Synchronization Polarity      */
+    uint32_t VSYNC_POL:1;               /**< bit:      3  Vertical Synchronization Polarity        */
+    uint32_t PIXCLK_POL:1;              /**< bit:      4  Pixel Clock Polarity                     */
+    uint32_t GRAYLE:1;                  /**< bit:      5  Grayscale Little Endian                  */
+    uint32_t EMB_SYNC:1;                /**< bit:      6  Embedded Synchronization                 */
+    uint32_t CRC_SYNC:1;                /**< bit:      7  Embedded Synchronization Correction      */
+    uint32_t FRATE:3;                   /**< bit:  8..10  Frame Rate [0..7]                        */
+    uint32_t DISCR:1;                   /**< bit:     11  Disable Codec Request                    */
+    uint32_t FULL:1;                    /**< bit:     12  Full Mode is Allowed                     */
+    uint32_t THMASK:2;                  /**< bit: 13..14  Threshold Mask                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SLD:8;                     /**< bit: 16..23  Start of Line Delay                      */
+    uint32_t SFD:8;                     /**< bit: 24..31  Start of Frame Delay                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CFG1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CFG1_OFFSET                     (0x00)                                        /**<  (ISI_CFG1) ISI Configuration 1 Register  Offset */
+
+#define ISI_CFG1_HSYNC_POL_Pos              2                                              /**< (ISI_CFG1) Horizontal Synchronization Polarity Position */
+#define ISI_CFG1_HSYNC_POL_Msk              (_U_(0x1) << ISI_CFG1_HSYNC_POL_Pos)           /**< (ISI_CFG1) Horizontal Synchronization Polarity Mask */
+#define ISI_CFG1_HSYNC_POL                  ISI_CFG1_HSYNC_POL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_HSYNC_POL_Msk instead */
+#define ISI_CFG1_VSYNC_POL_Pos              3                                              /**< (ISI_CFG1) Vertical Synchronization Polarity Position */
+#define ISI_CFG1_VSYNC_POL_Msk              (_U_(0x1) << ISI_CFG1_VSYNC_POL_Pos)           /**< (ISI_CFG1) Vertical Synchronization Polarity Mask */
+#define ISI_CFG1_VSYNC_POL                  ISI_CFG1_VSYNC_POL_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_VSYNC_POL_Msk instead */
+#define ISI_CFG1_PIXCLK_POL_Pos             4                                              /**< (ISI_CFG1) Pixel Clock Polarity Position */
+#define ISI_CFG1_PIXCLK_POL_Msk             (_U_(0x1) << ISI_CFG1_PIXCLK_POL_Pos)          /**< (ISI_CFG1) Pixel Clock Polarity Mask */
+#define ISI_CFG1_PIXCLK_POL                 ISI_CFG1_PIXCLK_POL_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_PIXCLK_POL_Msk instead */
+#define ISI_CFG1_GRAYLE_Pos                 5                                              /**< (ISI_CFG1) Grayscale Little Endian Position */
+#define ISI_CFG1_GRAYLE_Msk                 (_U_(0x1) << ISI_CFG1_GRAYLE_Pos)              /**< (ISI_CFG1) Grayscale Little Endian Mask */
+#define ISI_CFG1_GRAYLE                     ISI_CFG1_GRAYLE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_GRAYLE_Msk instead */
+#define ISI_CFG1_EMB_SYNC_Pos               6                                              /**< (ISI_CFG1) Embedded Synchronization Position */
+#define ISI_CFG1_EMB_SYNC_Msk               (_U_(0x1) << ISI_CFG1_EMB_SYNC_Pos)            /**< (ISI_CFG1) Embedded Synchronization Mask */
+#define ISI_CFG1_EMB_SYNC                   ISI_CFG1_EMB_SYNC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_EMB_SYNC_Msk instead */
+#define ISI_CFG1_CRC_SYNC_Pos               7                                              /**< (ISI_CFG1) Embedded Synchronization Correction Position */
+#define ISI_CFG1_CRC_SYNC_Msk               (_U_(0x1) << ISI_CFG1_CRC_SYNC_Pos)            /**< (ISI_CFG1) Embedded Synchronization Correction Mask */
+#define ISI_CFG1_CRC_SYNC                   ISI_CFG1_CRC_SYNC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_CRC_SYNC_Msk instead */
+#define ISI_CFG1_FRATE_Pos                  8                                              /**< (ISI_CFG1) Frame Rate [0..7] Position */
+#define ISI_CFG1_FRATE_Msk                  (_U_(0x7) << ISI_CFG1_FRATE_Pos)               /**< (ISI_CFG1) Frame Rate [0..7] Mask */
+#define ISI_CFG1_FRATE(value)               (ISI_CFG1_FRATE_Msk & ((value) << ISI_CFG1_FRATE_Pos))
+#define ISI_CFG1_DISCR_Pos                  11                                             /**< (ISI_CFG1) Disable Codec Request Position */
+#define ISI_CFG1_DISCR_Msk                  (_U_(0x1) << ISI_CFG1_DISCR_Pos)               /**< (ISI_CFG1) Disable Codec Request Mask */
+#define ISI_CFG1_DISCR                      ISI_CFG1_DISCR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_DISCR_Msk instead */
+#define ISI_CFG1_FULL_Pos                   12                                             /**< (ISI_CFG1) Full Mode is Allowed Position */
+#define ISI_CFG1_FULL_Msk                   (_U_(0x1) << ISI_CFG1_FULL_Pos)                /**< (ISI_CFG1) Full Mode is Allowed Mask */
+#define ISI_CFG1_FULL                       ISI_CFG1_FULL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG1_FULL_Msk instead */
+#define ISI_CFG1_THMASK_Pos                 13                                             /**< (ISI_CFG1) Threshold Mask Position */
+#define ISI_CFG1_THMASK_Msk                 (_U_(0x3) << ISI_CFG1_THMASK_Pos)              /**< (ISI_CFG1) Threshold Mask Mask */
+#define ISI_CFG1_THMASK(value)              (ISI_CFG1_THMASK_Msk & ((value) << ISI_CFG1_THMASK_Pos))
+#define   ISI_CFG1_THMASK_BEATS_4_Val       _U_(0x0)                                       /**< (ISI_CFG1) Only 4 beats AHB burst allowed  */
+#define   ISI_CFG1_THMASK_BEATS_8_Val       _U_(0x1)                                       /**< (ISI_CFG1) Only 4 and 8 beats AHB burst allowed  */
+#define   ISI_CFG1_THMASK_BEATS_16_Val      _U_(0x2)                                       /**< (ISI_CFG1) 4, 8 and 16 beats AHB burst allowed  */
+#define ISI_CFG1_THMASK_BEATS_4             (ISI_CFG1_THMASK_BEATS_4_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) Only 4 beats AHB burst allowed Position  */
+#define ISI_CFG1_THMASK_BEATS_8             (ISI_CFG1_THMASK_BEATS_8_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) Only 4 and 8 beats AHB burst allowed Position  */
+#define ISI_CFG1_THMASK_BEATS_16            (ISI_CFG1_THMASK_BEATS_16_Val << ISI_CFG1_THMASK_Pos)  /**< (ISI_CFG1) 4, 8 and 16 beats AHB burst allowed Position  */
+#define ISI_CFG1_SLD_Pos                    16                                             /**< (ISI_CFG1) Start of Line Delay Position */
+#define ISI_CFG1_SLD_Msk                    (_U_(0xFF) << ISI_CFG1_SLD_Pos)                /**< (ISI_CFG1) Start of Line Delay Mask */
+#define ISI_CFG1_SLD(value)                 (ISI_CFG1_SLD_Msk & ((value) << ISI_CFG1_SLD_Pos))
+#define ISI_CFG1_SFD_Pos                    24                                             /**< (ISI_CFG1) Start of Frame Delay Position */
+#define ISI_CFG1_SFD_Msk                    (_U_(0xFF) << ISI_CFG1_SFD_Pos)                /**< (ISI_CFG1) Start of Frame Delay Mask */
+#define ISI_CFG1_SFD(value)                 (ISI_CFG1_SFD_Msk & ((value) << ISI_CFG1_SFD_Pos))
+#define ISI_CFG1_Msk                        _U_(0xFFFF7FFC)                                /**< (ISI_CFG1) Register Mask  */
+
+
+/* -------- ISI_CFG2 : (ISI Offset: 0x04) (R/W 32) ISI Configuration 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IM_VSIZE:11;               /**< bit:  0..10  Vertical Size of the Image Sensor [0..2047] */
+    uint32_t GS_MODE:1;                 /**< bit:     11  Grayscale Pixel Format Mode              */
+    uint32_t RGB_MODE:1;                /**< bit:     12  RGB Input Mode                           */
+    uint32_t GRAYSCALE:1;               /**< bit:     13  Grayscale Mode Format Enable             */
+    uint32_t RGB_SWAP:1;                /**< bit:     14  RGB Format Swap Mode                     */
+    uint32_t COL_SPACE:1;               /**< bit:     15  Color Space for the Image Data           */
+    uint32_t IM_HSIZE:11;               /**< bit: 16..26  Horizontal Size of the Image Sensor [0..2047] */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t YCC_SWAP:2;                /**< bit: 28..29  YCrCb Format Swap Mode                   */
+    uint32_t RGB_CFG:2;                 /**< bit: 30..31  RGB Pixel Mapping Configuration          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CFG2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CFG2_OFFSET                     (0x04)                                        /**<  (ISI_CFG2) ISI Configuration 2 Register  Offset */
+
+#define ISI_CFG2_IM_VSIZE_Pos               0                                              /**< (ISI_CFG2) Vertical Size of the Image Sensor [0..2047] Position */
+#define ISI_CFG2_IM_VSIZE_Msk               (_U_(0x7FF) << ISI_CFG2_IM_VSIZE_Pos)          /**< (ISI_CFG2) Vertical Size of the Image Sensor [0..2047] Mask */
+#define ISI_CFG2_IM_VSIZE(value)            (ISI_CFG2_IM_VSIZE_Msk & ((value) << ISI_CFG2_IM_VSIZE_Pos))
+#define ISI_CFG2_GS_MODE_Pos                11                                             /**< (ISI_CFG2) Grayscale Pixel Format Mode Position */
+#define ISI_CFG2_GS_MODE_Msk                (_U_(0x1) << ISI_CFG2_GS_MODE_Pos)             /**< (ISI_CFG2) Grayscale Pixel Format Mode Mask */
+#define ISI_CFG2_GS_MODE                    ISI_CFG2_GS_MODE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_GS_MODE_Msk instead */
+#define ISI_CFG2_RGB_MODE_Pos               12                                             /**< (ISI_CFG2) RGB Input Mode Position */
+#define ISI_CFG2_RGB_MODE_Msk               (_U_(0x1) << ISI_CFG2_RGB_MODE_Pos)            /**< (ISI_CFG2) RGB Input Mode Mask */
+#define ISI_CFG2_RGB_MODE                   ISI_CFG2_RGB_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_RGB_MODE_Msk instead */
+#define ISI_CFG2_GRAYSCALE_Pos              13                                             /**< (ISI_CFG2) Grayscale Mode Format Enable Position */
+#define ISI_CFG2_GRAYSCALE_Msk              (_U_(0x1) << ISI_CFG2_GRAYSCALE_Pos)           /**< (ISI_CFG2) Grayscale Mode Format Enable Mask */
+#define ISI_CFG2_GRAYSCALE                  ISI_CFG2_GRAYSCALE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_GRAYSCALE_Msk instead */
+#define ISI_CFG2_RGB_SWAP_Pos               14                                             /**< (ISI_CFG2) RGB Format Swap Mode Position */
+#define ISI_CFG2_RGB_SWAP_Msk               (_U_(0x1) << ISI_CFG2_RGB_SWAP_Pos)            /**< (ISI_CFG2) RGB Format Swap Mode Mask */
+#define ISI_CFG2_RGB_SWAP                   ISI_CFG2_RGB_SWAP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_RGB_SWAP_Msk instead */
+#define ISI_CFG2_COL_SPACE_Pos              15                                             /**< (ISI_CFG2) Color Space for the Image Data Position */
+#define ISI_CFG2_COL_SPACE_Msk              (_U_(0x1) << ISI_CFG2_COL_SPACE_Pos)           /**< (ISI_CFG2) Color Space for the Image Data Mask */
+#define ISI_CFG2_COL_SPACE                  ISI_CFG2_COL_SPACE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CFG2_COL_SPACE_Msk instead */
+#define ISI_CFG2_IM_HSIZE_Pos               16                                             /**< (ISI_CFG2) Horizontal Size of the Image Sensor [0..2047] Position */
+#define ISI_CFG2_IM_HSIZE_Msk               (_U_(0x7FF) << ISI_CFG2_IM_HSIZE_Pos)          /**< (ISI_CFG2) Horizontal Size of the Image Sensor [0..2047] Mask */
+#define ISI_CFG2_IM_HSIZE(value)            (ISI_CFG2_IM_HSIZE_Msk & ((value) << ISI_CFG2_IM_HSIZE_Pos))
+#define ISI_CFG2_YCC_SWAP_Pos               28                                             /**< (ISI_CFG2) YCrCb Format Swap Mode Position */
+#define ISI_CFG2_YCC_SWAP_Msk               (_U_(0x3) << ISI_CFG2_YCC_SWAP_Pos)            /**< (ISI_CFG2) YCrCb Format Swap Mode Mask */
+#define ISI_CFG2_YCC_SWAP(value)            (ISI_CFG2_YCC_SWAP_Msk & ((value) << ISI_CFG2_YCC_SWAP_Pos))
+#define   ISI_CFG2_YCC_SWAP_DEFAULT_Val     _U_(0x0)                                       /**< (ISI_CFG2) Byte 0 Cb(i)Byte 1 Y(i)Byte 2 Cr(i)Byte 3 Y(i+1)  */
+#define   ISI_CFG2_YCC_SWAP_MODE1_Val       _U_(0x1)                                       /**< (ISI_CFG2) Byte 0 Cr(i)Byte 1 Y(i)Byte 2 Cb(i)Byte 3 Y(i+1)  */
+#define   ISI_CFG2_YCC_SWAP_MODE2_Val       _U_(0x2)                                       /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cb(i)Byte 2 Y(i+1)Byte 3 Cr(i)  */
+#define   ISI_CFG2_YCC_SWAP_MODE3_Val       _U_(0x3)                                       /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cr(i)Byte 2 Y(i+1)Byte 3 Cb(i)  */
+#define ISI_CFG2_YCC_SWAP_DEFAULT           (ISI_CFG2_YCC_SWAP_DEFAULT_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Cb(i)Byte 1 Y(i)Byte 2 Cr(i)Byte 3 Y(i+1) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE1             (ISI_CFG2_YCC_SWAP_MODE1_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Cr(i)Byte 1 Y(i)Byte 2 Cb(i)Byte 3 Y(i+1) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE2             (ISI_CFG2_YCC_SWAP_MODE2_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cb(i)Byte 2 Y(i+1)Byte 3 Cr(i) Position  */
+#define ISI_CFG2_YCC_SWAP_MODE3             (ISI_CFG2_YCC_SWAP_MODE3_Val << ISI_CFG2_YCC_SWAP_Pos)  /**< (ISI_CFG2) Byte 0 Y(i)Byte 1 Cr(i)Byte 2 Y(i+1)Byte 3 Cb(i) Position  */
+#define ISI_CFG2_RGB_CFG_Pos                30                                             /**< (ISI_CFG2) RGB Pixel Mapping Configuration Position */
+#define ISI_CFG2_RGB_CFG_Msk                (_U_(0x3) << ISI_CFG2_RGB_CFG_Pos)             /**< (ISI_CFG2) RGB Pixel Mapping Configuration Mask */
+#define ISI_CFG2_RGB_CFG(value)             (ISI_CFG2_RGB_CFG_Msk & ((value) << ISI_CFG2_RGB_CFG_Pos))
+#define   ISI_CFG2_RGB_CFG_DEFAULT_Val      _U_(0x0)                                       /**< (ISI_CFG2) Byte 0 R/G(MSB)Byte 1 G(LSB)/BByte 2 R/G(MSB)Byte 3 G(LSB)/B  */
+#define   ISI_CFG2_RGB_CFG_MODE1_Val        _U_(0x1)                                       /**< (ISI_CFG2) Byte 0 B/G(MSB)Byte 1 G(LSB)/RByte 2 B/G(MSB)Byte 3 G(LSB)/R  */
+#define   ISI_CFG2_RGB_CFG_MODE2_Val        _U_(0x2)                                       /**< (ISI_CFG2) Byte 0 G(LSB)/RByte 1 B/G(MSB)Byte 2 G(LSB)/RByte 3 B/G(MSB)  */
+#define   ISI_CFG2_RGB_CFG_MODE3_Val        _U_(0x3)                                       /**< (ISI_CFG2) Byte 0 G(LSB)/BByte 1 R/G(MSB)Byte 2 G(LSB)/BByte 3 R/G(MSB)  */
+#define ISI_CFG2_RGB_CFG_DEFAULT            (ISI_CFG2_RGB_CFG_DEFAULT_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 R/G(MSB)Byte 1 G(LSB)/BByte 2 R/G(MSB)Byte 3 G(LSB)/B Position  */
+#define ISI_CFG2_RGB_CFG_MODE1              (ISI_CFG2_RGB_CFG_MODE1_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 B/G(MSB)Byte 1 G(LSB)/RByte 2 B/G(MSB)Byte 3 G(LSB)/R Position  */
+#define ISI_CFG2_RGB_CFG_MODE2              (ISI_CFG2_RGB_CFG_MODE2_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 G(LSB)/RByte 1 B/G(MSB)Byte 2 G(LSB)/RByte 3 B/G(MSB) Position  */
+#define ISI_CFG2_RGB_CFG_MODE3              (ISI_CFG2_RGB_CFG_MODE3_Val << ISI_CFG2_RGB_CFG_Pos)  /**< (ISI_CFG2) Byte 0 G(LSB)/BByte 1 R/G(MSB)Byte 2 G(LSB)/BByte 3 R/G(MSB) Position  */
+#define ISI_CFG2_MASK                       _U_(0xF7FFFFFF)                                /**< \deprecated (ISI_CFG2) Register MASK  (Use ISI_CFG2_Msk instead)  */
+#define ISI_CFG2_Msk                        _U_(0xF7FFFFFF)                                /**< (ISI_CFG2) Register Mask  */
+
+
+/* -------- ISI_PSIZE : (ISI Offset: 0x08) (R/W 32) ISI Preview Size Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PREV_VSIZE:10;             /**< bit:   0..9  Vertical Size for the Preview Path       */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t PREV_HSIZE:10;             /**< bit: 16..25  Horizontal Size for the Preview Path     */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_PSIZE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_PSIZE_OFFSET                    (0x08)                                        /**<  (ISI_PSIZE) ISI Preview Size Register  Offset */
+
+#define ISI_PSIZE_PREV_VSIZE_Pos            0                                              /**< (ISI_PSIZE) Vertical Size for the Preview Path Position */
+#define ISI_PSIZE_PREV_VSIZE_Msk            (_U_(0x3FF) << ISI_PSIZE_PREV_VSIZE_Pos)       /**< (ISI_PSIZE) Vertical Size for the Preview Path Mask */
+#define ISI_PSIZE_PREV_VSIZE(value)         (ISI_PSIZE_PREV_VSIZE_Msk & ((value) << ISI_PSIZE_PREV_VSIZE_Pos))
+#define ISI_PSIZE_PREV_HSIZE_Pos            16                                             /**< (ISI_PSIZE) Horizontal Size for the Preview Path Position */
+#define ISI_PSIZE_PREV_HSIZE_Msk            (_U_(0x3FF) << ISI_PSIZE_PREV_HSIZE_Pos)       /**< (ISI_PSIZE) Horizontal Size for the Preview Path Mask */
+#define ISI_PSIZE_PREV_HSIZE(value)         (ISI_PSIZE_PREV_HSIZE_Msk & ((value) << ISI_PSIZE_PREV_HSIZE_Pos))
+#define ISI_PSIZE_MASK                      _U_(0x3FF03FF)                                 /**< \deprecated (ISI_PSIZE) Register MASK  (Use ISI_PSIZE_Msk instead)  */
+#define ISI_PSIZE_Msk                       _U_(0x3FF03FF)                                 /**< (ISI_PSIZE) Register Mask  */
+
+
+/* -------- ISI_PDECF : (ISI Offset: 0x0c) (R/W 32) ISI Preview Decimation Factor Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DEC_FACTOR:8;              /**< bit:   0..7  Decimation Factor                        */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_PDECF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_PDECF_OFFSET                    (0x0C)                                        /**<  (ISI_PDECF) ISI Preview Decimation Factor Register  Offset */
+
+#define ISI_PDECF_DEC_FACTOR_Pos            0                                              /**< (ISI_PDECF) Decimation Factor Position */
+#define ISI_PDECF_DEC_FACTOR_Msk            (_U_(0xFF) << ISI_PDECF_DEC_FACTOR_Pos)        /**< (ISI_PDECF) Decimation Factor Mask */
+#define ISI_PDECF_DEC_FACTOR(value)         (ISI_PDECF_DEC_FACTOR_Msk & ((value) << ISI_PDECF_DEC_FACTOR_Pos))
+#define ISI_PDECF_MASK                      _U_(0xFF)                                      /**< \deprecated (ISI_PDECF) Register MASK  (Use ISI_PDECF_Msk instead)  */
+#define ISI_PDECF_Msk                       _U_(0xFF)                                      /**< (ISI_PDECF) Register Mask  */
+
+
+/* -------- ISI_Y2R_SET0 : (ISI Offset: 0x10) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C0:8;                      /**< bit:   0..7  Color Space Conversion Matrix Coefficient C0 */
+    uint32_t C1:8;                      /**< bit:  8..15  Color Space Conversion Matrix Coefficient C1 */
+    uint32_t C2:8;                      /**< bit: 16..23  Color Space Conversion Matrix Coefficient C2 */
+    uint32_t C3:8;                      /**< bit: 24..31  Color Space Conversion Matrix Coefficient C3 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_Y2R_SET0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_Y2R_SET0_OFFSET                 (0x10)                                        /**<  (ISI_Y2R_SET0) ISI Color Space Conversion YCrCb To RGB Set 0 Register  Offset */
+
+#define ISI_Y2R_SET0_C0_Pos                 0                                              /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C0 Position */
+#define ISI_Y2R_SET0_C0_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C0_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C0 Mask */
+#define ISI_Y2R_SET0_C0(value)              (ISI_Y2R_SET0_C0_Msk & ((value) << ISI_Y2R_SET0_C0_Pos))
+#define ISI_Y2R_SET0_C1_Pos                 8                                              /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C1 Position */
+#define ISI_Y2R_SET0_C1_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C1_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C1 Mask */
+#define ISI_Y2R_SET0_C1(value)              (ISI_Y2R_SET0_C1_Msk & ((value) << ISI_Y2R_SET0_C1_Pos))
+#define ISI_Y2R_SET0_C2_Pos                 16                                             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C2 Position */
+#define ISI_Y2R_SET0_C2_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C2_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C2 Mask */
+#define ISI_Y2R_SET0_C2(value)              (ISI_Y2R_SET0_C2_Msk & ((value) << ISI_Y2R_SET0_C2_Pos))
+#define ISI_Y2R_SET0_C3_Pos                 24                                             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C3 Position */
+#define ISI_Y2R_SET0_C3_Msk                 (_U_(0xFF) << ISI_Y2R_SET0_C3_Pos)             /**< (ISI_Y2R_SET0) Color Space Conversion Matrix Coefficient C3 Mask */
+#define ISI_Y2R_SET0_C3(value)              (ISI_Y2R_SET0_C3_Msk & ((value) << ISI_Y2R_SET0_C3_Pos))
+#define ISI_Y2R_SET0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (ISI_Y2R_SET0) Register MASK  (Use ISI_Y2R_SET0_Msk instead)  */
+#define ISI_Y2R_SET0_Msk                    _U_(0xFFFFFFFF)                                /**< (ISI_Y2R_SET0) Register Mask  */
+
+
+/* -------- ISI_Y2R_SET1 : (ISI Offset: 0x14) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C4:9;                      /**< bit:   0..8  Color Space Conversion Matrix Coefficient C4 */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t Yoff:1;                    /**< bit:     12  Color Space Conversion Luminance Default Offset */
+    uint32_t Croff:1;                   /**< bit:     13  Color Space Conversion Red Chrominance Default Offset */
+    uint32_t Cboff:1;                   /**< bit:     14  Color Space Conversion Blue Chrominance Default Offset */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_Y2R_SET1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_Y2R_SET1_OFFSET                 (0x14)                                        /**<  (ISI_Y2R_SET1) ISI Color Space Conversion YCrCb To RGB Set 1 Register  Offset */
+
+#define ISI_Y2R_SET1_C4_Pos                 0                                              /**< (ISI_Y2R_SET1) Color Space Conversion Matrix Coefficient C4 Position */
+#define ISI_Y2R_SET1_C4_Msk                 (_U_(0x1FF) << ISI_Y2R_SET1_C4_Pos)            /**< (ISI_Y2R_SET1) Color Space Conversion Matrix Coefficient C4 Mask */
+#define ISI_Y2R_SET1_C4(value)              (ISI_Y2R_SET1_C4_Msk & ((value) << ISI_Y2R_SET1_C4_Pos))
+#define ISI_Y2R_SET1_Yoff_Pos               12                                             /**< (ISI_Y2R_SET1) Color Space Conversion Luminance Default Offset Position */
+#define ISI_Y2R_SET1_Yoff_Msk               (_U_(0x1) << ISI_Y2R_SET1_Yoff_Pos)            /**< (ISI_Y2R_SET1) Color Space Conversion Luminance Default Offset Mask */
+#define ISI_Y2R_SET1_Yoff                   ISI_Y2R_SET1_Yoff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Yoff_Msk instead */
+#define ISI_Y2R_SET1_Croff_Pos              13                                             /**< (ISI_Y2R_SET1) Color Space Conversion Red Chrominance Default Offset Position */
+#define ISI_Y2R_SET1_Croff_Msk              (_U_(0x1) << ISI_Y2R_SET1_Croff_Pos)           /**< (ISI_Y2R_SET1) Color Space Conversion Red Chrominance Default Offset Mask */
+#define ISI_Y2R_SET1_Croff                  ISI_Y2R_SET1_Croff_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Croff_Msk instead */
+#define ISI_Y2R_SET1_Cboff_Pos              14                                             /**< (ISI_Y2R_SET1) Color Space Conversion Blue Chrominance Default Offset Position */
+#define ISI_Y2R_SET1_Cboff_Msk              (_U_(0x1) << ISI_Y2R_SET1_Cboff_Pos)           /**< (ISI_Y2R_SET1) Color Space Conversion Blue Chrominance Default Offset Mask */
+#define ISI_Y2R_SET1_Cboff                  ISI_Y2R_SET1_Cboff_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_Y2R_SET1_Cboff_Msk instead */
+#define ISI_Y2R_SET1_MASK                   _U_(0x71FF)                                    /**< \deprecated (ISI_Y2R_SET1) Register MASK  (Use ISI_Y2R_SET1_Msk instead)  */
+#define ISI_Y2R_SET1_Msk                    _U_(0x71FF)                                    /**< (ISI_Y2R_SET1) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET0 : (ISI Offset: 0x18) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C0:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C0 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C1:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C1 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C2:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C2 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Roff:1;                    /**< bit:     24  Color Space Conversion Red Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET0_OFFSET                 (0x18)                                        /**<  (ISI_R2Y_SET0) ISI Color Space Conversion RGB To YCrCb Set 0 Register  Offset */
+
+#define ISI_R2Y_SET0_C0_Pos                 0                                              /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C0 Position */
+#define ISI_R2Y_SET0_C0_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C0_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C0 Mask */
+#define ISI_R2Y_SET0_C0(value)              (ISI_R2Y_SET0_C0_Msk & ((value) << ISI_R2Y_SET0_C0_Pos))
+#define ISI_R2Y_SET0_C1_Pos                 8                                              /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C1 Position */
+#define ISI_R2Y_SET0_C1_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C1_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C1 Mask */
+#define ISI_R2Y_SET0_C1(value)              (ISI_R2Y_SET0_C1_Msk & ((value) << ISI_R2Y_SET0_C1_Pos))
+#define ISI_R2Y_SET0_C2_Pos                 16                                             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C2 Position */
+#define ISI_R2Y_SET0_C2_Msk                 (_U_(0x7F) << ISI_R2Y_SET0_C2_Pos)             /**< (ISI_R2Y_SET0) Color Space Conversion Matrix Coefficient C2 Mask */
+#define ISI_R2Y_SET0_C2(value)              (ISI_R2Y_SET0_C2_Msk & ((value) << ISI_R2Y_SET0_C2_Pos))
+#define ISI_R2Y_SET0_Roff_Pos               24                                             /**< (ISI_R2Y_SET0) Color Space Conversion Red Component Offset Position */
+#define ISI_R2Y_SET0_Roff_Msk               (_U_(0x1) << ISI_R2Y_SET0_Roff_Pos)            /**< (ISI_R2Y_SET0) Color Space Conversion Red Component Offset Mask */
+#define ISI_R2Y_SET0_Roff                   ISI_R2Y_SET0_Roff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET0_Roff_Msk instead */
+#define ISI_R2Y_SET0_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET0) Register MASK  (Use ISI_R2Y_SET0_Msk instead)  */
+#define ISI_R2Y_SET0_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET0) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET1 : (ISI Offset: 0x1c) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C3:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C3 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C4:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C4 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C5:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C5 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Goff:1;                    /**< bit:     24  Color Space Conversion Green Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET1_OFFSET                 (0x1C)                                        /**<  (ISI_R2Y_SET1) ISI Color Space Conversion RGB To YCrCb Set 1 Register  Offset */
+
+#define ISI_R2Y_SET1_C3_Pos                 0                                              /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C3 Position */
+#define ISI_R2Y_SET1_C3_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C3_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C3 Mask */
+#define ISI_R2Y_SET1_C3(value)              (ISI_R2Y_SET1_C3_Msk & ((value) << ISI_R2Y_SET1_C3_Pos))
+#define ISI_R2Y_SET1_C4_Pos                 8                                              /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C4 Position */
+#define ISI_R2Y_SET1_C4_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C4_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C4 Mask */
+#define ISI_R2Y_SET1_C4(value)              (ISI_R2Y_SET1_C4_Msk & ((value) << ISI_R2Y_SET1_C4_Pos))
+#define ISI_R2Y_SET1_C5_Pos                 16                                             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C5 Position */
+#define ISI_R2Y_SET1_C5_Msk                 (_U_(0x7F) << ISI_R2Y_SET1_C5_Pos)             /**< (ISI_R2Y_SET1) Color Space Conversion Matrix Coefficient C5 Mask */
+#define ISI_R2Y_SET1_C5(value)              (ISI_R2Y_SET1_C5_Msk & ((value) << ISI_R2Y_SET1_C5_Pos))
+#define ISI_R2Y_SET1_Goff_Pos               24                                             /**< (ISI_R2Y_SET1) Color Space Conversion Green Component Offset Position */
+#define ISI_R2Y_SET1_Goff_Msk               (_U_(0x1) << ISI_R2Y_SET1_Goff_Pos)            /**< (ISI_R2Y_SET1) Color Space Conversion Green Component Offset Mask */
+#define ISI_R2Y_SET1_Goff                   ISI_R2Y_SET1_Goff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET1_Goff_Msk instead */
+#define ISI_R2Y_SET1_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET1) Register MASK  (Use ISI_R2Y_SET1_Msk instead)  */
+#define ISI_R2Y_SET1_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET1) Register Mask  */
+
+
+/* -------- ISI_R2Y_SET2 : (ISI Offset: 0x20) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C6:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C6 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t C7:7;                      /**< bit:  8..14  Color Space Conversion Matrix Coefficient C7 */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t C8:7;                      /**< bit: 16..22  Color Space Conversion Matrix Coefficient C8 */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t Boff:1;                    /**< bit:     24  Color Space Conversion Blue Component Offset */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_R2Y_SET2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_R2Y_SET2_OFFSET                 (0x20)                                        /**<  (ISI_R2Y_SET2) ISI Color Space Conversion RGB To YCrCb Set 2 Register  Offset */
+
+#define ISI_R2Y_SET2_C6_Pos                 0                                              /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C6 Position */
+#define ISI_R2Y_SET2_C6_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C6_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C6 Mask */
+#define ISI_R2Y_SET2_C6(value)              (ISI_R2Y_SET2_C6_Msk & ((value) << ISI_R2Y_SET2_C6_Pos))
+#define ISI_R2Y_SET2_C7_Pos                 8                                              /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C7 Position */
+#define ISI_R2Y_SET2_C7_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C7_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C7 Mask */
+#define ISI_R2Y_SET2_C7(value)              (ISI_R2Y_SET2_C7_Msk & ((value) << ISI_R2Y_SET2_C7_Pos))
+#define ISI_R2Y_SET2_C8_Pos                 16                                             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C8 Position */
+#define ISI_R2Y_SET2_C8_Msk                 (_U_(0x7F) << ISI_R2Y_SET2_C8_Pos)             /**< (ISI_R2Y_SET2) Color Space Conversion Matrix Coefficient C8 Mask */
+#define ISI_R2Y_SET2_C8(value)              (ISI_R2Y_SET2_C8_Msk & ((value) << ISI_R2Y_SET2_C8_Pos))
+#define ISI_R2Y_SET2_Boff_Pos               24                                             /**< (ISI_R2Y_SET2) Color Space Conversion Blue Component Offset Position */
+#define ISI_R2Y_SET2_Boff_Msk               (_U_(0x1) << ISI_R2Y_SET2_Boff_Pos)            /**< (ISI_R2Y_SET2) Color Space Conversion Blue Component Offset Mask */
+#define ISI_R2Y_SET2_Boff                   ISI_R2Y_SET2_Boff_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_R2Y_SET2_Boff_Msk instead */
+#define ISI_R2Y_SET2_MASK                   _U_(0x17F7F7F)                                 /**< \deprecated (ISI_R2Y_SET2) Register MASK  (Use ISI_R2Y_SET2_Msk instead)  */
+#define ISI_R2Y_SET2_Msk                    _U_(0x17F7F7F)                                 /**< (ISI_R2Y_SET2) Register Mask  */
+
+
+/* -------- ISI_CR : (ISI Offset: 0x24) (/W 32) ISI Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISI_EN:1;                  /**< bit:      0  ISI Module Enable Request                */
+    uint32_t ISI_DIS:1;                 /**< bit:      1  ISI Module Disable Request               */
+    uint32_t ISI_SRST:1;                /**< bit:      2  ISI Software Reset Request               */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t ISI_CDC:1;                 /**< bit:      8  ISI Codec Request                        */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_CR_OFFSET                       (0x24)                                        /**<  (ISI_CR) ISI Control Register  Offset */
+
+#define ISI_CR_ISI_EN_Pos                   0                                              /**< (ISI_CR) ISI Module Enable Request Position */
+#define ISI_CR_ISI_EN_Msk                   (_U_(0x1) << ISI_CR_ISI_EN_Pos)                /**< (ISI_CR) ISI Module Enable Request Mask */
+#define ISI_CR_ISI_EN                       ISI_CR_ISI_EN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_EN_Msk instead */
+#define ISI_CR_ISI_DIS_Pos                  1                                              /**< (ISI_CR) ISI Module Disable Request Position */
+#define ISI_CR_ISI_DIS_Msk                  (_U_(0x1) << ISI_CR_ISI_DIS_Pos)               /**< (ISI_CR) ISI Module Disable Request Mask */
+#define ISI_CR_ISI_DIS                      ISI_CR_ISI_DIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_DIS_Msk instead */
+#define ISI_CR_ISI_SRST_Pos                 2                                              /**< (ISI_CR) ISI Software Reset Request Position */
+#define ISI_CR_ISI_SRST_Msk                 (_U_(0x1) << ISI_CR_ISI_SRST_Pos)              /**< (ISI_CR) ISI Software Reset Request Mask */
+#define ISI_CR_ISI_SRST                     ISI_CR_ISI_SRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_SRST_Msk instead */
+#define ISI_CR_ISI_CDC_Pos                  8                                              /**< (ISI_CR) ISI Codec Request Position */
+#define ISI_CR_ISI_CDC_Msk                  (_U_(0x1) << ISI_CR_ISI_CDC_Pos)               /**< (ISI_CR) ISI Codec Request Mask */
+#define ISI_CR_ISI_CDC                      ISI_CR_ISI_CDC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_CR_ISI_CDC_Msk instead */
+#define ISI_CR_MASK                         _U_(0x107)                                     /**< \deprecated (ISI_CR) Register MASK  (Use ISI_CR_Msk instead)  */
+#define ISI_CR_Msk                          _U_(0x107)                                     /**< (ISI_CR) Register Mask  */
+
+
+/* -------- ISI_SR : (ISI Offset: 0x28) (R/ 32) ISI Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  Module Enable                            */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Module Disable Request has Terminated (cleared on read) */
+    uint32_t SRST:1;                    /**< bit:      2  Module Software Reset Request has Terminated (cleared on read) */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t CDC_PND:1;                 /**< bit:      8  Pending Codec Request                    */
+    uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization (cleared on read) */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer has Terminated (cleared on read) */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer has Terminated (cleared on read) */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t SIP:1;                     /**< bit:     19  Synchronization in Progress              */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow (cleared on read) */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow (cleared on read) */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  CRC Synchronization Error (cleared on read) */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overrun (cleared on read)     */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_SR_OFFSET                       (0x28)                                        /**<  (ISI_SR) ISI Status Register  Offset */
+
+#define ISI_SR_ENABLE_Pos                   0                                              /**< (ISI_SR) Module Enable Position */
+#define ISI_SR_ENABLE_Msk                   (_U_(0x1) << ISI_SR_ENABLE_Pos)                /**< (ISI_SR) Module Enable Mask */
+#define ISI_SR_ENABLE                       ISI_SR_ENABLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_ENABLE_Msk instead */
+#define ISI_SR_DIS_DONE_Pos                 1                                              /**< (ISI_SR) Module Disable Request has Terminated (cleared on read) Position */
+#define ISI_SR_DIS_DONE_Msk                 (_U_(0x1) << ISI_SR_DIS_DONE_Pos)              /**< (ISI_SR) Module Disable Request has Terminated (cleared on read) Mask */
+#define ISI_SR_DIS_DONE                     ISI_SR_DIS_DONE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_DIS_DONE_Msk instead */
+#define ISI_SR_SRST_Pos                     2                                              /**< (ISI_SR) Module Software Reset Request has Terminated (cleared on read) Position */
+#define ISI_SR_SRST_Msk                     (_U_(0x1) << ISI_SR_SRST_Pos)                  /**< (ISI_SR) Module Software Reset Request has Terminated (cleared on read) Mask */
+#define ISI_SR_SRST                         ISI_SR_SRST_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_SRST_Msk instead */
+#define ISI_SR_CDC_PND_Pos                  8                                              /**< (ISI_SR) Pending Codec Request Position */
+#define ISI_SR_CDC_PND_Msk                  (_U_(0x1) << ISI_SR_CDC_PND_Pos)               /**< (ISI_SR) Pending Codec Request Mask */
+#define ISI_SR_CDC_PND                      ISI_SR_CDC_PND_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CDC_PND_Msk instead */
+#define ISI_SR_VSYNC_Pos                    10                                             /**< (ISI_SR) Vertical Synchronization (cleared on read) Position */
+#define ISI_SR_VSYNC_Msk                    (_U_(0x1) << ISI_SR_VSYNC_Pos)                 /**< (ISI_SR) Vertical Synchronization (cleared on read) Mask */
+#define ISI_SR_VSYNC                        ISI_SR_VSYNC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_VSYNC_Msk instead */
+#define ISI_SR_PXFR_DONE_Pos                16                                             /**< (ISI_SR) Preview DMA Transfer has Terminated (cleared on read) Position */
+#define ISI_SR_PXFR_DONE_Msk                (_U_(0x1) << ISI_SR_PXFR_DONE_Pos)             /**< (ISI_SR) Preview DMA Transfer has Terminated (cleared on read) Mask */
+#define ISI_SR_PXFR_DONE                    ISI_SR_PXFR_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_PXFR_DONE_Msk instead */
+#define ISI_SR_CXFR_DONE_Pos                17                                             /**< (ISI_SR) Codec DMA Transfer has Terminated (cleared on read) Position */
+#define ISI_SR_CXFR_DONE_Msk                (_U_(0x1) << ISI_SR_CXFR_DONE_Pos)             /**< (ISI_SR) Codec DMA Transfer has Terminated (cleared on read) Mask */
+#define ISI_SR_CXFR_DONE                    ISI_SR_CXFR_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CXFR_DONE_Msk instead */
+#define ISI_SR_SIP_Pos                      19                                             /**< (ISI_SR) Synchronization in Progress Position */
+#define ISI_SR_SIP_Msk                      (_U_(0x1) << ISI_SR_SIP_Pos)                   /**< (ISI_SR) Synchronization in Progress Mask */
+#define ISI_SR_SIP                          ISI_SR_SIP_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_SIP_Msk instead */
+#define ISI_SR_P_OVR_Pos                    24                                             /**< (ISI_SR) Preview Datapath Overflow (cleared on read) Position */
+#define ISI_SR_P_OVR_Msk                    (_U_(0x1) << ISI_SR_P_OVR_Pos)                 /**< (ISI_SR) Preview Datapath Overflow (cleared on read) Mask */
+#define ISI_SR_P_OVR                        ISI_SR_P_OVR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_P_OVR_Msk instead */
+#define ISI_SR_C_OVR_Pos                    25                                             /**< (ISI_SR) Codec Datapath Overflow (cleared on read) Position */
+#define ISI_SR_C_OVR_Msk                    (_U_(0x1) << ISI_SR_C_OVR_Pos)                 /**< (ISI_SR) Codec Datapath Overflow (cleared on read) Mask */
+#define ISI_SR_C_OVR                        ISI_SR_C_OVR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_C_OVR_Msk instead */
+#define ISI_SR_CRC_ERR_Pos                  26                                             /**< (ISI_SR) CRC Synchronization Error (cleared on read) Position */
+#define ISI_SR_CRC_ERR_Msk                  (_U_(0x1) << ISI_SR_CRC_ERR_Pos)               /**< (ISI_SR) CRC Synchronization Error (cleared on read) Mask */
+#define ISI_SR_CRC_ERR                      ISI_SR_CRC_ERR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_CRC_ERR_Msk instead */
+#define ISI_SR_FR_OVR_Pos                   27                                             /**< (ISI_SR) Frame Rate Overrun (cleared on read) Position */
+#define ISI_SR_FR_OVR_Msk                   (_U_(0x1) << ISI_SR_FR_OVR_Pos)                /**< (ISI_SR) Frame Rate Overrun (cleared on read) Mask */
+#define ISI_SR_FR_OVR                       ISI_SR_FR_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_SR_FR_OVR_Msk instead */
+#define ISI_SR_MASK                         _U_(0xF0B0507)                                 /**< \deprecated (ISI_SR) Register MASK  (Use ISI_SR_Msk instead)  */
+#define ISI_SR_Msk                          _U_(0xF0B0507)                                 /**< (ISI_SR) Register Mask  */
+
+
+/* -------- ISI_IER : (ISI Offset: 0x2c) (/W 32) ISI Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Disable Done Interrupt Enable            */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Interrupt Enable          */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization Interrupt Enable */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Done Interrupt Enable */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Done Interrupt Enable */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow Interrupt Enable */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow Interrupt Enable */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  Embedded Synchronization CRC Error Interrupt Enable */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overflow Interrupt Enable     */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IER_OFFSET                      (0x2C)                                        /**<  (ISI_IER) ISI Interrupt Enable Register  Offset */
+
+#define ISI_IER_DIS_DONE_Pos                1                                              /**< (ISI_IER) Disable Done Interrupt Enable Position */
+#define ISI_IER_DIS_DONE_Msk                (_U_(0x1) << ISI_IER_DIS_DONE_Pos)             /**< (ISI_IER) Disable Done Interrupt Enable Mask */
+#define ISI_IER_DIS_DONE                    ISI_IER_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_DIS_DONE_Msk instead */
+#define ISI_IER_SRST_Pos                    2                                              /**< (ISI_IER) Software Reset Interrupt Enable Position */
+#define ISI_IER_SRST_Msk                    (_U_(0x1) << ISI_IER_SRST_Pos)                 /**< (ISI_IER) Software Reset Interrupt Enable Mask */
+#define ISI_IER_SRST                        ISI_IER_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_SRST_Msk instead */
+#define ISI_IER_VSYNC_Pos                   10                                             /**< (ISI_IER) Vertical Synchronization Interrupt Enable Position */
+#define ISI_IER_VSYNC_Msk                   (_U_(0x1) << ISI_IER_VSYNC_Pos)                /**< (ISI_IER) Vertical Synchronization Interrupt Enable Mask */
+#define ISI_IER_VSYNC                       ISI_IER_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_VSYNC_Msk instead */
+#define ISI_IER_PXFR_DONE_Pos               16                                             /**< (ISI_IER) Preview DMA Transfer Done Interrupt Enable Position */
+#define ISI_IER_PXFR_DONE_Msk               (_U_(0x1) << ISI_IER_PXFR_DONE_Pos)            /**< (ISI_IER) Preview DMA Transfer Done Interrupt Enable Mask */
+#define ISI_IER_PXFR_DONE                   ISI_IER_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_PXFR_DONE_Msk instead */
+#define ISI_IER_CXFR_DONE_Pos               17                                             /**< (ISI_IER) Codec DMA Transfer Done Interrupt Enable Position */
+#define ISI_IER_CXFR_DONE_Msk               (_U_(0x1) << ISI_IER_CXFR_DONE_Pos)            /**< (ISI_IER) Codec DMA Transfer Done Interrupt Enable Mask */
+#define ISI_IER_CXFR_DONE                   ISI_IER_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_CXFR_DONE_Msk instead */
+#define ISI_IER_P_OVR_Pos                   24                                             /**< (ISI_IER) Preview Datapath Overflow Interrupt Enable Position */
+#define ISI_IER_P_OVR_Msk                   (_U_(0x1) << ISI_IER_P_OVR_Pos)                /**< (ISI_IER) Preview Datapath Overflow Interrupt Enable Mask */
+#define ISI_IER_P_OVR                       ISI_IER_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_P_OVR_Msk instead */
+#define ISI_IER_C_OVR_Pos                   25                                             /**< (ISI_IER) Codec Datapath Overflow Interrupt Enable Position */
+#define ISI_IER_C_OVR_Msk                   (_U_(0x1) << ISI_IER_C_OVR_Pos)                /**< (ISI_IER) Codec Datapath Overflow Interrupt Enable Mask */
+#define ISI_IER_C_OVR                       ISI_IER_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_C_OVR_Msk instead */
+#define ISI_IER_CRC_ERR_Pos                 26                                             /**< (ISI_IER) Embedded Synchronization CRC Error Interrupt Enable Position */
+#define ISI_IER_CRC_ERR_Msk                 (_U_(0x1) << ISI_IER_CRC_ERR_Pos)              /**< (ISI_IER) Embedded Synchronization CRC Error Interrupt Enable Mask */
+#define ISI_IER_CRC_ERR                     ISI_IER_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_CRC_ERR_Msk instead */
+#define ISI_IER_FR_OVR_Pos                  27                                             /**< (ISI_IER) Frame Rate Overflow Interrupt Enable Position */
+#define ISI_IER_FR_OVR_Msk                  (_U_(0x1) << ISI_IER_FR_OVR_Pos)               /**< (ISI_IER) Frame Rate Overflow Interrupt Enable Mask */
+#define ISI_IER_FR_OVR                      ISI_IER_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IER_FR_OVR_Msk instead */
+#define ISI_IER_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IER) Register MASK  (Use ISI_IER_Msk instead)  */
+#define ISI_IER_Msk                         _U_(0xF030406)                                 /**< (ISI_IER) Register Mask  */
+
+
+/* -------- ISI_IDR : (ISI Offset: 0x30) (/W 32) ISI Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Disable Done Interrupt Disable           */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Interrupt Disable         */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization Interrupt Disable */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Done Interrupt Disable */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Done Interrupt Disable */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview Datapath Overflow Interrupt Disable */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec Datapath Overflow Interrupt Disable */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  Embedded Synchronization CRC Error Interrupt Disable */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overflow Interrupt Disable    */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IDR_OFFSET                      (0x30)                                        /**<  (ISI_IDR) ISI Interrupt Disable Register  Offset */
+
+#define ISI_IDR_DIS_DONE_Pos                1                                              /**< (ISI_IDR) Disable Done Interrupt Disable Position */
+#define ISI_IDR_DIS_DONE_Msk                (_U_(0x1) << ISI_IDR_DIS_DONE_Pos)             /**< (ISI_IDR) Disable Done Interrupt Disable Mask */
+#define ISI_IDR_DIS_DONE                    ISI_IDR_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_DIS_DONE_Msk instead */
+#define ISI_IDR_SRST_Pos                    2                                              /**< (ISI_IDR) Software Reset Interrupt Disable Position */
+#define ISI_IDR_SRST_Msk                    (_U_(0x1) << ISI_IDR_SRST_Pos)                 /**< (ISI_IDR) Software Reset Interrupt Disable Mask */
+#define ISI_IDR_SRST                        ISI_IDR_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_SRST_Msk instead */
+#define ISI_IDR_VSYNC_Pos                   10                                             /**< (ISI_IDR) Vertical Synchronization Interrupt Disable Position */
+#define ISI_IDR_VSYNC_Msk                   (_U_(0x1) << ISI_IDR_VSYNC_Pos)                /**< (ISI_IDR) Vertical Synchronization Interrupt Disable Mask */
+#define ISI_IDR_VSYNC                       ISI_IDR_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_VSYNC_Msk instead */
+#define ISI_IDR_PXFR_DONE_Pos               16                                             /**< (ISI_IDR) Preview DMA Transfer Done Interrupt Disable Position */
+#define ISI_IDR_PXFR_DONE_Msk               (_U_(0x1) << ISI_IDR_PXFR_DONE_Pos)            /**< (ISI_IDR) Preview DMA Transfer Done Interrupt Disable Mask */
+#define ISI_IDR_PXFR_DONE                   ISI_IDR_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_PXFR_DONE_Msk instead */
+#define ISI_IDR_CXFR_DONE_Pos               17                                             /**< (ISI_IDR) Codec DMA Transfer Done Interrupt Disable Position */
+#define ISI_IDR_CXFR_DONE_Msk               (_U_(0x1) << ISI_IDR_CXFR_DONE_Pos)            /**< (ISI_IDR) Codec DMA Transfer Done Interrupt Disable Mask */
+#define ISI_IDR_CXFR_DONE                   ISI_IDR_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_CXFR_DONE_Msk instead */
+#define ISI_IDR_P_OVR_Pos                   24                                             /**< (ISI_IDR) Preview Datapath Overflow Interrupt Disable Position */
+#define ISI_IDR_P_OVR_Msk                   (_U_(0x1) << ISI_IDR_P_OVR_Pos)                /**< (ISI_IDR) Preview Datapath Overflow Interrupt Disable Mask */
+#define ISI_IDR_P_OVR                       ISI_IDR_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_P_OVR_Msk instead */
+#define ISI_IDR_C_OVR_Pos                   25                                             /**< (ISI_IDR) Codec Datapath Overflow Interrupt Disable Position */
+#define ISI_IDR_C_OVR_Msk                   (_U_(0x1) << ISI_IDR_C_OVR_Pos)                /**< (ISI_IDR) Codec Datapath Overflow Interrupt Disable Mask */
+#define ISI_IDR_C_OVR                       ISI_IDR_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_C_OVR_Msk instead */
+#define ISI_IDR_CRC_ERR_Pos                 26                                             /**< (ISI_IDR) Embedded Synchronization CRC Error Interrupt Disable Position */
+#define ISI_IDR_CRC_ERR_Msk                 (_U_(0x1) << ISI_IDR_CRC_ERR_Pos)              /**< (ISI_IDR) Embedded Synchronization CRC Error Interrupt Disable Mask */
+#define ISI_IDR_CRC_ERR                     ISI_IDR_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_CRC_ERR_Msk instead */
+#define ISI_IDR_FR_OVR_Pos                  27                                             /**< (ISI_IDR) Frame Rate Overflow Interrupt Disable Position */
+#define ISI_IDR_FR_OVR_Msk                  (_U_(0x1) << ISI_IDR_FR_OVR_Pos)               /**< (ISI_IDR) Frame Rate Overflow Interrupt Disable Mask */
+#define ISI_IDR_FR_OVR                      ISI_IDR_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IDR_FR_OVR_Msk instead */
+#define ISI_IDR_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IDR) Register MASK  (Use ISI_IDR_Msk instead)  */
+#define ISI_IDR_Msk                         _U_(0xF030406)                                 /**< (ISI_IDR) Register Mask  */
+
+
+/* -------- ISI_IMR : (ISI Offset: 0x34) (R/ 32) ISI Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t DIS_DONE:1;                /**< bit:      1  Module Disable Operation Completed       */
+    uint32_t SRST:1;                    /**< bit:      2  Software Reset Completed                 */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t VSYNC:1;                   /**< bit:     10  Vertical Synchronization                 */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t PXFR_DONE:1;               /**< bit:     16  Preview DMA Transfer Completed           */
+    uint32_t CXFR_DONE:1;               /**< bit:     17  Codec DMA Transfer Completed             */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t P_OVR:1;                   /**< bit:     24  Preview FIFO Overflow                    */
+    uint32_t C_OVR:1;                   /**< bit:     25  Codec FIFO Overflow                      */
+    uint32_t CRC_ERR:1;                 /**< bit:     26  CRC Synchronization Error                */
+    uint32_t FR_OVR:1;                  /**< bit:     27  Frame Rate Overrun                       */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_IMR_OFFSET                      (0x34)                                        /**<  (ISI_IMR) ISI Interrupt Mask Register  Offset */
+
+#define ISI_IMR_DIS_DONE_Pos                1                                              /**< (ISI_IMR) Module Disable Operation Completed Position */
+#define ISI_IMR_DIS_DONE_Msk                (_U_(0x1) << ISI_IMR_DIS_DONE_Pos)             /**< (ISI_IMR) Module Disable Operation Completed Mask */
+#define ISI_IMR_DIS_DONE                    ISI_IMR_DIS_DONE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_DIS_DONE_Msk instead */
+#define ISI_IMR_SRST_Pos                    2                                              /**< (ISI_IMR) Software Reset Completed Position */
+#define ISI_IMR_SRST_Msk                    (_U_(0x1) << ISI_IMR_SRST_Pos)                 /**< (ISI_IMR) Software Reset Completed Mask */
+#define ISI_IMR_SRST                        ISI_IMR_SRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_SRST_Msk instead */
+#define ISI_IMR_VSYNC_Pos                   10                                             /**< (ISI_IMR) Vertical Synchronization Position */
+#define ISI_IMR_VSYNC_Msk                   (_U_(0x1) << ISI_IMR_VSYNC_Pos)                /**< (ISI_IMR) Vertical Synchronization Mask */
+#define ISI_IMR_VSYNC                       ISI_IMR_VSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_VSYNC_Msk instead */
+#define ISI_IMR_PXFR_DONE_Pos               16                                             /**< (ISI_IMR) Preview DMA Transfer Completed Position */
+#define ISI_IMR_PXFR_DONE_Msk               (_U_(0x1) << ISI_IMR_PXFR_DONE_Pos)            /**< (ISI_IMR) Preview DMA Transfer Completed Mask */
+#define ISI_IMR_PXFR_DONE                   ISI_IMR_PXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_PXFR_DONE_Msk instead */
+#define ISI_IMR_CXFR_DONE_Pos               17                                             /**< (ISI_IMR) Codec DMA Transfer Completed Position */
+#define ISI_IMR_CXFR_DONE_Msk               (_U_(0x1) << ISI_IMR_CXFR_DONE_Pos)            /**< (ISI_IMR) Codec DMA Transfer Completed Mask */
+#define ISI_IMR_CXFR_DONE                   ISI_IMR_CXFR_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_CXFR_DONE_Msk instead */
+#define ISI_IMR_P_OVR_Pos                   24                                             /**< (ISI_IMR) Preview FIFO Overflow Position */
+#define ISI_IMR_P_OVR_Msk                   (_U_(0x1) << ISI_IMR_P_OVR_Pos)                /**< (ISI_IMR) Preview FIFO Overflow Mask */
+#define ISI_IMR_P_OVR                       ISI_IMR_P_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_P_OVR_Msk instead */
+#define ISI_IMR_C_OVR_Pos                   25                                             /**< (ISI_IMR) Codec FIFO Overflow Position */
+#define ISI_IMR_C_OVR_Msk                   (_U_(0x1) << ISI_IMR_C_OVR_Pos)                /**< (ISI_IMR) Codec FIFO Overflow Mask */
+#define ISI_IMR_C_OVR                       ISI_IMR_C_OVR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_C_OVR_Msk instead */
+#define ISI_IMR_CRC_ERR_Pos                 26                                             /**< (ISI_IMR) CRC Synchronization Error Position */
+#define ISI_IMR_CRC_ERR_Msk                 (_U_(0x1) << ISI_IMR_CRC_ERR_Pos)              /**< (ISI_IMR) CRC Synchronization Error Mask */
+#define ISI_IMR_CRC_ERR                     ISI_IMR_CRC_ERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_CRC_ERR_Msk instead */
+#define ISI_IMR_FR_OVR_Pos                  27                                             /**< (ISI_IMR) Frame Rate Overrun Position */
+#define ISI_IMR_FR_OVR_Msk                  (_U_(0x1) << ISI_IMR_FR_OVR_Pos)               /**< (ISI_IMR) Frame Rate Overrun Mask */
+#define ISI_IMR_FR_OVR                      ISI_IMR_FR_OVR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_IMR_FR_OVR_Msk instead */
+#define ISI_IMR_MASK                        _U_(0xF030406)                                 /**< \deprecated (ISI_IMR) Register MASK  (Use ISI_IMR_Msk instead)  */
+#define ISI_IMR_Msk                         _U_(0xF030406)                                 /**< (ISI_IMR) Register Mask  */
+
+
+/* -------- ISI_DMA_CHER : (ISI Offset: 0x38) (/W 32) DMA Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_EN:1;                 /**< bit:      0  Preview Channel Enable                   */
+    uint32_t C_CH_EN:1;                 /**< bit:      1  Codec Channel Enable                     */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHER_OFFSET                 (0x38)                                        /**<  (ISI_DMA_CHER) DMA Channel Enable Register  Offset */
+
+#define ISI_DMA_CHER_P_CH_EN_Pos            0                                              /**< (ISI_DMA_CHER) Preview Channel Enable Position */
+#define ISI_DMA_CHER_P_CH_EN_Msk            (_U_(0x1) << ISI_DMA_CHER_P_CH_EN_Pos)         /**< (ISI_DMA_CHER) Preview Channel Enable Mask */
+#define ISI_DMA_CHER_P_CH_EN                ISI_DMA_CHER_P_CH_EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHER_P_CH_EN_Msk instead */
+#define ISI_DMA_CHER_C_CH_EN_Pos            1                                              /**< (ISI_DMA_CHER) Codec Channel Enable Position */
+#define ISI_DMA_CHER_C_CH_EN_Msk            (_U_(0x1) << ISI_DMA_CHER_C_CH_EN_Pos)         /**< (ISI_DMA_CHER) Codec Channel Enable Mask */
+#define ISI_DMA_CHER_C_CH_EN                ISI_DMA_CHER_C_CH_EN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHER_C_CH_EN_Msk instead */
+#define ISI_DMA_CHER_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHER) Register MASK  (Use ISI_DMA_CHER_Msk instead)  */
+#define ISI_DMA_CHER_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHER) Register Mask  */
+
+
+/* -------- ISI_DMA_CHDR : (ISI Offset: 0x3c) (/W 32) DMA Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_DIS:1;                /**< bit:      0  Preview Channel Disable Request          */
+    uint32_t C_CH_DIS:1;                /**< bit:      1  Codec Channel Disable Request            */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHDR_OFFSET                 (0x3C)                                        /**<  (ISI_DMA_CHDR) DMA Channel Disable Register  Offset */
+
+#define ISI_DMA_CHDR_P_CH_DIS_Pos           0                                              /**< (ISI_DMA_CHDR) Preview Channel Disable Request Position */
+#define ISI_DMA_CHDR_P_CH_DIS_Msk           (_U_(0x1) << ISI_DMA_CHDR_P_CH_DIS_Pos)        /**< (ISI_DMA_CHDR) Preview Channel Disable Request Mask */
+#define ISI_DMA_CHDR_P_CH_DIS               ISI_DMA_CHDR_P_CH_DIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHDR_P_CH_DIS_Msk instead */
+#define ISI_DMA_CHDR_C_CH_DIS_Pos           1                                              /**< (ISI_DMA_CHDR) Codec Channel Disable Request Position */
+#define ISI_DMA_CHDR_C_CH_DIS_Msk           (_U_(0x1) << ISI_DMA_CHDR_C_CH_DIS_Pos)        /**< (ISI_DMA_CHDR) Codec Channel Disable Request Mask */
+#define ISI_DMA_CHDR_C_CH_DIS               ISI_DMA_CHDR_C_CH_DIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHDR_C_CH_DIS_Msk instead */
+#define ISI_DMA_CHDR_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHDR) Register MASK  (Use ISI_DMA_CHDR_Msk instead)  */
+#define ISI_DMA_CHDR_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHDR) Register Mask  */
+
+
+/* -------- ISI_DMA_CHSR : (ISI Offset: 0x40) (R/ 32) DMA Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_CH_S:1;                  /**< bit:      0  Preview DMA Channel Status               */
+    uint32_t C_CH_S:1;                  /**< bit:      1  Code DMA Channel Status                  */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_CHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_CHSR_OFFSET                 (0x40)                                        /**<  (ISI_DMA_CHSR) DMA Channel Status Register  Offset */
+
+#define ISI_DMA_CHSR_P_CH_S_Pos             0                                              /**< (ISI_DMA_CHSR) Preview DMA Channel Status Position */
+#define ISI_DMA_CHSR_P_CH_S_Msk             (_U_(0x1) << ISI_DMA_CHSR_P_CH_S_Pos)          /**< (ISI_DMA_CHSR) Preview DMA Channel Status Mask */
+#define ISI_DMA_CHSR_P_CH_S                 ISI_DMA_CHSR_P_CH_S_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHSR_P_CH_S_Msk instead */
+#define ISI_DMA_CHSR_C_CH_S_Pos             1                                              /**< (ISI_DMA_CHSR) Code DMA Channel Status Position */
+#define ISI_DMA_CHSR_C_CH_S_Msk             (_U_(0x1) << ISI_DMA_CHSR_C_CH_S_Pos)          /**< (ISI_DMA_CHSR) Code DMA Channel Status Mask */
+#define ISI_DMA_CHSR_C_CH_S                 ISI_DMA_CHSR_C_CH_S_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_CHSR_C_CH_S_Msk instead */
+#define ISI_DMA_CHSR_MASK                   _U_(0x03)                                      /**< \deprecated (ISI_DMA_CHSR) Register MASK  (Use ISI_DMA_CHSR_Msk instead)  */
+#define ISI_DMA_CHSR_Msk                    _U_(0x03)                                      /**< (ISI_DMA_CHSR) Register Mask  */
+
+
+/* -------- ISI_DMA_P_ADDR : (ISI Offset: 0x44) (R/W 32) DMA Preview Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t P_ADDR:30;                 /**< bit:  2..31  Preview Image Base Address               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_ADDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_ADDR_OFFSET               (0x44)                                        /**<  (ISI_DMA_P_ADDR) DMA Preview Base Address Register  Offset */
+
+#define ISI_DMA_P_ADDR_P_ADDR_Pos           2                                              /**< (ISI_DMA_P_ADDR) Preview Image Base Address Position */
+#define ISI_DMA_P_ADDR_P_ADDR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_P_ADDR_P_ADDR_Pos)  /**< (ISI_DMA_P_ADDR) Preview Image Base Address Mask */
+#define ISI_DMA_P_ADDR_P_ADDR(value)        (ISI_DMA_P_ADDR_P_ADDR_Msk & ((value) << ISI_DMA_P_ADDR_P_ADDR_Pos))
+#define ISI_DMA_P_ADDR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_P_ADDR) Register MASK  (Use ISI_DMA_P_ADDR_Msk instead)  */
+#define ISI_DMA_P_ADDR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_P_ADDR) Register Mask  */
+
+
+/* -------- ISI_DMA_P_CTRL : (ISI Offset: 0x48) (R/W 32) DMA Preview Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
+    uint32_t P_WB:1;                    /**< bit:      1  Descriptor Writeback Control Bit         */
+    uint32_t P_IEN:1;                   /**< bit:      2  Transfer Done Flag Control               */
+    uint32_t P_DONE:1;                  /**< bit:      3  Preview Transfer Done                    */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_CTRL_OFFSET               (0x48)                                        /**<  (ISI_DMA_P_CTRL) DMA Preview Control Register  Offset */
+
+#define ISI_DMA_P_CTRL_P_FETCH_Pos          0                                              /**< (ISI_DMA_P_CTRL) Descriptor Fetch Control Bit Position */
+#define ISI_DMA_P_CTRL_P_FETCH_Msk          (_U_(0x1) << ISI_DMA_P_CTRL_P_FETCH_Pos)       /**< (ISI_DMA_P_CTRL) Descriptor Fetch Control Bit Mask */
+#define ISI_DMA_P_CTRL_P_FETCH              ISI_DMA_P_CTRL_P_FETCH_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_FETCH_Msk instead */
+#define ISI_DMA_P_CTRL_P_WB_Pos             1                                              /**< (ISI_DMA_P_CTRL) Descriptor Writeback Control Bit Position */
+#define ISI_DMA_P_CTRL_P_WB_Msk             (_U_(0x1) << ISI_DMA_P_CTRL_P_WB_Pos)          /**< (ISI_DMA_P_CTRL) Descriptor Writeback Control Bit Mask */
+#define ISI_DMA_P_CTRL_P_WB                 ISI_DMA_P_CTRL_P_WB_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_WB_Msk instead */
+#define ISI_DMA_P_CTRL_P_IEN_Pos            2                                              /**< (ISI_DMA_P_CTRL) Transfer Done Flag Control Position */
+#define ISI_DMA_P_CTRL_P_IEN_Msk            (_U_(0x1) << ISI_DMA_P_CTRL_P_IEN_Pos)         /**< (ISI_DMA_P_CTRL) Transfer Done Flag Control Mask */
+#define ISI_DMA_P_CTRL_P_IEN                ISI_DMA_P_CTRL_P_IEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_IEN_Msk instead */
+#define ISI_DMA_P_CTRL_P_DONE_Pos           3                                              /**< (ISI_DMA_P_CTRL) Preview Transfer Done Position */
+#define ISI_DMA_P_CTRL_P_DONE_Msk           (_U_(0x1) << ISI_DMA_P_CTRL_P_DONE_Pos)        /**< (ISI_DMA_P_CTRL) Preview Transfer Done Mask */
+#define ISI_DMA_P_CTRL_P_DONE               ISI_DMA_P_CTRL_P_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_P_CTRL_P_DONE_Msk instead */
+#define ISI_DMA_P_CTRL_MASK                 _U_(0x0F)                                      /**< \deprecated (ISI_DMA_P_CTRL) Register MASK  (Use ISI_DMA_P_CTRL_Msk instead)  */
+#define ISI_DMA_P_CTRL_Msk                  _U_(0x0F)                                      /**< (ISI_DMA_P_CTRL) Register Mask  */
+
+
+/* -------- ISI_DMA_P_DSCR : (ISI Offset: 0x4c) (R/W 32) DMA Preview Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t P_DSCR:30;                 /**< bit:  2..31  Preview Descriptor Base Address          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_P_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_P_DSCR_OFFSET               (0x4C)                                        /**<  (ISI_DMA_P_DSCR) DMA Preview Descriptor Address Register  Offset */
+
+#define ISI_DMA_P_DSCR_P_DSCR_Pos           2                                              /**< (ISI_DMA_P_DSCR) Preview Descriptor Base Address Position */
+#define ISI_DMA_P_DSCR_P_DSCR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_P_DSCR_P_DSCR_Pos)  /**< (ISI_DMA_P_DSCR) Preview Descriptor Base Address Mask */
+#define ISI_DMA_P_DSCR_P_DSCR(value)        (ISI_DMA_P_DSCR_P_DSCR_Msk & ((value) << ISI_DMA_P_DSCR_P_DSCR_Pos))
+#define ISI_DMA_P_DSCR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_P_DSCR) Register MASK  (Use ISI_DMA_P_DSCR_Msk instead)  */
+#define ISI_DMA_P_DSCR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_P_DSCR) Register Mask  */
+
+
+/* -------- ISI_DMA_C_ADDR : (ISI Offset: 0x50) (R/W 32) DMA Codec Base Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t C_ADDR:30;                 /**< bit:  2..31  Codec Image Base Address                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_ADDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_ADDR_OFFSET               (0x50)                                        /**<  (ISI_DMA_C_ADDR) DMA Codec Base Address Register  Offset */
+
+#define ISI_DMA_C_ADDR_C_ADDR_Pos           2                                              /**< (ISI_DMA_C_ADDR) Codec Image Base Address Position */
+#define ISI_DMA_C_ADDR_C_ADDR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_C_ADDR_C_ADDR_Pos)  /**< (ISI_DMA_C_ADDR) Codec Image Base Address Mask */
+#define ISI_DMA_C_ADDR_C_ADDR(value)        (ISI_DMA_C_ADDR_C_ADDR_Msk & ((value) << ISI_DMA_C_ADDR_C_ADDR_Pos))
+#define ISI_DMA_C_ADDR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_C_ADDR) Register MASK  (Use ISI_DMA_C_ADDR_Msk instead)  */
+#define ISI_DMA_C_ADDR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_C_ADDR) Register Mask  */
+
+
+/* -------- ISI_DMA_C_CTRL : (ISI Offset: 0x54) (R/W 32) DMA Codec Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t C_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
+    uint32_t C_WB:1;                    /**< bit:      1  Descriptor Writeback Control Bit         */
+    uint32_t C_IEN:1;                   /**< bit:      2  Transfer Done Flag Control               */
+    uint32_t C_DONE:1;                  /**< bit:      3  Codec Transfer Done                      */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_CTRL_OFFSET               (0x54)                                        /**<  (ISI_DMA_C_CTRL) DMA Codec Control Register  Offset */
+
+#define ISI_DMA_C_CTRL_C_FETCH_Pos          0                                              /**< (ISI_DMA_C_CTRL) Descriptor Fetch Control Bit Position */
+#define ISI_DMA_C_CTRL_C_FETCH_Msk          (_U_(0x1) << ISI_DMA_C_CTRL_C_FETCH_Pos)       /**< (ISI_DMA_C_CTRL) Descriptor Fetch Control Bit Mask */
+#define ISI_DMA_C_CTRL_C_FETCH              ISI_DMA_C_CTRL_C_FETCH_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_FETCH_Msk instead */
+#define ISI_DMA_C_CTRL_C_WB_Pos             1                                              /**< (ISI_DMA_C_CTRL) Descriptor Writeback Control Bit Position */
+#define ISI_DMA_C_CTRL_C_WB_Msk             (_U_(0x1) << ISI_DMA_C_CTRL_C_WB_Pos)          /**< (ISI_DMA_C_CTRL) Descriptor Writeback Control Bit Mask */
+#define ISI_DMA_C_CTRL_C_WB                 ISI_DMA_C_CTRL_C_WB_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_WB_Msk instead */
+#define ISI_DMA_C_CTRL_C_IEN_Pos            2                                              /**< (ISI_DMA_C_CTRL) Transfer Done Flag Control Position */
+#define ISI_DMA_C_CTRL_C_IEN_Msk            (_U_(0x1) << ISI_DMA_C_CTRL_C_IEN_Pos)         /**< (ISI_DMA_C_CTRL) Transfer Done Flag Control Mask */
+#define ISI_DMA_C_CTRL_C_IEN                ISI_DMA_C_CTRL_C_IEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_IEN_Msk instead */
+#define ISI_DMA_C_CTRL_C_DONE_Pos           3                                              /**< (ISI_DMA_C_CTRL) Codec Transfer Done Position */
+#define ISI_DMA_C_CTRL_C_DONE_Msk           (_U_(0x1) << ISI_DMA_C_CTRL_C_DONE_Pos)        /**< (ISI_DMA_C_CTRL) Codec Transfer Done Mask */
+#define ISI_DMA_C_CTRL_C_DONE               ISI_DMA_C_CTRL_C_DONE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_DMA_C_CTRL_C_DONE_Msk instead */
+#define ISI_DMA_C_CTRL_MASK                 _U_(0x0F)                                      /**< \deprecated (ISI_DMA_C_CTRL) Register MASK  (Use ISI_DMA_C_CTRL_Msk instead)  */
+#define ISI_DMA_C_CTRL_Msk                  _U_(0x0F)                                      /**< (ISI_DMA_C_CTRL) Register Mask  */
+
+
+/* -------- ISI_DMA_C_DSCR : (ISI Offset: 0x58) (R/W 32) DMA Codec Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t C_DSCR:30;                 /**< bit:  2..31  Codec Descriptor Base Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_DMA_C_DSCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_DMA_C_DSCR_OFFSET               (0x58)                                        /**<  (ISI_DMA_C_DSCR) DMA Codec Descriptor Address Register  Offset */
+
+#define ISI_DMA_C_DSCR_C_DSCR_Pos           2                                              /**< (ISI_DMA_C_DSCR) Codec Descriptor Base Address Position */
+#define ISI_DMA_C_DSCR_C_DSCR_Msk           (_U_(0x3FFFFFFF) << ISI_DMA_C_DSCR_C_DSCR_Pos)  /**< (ISI_DMA_C_DSCR) Codec Descriptor Base Address Mask */
+#define ISI_DMA_C_DSCR_C_DSCR(value)        (ISI_DMA_C_DSCR_C_DSCR_Msk & ((value) << ISI_DMA_C_DSCR_C_DSCR_Pos))
+#define ISI_DMA_C_DSCR_MASK                 _U_(0xFFFFFFFC)                                /**< \deprecated (ISI_DMA_C_DSCR) Register MASK  (Use ISI_DMA_C_DSCR_Msk instead)  */
+#define ISI_DMA_C_DSCR_Msk                  _U_(0xFFFFFFFC)                                /**< (ISI_DMA_C_DSCR) Register Mask  */
+
+
+/* -------- ISI_WPMR : (ISI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key Password            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_WPMR_OFFSET                     (0xE4)                                        /**<  (ISI_WPMR) Write Protection Mode Register  Offset */
+
+#define ISI_WPMR_WPEN_Pos                   0                                              /**< (ISI_WPMR) Write Protection Enable Position */
+#define ISI_WPMR_WPEN_Msk                   (_U_(0x1) << ISI_WPMR_WPEN_Pos)                /**< (ISI_WPMR) Write Protection Enable Mask */
+#define ISI_WPMR_WPEN                       ISI_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_WPMR_WPEN_Msk instead */
+#define ISI_WPMR_WPKEY_Pos                  8                                              /**< (ISI_WPMR) Write Protection Key Password Position */
+#define ISI_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << ISI_WPMR_WPKEY_Pos)          /**< (ISI_WPMR) Write Protection Key Password Mask */
+#define ISI_WPMR_WPKEY(value)               (ISI_WPMR_WPKEY_Msk & ((value) << ISI_WPMR_WPKEY_Pos))
+#define   ISI_WPMR_WPKEY_PASSWD_Val         _U_(0x495349)                                  /**< (ISI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define ISI_WPMR_WPKEY_PASSWD               (ISI_WPMR_WPKEY_PASSWD_Val << ISI_WPMR_WPKEY_Pos)  /**< (ISI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define ISI_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (ISI_WPMR) Register MASK  (Use ISI_WPMR_Msk instead)  */
+#define ISI_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (ISI_WPMR) Register Mask  */
+
+
+/* -------- ISI_WPSR : (ISI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} ISI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ISI_WPSR_OFFSET                     (0xE8)                                        /**<  (ISI_WPSR) Write Protection Status Register  Offset */
+
+#define ISI_WPSR_WPVS_Pos                   0                                              /**< (ISI_WPSR) Write Protection Violation Status Position */
+#define ISI_WPSR_WPVS_Msk                   (_U_(0x1) << ISI_WPSR_WPVS_Pos)                /**< (ISI_WPSR) Write Protection Violation Status Mask */
+#define ISI_WPSR_WPVS                       ISI_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use ISI_WPSR_WPVS_Msk instead */
+#define ISI_WPSR_WPVSRC_Pos                 8                                              /**< (ISI_WPSR) Write Protection Violation Source Position */
+#define ISI_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << ISI_WPSR_WPVSRC_Pos)           /**< (ISI_WPSR) Write Protection Violation Source Mask */
+#define ISI_WPSR_WPVSRC(value)              (ISI_WPSR_WPVSRC_Msk & ((value) << ISI_WPSR_WPVSRC_Pos))
+#define ISI_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (ISI_WPSR) Register MASK  (Use ISI_WPSR_Msk instead)  */
+#define ISI_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (ISI_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief ISI hardware registers */
+typedef struct {  
+  __IO uint32_t ISI_CFG1;       /**< (ISI Offset: 0x00) ISI Configuration 1 Register */
+  __IO uint32_t ISI_CFG2;       /**< (ISI Offset: 0x04) ISI Configuration 2 Register */
+  __IO uint32_t ISI_PSIZE;      /**< (ISI Offset: 0x08) ISI Preview Size Register */
+  __IO uint32_t ISI_PDECF;      /**< (ISI Offset: 0x0C) ISI Preview Decimation Factor Register */
+  __IO uint32_t ISI_Y2R_SET0;   /**< (ISI Offset: 0x10) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+  __IO uint32_t ISI_Y2R_SET1;   /**< (ISI Offset: 0x14) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+  __IO uint32_t ISI_R2Y_SET0;   /**< (ISI Offset: 0x18) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+  __IO uint32_t ISI_R2Y_SET1;   /**< (ISI Offset: 0x1C) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+  __IO uint32_t ISI_R2Y_SET2;   /**< (ISI Offset: 0x20) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+  __O  uint32_t ISI_CR;         /**< (ISI Offset: 0x24) ISI Control Register */
+  __I  uint32_t ISI_SR;         /**< (ISI Offset: 0x28) ISI Status Register */
+  __O  uint32_t ISI_IER;        /**< (ISI Offset: 0x2C) ISI Interrupt Enable Register */
+  __O  uint32_t ISI_IDR;        /**< (ISI Offset: 0x30) ISI Interrupt Disable Register */
+  __I  uint32_t ISI_IMR;        /**< (ISI Offset: 0x34) ISI Interrupt Mask Register */
+  __O  uint32_t ISI_DMA_CHER;   /**< (ISI Offset: 0x38) DMA Channel Enable Register */
+  __O  uint32_t ISI_DMA_CHDR;   /**< (ISI Offset: 0x3C) DMA Channel Disable Register */
+  __I  uint32_t ISI_DMA_CHSR;   /**< (ISI Offset: 0x40) DMA Channel Status Register */
+  __IO uint32_t ISI_DMA_P_ADDR; /**< (ISI Offset: 0x44) DMA Preview Base Address Register */
+  __IO uint32_t ISI_DMA_P_CTRL; /**< (ISI Offset: 0x48) DMA Preview Control Register */
+  __IO uint32_t ISI_DMA_P_DSCR; /**< (ISI Offset: 0x4C) DMA Preview Descriptor Address Register */
+  __IO uint32_t ISI_DMA_C_ADDR; /**< (ISI Offset: 0x50) DMA Codec Base Address Register */
+  __IO uint32_t ISI_DMA_C_CTRL; /**< (ISI Offset: 0x54) DMA Codec Control Register */
+  __IO uint32_t ISI_DMA_C_DSCR; /**< (ISI Offset: 0x58) DMA Codec Descriptor Address Register */
+  __I  uint8_t                        Reserved1[136];
+  __IO uint32_t ISI_WPMR;       /**< (ISI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t ISI_WPSR;       /**< (ISI Offset: 0xE8) Write Protection Status Register */
+} Isi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief ISI hardware registers */
+typedef struct {  
+  __IO ISI_CFG1_Type                  ISI_CFG1;       /**< Offset: 0x00 (R/W  32) ISI Configuration 1 Register */
+  __IO ISI_CFG2_Type                  ISI_CFG2;       /**< Offset: 0x04 (R/W  32) ISI Configuration 2 Register */
+  __IO ISI_PSIZE_Type                 ISI_PSIZE;      /**< Offset: 0x08 (R/W  32) ISI Preview Size Register */
+  __IO ISI_PDECF_Type                 ISI_PDECF;      /**< Offset: 0x0C (R/W  32) ISI Preview Decimation Factor Register */
+  __IO ISI_Y2R_SET0_Type              ISI_Y2R_SET0;   /**< Offset: 0x10 (R/W  32) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+  __IO ISI_Y2R_SET1_Type              ISI_Y2R_SET1;   /**< Offset: 0x14 (R/W  32) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+  __IO ISI_R2Y_SET0_Type              ISI_R2Y_SET0;   /**< Offset: 0x18 (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+  __IO ISI_R2Y_SET1_Type              ISI_R2Y_SET1;   /**< Offset: 0x1C (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+  __IO ISI_R2Y_SET2_Type              ISI_R2Y_SET2;   /**< Offset: 0x20 (R/W  32) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+  __O  ISI_CR_Type                    ISI_CR;         /**< Offset: 0x24 ( /W  32) ISI Control Register */
+  __I  ISI_SR_Type                    ISI_SR;         /**< Offset: 0x28 (R/   32) ISI Status Register */
+  __O  ISI_IER_Type                   ISI_IER;        /**< Offset: 0x2C ( /W  32) ISI Interrupt Enable Register */
+  __O  ISI_IDR_Type                   ISI_IDR;        /**< Offset: 0x30 ( /W  32) ISI Interrupt Disable Register */
+  __I  ISI_IMR_Type                   ISI_IMR;        /**< Offset: 0x34 (R/   32) ISI Interrupt Mask Register */
+  __O  ISI_DMA_CHER_Type              ISI_DMA_CHER;   /**< Offset: 0x38 ( /W  32) DMA Channel Enable Register */
+  __O  ISI_DMA_CHDR_Type              ISI_DMA_CHDR;   /**< Offset: 0x3C ( /W  32) DMA Channel Disable Register */
+  __I  ISI_DMA_CHSR_Type              ISI_DMA_CHSR;   /**< Offset: 0x40 (R/   32) DMA Channel Status Register */
+  __IO ISI_DMA_P_ADDR_Type            ISI_DMA_P_ADDR; /**< Offset: 0x44 (R/W  32) DMA Preview Base Address Register */
+  __IO ISI_DMA_P_CTRL_Type            ISI_DMA_P_CTRL; /**< Offset: 0x48 (R/W  32) DMA Preview Control Register */
+  __IO ISI_DMA_P_DSCR_Type            ISI_DMA_P_DSCR; /**< Offset: 0x4C (R/W  32) DMA Preview Descriptor Address Register */
+  __IO ISI_DMA_C_ADDR_Type            ISI_DMA_C_ADDR; /**< Offset: 0x50 (R/W  32) DMA Codec Base Address Register */
+  __IO ISI_DMA_C_CTRL_Type            ISI_DMA_C_CTRL; /**< Offset: 0x54 (R/W  32) DMA Codec Control Register */
+  __IO ISI_DMA_C_DSCR_Type            ISI_DMA_C_DSCR; /**< Offset: 0x58 (R/W  32) DMA Codec Descriptor Address Register */
+  __I  uint8_t                        Reserved1[136];
+  __IO ISI_WPMR_Type                  ISI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  ISI_WPSR_Type                  ISI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Isi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Image Sensor Interface */
+
+#endif /* _SAMV71_ISI_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/matrix.h
+++ b/asf/sam/include/samv71b/component/matrix.h
@@ -1,0 +1,599 @@
+/**
+ * \file
+ *
+ * \brief Component description for MATRIX
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MATRIX_COMPONENT_H_
+#define _SAMV71_MATRIX_COMPONENT_H_
+#define _SAMV71_MATRIX_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 AHB Bus Matrix
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MATRIX */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MATRIX_11282                      /**< (MATRIX) Module ID */
+#define REV_MATRIX L                      /**< (MATRIX) Module revision */
+
+/* -------- MATRIX_PRAS : (MATRIX Offset: 0x00) (R/W 32) Priority Register A for Slave 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t M0PR:2;                    /**< bit:   0..1  Master 0 Priority                        */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t M1PR:2;                    /**< bit:   4..5  Master 1 Priority                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t M2PR:2;                    /**< bit:   8..9  Master 2 Priority                        */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t M3PR:2;                    /**< bit: 12..13  Master 3 Priority                        */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t M4PR:2;                    /**< bit: 16..17  Master 4 Priority                        */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t M5PR:2;                    /**< bit: 20..21  Master 5 Priority                        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t M6PR:2;                    /**< bit: 24..25  Master 6 Priority                        */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t M7PR:2;                    /**< bit: 28..29  Master 7 Priority                        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_PRAS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_PRAS_OFFSET                  (0x00)                                        /**<  (MATRIX_PRAS) Priority Register A for Slave 0  Offset */
+
+#define MATRIX_PRAS_M0PR_Pos                0                                              /**< (MATRIX_PRAS) Master 0 Priority Position */
+#define MATRIX_PRAS_M0PR_Msk                (_U_(0x3) << MATRIX_PRAS_M0PR_Pos)             /**< (MATRIX_PRAS) Master 0 Priority Mask */
+#define MATRIX_PRAS_M0PR(value)             (MATRIX_PRAS_M0PR_Msk & ((value) << MATRIX_PRAS_M0PR_Pos))
+#define MATRIX_PRAS_M1PR_Pos                4                                              /**< (MATRIX_PRAS) Master 1 Priority Position */
+#define MATRIX_PRAS_M1PR_Msk                (_U_(0x3) << MATRIX_PRAS_M1PR_Pos)             /**< (MATRIX_PRAS) Master 1 Priority Mask */
+#define MATRIX_PRAS_M1PR(value)             (MATRIX_PRAS_M1PR_Msk & ((value) << MATRIX_PRAS_M1PR_Pos))
+#define MATRIX_PRAS_M2PR_Pos                8                                              /**< (MATRIX_PRAS) Master 2 Priority Position */
+#define MATRIX_PRAS_M2PR_Msk                (_U_(0x3) << MATRIX_PRAS_M2PR_Pos)             /**< (MATRIX_PRAS) Master 2 Priority Mask */
+#define MATRIX_PRAS_M2PR(value)             (MATRIX_PRAS_M2PR_Msk & ((value) << MATRIX_PRAS_M2PR_Pos))
+#define MATRIX_PRAS_M3PR_Pos                12                                             /**< (MATRIX_PRAS) Master 3 Priority Position */
+#define MATRIX_PRAS_M3PR_Msk                (_U_(0x3) << MATRIX_PRAS_M3PR_Pos)             /**< (MATRIX_PRAS) Master 3 Priority Mask */
+#define MATRIX_PRAS_M3PR(value)             (MATRIX_PRAS_M3PR_Msk & ((value) << MATRIX_PRAS_M3PR_Pos))
+#define MATRIX_PRAS_M4PR_Pos                16                                             /**< (MATRIX_PRAS) Master 4 Priority Position */
+#define MATRIX_PRAS_M4PR_Msk                (_U_(0x3) << MATRIX_PRAS_M4PR_Pos)             /**< (MATRIX_PRAS) Master 4 Priority Mask */
+#define MATRIX_PRAS_M4PR(value)             (MATRIX_PRAS_M4PR_Msk & ((value) << MATRIX_PRAS_M4PR_Pos))
+#define MATRIX_PRAS_M5PR_Pos                20                                             /**< (MATRIX_PRAS) Master 5 Priority Position */
+#define MATRIX_PRAS_M5PR_Msk                (_U_(0x3) << MATRIX_PRAS_M5PR_Pos)             /**< (MATRIX_PRAS) Master 5 Priority Mask */
+#define MATRIX_PRAS_M5PR(value)             (MATRIX_PRAS_M5PR_Msk & ((value) << MATRIX_PRAS_M5PR_Pos))
+#define MATRIX_PRAS_M6PR_Pos                24                                             /**< (MATRIX_PRAS) Master 6 Priority Position */
+#define MATRIX_PRAS_M6PR_Msk                (_U_(0x3) << MATRIX_PRAS_M6PR_Pos)             /**< (MATRIX_PRAS) Master 6 Priority Mask */
+#define MATRIX_PRAS_M6PR(value)             (MATRIX_PRAS_M6PR_Msk & ((value) << MATRIX_PRAS_M6PR_Pos))
+#define MATRIX_PRAS_M7PR_Pos                28                                             /**< (MATRIX_PRAS) Master 7 Priority Position */
+#define MATRIX_PRAS_M7PR_Msk                (_U_(0x3) << MATRIX_PRAS_M7PR_Pos)             /**< (MATRIX_PRAS) Master 7 Priority Mask */
+#define MATRIX_PRAS_M7PR(value)             (MATRIX_PRAS_M7PR_Msk & ((value) << MATRIX_PRAS_M7PR_Pos))
+#define MATRIX_PRAS_MASK                    _U_(0x33333333)                                /**< \deprecated (MATRIX_PRAS) Register MASK  (Use MATRIX_PRAS_Msk instead)  */
+#define MATRIX_PRAS_Msk                     _U_(0x33333333)                                /**< (MATRIX_PRAS) Register Mask  */
+
+
+/* -------- MATRIX_PRBS : (MATRIX Offset: 0x04) (R/W 32) Priority Register B for Slave 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t M8PR:2;                    /**< bit:   0..1  Master 8 Priority                        */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t M9PR:2;                    /**< bit:   4..5  Master 9 Priority                        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t M10PR:2;                   /**< bit:   8..9  Master 10 Priority                       */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t M11PR:2;                   /**< bit: 12..13  Master 11 Priority                       */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t M12PR:2;                   /**< bit: 16..17  Master 12 Priority                       */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_PRBS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_PRBS_OFFSET                  (0x04)                                        /**<  (MATRIX_PRBS) Priority Register B for Slave 0  Offset */
+
+#define MATRIX_PRBS_M8PR_Pos                0                                              /**< (MATRIX_PRBS) Master 8 Priority Position */
+#define MATRIX_PRBS_M8PR_Msk                (_U_(0x3) << MATRIX_PRBS_M8PR_Pos)             /**< (MATRIX_PRBS) Master 8 Priority Mask */
+#define MATRIX_PRBS_M8PR(value)             (MATRIX_PRBS_M8PR_Msk & ((value) << MATRIX_PRBS_M8PR_Pos))
+#define MATRIX_PRBS_M9PR_Pos                4                                              /**< (MATRIX_PRBS) Master 9 Priority Position */
+#define MATRIX_PRBS_M9PR_Msk                (_U_(0x3) << MATRIX_PRBS_M9PR_Pos)             /**< (MATRIX_PRBS) Master 9 Priority Mask */
+#define MATRIX_PRBS_M9PR(value)             (MATRIX_PRBS_M9PR_Msk & ((value) << MATRIX_PRBS_M9PR_Pos))
+#define MATRIX_PRBS_M10PR_Pos               8                                              /**< (MATRIX_PRBS) Master 10 Priority Position */
+#define MATRIX_PRBS_M10PR_Msk               (_U_(0x3) << MATRIX_PRBS_M10PR_Pos)            /**< (MATRIX_PRBS) Master 10 Priority Mask */
+#define MATRIX_PRBS_M10PR(value)            (MATRIX_PRBS_M10PR_Msk & ((value) << MATRIX_PRBS_M10PR_Pos))
+#define MATRIX_PRBS_M11PR_Pos               12                                             /**< (MATRIX_PRBS) Master 11 Priority Position */
+#define MATRIX_PRBS_M11PR_Msk               (_U_(0x3) << MATRIX_PRBS_M11PR_Pos)            /**< (MATRIX_PRBS) Master 11 Priority Mask */
+#define MATRIX_PRBS_M11PR(value)            (MATRIX_PRBS_M11PR_Msk & ((value) << MATRIX_PRBS_M11PR_Pos))
+#define MATRIX_PRBS_M12PR_Pos               16                                             /**< (MATRIX_PRBS) Master 12 Priority Position */
+#define MATRIX_PRBS_M12PR_Msk               (_U_(0x3) << MATRIX_PRBS_M12PR_Pos)            /**< (MATRIX_PRBS) Master 12 Priority Mask */
+#define MATRIX_PRBS_M12PR(value)            (MATRIX_PRBS_M12PR_Msk & ((value) << MATRIX_PRBS_M12PR_Pos))
+#define MATRIX_PRBS_MASK                    _U_(0x33333)                                   /**< \deprecated (MATRIX_PRBS) Register MASK  (Use MATRIX_PRBS_Msk instead)  */
+#define MATRIX_PRBS_Msk                     _U_(0x33333)                                   /**< (MATRIX_PRBS) Register Mask  */
+
+
+/* -------- MATRIX_MCFG : (MATRIX Offset: 0x00) (R/W 32) Master Configuration Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ULBT:3;                    /**< bit:   0..2  Undefined Length Burst Type              */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_MCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_MCFG_OFFSET                  (0x00)                                        /**<  (MATRIX_MCFG) Master Configuration Register 0  Offset */
+
+#define MATRIX_MCFG_ULBT_Pos                0                                              /**< (MATRIX_MCFG) Undefined Length Burst Type Position */
+#define MATRIX_MCFG_ULBT_Msk                (_U_(0x7) << MATRIX_MCFG_ULBT_Pos)             /**< (MATRIX_MCFG) Undefined Length Burst Type Mask */
+#define MATRIX_MCFG_ULBT(value)             (MATRIX_MCFG_ULBT_Msk & ((value) << MATRIX_MCFG_ULBT_Pos))
+#define   MATRIX_MCFG_ULBT_UNLTD_LENGTH_Val _U_(0x0)                                       /**< (MATRIX_MCFG) Unlimited Length Burst-No predicted end of burst is generated, therefore INCR bursts coming from this master can only be broken if the Slave Slot Cycle Limit is reached. If the Slot Cycle Limit is not reached, the burst is normally completed by the master, at the latest, on the next AHB 1-Kbyte address boundary, allowing up to 256-beat word bursts or 128-beat double-word bursts.This value should not be used in the very particular case of a master capable of performing back-to-back undefined length bursts on a single slave, since this could indefinitely freeze the slave arbitration and thus prevent another master from accessing this slave.  */
+#define   MATRIX_MCFG_ULBT_SINGLE_ACCESS_Val _U_(0x1)                                       /**< (MATRIX_MCFG) Single Access-The undefined length burst is treated as a succession of single accesses, allowing re-arbitration at each beat of the INCR burst or bursts sequence.  */
+#define   MATRIX_MCFG_ULBT_4BEAT_BURST_Val  _U_(0x2)                                       /**< (MATRIX_MCFG) 4-beat Burst-The undefined length burst or bursts sequence is split into 4-beat bursts or less, allowing re-arbitration every 4 beats.  */
+#define   MATRIX_MCFG_ULBT_8BEAT_BURST_Val  _U_(0x3)                                       /**< (MATRIX_MCFG) 8-beat Burst-The undefined length burst or bursts sequence is split into 8-beat bursts or less, allowing re-arbitration every 8 beats.  */
+#define   MATRIX_MCFG_ULBT_16BEAT_BURST_Val _U_(0x4)                                       /**< (MATRIX_MCFG) 16-beat Burst-The undefined length burst or bursts sequence is split into 16-beat bursts or less, allowing re-arbitration every 16 beats.  */
+#define   MATRIX_MCFG_ULBT_32BEAT_BURST_Val _U_(0x5)                                       /**< (MATRIX_MCFG) 32-beat Burst -The undefined length burst or bursts sequence is split into 32-beat bursts or less, allowing re-arbitration every 32 beats.  */
+#define   MATRIX_MCFG_ULBT_64BEAT_BURST_Val _U_(0x6)                                       /**< (MATRIX_MCFG) 64-beat Burst-The undefined length burst or bursts sequence is split into 64-beat bursts or less, allowing re-arbitration every 64 beats.  */
+#define   MATRIX_MCFG_ULBT_128BEAT_BURST_Val _U_(0x7)                                       /**< (MATRIX_MCFG) 128-beat Burst-The undefined length burst or bursts sequence is split into 128-beat bursts or less, allowing re-arbitration every 128 beats.  */
+#define MATRIX_MCFG_ULBT_UNLTD_LENGTH       (MATRIX_MCFG_ULBT_UNLTD_LENGTH_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) Unlimited Length Burst-No predicted end of burst is generated, therefore INCR bursts coming from this master can only be broken if the Slave Slot Cycle Limit is reached. If the Slot Cycle Limit is not reached, the burst is normally completed by the master, at the latest, on the next AHB 1-Kbyte address boundary, allowing up to 256-beat word bursts or 128-beat double-word bursts.This value should not be used in the very particular case of a master capable of performing back-to-back undefined length bursts on a single slave, since this could indefinitely freeze the slave arbitration and thus prevent another master from accessing this slave. Position  */
+#define MATRIX_MCFG_ULBT_SINGLE_ACCESS      (MATRIX_MCFG_ULBT_SINGLE_ACCESS_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) Single Access-The undefined length burst is treated as a succession of single accesses, allowing re-arbitration at each beat of the INCR burst or bursts sequence. Position  */
+#define MATRIX_MCFG_ULBT_4BEAT_BURST        (MATRIX_MCFG_ULBT_4BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 4-beat Burst-The undefined length burst or bursts sequence is split into 4-beat bursts or less, allowing re-arbitration every 4 beats. Position  */
+#define MATRIX_MCFG_ULBT_8BEAT_BURST        (MATRIX_MCFG_ULBT_8BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 8-beat Burst-The undefined length burst or bursts sequence is split into 8-beat bursts or less, allowing re-arbitration every 8 beats. Position  */
+#define MATRIX_MCFG_ULBT_16BEAT_BURST       (MATRIX_MCFG_ULBT_16BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 16-beat Burst-The undefined length burst or bursts sequence is split into 16-beat bursts or less, allowing re-arbitration every 16 beats. Position  */
+#define MATRIX_MCFG_ULBT_32BEAT_BURST       (MATRIX_MCFG_ULBT_32BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 32-beat Burst -The undefined length burst or bursts sequence is split into 32-beat bursts or less, allowing re-arbitration every 32 beats. Position  */
+#define MATRIX_MCFG_ULBT_64BEAT_BURST       (MATRIX_MCFG_ULBT_64BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 64-beat Burst-The undefined length burst or bursts sequence is split into 64-beat bursts or less, allowing re-arbitration every 64 beats. Position  */
+#define MATRIX_MCFG_ULBT_128BEAT_BURST      (MATRIX_MCFG_ULBT_128BEAT_BURST_Val << MATRIX_MCFG_ULBT_Pos)  /**< (MATRIX_MCFG) 128-beat Burst-The undefined length burst or bursts sequence is split into 128-beat bursts or less, allowing re-arbitration every 128 beats. Position  */
+#define MATRIX_MCFG_MASK                    _U_(0x07)                                      /**< \deprecated (MATRIX_MCFG) Register MASK  (Use MATRIX_MCFG_Msk instead)  */
+#define MATRIX_MCFG_Msk                     _U_(0x07)                                      /**< (MATRIX_MCFG) Register Mask  */
+
+
+/* -------- MATRIX_SCFG : (MATRIX Offset: 0x40) (R/W 32) Slave Configuration Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SLOT_CYCLE:9;              /**< bit:   0..8  Maximum Bus Grant Duration for Masters   */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t DEFMSTR_TYPE:2;            /**< bit: 16..17  Default Master Type                      */
+    uint32_t FIXED_DEFMSTR:4;           /**< bit: 18..21  Fixed Default Master                     */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_SCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_SCFG_OFFSET                  (0x40)                                        /**<  (MATRIX_SCFG) Slave Configuration Register 0  Offset */
+
+#define MATRIX_SCFG_SLOT_CYCLE_Pos          0                                              /**< (MATRIX_SCFG) Maximum Bus Grant Duration for Masters Position */
+#define MATRIX_SCFG_SLOT_CYCLE_Msk          (_U_(0x1FF) << MATRIX_SCFG_SLOT_CYCLE_Pos)     /**< (MATRIX_SCFG) Maximum Bus Grant Duration for Masters Mask */
+#define MATRIX_SCFG_SLOT_CYCLE(value)       (MATRIX_SCFG_SLOT_CYCLE_Msk & ((value) << MATRIX_SCFG_SLOT_CYCLE_Pos))
+#define MATRIX_SCFG_DEFMSTR_TYPE_Pos        16                                             /**< (MATRIX_SCFG) Default Master Type Position */
+#define MATRIX_SCFG_DEFMSTR_TYPE_Msk        (_U_(0x3) << MATRIX_SCFG_DEFMSTR_TYPE_Pos)     /**< (MATRIX_SCFG) Default Master Type Mask */
+#define MATRIX_SCFG_DEFMSTR_TYPE(value)     (MATRIX_SCFG_DEFMSTR_TYPE_Msk & ((value) << MATRIX_SCFG_DEFMSTR_TYPE_Pos))
+#define   MATRIX_SCFG_DEFMSTR_TYPE_NONE_Val _U_(0x0)                                       /**< (MATRIX_SCFG) No Default Master-At the end of the current slave access, if no other master request is pending, the slave is disconnected from all masters.This results in a one clock cycle latency for the first access of a burst transfer or for a single access.  */
+#define   MATRIX_SCFG_DEFMSTR_TYPE_LAST_Val _U_(0x1)                                       /**< (MATRIX_SCFG) Last Default Master-At the end of the current slave access, if no other master request is pending, the slave stays connected to the last master having accessed it.This results in not having one clock cycle latency when the last master tries to access the slave again.  */
+#define   MATRIX_SCFG_DEFMSTR_TYPE_FIXED_Val _U_(0x2)                                       /**< (MATRIX_SCFG) Fixed Default Master-At the end of the current slave access, if no other master request is pending, the slave connects to the fixed master the number that has been written in the FIXED_DEFMSTR field.This results in not having one clock cycle latency when the fixed master tries to access the slave again.  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_NONE       (MATRIX_SCFG_DEFMSTR_TYPE_NONE_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) No Default Master-At the end of the current slave access, if no other master request is pending, the slave is disconnected from all masters.This results in a one clock cycle latency for the first access of a burst transfer or for a single access. Position  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_LAST       (MATRIX_SCFG_DEFMSTR_TYPE_LAST_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) Last Default Master-At the end of the current slave access, if no other master request is pending, the slave stays connected to the last master having accessed it.This results in not having one clock cycle latency when the last master tries to access the slave again. Position  */
+#define MATRIX_SCFG_DEFMSTR_TYPE_FIXED      (MATRIX_SCFG_DEFMSTR_TYPE_FIXED_Val << MATRIX_SCFG_DEFMSTR_TYPE_Pos)  /**< (MATRIX_SCFG) Fixed Default Master-At the end of the current slave access, if no other master request is pending, the slave connects to the fixed master the number that has been written in the FIXED_DEFMSTR field.This results in not having one clock cycle latency when the fixed master tries to access the slave again. Position  */
+#define MATRIX_SCFG_FIXED_DEFMSTR_Pos       18                                             /**< (MATRIX_SCFG) Fixed Default Master Position */
+#define MATRIX_SCFG_FIXED_DEFMSTR_Msk       (_U_(0xF) << MATRIX_SCFG_FIXED_DEFMSTR_Pos)    /**< (MATRIX_SCFG) Fixed Default Master Mask */
+#define MATRIX_SCFG_FIXED_DEFMSTR(value)    (MATRIX_SCFG_FIXED_DEFMSTR_Msk & ((value) << MATRIX_SCFG_FIXED_DEFMSTR_Pos))
+#define MATRIX_SCFG_MASK                    _U_(0x3F01FF)                                  /**< \deprecated (MATRIX_SCFG) Register MASK  (Use MATRIX_SCFG_Msk instead)  */
+#define MATRIX_SCFG_Msk                     _U_(0x3F01FF)                                  /**< (MATRIX_SCFG) Register Mask  */
+
+
+/* -------- MATRIX_MRCR : (MATRIX Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RCB0:1;                    /**< bit:      0  Remap Command Bit for Master 0           */
+    uint32_t RCB1:1;                    /**< bit:      1  Remap Command Bit for Master 1           */
+    uint32_t RCB2:1;                    /**< bit:      2  Remap Command Bit for Master 2           */
+    uint32_t RCB3:1;                    /**< bit:      3  Remap Command Bit for Master 3           */
+    uint32_t RCB4:1;                    /**< bit:      4  Remap Command Bit for Master 4           */
+    uint32_t RCB5:1;                    /**< bit:      5  Remap Command Bit for Master 5           */
+    uint32_t RCB6:1;                    /**< bit:      6  Remap Command Bit for Master 6           */
+    uint32_t RCB7:1;                    /**< bit:      7  Remap Command Bit for Master 7           */
+    uint32_t RCB8:1;                    /**< bit:      8  Remap Command Bit for Master 8           */
+    uint32_t RCB9:1;                    /**< bit:      9  Remap Command Bit for Master 9           */
+    uint32_t RCB10:1;                   /**< bit:     10  Remap Command Bit for Master 10          */
+    uint32_t RCB11:1;                   /**< bit:     11  Remap Command Bit for Master 11          */
+    uint32_t RCB12:1;                   /**< bit:     12  Remap Command Bit for Master 12          */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RCB:13;                    /**< bit:  0..12  Remap Command Bit for Master x2          */
+    uint32_t :19;                       /**< bit: 13..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_MRCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_MRCR_OFFSET                  (0x100)                                       /**<  (MATRIX_MRCR) Master Remap Control Register  Offset */
+
+#define MATRIX_MRCR_RCB0_Pos                0                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 0 Position */
+#define MATRIX_MRCR_RCB0_Msk                (_U_(0x1) << MATRIX_MRCR_RCB0_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 0 Mask */
+#define MATRIX_MRCR_RCB0                    MATRIX_MRCR_RCB0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB0_Msk instead */
+#define MATRIX_MRCR_RCB1_Pos                1                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 1 Position */
+#define MATRIX_MRCR_RCB1_Msk                (_U_(0x1) << MATRIX_MRCR_RCB1_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 1 Mask */
+#define MATRIX_MRCR_RCB1                    MATRIX_MRCR_RCB1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB1_Msk instead */
+#define MATRIX_MRCR_RCB2_Pos                2                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 2 Position */
+#define MATRIX_MRCR_RCB2_Msk                (_U_(0x1) << MATRIX_MRCR_RCB2_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 2 Mask */
+#define MATRIX_MRCR_RCB2                    MATRIX_MRCR_RCB2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB2_Msk instead */
+#define MATRIX_MRCR_RCB3_Pos                3                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 3 Position */
+#define MATRIX_MRCR_RCB3_Msk                (_U_(0x1) << MATRIX_MRCR_RCB3_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 3 Mask */
+#define MATRIX_MRCR_RCB3                    MATRIX_MRCR_RCB3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB3_Msk instead */
+#define MATRIX_MRCR_RCB4_Pos                4                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 4 Position */
+#define MATRIX_MRCR_RCB4_Msk                (_U_(0x1) << MATRIX_MRCR_RCB4_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 4 Mask */
+#define MATRIX_MRCR_RCB4                    MATRIX_MRCR_RCB4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB4_Msk instead */
+#define MATRIX_MRCR_RCB5_Pos                5                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 5 Position */
+#define MATRIX_MRCR_RCB5_Msk                (_U_(0x1) << MATRIX_MRCR_RCB5_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 5 Mask */
+#define MATRIX_MRCR_RCB5                    MATRIX_MRCR_RCB5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB5_Msk instead */
+#define MATRIX_MRCR_RCB6_Pos                6                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 6 Position */
+#define MATRIX_MRCR_RCB6_Msk                (_U_(0x1) << MATRIX_MRCR_RCB6_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 6 Mask */
+#define MATRIX_MRCR_RCB6                    MATRIX_MRCR_RCB6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB6_Msk instead */
+#define MATRIX_MRCR_RCB7_Pos                7                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 7 Position */
+#define MATRIX_MRCR_RCB7_Msk                (_U_(0x1) << MATRIX_MRCR_RCB7_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 7 Mask */
+#define MATRIX_MRCR_RCB7                    MATRIX_MRCR_RCB7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB7_Msk instead */
+#define MATRIX_MRCR_RCB8_Pos                8                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 8 Position */
+#define MATRIX_MRCR_RCB8_Msk                (_U_(0x1) << MATRIX_MRCR_RCB8_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 8 Mask */
+#define MATRIX_MRCR_RCB8                    MATRIX_MRCR_RCB8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB8_Msk instead */
+#define MATRIX_MRCR_RCB9_Pos                9                                              /**< (MATRIX_MRCR) Remap Command Bit for Master 9 Position */
+#define MATRIX_MRCR_RCB9_Msk                (_U_(0x1) << MATRIX_MRCR_RCB9_Pos)             /**< (MATRIX_MRCR) Remap Command Bit for Master 9 Mask */
+#define MATRIX_MRCR_RCB9                    MATRIX_MRCR_RCB9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB9_Msk instead */
+#define MATRIX_MRCR_RCB10_Pos               10                                             /**< (MATRIX_MRCR) Remap Command Bit for Master 10 Position */
+#define MATRIX_MRCR_RCB10_Msk               (_U_(0x1) << MATRIX_MRCR_RCB10_Pos)            /**< (MATRIX_MRCR) Remap Command Bit for Master 10 Mask */
+#define MATRIX_MRCR_RCB10                   MATRIX_MRCR_RCB10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB10_Msk instead */
+#define MATRIX_MRCR_RCB11_Pos               11                                             /**< (MATRIX_MRCR) Remap Command Bit for Master 11 Position */
+#define MATRIX_MRCR_RCB11_Msk               (_U_(0x1) << MATRIX_MRCR_RCB11_Pos)            /**< (MATRIX_MRCR) Remap Command Bit for Master 11 Mask */
+#define MATRIX_MRCR_RCB11                   MATRIX_MRCR_RCB11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB11_Msk instead */
+#define MATRIX_MRCR_RCB12_Pos               12                                             /**< (MATRIX_MRCR) Remap Command Bit for Master 12 Position */
+#define MATRIX_MRCR_RCB12_Msk               (_U_(0x1) << MATRIX_MRCR_RCB12_Pos)            /**< (MATRIX_MRCR) Remap Command Bit for Master 12 Mask */
+#define MATRIX_MRCR_RCB12                   MATRIX_MRCR_RCB12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_MRCR_RCB12_Msk instead */
+#define MATRIX_MRCR_MASK                    _U_(0x1FFF)                                    /**< \deprecated (MATRIX_MRCR) Register MASK  (Use MATRIX_MRCR_Msk instead)  */
+#define MATRIX_MRCR_Msk                     _U_(0x1FFF)                                    /**< (MATRIX_MRCR) Register Mask  */
+
+#define MATRIX_MRCR_RCB_Pos                 0                                              /**< (MATRIX_MRCR Position) Remap Command Bit for Master x2 */
+#define MATRIX_MRCR_RCB_Msk                 (_U_(0x1FFF) << MATRIX_MRCR_RCB_Pos)           /**< (MATRIX_MRCR Mask) RCB */
+#define MATRIX_MRCR_RCB(value)              (MATRIX_MRCR_RCB_Msk & ((value) << MATRIX_MRCR_RCB_Pos))  
+
+/* -------- CCFG_CAN0 : (MATRIX Offset: 0x110) (R/W 32) CAN0 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t CAN0DMABA:16;              /**< bit: 16..31  CAN0 DMA Base Address                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_CAN0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_CAN0_OFFSET                    (0x110)                                       /**<  (CCFG_CAN0) CAN0 Configuration Register  Offset */
+
+#define CCFG_CAN0_CAN0DMABA_Pos             16                                             /**< (CCFG_CAN0) CAN0 DMA Base Address Position */
+#define CCFG_CAN0_CAN0DMABA_Msk             (_U_(0xFFFF) << CCFG_CAN0_CAN0DMABA_Pos)       /**< (CCFG_CAN0) CAN0 DMA Base Address Mask */
+#define CCFG_CAN0_CAN0DMABA(value)          (CCFG_CAN0_CAN0DMABA_Msk & ((value) << CCFG_CAN0_CAN0DMABA_Pos))
+#define CCFG_CAN0_MASK                      _U_(0xFFFF0000)                                /**< \deprecated (CCFG_CAN0) Register MASK  (Use CCFG_CAN0_Msk instead)  */
+#define CCFG_CAN0_Msk                       _U_(0xFFFF0000)                                /**< (CCFG_CAN0) Register Mask  */
+
+
+/* -------- CCFG_SYSIO : (MATRIX Offset: 0x114) (R/W 32) System I/O and CAN1 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t SYSIO4:1;                  /**< bit:      4  PB4 or TDI Assignment                    */
+    uint32_t SYSIO5:1;                  /**< bit:      5  PB5 or TDO/TRACESWO Assignment           */
+    uint32_t SYSIO6:1;                  /**< bit:      6  PB6 or TMS/SWDIO Assignment              */
+    uint32_t SYSIO7:1;                  /**< bit:      7  PB7 or TCK/SWCLK Assignment              */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t SYSIO12:1;                 /**< bit:     12  PB12 or ERASE Assignment                 */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t CAN1DMABA:16;              /**< bit: 16..31  CAN1 DMA Base Address                    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t SYSIO:5;                   /**< bit:   4..8  PB4 or TDI Assignment                    */
+    uint32_t :23;                       /**< bit:  9..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_SYSIO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_SYSIO_OFFSET                   (0x114)                                       /**<  (CCFG_SYSIO) System I/O and CAN1 Configuration Register  Offset */
+
+#define CCFG_SYSIO_SYSIO4_Pos               4                                              /**< (CCFG_SYSIO) PB4 or TDI Assignment Position */
+#define CCFG_SYSIO_SYSIO4_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO4_Pos)            /**< (CCFG_SYSIO) PB4 or TDI Assignment Mask */
+#define CCFG_SYSIO_SYSIO4                   CCFG_SYSIO_SYSIO4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO4_Msk instead */
+#define CCFG_SYSIO_SYSIO5_Pos               5                                              /**< (CCFG_SYSIO) PB5 or TDO/TRACESWO Assignment Position */
+#define CCFG_SYSIO_SYSIO5_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO5_Pos)            /**< (CCFG_SYSIO) PB5 or TDO/TRACESWO Assignment Mask */
+#define CCFG_SYSIO_SYSIO5                   CCFG_SYSIO_SYSIO5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO5_Msk instead */
+#define CCFG_SYSIO_SYSIO6_Pos               6                                              /**< (CCFG_SYSIO) PB6 or TMS/SWDIO Assignment Position */
+#define CCFG_SYSIO_SYSIO6_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO6_Pos)            /**< (CCFG_SYSIO) PB6 or TMS/SWDIO Assignment Mask */
+#define CCFG_SYSIO_SYSIO6                   CCFG_SYSIO_SYSIO6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO6_Msk instead */
+#define CCFG_SYSIO_SYSIO7_Pos               7                                              /**< (CCFG_SYSIO) PB7 or TCK/SWCLK Assignment Position */
+#define CCFG_SYSIO_SYSIO7_Msk               (_U_(0x1) << CCFG_SYSIO_SYSIO7_Pos)            /**< (CCFG_SYSIO) PB7 or TCK/SWCLK Assignment Mask */
+#define CCFG_SYSIO_SYSIO7                   CCFG_SYSIO_SYSIO7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO7_Msk instead */
+#define CCFG_SYSIO_SYSIO12_Pos              12                                             /**< (CCFG_SYSIO) PB12 or ERASE Assignment Position */
+#define CCFG_SYSIO_SYSIO12_Msk              (_U_(0x1) << CCFG_SYSIO_SYSIO12_Pos)           /**< (CCFG_SYSIO) PB12 or ERASE Assignment Mask */
+#define CCFG_SYSIO_SYSIO12                  CCFG_SYSIO_SYSIO12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SYSIO_SYSIO12_Msk instead */
+#define CCFG_SYSIO_CAN1DMABA_Pos            16                                             /**< (CCFG_SYSIO) CAN1 DMA Base Address Position */
+#define CCFG_SYSIO_CAN1DMABA_Msk            (_U_(0xFFFF) << CCFG_SYSIO_CAN1DMABA_Pos)      /**< (CCFG_SYSIO) CAN1 DMA Base Address Mask */
+#define CCFG_SYSIO_CAN1DMABA(value)         (CCFG_SYSIO_CAN1DMABA_Msk & ((value) << CCFG_SYSIO_CAN1DMABA_Pos))
+#define CCFG_SYSIO_MASK                     _U_(0xFFFF10F0)                                /**< \deprecated (CCFG_SYSIO) Register MASK  (Use CCFG_SYSIO_Msk instead)  */
+#define CCFG_SYSIO_Msk                      _U_(0xFFFF10F0)                                /**< (CCFG_SYSIO) Register Mask  */
+
+#define CCFG_SYSIO_SYSIO_Pos                4                                              /**< (CCFG_SYSIO Position) PB4 or TDI Assignment */
+#define CCFG_SYSIO_SYSIO_Msk                (_U_(0x1F) << CCFG_SYSIO_SYSIO_Pos)            /**< (CCFG_SYSIO Mask) SYSIO */
+#define CCFG_SYSIO_SYSIO(value)             (CCFG_SYSIO_SYSIO_Msk & ((value) << CCFG_SYSIO_SYSIO_Pos))  
+
+/* -------- CCFG_PCCR : (MATRIX Offset: 0x118) (R/W 32) Peripheral Clock Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :20;                       /**< bit:  0..19  Reserved */
+    uint32_t TC0CC:1;                   /**< bit:     20  TC0 Clock Configuration                  */
+    uint32_t I2SC0CC:1;                 /**< bit:     21  I2SC0 Clock Configuration                */
+    uint32_t I2SC1CC:1;                 /**< bit:     22  I2SC1 Clock Configuration                */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_PCCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_PCCR_OFFSET                    (0x118)                                       /**<  (CCFG_PCCR) Peripheral Clock Configuration Register  Offset */
+
+#define CCFG_PCCR_TC0CC_Pos                 20                                             /**< (CCFG_PCCR) TC0 Clock Configuration Position */
+#define CCFG_PCCR_TC0CC_Msk                 (_U_(0x1) << CCFG_PCCR_TC0CC_Pos)              /**< (CCFG_PCCR) TC0 Clock Configuration Mask */
+#define CCFG_PCCR_TC0CC                     CCFG_PCCR_TC0CC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_PCCR_TC0CC_Msk instead */
+#define CCFG_PCCR_I2SC0CC_Pos               21                                             /**< (CCFG_PCCR) I2SC0 Clock Configuration Position */
+#define CCFG_PCCR_I2SC0CC_Msk               (_U_(0x1) << CCFG_PCCR_I2SC0CC_Pos)            /**< (CCFG_PCCR) I2SC0 Clock Configuration Mask */
+#define CCFG_PCCR_I2SC0CC                   CCFG_PCCR_I2SC0CC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_PCCR_I2SC0CC_Msk instead */
+#define CCFG_PCCR_I2SC1CC_Pos               22                                             /**< (CCFG_PCCR) I2SC1 Clock Configuration Position */
+#define CCFG_PCCR_I2SC1CC_Msk               (_U_(0x1) << CCFG_PCCR_I2SC1CC_Pos)            /**< (CCFG_PCCR) I2SC1 Clock Configuration Mask */
+#define CCFG_PCCR_I2SC1CC                   CCFG_PCCR_I2SC1CC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_PCCR_I2SC1CC_Msk instead */
+#define CCFG_PCCR_MASK                      _U_(0x700000)                                  /**< \deprecated (CCFG_PCCR) Register MASK  (Use CCFG_PCCR_Msk instead)  */
+#define CCFG_PCCR_Msk                       _U_(0x700000)                                  /**< (CCFG_PCCR) Register Mask  */
+
+
+/* -------- CCFG_DYNCKG : (MATRIX Offset: 0x11c) (R/W 32) Dynamic Clock Gating Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MATCKG:1;                  /**< bit:      0  MATRIX Dynamic Clock Gating              */
+    uint32_t BRIDCKG:1;                 /**< bit:      1  Bridge Dynamic Clock Gating Enable       */
+    uint32_t EFCCKG:1;                  /**< bit:      2  EFC Dynamic Clock Gating Enable          */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_DYNCKG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_DYNCKG_OFFSET                  (0x11C)                                       /**<  (CCFG_DYNCKG) Dynamic Clock Gating Register  Offset */
+
+#define CCFG_DYNCKG_MATCKG_Pos              0                                              /**< (CCFG_DYNCKG) MATRIX Dynamic Clock Gating Position */
+#define CCFG_DYNCKG_MATCKG_Msk              (_U_(0x1) << CCFG_DYNCKG_MATCKG_Pos)           /**< (CCFG_DYNCKG) MATRIX Dynamic Clock Gating Mask */
+#define CCFG_DYNCKG_MATCKG                  CCFG_DYNCKG_MATCKG_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_DYNCKG_MATCKG_Msk instead */
+#define CCFG_DYNCKG_BRIDCKG_Pos             1                                              /**< (CCFG_DYNCKG) Bridge Dynamic Clock Gating Enable Position */
+#define CCFG_DYNCKG_BRIDCKG_Msk             (_U_(0x1) << CCFG_DYNCKG_BRIDCKG_Pos)          /**< (CCFG_DYNCKG) Bridge Dynamic Clock Gating Enable Mask */
+#define CCFG_DYNCKG_BRIDCKG                 CCFG_DYNCKG_BRIDCKG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_DYNCKG_BRIDCKG_Msk instead */
+#define CCFG_DYNCKG_EFCCKG_Pos              2                                              /**< (CCFG_DYNCKG) EFC Dynamic Clock Gating Enable Position */
+#define CCFG_DYNCKG_EFCCKG_Msk              (_U_(0x1) << CCFG_DYNCKG_EFCCKG_Pos)           /**< (CCFG_DYNCKG) EFC Dynamic Clock Gating Enable Mask */
+#define CCFG_DYNCKG_EFCCKG                  CCFG_DYNCKG_EFCCKG_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_DYNCKG_EFCCKG_Msk instead */
+#define CCFG_DYNCKG_MASK                    _U_(0x07)                                      /**< \deprecated (CCFG_DYNCKG) Register MASK  (Use CCFG_DYNCKG_Msk instead)  */
+#define CCFG_DYNCKG_Msk                     _U_(0x07)                                      /**< (CCFG_DYNCKG) Register Mask  */
+
+
+/* -------- CCFG_SMCNFCS : (MATRIX Offset: 0x124) (R/W 32) SMC NAND Flash Chip Select Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMC_NFCS0:1;               /**< bit:      0  SMC NAND Flash Chip Select 0 Assignment  */
+    uint32_t SMC_NFCS1:1;               /**< bit:      1  SMC NAND Flash Chip Select 1 Assignment  */
+    uint32_t SMC_NFCS2:1;               /**< bit:      2  SMC NAND Flash Chip Select 2 Assignment  */
+    uint32_t SMC_NFCS3:1;               /**< bit:      3  SMC NAND Flash Chip Select 3 Assignment  */
+    uint32_t SDRAMEN:1;                 /**< bit:      4  SDRAM Enable                             */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SMC_NFCS:4;                /**< bit:   0..3  SMC NAND Flash Chip Select x Assignment  */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} CCFG_SMCNFCS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCFG_SMCNFCS_OFFSET                 (0x124)                                       /**<  (CCFG_SMCNFCS) SMC NAND Flash Chip Select Configuration Register  Offset */
+
+#define CCFG_SMCNFCS_SMC_NFCS0_Pos          0                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 0 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS0_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS0_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 0 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS0              CCFG_SMCNFCS_SMC_NFCS0_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS0_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS1_Pos          1                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 1 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS1_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS1_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 1 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS1              CCFG_SMCNFCS_SMC_NFCS1_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS1_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS2_Pos          2                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 2 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS2_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS2_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 2 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS2              CCFG_SMCNFCS_SMC_NFCS2_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS2_Msk instead */
+#define CCFG_SMCNFCS_SMC_NFCS3_Pos          3                                              /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 3 Assignment Position */
+#define CCFG_SMCNFCS_SMC_NFCS3_Msk          (_U_(0x1) << CCFG_SMCNFCS_SMC_NFCS3_Pos)       /**< (CCFG_SMCNFCS) SMC NAND Flash Chip Select 3 Assignment Mask */
+#define CCFG_SMCNFCS_SMC_NFCS3              CCFG_SMCNFCS_SMC_NFCS3_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SMC_NFCS3_Msk instead */
+#define CCFG_SMCNFCS_SDRAMEN_Pos            4                                              /**< (CCFG_SMCNFCS) SDRAM Enable Position */
+#define CCFG_SMCNFCS_SDRAMEN_Msk            (_U_(0x1) << CCFG_SMCNFCS_SDRAMEN_Pos)         /**< (CCFG_SMCNFCS) SDRAM Enable Mask */
+#define CCFG_SMCNFCS_SDRAMEN                CCFG_SMCNFCS_SDRAMEN_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use CCFG_SMCNFCS_SDRAMEN_Msk instead */
+#define CCFG_SMCNFCS_MASK                   _U_(0x1F)                                      /**< \deprecated (CCFG_SMCNFCS) Register MASK  (Use CCFG_SMCNFCS_Msk instead)  */
+#define CCFG_SMCNFCS_Msk                    _U_(0x1F)                                      /**< (CCFG_SMCNFCS) Register Mask  */
+
+#define CCFG_SMCNFCS_SMC_NFCS_Pos           0                                              /**< (CCFG_SMCNFCS Position) SMC NAND Flash Chip Select x Assignment */
+#define CCFG_SMCNFCS_SMC_NFCS_Msk           (_U_(0xF) << CCFG_SMCNFCS_SMC_NFCS_Pos)        /**< (CCFG_SMCNFCS Mask) SMC_NFCS */
+#define CCFG_SMCNFCS_SMC_NFCS(value)        (CCFG_SMCNFCS_SMC_NFCS_Msk & ((value) << CCFG_SMCNFCS_SMC_NFCS_Pos))  
+
+/* -------- MATRIX_WPMR : (MATRIX Offset: 0x1e4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_WPMR_OFFSET                  (0x1E4)                                       /**<  (MATRIX_WPMR) Write Protection Mode Register  Offset */
+
+#define MATRIX_WPMR_WPEN_Pos                0                                              /**< (MATRIX_WPMR) Write Protection Enable Position */
+#define MATRIX_WPMR_WPEN_Msk                (_U_(0x1) << MATRIX_WPMR_WPEN_Pos)             /**< (MATRIX_WPMR) Write Protection Enable Mask */
+#define MATRIX_WPMR_WPEN                    MATRIX_WPMR_WPEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_WPMR_WPEN_Msk instead */
+#define MATRIX_WPMR_WPKEY_Pos               8                                              /**< (MATRIX_WPMR) Write Protection Key Position */
+#define MATRIX_WPMR_WPKEY_Msk               (_U_(0xFFFFFF) << MATRIX_WPMR_WPKEY_Pos)       /**< (MATRIX_WPMR) Write Protection Key Mask */
+#define MATRIX_WPMR_WPKEY(value)            (MATRIX_WPMR_WPKEY_Msk & ((value) << MATRIX_WPMR_WPKEY_Pos))
+#define   MATRIX_WPMR_WPKEY_PASSWD_Val      _U_(0x4D4154)                                  /**< (MATRIX_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define MATRIX_WPMR_WPKEY_PASSWD            (MATRIX_WPMR_WPKEY_PASSWD_Val << MATRIX_WPMR_WPKEY_Pos)  /**< (MATRIX_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define MATRIX_WPMR_MASK                    _U_(0xFFFFFF01)                                /**< \deprecated (MATRIX_WPMR) Register MASK  (Use MATRIX_WPMR_Msk instead)  */
+#define MATRIX_WPMR_Msk                     _U_(0xFFFFFF01)                                /**< (MATRIX_WPMR) Register Mask  */
+
+
+/* -------- MATRIX_WPSR : (MATRIX Offset: 0x1e8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MATRIX_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MATRIX_WPSR_OFFSET                  (0x1E8)                                       /**<  (MATRIX_WPSR) Write Protection Status Register  Offset */
+
+#define MATRIX_WPSR_WPVS_Pos                0                                              /**< (MATRIX_WPSR) Write Protection Violation Status Position */
+#define MATRIX_WPSR_WPVS_Msk                (_U_(0x1) << MATRIX_WPSR_WPVS_Pos)             /**< (MATRIX_WPSR) Write Protection Violation Status Mask */
+#define MATRIX_WPSR_WPVS                    MATRIX_WPSR_WPVS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MATRIX_WPSR_WPVS_Msk instead */
+#define MATRIX_WPSR_WPVSRC_Pos              8                                              /**< (MATRIX_WPSR) Write Protection Violation Source Position */
+#define MATRIX_WPSR_WPVSRC_Msk              (_U_(0xFFFF) << MATRIX_WPSR_WPVSRC_Pos)        /**< (MATRIX_WPSR) Write Protection Violation Source Mask */
+#define MATRIX_WPSR_WPVSRC(value)           (MATRIX_WPSR_WPVSRC_Msk & ((value) << MATRIX_WPSR_WPVSRC_Pos))
+#define MATRIX_WPSR_MASK                    _U_(0xFFFF01)                                  /**< \deprecated (MATRIX_WPSR) Register MASK  (Use MATRIX_WPSR_Msk instead)  */
+#define MATRIX_WPSR_Msk                     _U_(0xFFFF01)                                  /**< (MATRIX_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MATRIX_PR hardware registers */
+typedef struct {  
+  __IO uint32_t MATRIX_PRAS;    /**< (MATRIX_PR Offset: 0x00) Priority Register A for Slave 0 */
+  __IO uint32_t MATRIX_PRBS;    /**< (MATRIX_PR Offset: 0x04) Priority Register B for Slave 0 */
+} MatrixPr;
+
+#define MATRIXPR_NUMBER 9
+/** \brief MATRIX hardware registers */
+typedef struct {  
+  __IO uint32_t MATRIX_MCFG[13]; /**< (MATRIX Offset: 0x00) Master Configuration Register 0 */
+  __I  uint8_t                        Reserved1[12];
+  __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
+  __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO uint32_t CCFG_CAN0;      /**< (MATRIX Offset: 0x110) CAN0 Configuration Register */
+  __IO uint32_t CCFG_SYSIO;     /**< (MATRIX Offset: 0x114) System I/O and CAN1 Configuration Register */
+  __IO uint32_t CCFG_PCCR;      /**< (MATRIX Offset: 0x118) Peripheral Clock Configuration Register */
+  __IO uint32_t CCFG_DYNCKG;    /**< (MATRIX Offset: 0x11C) Dynamic Clock Gating Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO uint32_t CCFG_SMCNFCS;   /**< (MATRIX Offset: 0x124) SMC NAND Flash Chip Select Configuration Register */
+  __I  uint8_t                        Reserved6[188];
+  __IO uint32_t MATRIX_WPMR;    /**< (MATRIX Offset: 0x1E4) Write Protection Mode Register */
+  __I  uint32_t MATRIX_WPSR;    /**< (MATRIX Offset: 0x1E8) Write Protection Status Register */
+} Matrix;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MATRIX_PR hardware registers */
+typedef struct {  
+  __IO MATRIX_PRAS_Type               MATRIX_PRAS;    /**< Offset: 0x00 (R/W  32) Priority Register A for Slave 0 */
+  __IO MATRIX_PRBS_Type               MATRIX_PRBS;    /**< Offset: 0x04 (R/W  32) Priority Register B for Slave 0 */
+} MatrixPr;
+
+/** \brief MATRIX hardware registers */
+typedef struct {  
+  __IO MATRIX_MCFG_Type               MATRIX_MCFG[13]; /**< Offset: 0x00 (R/W  32) Master Configuration Register 0 */
+  __I  uint8_t                        Reserved1[12];
+  __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
+  __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO CCFG_CAN0_Type                 CCFG_CAN0;      /**< Offset: 0x110 (R/W  32) CAN0 Configuration Register */
+  __IO CCFG_SYSIO_Type                CCFG_SYSIO;     /**< Offset: 0x114 (R/W  32) System I/O and CAN1 Configuration Register */
+  __IO CCFG_PCCR_Type                 CCFG_PCCR;      /**< Offset: 0x118 (R/W  32) Peripheral Clock Configuration Register */
+  __IO CCFG_DYNCKG_Type               CCFG_DYNCKG;    /**< Offset: 0x11C (R/W  32) Dynamic Clock Gating Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO CCFG_SMCNFCS_Type              CCFG_SMCNFCS;   /**< Offset: 0x124 (R/W  32) SMC NAND Flash Chip Select Configuration Register */
+  __I  uint8_t                        Reserved6[188];
+  __IO MATRIX_WPMR_Type               MATRIX_WPMR;    /**< Offset: 0x1E4 (R/W  32) Write Protection Mode Register */
+  __I  MATRIX_WPSR_Type               MATRIX_WPSR;    /**< Offset: 0x1E8 (R/   32) Write Protection Status Register */
+} Matrix;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of AHB Bus Matrix */
+
+#endif /* _SAMV71_MATRIX_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/mcan.h
+++ b/asf/sam/include/samv71b/component/mcan.h
@@ -1,0 +1,4032 @@
+/**
+ * \file
+ *
+ * \brief Component description for MCAN
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MCAN_COMPONENT_H_
+#define _SAMV71_MCAN_COMPONENT_H_
+#define _SAMV71_MCAN_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Controller Area Network
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MCAN */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MCAN_11273                      /**< (MCAN) Module ID */
+#define REV_MCAN N                      /**< (MCAN) Module revision */
+
+/* -------- MCAN_RXBE_0 : (MCAN Offset: 0x00) (R/W 32) Rx Buffer Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_0_OFFSET                  (0x00)                                        /**<  (MCAN_RXBE_0) Rx Buffer Element 0  Offset */
+
+#define MCAN_RXBE_0_ID_Pos                  0                                              /**< (MCAN_RXBE_0) Identifier Position */
+#define MCAN_RXBE_0_ID_Msk                  (_U_(0x1FFFFFFF) << MCAN_RXBE_0_ID_Pos)        /**< (MCAN_RXBE_0) Identifier Mask */
+#define MCAN_RXBE_0_ID(value)               (MCAN_RXBE_0_ID_Msk & ((value) << MCAN_RXBE_0_ID_Pos))
+#define MCAN_RXBE_0_RTR_Pos                 29                                             /**< (MCAN_RXBE_0) Remote Transmission Request Position */
+#define MCAN_RXBE_0_RTR_Msk                 (_U_(0x1) << MCAN_RXBE_0_RTR_Pos)              /**< (MCAN_RXBE_0) Remote Transmission Request Mask */
+#define MCAN_RXBE_0_RTR                     MCAN_RXBE_0_RTR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_RTR_Msk instead */
+#define MCAN_RXBE_0_XTD_Pos                 30                                             /**< (MCAN_RXBE_0) Extended Identifier Position */
+#define MCAN_RXBE_0_XTD_Msk                 (_U_(0x1) << MCAN_RXBE_0_XTD_Pos)              /**< (MCAN_RXBE_0) Extended Identifier Mask */
+#define MCAN_RXBE_0_XTD                     MCAN_RXBE_0_XTD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_XTD_Msk instead */
+#define MCAN_RXBE_0_ESI_Pos                 31                                             /**< (MCAN_RXBE_0) Error State Indicator Position */
+#define MCAN_RXBE_0_ESI_Msk                 (_U_(0x1) << MCAN_RXBE_0_ESI_Pos)              /**< (MCAN_RXBE_0) Error State Indicator Mask */
+#define MCAN_RXBE_0_ESI                     MCAN_RXBE_0_ESI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_ESI_Msk instead */
+#define MCAN_RXBE_0_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXBE_0) Register MASK  (Use MCAN_RXBE_0_Msk instead)  */
+#define MCAN_RXBE_0_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_RXBE_0) Register Mask  */
+
+
+/* -------- MCAN_RXBE_1 : (MCAN Offset: 0x04) (R/W 32) Rx Buffer Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_1_OFFSET                  (0x04)                                        /**<  (MCAN_RXBE_1) Rx Buffer Element 1  Offset */
+
+#define MCAN_RXBE_1_RXTS_Pos                0                                              /**< (MCAN_RXBE_1) Rx Timestamp Position */
+#define MCAN_RXBE_1_RXTS_Msk                (_U_(0xFFFF) << MCAN_RXBE_1_RXTS_Pos)          /**< (MCAN_RXBE_1) Rx Timestamp Mask */
+#define MCAN_RXBE_1_RXTS(value)             (MCAN_RXBE_1_RXTS_Msk & ((value) << MCAN_RXBE_1_RXTS_Pos))
+#define MCAN_RXBE_1_DLC_Pos                 16                                             /**< (MCAN_RXBE_1) Data Length Code Position */
+#define MCAN_RXBE_1_DLC_Msk                 (_U_(0xF) << MCAN_RXBE_1_DLC_Pos)              /**< (MCAN_RXBE_1) Data Length Code Mask */
+#define MCAN_RXBE_1_DLC(value)              (MCAN_RXBE_1_DLC_Msk & ((value) << MCAN_RXBE_1_DLC_Pos))
+#define MCAN_RXBE_1_BRS_Pos                 20                                             /**< (MCAN_RXBE_1) Bit Rate Switch Position */
+#define MCAN_RXBE_1_BRS_Msk                 (_U_(0x1) << MCAN_RXBE_1_BRS_Pos)              /**< (MCAN_RXBE_1) Bit Rate Switch Mask */
+#define MCAN_RXBE_1_BRS                     MCAN_RXBE_1_BRS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_BRS_Msk instead */
+#define MCAN_RXBE_1_FDF_Pos                 21                                             /**< (MCAN_RXBE_1) FD Format Position */
+#define MCAN_RXBE_1_FDF_Msk                 (_U_(0x1) << MCAN_RXBE_1_FDF_Pos)              /**< (MCAN_RXBE_1) FD Format Mask */
+#define MCAN_RXBE_1_FDF                     MCAN_RXBE_1_FDF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_FDF_Msk instead */
+#define MCAN_RXBE_1_FIDX_Pos                24                                             /**< (MCAN_RXBE_1) Filter Index Position */
+#define MCAN_RXBE_1_FIDX_Msk                (_U_(0x7F) << MCAN_RXBE_1_FIDX_Pos)            /**< (MCAN_RXBE_1) Filter Index Mask */
+#define MCAN_RXBE_1_FIDX(value)             (MCAN_RXBE_1_FIDX_Msk & ((value) << MCAN_RXBE_1_FIDX_Pos))
+#define MCAN_RXBE_1_ANMF_Pos                31                                             /**< (MCAN_RXBE_1) Accepted Non-matching Frame Position */
+#define MCAN_RXBE_1_ANMF_Msk                (_U_(0x1) << MCAN_RXBE_1_ANMF_Pos)             /**< (MCAN_RXBE_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXBE_1_ANMF                    MCAN_RXBE_1_ANMF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_ANMF_Msk instead */
+#define MCAN_RXBE_1_MASK                    _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXBE_1) Register MASK  (Use MCAN_RXBE_1_Msk instead)  */
+#define MCAN_RXBE_1_Msk                     _U_(0xFF3FFFFF)                                /**< (MCAN_RXBE_1) Register Mask  */
+
+
+/* -------- MCAN_RXBE_DATA : (MCAN Offset: 0x08) (R/W 32) Rx Buffer Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_DATA_OFFSET               (0x08)                                        /**<  (MCAN_RXBE_DATA) Rx Buffer Element Data  Offset */
+
+#define MCAN_RXBE_DATA_DB0_Pos              0                                              /**< (MCAN_RXBE_DATA) Data Byte 0 Position */
+#define MCAN_RXBE_DATA_DB0_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB0_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 0 Mask */
+#define MCAN_RXBE_DATA_DB0(value)           (MCAN_RXBE_DATA_DB0_Msk & ((value) << MCAN_RXBE_DATA_DB0_Pos))
+#define MCAN_RXBE_DATA_DB1_Pos              8                                              /**< (MCAN_RXBE_DATA) Data Byte 1 Position */
+#define MCAN_RXBE_DATA_DB1_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB1_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 1 Mask */
+#define MCAN_RXBE_DATA_DB1(value)           (MCAN_RXBE_DATA_DB1_Msk & ((value) << MCAN_RXBE_DATA_DB1_Pos))
+#define MCAN_RXBE_DATA_DB2_Pos              16                                             /**< (MCAN_RXBE_DATA) Data Byte 2 Position */
+#define MCAN_RXBE_DATA_DB2_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB2_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 2 Mask */
+#define MCAN_RXBE_DATA_DB2(value)           (MCAN_RXBE_DATA_DB2_Msk & ((value) << MCAN_RXBE_DATA_DB2_Pos))
+#define MCAN_RXBE_DATA_DB3_Pos              24                                             /**< (MCAN_RXBE_DATA) Data Byte 3 Position */
+#define MCAN_RXBE_DATA_DB3_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB3_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 3 Mask */
+#define MCAN_RXBE_DATA_DB3(value)           (MCAN_RXBE_DATA_DB3_Msk & ((value) << MCAN_RXBE_DATA_DB3_Pos))
+#define MCAN_RXBE_DATA_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXBE_DATA) Register MASK  (Use MCAN_RXBE_DATA_Msk instead)  */
+#define MCAN_RXBE_DATA_Msk                  _U_(0xFFFFFFFF)                                /**< (MCAN_RXBE_DATA) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_0 : (MCAN Offset: 0x00) (R/W 32) Rx FIFO 0 Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_0_OFFSET                 (0x00)                                        /**<  (MCAN_RXF0E_0) Rx FIFO 0 Element 0  Offset */
+
+#define MCAN_RXF0E_0_ID_Pos                 0                                              /**< (MCAN_RXF0E_0) Identifier Position */
+#define MCAN_RXF0E_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_RXF0E_0_ID_Pos)       /**< (MCAN_RXF0E_0) Identifier Mask */
+#define MCAN_RXF0E_0_ID(value)              (MCAN_RXF0E_0_ID_Msk & ((value) << MCAN_RXF0E_0_ID_Pos))
+#define MCAN_RXF0E_0_RTR_Pos                29                                             /**< (MCAN_RXF0E_0) Remote Transmission Request Position */
+#define MCAN_RXF0E_0_RTR_Msk                (_U_(0x1) << MCAN_RXF0E_0_RTR_Pos)             /**< (MCAN_RXF0E_0) Remote Transmission Request Mask */
+#define MCAN_RXF0E_0_RTR                    MCAN_RXF0E_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_RTR_Msk instead */
+#define MCAN_RXF0E_0_XTD_Pos                30                                             /**< (MCAN_RXF0E_0) Extended Identifier Position */
+#define MCAN_RXF0E_0_XTD_Msk                (_U_(0x1) << MCAN_RXF0E_0_XTD_Pos)             /**< (MCAN_RXF0E_0) Extended Identifier Mask */
+#define MCAN_RXF0E_0_XTD                    MCAN_RXF0E_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_XTD_Msk instead */
+#define MCAN_RXF0E_0_ESI_Pos                31                                             /**< (MCAN_RXF0E_0) Error State Indicator Position */
+#define MCAN_RXF0E_0_ESI_Msk                (_U_(0x1) << MCAN_RXF0E_0_ESI_Pos)             /**< (MCAN_RXF0E_0) Error State Indicator Mask */
+#define MCAN_RXF0E_0_ESI                    MCAN_RXF0E_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_ESI_Msk instead */
+#define MCAN_RXF0E_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF0E_0) Register MASK  (Use MCAN_RXF0E_0_Msk instead)  */
+#define MCAN_RXF0E_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_RXF0E_0) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_1 : (MCAN Offset: 0x04) (R/W 32) Rx FIFO 0 Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_1_OFFSET                 (0x04)                                        /**<  (MCAN_RXF0E_1) Rx FIFO 0 Element 1  Offset */
+
+#define MCAN_RXF0E_1_RXTS_Pos               0                                              /**< (MCAN_RXF0E_1) Rx Timestamp Position */
+#define MCAN_RXF0E_1_RXTS_Msk               (_U_(0xFFFF) << MCAN_RXF0E_1_RXTS_Pos)         /**< (MCAN_RXF0E_1) Rx Timestamp Mask */
+#define MCAN_RXF0E_1_RXTS(value)            (MCAN_RXF0E_1_RXTS_Msk & ((value) << MCAN_RXF0E_1_RXTS_Pos))
+#define MCAN_RXF0E_1_DLC_Pos                16                                             /**< (MCAN_RXF0E_1) Data Length Code Position */
+#define MCAN_RXF0E_1_DLC_Msk                (_U_(0xF) << MCAN_RXF0E_1_DLC_Pos)             /**< (MCAN_RXF0E_1) Data Length Code Mask */
+#define MCAN_RXF0E_1_DLC(value)             (MCAN_RXF0E_1_DLC_Msk & ((value) << MCAN_RXF0E_1_DLC_Pos))
+#define MCAN_RXF0E_1_BRS_Pos                20                                             /**< (MCAN_RXF0E_1) Bit Rate Switch Position */
+#define MCAN_RXF0E_1_BRS_Msk                (_U_(0x1) << MCAN_RXF0E_1_BRS_Pos)             /**< (MCAN_RXF0E_1) Bit Rate Switch Mask */
+#define MCAN_RXF0E_1_BRS                    MCAN_RXF0E_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_BRS_Msk instead */
+#define MCAN_RXF0E_1_FDF_Pos                21                                             /**< (MCAN_RXF0E_1) FD Format Position */
+#define MCAN_RXF0E_1_FDF_Msk                (_U_(0x1) << MCAN_RXF0E_1_FDF_Pos)             /**< (MCAN_RXF0E_1) FD Format Mask */
+#define MCAN_RXF0E_1_FDF                    MCAN_RXF0E_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_FDF_Msk instead */
+#define MCAN_RXF0E_1_FIDX_Pos               24                                             /**< (MCAN_RXF0E_1) Filter Index Position */
+#define MCAN_RXF0E_1_FIDX_Msk               (_U_(0x7F) << MCAN_RXF0E_1_FIDX_Pos)           /**< (MCAN_RXF0E_1) Filter Index Mask */
+#define MCAN_RXF0E_1_FIDX(value)            (MCAN_RXF0E_1_FIDX_Msk & ((value) << MCAN_RXF0E_1_FIDX_Pos))
+#define MCAN_RXF0E_1_ANMF_Pos               31                                             /**< (MCAN_RXF0E_1) Accepted Non-matching Frame Position */
+#define MCAN_RXF0E_1_ANMF_Msk               (_U_(0x1) << MCAN_RXF0E_1_ANMF_Pos)            /**< (MCAN_RXF0E_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXF0E_1_ANMF                   MCAN_RXF0E_1_ANMF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_ANMF_Msk instead */
+#define MCAN_RXF0E_1_MASK                   _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXF0E_1) Register MASK  (Use MCAN_RXF0E_1_Msk instead)  */
+#define MCAN_RXF0E_1_Msk                    _U_(0xFF3FFFFF)                                /**< (MCAN_RXF0E_1) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_DATA : (MCAN Offset: 0x08) (R/W 32) Rx FIFO 0 Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_DATA_OFFSET              (0x08)                                        /**<  (MCAN_RXF0E_DATA) Rx FIFO 0 Element Data  Offset */
+
+#define MCAN_RXF0E_DATA_DB0_Pos             0                                              /**< (MCAN_RXF0E_DATA) Data Byte 0 Position */
+#define MCAN_RXF0E_DATA_DB0_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB0_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 0 Mask */
+#define MCAN_RXF0E_DATA_DB0(value)          (MCAN_RXF0E_DATA_DB0_Msk & ((value) << MCAN_RXF0E_DATA_DB0_Pos))
+#define MCAN_RXF0E_DATA_DB1_Pos             8                                              /**< (MCAN_RXF0E_DATA) Data Byte 1 Position */
+#define MCAN_RXF0E_DATA_DB1_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB1_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 1 Mask */
+#define MCAN_RXF0E_DATA_DB1(value)          (MCAN_RXF0E_DATA_DB1_Msk & ((value) << MCAN_RXF0E_DATA_DB1_Pos))
+#define MCAN_RXF0E_DATA_DB2_Pos             16                                             /**< (MCAN_RXF0E_DATA) Data Byte 2 Position */
+#define MCAN_RXF0E_DATA_DB2_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB2_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 2 Mask */
+#define MCAN_RXF0E_DATA_DB2(value)          (MCAN_RXF0E_DATA_DB2_Msk & ((value) << MCAN_RXF0E_DATA_DB2_Pos))
+#define MCAN_RXF0E_DATA_DB3_Pos             24                                             /**< (MCAN_RXF0E_DATA) Data Byte 3 Position */
+#define MCAN_RXF0E_DATA_DB3_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB3_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 3 Mask */
+#define MCAN_RXF0E_DATA_DB3(value)          (MCAN_RXF0E_DATA_DB3_Msk & ((value) << MCAN_RXF0E_DATA_DB3_Pos))
+#define MCAN_RXF0E_DATA_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF0E_DATA) Register MASK  (Use MCAN_RXF0E_DATA_Msk instead)  */
+#define MCAN_RXF0E_DATA_Msk                 _U_(0xFFFFFFFF)                                /**< (MCAN_RXF0E_DATA) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_0 : (MCAN Offset: 0x00) (R/W 32) Rx FIFO 1 Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_0_OFFSET                 (0x00)                                        /**<  (MCAN_RXF1E_0) Rx FIFO 1 Element 0  Offset */
+
+#define MCAN_RXF1E_0_ID_Pos                 0                                              /**< (MCAN_RXF1E_0) Identifier Position */
+#define MCAN_RXF1E_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_RXF1E_0_ID_Pos)       /**< (MCAN_RXF1E_0) Identifier Mask */
+#define MCAN_RXF1E_0_ID(value)              (MCAN_RXF1E_0_ID_Msk & ((value) << MCAN_RXF1E_0_ID_Pos))
+#define MCAN_RXF1E_0_RTR_Pos                29                                             /**< (MCAN_RXF1E_0) Remote Transmission Request Position */
+#define MCAN_RXF1E_0_RTR_Msk                (_U_(0x1) << MCAN_RXF1E_0_RTR_Pos)             /**< (MCAN_RXF1E_0) Remote Transmission Request Mask */
+#define MCAN_RXF1E_0_RTR                    MCAN_RXF1E_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_RTR_Msk instead */
+#define MCAN_RXF1E_0_XTD_Pos                30                                             /**< (MCAN_RXF1E_0) Extended Identifier Position */
+#define MCAN_RXF1E_0_XTD_Msk                (_U_(0x1) << MCAN_RXF1E_0_XTD_Pos)             /**< (MCAN_RXF1E_0) Extended Identifier Mask */
+#define MCAN_RXF1E_0_XTD                    MCAN_RXF1E_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_XTD_Msk instead */
+#define MCAN_RXF1E_0_ESI_Pos                31                                             /**< (MCAN_RXF1E_0) Error State Indicator Position */
+#define MCAN_RXF1E_0_ESI_Msk                (_U_(0x1) << MCAN_RXF1E_0_ESI_Pos)             /**< (MCAN_RXF1E_0) Error State Indicator Mask */
+#define MCAN_RXF1E_0_ESI                    MCAN_RXF1E_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_ESI_Msk instead */
+#define MCAN_RXF1E_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF1E_0) Register MASK  (Use MCAN_RXF1E_0_Msk instead)  */
+#define MCAN_RXF1E_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_RXF1E_0) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_1 : (MCAN Offset: 0x04) (R/W 32) Rx FIFO 1 Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_1_OFFSET                 (0x04)                                        /**<  (MCAN_RXF1E_1) Rx FIFO 1 Element 1  Offset */
+
+#define MCAN_RXF1E_1_RXTS_Pos               0                                              /**< (MCAN_RXF1E_1) Rx Timestamp Position */
+#define MCAN_RXF1E_1_RXTS_Msk               (_U_(0xFFFF) << MCAN_RXF1E_1_RXTS_Pos)         /**< (MCAN_RXF1E_1) Rx Timestamp Mask */
+#define MCAN_RXF1E_1_RXTS(value)            (MCAN_RXF1E_1_RXTS_Msk & ((value) << MCAN_RXF1E_1_RXTS_Pos))
+#define MCAN_RXF1E_1_DLC_Pos                16                                             /**< (MCAN_RXF1E_1) Data Length Code Position */
+#define MCAN_RXF1E_1_DLC_Msk                (_U_(0xF) << MCAN_RXF1E_1_DLC_Pos)             /**< (MCAN_RXF1E_1) Data Length Code Mask */
+#define MCAN_RXF1E_1_DLC(value)             (MCAN_RXF1E_1_DLC_Msk & ((value) << MCAN_RXF1E_1_DLC_Pos))
+#define MCAN_RXF1E_1_BRS_Pos                20                                             /**< (MCAN_RXF1E_1) Bit Rate Switch Position */
+#define MCAN_RXF1E_1_BRS_Msk                (_U_(0x1) << MCAN_RXF1E_1_BRS_Pos)             /**< (MCAN_RXF1E_1) Bit Rate Switch Mask */
+#define MCAN_RXF1E_1_BRS                    MCAN_RXF1E_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_BRS_Msk instead */
+#define MCAN_RXF1E_1_FDF_Pos                21                                             /**< (MCAN_RXF1E_1) FD Format Position */
+#define MCAN_RXF1E_1_FDF_Msk                (_U_(0x1) << MCAN_RXF1E_1_FDF_Pos)             /**< (MCAN_RXF1E_1) FD Format Mask */
+#define MCAN_RXF1E_1_FDF                    MCAN_RXF1E_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_FDF_Msk instead */
+#define MCAN_RXF1E_1_FIDX_Pos               24                                             /**< (MCAN_RXF1E_1) Filter Index Position */
+#define MCAN_RXF1E_1_FIDX_Msk               (_U_(0x7F) << MCAN_RXF1E_1_FIDX_Pos)           /**< (MCAN_RXF1E_1) Filter Index Mask */
+#define MCAN_RXF1E_1_FIDX(value)            (MCAN_RXF1E_1_FIDX_Msk & ((value) << MCAN_RXF1E_1_FIDX_Pos))
+#define MCAN_RXF1E_1_ANMF_Pos               31                                             /**< (MCAN_RXF1E_1) Accepted Non-matching Frame Position */
+#define MCAN_RXF1E_1_ANMF_Msk               (_U_(0x1) << MCAN_RXF1E_1_ANMF_Pos)            /**< (MCAN_RXF1E_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXF1E_1_ANMF                   MCAN_RXF1E_1_ANMF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_ANMF_Msk instead */
+#define MCAN_RXF1E_1_MASK                   _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXF1E_1) Register MASK  (Use MCAN_RXF1E_1_Msk instead)  */
+#define MCAN_RXF1E_1_Msk                    _U_(0xFF3FFFFF)                                /**< (MCAN_RXF1E_1) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_DATA : (MCAN Offset: 0x08) (R/W 32) Rx FIFO 1 Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_DATA_OFFSET              (0x08)                                        /**<  (MCAN_RXF1E_DATA) Rx FIFO 1 Element Data  Offset */
+
+#define MCAN_RXF1E_DATA_DB0_Pos             0                                              /**< (MCAN_RXF1E_DATA) Data Byte 0 Position */
+#define MCAN_RXF1E_DATA_DB0_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB0_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 0 Mask */
+#define MCAN_RXF1E_DATA_DB0(value)          (MCAN_RXF1E_DATA_DB0_Msk & ((value) << MCAN_RXF1E_DATA_DB0_Pos))
+#define MCAN_RXF1E_DATA_DB1_Pos             8                                              /**< (MCAN_RXF1E_DATA) Data Byte 1 Position */
+#define MCAN_RXF1E_DATA_DB1_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB1_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 1 Mask */
+#define MCAN_RXF1E_DATA_DB1(value)          (MCAN_RXF1E_DATA_DB1_Msk & ((value) << MCAN_RXF1E_DATA_DB1_Pos))
+#define MCAN_RXF1E_DATA_DB2_Pos             16                                             /**< (MCAN_RXF1E_DATA) Data Byte 2 Position */
+#define MCAN_RXF1E_DATA_DB2_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB2_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 2 Mask */
+#define MCAN_RXF1E_DATA_DB2(value)          (MCAN_RXF1E_DATA_DB2_Msk & ((value) << MCAN_RXF1E_DATA_DB2_Pos))
+#define MCAN_RXF1E_DATA_DB3_Pos             24                                             /**< (MCAN_RXF1E_DATA) Data Byte 3 Position */
+#define MCAN_RXF1E_DATA_DB3_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB3_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 3 Mask */
+#define MCAN_RXF1E_DATA_DB3(value)          (MCAN_RXF1E_DATA_DB3_Msk & ((value) << MCAN_RXF1E_DATA_DB3_Pos))
+#define MCAN_RXF1E_DATA_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF1E_DATA) Register MASK  (Use MCAN_RXF1E_DATA_Msk instead)  */
+#define MCAN_RXF1E_DATA_Msk                 _U_(0xFFFFFFFF)                                /**< (MCAN_RXF1E_DATA) Register Mask  */
+
+
+/* -------- MCAN_TXBE_0 : (MCAN Offset: 0x00) (R/W 32) Tx Buffer Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_0_OFFSET                  (0x00)                                        /**<  (MCAN_TXBE_0) Tx Buffer Element 0  Offset */
+
+#define MCAN_TXBE_0_ID_Pos                  0                                              /**< (MCAN_TXBE_0) Identifier Position */
+#define MCAN_TXBE_0_ID_Msk                  (_U_(0x1FFFFFFF) << MCAN_TXBE_0_ID_Pos)        /**< (MCAN_TXBE_0) Identifier Mask */
+#define MCAN_TXBE_0_ID(value)               (MCAN_TXBE_0_ID_Msk & ((value) << MCAN_TXBE_0_ID_Pos))
+#define MCAN_TXBE_0_RTR_Pos                 29                                             /**< (MCAN_TXBE_0) Remote Transmission Request Position */
+#define MCAN_TXBE_0_RTR_Msk                 (_U_(0x1) << MCAN_TXBE_0_RTR_Pos)              /**< (MCAN_TXBE_0) Remote Transmission Request Mask */
+#define MCAN_TXBE_0_RTR                     MCAN_TXBE_0_RTR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_RTR_Msk instead */
+#define MCAN_TXBE_0_XTD_Pos                 30                                             /**< (MCAN_TXBE_0) Extended Identifier Position */
+#define MCAN_TXBE_0_XTD_Msk                 (_U_(0x1) << MCAN_TXBE_0_XTD_Pos)              /**< (MCAN_TXBE_0) Extended Identifier Mask */
+#define MCAN_TXBE_0_XTD                     MCAN_TXBE_0_XTD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_XTD_Msk instead */
+#define MCAN_TXBE_0_ESI_Pos                 31                                             /**< (MCAN_TXBE_0) Error State Indicator Position */
+#define MCAN_TXBE_0_ESI_Msk                 (_U_(0x1) << MCAN_TXBE_0_ESI_Pos)              /**< (MCAN_TXBE_0) Error State Indicator Mask */
+#define MCAN_TXBE_0_ESI                     MCAN_TXBE_0_ESI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_ESI_Msk instead */
+#define MCAN_TXBE_0_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBE_0) Register MASK  (Use MCAN_TXBE_0_Msk instead)  */
+#define MCAN_TXBE_0_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBE_0) Register Mask  */
+
+
+/* -------- MCAN_TXBE_1 : (MCAN Offset: 0x04) (R/W 32) Tx Buffer Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t EFC:1;                     /**< bit:     23  Event FIFO Control                       */
+    uint32_t MM:8;                      /**< bit: 24..31  Message Marker                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_1_OFFSET                  (0x04)                                        /**<  (MCAN_TXBE_1) Tx Buffer Element 1  Offset */
+
+#define MCAN_TXBE_1_DLC_Pos                 16                                             /**< (MCAN_TXBE_1) Data Length Code Position */
+#define MCAN_TXBE_1_DLC_Msk                 (_U_(0xF) << MCAN_TXBE_1_DLC_Pos)              /**< (MCAN_TXBE_1) Data Length Code Mask */
+#define MCAN_TXBE_1_DLC(value)              (MCAN_TXBE_1_DLC_Msk & ((value) << MCAN_TXBE_1_DLC_Pos))
+#define MCAN_TXBE_1_BRS_Pos                 20                                             /**< (MCAN_TXBE_1) Bit Rate Switch Position */
+#define MCAN_TXBE_1_BRS_Msk                 (_U_(0x1) << MCAN_TXBE_1_BRS_Pos)              /**< (MCAN_TXBE_1) Bit Rate Switch Mask */
+#define MCAN_TXBE_1_BRS                     MCAN_TXBE_1_BRS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_BRS_Msk instead */
+#define MCAN_TXBE_1_FDF_Pos                 21                                             /**< (MCAN_TXBE_1) FD Format Position */
+#define MCAN_TXBE_1_FDF_Msk                 (_U_(0x1) << MCAN_TXBE_1_FDF_Pos)              /**< (MCAN_TXBE_1) FD Format Mask */
+#define MCAN_TXBE_1_FDF                     MCAN_TXBE_1_FDF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_FDF_Msk instead */
+#define MCAN_TXBE_1_EFC_Pos                 23                                             /**< (MCAN_TXBE_1) Event FIFO Control Position */
+#define MCAN_TXBE_1_EFC_Msk                 (_U_(0x1) << MCAN_TXBE_1_EFC_Pos)              /**< (MCAN_TXBE_1) Event FIFO Control Mask */
+#define MCAN_TXBE_1_EFC                     MCAN_TXBE_1_EFC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_EFC_Msk instead */
+#define MCAN_TXBE_1_MM_Pos                  24                                             /**< (MCAN_TXBE_1) Message Marker Position */
+#define MCAN_TXBE_1_MM_Msk                  (_U_(0xFF) << MCAN_TXBE_1_MM_Pos)              /**< (MCAN_TXBE_1) Message Marker Mask */
+#define MCAN_TXBE_1_MM(value)               (MCAN_TXBE_1_MM_Msk & ((value) << MCAN_TXBE_1_MM_Pos))
+#define MCAN_TXBE_1_MASK                    _U_(0xFFBF0000)                                /**< \deprecated (MCAN_TXBE_1) Register MASK  (Use MCAN_TXBE_1_Msk instead)  */
+#define MCAN_TXBE_1_Msk                     _U_(0xFFBF0000)                                /**< (MCAN_TXBE_1) Register Mask  */
+
+
+/* -------- MCAN_TXBE_DATA : (MCAN Offset: 0x08) (R/W 32) Tx Buffer Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_DATA_OFFSET               (0x08)                                        /**<  (MCAN_TXBE_DATA) Tx Buffer Element Data  Offset */
+
+#define MCAN_TXBE_DATA_DB0_Pos              0                                              /**< (MCAN_TXBE_DATA) Data Byte 0 Position */
+#define MCAN_TXBE_DATA_DB0_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB0_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 0 Mask */
+#define MCAN_TXBE_DATA_DB0(value)           (MCAN_TXBE_DATA_DB0_Msk & ((value) << MCAN_TXBE_DATA_DB0_Pos))
+#define MCAN_TXBE_DATA_DB1_Pos              8                                              /**< (MCAN_TXBE_DATA) Data Byte 1 Position */
+#define MCAN_TXBE_DATA_DB1_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB1_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 1 Mask */
+#define MCAN_TXBE_DATA_DB1(value)           (MCAN_TXBE_DATA_DB1_Msk & ((value) << MCAN_TXBE_DATA_DB1_Pos))
+#define MCAN_TXBE_DATA_DB2_Pos              16                                             /**< (MCAN_TXBE_DATA) Data Byte 2 Position */
+#define MCAN_TXBE_DATA_DB2_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB2_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 2 Mask */
+#define MCAN_TXBE_DATA_DB2(value)           (MCAN_TXBE_DATA_DB2_Msk & ((value) << MCAN_TXBE_DATA_DB2_Pos))
+#define MCAN_TXBE_DATA_DB3_Pos              24                                             /**< (MCAN_TXBE_DATA) Data Byte 3 Position */
+#define MCAN_TXBE_DATA_DB3_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB3_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 3 Mask */
+#define MCAN_TXBE_DATA_DB3(value)           (MCAN_TXBE_DATA_DB3_Msk & ((value) << MCAN_TXBE_DATA_DB3_Pos))
+#define MCAN_TXBE_DATA_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBE_DATA) Register MASK  (Use MCAN_TXBE_DATA_Msk instead)  */
+#define MCAN_TXBE_DATA_Msk                  _U_(0xFFFFFFFF)                                /**< (MCAN_TXBE_DATA) Register Mask  */
+
+
+/* -------- MCAN_TXEFE_0 : (MCAN Offset: 0x00) (R/W 32) Tx Event FIFO Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_TXEFE_0) Tx Event FIFO Element 0  Offset */
+
+#define MCAN_TXEFE_0_ID_Pos                 0                                              /**< (MCAN_TXEFE_0) Identifier Position */
+#define MCAN_TXEFE_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_TXEFE_0_ID_Pos)       /**< (MCAN_TXEFE_0) Identifier Mask */
+#define MCAN_TXEFE_0_ID(value)              (MCAN_TXEFE_0_ID_Msk & ((value) << MCAN_TXEFE_0_ID_Pos))
+#define MCAN_TXEFE_0_RTR_Pos                29                                             /**< (MCAN_TXEFE_0) Remote Transmission Request Position */
+#define MCAN_TXEFE_0_RTR_Msk                (_U_(0x1) << MCAN_TXEFE_0_RTR_Pos)             /**< (MCAN_TXEFE_0) Remote Transmission Request Mask */
+#define MCAN_TXEFE_0_RTR                    MCAN_TXEFE_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_RTR_Msk instead */
+#define MCAN_TXEFE_0_XTD_Pos                30                                             /**< (MCAN_TXEFE_0) Extended Identifier Position */
+#define MCAN_TXEFE_0_XTD_Msk                (_U_(0x1) << MCAN_TXEFE_0_XTD_Pos)             /**< (MCAN_TXEFE_0) Extended Identifier Mask */
+#define MCAN_TXEFE_0_XTD                    MCAN_TXEFE_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_XTD_Msk instead */
+#define MCAN_TXEFE_0_ESI_Pos                31                                             /**< (MCAN_TXEFE_0) Error State Indicator Position */
+#define MCAN_TXEFE_0_ESI_Msk                (_U_(0x1) << MCAN_TXEFE_0_ESI_Pos)             /**< (MCAN_TXEFE_0) Error State Indicator Mask */
+#define MCAN_TXEFE_0_ESI                    MCAN_TXEFE_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_ESI_Msk instead */
+#define MCAN_TXEFE_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXEFE_0) Register MASK  (Use MCAN_TXEFE_0_Msk instead)  */
+#define MCAN_TXEFE_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_TXEFE_0) Register Mask  */
+
+
+/* -------- MCAN_TXEFE_1 : (MCAN Offset: 0x04) (R/W 32) Tx Event FIFO Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXTS:16;                   /**< bit:  0..15  Tx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t ET:2;                      /**< bit: 22..23  Event Type                               */
+    uint32_t MM:8;                      /**< bit: 24..31  Message Marker                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFE_1_OFFSET                 (0x04)                                        /**<  (MCAN_TXEFE_1) Tx Event FIFO Element 1  Offset */
+
+#define MCAN_TXEFE_1_TXTS_Pos               0                                              /**< (MCAN_TXEFE_1) Tx Timestamp Position */
+#define MCAN_TXEFE_1_TXTS_Msk               (_U_(0xFFFF) << MCAN_TXEFE_1_TXTS_Pos)         /**< (MCAN_TXEFE_1) Tx Timestamp Mask */
+#define MCAN_TXEFE_1_TXTS(value)            (MCAN_TXEFE_1_TXTS_Msk & ((value) << MCAN_TXEFE_1_TXTS_Pos))
+#define MCAN_TXEFE_1_DLC_Pos                16                                             /**< (MCAN_TXEFE_1) Data Length Code Position */
+#define MCAN_TXEFE_1_DLC_Msk                (_U_(0xF) << MCAN_TXEFE_1_DLC_Pos)             /**< (MCAN_TXEFE_1) Data Length Code Mask */
+#define MCAN_TXEFE_1_DLC(value)             (MCAN_TXEFE_1_DLC_Msk & ((value) << MCAN_TXEFE_1_DLC_Pos))
+#define MCAN_TXEFE_1_BRS_Pos                20                                             /**< (MCAN_TXEFE_1) Bit Rate Switch Position */
+#define MCAN_TXEFE_1_BRS_Msk                (_U_(0x1) << MCAN_TXEFE_1_BRS_Pos)             /**< (MCAN_TXEFE_1) Bit Rate Switch Mask */
+#define MCAN_TXEFE_1_BRS                    MCAN_TXEFE_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_1_BRS_Msk instead */
+#define MCAN_TXEFE_1_FDF_Pos                21                                             /**< (MCAN_TXEFE_1) FD Format Position */
+#define MCAN_TXEFE_1_FDF_Msk                (_U_(0x1) << MCAN_TXEFE_1_FDF_Pos)             /**< (MCAN_TXEFE_1) FD Format Mask */
+#define MCAN_TXEFE_1_FDF                    MCAN_TXEFE_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_1_FDF_Msk instead */
+#define MCAN_TXEFE_1_ET_Pos                 22                                             /**< (MCAN_TXEFE_1) Event Type Position */
+#define MCAN_TXEFE_1_ET_Msk                 (_U_(0x3) << MCAN_TXEFE_1_ET_Pos)              /**< (MCAN_TXEFE_1) Event Type Mask */
+#define MCAN_TXEFE_1_ET(value)              (MCAN_TXEFE_1_ET_Msk & ((value) << MCAN_TXEFE_1_ET_Pos))
+#define   MCAN_TXEFE_1_ET_TXE_Val           _U_(0x1)                                       /**< (MCAN_TXEFE_1) Tx event  */
+#define   MCAN_TXEFE_1_ET_TXC_Val           _U_(0x2)                                       /**< (MCAN_TXEFE_1) Transmission in spite of cancellation  */
+#define MCAN_TXEFE_1_ET_TXE                 (MCAN_TXEFE_1_ET_TXE_Val << MCAN_TXEFE_1_ET_Pos)  /**< (MCAN_TXEFE_1) Tx event Position  */
+#define MCAN_TXEFE_1_ET_TXC                 (MCAN_TXEFE_1_ET_TXC_Val << MCAN_TXEFE_1_ET_Pos)  /**< (MCAN_TXEFE_1) Transmission in spite of cancellation Position  */
+#define MCAN_TXEFE_1_MM_Pos                 24                                             /**< (MCAN_TXEFE_1) Message Marker Position */
+#define MCAN_TXEFE_1_MM_Msk                 (_U_(0xFF) << MCAN_TXEFE_1_MM_Pos)             /**< (MCAN_TXEFE_1) Message Marker Mask */
+#define MCAN_TXEFE_1_MM(value)              (MCAN_TXEFE_1_MM_Msk & ((value) << MCAN_TXEFE_1_MM_Pos))
+#define MCAN_TXEFE_1_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXEFE_1) Register MASK  (Use MCAN_TXEFE_1_Msk instead)  */
+#define MCAN_TXEFE_1_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_TXEFE_1) Register Mask  */
+
+
+/* -------- MCAN_SIDFE_0 : (MCAN Offset: 0x00) (R/W 32) Standard Message ID Filter Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SFID2:11;                  /**< bit:  0..10  Standard Filter ID 2                     */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t SFID1:11;                  /**< bit: 16..26  Standard Filter ID 1                     */
+    uint32_t SFEC:3;                    /**< bit: 27..29  Standard Filter Element Configuration    */
+    uint32_t SFT:2;                     /**< bit: 30..31  Standard Filter Type                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_SIDFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_SIDFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_SIDFE_0) Standard Message ID Filter Element 0  Offset */
+
+#define MCAN_SIDFE_0_SFID2_Pos              0                                              /**< (MCAN_SIDFE_0) Standard Filter ID 2 Position */
+#define MCAN_SIDFE_0_SFID2_Msk              (_U_(0x7FF) << MCAN_SIDFE_0_SFID2_Pos)         /**< (MCAN_SIDFE_0) Standard Filter ID 2 Mask */
+#define MCAN_SIDFE_0_SFID2(value)           (MCAN_SIDFE_0_SFID2_Msk & ((value) << MCAN_SIDFE_0_SFID2_Pos))
+#define MCAN_SIDFE_0_SFID1_Pos              16                                             /**< (MCAN_SIDFE_0) Standard Filter ID 1 Position */
+#define MCAN_SIDFE_0_SFID1_Msk              (_U_(0x7FF) << MCAN_SIDFE_0_SFID1_Pos)         /**< (MCAN_SIDFE_0) Standard Filter ID 1 Mask */
+#define MCAN_SIDFE_0_SFID1(value)           (MCAN_SIDFE_0_SFID1_Msk & ((value) << MCAN_SIDFE_0_SFID1_Pos))
+#define MCAN_SIDFE_0_SFEC_Pos               27                                             /**< (MCAN_SIDFE_0) Standard Filter Element Configuration Position */
+#define MCAN_SIDFE_0_SFEC_Msk               (_U_(0x7) << MCAN_SIDFE_0_SFEC_Pos)            /**< (MCAN_SIDFE_0) Standard Filter Element Configuration Mask */
+#define MCAN_SIDFE_0_SFEC(value)            (MCAN_SIDFE_0_SFEC_Msk & ((value) << MCAN_SIDFE_0_SFEC_Pos))
+#define   MCAN_SIDFE_0_SFEC_DISABLE_Val     _U_(0x0)                                       /**< (MCAN_SIDFE_0) Disable filter element  */
+#define   MCAN_SIDFE_0_SFEC_STF0M_Val       _U_(0x1)                                       /**< (MCAN_SIDFE_0) Store in Rx FIFO 0 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_STF1M_Val       _U_(0x2)                                       /**< (MCAN_SIDFE_0) Store in Rx FIFO 1 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_REJECT_Val      _U_(0x3)                                       /**< (MCAN_SIDFE_0) Reject ID if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIORITY_Val    _U_(0x4)                                       /**< (MCAN_SIDFE_0) Set priority if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIF0M_Val      _U_(0x5)                                       /**< (MCAN_SIDFE_0) Set priority and store in FIFO 0 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIF1M_Val      _U_(0x6)                                       /**< (MCAN_SIDFE_0) Set priority and store in FIFO 1 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_STRXBUF_Val     _U_(0x7)                                       /**< (MCAN_SIDFE_0) Store into Rx Buffer  */
+#define MCAN_SIDFE_0_SFEC_DISABLE           (MCAN_SIDFE_0_SFEC_DISABLE_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Disable filter element Position  */
+#define MCAN_SIDFE_0_SFEC_STF0M             (MCAN_SIDFE_0_SFEC_STF0M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store in Rx FIFO 0 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_STF1M             (MCAN_SIDFE_0_SFEC_STF1M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store in Rx FIFO 1 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_REJECT            (MCAN_SIDFE_0_SFEC_REJECT_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Reject ID if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIORITY          (MCAN_SIDFE_0_SFEC_PRIORITY_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIF0M            (MCAN_SIDFE_0_SFEC_PRIF0M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority and store in FIFO 0 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIF1M            (MCAN_SIDFE_0_SFEC_PRIF1M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority and store in FIFO 1 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_STRXBUF           (MCAN_SIDFE_0_SFEC_STRXBUF_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store into Rx Buffer Position  */
+#define MCAN_SIDFE_0_SFT_Pos                30                                             /**< (MCAN_SIDFE_0) Standard Filter Type Position */
+#define MCAN_SIDFE_0_SFT_Msk                (_U_(0x3) << MCAN_SIDFE_0_SFT_Pos)             /**< (MCAN_SIDFE_0) Standard Filter Type Mask */
+#define MCAN_SIDFE_0_SFT(value)             (MCAN_SIDFE_0_SFT_Msk & ((value) << MCAN_SIDFE_0_SFT_Pos))
+#define   MCAN_SIDFE_0_SFT_RANGE_Val        _U_(0x0)                                       /**< (MCAN_SIDFE_0) Range filter from SFID1 to SFID2  */
+#define   MCAN_SIDFE_0_SFT_DUAL_Val         _U_(0x1)                                       /**< (MCAN_SIDFE_0) Dual ID filter for SF1ID or SF2ID  */
+#define   MCAN_SIDFE_0_SFT_CLASSIC_Val      _U_(0x2)                                       /**< (MCAN_SIDFE_0) Classic filter  */
+#define MCAN_SIDFE_0_SFT_RANGE              (MCAN_SIDFE_0_SFT_RANGE_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Range filter from SFID1 to SFID2 Position  */
+#define MCAN_SIDFE_0_SFT_DUAL               (MCAN_SIDFE_0_SFT_DUAL_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Dual ID filter for SF1ID or SF2ID Position  */
+#define MCAN_SIDFE_0_SFT_CLASSIC            (MCAN_SIDFE_0_SFT_CLASSIC_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Classic filter Position  */
+#define MCAN_SIDFE_0_MASK                   _U_(0xFFFF07FF)                                /**< \deprecated (MCAN_SIDFE_0) Register MASK  (Use MCAN_SIDFE_0_Msk instead)  */
+#define MCAN_SIDFE_0_Msk                    _U_(0xFFFF07FF)                                /**< (MCAN_SIDFE_0) Register Mask  */
+
+
+/* -------- MCAN_XIDFE_0 : (MCAN Offset: 0x00) (R/W 32) Extended Message ID Filter Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFID1:29;                  /**< bit:  0..28  Extended Filter ID 1                     */
+    uint32_t EFEC:3;                    /**< bit: 29..31  Extended Filter Element Configuration    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_XIDFE_0) Extended Message ID Filter Element 0  Offset */
+
+#define MCAN_XIDFE_0_EFID1_Pos              0                                              /**< (MCAN_XIDFE_0) Extended Filter ID 1 Position */
+#define MCAN_XIDFE_0_EFID1_Msk              (_U_(0x1FFFFFFF) << MCAN_XIDFE_0_EFID1_Pos)    /**< (MCAN_XIDFE_0) Extended Filter ID 1 Mask */
+#define MCAN_XIDFE_0_EFID1(value)           (MCAN_XIDFE_0_EFID1_Msk & ((value) << MCAN_XIDFE_0_EFID1_Pos))
+#define MCAN_XIDFE_0_EFEC_Pos               29                                             /**< (MCAN_XIDFE_0) Extended Filter Element Configuration Position */
+#define MCAN_XIDFE_0_EFEC_Msk               (_U_(0x7) << MCAN_XIDFE_0_EFEC_Pos)            /**< (MCAN_XIDFE_0) Extended Filter Element Configuration Mask */
+#define MCAN_XIDFE_0_EFEC(value)            (MCAN_XIDFE_0_EFEC_Msk & ((value) << MCAN_XIDFE_0_EFEC_Pos))
+#define   MCAN_XIDFE_0_EFEC_DISABLE_Val     _U_(0x0)                                       /**< (MCAN_XIDFE_0) Disable filter element  */
+#define   MCAN_XIDFE_0_EFEC_STF0M_Val       _U_(0x1)                                       /**< (MCAN_XIDFE_0) Store in Rx FIFO 0 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_STF1M_Val       _U_(0x2)                                       /**< (MCAN_XIDFE_0) Store in Rx FIFO 1 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_REJECT_Val      _U_(0x3)                                       /**< (MCAN_XIDFE_0) Reject ID if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIORITY_Val    _U_(0x4)                                       /**< (MCAN_XIDFE_0) Set priority if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIF0M_Val      _U_(0x5)                                       /**< (MCAN_XIDFE_0) Set priority and store in FIFO 0 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIF1M_Val      _U_(0x6)                                       /**< (MCAN_XIDFE_0) Set priority and store in FIFO 1 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_STRXBUF_Val     _U_(0x7)                                       /**< (MCAN_XIDFE_0) Store into Rx Buffer  */
+#define MCAN_XIDFE_0_EFEC_DISABLE           (MCAN_XIDFE_0_EFEC_DISABLE_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Disable filter element Position  */
+#define MCAN_XIDFE_0_EFEC_STF0M             (MCAN_XIDFE_0_EFEC_STF0M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store in Rx FIFO 0 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_STF1M             (MCAN_XIDFE_0_EFEC_STF1M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store in Rx FIFO 1 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_REJECT            (MCAN_XIDFE_0_EFEC_REJECT_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Reject ID if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIORITY          (MCAN_XIDFE_0_EFEC_PRIORITY_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIF0M            (MCAN_XIDFE_0_EFEC_PRIF0M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority and store in FIFO 0 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIF1M            (MCAN_XIDFE_0_EFEC_PRIF1M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority and store in FIFO 1 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_STRXBUF           (MCAN_XIDFE_0_EFEC_STRXBUF_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store into Rx Buffer Position  */
+#define MCAN_XIDFE_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_XIDFE_0) Register MASK  (Use MCAN_XIDFE_0_Msk instead)  */
+#define MCAN_XIDFE_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_XIDFE_0) Register Mask  */
+
+
+/* -------- MCAN_XIDFE_1 : (MCAN Offset: 0x04) (R/W 32) Extended Message ID Filter Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFID2:29;                  /**< bit:  0..28  Extended Filter ID 2                     */
+    uint32_t :1;                        /**< bit:     29  Reserved */
+    uint32_t EFT:2;                     /**< bit: 30..31  Extended Filter Type                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFE_1_OFFSET                 (0x04)                                        /**<  (MCAN_XIDFE_1) Extended Message ID Filter Element 1  Offset */
+
+#define MCAN_XIDFE_1_EFID2_Pos              0                                              /**< (MCAN_XIDFE_1) Extended Filter ID 2 Position */
+#define MCAN_XIDFE_1_EFID2_Msk              (_U_(0x1FFFFFFF) << MCAN_XIDFE_1_EFID2_Pos)    /**< (MCAN_XIDFE_1) Extended Filter ID 2 Mask */
+#define MCAN_XIDFE_1_EFID2(value)           (MCAN_XIDFE_1_EFID2_Msk & ((value) << MCAN_XIDFE_1_EFID2_Pos))
+#define MCAN_XIDFE_1_EFT_Pos                30                                             /**< (MCAN_XIDFE_1) Extended Filter Type Position */
+#define MCAN_XIDFE_1_EFT_Msk                (_U_(0x3) << MCAN_XIDFE_1_EFT_Pos)             /**< (MCAN_XIDFE_1) Extended Filter Type Mask */
+#define MCAN_XIDFE_1_EFT(value)             (MCAN_XIDFE_1_EFT_Msk & ((value) << MCAN_XIDFE_1_EFT_Pos))
+#define   MCAN_XIDFE_1_EFT_RANGE_Val        _U_(0x0)                                       /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2  */
+#define   MCAN_XIDFE_1_EFT_DUAL_Val         _U_(0x1)                                       /**< (MCAN_XIDFE_1) Dual ID filter for EFID1 or EFID2  */
+#define   MCAN_XIDFE_1_EFT_CLASSIC_Val      _U_(0x2)                                       /**< (MCAN_XIDFE_1) Classic filter  */
+#define   MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM_Val _U_(0x3)                                       /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 with no XIDAM mask  */
+#define MCAN_XIDFE_1_EFT_RANGE              (MCAN_XIDFE_1_EFT_RANGE_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 Position  */
+#define MCAN_XIDFE_1_EFT_DUAL               (MCAN_XIDFE_1_EFT_DUAL_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Dual ID filter for EFID1 or EFID2 Position  */
+#define MCAN_XIDFE_1_EFT_CLASSIC            (MCAN_XIDFE_1_EFT_CLASSIC_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Classic filter Position  */
+#define MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM     (MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 with no XIDAM mask Position  */
+#define MCAN_XIDFE_1_MASK                   _U_(0xDFFFFFFF)                                /**< \deprecated (MCAN_XIDFE_1) Register MASK  (Use MCAN_XIDFE_1_Msk instead)  */
+#define MCAN_XIDFE_1_Msk                    _U_(0xDFFFFFFF)                                /**< (MCAN_XIDFE_1) Register Mask  */
+
+
+/* -------- MCAN_CREL : (MCAN Offset: 0x00) (R/ 32) Core Release Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DAY:8;                     /**< bit:   0..7  Timestamp Day                            */
+    uint32_t MON:8;                     /**< bit:  8..15  Timestamp Month                          */
+    uint32_t YEAR:4;                    /**< bit: 16..19  Timestamp Year                           */
+    uint32_t SUBSTEP:4;                 /**< bit: 20..23  Sub-step of Core Release                 */
+    uint32_t STEP:4;                    /**< bit: 24..27  Step of Core Release                     */
+    uint32_t REL:4;                     /**< bit: 28..31  Core Release                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CREL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CREL_OFFSET                    (0x00)                                        /**<  (MCAN_CREL) Core Release Register  Offset */
+
+#define MCAN_CREL_DAY_Pos                   0                                              /**< (MCAN_CREL) Timestamp Day Position */
+#define MCAN_CREL_DAY_Msk                   (_U_(0xFF) << MCAN_CREL_DAY_Pos)               /**< (MCAN_CREL) Timestamp Day Mask */
+#define MCAN_CREL_DAY(value)                (MCAN_CREL_DAY_Msk & ((value) << MCAN_CREL_DAY_Pos))
+#define MCAN_CREL_MON_Pos                   8                                              /**< (MCAN_CREL) Timestamp Month Position */
+#define MCAN_CREL_MON_Msk                   (_U_(0xFF) << MCAN_CREL_MON_Pos)               /**< (MCAN_CREL) Timestamp Month Mask */
+#define MCAN_CREL_MON(value)                (MCAN_CREL_MON_Msk & ((value) << MCAN_CREL_MON_Pos))
+#define MCAN_CREL_YEAR_Pos                  16                                             /**< (MCAN_CREL) Timestamp Year Position */
+#define MCAN_CREL_YEAR_Msk                  (_U_(0xF) << MCAN_CREL_YEAR_Pos)               /**< (MCAN_CREL) Timestamp Year Mask */
+#define MCAN_CREL_YEAR(value)               (MCAN_CREL_YEAR_Msk & ((value) << MCAN_CREL_YEAR_Pos))
+#define MCAN_CREL_SUBSTEP_Pos               20                                             /**< (MCAN_CREL) Sub-step of Core Release Position */
+#define MCAN_CREL_SUBSTEP_Msk               (_U_(0xF) << MCAN_CREL_SUBSTEP_Pos)            /**< (MCAN_CREL) Sub-step of Core Release Mask */
+#define MCAN_CREL_SUBSTEP(value)            (MCAN_CREL_SUBSTEP_Msk & ((value) << MCAN_CREL_SUBSTEP_Pos))
+#define MCAN_CREL_STEP_Pos                  24                                             /**< (MCAN_CREL) Step of Core Release Position */
+#define MCAN_CREL_STEP_Msk                  (_U_(0xF) << MCAN_CREL_STEP_Pos)               /**< (MCAN_CREL) Step of Core Release Mask */
+#define MCAN_CREL_STEP(value)               (MCAN_CREL_STEP_Msk & ((value) << MCAN_CREL_STEP_Pos))
+#define MCAN_CREL_REL_Pos                   28                                             /**< (MCAN_CREL) Core Release Position */
+#define MCAN_CREL_REL_Msk                   (_U_(0xF) << MCAN_CREL_REL_Pos)                /**< (MCAN_CREL) Core Release Mask */
+#define MCAN_CREL_REL(value)                (MCAN_CREL_REL_Msk & ((value) << MCAN_CREL_REL_Pos))
+#define MCAN_CREL_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_CREL) Register MASK  (Use MCAN_CREL_Msk instead)  */
+#define MCAN_CREL_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_CREL) Register Mask  */
+
+
+/* -------- MCAN_ENDN : (MCAN Offset: 0x04) (R/ 32) Endian Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ETV:32;                    /**< bit:  0..31  Endianness Test Value                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ENDN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ENDN_OFFSET                    (0x04)                                        /**<  (MCAN_ENDN) Endian Register  Offset */
+
+#define MCAN_ENDN_ETV_Pos                   0                                              /**< (MCAN_ENDN) Endianness Test Value Position */
+#define MCAN_ENDN_ETV_Msk                   (_U_(0xFFFFFFFF) << MCAN_ENDN_ETV_Pos)         /**< (MCAN_ENDN) Endianness Test Value Mask */
+#define MCAN_ENDN_ETV(value)                (MCAN_ENDN_ETV_Msk & ((value) << MCAN_ENDN_ETV_Pos))
+#define MCAN_ENDN_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_ENDN) Register MASK  (Use MCAN_ENDN_Msk instead)  */
+#define MCAN_ENDN_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_ENDN) Register Mask  */
+
+
+/* -------- MCAN_CUST : (MCAN Offset: 0x08) (R/W 32) Customer Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSV:32;                    /**< bit:  0..31  Customer-specific Value                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CUST_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CUST_OFFSET                    (0x08)                                        /**<  (MCAN_CUST) Customer Register  Offset */
+
+#define MCAN_CUST_CSV_Pos                   0                                              /**< (MCAN_CUST) Customer-specific Value Position */
+#define MCAN_CUST_CSV_Msk                   (_U_(0xFFFFFFFF) << MCAN_CUST_CSV_Pos)         /**< (MCAN_CUST) Customer-specific Value Mask */
+#define MCAN_CUST_CSV(value)                (MCAN_CUST_CSV_Msk & ((value) << MCAN_CUST_CSV_Pos))
+#define MCAN_CUST_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_CUST) Register MASK  (Use MCAN_CUST_Msk instead)  */
+#define MCAN_CUST_Msk                       _U_(0xFFFFFFFF)                                /**< (MCAN_CUST) Register Mask  */
+
+
+/* -------- MCAN_DBTP : (MCAN Offset: 0x0c) (R/W 32) Data Bit Timing and Prescaler Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DSJW:3;                    /**< bit:   0..2  Data (Re) Synchronization Jump Width     */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t DTSEG2:4;                  /**< bit:   4..7  Data Time Segment After Sample Point     */
+    uint32_t DTSEG1:5;                  /**< bit:  8..12  Data Time Segment Before Sample Point    */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t DBRP:5;                    /**< bit: 16..20  Data Bit Rate Prescaler                  */
+    uint32_t :2;                        /**< bit: 21..22  Reserved */
+    uint32_t TDC:1;                     /**< bit:     23  Transmitter Delay Compensation           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_DBTP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_DBTP_OFFSET                    (0x0C)                                        /**<  (MCAN_DBTP) Data Bit Timing and Prescaler Register  Offset */
+
+#define MCAN_DBTP_DSJW_Pos                  0                                              /**< (MCAN_DBTP) Data (Re) Synchronization Jump Width Position */
+#define MCAN_DBTP_DSJW_Msk                  (_U_(0x7) << MCAN_DBTP_DSJW_Pos)               /**< (MCAN_DBTP) Data (Re) Synchronization Jump Width Mask */
+#define MCAN_DBTP_DSJW(value)               (MCAN_DBTP_DSJW_Msk & ((value) << MCAN_DBTP_DSJW_Pos))
+#define MCAN_DBTP_DTSEG2_Pos                4                                              /**< (MCAN_DBTP) Data Time Segment After Sample Point Position */
+#define MCAN_DBTP_DTSEG2_Msk                (_U_(0xF) << MCAN_DBTP_DTSEG2_Pos)             /**< (MCAN_DBTP) Data Time Segment After Sample Point Mask */
+#define MCAN_DBTP_DTSEG2(value)             (MCAN_DBTP_DTSEG2_Msk & ((value) << MCAN_DBTP_DTSEG2_Pos))
+#define MCAN_DBTP_DTSEG1_Pos                8                                              /**< (MCAN_DBTP) Data Time Segment Before Sample Point Position */
+#define MCAN_DBTP_DTSEG1_Msk                (_U_(0x1F) << MCAN_DBTP_DTSEG1_Pos)            /**< (MCAN_DBTP) Data Time Segment Before Sample Point Mask */
+#define MCAN_DBTP_DTSEG1(value)             (MCAN_DBTP_DTSEG1_Msk & ((value) << MCAN_DBTP_DTSEG1_Pos))
+#define MCAN_DBTP_DBRP_Pos                  16                                             /**< (MCAN_DBTP) Data Bit Rate Prescaler Position */
+#define MCAN_DBTP_DBRP_Msk                  (_U_(0x1F) << MCAN_DBTP_DBRP_Pos)              /**< (MCAN_DBTP) Data Bit Rate Prescaler Mask */
+#define MCAN_DBTP_DBRP(value)               (MCAN_DBTP_DBRP_Msk & ((value) << MCAN_DBTP_DBRP_Pos))
+#define MCAN_DBTP_TDC_Pos                   23                                             /**< (MCAN_DBTP) Transmitter Delay Compensation Position */
+#define MCAN_DBTP_TDC_Msk                   (_U_(0x1) << MCAN_DBTP_TDC_Pos)                /**< (MCAN_DBTP) Transmitter Delay Compensation Mask */
+#define MCAN_DBTP_TDC                       MCAN_DBTP_TDC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_DBTP_TDC_Msk instead */
+#define   MCAN_DBTP_TDC_DISABLED_Val        _U_(0x0)                                       /**< (MCAN_DBTP) Transmitter Delay Compensation disabled.  */
+#define   MCAN_DBTP_TDC_ENABLED_Val         _U_(0x1)                                       /**< (MCAN_DBTP) Transmitter Delay Compensation enabled.  */
+#define MCAN_DBTP_TDC_DISABLED              (MCAN_DBTP_TDC_DISABLED_Val << MCAN_DBTP_TDC_Pos)  /**< (MCAN_DBTP) Transmitter Delay Compensation disabled. Position  */
+#define MCAN_DBTP_TDC_ENABLED               (MCAN_DBTP_TDC_ENABLED_Val << MCAN_DBTP_TDC_Pos)  /**< (MCAN_DBTP) Transmitter Delay Compensation enabled. Position  */
+#define MCAN_DBTP_MASK                      _U_(0x9F1FF7)                                  /**< \deprecated (MCAN_DBTP) Register MASK  (Use MCAN_DBTP_Msk instead)  */
+#define MCAN_DBTP_Msk                       _U_(0x9F1FF7)                                  /**< (MCAN_DBTP) Register Mask  */
+
+
+/* -------- MCAN_TEST : (MCAN Offset: 0x10) (R/W 32) Test Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t LBCK:1;                    /**< bit:      4  Loop Back Mode (read/write)              */
+    uint32_t TX:2;                      /**< bit:   5..6  Control of Transmit Pin (read/write)     */
+    uint32_t RX:1;                      /**< bit:      7  Receive Pin (read-only)                  */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TEST_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TEST_OFFSET                    (0x10)                                        /**<  (MCAN_TEST) Test Register  Offset */
+
+#define MCAN_TEST_LBCK_Pos                  4                                              /**< (MCAN_TEST) Loop Back Mode (read/write) Position */
+#define MCAN_TEST_LBCK_Msk                  (_U_(0x1) << MCAN_TEST_LBCK_Pos)               /**< (MCAN_TEST) Loop Back Mode (read/write) Mask */
+#define MCAN_TEST_LBCK                      MCAN_TEST_LBCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TEST_LBCK_Msk instead */
+#define   MCAN_TEST_LBCK_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_TEST) Reset value. Loop Back mode is disabled.  */
+#define   MCAN_TEST_LBCK_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_TEST) Loop Back mode is enabled (see Section 6.1.9).  */
+#define MCAN_TEST_LBCK_DISABLED             (MCAN_TEST_LBCK_DISABLED_Val << MCAN_TEST_LBCK_Pos)  /**< (MCAN_TEST) Reset value. Loop Back mode is disabled. Position  */
+#define MCAN_TEST_LBCK_ENABLED              (MCAN_TEST_LBCK_ENABLED_Val << MCAN_TEST_LBCK_Pos)  /**< (MCAN_TEST) Loop Back mode is enabled (see Section 6.1.9). Position  */
+#define MCAN_TEST_TX_Pos                    5                                              /**< (MCAN_TEST) Control of Transmit Pin (read/write) Position */
+#define MCAN_TEST_TX_Msk                    (_U_(0x3) << MCAN_TEST_TX_Pos)                 /**< (MCAN_TEST) Control of Transmit Pin (read/write) Mask */
+#define MCAN_TEST_TX(value)                 (MCAN_TEST_TX_Msk & ((value) << MCAN_TEST_TX_Pos))
+#define   MCAN_TEST_TX_RESET_Val            _U_(0x0)                                       /**< (MCAN_TEST) Reset value, CANTX controlled by the CAN Core, updated at the end of the CAN bit time.  */
+#define   MCAN_TEST_TX_SAMPLE_POINT_MONITORING_Val _U_(0x1)                                       /**< (MCAN_TEST) Sample Point can be monitored at pin CANTX.  */
+#define   MCAN_TEST_TX_DOMINANT_Val         _U_(0x2)                                       /**< (MCAN_TEST) Dominant ('0') level at pin CANTX.  */
+#define   MCAN_TEST_TX_RECESSIVE_Val        _U_(0x3)                                       /**< (MCAN_TEST) Recessive ('1') at pin CANTX.  */
+#define MCAN_TEST_TX_RESET                  (MCAN_TEST_TX_RESET_Val << MCAN_TEST_TX_Pos)   /**< (MCAN_TEST) Reset value, CANTX controlled by the CAN Core, updated at the end of the CAN bit time. Position  */
+#define MCAN_TEST_TX_SAMPLE_POINT_MONITORING (MCAN_TEST_TX_SAMPLE_POINT_MONITORING_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Sample Point can be monitored at pin CANTX. Position  */
+#define MCAN_TEST_TX_DOMINANT               (MCAN_TEST_TX_DOMINANT_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Dominant ('0') level at pin CANTX. Position  */
+#define MCAN_TEST_TX_RECESSIVE              (MCAN_TEST_TX_RECESSIVE_Val << MCAN_TEST_TX_Pos)  /**< (MCAN_TEST) Recessive ('1') at pin CANTX. Position  */
+#define MCAN_TEST_RX_Pos                    7                                              /**< (MCAN_TEST) Receive Pin (read-only) Position */
+#define MCAN_TEST_RX_Msk                    (_U_(0x1) << MCAN_TEST_RX_Pos)                 /**< (MCAN_TEST) Receive Pin (read-only) Mask */
+#define MCAN_TEST_RX                        MCAN_TEST_RX_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TEST_RX_Msk instead */
+#define MCAN_TEST_MASK                      _U_(0xF0)                                      /**< \deprecated (MCAN_TEST) Register MASK  (Use MCAN_TEST_Msk instead)  */
+#define MCAN_TEST_Msk                       _U_(0xF0)                                      /**< (MCAN_TEST) Register Mask  */
+
+
+/* -------- MCAN_RWD : (MCAN Offset: 0x14) (R/W 32) RAM Watchdog Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDC:8;                     /**< bit:   0..7  Watchdog Configuration (read/write)      */
+    uint32_t WDV:8;                     /**< bit:  8..15  Watchdog Value (read-only)               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RWD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RWD_OFFSET                     (0x14)                                        /**<  (MCAN_RWD) RAM Watchdog Register  Offset */
+
+#define MCAN_RWD_WDC_Pos                    0                                              /**< (MCAN_RWD) Watchdog Configuration (read/write) Position */
+#define MCAN_RWD_WDC_Msk                    (_U_(0xFF) << MCAN_RWD_WDC_Pos)                /**< (MCAN_RWD) Watchdog Configuration (read/write) Mask */
+#define MCAN_RWD_WDC(value)                 (MCAN_RWD_WDC_Msk & ((value) << MCAN_RWD_WDC_Pos))
+#define MCAN_RWD_WDV_Pos                    8                                              /**< (MCAN_RWD) Watchdog Value (read-only) Position */
+#define MCAN_RWD_WDV_Msk                    (_U_(0xFF) << MCAN_RWD_WDV_Pos)                /**< (MCAN_RWD) Watchdog Value (read-only) Mask */
+#define MCAN_RWD_WDV(value)                 (MCAN_RWD_WDV_Msk & ((value) << MCAN_RWD_WDV_Pos))
+#define MCAN_RWD_MASK                       _U_(0xFFFF)                                    /**< \deprecated (MCAN_RWD) Register MASK  (Use MCAN_RWD_Msk instead)  */
+#define MCAN_RWD_Msk                        _U_(0xFFFF)                                    /**< (MCAN_RWD) Register Mask  */
+
+
+/* -------- MCAN_CCCR : (MCAN Offset: 0x18) (R/W 32) CC Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INIT:1;                    /**< bit:      0  Initialization (read/write)              */
+    uint32_t CCE:1;                     /**< bit:      1  Configuration Change Enable (read/write, write protection) */
+    uint32_t ASM:1;                     /**< bit:      2  Restricted Operation Mode (read/write, write protection against '1') */
+    uint32_t CSA:1;                     /**< bit:      3  Clock Stop Acknowledge (read-only)       */
+    uint32_t CSR:1;                     /**< bit:      4  Clock Stop Request (read/write)          */
+    uint32_t MON:1;                     /**< bit:      5  Bus Monitoring Mode (read/write, write protection against '1') */
+    uint32_t DAR:1;                     /**< bit:      6  Disable Automatic Retransmission (read/write, write protection) */
+    uint32_t TEST:1;                    /**< bit:      7  Test Mode Enable (read/write, write protection against '1') */
+    uint32_t FDOE:1;                    /**< bit:      8  CAN FD Operation Enable (read/write, write protection) */
+    uint32_t BRSE:1;                    /**< bit:      9  Bit Rate Switching Enable (read/write, write protection) */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t PXHD:1;                    /**< bit:     12  Protocol Exception Event Handling (read/write, write protection) */
+    uint32_t EFBI:1;                    /**< bit:     13  Edge Filtering during Bus Integration (read/write, write protection) */
+    uint32_t TXP:1;                     /**< bit:     14  Transmit Pause (read/write, write protection) */
+    uint32_t NISO:1;                    /**< bit:     15  Non-ISO Operation                        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_CCCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_CCCR_OFFSET                    (0x18)                                        /**<  (MCAN_CCCR) CC Control Register  Offset */
+
+#define MCAN_CCCR_INIT_Pos                  0                                              /**< (MCAN_CCCR) Initialization (read/write) Position */
+#define MCAN_CCCR_INIT_Msk                  (_U_(0x1) << MCAN_CCCR_INIT_Pos)               /**< (MCAN_CCCR) Initialization (read/write) Mask */
+#define MCAN_CCCR_INIT                      MCAN_CCCR_INIT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_INIT_Msk instead */
+#define   MCAN_CCCR_INIT_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Normal operation.  */
+#define   MCAN_CCCR_INIT_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) Initialization is started.  */
+#define MCAN_CCCR_INIT_DISABLED             (MCAN_CCCR_INIT_DISABLED_Val << MCAN_CCCR_INIT_Pos)  /**< (MCAN_CCCR) Normal operation. Position  */
+#define MCAN_CCCR_INIT_ENABLED              (MCAN_CCCR_INIT_ENABLED_Val << MCAN_CCCR_INIT_Pos)  /**< (MCAN_CCCR) Initialization is started. Position  */
+#define MCAN_CCCR_CCE_Pos                   1                                              /**< (MCAN_CCCR) Configuration Change Enable (read/write, write protection) Position */
+#define MCAN_CCCR_CCE_Msk                   (_U_(0x1) << MCAN_CCCR_CCE_Pos)                /**< (MCAN_CCCR) Configuration Change Enable (read/write, write protection) Mask */
+#define MCAN_CCCR_CCE                       MCAN_CCCR_CCE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CCE_Msk instead */
+#define   MCAN_CCCR_CCE_PROTECTED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) The processor has no write access to the protected configuration registers.  */
+#define   MCAN_CCCR_CCE_CONFIGURABLE_Val    _U_(0x1)                                       /**< (MCAN_CCCR) The processor has write access to the protected configuration registers (while MCAN_CCCR.INIT = '1').  */
+#define MCAN_CCCR_CCE_PROTECTED             (MCAN_CCCR_CCE_PROTECTED_Val << MCAN_CCCR_CCE_Pos)  /**< (MCAN_CCCR) The processor has no write access to the protected configuration registers. Position  */
+#define MCAN_CCCR_CCE_CONFIGURABLE          (MCAN_CCCR_CCE_CONFIGURABLE_Val << MCAN_CCCR_CCE_Pos)  /**< (MCAN_CCCR) The processor has write access to the protected configuration registers (while MCAN_CCCR.INIT = '1'). Position  */
+#define MCAN_CCCR_ASM_Pos                   2                                              /**< (MCAN_CCCR) Restricted Operation Mode (read/write, write protection against '1') Position */
+#define MCAN_CCCR_ASM_Msk                   (_U_(0x1) << MCAN_CCCR_ASM_Pos)                /**< (MCAN_CCCR) Restricted Operation Mode (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_ASM                       MCAN_CCCR_ASM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_ASM_Msk instead */
+#define   MCAN_CCCR_ASM_NORMAL_Val          _U_(0x0)                                       /**< (MCAN_CCCR) Normal CAN operation.  */
+#define   MCAN_CCCR_ASM_RESTRICTED_Val      _U_(0x1)                                       /**< (MCAN_CCCR) Restricted Operation mode active.  */
+#define MCAN_CCCR_ASM_NORMAL                (MCAN_CCCR_ASM_NORMAL_Val << MCAN_CCCR_ASM_Pos)  /**< (MCAN_CCCR) Normal CAN operation. Position  */
+#define MCAN_CCCR_ASM_RESTRICTED            (MCAN_CCCR_ASM_RESTRICTED_Val << MCAN_CCCR_ASM_Pos)  /**< (MCAN_CCCR) Restricted Operation mode active. Position  */
+#define MCAN_CCCR_CSA_Pos                   3                                              /**< (MCAN_CCCR) Clock Stop Acknowledge (read-only) Position */
+#define MCAN_CCCR_CSA_Msk                   (_U_(0x1) << MCAN_CCCR_CSA_Pos)                /**< (MCAN_CCCR) Clock Stop Acknowledge (read-only) Mask */
+#define MCAN_CCCR_CSA                       MCAN_CCCR_CSA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CSA_Msk instead */
+#define MCAN_CCCR_CSR_Pos                   4                                              /**< (MCAN_CCCR) Clock Stop Request (read/write) Position */
+#define MCAN_CCCR_CSR_Msk                   (_U_(0x1) << MCAN_CCCR_CSR_Pos)                /**< (MCAN_CCCR) Clock Stop Request (read/write) Mask */
+#define MCAN_CCCR_CSR                       MCAN_CCCR_CSR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_CSR_Msk instead */
+#define   MCAN_CCCR_CSR_NO_CLOCK_STOP_Val   _U_(0x0)                                       /**< (MCAN_CCCR) No clock stop is requested.  */
+#define   MCAN_CCCR_CSR_CLOCK_STOP_Val      _U_(0x1)                                       /**< (MCAN_CCCR) Clock stop requested. When clock stop is requested, first INIT and then CSA will be set after all pend-ing transfer requests have been completed and the CAN bus reached idle.  */
+#define MCAN_CCCR_CSR_NO_CLOCK_STOP         (MCAN_CCCR_CSR_NO_CLOCK_STOP_Val << MCAN_CCCR_CSR_Pos)  /**< (MCAN_CCCR) No clock stop is requested. Position  */
+#define MCAN_CCCR_CSR_CLOCK_STOP            (MCAN_CCCR_CSR_CLOCK_STOP_Val << MCAN_CCCR_CSR_Pos)  /**< (MCAN_CCCR) Clock stop requested. When clock stop is requested, first INIT and then CSA will be set after all pend-ing transfer requests have been completed and the CAN bus reached idle. Position  */
+#define MCAN_CCCR_MON_Pos                   5                                              /**< (MCAN_CCCR) Bus Monitoring Mode (read/write, write protection against '1') Position */
+#define MCAN_CCCR_MON_Msk                   (_U_(0x1) << MCAN_CCCR_MON_Pos)                /**< (MCAN_CCCR) Bus Monitoring Mode (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_MON                       MCAN_CCCR_MON_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_MON_Msk instead */
+#define   MCAN_CCCR_MON_DISABLED_Val        _U_(0x0)                                       /**< (MCAN_CCCR) Bus Monitoring mode is disabled.  */
+#define   MCAN_CCCR_MON_ENABLED_Val         _U_(0x1)                                       /**< (MCAN_CCCR) Bus Monitoring mode is enabled.  */
+#define MCAN_CCCR_MON_DISABLED              (MCAN_CCCR_MON_DISABLED_Val << MCAN_CCCR_MON_Pos)  /**< (MCAN_CCCR) Bus Monitoring mode is disabled. Position  */
+#define MCAN_CCCR_MON_ENABLED               (MCAN_CCCR_MON_ENABLED_Val << MCAN_CCCR_MON_Pos)  /**< (MCAN_CCCR) Bus Monitoring mode is enabled. Position  */
+#define MCAN_CCCR_DAR_Pos                   6                                              /**< (MCAN_CCCR) Disable Automatic Retransmission (read/write, write protection) Position */
+#define MCAN_CCCR_DAR_Msk                   (_U_(0x1) << MCAN_CCCR_DAR_Pos)                /**< (MCAN_CCCR) Disable Automatic Retransmission (read/write, write protection) Mask */
+#define MCAN_CCCR_DAR                       MCAN_CCCR_DAR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_DAR_Msk instead */
+#define   MCAN_CCCR_DAR_AUTO_RETX_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Automatic retransmission of messages not transmitted successfully enabled.  */
+#define   MCAN_CCCR_DAR_NO_AUTO_RETX_Val    _U_(0x1)                                       /**< (MCAN_CCCR) Automatic retransmission disabled.  */
+#define MCAN_CCCR_DAR_AUTO_RETX             (MCAN_CCCR_DAR_AUTO_RETX_Val << MCAN_CCCR_DAR_Pos)  /**< (MCAN_CCCR) Automatic retransmission of messages not transmitted successfully enabled. Position  */
+#define MCAN_CCCR_DAR_NO_AUTO_RETX          (MCAN_CCCR_DAR_NO_AUTO_RETX_Val << MCAN_CCCR_DAR_Pos)  /**< (MCAN_CCCR) Automatic retransmission disabled. Position  */
+#define MCAN_CCCR_TEST_Pos                  7                                              /**< (MCAN_CCCR) Test Mode Enable (read/write, write protection against '1') Position */
+#define MCAN_CCCR_TEST_Msk                  (_U_(0x1) << MCAN_CCCR_TEST_Pos)               /**< (MCAN_CCCR) Test Mode Enable (read/write, write protection against '1') Mask */
+#define MCAN_CCCR_TEST                      MCAN_CCCR_TEST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_TEST_Msk instead */
+#define   MCAN_CCCR_TEST_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Normal operation, MCAN_TEST register holds reset values.  */
+#define   MCAN_CCCR_TEST_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) Test mode, write access to MCAN_TEST register enabled.  */
+#define MCAN_CCCR_TEST_DISABLED             (MCAN_CCCR_TEST_DISABLED_Val << MCAN_CCCR_TEST_Pos)  /**< (MCAN_CCCR) Normal operation, MCAN_TEST register holds reset values. Position  */
+#define MCAN_CCCR_TEST_ENABLED              (MCAN_CCCR_TEST_ENABLED_Val << MCAN_CCCR_TEST_Pos)  /**< (MCAN_CCCR) Test mode, write access to MCAN_TEST register enabled. Position  */
+#define MCAN_CCCR_FDOE_Pos                  8                                              /**< (MCAN_CCCR) CAN FD Operation Enable (read/write, write protection) Position */
+#define MCAN_CCCR_FDOE_Msk                  (_U_(0x1) << MCAN_CCCR_FDOE_Pos)               /**< (MCAN_CCCR) CAN FD Operation Enable (read/write, write protection) Mask */
+#define MCAN_CCCR_FDOE                      MCAN_CCCR_FDOE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_FDOE_Msk instead */
+#define   MCAN_CCCR_FDOE_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) FD operation disabled.  */
+#define   MCAN_CCCR_FDOE_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) FD operation enabled.  */
+#define MCAN_CCCR_FDOE_DISABLED             (MCAN_CCCR_FDOE_DISABLED_Val << MCAN_CCCR_FDOE_Pos)  /**< (MCAN_CCCR) FD operation disabled. Position  */
+#define MCAN_CCCR_FDOE_ENABLED              (MCAN_CCCR_FDOE_ENABLED_Val << MCAN_CCCR_FDOE_Pos)  /**< (MCAN_CCCR) FD operation enabled. Position  */
+#define MCAN_CCCR_BRSE_Pos                  9                                              /**< (MCAN_CCCR) Bit Rate Switching Enable (read/write, write protection) Position */
+#define MCAN_CCCR_BRSE_Msk                  (_U_(0x1) << MCAN_CCCR_BRSE_Pos)               /**< (MCAN_CCCR) Bit Rate Switching Enable (read/write, write protection) Mask */
+#define MCAN_CCCR_BRSE                      MCAN_CCCR_BRSE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_BRSE_Msk instead */
+#define   MCAN_CCCR_BRSE_DISABLED_Val       _U_(0x0)                                       /**< (MCAN_CCCR) Bit rate switching for transmissions disabled.  */
+#define   MCAN_CCCR_BRSE_ENABLED_Val        _U_(0x1)                                       /**< (MCAN_CCCR) Bit rate switching for transmissions enabled.  */
+#define MCAN_CCCR_BRSE_DISABLED             (MCAN_CCCR_BRSE_DISABLED_Val << MCAN_CCCR_BRSE_Pos)  /**< (MCAN_CCCR) Bit rate switching for transmissions disabled. Position  */
+#define MCAN_CCCR_BRSE_ENABLED              (MCAN_CCCR_BRSE_ENABLED_Val << MCAN_CCCR_BRSE_Pos)  /**< (MCAN_CCCR) Bit rate switching for transmissions enabled. Position  */
+#define MCAN_CCCR_PXHD_Pos                  12                                             /**< (MCAN_CCCR) Protocol Exception Event Handling (read/write, write protection) Position */
+#define MCAN_CCCR_PXHD_Msk                  (_U_(0x1) << MCAN_CCCR_PXHD_Pos)               /**< (MCAN_CCCR) Protocol Exception Event Handling (read/write, write protection) Mask */
+#define MCAN_CCCR_PXHD                      MCAN_CCCR_PXHD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_PXHD_Msk instead */
+#define MCAN_CCCR_EFBI_Pos                  13                                             /**< (MCAN_CCCR) Edge Filtering during Bus Integration (read/write, write protection) Position */
+#define MCAN_CCCR_EFBI_Msk                  (_U_(0x1) << MCAN_CCCR_EFBI_Pos)               /**< (MCAN_CCCR) Edge Filtering during Bus Integration (read/write, write protection) Mask */
+#define MCAN_CCCR_EFBI                      MCAN_CCCR_EFBI_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_EFBI_Msk instead */
+#define MCAN_CCCR_TXP_Pos                   14                                             /**< (MCAN_CCCR) Transmit Pause (read/write, write protection) Position */
+#define MCAN_CCCR_TXP_Msk                   (_U_(0x1) << MCAN_CCCR_TXP_Pos)                /**< (MCAN_CCCR) Transmit Pause (read/write, write protection) Mask */
+#define MCAN_CCCR_TXP                       MCAN_CCCR_TXP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_TXP_Msk instead */
+#define MCAN_CCCR_NISO_Pos                  15                                             /**< (MCAN_CCCR) Non-ISO Operation Position */
+#define MCAN_CCCR_NISO_Msk                  (_U_(0x1) << MCAN_CCCR_NISO_Pos)               /**< (MCAN_CCCR) Non-ISO Operation Mask */
+#define MCAN_CCCR_NISO                      MCAN_CCCR_NISO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_CCCR_NISO_Msk instead */
+#define MCAN_CCCR_MASK                      _U_(0xF3FF)                                    /**< \deprecated (MCAN_CCCR) Register MASK  (Use MCAN_CCCR_Msk instead)  */
+#define MCAN_CCCR_Msk                       _U_(0xF3FF)                                    /**< (MCAN_CCCR) Register Mask  */
+
+
+/* -------- MCAN_NBTP : (MCAN Offset: 0x1c) (R/W 32) Nominal Bit Timing and Prescaler Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NTSEG2:7;                  /**< bit:   0..6  Nominal Time Segment After Sample Point  */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t NTSEG1:8;                  /**< bit:  8..15  Nominal Time Segment Before Sample Point */
+    uint32_t NBRP:9;                    /**< bit: 16..24  Nominal Bit Rate Prescaler               */
+    uint32_t NSJW:7;                    /**< bit: 25..31  Nominal (Re) Synchronization Jump Width  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_NBTP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_NBTP_OFFSET                    (0x1C)                                        /**<  (MCAN_NBTP) Nominal Bit Timing and Prescaler Register  Offset */
+
+#define MCAN_NBTP_NTSEG2_Pos                0                                              /**< (MCAN_NBTP) Nominal Time Segment After Sample Point Position */
+#define MCAN_NBTP_NTSEG2_Msk                (_U_(0x7F) << MCAN_NBTP_NTSEG2_Pos)            /**< (MCAN_NBTP) Nominal Time Segment After Sample Point Mask */
+#define MCAN_NBTP_NTSEG2(value)             (MCAN_NBTP_NTSEG2_Msk & ((value) << MCAN_NBTP_NTSEG2_Pos))
+#define MCAN_NBTP_NTSEG1_Pos                8                                              /**< (MCAN_NBTP) Nominal Time Segment Before Sample Point Position */
+#define MCAN_NBTP_NTSEG1_Msk                (_U_(0xFF) << MCAN_NBTP_NTSEG1_Pos)            /**< (MCAN_NBTP) Nominal Time Segment Before Sample Point Mask */
+#define MCAN_NBTP_NTSEG1(value)             (MCAN_NBTP_NTSEG1_Msk & ((value) << MCAN_NBTP_NTSEG1_Pos))
+#define MCAN_NBTP_NBRP_Pos                  16                                             /**< (MCAN_NBTP) Nominal Bit Rate Prescaler Position */
+#define MCAN_NBTP_NBRP_Msk                  (_U_(0x1FF) << MCAN_NBTP_NBRP_Pos)             /**< (MCAN_NBTP) Nominal Bit Rate Prescaler Mask */
+#define MCAN_NBTP_NBRP(value)               (MCAN_NBTP_NBRP_Msk & ((value) << MCAN_NBTP_NBRP_Pos))
+#define MCAN_NBTP_NSJW_Pos                  25                                             /**< (MCAN_NBTP) Nominal (Re) Synchronization Jump Width Position */
+#define MCAN_NBTP_NSJW_Msk                  (_U_(0x7F) << MCAN_NBTP_NSJW_Pos)              /**< (MCAN_NBTP) Nominal (Re) Synchronization Jump Width Mask */
+#define MCAN_NBTP_NSJW(value)               (MCAN_NBTP_NSJW_Msk & ((value) << MCAN_NBTP_NSJW_Pos))
+#define MCAN_NBTP_MASK                      _U_(0xFFFFFF7F)                                /**< \deprecated (MCAN_NBTP) Register MASK  (Use MCAN_NBTP_Msk instead)  */
+#define MCAN_NBTP_Msk                       _U_(0xFFFFFF7F)                                /**< (MCAN_NBTP) Register Mask  */
+
+
+/* -------- MCAN_TSCC : (MCAN Offset: 0x20) (R/W 32) Timestamp Counter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSS:2;                     /**< bit:   0..1  Timestamp Select                         */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t TCP:4;                     /**< bit: 16..19  Timestamp Counter Prescaler              */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TSCC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TSCC_OFFSET                    (0x20)                                        /**<  (MCAN_TSCC) Timestamp Counter Configuration Register  Offset */
+
+#define MCAN_TSCC_TSS_Pos                   0                                              /**< (MCAN_TSCC) Timestamp Select Position */
+#define MCAN_TSCC_TSS_Msk                   (_U_(0x3) << MCAN_TSCC_TSS_Pos)                /**< (MCAN_TSCC) Timestamp Select Mask */
+#define MCAN_TSCC_TSS(value)                (MCAN_TSCC_TSS_Msk & ((value) << MCAN_TSCC_TSS_Pos))
+#define   MCAN_TSCC_TSS_ALWAYS_0_Val        _U_(0x0)                                       /**< (MCAN_TSCC) Timestamp counter value always 0x0000  */
+#define   MCAN_TSCC_TSS_TCP_INC_Val         _U_(0x1)                                       /**< (MCAN_TSCC) Timestamp counter value incremented according to TCP  */
+#define   MCAN_TSCC_TSS_EXT_TIMESTAMP_Val   _U_(0x2)                                       /**< (MCAN_TSCC) External timestamp counter value used  */
+#define MCAN_TSCC_TSS_ALWAYS_0              (MCAN_TSCC_TSS_ALWAYS_0_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) Timestamp counter value always 0x0000 Position  */
+#define MCAN_TSCC_TSS_TCP_INC               (MCAN_TSCC_TSS_TCP_INC_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) Timestamp counter value incremented according to TCP Position  */
+#define MCAN_TSCC_TSS_EXT_TIMESTAMP         (MCAN_TSCC_TSS_EXT_TIMESTAMP_Val << MCAN_TSCC_TSS_Pos)  /**< (MCAN_TSCC) External timestamp counter value used Position  */
+#define MCAN_TSCC_TCP_Pos                   16                                             /**< (MCAN_TSCC) Timestamp Counter Prescaler Position */
+#define MCAN_TSCC_TCP_Msk                   (_U_(0xF) << MCAN_TSCC_TCP_Pos)                /**< (MCAN_TSCC) Timestamp Counter Prescaler Mask */
+#define MCAN_TSCC_TCP(value)                (MCAN_TSCC_TCP_Msk & ((value) << MCAN_TSCC_TCP_Pos))
+#define MCAN_TSCC_MASK                      _U_(0xF0003)                                   /**< \deprecated (MCAN_TSCC) Register MASK  (Use MCAN_TSCC_Msk instead)  */
+#define MCAN_TSCC_Msk                       _U_(0xF0003)                                   /**< (MCAN_TSCC) Register Mask  */
+
+
+/* -------- MCAN_TSCV : (MCAN Offset: 0x24) (R/W 32) Timestamp Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSC:16;                    /**< bit:  0..15  Timestamp Counter (cleared on write)     */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TSCV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TSCV_OFFSET                    (0x24)                                        /**<  (MCAN_TSCV) Timestamp Counter Value Register  Offset */
+
+#define MCAN_TSCV_TSC_Pos                   0                                              /**< (MCAN_TSCV) Timestamp Counter (cleared on write) Position */
+#define MCAN_TSCV_TSC_Msk                   (_U_(0xFFFF) << MCAN_TSCV_TSC_Pos)             /**< (MCAN_TSCV) Timestamp Counter (cleared on write) Mask */
+#define MCAN_TSCV_TSC(value)                (MCAN_TSCV_TSC_Msk & ((value) << MCAN_TSCV_TSC_Pos))
+#define MCAN_TSCV_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_TSCV) Register MASK  (Use MCAN_TSCV_Msk instead)  */
+#define MCAN_TSCV_Msk                       _U_(0xFFFF)                                    /**< (MCAN_TSCV) Register Mask  */
+
+
+/* -------- MCAN_TOCC : (MCAN Offset: 0x28) (R/W 32) Timeout Counter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ETOC:1;                    /**< bit:      0  Enable Timeout Counter                   */
+    uint32_t TOS:2;                     /**< bit:   1..2  Timeout Select                           */
+    uint32_t :13;                       /**< bit:  3..15  Reserved */
+    uint32_t TOP:16;                    /**< bit: 16..31  Timeout Period                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TOCC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TOCC_OFFSET                    (0x28)                                        /**<  (MCAN_TOCC) Timeout Counter Configuration Register  Offset */
+
+#define MCAN_TOCC_ETOC_Pos                  0                                              /**< (MCAN_TOCC) Enable Timeout Counter Position */
+#define MCAN_TOCC_ETOC_Msk                  (_U_(0x1) << MCAN_TOCC_ETOC_Pos)               /**< (MCAN_TOCC) Enable Timeout Counter Mask */
+#define MCAN_TOCC_ETOC                      MCAN_TOCC_ETOC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TOCC_ETOC_Msk instead */
+#define   MCAN_TOCC_ETOC_NO_TIMEOUT_Val     _U_(0x0)                                       /**< (MCAN_TOCC) Timeout Counter disabled.  */
+#define   MCAN_TOCC_ETOC_TOS_CONTROLLED_Val _U_(0x1)                                       /**< (MCAN_TOCC) Timeout Counter enabled.  */
+#define MCAN_TOCC_ETOC_NO_TIMEOUT           (MCAN_TOCC_ETOC_NO_TIMEOUT_Val << MCAN_TOCC_ETOC_Pos)  /**< (MCAN_TOCC) Timeout Counter disabled. Position  */
+#define MCAN_TOCC_ETOC_TOS_CONTROLLED       (MCAN_TOCC_ETOC_TOS_CONTROLLED_Val << MCAN_TOCC_ETOC_Pos)  /**< (MCAN_TOCC) Timeout Counter enabled. Position  */
+#define MCAN_TOCC_TOS_Pos                   1                                              /**< (MCAN_TOCC) Timeout Select Position */
+#define MCAN_TOCC_TOS_Msk                   (_U_(0x3) << MCAN_TOCC_TOS_Pos)                /**< (MCAN_TOCC) Timeout Select Mask */
+#define MCAN_TOCC_TOS(value)                (MCAN_TOCC_TOS_Msk & ((value) << MCAN_TOCC_TOS_Pos))
+#define   MCAN_TOCC_TOS_CONTINUOUS_Val      _U_(0x0)                                       /**< (MCAN_TOCC) Continuous operation  */
+#define   MCAN_TOCC_TOS_TX_EV_TIMEOUT_Val   _U_(0x1)                                       /**< (MCAN_TOCC) Timeout controlled by Tx Event FIFO  */
+#define   MCAN_TOCC_TOS_RX0_EV_TIMEOUT_Val  _U_(0x2)                                       /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 0  */
+#define   MCAN_TOCC_TOS_RX1_EV_TIMEOUT_Val  _U_(0x3)                                       /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 1  */
+#define MCAN_TOCC_TOS_CONTINUOUS            (MCAN_TOCC_TOS_CONTINUOUS_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Continuous operation Position  */
+#define MCAN_TOCC_TOS_TX_EV_TIMEOUT         (MCAN_TOCC_TOS_TX_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Tx Event FIFO Position  */
+#define MCAN_TOCC_TOS_RX0_EV_TIMEOUT        (MCAN_TOCC_TOS_RX0_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 0 Position  */
+#define MCAN_TOCC_TOS_RX1_EV_TIMEOUT        (MCAN_TOCC_TOS_RX1_EV_TIMEOUT_Val << MCAN_TOCC_TOS_Pos)  /**< (MCAN_TOCC) Timeout controlled by Receive FIFO 1 Position  */
+#define MCAN_TOCC_TOP_Pos                   16                                             /**< (MCAN_TOCC) Timeout Period Position */
+#define MCAN_TOCC_TOP_Msk                   (_U_(0xFFFF) << MCAN_TOCC_TOP_Pos)             /**< (MCAN_TOCC) Timeout Period Mask */
+#define MCAN_TOCC_TOP(value)                (MCAN_TOCC_TOP_Msk & ((value) << MCAN_TOCC_TOP_Pos))
+#define MCAN_TOCC_MASK                      _U_(0xFFFF0007)                                /**< \deprecated (MCAN_TOCC) Register MASK  (Use MCAN_TOCC_Msk instead)  */
+#define MCAN_TOCC_Msk                       _U_(0xFFFF0007)                                /**< (MCAN_TOCC) Register Mask  */
+
+
+/* -------- MCAN_TOCV : (MCAN Offset: 0x2c) (R/W 32) Timeout Counter Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TOC:16;                    /**< bit:  0..15  Timeout Counter (cleared on write)       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TOCV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TOCV_OFFSET                    (0x2C)                                        /**<  (MCAN_TOCV) Timeout Counter Value Register  Offset */
+
+#define MCAN_TOCV_TOC_Pos                   0                                              /**< (MCAN_TOCV) Timeout Counter (cleared on write) Position */
+#define MCAN_TOCV_TOC_Msk                   (_U_(0xFFFF) << MCAN_TOCV_TOC_Pos)             /**< (MCAN_TOCV) Timeout Counter (cleared on write) Mask */
+#define MCAN_TOCV_TOC(value)                (MCAN_TOCV_TOC_Msk & ((value) << MCAN_TOCV_TOC_Pos))
+#define MCAN_TOCV_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_TOCV) Register MASK  (Use MCAN_TOCV_Msk instead)  */
+#define MCAN_TOCV_Msk                       _U_(0xFFFF)                                    /**< (MCAN_TOCV) Register Mask  */
+
+
+/* -------- MCAN_ECR : (MCAN Offset: 0x40) (R/ 32) Error Counter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TEC:8;                     /**< bit:   0..7  Transmit Error Counter                   */
+    uint32_t REC:7;                     /**< bit:  8..14  Receive Error Counter                    */
+    uint32_t RP:1;                      /**< bit:     15  Receive Error Passive                    */
+    uint32_t CEL:8;                     /**< bit: 16..23  CAN Error Logging (cleared on read)      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ECR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ECR_OFFSET                     (0x40)                                        /**<  (MCAN_ECR) Error Counter Register  Offset */
+
+#define MCAN_ECR_TEC_Pos                    0                                              /**< (MCAN_ECR) Transmit Error Counter Position */
+#define MCAN_ECR_TEC_Msk                    (_U_(0xFF) << MCAN_ECR_TEC_Pos)                /**< (MCAN_ECR) Transmit Error Counter Mask */
+#define MCAN_ECR_TEC(value)                 (MCAN_ECR_TEC_Msk & ((value) << MCAN_ECR_TEC_Pos))
+#define MCAN_ECR_REC_Pos                    8                                              /**< (MCAN_ECR) Receive Error Counter Position */
+#define MCAN_ECR_REC_Msk                    (_U_(0x7F) << MCAN_ECR_REC_Pos)                /**< (MCAN_ECR) Receive Error Counter Mask */
+#define MCAN_ECR_REC(value)                 (MCAN_ECR_REC_Msk & ((value) << MCAN_ECR_REC_Pos))
+#define MCAN_ECR_RP_Pos                     15                                             /**< (MCAN_ECR) Receive Error Passive Position */
+#define MCAN_ECR_RP_Msk                     (_U_(0x1) << MCAN_ECR_RP_Pos)                  /**< (MCAN_ECR) Receive Error Passive Mask */
+#define MCAN_ECR_RP                         MCAN_ECR_RP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ECR_RP_Msk instead */
+#define MCAN_ECR_CEL_Pos                    16                                             /**< (MCAN_ECR) CAN Error Logging (cleared on read) Position */
+#define MCAN_ECR_CEL_Msk                    (_U_(0xFF) << MCAN_ECR_CEL_Pos)                /**< (MCAN_ECR) CAN Error Logging (cleared on read) Mask */
+#define MCAN_ECR_CEL(value)                 (MCAN_ECR_CEL_Msk & ((value) << MCAN_ECR_CEL_Pos))
+#define MCAN_ECR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (MCAN_ECR) Register MASK  (Use MCAN_ECR_Msk instead)  */
+#define MCAN_ECR_Msk                        _U_(0xFFFFFF)                                  /**< (MCAN_ECR) Register Mask  */
+
+
+/* -------- MCAN_PSR : (MCAN Offset: 0x44) (R/ 32) Protocol Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEC:3;                     /**< bit:   0..2  Last Error Code (set to 111 on read)     */
+    uint32_t ACT:2;                     /**< bit:   3..4  Activity                                 */
+    uint32_t EP:1;                      /**< bit:      5  Error Passive                            */
+    uint32_t EW:1;                      /**< bit:      6  Warning Status                           */
+    uint32_t BO:1;                      /**< bit:      7  Bus_Off Status                           */
+    uint32_t DLEC:3;                    /**< bit:  8..10  Data Phase Last Error Code (set to 111 on read) */
+    uint32_t RESI:1;                    /**< bit:     11  ESI Flag of Last Received CAN FD Message (cleared on read) */
+    uint32_t RBRS:1;                    /**< bit:     12  BRS Flag of Last Received CAN FD Message (cleared on read) */
+    uint32_t RFDF:1;                    /**< bit:     13  Received a CAN FD Message (cleared on read) */
+    uint32_t PXE:1;                     /**< bit:     14  Protocol Exception Event (cleared on read) */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t TDCV:7;                    /**< bit: 16..22  Transmitter Delay Compensation Value     */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_PSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_PSR_OFFSET                     (0x44)                                        /**<  (MCAN_PSR) Protocol Status Register  Offset */
+
+#define MCAN_PSR_LEC_Pos                    0                                              /**< (MCAN_PSR) Last Error Code (set to 111 on read) Position */
+#define MCAN_PSR_LEC_Msk                    (_U_(0x7) << MCAN_PSR_LEC_Pos)                 /**< (MCAN_PSR) Last Error Code (set to 111 on read) Mask */
+#define MCAN_PSR_LEC(value)                 (MCAN_PSR_LEC_Msk & ((value) << MCAN_PSR_LEC_Pos))
+#define   MCAN_PSR_LEC_NO_ERROR_Val         _U_(0x0)                                       /**< (MCAN_PSR) No error occurred since LEC has been reset by successful reception or transmission.  */
+#define   MCAN_PSR_LEC_STUFF_ERROR_Val      _U_(0x1)                                       /**< (MCAN_PSR) More than 5 equal bits in a sequence have occurred in a part of a received message where this is not allowed.  */
+#define   MCAN_PSR_LEC_FORM_ERROR_Val       _U_(0x2)                                       /**< (MCAN_PSR) A fixed format part of a received frame has the wrong format.  */
+#define   MCAN_PSR_LEC_ACK_ERROR_Val        _U_(0x3)                                       /**< (MCAN_PSR) The message transmitted by the MCAN was not acknowledged by another node.  */
+#define   MCAN_PSR_LEC_BIT1_ERROR_Val       _U_(0x4)                                       /**< (MCAN_PSR) During transmission of a message (with the exception of the arbitration field), the device tried to send a recessive level (bit of logical value '1'), but the monitored bus value was dominant.  */
+#define   MCAN_PSR_LEC_BIT0_ERROR_Val       _U_(0x5)                                       /**< (MCAN_PSR) During transmission of a message (or acknowledge bit, or active error flag, or overload flag), the device tried to send a dominant level (data or identifier bit logical value '0'), but the monitored bus value was recessive. During Bus_Off recovery, this status is set each time a sequence of 11 recessive bits has been monitored. This enables the processor to monitor the proceeding of the Bus_Off recovery sequence (indicating the bus is not stuck at dominant or continuously disturbed).  */
+#define   MCAN_PSR_LEC_CRC_ERROR_Val        _U_(0x6)                                       /**< (MCAN_PSR) The CRC check sum of a received message was incorrect. The CRC of an incoming message does not match the CRC calculated from the received data.  */
+#define   MCAN_PSR_LEC_NO_CHANGE_Val        _U_(0x7)                                       /**< (MCAN_PSR) Any read access to the Protocol Status Register re-initializes the LEC to '7'. When the LEC shows value '7', no CAN bus event was detected since the last processor read access to the Protocol Status Register.  */
+#define MCAN_PSR_LEC_NO_ERROR               (MCAN_PSR_LEC_NO_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) No error occurred since LEC has been reset by successful reception or transmission. Position  */
+#define MCAN_PSR_LEC_STUFF_ERROR            (MCAN_PSR_LEC_STUFF_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) More than 5 equal bits in a sequence have occurred in a part of a received message where this is not allowed. Position  */
+#define MCAN_PSR_LEC_FORM_ERROR             (MCAN_PSR_LEC_FORM_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) A fixed format part of a received frame has the wrong format. Position  */
+#define MCAN_PSR_LEC_ACK_ERROR              (MCAN_PSR_LEC_ACK_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) The message transmitted by the MCAN was not acknowledged by another node. Position  */
+#define MCAN_PSR_LEC_BIT1_ERROR             (MCAN_PSR_LEC_BIT1_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) During transmission of a message (with the exception of the arbitration field), the device tried to send a recessive level (bit of logical value '1'), but the monitored bus value was dominant. Position  */
+#define MCAN_PSR_LEC_BIT0_ERROR             (MCAN_PSR_LEC_BIT0_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) During transmission of a message (or acknowledge bit, or active error flag, or overload flag), the device tried to send a dominant level (data or identifier bit logical value '0'), but the monitored bus value was recessive. During Bus_Off recovery, this status is set each time a sequence of 11 recessive bits has been monitored. This enables the processor to monitor the proceeding of the Bus_Off recovery sequence (indicating the bus is not stuck at dominant or continuously disturbed). Position  */
+#define MCAN_PSR_LEC_CRC_ERROR              (MCAN_PSR_LEC_CRC_ERROR_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) The CRC check sum of a received message was incorrect. The CRC of an incoming message does not match the CRC calculated from the received data. Position  */
+#define MCAN_PSR_LEC_NO_CHANGE              (MCAN_PSR_LEC_NO_CHANGE_Val << MCAN_PSR_LEC_Pos)  /**< (MCAN_PSR) Any read access to the Protocol Status Register re-initializes the LEC to '7'. When the LEC shows value '7', no CAN bus event was detected since the last processor read access to the Protocol Status Register. Position  */
+#define MCAN_PSR_ACT_Pos                    3                                              /**< (MCAN_PSR) Activity Position */
+#define MCAN_PSR_ACT_Msk                    (_U_(0x3) << MCAN_PSR_ACT_Pos)                 /**< (MCAN_PSR) Activity Mask */
+#define MCAN_PSR_ACT(value)                 (MCAN_PSR_ACT_Msk & ((value) << MCAN_PSR_ACT_Pos))
+#define   MCAN_PSR_ACT_SYNCHRONIZING_Val    _U_(0x0)                                       /**< (MCAN_PSR) Node is synchronizing on CAN communication  */
+#define   MCAN_PSR_ACT_IDLE_Val             _U_(0x1)                                       /**< (MCAN_PSR) Node is neither receiver nor transmitter  */
+#define   MCAN_PSR_ACT_RECEIVER_Val         _U_(0x2)                                       /**< (MCAN_PSR) Node is operating as receiver  */
+#define   MCAN_PSR_ACT_TRANSMITTER_Val      _U_(0x3)                                       /**< (MCAN_PSR) Node is operating as transmitter  */
+#define MCAN_PSR_ACT_SYNCHRONIZING          (MCAN_PSR_ACT_SYNCHRONIZING_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is synchronizing on CAN communication Position  */
+#define MCAN_PSR_ACT_IDLE                   (MCAN_PSR_ACT_IDLE_Val << MCAN_PSR_ACT_Pos)    /**< (MCAN_PSR) Node is neither receiver nor transmitter Position  */
+#define MCAN_PSR_ACT_RECEIVER               (MCAN_PSR_ACT_RECEIVER_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is operating as receiver Position  */
+#define MCAN_PSR_ACT_TRANSMITTER            (MCAN_PSR_ACT_TRANSMITTER_Val << MCAN_PSR_ACT_Pos)  /**< (MCAN_PSR) Node is operating as transmitter Position  */
+#define MCAN_PSR_EP_Pos                     5                                              /**< (MCAN_PSR) Error Passive Position */
+#define MCAN_PSR_EP_Msk                     (_U_(0x1) << MCAN_PSR_EP_Pos)                  /**< (MCAN_PSR) Error Passive Mask */
+#define MCAN_PSR_EP                         MCAN_PSR_EP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_EP_Msk instead */
+#define MCAN_PSR_EW_Pos                     6                                              /**< (MCAN_PSR) Warning Status Position */
+#define MCAN_PSR_EW_Msk                     (_U_(0x1) << MCAN_PSR_EW_Pos)                  /**< (MCAN_PSR) Warning Status Mask */
+#define MCAN_PSR_EW                         MCAN_PSR_EW_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_EW_Msk instead */
+#define MCAN_PSR_BO_Pos                     7                                              /**< (MCAN_PSR) Bus_Off Status Position */
+#define MCAN_PSR_BO_Msk                     (_U_(0x1) << MCAN_PSR_BO_Pos)                  /**< (MCAN_PSR) Bus_Off Status Mask */
+#define MCAN_PSR_BO                         MCAN_PSR_BO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_BO_Msk instead */
+#define MCAN_PSR_DLEC_Pos                   8                                              /**< (MCAN_PSR) Data Phase Last Error Code (set to 111 on read) Position */
+#define MCAN_PSR_DLEC_Msk                   (_U_(0x7) << MCAN_PSR_DLEC_Pos)                /**< (MCAN_PSR) Data Phase Last Error Code (set to 111 on read) Mask */
+#define MCAN_PSR_DLEC(value)                (MCAN_PSR_DLEC_Msk & ((value) << MCAN_PSR_DLEC_Pos))
+#define MCAN_PSR_RESI_Pos                   11                                             /**< (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_RESI_Msk                   (_U_(0x1) << MCAN_PSR_RESI_Pos)                /**< (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_RESI                       MCAN_PSR_RESI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_RESI_Msk instead */
+#define MCAN_PSR_RBRS_Pos                   12                                             /**< (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_RBRS_Msk                   (_U_(0x1) << MCAN_PSR_RBRS_Pos)                /**< (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_RBRS                       MCAN_PSR_RBRS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_RBRS_Msk instead */
+#define MCAN_PSR_RFDF_Pos                   13                                             /**< (MCAN_PSR) Received a CAN FD Message (cleared on read) Position */
+#define MCAN_PSR_RFDF_Msk                   (_U_(0x1) << MCAN_PSR_RFDF_Pos)                /**< (MCAN_PSR) Received a CAN FD Message (cleared on read) Mask */
+#define MCAN_PSR_RFDF                       MCAN_PSR_RFDF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_RFDF_Msk instead */
+#define MCAN_PSR_PXE_Pos                    14                                             /**< (MCAN_PSR) Protocol Exception Event (cleared on read) Position */
+#define MCAN_PSR_PXE_Msk                    (_U_(0x1) << MCAN_PSR_PXE_Pos)                 /**< (MCAN_PSR) Protocol Exception Event (cleared on read) Mask */
+#define MCAN_PSR_PXE                        MCAN_PSR_PXE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_PSR_PXE_Msk instead */
+#define MCAN_PSR_TDCV_Pos                   16                                             /**< (MCAN_PSR) Transmitter Delay Compensation Value Position */
+#define MCAN_PSR_TDCV_Msk                   (_U_(0x7F) << MCAN_PSR_TDCV_Pos)               /**< (MCAN_PSR) Transmitter Delay Compensation Value Mask */
+#define MCAN_PSR_TDCV(value)                (MCAN_PSR_TDCV_Msk & ((value) << MCAN_PSR_TDCV_Pos))
+#define MCAN_PSR_MASK                       _U_(0x7F7FFF)                                  /**< \deprecated (MCAN_PSR) Register MASK  (Use MCAN_PSR_Msk instead)  */
+#define MCAN_PSR_Msk                        _U_(0x7F7FFF)                                  /**< (MCAN_PSR) Register Mask  */
+
+
+/* -------- MCAN_TDCR : (MCAN Offset: 0x48) (R/W 32) Transmit Delay Compensation Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TDCF:7;                    /**< bit:   0..6  Transmitter Delay Compensation Filter    */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TDCO:7;                    /**< bit:  8..14  Transmitter Delay Compensation Offset    */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TDCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TDCR_OFFSET                    (0x48)                                        /**<  (MCAN_TDCR) Transmit Delay Compensation Register  Offset */
+
+#define MCAN_TDCR_TDCF_Pos                  0                                              /**< (MCAN_TDCR) Transmitter Delay Compensation Filter Position */
+#define MCAN_TDCR_TDCF_Msk                  (_U_(0x7F) << MCAN_TDCR_TDCF_Pos)              /**< (MCAN_TDCR) Transmitter Delay Compensation Filter Mask */
+#define MCAN_TDCR_TDCF(value)               (MCAN_TDCR_TDCF_Msk & ((value) << MCAN_TDCR_TDCF_Pos))
+#define MCAN_TDCR_TDCO_Pos                  8                                              /**< (MCAN_TDCR) Transmitter Delay Compensation Offset Position */
+#define MCAN_TDCR_TDCO_Msk                  (_U_(0x7F) << MCAN_TDCR_TDCO_Pos)              /**< (MCAN_TDCR) Transmitter Delay Compensation Offset Mask */
+#define MCAN_TDCR_TDCO(value)               (MCAN_TDCR_TDCO_Msk & ((value) << MCAN_TDCR_TDCO_Pos))
+#define MCAN_TDCR_MASK                      _U_(0x7F7F)                                    /**< \deprecated (MCAN_TDCR) Register MASK  (Use MCAN_TDCR_Msk instead)  */
+#define MCAN_TDCR_Msk                       _U_(0x7F7F)                                    /**< (MCAN_TDCR) Register Mask  */
+
+
+/* -------- MCAN_IR : (MCAN Offset: 0x50) (R/W 32) Interrupt Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0N:1;                    /**< bit:      0  Receive FIFO 0 New Message               */
+    uint32_t RF0W:1;                    /**< bit:      1  Receive FIFO 0 Watermark Reached         */
+    uint32_t RF0F:1;                    /**< bit:      2  Receive FIFO 0 Full                      */
+    uint32_t RF0L:1;                    /**< bit:      3  Receive FIFO 0 Message Lost              */
+    uint32_t RF1N:1;                    /**< bit:      4  Receive FIFO 1 New Message               */
+    uint32_t RF1W:1;                    /**< bit:      5  Receive FIFO 1 Watermark Reached         */
+    uint32_t RF1F:1;                    /**< bit:      6  Receive FIFO 1 Full                      */
+    uint32_t RF1L:1;                    /**< bit:      7  Receive FIFO 1 Message Lost              */
+    uint32_t HPM:1;                     /**< bit:      8  High Priority Message                    */
+    uint32_t TC:1;                      /**< bit:      9  Transmission Completed                   */
+    uint32_t TCF:1;                     /**< bit:     10  Transmission Cancellation Finished       */
+    uint32_t TFE:1;                     /**< bit:     11  Tx FIFO Empty                            */
+    uint32_t TEFN:1;                    /**< bit:     12  Tx Event FIFO New Entry                  */
+    uint32_t TEFW:1;                    /**< bit:     13  Tx Event FIFO Watermark Reached          */
+    uint32_t TEFF:1;                    /**< bit:     14  Tx Event FIFO Full                       */
+    uint32_t TEFL:1;                    /**< bit:     15  Tx Event FIFO Element Lost               */
+    uint32_t TSW:1;                     /**< bit:     16  Timestamp Wraparound                     */
+    uint32_t MRAF:1;                    /**< bit:     17  Message RAM Access Failure               */
+    uint32_t TOO:1;                     /**< bit:     18  Timeout Occurred                         */
+    uint32_t DRX:1;                     /**< bit:     19  Message stored to Dedicated Receive Buffer */
+    uint32_t :2;                        /**< bit: 20..21  Reserved */
+    uint32_t ELO:1;                     /**< bit:     22  Error Logging Overflow                   */
+    uint32_t EP:1;                      /**< bit:     23  Error Passive                            */
+    uint32_t EW:1;                      /**< bit:     24  Warning Status                           */
+    uint32_t BO:1;                      /**< bit:     25  Bus_Off Status                           */
+    uint32_t WDI:1;                     /**< bit:     26  Watchdog Interrupt                       */
+    uint32_t PEA:1;                     /**< bit:     27  Protocol Error in Arbitration Phase      */
+    uint32_t PED:1;                     /**< bit:     28  Protocol Error in Data Phase             */
+    uint32_t ARA:1;                     /**< bit:     29  Access to Reserved Address               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_IR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_IR_OFFSET                      (0x50)                                        /**<  (MCAN_IR) Interrupt Register  Offset */
+
+#define MCAN_IR_RF0N_Pos                    0                                              /**< (MCAN_IR) Receive FIFO 0 New Message Position */
+#define MCAN_IR_RF0N_Msk                    (_U_(0x1) << MCAN_IR_RF0N_Pos)                 /**< (MCAN_IR) Receive FIFO 0 New Message Mask */
+#define MCAN_IR_RF0N                        MCAN_IR_RF0N_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0N_Msk instead */
+#define MCAN_IR_RF0W_Pos                    1                                              /**< (MCAN_IR) Receive FIFO 0 Watermark Reached Position */
+#define MCAN_IR_RF0W_Msk                    (_U_(0x1) << MCAN_IR_RF0W_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Watermark Reached Mask */
+#define MCAN_IR_RF0W                        MCAN_IR_RF0W_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0W_Msk instead */
+#define MCAN_IR_RF0F_Pos                    2                                              /**< (MCAN_IR) Receive FIFO 0 Full Position */
+#define MCAN_IR_RF0F_Msk                    (_U_(0x1) << MCAN_IR_RF0F_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Full Mask */
+#define MCAN_IR_RF0F                        MCAN_IR_RF0F_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0F_Msk instead */
+#define MCAN_IR_RF0L_Pos                    3                                              /**< (MCAN_IR) Receive FIFO 0 Message Lost Position */
+#define MCAN_IR_RF0L_Msk                    (_U_(0x1) << MCAN_IR_RF0L_Pos)                 /**< (MCAN_IR) Receive FIFO 0 Message Lost Mask */
+#define MCAN_IR_RF0L                        MCAN_IR_RF0L_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF0L_Msk instead */
+#define MCAN_IR_RF1N_Pos                    4                                              /**< (MCAN_IR) Receive FIFO 1 New Message Position */
+#define MCAN_IR_RF1N_Msk                    (_U_(0x1) << MCAN_IR_RF1N_Pos)                 /**< (MCAN_IR) Receive FIFO 1 New Message Mask */
+#define MCAN_IR_RF1N                        MCAN_IR_RF1N_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1N_Msk instead */
+#define MCAN_IR_RF1W_Pos                    5                                              /**< (MCAN_IR) Receive FIFO 1 Watermark Reached Position */
+#define MCAN_IR_RF1W_Msk                    (_U_(0x1) << MCAN_IR_RF1W_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Watermark Reached Mask */
+#define MCAN_IR_RF1W                        MCAN_IR_RF1W_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1W_Msk instead */
+#define MCAN_IR_RF1F_Pos                    6                                              /**< (MCAN_IR) Receive FIFO 1 Full Position */
+#define MCAN_IR_RF1F_Msk                    (_U_(0x1) << MCAN_IR_RF1F_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Full Mask */
+#define MCAN_IR_RF1F                        MCAN_IR_RF1F_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1F_Msk instead */
+#define MCAN_IR_RF1L_Pos                    7                                              /**< (MCAN_IR) Receive FIFO 1 Message Lost Position */
+#define MCAN_IR_RF1L_Msk                    (_U_(0x1) << MCAN_IR_RF1L_Pos)                 /**< (MCAN_IR) Receive FIFO 1 Message Lost Mask */
+#define MCAN_IR_RF1L                        MCAN_IR_RF1L_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_RF1L_Msk instead */
+#define MCAN_IR_HPM_Pos                     8                                              /**< (MCAN_IR) High Priority Message Position */
+#define MCAN_IR_HPM_Msk                     (_U_(0x1) << MCAN_IR_HPM_Pos)                  /**< (MCAN_IR) High Priority Message Mask */
+#define MCAN_IR_HPM                         MCAN_IR_HPM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_HPM_Msk instead */
+#define MCAN_IR_TC_Pos                      9                                              /**< (MCAN_IR) Transmission Completed Position */
+#define MCAN_IR_TC_Msk                      (_U_(0x1) << MCAN_IR_TC_Pos)                   /**< (MCAN_IR) Transmission Completed Mask */
+#define MCAN_IR_TC                          MCAN_IR_TC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TC_Msk instead */
+#define MCAN_IR_TCF_Pos                     10                                             /**< (MCAN_IR) Transmission Cancellation Finished Position */
+#define MCAN_IR_TCF_Msk                     (_U_(0x1) << MCAN_IR_TCF_Pos)                  /**< (MCAN_IR) Transmission Cancellation Finished Mask */
+#define MCAN_IR_TCF                         MCAN_IR_TCF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TCF_Msk instead */
+#define MCAN_IR_TFE_Pos                     11                                             /**< (MCAN_IR) Tx FIFO Empty Position */
+#define MCAN_IR_TFE_Msk                     (_U_(0x1) << MCAN_IR_TFE_Pos)                  /**< (MCAN_IR) Tx FIFO Empty Mask */
+#define MCAN_IR_TFE                         MCAN_IR_TFE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TFE_Msk instead */
+#define MCAN_IR_TEFN_Pos                    12                                             /**< (MCAN_IR) Tx Event FIFO New Entry Position */
+#define MCAN_IR_TEFN_Msk                    (_U_(0x1) << MCAN_IR_TEFN_Pos)                 /**< (MCAN_IR) Tx Event FIFO New Entry Mask */
+#define MCAN_IR_TEFN                        MCAN_IR_TEFN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFN_Msk instead */
+#define MCAN_IR_TEFW_Pos                    13                                             /**< (MCAN_IR) Tx Event FIFO Watermark Reached Position */
+#define MCAN_IR_TEFW_Msk                    (_U_(0x1) << MCAN_IR_TEFW_Pos)                 /**< (MCAN_IR) Tx Event FIFO Watermark Reached Mask */
+#define MCAN_IR_TEFW                        MCAN_IR_TEFW_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFW_Msk instead */
+#define MCAN_IR_TEFF_Pos                    14                                             /**< (MCAN_IR) Tx Event FIFO Full Position */
+#define MCAN_IR_TEFF_Msk                    (_U_(0x1) << MCAN_IR_TEFF_Pos)                 /**< (MCAN_IR) Tx Event FIFO Full Mask */
+#define MCAN_IR_TEFF                        MCAN_IR_TEFF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFF_Msk instead */
+#define MCAN_IR_TEFL_Pos                    15                                             /**< (MCAN_IR) Tx Event FIFO Element Lost Position */
+#define MCAN_IR_TEFL_Msk                    (_U_(0x1) << MCAN_IR_TEFL_Pos)                 /**< (MCAN_IR) Tx Event FIFO Element Lost Mask */
+#define MCAN_IR_TEFL                        MCAN_IR_TEFL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TEFL_Msk instead */
+#define MCAN_IR_TSW_Pos                     16                                             /**< (MCAN_IR) Timestamp Wraparound Position */
+#define MCAN_IR_TSW_Msk                     (_U_(0x1) << MCAN_IR_TSW_Pos)                  /**< (MCAN_IR) Timestamp Wraparound Mask */
+#define MCAN_IR_TSW                         MCAN_IR_TSW_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TSW_Msk instead */
+#define MCAN_IR_MRAF_Pos                    17                                             /**< (MCAN_IR) Message RAM Access Failure Position */
+#define MCAN_IR_MRAF_Msk                    (_U_(0x1) << MCAN_IR_MRAF_Pos)                 /**< (MCAN_IR) Message RAM Access Failure Mask */
+#define MCAN_IR_MRAF                        MCAN_IR_MRAF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_MRAF_Msk instead */
+#define MCAN_IR_TOO_Pos                     18                                             /**< (MCAN_IR) Timeout Occurred Position */
+#define MCAN_IR_TOO_Msk                     (_U_(0x1) << MCAN_IR_TOO_Pos)                  /**< (MCAN_IR) Timeout Occurred Mask */
+#define MCAN_IR_TOO                         MCAN_IR_TOO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_TOO_Msk instead */
+#define MCAN_IR_DRX_Pos                     19                                             /**< (MCAN_IR) Message stored to Dedicated Receive Buffer Position */
+#define MCAN_IR_DRX_Msk                     (_U_(0x1) << MCAN_IR_DRX_Pos)                  /**< (MCAN_IR) Message stored to Dedicated Receive Buffer Mask */
+#define MCAN_IR_DRX                         MCAN_IR_DRX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_DRX_Msk instead */
+#define MCAN_IR_ELO_Pos                     22                                             /**< (MCAN_IR) Error Logging Overflow Position */
+#define MCAN_IR_ELO_Msk                     (_U_(0x1) << MCAN_IR_ELO_Pos)                  /**< (MCAN_IR) Error Logging Overflow Mask */
+#define MCAN_IR_ELO                         MCAN_IR_ELO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_ELO_Msk instead */
+#define MCAN_IR_EP_Pos                      23                                             /**< (MCAN_IR) Error Passive Position */
+#define MCAN_IR_EP_Msk                      (_U_(0x1) << MCAN_IR_EP_Pos)                   /**< (MCAN_IR) Error Passive Mask */
+#define MCAN_IR_EP                          MCAN_IR_EP_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_EP_Msk instead */
+#define MCAN_IR_EW_Pos                      24                                             /**< (MCAN_IR) Warning Status Position */
+#define MCAN_IR_EW_Msk                      (_U_(0x1) << MCAN_IR_EW_Pos)                   /**< (MCAN_IR) Warning Status Mask */
+#define MCAN_IR_EW                          MCAN_IR_EW_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_EW_Msk instead */
+#define MCAN_IR_BO_Pos                      25                                             /**< (MCAN_IR) Bus_Off Status Position */
+#define MCAN_IR_BO_Msk                      (_U_(0x1) << MCAN_IR_BO_Pos)                   /**< (MCAN_IR) Bus_Off Status Mask */
+#define MCAN_IR_BO                          MCAN_IR_BO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_BO_Msk instead */
+#define MCAN_IR_WDI_Pos                     26                                             /**< (MCAN_IR) Watchdog Interrupt Position */
+#define MCAN_IR_WDI_Msk                     (_U_(0x1) << MCAN_IR_WDI_Pos)                  /**< (MCAN_IR) Watchdog Interrupt Mask */
+#define MCAN_IR_WDI                         MCAN_IR_WDI_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_WDI_Msk instead */
+#define MCAN_IR_PEA_Pos                     27                                             /**< (MCAN_IR) Protocol Error in Arbitration Phase Position */
+#define MCAN_IR_PEA_Msk                     (_U_(0x1) << MCAN_IR_PEA_Pos)                  /**< (MCAN_IR) Protocol Error in Arbitration Phase Mask */
+#define MCAN_IR_PEA                         MCAN_IR_PEA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_PEA_Msk instead */
+#define MCAN_IR_PED_Pos                     28                                             /**< (MCAN_IR) Protocol Error in Data Phase Position */
+#define MCAN_IR_PED_Msk                     (_U_(0x1) << MCAN_IR_PED_Pos)                  /**< (MCAN_IR) Protocol Error in Data Phase Mask */
+#define MCAN_IR_PED                         MCAN_IR_PED_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_PED_Msk instead */
+#define MCAN_IR_ARA_Pos                     29                                             /**< (MCAN_IR) Access to Reserved Address Position */
+#define MCAN_IR_ARA_Msk                     (_U_(0x1) << MCAN_IR_ARA_Pos)                  /**< (MCAN_IR) Access to Reserved Address Mask */
+#define MCAN_IR_ARA                         MCAN_IR_ARA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IR_ARA_Msk instead */
+#define MCAN_IR_MASK                        _U_(0x3FCFFFFF)                                /**< \deprecated (MCAN_IR) Register MASK  (Use MCAN_IR_Msk instead)  */
+#define MCAN_IR_Msk                         _U_(0x3FCFFFFF)                                /**< (MCAN_IR) Register Mask  */
+
+
+/* -------- MCAN_IE : (MCAN Offset: 0x54) (R/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0NE:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Enable */
+    uint32_t RF0WE:1;                   /**< bit:      1  Receive FIFO 0 Watermark Reached Interrupt Enable */
+    uint32_t RF0FE:1;                   /**< bit:      2  Receive FIFO 0 Full Interrupt Enable     */
+    uint32_t RF0LE:1;                   /**< bit:      3  Receive FIFO 0 Message Lost Interrupt Enable */
+    uint32_t RF1NE:1;                   /**< bit:      4  Receive FIFO 1 New Message Interrupt Enable */
+    uint32_t RF1WE:1;                   /**< bit:      5  Receive FIFO 1 Watermark Reached Interrupt Enable */
+    uint32_t RF1FE:1;                   /**< bit:      6  Receive FIFO 1 Full Interrupt Enable     */
+    uint32_t RF1LE:1;                   /**< bit:      7  Receive FIFO 1 Message Lost Interrupt Enable */
+    uint32_t HPME:1;                    /**< bit:      8  High Priority Message Interrupt Enable   */
+    uint32_t TCE:1;                     /**< bit:      9  Transmission Completed Interrupt Enable  */
+    uint32_t TCFE:1;                    /**< bit:     10  Transmission Cancellation Finished Interrupt Enable */
+    uint32_t TFEE:1;                    /**< bit:     11  Tx FIFO Empty Interrupt Enable           */
+    uint32_t TEFNE:1;                   /**< bit:     12  Tx Event FIFO New Entry Interrupt Enable */
+    uint32_t TEFWE:1;                   /**< bit:     13  Tx Event FIFO Watermark Reached Interrupt Enable */
+    uint32_t TEFFE:1;                   /**< bit:     14  Tx Event FIFO Full Interrupt Enable      */
+    uint32_t TEFLE:1;                   /**< bit:     15  Tx Event FIFO Event Lost Interrupt Enable */
+    uint32_t TSWE:1;                    /**< bit:     16  Timestamp Wraparound Interrupt Enable    */
+    uint32_t MRAFE:1;                   /**< bit:     17  Message RAM Access Failure Interrupt Enable */
+    uint32_t TOOE:1;                    /**< bit:     18  Timeout Occurred Interrupt Enable        */
+    uint32_t DRXE:1;                    /**< bit:     19  Message stored to Dedicated Receive Buffer Interrupt Enable */
+    uint32_t :2;                        /**< bit: 20..21  Reserved */
+    uint32_t ELOE:1;                    /**< bit:     22  Error Logging Overflow Interrupt Enable  */
+    uint32_t EPE:1;                     /**< bit:     23  Error Passive Interrupt Enable           */
+    uint32_t EWE:1;                     /**< bit:     24  Warning Status Interrupt Enable          */
+    uint32_t BOE:1;                     /**< bit:     25  Bus_Off Status Interrupt Enable          */
+    uint32_t WDIE:1;                    /**< bit:     26  Watchdog Interrupt Enable                */
+    uint32_t PEAE:1;                    /**< bit:     27  Protocol Error in Arbitration Phase Enable */
+    uint32_t PEDE:1;                    /**< bit:     28  Protocol Error in Data Phase Enable      */
+    uint32_t ARAE:1;                    /**< bit:     29  Access to Reserved Address Enable        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_IE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_IE_OFFSET                      (0x54)                                        /**<  (MCAN_IE) Interrupt Enable Register  Offset */
+
+#define MCAN_IE_RF0NE_Pos                   0                                              /**< (MCAN_IE) Receive FIFO 0 New Message Interrupt Enable Position */
+#define MCAN_IE_RF0NE_Msk                   (_U_(0x1) << MCAN_IE_RF0NE_Pos)                /**< (MCAN_IE) Receive FIFO 0 New Message Interrupt Enable Mask */
+#define MCAN_IE_RF0NE                       MCAN_IE_RF0NE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0NE_Msk instead */
+#define MCAN_IE_RF0WE_Pos                   1                                              /**< (MCAN_IE) Receive FIFO 0 Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_RF0WE_Msk                   (_U_(0x1) << MCAN_IE_RF0WE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_RF0WE                       MCAN_IE_RF0WE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0WE_Msk instead */
+#define MCAN_IE_RF0FE_Pos                   2                                              /**< (MCAN_IE) Receive FIFO 0 Full Interrupt Enable Position */
+#define MCAN_IE_RF0FE_Msk                   (_U_(0x1) << MCAN_IE_RF0FE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Full Interrupt Enable Mask */
+#define MCAN_IE_RF0FE                       MCAN_IE_RF0FE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0FE_Msk instead */
+#define MCAN_IE_RF0LE_Pos                   3                                              /**< (MCAN_IE) Receive FIFO 0 Message Lost Interrupt Enable Position */
+#define MCAN_IE_RF0LE_Msk                   (_U_(0x1) << MCAN_IE_RF0LE_Pos)                /**< (MCAN_IE) Receive FIFO 0 Message Lost Interrupt Enable Mask */
+#define MCAN_IE_RF0LE                       MCAN_IE_RF0LE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF0LE_Msk instead */
+#define MCAN_IE_RF1NE_Pos                   4                                              /**< (MCAN_IE) Receive FIFO 1 New Message Interrupt Enable Position */
+#define MCAN_IE_RF1NE_Msk                   (_U_(0x1) << MCAN_IE_RF1NE_Pos)                /**< (MCAN_IE) Receive FIFO 1 New Message Interrupt Enable Mask */
+#define MCAN_IE_RF1NE                       MCAN_IE_RF1NE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1NE_Msk instead */
+#define MCAN_IE_RF1WE_Pos                   5                                              /**< (MCAN_IE) Receive FIFO 1 Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_RF1WE_Msk                   (_U_(0x1) << MCAN_IE_RF1WE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_RF1WE                       MCAN_IE_RF1WE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1WE_Msk instead */
+#define MCAN_IE_RF1FE_Pos                   6                                              /**< (MCAN_IE) Receive FIFO 1 Full Interrupt Enable Position */
+#define MCAN_IE_RF1FE_Msk                   (_U_(0x1) << MCAN_IE_RF1FE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Full Interrupt Enable Mask */
+#define MCAN_IE_RF1FE                       MCAN_IE_RF1FE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1FE_Msk instead */
+#define MCAN_IE_RF1LE_Pos                   7                                              /**< (MCAN_IE) Receive FIFO 1 Message Lost Interrupt Enable Position */
+#define MCAN_IE_RF1LE_Msk                   (_U_(0x1) << MCAN_IE_RF1LE_Pos)                /**< (MCAN_IE) Receive FIFO 1 Message Lost Interrupt Enable Mask */
+#define MCAN_IE_RF1LE                       MCAN_IE_RF1LE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_RF1LE_Msk instead */
+#define MCAN_IE_HPME_Pos                    8                                              /**< (MCAN_IE) High Priority Message Interrupt Enable Position */
+#define MCAN_IE_HPME_Msk                    (_U_(0x1) << MCAN_IE_HPME_Pos)                 /**< (MCAN_IE) High Priority Message Interrupt Enable Mask */
+#define MCAN_IE_HPME                        MCAN_IE_HPME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_HPME_Msk instead */
+#define MCAN_IE_TCE_Pos                     9                                              /**< (MCAN_IE) Transmission Completed Interrupt Enable Position */
+#define MCAN_IE_TCE_Msk                     (_U_(0x1) << MCAN_IE_TCE_Pos)                  /**< (MCAN_IE) Transmission Completed Interrupt Enable Mask */
+#define MCAN_IE_TCE                         MCAN_IE_TCE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TCE_Msk instead */
+#define MCAN_IE_TCFE_Pos                    10                                             /**< (MCAN_IE) Transmission Cancellation Finished Interrupt Enable Position */
+#define MCAN_IE_TCFE_Msk                    (_U_(0x1) << MCAN_IE_TCFE_Pos)                 /**< (MCAN_IE) Transmission Cancellation Finished Interrupt Enable Mask */
+#define MCAN_IE_TCFE                        MCAN_IE_TCFE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TCFE_Msk instead */
+#define MCAN_IE_TFEE_Pos                    11                                             /**< (MCAN_IE) Tx FIFO Empty Interrupt Enable Position */
+#define MCAN_IE_TFEE_Msk                    (_U_(0x1) << MCAN_IE_TFEE_Pos)                 /**< (MCAN_IE) Tx FIFO Empty Interrupt Enable Mask */
+#define MCAN_IE_TFEE                        MCAN_IE_TFEE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TFEE_Msk instead */
+#define MCAN_IE_TEFNE_Pos                   12                                             /**< (MCAN_IE) Tx Event FIFO New Entry Interrupt Enable Position */
+#define MCAN_IE_TEFNE_Msk                   (_U_(0x1) << MCAN_IE_TEFNE_Pos)                /**< (MCAN_IE) Tx Event FIFO New Entry Interrupt Enable Mask */
+#define MCAN_IE_TEFNE                       MCAN_IE_TEFNE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFNE_Msk instead */
+#define MCAN_IE_TEFWE_Pos                   13                                             /**< (MCAN_IE) Tx Event FIFO Watermark Reached Interrupt Enable Position */
+#define MCAN_IE_TEFWE_Msk                   (_U_(0x1) << MCAN_IE_TEFWE_Pos)                /**< (MCAN_IE) Tx Event FIFO Watermark Reached Interrupt Enable Mask */
+#define MCAN_IE_TEFWE                       MCAN_IE_TEFWE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFWE_Msk instead */
+#define MCAN_IE_TEFFE_Pos                   14                                             /**< (MCAN_IE) Tx Event FIFO Full Interrupt Enable Position */
+#define MCAN_IE_TEFFE_Msk                   (_U_(0x1) << MCAN_IE_TEFFE_Pos)                /**< (MCAN_IE) Tx Event FIFO Full Interrupt Enable Mask */
+#define MCAN_IE_TEFFE                       MCAN_IE_TEFFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFFE_Msk instead */
+#define MCAN_IE_TEFLE_Pos                   15                                             /**< (MCAN_IE) Tx Event FIFO Event Lost Interrupt Enable Position */
+#define MCAN_IE_TEFLE_Msk                   (_U_(0x1) << MCAN_IE_TEFLE_Pos)                /**< (MCAN_IE) Tx Event FIFO Event Lost Interrupt Enable Mask */
+#define MCAN_IE_TEFLE                       MCAN_IE_TEFLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TEFLE_Msk instead */
+#define MCAN_IE_TSWE_Pos                    16                                             /**< (MCAN_IE) Timestamp Wraparound Interrupt Enable Position */
+#define MCAN_IE_TSWE_Msk                    (_U_(0x1) << MCAN_IE_TSWE_Pos)                 /**< (MCAN_IE) Timestamp Wraparound Interrupt Enable Mask */
+#define MCAN_IE_TSWE                        MCAN_IE_TSWE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TSWE_Msk instead */
+#define MCAN_IE_MRAFE_Pos                   17                                             /**< (MCAN_IE) Message RAM Access Failure Interrupt Enable Position */
+#define MCAN_IE_MRAFE_Msk                   (_U_(0x1) << MCAN_IE_MRAFE_Pos)                /**< (MCAN_IE) Message RAM Access Failure Interrupt Enable Mask */
+#define MCAN_IE_MRAFE                       MCAN_IE_MRAFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_MRAFE_Msk instead */
+#define MCAN_IE_TOOE_Pos                    18                                             /**< (MCAN_IE) Timeout Occurred Interrupt Enable Position */
+#define MCAN_IE_TOOE_Msk                    (_U_(0x1) << MCAN_IE_TOOE_Pos)                 /**< (MCAN_IE) Timeout Occurred Interrupt Enable Mask */
+#define MCAN_IE_TOOE                        MCAN_IE_TOOE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_TOOE_Msk instead */
+#define MCAN_IE_DRXE_Pos                    19                                             /**< (MCAN_IE) Message stored to Dedicated Receive Buffer Interrupt Enable Position */
+#define MCAN_IE_DRXE_Msk                    (_U_(0x1) << MCAN_IE_DRXE_Pos)                 /**< (MCAN_IE) Message stored to Dedicated Receive Buffer Interrupt Enable Mask */
+#define MCAN_IE_DRXE                        MCAN_IE_DRXE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_DRXE_Msk instead */
+#define MCAN_IE_ELOE_Pos                    22                                             /**< (MCAN_IE) Error Logging Overflow Interrupt Enable Position */
+#define MCAN_IE_ELOE_Msk                    (_U_(0x1) << MCAN_IE_ELOE_Pos)                 /**< (MCAN_IE) Error Logging Overflow Interrupt Enable Mask */
+#define MCAN_IE_ELOE                        MCAN_IE_ELOE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_ELOE_Msk instead */
+#define MCAN_IE_EPE_Pos                     23                                             /**< (MCAN_IE) Error Passive Interrupt Enable Position */
+#define MCAN_IE_EPE_Msk                     (_U_(0x1) << MCAN_IE_EPE_Pos)                  /**< (MCAN_IE) Error Passive Interrupt Enable Mask */
+#define MCAN_IE_EPE                         MCAN_IE_EPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_EPE_Msk instead */
+#define MCAN_IE_EWE_Pos                     24                                             /**< (MCAN_IE) Warning Status Interrupt Enable Position */
+#define MCAN_IE_EWE_Msk                     (_U_(0x1) << MCAN_IE_EWE_Pos)                  /**< (MCAN_IE) Warning Status Interrupt Enable Mask */
+#define MCAN_IE_EWE                         MCAN_IE_EWE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_EWE_Msk instead */
+#define MCAN_IE_BOE_Pos                     25                                             /**< (MCAN_IE) Bus_Off Status Interrupt Enable Position */
+#define MCAN_IE_BOE_Msk                     (_U_(0x1) << MCAN_IE_BOE_Pos)                  /**< (MCAN_IE) Bus_Off Status Interrupt Enable Mask */
+#define MCAN_IE_BOE                         MCAN_IE_BOE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_BOE_Msk instead */
+#define MCAN_IE_WDIE_Pos                    26                                             /**< (MCAN_IE) Watchdog Interrupt Enable Position */
+#define MCAN_IE_WDIE_Msk                    (_U_(0x1) << MCAN_IE_WDIE_Pos)                 /**< (MCAN_IE) Watchdog Interrupt Enable Mask */
+#define MCAN_IE_WDIE                        MCAN_IE_WDIE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_WDIE_Msk instead */
+#define MCAN_IE_PEAE_Pos                    27                                             /**< (MCAN_IE) Protocol Error in Arbitration Phase Enable Position */
+#define MCAN_IE_PEAE_Msk                    (_U_(0x1) << MCAN_IE_PEAE_Pos)                 /**< (MCAN_IE) Protocol Error in Arbitration Phase Enable Mask */
+#define MCAN_IE_PEAE                        MCAN_IE_PEAE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_PEAE_Msk instead */
+#define MCAN_IE_PEDE_Pos                    28                                             /**< (MCAN_IE) Protocol Error in Data Phase Enable Position */
+#define MCAN_IE_PEDE_Msk                    (_U_(0x1) << MCAN_IE_PEDE_Pos)                 /**< (MCAN_IE) Protocol Error in Data Phase Enable Mask */
+#define MCAN_IE_PEDE                        MCAN_IE_PEDE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_PEDE_Msk instead */
+#define MCAN_IE_ARAE_Pos                    29                                             /**< (MCAN_IE) Access to Reserved Address Enable Position */
+#define MCAN_IE_ARAE_Msk                    (_U_(0x1) << MCAN_IE_ARAE_Pos)                 /**< (MCAN_IE) Access to Reserved Address Enable Mask */
+#define MCAN_IE_ARAE                        MCAN_IE_ARAE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_IE_ARAE_Msk instead */
+#define MCAN_IE_MASK                        _U_(0x3FCFFFFF)                                /**< \deprecated (MCAN_IE) Register MASK  (Use MCAN_IE_Msk instead)  */
+#define MCAN_IE_Msk                         _U_(0x3FCFFFFF)                                /**< (MCAN_IE) Register Mask  */
+
+
+/* -------- MCAN_ILS : (MCAN Offset: 0x58) (R/W 32) Interrupt Line Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RF0NL:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Line */
+    uint32_t RF0WL:1;                   /**< bit:      1  Receive FIFO 0 Watermark Reached Interrupt Line */
+    uint32_t RF0FL:1;                   /**< bit:      2  Receive FIFO 0 Full Interrupt Line       */
+    uint32_t RF0LL:1;                   /**< bit:      3  Receive FIFO 0 Message Lost Interrupt Line */
+    uint32_t RF1NL:1;                   /**< bit:      4  Receive FIFO 1 New Message Interrupt Line */
+    uint32_t RF1WL:1;                   /**< bit:      5  Receive FIFO 1 Watermark Reached Interrupt Line */
+    uint32_t RF1FL:1;                   /**< bit:      6  Receive FIFO 1 Full Interrupt Line       */
+    uint32_t RF1LL:1;                   /**< bit:      7  Receive FIFO 1 Message Lost Interrupt Line */
+    uint32_t HPML:1;                    /**< bit:      8  High Priority Message Interrupt Line     */
+    uint32_t TCL:1;                     /**< bit:      9  Transmission Completed Interrupt Line    */
+    uint32_t TCFL:1;                    /**< bit:     10  Transmission Cancellation Finished Interrupt Line */
+    uint32_t TFEL:1;                    /**< bit:     11  Tx FIFO Empty Interrupt Line             */
+    uint32_t TEFNL:1;                   /**< bit:     12  Tx Event FIFO New Entry Interrupt Line   */
+    uint32_t TEFWL:1;                   /**< bit:     13  Tx Event FIFO Watermark Reached Interrupt Line */
+    uint32_t TEFFL:1;                   /**< bit:     14  Tx Event FIFO Full Interrupt Line        */
+    uint32_t TEFLL:1;                   /**< bit:     15  Tx Event FIFO Event Lost Interrupt Line  */
+    uint32_t TSWL:1;                    /**< bit:     16  Timestamp Wraparound Interrupt Line      */
+    uint32_t MRAFL:1;                   /**< bit:     17  Message RAM Access Failure Interrupt Line */
+    uint32_t TOOL:1;                    /**< bit:     18  Timeout Occurred Interrupt Line          */
+    uint32_t DRXL:1;                    /**< bit:     19  Message stored to Dedicated Receive Buffer Interrupt Line */
+    uint32_t :2;                        /**< bit: 20..21  Reserved */
+    uint32_t ELOL:1;                    /**< bit:     22  Error Logging Overflow Interrupt Line    */
+    uint32_t EPL:1;                     /**< bit:     23  Error Passive Interrupt Line             */
+    uint32_t EWL:1;                     /**< bit:     24  Warning Status Interrupt Line            */
+    uint32_t BOL:1;                     /**< bit:     25  Bus_Off Status Interrupt Line            */
+    uint32_t WDIL:1;                    /**< bit:     26  Watchdog Interrupt Line                  */
+    uint32_t PEAL:1;                    /**< bit:     27  Protocol Error in Arbitration Phase Line */
+    uint32_t PEDL:1;                    /**< bit:     28  Protocol Error in Data Phase Line        */
+    uint32_t ARAL:1;                    /**< bit:     29  Access to Reserved Address Line          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ILS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ILS_OFFSET                     (0x58)                                        /**<  (MCAN_ILS) Interrupt Line Select Register  Offset */
+
+#define MCAN_ILS_RF0NL_Pos                  0                                              /**< (MCAN_ILS) Receive FIFO 0 New Message Interrupt Line Position */
+#define MCAN_ILS_RF0NL_Msk                  (_U_(0x1) << MCAN_ILS_RF0NL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 New Message Interrupt Line Mask */
+#define MCAN_ILS_RF0NL                      MCAN_ILS_RF0NL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0NL_Msk instead */
+#define MCAN_ILS_RF0WL_Pos                  1                                              /**< (MCAN_ILS) Receive FIFO 0 Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_RF0WL_Msk                  (_U_(0x1) << MCAN_ILS_RF0WL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_RF0WL                      MCAN_ILS_RF0WL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0WL_Msk instead */
+#define MCAN_ILS_RF0FL_Pos                  2                                              /**< (MCAN_ILS) Receive FIFO 0 Full Interrupt Line Position */
+#define MCAN_ILS_RF0FL_Msk                  (_U_(0x1) << MCAN_ILS_RF0FL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Full Interrupt Line Mask */
+#define MCAN_ILS_RF0FL                      MCAN_ILS_RF0FL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0FL_Msk instead */
+#define MCAN_ILS_RF0LL_Pos                  3                                              /**< (MCAN_ILS) Receive FIFO 0 Message Lost Interrupt Line Position */
+#define MCAN_ILS_RF0LL_Msk                  (_U_(0x1) << MCAN_ILS_RF0LL_Pos)               /**< (MCAN_ILS) Receive FIFO 0 Message Lost Interrupt Line Mask */
+#define MCAN_ILS_RF0LL                      MCAN_ILS_RF0LL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF0LL_Msk instead */
+#define MCAN_ILS_RF1NL_Pos                  4                                              /**< (MCAN_ILS) Receive FIFO 1 New Message Interrupt Line Position */
+#define MCAN_ILS_RF1NL_Msk                  (_U_(0x1) << MCAN_ILS_RF1NL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 New Message Interrupt Line Mask */
+#define MCAN_ILS_RF1NL                      MCAN_ILS_RF1NL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1NL_Msk instead */
+#define MCAN_ILS_RF1WL_Pos                  5                                              /**< (MCAN_ILS) Receive FIFO 1 Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_RF1WL_Msk                  (_U_(0x1) << MCAN_ILS_RF1WL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_RF1WL                      MCAN_ILS_RF1WL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1WL_Msk instead */
+#define MCAN_ILS_RF1FL_Pos                  6                                              /**< (MCAN_ILS) Receive FIFO 1 Full Interrupt Line Position */
+#define MCAN_ILS_RF1FL_Msk                  (_U_(0x1) << MCAN_ILS_RF1FL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Full Interrupt Line Mask */
+#define MCAN_ILS_RF1FL                      MCAN_ILS_RF1FL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1FL_Msk instead */
+#define MCAN_ILS_RF1LL_Pos                  7                                              /**< (MCAN_ILS) Receive FIFO 1 Message Lost Interrupt Line Position */
+#define MCAN_ILS_RF1LL_Msk                  (_U_(0x1) << MCAN_ILS_RF1LL_Pos)               /**< (MCAN_ILS) Receive FIFO 1 Message Lost Interrupt Line Mask */
+#define MCAN_ILS_RF1LL                      MCAN_ILS_RF1LL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_RF1LL_Msk instead */
+#define MCAN_ILS_HPML_Pos                   8                                              /**< (MCAN_ILS) High Priority Message Interrupt Line Position */
+#define MCAN_ILS_HPML_Msk                   (_U_(0x1) << MCAN_ILS_HPML_Pos)                /**< (MCAN_ILS) High Priority Message Interrupt Line Mask */
+#define MCAN_ILS_HPML                       MCAN_ILS_HPML_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_HPML_Msk instead */
+#define MCAN_ILS_TCL_Pos                    9                                              /**< (MCAN_ILS) Transmission Completed Interrupt Line Position */
+#define MCAN_ILS_TCL_Msk                    (_U_(0x1) << MCAN_ILS_TCL_Pos)                 /**< (MCAN_ILS) Transmission Completed Interrupt Line Mask */
+#define MCAN_ILS_TCL                        MCAN_ILS_TCL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TCL_Msk instead */
+#define MCAN_ILS_TCFL_Pos                   10                                             /**< (MCAN_ILS) Transmission Cancellation Finished Interrupt Line Position */
+#define MCAN_ILS_TCFL_Msk                   (_U_(0x1) << MCAN_ILS_TCFL_Pos)                /**< (MCAN_ILS) Transmission Cancellation Finished Interrupt Line Mask */
+#define MCAN_ILS_TCFL                       MCAN_ILS_TCFL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TCFL_Msk instead */
+#define MCAN_ILS_TFEL_Pos                   11                                             /**< (MCAN_ILS) Tx FIFO Empty Interrupt Line Position */
+#define MCAN_ILS_TFEL_Msk                   (_U_(0x1) << MCAN_ILS_TFEL_Pos)                /**< (MCAN_ILS) Tx FIFO Empty Interrupt Line Mask */
+#define MCAN_ILS_TFEL                       MCAN_ILS_TFEL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TFEL_Msk instead */
+#define MCAN_ILS_TEFNL_Pos                  12                                             /**< (MCAN_ILS) Tx Event FIFO New Entry Interrupt Line Position */
+#define MCAN_ILS_TEFNL_Msk                  (_U_(0x1) << MCAN_ILS_TEFNL_Pos)               /**< (MCAN_ILS) Tx Event FIFO New Entry Interrupt Line Mask */
+#define MCAN_ILS_TEFNL                      MCAN_ILS_TEFNL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFNL_Msk instead */
+#define MCAN_ILS_TEFWL_Pos                  13                                             /**< (MCAN_ILS) Tx Event FIFO Watermark Reached Interrupt Line Position */
+#define MCAN_ILS_TEFWL_Msk                  (_U_(0x1) << MCAN_ILS_TEFWL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Watermark Reached Interrupt Line Mask */
+#define MCAN_ILS_TEFWL                      MCAN_ILS_TEFWL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFWL_Msk instead */
+#define MCAN_ILS_TEFFL_Pos                  14                                             /**< (MCAN_ILS) Tx Event FIFO Full Interrupt Line Position */
+#define MCAN_ILS_TEFFL_Msk                  (_U_(0x1) << MCAN_ILS_TEFFL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Full Interrupt Line Mask */
+#define MCAN_ILS_TEFFL                      MCAN_ILS_TEFFL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFFL_Msk instead */
+#define MCAN_ILS_TEFLL_Pos                  15                                             /**< (MCAN_ILS) Tx Event FIFO Event Lost Interrupt Line Position */
+#define MCAN_ILS_TEFLL_Msk                  (_U_(0x1) << MCAN_ILS_TEFLL_Pos)               /**< (MCAN_ILS) Tx Event FIFO Event Lost Interrupt Line Mask */
+#define MCAN_ILS_TEFLL                      MCAN_ILS_TEFLL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TEFLL_Msk instead */
+#define MCAN_ILS_TSWL_Pos                   16                                             /**< (MCAN_ILS) Timestamp Wraparound Interrupt Line Position */
+#define MCAN_ILS_TSWL_Msk                   (_U_(0x1) << MCAN_ILS_TSWL_Pos)                /**< (MCAN_ILS) Timestamp Wraparound Interrupt Line Mask */
+#define MCAN_ILS_TSWL                       MCAN_ILS_TSWL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TSWL_Msk instead */
+#define MCAN_ILS_MRAFL_Pos                  17                                             /**< (MCAN_ILS) Message RAM Access Failure Interrupt Line Position */
+#define MCAN_ILS_MRAFL_Msk                  (_U_(0x1) << MCAN_ILS_MRAFL_Pos)               /**< (MCAN_ILS) Message RAM Access Failure Interrupt Line Mask */
+#define MCAN_ILS_MRAFL                      MCAN_ILS_MRAFL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_MRAFL_Msk instead */
+#define MCAN_ILS_TOOL_Pos                   18                                             /**< (MCAN_ILS) Timeout Occurred Interrupt Line Position */
+#define MCAN_ILS_TOOL_Msk                   (_U_(0x1) << MCAN_ILS_TOOL_Pos)                /**< (MCAN_ILS) Timeout Occurred Interrupt Line Mask */
+#define MCAN_ILS_TOOL                       MCAN_ILS_TOOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_TOOL_Msk instead */
+#define MCAN_ILS_DRXL_Pos                   19                                             /**< (MCAN_ILS) Message stored to Dedicated Receive Buffer Interrupt Line Position */
+#define MCAN_ILS_DRXL_Msk                   (_U_(0x1) << MCAN_ILS_DRXL_Pos)                /**< (MCAN_ILS) Message stored to Dedicated Receive Buffer Interrupt Line Mask */
+#define MCAN_ILS_DRXL                       MCAN_ILS_DRXL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_DRXL_Msk instead */
+#define MCAN_ILS_ELOL_Pos                   22                                             /**< (MCAN_ILS) Error Logging Overflow Interrupt Line Position */
+#define MCAN_ILS_ELOL_Msk                   (_U_(0x1) << MCAN_ILS_ELOL_Pos)                /**< (MCAN_ILS) Error Logging Overflow Interrupt Line Mask */
+#define MCAN_ILS_ELOL                       MCAN_ILS_ELOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_ELOL_Msk instead */
+#define MCAN_ILS_EPL_Pos                    23                                             /**< (MCAN_ILS) Error Passive Interrupt Line Position */
+#define MCAN_ILS_EPL_Msk                    (_U_(0x1) << MCAN_ILS_EPL_Pos)                 /**< (MCAN_ILS) Error Passive Interrupt Line Mask */
+#define MCAN_ILS_EPL                        MCAN_ILS_EPL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_EPL_Msk instead */
+#define MCAN_ILS_EWL_Pos                    24                                             /**< (MCAN_ILS) Warning Status Interrupt Line Position */
+#define MCAN_ILS_EWL_Msk                    (_U_(0x1) << MCAN_ILS_EWL_Pos)                 /**< (MCAN_ILS) Warning Status Interrupt Line Mask */
+#define MCAN_ILS_EWL                        MCAN_ILS_EWL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_EWL_Msk instead */
+#define MCAN_ILS_BOL_Pos                    25                                             /**< (MCAN_ILS) Bus_Off Status Interrupt Line Position */
+#define MCAN_ILS_BOL_Msk                    (_U_(0x1) << MCAN_ILS_BOL_Pos)                 /**< (MCAN_ILS) Bus_Off Status Interrupt Line Mask */
+#define MCAN_ILS_BOL                        MCAN_ILS_BOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_BOL_Msk instead */
+#define MCAN_ILS_WDIL_Pos                   26                                             /**< (MCAN_ILS) Watchdog Interrupt Line Position */
+#define MCAN_ILS_WDIL_Msk                   (_U_(0x1) << MCAN_ILS_WDIL_Pos)                /**< (MCAN_ILS) Watchdog Interrupt Line Mask */
+#define MCAN_ILS_WDIL                       MCAN_ILS_WDIL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_WDIL_Msk instead */
+#define MCAN_ILS_PEAL_Pos                   27                                             /**< (MCAN_ILS) Protocol Error in Arbitration Phase Line Position */
+#define MCAN_ILS_PEAL_Msk                   (_U_(0x1) << MCAN_ILS_PEAL_Pos)                /**< (MCAN_ILS) Protocol Error in Arbitration Phase Line Mask */
+#define MCAN_ILS_PEAL                       MCAN_ILS_PEAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_PEAL_Msk instead */
+#define MCAN_ILS_PEDL_Pos                   28                                             /**< (MCAN_ILS) Protocol Error in Data Phase Line Position */
+#define MCAN_ILS_PEDL_Msk                   (_U_(0x1) << MCAN_ILS_PEDL_Pos)                /**< (MCAN_ILS) Protocol Error in Data Phase Line Mask */
+#define MCAN_ILS_PEDL                       MCAN_ILS_PEDL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_PEDL_Msk instead */
+#define MCAN_ILS_ARAL_Pos                   29                                             /**< (MCAN_ILS) Access to Reserved Address Line Position */
+#define MCAN_ILS_ARAL_Msk                   (_U_(0x1) << MCAN_ILS_ARAL_Pos)                /**< (MCAN_ILS) Access to Reserved Address Line Mask */
+#define MCAN_ILS_ARAL                       MCAN_ILS_ARAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILS_ARAL_Msk instead */
+#define MCAN_ILS_MASK                       _U_(0x3FCFFFFF)                                /**< \deprecated (MCAN_ILS) Register MASK  (Use MCAN_ILS_Msk instead)  */
+#define MCAN_ILS_Msk                        _U_(0x3FCFFFFF)                                /**< (MCAN_ILS) Register Mask  */
+
+
+/* -------- MCAN_ILE : (MCAN Offset: 0x5c) (R/W 32) Interrupt Line Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EINT0:1;                   /**< bit:      0  Enable Interrupt Line 0                  */
+    uint32_t EINT1:1;                   /**< bit:      1  Enable Interrupt Line 1                  */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EINT:2;                    /**< bit:   0..1  Enable Interrupt Line x                  */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_ILE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_ILE_OFFSET                     (0x5C)                                        /**<  (MCAN_ILE) Interrupt Line Enable Register  Offset */
+
+#define MCAN_ILE_EINT0_Pos                  0                                              /**< (MCAN_ILE) Enable Interrupt Line 0 Position */
+#define MCAN_ILE_EINT0_Msk                  (_U_(0x1) << MCAN_ILE_EINT0_Pos)               /**< (MCAN_ILE) Enable Interrupt Line 0 Mask */
+#define MCAN_ILE_EINT0                      MCAN_ILE_EINT0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILE_EINT0_Msk instead */
+#define MCAN_ILE_EINT1_Pos                  1                                              /**< (MCAN_ILE) Enable Interrupt Line 1 Position */
+#define MCAN_ILE_EINT1_Msk                  (_U_(0x1) << MCAN_ILE_EINT1_Pos)               /**< (MCAN_ILE) Enable Interrupt Line 1 Mask */
+#define MCAN_ILE_EINT1                      MCAN_ILE_EINT1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_ILE_EINT1_Msk instead */
+#define MCAN_ILE_MASK                       _U_(0x03)                                      /**< \deprecated (MCAN_ILE) Register MASK  (Use MCAN_ILE_Msk instead)  */
+#define MCAN_ILE_Msk                        _U_(0x03)                                      /**< (MCAN_ILE) Register Mask  */
+
+#define MCAN_ILE_EINT_Pos                   0                                              /**< (MCAN_ILE Position) Enable Interrupt Line x */
+#define MCAN_ILE_EINT_Msk                   (_U_(0x3) << MCAN_ILE_EINT_Pos)                /**< (MCAN_ILE Mask) EINT */
+#define MCAN_ILE_EINT(value)                (MCAN_ILE_EINT_Msk & ((value) << MCAN_ILE_EINT_Pos))  
+
+/* -------- MCAN_GFC : (MCAN Offset: 0x80) (R/W 32) Global Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RRFE:1;                    /**< bit:      0  Reject Remote Frames Extended            */
+    uint32_t RRFS:1;                    /**< bit:      1  Reject Remote Frames Standard            */
+    uint32_t ANFE:2;                    /**< bit:   2..3  Accept Non-matching Frames Extended      */
+    uint32_t ANFS:2;                    /**< bit:   4..5  Accept Non-matching Frames Standard      */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_GFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_GFC_OFFSET                     (0x80)                                        /**<  (MCAN_GFC) Global Filter Configuration Register  Offset */
+
+#define MCAN_GFC_RRFE_Pos                   0                                              /**< (MCAN_GFC) Reject Remote Frames Extended Position */
+#define MCAN_GFC_RRFE_Msk                   (_U_(0x1) << MCAN_GFC_RRFE_Pos)                /**< (MCAN_GFC) Reject Remote Frames Extended Mask */
+#define MCAN_GFC_RRFE                       MCAN_GFC_RRFE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_GFC_RRFE_Msk instead */
+#define   MCAN_GFC_RRFE_FILTER_Val          _U_(0x0)                                       /**< (MCAN_GFC) Filter remote frames with 29-bit extended IDs.  */
+#define   MCAN_GFC_RRFE_REJECT_Val          _U_(0x1)                                       /**< (MCAN_GFC) Reject all remote frames with 29-bit extended IDs.  */
+#define MCAN_GFC_RRFE_FILTER                (MCAN_GFC_RRFE_FILTER_Val << MCAN_GFC_RRFE_Pos)  /**< (MCAN_GFC) Filter remote frames with 29-bit extended IDs. Position  */
+#define MCAN_GFC_RRFE_REJECT                (MCAN_GFC_RRFE_REJECT_Val << MCAN_GFC_RRFE_Pos)  /**< (MCAN_GFC) Reject all remote frames with 29-bit extended IDs. Position  */
+#define MCAN_GFC_RRFS_Pos                   1                                              /**< (MCAN_GFC) Reject Remote Frames Standard Position */
+#define MCAN_GFC_RRFS_Msk                   (_U_(0x1) << MCAN_GFC_RRFS_Pos)                /**< (MCAN_GFC) Reject Remote Frames Standard Mask */
+#define MCAN_GFC_RRFS                       MCAN_GFC_RRFS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_GFC_RRFS_Msk instead */
+#define   MCAN_GFC_RRFS_FILTER_Val          _U_(0x0)                                       /**< (MCAN_GFC) Filter remote frames with 11-bit standard IDs.  */
+#define   MCAN_GFC_RRFS_REJECT_Val          _U_(0x1)                                       /**< (MCAN_GFC) Reject all remote frames with 11-bit standard IDs.  */
+#define MCAN_GFC_RRFS_FILTER                (MCAN_GFC_RRFS_FILTER_Val << MCAN_GFC_RRFS_Pos)  /**< (MCAN_GFC) Filter remote frames with 11-bit standard IDs. Position  */
+#define MCAN_GFC_RRFS_REJECT                (MCAN_GFC_RRFS_REJECT_Val << MCAN_GFC_RRFS_Pos)  /**< (MCAN_GFC) Reject all remote frames with 11-bit standard IDs. Position  */
+#define MCAN_GFC_ANFE_Pos                   2                                              /**< (MCAN_GFC) Accept Non-matching Frames Extended Position */
+#define MCAN_GFC_ANFE_Msk                   (_U_(0x3) << MCAN_GFC_ANFE_Pos)                /**< (MCAN_GFC) Accept Non-matching Frames Extended Mask */
+#define MCAN_GFC_ANFE(value)                (MCAN_GFC_ANFE_Msk & ((value) << MCAN_GFC_ANFE_Pos))
+#define   MCAN_GFC_ANFE_RX_FIFO_0_Val       _U_(0x0)                                       /**< (MCAN_GFC) Accept in Rx FIFO 0  */
+#define   MCAN_GFC_ANFE_RX_FIFO_1_Val       _U_(0x1)                                       /**< (MCAN_GFC) Accept in Rx FIFO 1  */
+#define MCAN_GFC_ANFE_RX_FIFO_0             (MCAN_GFC_ANFE_RX_FIFO_0_Val << MCAN_GFC_ANFE_Pos)  /**< (MCAN_GFC) Accept in Rx FIFO 0 Position  */
+#define MCAN_GFC_ANFE_RX_FIFO_1             (MCAN_GFC_ANFE_RX_FIFO_1_Val << MCAN_GFC_ANFE_Pos)  /**< (MCAN_GFC) Accept in Rx FIFO 1 Position  */
+#define MCAN_GFC_ANFS_Pos                   4                                              /**< (MCAN_GFC) Accept Non-matching Frames Standard Position */
+#define MCAN_GFC_ANFS_Msk                   (_U_(0x3) << MCAN_GFC_ANFS_Pos)                /**< (MCAN_GFC) Accept Non-matching Frames Standard Mask */
+#define MCAN_GFC_ANFS(value)                (MCAN_GFC_ANFS_Msk & ((value) << MCAN_GFC_ANFS_Pos))
+#define   MCAN_GFC_ANFS_RX_FIFO_0_Val       _U_(0x0)                                       /**< (MCAN_GFC) Accept in Rx FIFO 0  */
+#define   MCAN_GFC_ANFS_RX_FIFO_1_Val       _U_(0x1)                                       /**< (MCAN_GFC) Accept in Rx FIFO 1  */
+#define MCAN_GFC_ANFS_RX_FIFO_0             (MCAN_GFC_ANFS_RX_FIFO_0_Val << MCAN_GFC_ANFS_Pos)  /**< (MCAN_GFC) Accept in Rx FIFO 0 Position  */
+#define MCAN_GFC_ANFS_RX_FIFO_1             (MCAN_GFC_ANFS_RX_FIFO_1_Val << MCAN_GFC_ANFS_Pos)  /**< (MCAN_GFC) Accept in Rx FIFO 1 Position  */
+#define MCAN_GFC_MASK                       _U_(0x3F)                                      /**< \deprecated (MCAN_GFC) Register MASK  (Use MCAN_GFC_Msk instead)  */
+#define MCAN_GFC_Msk                        _U_(0x3F)                                      /**< (MCAN_GFC) Register Mask  */
+
+
+/* -------- MCAN_SIDFC : (MCAN Offset: 0x84) (R/W 32) Standard ID Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t FLSSA:14;                  /**< bit:  2..15  Filter List Standard Start Address       */
+    uint32_t LSS:8;                     /**< bit: 16..23  List Size Standard                       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_SIDFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_SIDFC_OFFSET                   (0x84)                                        /**<  (MCAN_SIDFC) Standard ID Filter Configuration Register  Offset */
+
+#define MCAN_SIDFC_FLSSA_Pos                2                                              /**< (MCAN_SIDFC) Filter List Standard Start Address Position */
+#define MCAN_SIDFC_FLSSA_Msk                (_U_(0x3FFF) << MCAN_SIDFC_FLSSA_Pos)          /**< (MCAN_SIDFC) Filter List Standard Start Address Mask */
+#define MCAN_SIDFC_FLSSA(value)             (MCAN_SIDFC_FLSSA_Msk & ((value) << MCAN_SIDFC_FLSSA_Pos))
+#define MCAN_SIDFC_LSS_Pos                  16                                             /**< (MCAN_SIDFC) List Size Standard Position */
+#define MCAN_SIDFC_LSS_Msk                  (_U_(0xFF) << MCAN_SIDFC_LSS_Pos)              /**< (MCAN_SIDFC) List Size Standard Mask */
+#define MCAN_SIDFC_LSS(value)               (MCAN_SIDFC_LSS_Msk & ((value) << MCAN_SIDFC_LSS_Pos))
+#define MCAN_SIDFC_MASK                     _U_(0xFFFFFC)                                  /**< \deprecated (MCAN_SIDFC) Register MASK  (Use MCAN_SIDFC_Msk instead)  */
+#define MCAN_SIDFC_Msk                      _U_(0xFFFFFC)                                  /**< (MCAN_SIDFC) Register Mask  */
+
+
+/* -------- MCAN_XIDFC : (MCAN Offset: 0x88) (R/W 32) Extended ID Filter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t FLESA:14;                  /**< bit:  2..15  Filter List Extended Start Address       */
+    uint32_t LSE:7;                     /**< bit: 16..22  List Size Extended                       */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFC_OFFSET                   (0x88)                                        /**<  (MCAN_XIDFC) Extended ID Filter Configuration Register  Offset */
+
+#define MCAN_XIDFC_FLESA_Pos                2                                              /**< (MCAN_XIDFC) Filter List Extended Start Address Position */
+#define MCAN_XIDFC_FLESA_Msk                (_U_(0x3FFF) << MCAN_XIDFC_FLESA_Pos)          /**< (MCAN_XIDFC) Filter List Extended Start Address Mask */
+#define MCAN_XIDFC_FLESA(value)             (MCAN_XIDFC_FLESA_Msk & ((value) << MCAN_XIDFC_FLESA_Pos))
+#define MCAN_XIDFC_LSE_Pos                  16                                             /**< (MCAN_XIDFC) List Size Extended Position */
+#define MCAN_XIDFC_LSE_Msk                  (_U_(0x7F) << MCAN_XIDFC_LSE_Pos)              /**< (MCAN_XIDFC) List Size Extended Mask */
+#define MCAN_XIDFC_LSE(value)               (MCAN_XIDFC_LSE_Msk & ((value) << MCAN_XIDFC_LSE_Pos))
+#define MCAN_XIDFC_MASK                     _U_(0x7FFFFC)                                  /**< \deprecated (MCAN_XIDFC) Register MASK  (Use MCAN_XIDFC_Msk instead)  */
+#define MCAN_XIDFC_Msk                      _U_(0x7FFFFC)                                  /**< (MCAN_XIDFC) Register Mask  */
+
+
+/* -------- MCAN_XIDAM : (MCAN Offset: 0x90) (R/W 32) Extended ID AND Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EIDM:29;                   /**< bit:  0..28  Extended ID Mask                         */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDAM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDAM_OFFSET                   (0x90)                                        /**<  (MCAN_XIDAM) Extended ID AND Mask Register  Offset */
+
+#define MCAN_XIDAM_EIDM_Pos                 0                                              /**< (MCAN_XIDAM) Extended ID Mask Position */
+#define MCAN_XIDAM_EIDM_Msk                 (_U_(0x1FFFFFFF) << MCAN_XIDAM_EIDM_Pos)       /**< (MCAN_XIDAM) Extended ID Mask Mask */
+#define MCAN_XIDAM_EIDM(value)              (MCAN_XIDAM_EIDM_Msk & ((value) << MCAN_XIDAM_EIDM_Pos))
+#define MCAN_XIDAM_MASK                     _U_(0x1FFFFFFF)                                /**< \deprecated (MCAN_XIDAM) Register MASK  (Use MCAN_XIDAM_Msk instead)  */
+#define MCAN_XIDAM_Msk                      _U_(0x1FFFFFFF)                                /**< (MCAN_XIDAM) Register Mask  */
+
+
+/* -------- MCAN_HPMS : (MCAN Offset: 0x94) (R/ 32) High Priority Message Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIDX:6;                    /**< bit:   0..5  Buffer Index                             */
+    uint32_t MSI:2;                     /**< bit:   6..7  Message Storage Indicator                */
+    uint32_t FIDX:7;                    /**< bit:  8..14  Filter Index                             */
+    uint32_t FLST:1;                    /**< bit:     15  Filter List                              */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_HPMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_HPMS_OFFSET                    (0x94)                                        /**<  (MCAN_HPMS) High Priority Message Status Register  Offset */
+
+#define MCAN_HPMS_BIDX_Pos                  0                                              /**< (MCAN_HPMS) Buffer Index Position */
+#define MCAN_HPMS_BIDX_Msk                  (_U_(0x3F) << MCAN_HPMS_BIDX_Pos)              /**< (MCAN_HPMS) Buffer Index Mask */
+#define MCAN_HPMS_BIDX(value)               (MCAN_HPMS_BIDX_Msk & ((value) << MCAN_HPMS_BIDX_Pos))
+#define MCAN_HPMS_MSI_Pos                   6                                              /**< (MCAN_HPMS) Message Storage Indicator Position */
+#define MCAN_HPMS_MSI_Msk                   (_U_(0x3) << MCAN_HPMS_MSI_Pos)                /**< (MCAN_HPMS) Message Storage Indicator Mask */
+#define MCAN_HPMS_MSI(value)                (MCAN_HPMS_MSI_Msk & ((value) << MCAN_HPMS_MSI_Pos))
+#define   MCAN_HPMS_MSI_NO_FIFO_SEL_Val     _U_(0x0)                                       /**< (MCAN_HPMS) No FIFO selected.  */
+#define   MCAN_HPMS_MSI_LOST_Val            _U_(0x1)                                       /**< (MCAN_HPMS) FIFO message lost.  */
+#define   MCAN_HPMS_MSI_FIFO_0_Val          _U_(0x2)                                       /**< (MCAN_HPMS) Message stored in FIFO 0.  */
+#define   MCAN_HPMS_MSI_FIFO_1_Val          _U_(0x3)                                       /**< (MCAN_HPMS) Message stored in FIFO 1.  */
+#define MCAN_HPMS_MSI_NO_FIFO_SEL           (MCAN_HPMS_MSI_NO_FIFO_SEL_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) No FIFO selected. Position  */
+#define MCAN_HPMS_MSI_LOST                  (MCAN_HPMS_MSI_LOST_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) FIFO message lost. Position  */
+#define MCAN_HPMS_MSI_FIFO_0                (MCAN_HPMS_MSI_FIFO_0_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) Message stored in FIFO 0. Position  */
+#define MCAN_HPMS_MSI_FIFO_1                (MCAN_HPMS_MSI_FIFO_1_Val << MCAN_HPMS_MSI_Pos)  /**< (MCAN_HPMS) Message stored in FIFO 1. Position  */
+#define MCAN_HPMS_FIDX_Pos                  8                                              /**< (MCAN_HPMS) Filter Index Position */
+#define MCAN_HPMS_FIDX_Msk                  (_U_(0x7F) << MCAN_HPMS_FIDX_Pos)              /**< (MCAN_HPMS) Filter Index Mask */
+#define MCAN_HPMS_FIDX(value)               (MCAN_HPMS_FIDX_Msk & ((value) << MCAN_HPMS_FIDX_Pos))
+#define MCAN_HPMS_FLST_Pos                  15                                             /**< (MCAN_HPMS) Filter List Position */
+#define MCAN_HPMS_FLST_Msk                  (_U_(0x1) << MCAN_HPMS_FLST_Pos)               /**< (MCAN_HPMS) Filter List Mask */
+#define MCAN_HPMS_FLST                      MCAN_HPMS_FLST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_HPMS_FLST_Msk instead */
+#define MCAN_HPMS_MASK                      _U_(0xFFFF)                                    /**< \deprecated (MCAN_HPMS) Register MASK  (Use MCAN_HPMS_Msk instead)  */
+#define MCAN_HPMS_Msk                       _U_(0xFFFF)                                    /**< (MCAN_HPMS) Register Mask  */
+
+
+/* -------- MCAN_NDAT1 : (MCAN Offset: 0x98) (R/W 32) New Data 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ND0:1;                     /**< bit:      0  New Data                                 */
+    uint32_t ND1:1;                     /**< bit:      1  New Data                                 */
+    uint32_t ND2:1;                     /**< bit:      2  New Data                                 */
+    uint32_t ND3:1;                     /**< bit:      3  New Data                                 */
+    uint32_t ND4:1;                     /**< bit:      4  New Data                                 */
+    uint32_t ND5:1;                     /**< bit:      5  New Data                                 */
+    uint32_t ND6:1;                     /**< bit:      6  New Data                                 */
+    uint32_t ND7:1;                     /**< bit:      7  New Data                                 */
+    uint32_t ND8:1;                     /**< bit:      8  New Data                                 */
+    uint32_t ND9:1;                     /**< bit:      9  New Data                                 */
+    uint32_t ND10:1;                    /**< bit:     10  New Data                                 */
+    uint32_t ND11:1;                    /**< bit:     11  New Data                                 */
+    uint32_t ND12:1;                    /**< bit:     12  New Data                                 */
+    uint32_t ND13:1;                    /**< bit:     13  New Data                                 */
+    uint32_t ND14:1;                    /**< bit:     14  New Data                                 */
+    uint32_t ND15:1;                    /**< bit:     15  New Data                                 */
+    uint32_t ND16:1;                    /**< bit:     16  New Data                                 */
+    uint32_t ND17:1;                    /**< bit:     17  New Data                                 */
+    uint32_t ND18:1;                    /**< bit:     18  New Data                                 */
+    uint32_t ND19:1;                    /**< bit:     19  New Data                                 */
+    uint32_t ND20:1;                    /**< bit:     20  New Data                                 */
+    uint32_t ND21:1;                    /**< bit:     21  New Data                                 */
+    uint32_t ND22:1;                    /**< bit:     22  New Data                                 */
+    uint32_t ND23:1;                    /**< bit:     23  New Data                                 */
+    uint32_t ND24:1;                    /**< bit:     24  New Data                                 */
+    uint32_t ND25:1;                    /**< bit:     25  New Data                                 */
+    uint32_t ND26:1;                    /**< bit:     26  New Data                                 */
+    uint32_t ND27:1;                    /**< bit:     27  New Data                                 */
+    uint32_t ND28:1;                    /**< bit:     28  New Data                                 */
+    uint32_t ND29:1;                    /**< bit:     29  New Data                                 */
+    uint32_t ND30:1;                    /**< bit:     30  New Data                                 */
+    uint32_t ND31:1;                    /**< bit:     31  New Data                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ND:32;                     /**< bit:  0..31  New Data                                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_NDAT1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_NDAT1_OFFSET                   (0x98)                                        /**<  (MCAN_NDAT1) New Data 1 Register  Offset */
+
+#define MCAN_NDAT1_ND0_Pos                  0                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND0_Msk                  (_U_(0x1) << MCAN_NDAT1_ND0_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND0                      MCAN_NDAT1_ND0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND0_Msk instead */
+#define MCAN_NDAT1_ND1_Pos                  1                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND1_Msk                  (_U_(0x1) << MCAN_NDAT1_ND1_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND1                      MCAN_NDAT1_ND1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND1_Msk instead */
+#define MCAN_NDAT1_ND2_Pos                  2                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND2_Msk                  (_U_(0x1) << MCAN_NDAT1_ND2_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND2                      MCAN_NDAT1_ND2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND2_Msk instead */
+#define MCAN_NDAT1_ND3_Pos                  3                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND3_Msk                  (_U_(0x1) << MCAN_NDAT1_ND3_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND3                      MCAN_NDAT1_ND3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND3_Msk instead */
+#define MCAN_NDAT1_ND4_Pos                  4                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND4_Msk                  (_U_(0x1) << MCAN_NDAT1_ND4_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND4                      MCAN_NDAT1_ND4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND4_Msk instead */
+#define MCAN_NDAT1_ND5_Pos                  5                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND5_Msk                  (_U_(0x1) << MCAN_NDAT1_ND5_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND5                      MCAN_NDAT1_ND5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND5_Msk instead */
+#define MCAN_NDAT1_ND6_Pos                  6                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND6_Msk                  (_U_(0x1) << MCAN_NDAT1_ND6_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND6                      MCAN_NDAT1_ND6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND6_Msk instead */
+#define MCAN_NDAT1_ND7_Pos                  7                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND7_Msk                  (_U_(0x1) << MCAN_NDAT1_ND7_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND7                      MCAN_NDAT1_ND7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND7_Msk instead */
+#define MCAN_NDAT1_ND8_Pos                  8                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND8_Msk                  (_U_(0x1) << MCAN_NDAT1_ND8_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND8                      MCAN_NDAT1_ND8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND8_Msk instead */
+#define MCAN_NDAT1_ND9_Pos                  9                                              /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND9_Msk                  (_U_(0x1) << MCAN_NDAT1_ND9_Pos)               /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND9                      MCAN_NDAT1_ND9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND9_Msk instead */
+#define MCAN_NDAT1_ND10_Pos                 10                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND10_Msk                 (_U_(0x1) << MCAN_NDAT1_ND10_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND10                     MCAN_NDAT1_ND10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND10_Msk instead */
+#define MCAN_NDAT1_ND11_Pos                 11                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND11_Msk                 (_U_(0x1) << MCAN_NDAT1_ND11_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND11                     MCAN_NDAT1_ND11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND11_Msk instead */
+#define MCAN_NDAT1_ND12_Pos                 12                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND12_Msk                 (_U_(0x1) << MCAN_NDAT1_ND12_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND12                     MCAN_NDAT1_ND12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND12_Msk instead */
+#define MCAN_NDAT1_ND13_Pos                 13                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND13_Msk                 (_U_(0x1) << MCAN_NDAT1_ND13_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND13                     MCAN_NDAT1_ND13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND13_Msk instead */
+#define MCAN_NDAT1_ND14_Pos                 14                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND14_Msk                 (_U_(0x1) << MCAN_NDAT1_ND14_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND14                     MCAN_NDAT1_ND14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND14_Msk instead */
+#define MCAN_NDAT1_ND15_Pos                 15                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND15_Msk                 (_U_(0x1) << MCAN_NDAT1_ND15_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND15                     MCAN_NDAT1_ND15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND15_Msk instead */
+#define MCAN_NDAT1_ND16_Pos                 16                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND16_Msk                 (_U_(0x1) << MCAN_NDAT1_ND16_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND16                     MCAN_NDAT1_ND16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND16_Msk instead */
+#define MCAN_NDAT1_ND17_Pos                 17                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND17_Msk                 (_U_(0x1) << MCAN_NDAT1_ND17_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND17                     MCAN_NDAT1_ND17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND17_Msk instead */
+#define MCAN_NDAT1_ND18_Pos                 18                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND18_Msk                 (_U_(0x1) << MCAN_NDAT1_ND18_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND18                     MCAN_NDAT1_ND18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND18_Msk instead */
+#define MCAN_NDAT1_ND19_Pos                 19                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND19_Msk                 (_U_(0x1) << MCAN_NDAT1_ND19_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND19                     MCAN_NDAT1_ND19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND19_Msk instead */
+#define MCAN_NDAT1_ND20_Pos                 20                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND20_Msk                 (_U_(0x1) << MCAN_NDAT1_ND20_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND20                     MCAN_NDAT1_ND20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND20_Msk instead */
+#define MCAN_NDAT1_ND21_Pos                 21                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND21_Msk                 (_U_(0x1) << MCAN_NDAT1_ND21_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND21                     MCAN_NDAT1_ND21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND21_Msk instead */
+#define MCAN_NDAT1_ND22_Pos                 22                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND22_Msk                 (_U_(0x1) << MCAN_NDAT1_ND22_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND22                     MCAN_NDAT1_ND22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND22_Msk instead */
+#define MCAN_NDAT1_ND23_Pos                 23                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND23_Msk                 (_U_(0x1) << MCAN_NDAT1_ND23_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND23                     MCAN_NDAT1_ND23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND23_Msk instead */
+#define MCAN_NDAT1_ND24_Pos                 24                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND24_Msk                 (_U_(0x1) << MCAN_NDAT1_ND24_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND24                     MCAN_NDAT1_ND24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND24_Msk instead */
+#define MCAN_NDAT1_ND25_Pos                 25                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND25_Msk                 (_U_(0x1) << MCAN_NDAT1_ND25_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND25                     MCAN_NDAT1_ND25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND25_Msk instead */
+#define MCAN_NDAT1_ND26_Pos                 26                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND26_Msk                 (_U_(0x1) << MCAN_NDAT1_ND26_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND26                     MCAN_NDAT1_ND26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND26_Msk instead */
+#define MCAN_NDAT1_ND27_Pos                 27                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND27_Msk                 (_U_(0x1) << MCAN_NDAT1_ND27_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND27                     MCAN_NDAT1_ND27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND27_Msk instead */
+#define MCAN_NDAT1_ND28_Pos                 28                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND28_Msk                 (_U_(0x1) << MCAN_NDAT1_ND28_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND28                     MCAN_NDAT1_ND28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND28_Msk instead */
+#define MCAN_NDAT1_ND29_Pos                 29                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND29_Msk                 (_U_(0x1) << MCAN_NDAT1_ND29_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND29                     MCAN_NDAT1_ND29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND29_Msk instead */
+#define MCAN_NDAT1_ND30_Pos                 30                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND30_Msk                 (_U_(0x1) << MCAN_NDAT1_ND30_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND30                     MCAN_NDAT1_ND30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND30_Msk instead */
+#define MCAN_NDAT1_ND31_Pos                 31                                             /**< (MCAN_NDAT1) New Data Position */
+#define MCAN_NDAT1_ND31_Msk                 (_U_(0x1) << MCAN_NDAT1_ND31_Pos)              /**< (MCAN_NDAT1) New Data Mask */
+#define MCAN_NDAT1_ND31                     MCAN_NDAT1_ND31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT1_ND31_Msk instead */
+#define MCAN_NDAT1_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_NDAT1) Register MASK  (Use MCAN_NDAT1_Msk instead)  */
+#define MCAN_NDAT1_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_NDAT1) Register Mask  */
+
+#define MCAN_NDAT1_ND_Pos                   0                                              /**< (MCAN_NDAT1 Position) New Data */
+#define MCAN_NDAT1_ND_Msk                   (_U_(0xFFFFFFFF) << MCAN_NDAT1_ND_Pos)         /**< (MCAN_NDAT1 Mask) ND */
+#define MCAN_NDAT1_ND(value)                (MCAN_NDAT1_ND_Msk & ((value) << MCAN_NDAT1_ND_Pos))  
+
+/* -------- MCAN_NDAT2 : (MCAN Offset: 0x9c) (R/W 32) New Data 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ND32:1;                    /**< bit:      0  New Data                                 */
+    uint32_t ND33:1;                    /**< bit:      1  New Data                                 */
+    uint32_t ND34:1;                    /**< bit:      2  New Data                                 */
+    uint32_t ND35:1;                    /**< bit:      3  New Data                                 */
+    uint32_t ND36:1;                    /**< bit:      4  New Data                                 */
+    uint32_t ND37:1;                    /**< bit:      5  New Data                                 */
+    uint32_t ND38:1;                    /**< bit:      6  New Data                                 */
+    uint32_t ND39:1;                    /**< bit:      7  New Data                                 */
+    uint32_t ND40:1;                    /**< bit:      8  New Data                                 */
+    uint32_t ND41:1;                    /**< bit:      9  New Data                                 */
+    uint32_t ND42:1;                    /**< bit:     10  New Data                                 */
+    uint32_t ND43:1;                    /**< bit:     11  New Data                                 */
+    uint32_t ND44:1;                    /**< bit:     12  New Data                                 */
+    uint32_t ND45:1;                    /**< bit:     13  New Data                                 */
+    uint32_t ND46:1;                    /**< bit:     14  New Data                                 */
+    uint32_t ND47:1;                    /**< bit:     15  New Data                                 */
+    uint32_t ND48:1;                    /**< bit:     16  New Data                                 */
+    uint32_t ND49:1;                    /**< bit:     17  New Data                                 */
+    uint32_t ND50:1;                    /**< bit:     18  New Data                                 */
+    uint32_t ND51:1;                    /**< bit:     19  New Data                                 */
+    uint32_t ND52:1;                    /**< bit:     20  New Data                                 */
+    uint32_t ND53:1;                    /**< bit:     21  New Data                                 */
+    uint32_t ND54:1;                    /**< bit:     22  New Data                                 */
+    uint32_t ND55:1;                    /**< bit:     23  New Data                                 */
+    uint32_t ND56:1;                    /**< bit:     24  New Data                                 */
+    uint32_t ND57:1;                    /**< bit:     25  New Data                                 */
+    uint32_t ND58:1;                    /**< bit:     26  New Data                                 */
+    uint32_t ND59:1;                    /**< bit:     27  New Data                                 */
+    uint32_t ND60:1;                    /**< bit:     28  New Data                                 */
+    uint32_t ND61:1;                    /**< bit:     29  New Data                                 */
+    uint32_t ND62:1;                    /**< bit:     30  New Data                                 */
+    uint32_t ND63:1;                    /**< bit:     31  New Data                                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ND:32;                     /**< bit:  0..31  New Data                                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_NDAT2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_NDAT2_OFFSET                   (0x9C)                                        /**<  (MCAN_NDAT2) New Data 2 Register  Offset */
+
+#define MCAN_NDAT2_ND32_Pos                 0                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND32_Msk                 (_U_(0x1) << MCAN_NDAT2_ND32_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND32                     MCAN_NDAT2_ND32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND32_Msk instead */
+#define MCAN_NDAT2_ND33_Pos                 1                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND33_Msk                 (_U_(0x1) << MCAN_NDAT2_ND33_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND33                     MCAN_NDAT2_ND33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND33_Msk instead */
+#define MCAN_NDAT2_ND34_Pos                 2                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND34_Msk                 (_U_(0x1) << MCAN_NDAT2_ND34_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND34                     MCAN_NDAT2_ND34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND34_Msk instead */
+#define MCAN_NDAT2_ND35_Pos                 3                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND35_Msk                 (_U_(0x1) << MCAN_NDAT2_ND35_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND35                     MCAN_NDAT2_ND35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND35_Msk instead */
+#define MCAN_NDAT2_ND36_Pos                 4                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND36_Msk                 (_U_(0x1) << MCAN_NDAT2_ND36_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND36                     MCAN_NDAT2_ND36_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND36_Msk instead */
+#define MCAN_NDAT2_ND37_Pos                 5                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND37_Msk                 (_U_(0x1) << MCAN_NDAT2_ND37_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND37                     MCAN_NDAT2_ND37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND37_Msk instead */
+#define MCAN_NDAT2_ND38_Pos                 6                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND38_Msk                 (_U_(0x1) << MCAN_NDAT2_ND38_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND38                     MCAN_NDAT2_ND38_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND38_Msk instead */
+#define MCAN_NDAT2_ND39_Pos                 7                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND39_Msk                 (_U_(0x1) << MCAN_NDAT2_ND39_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND39                     MCAN_NDAT2_ND39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND39_Msk instead */
+#define MCAN_NDAT2_ND40_Pos                 8                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND40_Msk                 (_U_(0x1) << MCAN_NDAT2_ND40_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND40                     MCAN_NDAT2_ND40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND40_Msk instead */
+#define MCAN_NDAT2_ND41_Pos                 9                                              /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND41_Msk                 (_U_(0x1) << MCAN_NDAT2_ND41_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND41                     MCAN_NDAT2_ND41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND41_Msk instead */
+#define MCAN_NDAT2_ND42_Pos                 10                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND42_Msk                 (_U_(0x1) << MCAN_NDAT2_ND42_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND42                     MCAN_NDAT2_ND42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND42_Msk instead */
+#define MCAN_NDAT2_ND43_Pos                 11                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND43_Msk                 (_U_(0x1) << MCAN_NDAT2_ND43_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND43                     MCAN_NDAT2_ND43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND43_Msk instead */
+#define MCAN_NDAT2_ND44_Pos                 12                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND44_Msk                 (_U_(0x1) << MCAN_NDAT2_ND44_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND44                     MCAN_NDAT2_ND44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND44_Msk instead */
+#define MCAN_NDAT2_ND45_Pos                 13                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND45_Msk                 (_U_(0x1) << MCAN_NDAT2_ND45_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND45                     MCAN_NDAT2_ND45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND45_Msk instead */
+#define MCAN_NDAT2_ND46_Pos                 14                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND46_Msk                 (_U_(0x1) << MCAN_NDAT2_ND46_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND46                     MCAN_NDAT2_ND46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND46_Msk instead */
+#define MCAN_NDAT2_ND47_Pos                 15                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND47_Msk                 (_U_(0x1) << MCAN_NDAT2_ND47_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND47                     MCAN_NDAT2_ND47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND47_Msk instead */
+#define MCAN_NDAT2_ND48_Pos                 16                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND48_Msk                 (_U_(0x1) << MCAN_NDAT2_ND48_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND48                     MCAN_NDAT2_ND48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND48_Msk instead */
+#define MCAN_NDAT2_ND49_Pos                 17                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND49_Msk                 (_U_(0x1) << MCAN_NDAT2_ND49_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND49                     MCAN_NDAT2_ND49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND49_Msk instead */
+#define MCAN_NDAT2_ND50_Pos                 18                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND50_Msk                 (_U_(0x1) << MCAN_NDAT2_ND50_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND50                     MCAN_NDAT2_ND50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND50_Msk instead */
+#define MCAN_NDAT2_ND51_Pos                 19                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND51_Msk                 (_U_(0x1) << MCAN_NDAT2_ND51_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND51                     MCAN_NDAT2_ND51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND51_Msk instead */
+#define MCAN_NDAT2_ND52_Pos                 20                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND52_Msk                 (_U_(0x1) << MCAN_NDAT2_ND52_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND52                     MCAN_NDAT2_ND52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND52_Msk instead */
+#define MCAN_NDAT2_ND53_Pos                 21                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND53_Msk                 (_U_(0x1) << MCAN_NDAT2_ND53_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND53                     MCAN_NDAT2_ND53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND53_Msk instead */
+#define MCAN_NDAT2_ND54_Pos                 22                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND54_Msk                 (_U_(0x1) << MCAN_NDAT2_ND54_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND54                     MCAN_NDAT2_ND54_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND54_Msk instead */
+#define MCAN_NDAT2_ND55_Pos                 23                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND55_Msk                 (_U_(0x1) << MCAN_NDAT2_ND55_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND55                     MCAN_NDAT2_ND55_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND55_Msk instead */
+#define MCAN_NDAT2_ND56_Pos                 24                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND56_Msk                 (_U_(0x1) << MCAN_NDAT2_ND56_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND56                     MCAN_NDAT2_ND56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND56_Msk instead */
+#define MCAN_NDAT2_ND57_Pos                 25                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND57_Msk                 (_U_(0x1) << MCAN_NDAT2_ND57_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND57                     MCAN_NDAT2_ND57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND57_Msk instead */
+#define MCAN_NDAT2_ND58_Pos                 26                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND58_Msk                 (_U_(0x1) << MCAN_NDAT2_ND58_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND58                     MCAN_NDAT2_ND58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND58_Msk instead */
+#define MCAN_NDAT2_ND59_Pos                 27                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND59_Msk                 (_U_(0x1) << MCAN_NDAT2_ND59_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND59                     MCAN_NDAT2_ND59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND59_Msk instead */
+#define MCAN_NDAT2_ND60_Pos                 28                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND60_Msk                 (_U_(0x1) << MCAN_NDAT2_ND60_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND60                     MCAN_NDAT2_ND60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND60_Msk instead */
+#define MCAN_NDAT2_ND61_Pos                 29                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND61_Msk                 (_U_(0x1) << MCAN_NDAT2_ND61_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND61                     MCAN_NDAT2_ND61_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND61_Msk instead */
+#define MCAN_NDAT2_ND62_Pos                 30                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND62_Msk                 (_U_(0x1) << MCAN_NDAT2_ND62_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND62                     MCAN_NDAT2_ND62_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND62_Msk instead */
+#define MCAN_NDAT2_ND63_Pos                 31                                             /**< (MCAN_NDAT2) New Data Position */
+#define MCAN_NDAT2_ND63_Msk                 (_U_(0x1) << MCAN_NDAT2_ND63_Pos)              /**< (MCAN_NDAT2) New Data Mask */
+#define MCAN_NDAT2_ND63                     MCAN_NDAT2_ND63_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_NDAT2_ND63_Msk instead */
+#define MCAN_NDAT2_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_NDAT2) Register MASK  (Use MCAN_NDAT2_Msk instead)  */
+#define MCAN_NDAT2_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_NDAT2) Register Mask  */
+
+#define MCAN_NDAT2_ND_Pos                   0                                              /**< (MCAN_NDAT2 Position) New Data */
+#define MCAN_NDAT2_ND_Msk                   (_U_(0xFFFFFFFF) << MCAN_NDAT2_ND_Pos)         /**< (MCAN_NDAT2 Mask) ND */
+#define MCAN_NDAT2_ND(value)                (MCAN_NDAT2_ND_Msk & ((value) << MCAN_NDAT2_ND_Pos))  
+
+/* -------- MCAN_RXF0C : (MCAN Offset: 0xa0) (R/W 32) Receive FIFO 0 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t F0SA:14;                   /**< bit:  2..15  Receive FIFO 0 Start Address             */
+    uint32_t F0S:7;                     /**< bit: 16..22  Receive FIFO 0 Start Address             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t F0WM:7;                    /**< bit: 24..30  Receive FIFO 0 Watermark                 */
+    uint32_t F0OM:1;                    /**< bit:     31  FIFO 0 Operation Mode                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0C_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0C_OFFSET                   (0xA0)                                        /**<  (MCAN_RXF0C) Receive FIFO 0 Configuration Register  Offset */
+
+#define MCAN_RXF0C_F0SA_Pos                 2                                              /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Position */
+#define MCAN_RXF0C_F0SA_Msk                 (_U_(0x3FFF) << MCAN_RXF0C_F0SA_Pos)           /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Mask */
+#define MCAN_RXF0C_F0SA(value)              (MCAN_RXF0C_F0SA_Msk & ((value) << MCAN_RXF0C_F0SA_Pos))
+#define MCAN_RXF0C_F0S_Pos                  16                                             /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Position */
+#define MCAN_RXF0C_F0S_Msk                  (_U_(0x7F) << MCAN_RXF0C_F0S_Pos)              /**< (MCAN_RXF0C) Receive FIFO 0 Start Address Mask */
+#define MCAN_RXF0C_F0S(value)               (MCAN_RXF0C_F0S_Msk & ((value) << MCAN_RXF0C_F0S_Pos))
+#define MCAN_RXF0C_F0WM_Pos                 24                                             /**< (MCAN_RXF0C) Receive FIFO 0 Watermark Position */
+#define MCAN_RXF0C_F0WM_Msk                 (_U_(0x7F) << MCAN_RXF0C_F0WM_Pos)             /**< (MCAN_RXF0C) Receive FIFO 0 Watermark Mask */
+#define MCAN_RXF0C_F0WM(value)              (MCAN_RXF0C_F0WM_Msk & ((value) << MCAN_RXF0C_F0WM_Pos))
+#define MCAN_RXF0C_F0OM_Pos                 31                                             /**< (MCAN_RXF0C) FIFO 0 Operation Mode Position */
+#define MCAN_RXF0C_F0OM_Msk                 (_U_(0x1) << MCAN_RXF0C_F0OM_Pos)              /**< (MCAN_RXF0C) FIFO 0 Operation Mode Mask */
+#define MCAN_RXF0C_F0OM                     MCAN_RXF0C_F0OM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0C_F0OM_Msk instead */
+#define MCAN_RXF0C_MASK                     _U_(0xFF7FFFFC)                                /**< \deprecated (MCAN_RXF0C) Register MASK  (Use MCAN_RXF0C_Msk instead)  */
+#define MCAN_RXF0C_Msk                      _U_(0xFF7FFFFC)                                /**< (MCAN_RXF0C) Register Mask  */
+
+
+/* -------- MCAN_RXF0S : (MCAN Offset: 0xa4) (R/ 32) Receive FIFO 0 Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0FL:7;                    /**< bit:   0..6  Receive FIFO 0 Fill Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t F0GI:6;                    /**< bit:  8..13  Receive FIFO 0 Get Index                 */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t F0PI:6;                    /**< bit: 16..21  Receive FIFO 0 Put Index                 */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t F0F:1;                     /**< bit:     24  Receive FIFO 0 Fill Level                */
+    uint32_t RF0L:1;                    /**< bit:     25  Receive FIFO 0 Message Lost              */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0S_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0S_OFFSET                   (0xA4)                                        /**<  (MCAN_RXF0S) Receive FIFO 0 Status Register  Offset */
+
+#define MCAN_RXF0S_F0FL_Pos                 0                                              /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Position */
+#define MCAN_RXF0S_F0FL_Msk                 (_U_(0x7F) << MCAN_RXF0S_F0FL_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Mask */
+#define MCAN_RXF0S_F0FL(value)              (MCAN_RXF0S_F0FL_Msk & ((value) << MCAN_RXF0S_F0FL_Pos))
+#define MCAN_RXF0S_F0GI_Pos                 8                                              /**< (MCAN_RXF0S) Receive FIFO 0 Get Index Position */
+#define MCAN_RXF0S_F0GI_Msk                 (_U_(0x3F) << MCAN_RXF0S_F0GI_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Get Index Mask */
+#define MCAN_RXF0S_F0GI(value)              (MCAN_RXF0S_F0GI_Msk & ((value) << MCAN_RXF0S_F0GI_Pos))
+#define MCAN_RXF0S_F0PI_Pos                 16                                             /**< (MCAN_RXF0S) Receive FIFO 0 Put Index Position */
+#define MCAN_RXF0S_F0PI_Msk                 (_U_(0x3F) << MCAN_RXF0S_F0PI_Pos)             /**< (MCAN_RXF0S) Receive FIFO 0 Put Index Mask */
+#define MCAN_RXF0S_F0PI(value)              (MCAN_RXF0S_F0PI_Msk & ((value) << MCAN_RXF0S_F0PI_Pos))
+#define MCAN_RXF0S_F0F_Pos                  24                                             /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Position */
+#define MCAN_RXF0S_F0F_Msk                  (_U_(0x1) << MCAN_RXF0S_F0F_Pos)               /**< (MCAN_RXF0S) Receive FIFO 0 Fill Level Mask */
+#define MCAN_RXF0S_F0F                      MCAN_RXF0S_F0F_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0S_F0F_Msk instead */
+#define MCAN_RXF0S_RF0L_Pos                 25                                             /**< (MCAN_RXF0S) Receive FIFO 0 Message Lost Position */
+#define MCAN_RXF0S_RF0L_Msk                 (_U_(0x1) << MCAN_RXF0S_RF0L_Pos)              /**< (MCAN_RXF0S) Receive FIFO 0 Message Lost Mask */
+#define MCAN_RXF0S_RF0L                     MCAN_RXF0S_RF0L_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0S_RF0L_Msk instead */
+#define MCAN_RXF0S_MASK                     _U_(0x33F3F7F)                                 /**< \deprecated (MCAN_RXF0S) Register MASK  (Use MCAN_RXF0S_Msk instead)  */
+#define MCAN_RXF0S_Msk                      _U_(0x33F3F7F)                                 /**< (MCAN_RXF0S) Register Mask  */
+
+
+/* -------- MCAN_RXF0A : (MCAN Offset: 0xa8) (R/W 32) Receive FIFO 0 Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0AI:6;                    /**< bit:   0..5  Receive FIFO 0 Acknowledge Index         */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0A_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0A_OFFSET                   (0xA8)                                        /**<  (MCAN_RXF0A) Receive FIFO 0 Acknowledge Register  Offset */
+
+#define MCAN_RXF0A_F0AI_Pos                 0                                              /**< (MCAN_RXF0A) Receive FIFO 0 Acknowledge Index Position */
+#define MCAN_RXF0A_F0AI_Msk                 (_U_(0x3F) << MCAN_RXF0A_F0AI_Pos)             /**< (MCAN_RXF0A) Receive FIFO 0 Acknowledge Index Mask */
+#define MCAN_RXF0A_F0AI(value)              (MCAN_RXF0A_F0AI_Msk & ((value) << MCAN_RXF0A_F0AI_Pos))
+#define MCAN_RXF0A_MASK                     _U_(0x3F)                                      /**< \deprecated (MCAN_RXF0A) Register MASK  (Use MCAN_RXF0A_Msk instead)  */
+#define MCAN_RXF0A_Msk                      _U_(0x3F)                                      /**< (MCAN_RXF0A) Register Mask  */
+
+
+/* -------- MCAN_RXBC : (MCAN Offset: 0xac) (R/W 32) Receive Rx Buffer Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RBSA:14;                   /**< bit:  2..15  Receive Buffer Start Address             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBC_OFFSET                    (0xAC)                                        /**<  (MCAN_RXBC) Receive Rx Buffer Configuration Register  Offset */
+
+#define MCAN_RXBC_RBSA_Pos                  2                                              /**< (MCAN_RXBC) Receive Buffer Start Address Position */
+#define MCAN_RXBC_RBSA_Msk                  (_U_(0x3FFF) << MCAN_RXBC_RBSA_Pos)            /**< (MCAN_RXBC) Receive Buffer Start Address Mask */
+#define MCAN_RXBC_RBSA(value)               (MCAN_RXBC_RBSA_Msk & ((value) << MCAN_RXBC_RBSA_Pos))
+#define MCAN_RXBC_MASK                      _U_(0xFFFC)                                    /**< \deprecated (MCAN_RXBC) Register MASK  (Use MCAN_RXBC_Msk instead)  */
+#define MCAN_RXBC_Msk                       _U_(0xFFFC)                                    /**< (MCAN_RXBC) Register Mask  */
+
+
+/* -------- MCAN_RXF1C : (MCAN Offset: 0xb0) (R/W 32) Receive FIFO 1 Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t F1SA:14;                   /**< bit:  2..15  Receive FIFO 1 Start Address             */
+    uint32_t F1S:7;                     /**< bit: 16..22  Receive FIFO 1 Start Address             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t F1WM:7;                    /**< bit: 24..30  Receive FIFO 1 Watermark                 */
+    uint32_t F1OM:1;                    /**< bit:     31  FIFO 1 Operation Mode                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1C_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1C_OFFSET                   (0xB0)                                        /**<  (MCAN_RXF1C) Receive FIFO 1 Configuration Register  Offset */
+
+#define MCAN_RXF1C_F1SA_Pos                 2                                              /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Position */
+#define MCAN_RXF1C_F1SA_Msk                 (_U_(0x3FFF) << MCAN_RXF1C_F1SA_Pos)           /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Mask */
+#define MCAN_RXF1C_F1SA(value)              (MCAN_RXF1C_F1SA_Msk & ((value) << MCAN_RXF1C_F1SA_Pos))
+#define MCAN_RXF1C_F1S_Pos                  16                                             /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Position */
+#define MCAN_RXF1C_F1S_Msk                  (_U_(0x7F) << MCAN_RXF1C_F1S_Pos)              /**< (MCAN_RXF1C) Receive FIFO 1 Start Address Mask */
+#define MCAN_RXF1C_F1S(value)               (MCAN_RXF1C_F1S_Msk & ((value) << MCAN_RXF1C_F1S_Pos))
+#define MCAN_RXF1C_F1WM_Pos                 24                                             /**< (MCAN_RXF1C) Receive FIFO 1 Watermark Position */
+#define MCAN_RXF1C_F1WM_Msk                 (_U_(0x7F) << MCAN_RXF1C_F1WM_Pos)             /**< (MCAN_RXF1C) Receive FIFO 1 Watermark Mask */
+#define MCAN_RXF1C_F1WM(value)              (MCAN_RXF1C_F1WM_Msk & ((value) << MCAN_RXF1C_F1WM_Pos))
+#define MCAN_RXF1C_F1OM_Pos                 31                                             /**< (MCAN_RXF1C) FIFO 1 Operation Mode Position */
+#define MCAN_RXF1C_F1OM_Msk                 (_U_(0x1) << MCAN_RXF1C_F1OM_Pos)              /**< (MCAN_RXF1C) FIFO 1 Operation Mode Mask */
+#define MCAN_RXF1C_F1OM                     MCAN_RXF1C_F1OM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1C_F1OM_Msk instead */
+#define MCAN_RXF1C_MASK                     _U_(0xFF7FFFFC)                                /**< \deprecated (MCAN_RXF1C) Register MASK  (Use MCAN_RXF1C_Msk instead)  */
+#define MCAN_RXF1C_Msk                      _U_(0xFF7FFFFC)                                /**< (MCAN_RXF1C) Register Mask  */
+
+
+/* -------- MCAN_RXF1S : (MCAN Offset: 0xb4) (R/ 32) Receive FIFO 1 Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F1FL:7;                    /**< bit:   0..6  Receive FIFO 1 Fill Level                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t F1GI:6;                    /**< bit:  8..13  Receive FIFO 1 Get Index                 */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t F1PI:6;                    /**< bit: 16..21  Receive FIFO 1 Put Index                 */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t F1F:1;                     /**< bit:     24  Receive FIFO 1 Fill Level                */
+    uint32_t RF1L:1;                    /**< bit:     25  Receive FIFO 1 Message Lost              */
+    uint32_t :4;                        /**< bit: 26..29  Reserved */
+    uint32_t DMS:2;                     /**< bit: 30..31  Debug Message Status                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1S_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1S_OFFSET                   (0xB4)                                        /**<  (MCAN_RXF1S) Receive FIFO 1 Status Register  Offset */
+
+#define MCAN_RXF1S_F1FL_Pos                 0                                              /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Position */
+#define MCAN_RXF1S_F1FL_Msk                 (_U_(0x7F) << MCAN_RXF1S_F1FL_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Mask */
+#define MCAN_RXF1S_F1FL(value)              (MCAN_RXF1S_F1FL_Msk & ((value) << MCAN_RXF1S_F1FL_Pos))
+#define MCAN_RXF1S_F1GI_Pos                 8                                              /**< (MCAN_RXF1S) Receive FIFO 1 Get Index Position */
+#define MCAN_RXF1S_F1GI_Msk                 (_U_(0x3F) << MCAN_RXF1S_F1GI_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Get Index Mask */
+#define MCAN_RXF1S_F1GI(value)              (MCAN_RXF1S_F1GI_Msk & ((value) << MCAN_RXF1S_F1GI_Pos))
+#define MCAN_RXF1S_F1PI_Pos                 16                                             /**< (MCAN_RXF1S) Receive FIFO 1 Put Index Position */
+#define MCAN_RXF1S_F1PI_Msk                 (_U_(0x3F) << MCAN_RXF1S_F1PI_Pos)             /**< (MCAN_RXF1S) Receive FIFO 1 Put Index Mask */
+#define MCAN_RXF1S_F1PI(value)              (MCAN_RXF1S_F1PI_Msk & ((value) << MCAN_RXF1S_F1PI_Pos))
+#define MCAN_RXF1S_F1F_Pos                  24                                             /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Position */
+#define MCAN_RXF1S_F1F_Msk                  (_U_(0x1) << MCAN_RXF1S_F1F_Pos)               /**< (MCAN_RXF1S) Receive FIFO 1 Fill Level Mask */
+#define MCAN_RXF1S_F1F                      MCAN_RXF1S_F1F_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1S_F1F_Msk instead */
+#define MCAN_RXF1S_RF1L_Pos                 25                                             /**< (MCAN_RXF1S) Receive FIFO 1 Message Lost Position */
+#define MCAN_RXF1S_RF1L_Msk                 (_U_(0x1) << MCAN_RXF1S_RF1L_Pos)              /**< (MCAN_RXF1S) Receive FIFO 1 Message Lost Mask */
+#define MCAN_RXF1S_RF1L                     MCAN_RXF1S_RF1L_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1S_RF1L_Msk instead */
+#define MCAN_RXF1S_DMS_Pos                  30                                             /**< (MCAN_RXF1S) Debug Message Status Position */
+#define MCAN_RXF1S_DMS_Msk                  (_U_(0x3) << MCAN_RXF1S_DMS_Pos)               /**< (MCAN_RXF1S) Debug Message Status Mask */
+#define MCAN_RXF1S_DMS(value)               (MCAN_RXF1S_DMS_Msk & ((value) << MCAN_RXF1S_DMS_Pos))
+#define   MCAN_RXF1S_DMS_IDLE_Val           _U_(0x0)                                       /**< (MCAN_RXF1S) Idle state, wait for reception of debug messages, DMA request is cleared.  */
+#define   MCAN_RXF1S_DMS_MSG_A_Val          _U_(0x1)                                       /**< (MCAN_RXF1S) Debug message A received.  */
+#define   MCAN_RXF1S_DMS_MSG_AB_Val         _U_(0x2)                                       /**< (MCAN_RXF1S) Debug messages A, B received.  */
+#define   MCAN_RXF1S_DMS_MSG_ABC_Val        _U_(0x3)                                       /**< (MCAN_RXF1S) Debug messages A, B, C received, DMA request is set.  */
+#define MCAN_RXF1S_DMS_IDLE                 (MCAN_RXF1S_DMS_IDLE_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Idle state, wait for reception of debug messages, DMA request is cleared. Position  */
+#define MCAN_RXF1S_DMS_MSG_A                (MCAN_RXF1S_DMS_MSG_A_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug message A received. Position  */
+#define MCAN_RXF1S_DMS_MSG_AB               (MCAN_RXF1S_DMS_MSG_AB_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug messages A, B received. Position  */
+#define MCAN_RXF1S_DMS_MSG_ABC              (MCAN_RXF1S_DMS_MSG_ABC_Val << MCAN_RXF1S_DMS_Pos)  /**< (MCAN_RXF1S) Debug messages A, B, C received, DMA request is set. Position  */
+#define MCAN_RXF1S_MASK                     _U_(0xC33F3F7F)                                /**< \deprecated (MCAN_RXF1S) Register MASK  (Use MCAN_RXF1S_Msk instead)  */
+#define MCAN_RXF1S_Msk                      _U_(0xC33F3F7F)                                /**< (MCAN_RXF1S) Register Mask  */
+
+
+/* -------- MCAN_RXF1A : (MCAN Offset: 0xb8) (R/W 32) Receive FIFO 1 Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F1AI:6;                    /**< bit:   0..5  Receive FIFO 1 Acknowledge Index         */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1A_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1A_OFFSET                   (0xB8)                                        /**<  (MCAN_RXF1A) Receive FIFO 1 Acknowledge Register  Offset */
+
+#define MCAN_RXF1A_F1AI_Pos                 0                                              /**< (MCAN_RXF1A) Receive FIFO 1 Acknowledge Index Position */
+#define MCAN_RXF1A_F1AI_Msk                 (_U_(0x3F) << MCAN_RXF1A_F1AI_Pos)             /**< (MCAN_RXF1A) Receive FIFO 1 Acknowledge Index Mask */
+#define MCAN_RXF1A_F1AI(value)              (MCAN_RXF1A_F1AI_Msk & ((value) << MCAN_RXF1A_F1AI_Pos))
+#define MCAN_RXF1A_MASK                     _U_(0x3F)                                      /**< \deprecated (MCAN_RXF1A) Register MASK  (Use MCAN_RXF1A_Msk instead)  */
+#define MCAN_RXF1A_Msk                      _U_(0x3F)                                      /**< (MCAN_RXF1A) Register Mask  */
+
+
+/* -------- MCAN_RXESC : (MCAN Offset: 0xbc) (R/W 32) Receive Buffer / FIFO Element Size Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t F0DS:3;                    /**< bit:   0..2  Receive FIFO 0 Data Field Size           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t F1DS:3;                    /**< bit:   4..6  Receive FIFO 1 Data Field Size           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t RBDS:3;                    /**< bit:  8..10  Receive Buffer Data Field Size           */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXESC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXESC_OFFSET                   (0xBC)                                        /**<  (MCAN_RXESC) Receive Buffer / FIFO Element Size Configuration Register  Offset */
+
+#define MCAN_RXESC_F0DS_Pos                 0                                              /**< (MCAN_RXESC) Receive FIFO 0 Data Field Size Position */
+#define MCAN_RXESC_F0DS_Msk                 (_U_(0x7) << MCAN_RXESC_F0DS_Pos)              /**< (MCAN_RXESC) Receive FIFO 0 Data Field Size Mask */
+#define MCAN_RXESC_F0DS(value)              (MCAN_RXESC_F0DS_Msk & ((value) << MCAN_RXESC_F0DS_Pos))
+#define   MCAN_RXESC_F0DS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_F0DS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_F0DS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_F0DS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_F0DS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_F0DS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_F0DS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_F0DS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_F0DS_8_BYTE              (MCAN_RXESC_F0DS_8_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_F0DS_12_BYTE             (MCAN_RXESC_F0DS_12_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_F0DS_16_BYTE             (MCAN_RXESC_F0DS_16_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_F0DS_20_BYTE             (MCAN_RXESC_F0DS_20_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_F0DS_24_BYTE             (MCAN_RXESC_F0DS_24_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_F0DS_32_BYTE             (MCAN_RXESC_F0DS_32_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_F0DS_48_BYTE             (MCAN_RXESC_F0DS_48_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_F0DS_64_BYTE             (MCAN_RXESC_F0DS_64_BYTE_Val << MCAN_RXESC_F0DS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_F1DS_Pos                 4                                              /**< (MCAN_RXESC) Receive FIFO 1 Data Field Size Position */
+#define MCAN_RXESC_F1DS_Msk                 (_U_(0x7) << MCAN_RXESC_F1DS_Pos)              /**< (MCAN_RXESC) Receive FIFO 1 Data Field Size Mask */
+#define MCAN_RXESC_F1DS(value)              (MCAN_RXESC_F1DS_Msk & ((value) << MCAN_RXESC_F1DS_Pos))
+#define   MCAN_RXESC_F1DS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_F1DS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_F1DS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_F1DS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_F1DS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_F1DS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_F1DS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_F1DS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_F1DS_8_BYTE              (MCAN_RXESC_F1DS_8_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_F1DS_12_BYTE             (MCAN_RXESC_F1DS_12_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_F1DS_16_BYTE             (MCAN_RXESC_F1DS_16_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_F1DS_20_BYTE             (MCAN_RXESC_F1DS_20_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_F1DS_24_BYTE             (MCAN_RXESC_F1DS_24_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_F1DS_32_BYTE             (MCAN_RXESC_F1DS_32_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_F1DS_48_BYTE             (MCAN_RXESC_F1DS_48_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_F1DS_64_BYTE             (MCAN_RXESC_F1DS_64_BYTE_Val << MCAN_RXESC_F1DS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_RBDS_Pos                 8                                              /**< (MCAN_RXESC) Receive Buffer Data Field Size Position */
+#define MCAN_RXESC_RBDS_Msk                 (_U_(0x7) << MCAN_RXESC_RBDS_Pos)              /**< (MCAN_RXESC) Receive Buffer Data Field Size Mask */
+#define MCAN_RXESC_RBDS(value)              (MCAN_RXESC_RBDS_Msk & ((value) << MCAN_RXESC_RBDS_Pos))
+#define   MCAN_RXESC_RBDS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_RXESC) 8-byte data field  */
+#define   MCAN_RXESC_RBDS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_RXESC) 12-byte data field  */
+#define   MCAN_RXESC_RBDS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_RXESC) 16-byte data field  */
+#define   MCAN_RXESC_RBDS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_RXESC) 20-byte data field  */
+#define   MCAN_RXESC_RBDS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_RXESC) 24-byte data field  */
+#define   MCAN_RXESC_RBDS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_RXESC) 32-byte data field  */
+#define   MCAN_RXESC_RBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_RXESC) 48-byte data field  */
+#define   MCAN_RXESC_RBDS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_RXESC) 64-byte data field  */
+#define MCAN_RXESC_RBDS_8_BYTE              (MCAN_RXESC_RBDS_8_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 8-byte data field Position  */
+#define MCAN_RXESC_RBDS_12_BYTE             (MCAN_RXESC_RBDS_12_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 12-byte data field Position  */
+#define MCAN_RXESC_RBDS_16_BYTE             (MCAN_RXESC_RBDS_16_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 16-byte data field Position  */
+#define MCAN_RXESC_RBDS_20_BYTE             (MCAN_RXESC_RBDS_20_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 20-byte data field Position  */
+#define MCAN_RXESC_RBDS_24_BYTE             (MCAN_RXESC_RBDS_24_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 24-byte data field Position  */
+#define MCAN_RXESC_RBDS_32_BYTE             (MCAN_RXESC_RBDS_32_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 32-byte data field Position  */
+#define MCAN_RXESC_RBDS_48_BYTE             (MCAN_RXESC_RBDS_48_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 48-byte data field Position  */
+#define MCAN_RXESC_RBDS_64_BYTE             (MCAN_RXESC_RBDS_64_BYTE_Val << MCAN_RXESC_RBDS_Pos)  /**< (MCAN_RXESC) 64-byte data field Position  */
+#define MCAN_RXESC_MASK                     _U_(0x777)                                     /**< \deprecated (MCAN_RXESC) Register MASK  (Use MCAN_RXESC_Msk instead)  */
+#define MCAN_RXESC_Msk                      _U_(0x777)                                     /**< (MCAN_RXESC) Register Mask  */
+
+
+/* -------- MCAN_TXBC : (MCAN Offset: 0xc0) (R/W 32) Transmit Buffer Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TBSA:14;                   /**< bit:  2..15  Tx Buffers Start Address                 */
+    uint32_t NDTB:6;                    /**< bit: 16..21  Number of Dedicated Transmit Buffers     */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t TFQS:6;                    /**< bit: 24..29  Transmit FIFO/Queue Size                 */
+    uint32_t TFQM:1;                    /**< bit:     30  Tx FIFO/Queue Mode                       */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBC_OFFSET                    (0xC0)                                        /**<  (MCAN_TXBC) Transmit Buffer Configuration Register  Offset */
+
+#define MCAN_TXBC_TBSA_Pos                  2                                              /**< (MCAN_TXBC) Tx Buffers Start Address Position */
+#define MCAN_TXBC_TBSA_Msk                  (_U_(0x3FFF) << MCAN_TXBC_TBSA_Pos)            /**< (MCAN_TXBC) Tx Buffers Start Address Mask */
+#define MCAN_TXBC_TBSA(value)               (MCAN_TXBC_TBSA_Msk & ((value) << MCAN_TXBC_TBSA_Pos))
+#define MCAN_TXBC_NDTB_Pos                  16                                             /**< (MCAN_TXBC) Number of Dedicated Transmit Buffers Position */
+#define MCAN_TXBC_NDTB_Msk                  (_U_(0x3F) << MCAN_TXBC_NDTB_Pos)              /**< (MCAN_TXBC) Number of Dedicated Transmit Buffers Mask */
+#define MCAN_TXBC_NDTB(value)               (MCAN_TXBC_NDTB_Msk & ((value) << MCAN_TXBC_NDTB_Pos))
+#define MCAN_TXBC_TFQS_Pos                  24                                             /**< (MCAN_TXBC) Transmit FIFO/Queue Size Position */
+#define MCAN_TXBC_TFQS_Msk                  (_U_(0x3F) << MCAN_TXBC_TFQS_Pos)              /**< (MCAN_TXBC) Transmit FIFO/Queue Size Mask */
+#define MCAN_TXBC_TFQS(value)               (MCAN_TXBC_TFQS_Msk & ((value) << MCAN_TXBC_TFQS_Pos))
+#define MCAN_TXBC_TFQM_Pos                  30                                             /**< (MCAN_TXBC) Tx FIFO/Queue Mode Position */
+#define MCAN_TXBC_TFQM_Msk                  (_U_(0x1) << MCAN_TXBC_TFQM_Pos)               /**< (MCAN_TXBC) Tx FIFO/Queue Mode Mask */
+#define MCAN_TXBC_TFQM                      MCAN_TXBC_TFQM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBC_TFQM_Msk instead */
+#define MCAN_TXBC_MASK                      _U_(0x7F3FFFFC)                                /**< \deprecated (MCAN_TXBC) Register MASK  (Use MCAN_TXBC_Msk instead)  */
+#define MCAN_TXBC_Msk                       _U_(0x7F3FFFFC)                                /**< (MCAN_TXBC) Register Mask  */
+
+
+/* -------- MCAN_TXFQS : (MCAN Offset: 0xc4) (R/ 32) Transmit FIFO/Queue Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TFFL:6;                    /**< bit:   0..5  Tx FIFO Free Level                       */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t TFGI:5;                    /**< bit:  8..12  Tx FIFO Get Index                        */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TFQPI:5;                   /**< bit: 16..20  Tx FIFO/Queue Put Index                  */
+    uint32_t TFQF:1;                    /**< bit:     21  Tx FIFO/Queue Full                       */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXFQS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXFQS_OFFSET                   (0xC4)                                        /**<  (MCAN_TXFQS) Transmit FIFO/Queue Status Register  Offset */
+
+#define MCAN_TXFQS_TFFL_Pos                 0                                              /**< (MCAN_TXFQS) Tx FIFO Free Level Position */
+#define MCAN_TXFQS_TFFL_Msk                 (_U_(0x3F) << MCAN_TXFQS_TFFL_Pos)             /**< (MCAN_TXFQS) Tx FIFO Free Level Mask */
+#define MCAN_TXFQS_TFFL(value)              (MCAN_TXFQS_TFFL_Msk & ((value) << MCAN_TXFQS_TFFL_Pos))
+#define MCAN_TXFQS_TFGI_Pos                 8                                              /**< (MCAN_TXFQS) Tx FIFO Get Index Position */
+#define MCAN_TXFQS_TFGI_Msk                 (_U_(0x1F) << MCAN_TXFQS_TFGI_Pos)             /**< (MCAN_TXFQS) Tx FIFO Get Index Mask */
+#define MCAN_TXFQS_TFGI(value)              (MCAN_TXFQS_TFGI_Msk & ((value) << MCAN_TXFQS_TFGI_Pos))
+#define MCAN_TXFQS_TFQPI_Pos                16                                             /**< (MCAN_TXFQS) Tx FIFO/Queue Put Index Position */
+#define MCAN_TXFQS_TFQPI_Msk                (_U_(0x1F) << MCAN_TXFQS_TFQPI_Pos)            /**< (MCAN_TXFQS) Tx FIFO/Queue Put Index Mask */
+#define MCAN_TXFQS_TFQPI(value)             (MCAN_TXFQS_TFQPI_Msk & ((value) << MCAN_TXFQS_TFQPI_Pos))
+#define MCAN_TXFQS_TFQF_Pos                 21                                             /**< (MCAN_TXFQS) Tx FIFO/Queue Full Position */
+#define MCAN_TXFQS_TFQF_Msk                 (_U_(0x1) << MCAN_TXFQS_TFQF_Pos)              /**< (MCAN_TXFQS) Tx FIFO/Queue Full Mask */
+#define MCAN_TXFQS_TFQF                     MCAN_TXFQS_TFQF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXFQS_TFQF_Msk instead */
+#define MCAN_TXFQS_MASK                     _U_(0x3F1F3F)                                  /**< \deprecated (MCAN_TXFQS) Register MASK  (Use MCAN_TXFQS_Msk instead)  */
+#define MCAN_TXFQS_Msk                      _U_(0x3F1F3F)                                  /**< (MCAN_TXFQS) Register Mask  */
+
+
+/* -------- MCAN_TXESC : (MCAN Offset: 0xc8) (R/W 32) Transmit Buffer Element Size Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TBDS:3;                    /**< bit:   0..2  Tx Buffer Data Field Size                */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXESC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXESC_OFFSET                   (0xC8)                                        /**<  (MCAN_TXESC) Transmit Buffer Element Size Configuration Register  Offset */
+
+#define MCAN_TXESC_TBDS_Pos                 0                                              /**< (MCAN_TXESC) Tx Buffer Data Field Size Position */
+#define MCAN_TXESC_TBDS_Msk                 (_U_(0x7) << MCAN_TXESC_TBDS_Pos)              /**< (MCAN_TXESC) Tx Buffer Data Field Size Mask */
+#define MCAN_TXESC_TBDS(value)              (MCAN_TXESC_TBDS_Msk & ((value) << MCAN_TXESC_TBDS_Pos))
+#define   MCAN_TXESC_TBDS_8_BYTE_Val        _U_(0x0)                                       /**< (MCAN_TXESC) 8-byte data field  */
+#define   MCAN_TXESC_TBDS_12_BYTE_Val       _U_(0x1)                                       /**< (MCAN_TXESC) 12-byte data field  */
+#define   MCAN_TXESC_TBDS_16_BYTE_Val       _U_(0x2)                                       /**< (MCAN_TXESC) 16-byte data field  */
+#define   MCAN_TXESC_TBDS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_TXESC) 20-byte data field  */
+#define   MCAN_TXESC_TBDS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_TXESC) 24-byte data field  */
+#define   MCAN_TXESC_TBDS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_TXESC) 32-byte data field  */
+#define   MCAN_TXESC_TBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_TXESC) 48-byte data field  */
+#define   MCAN_TXESC_TBDS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_TXESC) 64-byte data field  */
+#define MCAN_TXESC_TBDS_8_BYTE              (MCAN_TXESC_TBDS_8_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 8-byte data field Position  */
+#define MCAN_TXESC_TBDS_12_BYTE             (MCAN_TXESC_TBDS_12_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 12-byte data field Position  */
+#define MCAN_TXESC_TBDS_16_BYTE             (MCAN_TXESC_TBDS_16_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 16-byte data field Position  */
+#define MCAN_TXESC_TBDS_20_BYTE             (MCAN_TXESC_TBDS_20_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 20-byte data field Position  */
+#define MCAN_TXESC_TBDS_24_BYTE             (MCAN_TXESC_TBDS_24_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 24-byte data field Position  */
+#define MCAN_TXESC_TBDS_32_BYTE             (MCAN_TXESC_TBDS_32_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 32-byte data field Position  */
+#define MCAN_TXESC_TBDS_48_BYTE             (MCAN_TXESC_TBDS_48_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 48-byte data field Position  */
+#define MCAN_TXESC_TBDS_64_BYTE             (MCAN_TXESC_TBDS_64_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 64-byte data field Position  */
+#define MCAN_TXESC_MASK                     _U_(0x07)                                      /**< \deprecated (MCAN_TXESC) Register MASK  (Use MCAN_TXESC_Msk instead)  */
+#define MCAN_TXESC_Msk                      _U_(0x07)                                      /**< (MCAN_TXESC) Register Mask  */
+
+
+/* -------- MCAN_TXBRP : (MCAN Offset: 0xcc) (R/ 32) Transmit Buffer Request Pending Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRP0:1;                    /**< bit:      0  Transmission Request Pending for Buffer 0 */
+    uint32_t TRP1:1;                    /**< bit:      1  Transmission Request Pending for Buffer 1 */
+    uint32_t TRP2:1;                    /**< bit:      2  Transmission Request Pending for Buffer 2 */
+    uint32_t TRP3:1;                    /**< bit:      3  Transmission Request Pending for Buffer 3 */
+    uint32_t TRP4:1;                    /**< bit:      4  Transmission Request Pending for Buffer 4 */
+    uint32_t TRP5:1;                    /**< bit:      5  Transmission Request Pending for Buffer 5 */
+    uint32_t TRP6:1;                    /**< bit:      6  Transmission Request Pending for Buffer 6 */
+    uint32_t TRP7:1;                    /**< bit:      7  Transmission Request Pending for Buffer 7 */
+    uint32_t TRP8:1;                    /**< bit:      8  Transmission Request Pending for Buffer 8 */
+    uint32_t TRP9:1;                    /**< bit:      9  Transmission Request Pending for Buffer 9 */
+    uint32_t TRP10:1;                   /**< bit:     10  Transmission Request Pending for Buffer 10 */
+    uint32_t TRP11:1;                   /**< bit:     11  Transmission Request Pending for Buffer 11 */
+    uint32_t TRP12:1;                   /**< bit:     12  Transmission Request Pending for Buffer 12 */
+    uint32_t TRP13:1;                   /**< bit:     13  Transmission Request Pending for Buffer 13 */
+    uint32_t TRP14:1;                   /**< bit:     14  Transmission Request Pending for Buffer 14 */
+    uint32_t TRP15:1;                   /**< bit:     15  Transmission Request Pending for Buffer 15 */
+    uint32_t TRP16:1;                   /**< bit:     16  Transmission Request Pending for Buffer 16 */
+    uint32_t TRP17:1;                   /**< bit:     17  Transmission Request Pending for Buffer 17 */
+    uint32_t TRP18:1;                   /**< bit:     18  Transmission Request Pending for Buffer 18 */
+    uint32_t TRP19:1;                   /**< bit:     19  Transmission Request Pending for Buffer 19 */
+    uint32_t TRP20:1;                   /**< bit:     20  Transmission Request Pending for Buffer 20 */
+    uint32_t TRP21:1;                   /**< bit:     21  Transmission Request Pending for Buffer 21 */
+    uint32_t TRP22:1;                   /**< bit:     22  Transmission Request Pending for Buffer 22 */
+    uint32_t TRP23:1;                   /**< bit:     23  Transmission Request Pending for Buffer 23 */
+    uint32_t TRP24:1;                   /**< bit:     24  Transmission Request Pending for Buffer 24 */
+    uint32_t TRP25:1;                   /**< bit:     25  Transmission Request Pending for Buffer 25 */
+    uint32_t TRP26:1;                   /**< bit:     26  Transmission Request Pending for Buffer 26 */
+    uint32_t TRP27:1;                   /**< bit:     27  Transmission Request Pending for Buffer 27 */
+    uint32_t TRP28:1;                   /**< bit:     28  Transmission Request Pending for Buffer 28 */
+    uint32_t TRP29:1;                   /**< bit:     29  Transmission Request Pending for Buffer 29 */
+    uint32_t TRP30:1;                   /**< bit:     30  Transmission Request Pending for Buffer 30 */
+    uint32_t TRP31:1;                   /**< bit:     31  Transmission Request Pending for Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TRP:32;                    /**< bit:  0..31  Transmission Request Pending for Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBRP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBRP_OFFSET                   (0xCC)                                        /**<  (MCAN_TXBRP) Transmit Buffer Request Pending Register  Offset */
+
+#define MCAN_TXBRP_TRP0_Pos                 0                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 0 Position */
+#define MCAN_TXBRP_TRP0_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP0_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 0 Mask */
+#define MCAN_TXBRP_TRP0                     MCAN_TXBRP_TRP0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP0_Msk instead */
+#define MCAN_TXBRP_TRP1_Pos                 1                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 1 Position */
+#define MCAN_TXBRP_TRP1_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP1_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 1 Mask */
+#define MCAN_TXBRP_TRP1                     MCAN_TXBRP_TRP1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP1_Msk instead */
+#define MCAN_TXBRP_TRP2_Pos                 2                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 2 Position */
+#define MCAN_TXBRP_TRP2_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP2_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 2 Mask */
+#define MCAN_TXBRP_TRP2                     MCAN_TXBRP_TRP2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP2_Msk instead */
+#define MCAN_TXBRP_TRP3_Pos                 3                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 3 Position */
+#define MCAN_TXBRP_TRP3_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP3_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 3 Mask */
+#define MCAN_TXBRP_TRP3                     MCAN_TXBRP_TRP3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP3_Msk instead */
+#define MCAN_TXBRP_TRP4_Pos                 4                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 4 Position */
+#define MCAN_TXBRP_TRP4_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP4_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 4 Mask */
+#define MCAN_TXBRP_TRP4                     MCAN_TXBRP_TRP4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP4_Msk instead */
+#define MCAN_TXBRP_TRP5_Pos                 5                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 5 Position */
+#define MCAN_TXBRP_TRP5_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP5_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 5 Mask */
+#define MCAN_TXBRP_TRP5                     MCAN_TXBRP_TRP5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP5_Msk instead */
+#define MCAN_TXBRP_TRP6_Pos                 6                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 6 Position */
+#define MCAN_TXBRP_TRP6_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP6_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 6 Mask */
+#define MCAN_TXBRP_TRP6                     MCAN_TXBRP_TRP6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP6_Msk instead */
+#define MCAN_TXBRP_TRP7_Pos                 7                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 7 Position */
+#define MCAN_TXBRP_TRP7_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP7_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 7 Mask */
+#define MCAN_TXBRP_TRP7                     MCAN_TXBRP_TRP7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP7_Msk instead */
+#define MCAN_TXBRP_TRP8_Pos                 8                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 8 Position */
+#define MCAN_TXBRP_TRP8_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP8_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 8 Mask */
+#define MCAN_TXBRP_TRP8                     MCAN_TXBRP_TRP8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP8_Msk instead */
+#define MCAN_TXBRP_TRP9_Pos                 9                                              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 9 Position */
+#define MCAN_TXBRP_TRP9_Msk                 (_U_(0x1) << MCAN_TXBRP_TRP9_Pos)              /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 9 Mask */
+#define MCAN_TXBRP_TRP9                     MCAN_TXBRP_TRP9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP9_Msk instead */
+#define MCAN_TXBRP_TRP10_Pos                10                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 10 Position */
+#define MCAN_TXBRP_TRP10_Msk                (_U_(0x1) << MCAN_TXBRP_TRP10_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 10 Mask */
+#define MCAN_TXBRP_TRP10                    MCAN_TXBRP_TRP10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP10_Msk instead */
+#define MCAN_TXBRP_TRP11_Pos                11                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 11 Position */
+#define MCAN_TXBRP_TRP11_Msk                (_U_(0x1) << MCAN_TXBRP_TRP11_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 11 Mask */
+#define MCAN_TXBRP_TRP11                    MCAN_TXBRP_TRP11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP11_Msk instead */
+#define MCAN_TXBRP_TRP12_Pos                12                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 12 Position */
+#define MCAN_TXBRP_TRP12_Msk                (_U_(0x1) << MCAN_TXBRP_TRP12_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 12 Mask */
+#define MCAN_TXBRP_TRP12                    MCAN_TXBRP_TRP12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP12_Msk instead */
+#define MCAN_TXBRP_TRP13_Pos                13                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 13 Position */
+#define MCAN_TXBRP_TRP13_Msk                (_U_(0x1) << MCAN_TXBRP_TRP13_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 13 Mask */
+#define MCAN_TXBRP_TRP13                    MCAN_TXBRP_TRP13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP13_Msk instead */
+#define MCAN_TXBRP_TRP14_Pos                14                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 14 Position */
+#define MCAN_TXBRP_TRP14_Msk                (_U_(0x1) << MCAN_TXBRP_TRP14_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 14 Mask */
+#define MCAN_TXBRP_TRP14                    MCAN_TXBRP_TRP14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP14_Msk instead */
+#define MCAN_TXBRP_TRP15_Pos                15                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 15 Position */
+#define MCAN_TXBRP_TRP15_Msk                (_U_(0x1) << MCAN_TXBRP_TRP15_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 15 Mask */
+#define MCAN_TXBRP_TRP15                    MCAN_TXBRP_TRP15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP15_Msk instead */
+#define MCAN_TXBRP_TRP16_Pos                16                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 16 Position */
+#define MCAN_TXBRP_TRP16_Msk                (_U_(0x1) << MCAN_TXBRP_TRP16_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 16 Mask */
+#define MCAN_TXBRP_TRP16                    MCAN_TXBRP_TRP16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP16_Msk instead */
+#define MCAN_TXBRP_TRP17_Pos                17                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 17 Position */
+#define MCAN_TXBRP_TRP17_Msk                (_U_(0x1) << MCAN_TXBRP_TRP17_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 17 Mask */
+#define MCAN_TXBRP_TRP17                    MCAN_TXBRP_TRP17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP17_Msk instead */
+#define MCAN_TXBRP_TRP18_Pos                18                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 18 Position */
+#define MCAN_TXBRP_TRP18_Msk                (_U_(0x1) << MCAN_TXBRP_TRP18_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 18 Mask */
+#define MCAN_TXBRP_TRP18                    MCAN_TXBRP_TRP18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP18_Msk instead */
+#define MCAN_TXBRP_TRP19_Pos                19                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 19 Position */
+#define MCAN_TXBRP_TRP19_Msk                (_U_(0x1) << MCAN_TXBRP_TRP19_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 19 Mask */
+#define MCAN_TXBRP_TRP19                    MCAN_TXBRP_TRP19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP19_Msk instead */
+#define MCAN_TXBRP_TRP20_Pos                20                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 20 Position */
+#define MCAN_TXBRP_TRP20_Msk                (_U_(0x1) << MCAN_TXBRP_TRP20_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 20 Mask */
+#define MCAN_TXBRP_TRP20                    MCAN_TXBRP_TRP20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP20_Msk instead */
+#define MCAN_TXBRP_TRP21_Pos                21                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 21 Position */
+#define MCAN_TXBRP_TRP21_Msk                (_U_(0x1) << MCAN_TXBRP_TRP21_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 21 Mask */
+#define MCAN_TXBRP_TRP21                    MCAN_TXBRP_TRP21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP21_Msk instead */
+#define MCAN_TXBRP_TRP22_Pos                22                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 22 Position */
+#define MCAN_TXBRP_TRP22_Msk                (_U_(0x1) << MCAN_TXBRP_TRP22_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 22 Mask */
+#define MCAN_TXBRP_TRP22                    MCAN_TXBRP_TRP22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP22_Msk instead */
+#define MCAN_TXBRP_TRP23_Pos                23                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 23 Position */
+#define MCAN_TXBRP_TRP23_Msk                (_U_(0x1) << MCAN_TXBRP_TRP23_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 23 Mask */
+#define MCAN_TXBRP_TRP23                    MCAN_TXBRP_TRP23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP23_Msk instead */
+#define MCAN_TXBRP_TRP24_Pos                24                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 24 Position */
+#define MCAN_TXBRP_TRP24_Msk                (_U_(0x1) << MCAN_TXBRP_TRP24_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 24 Mask */
+#define MCAN_TXBRP_TRP24                    MCAN_TXBRP_TRP24_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP24_Msk instead */
+#define MCAN_TXBRP_TRP25_Pos                25                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 25 Position */
+#define MCAN_TXBRP_TRP25_Msk                (_U_(0x1) << MCAN_TXBRP_TRP25_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 25 Mask */
+#define MCAN_TXBRP_TRP25                    MCAN_TXBRP_TRP25_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP25_Msk instead */
+#define MCAN_TXBRP_TRP26_Pos                26                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 26 Position */
+#define MCAN_TXBRP_TRP26_Msk                (_U_(0x1) << MCAN_TXBRP_TRP26_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 26 Mask */
+#define MCAN_TXBRP_TRP26                    MCAN_TXBRP_TRP26_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP26_Msk instead */
+#define MCAN_TXBRP_TRP27_Pos                27                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 27 Position */
+#define MCAN_TXBRP_TRP27_Msk                (_U_(0x1) << MCAN_TXBRP_TRP27_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 27 Mask */
+#define MCAN_TXBRP_TRP27                    MCAN_TXBRP_TRP27_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP27_Msk instead */
+#define MCAN_TXBRP_TRP28_Pos                28                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 28 Position */
+#define MCAN_TXBRP_TRP28_Msk                (_U_(0x1) << MCAN_TXBRP_TRP28_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 28 Mask */
+#define MCAN_TXBRP_TRP28                    MCAN_TXBRP_TRP28_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP28_Msk instead */
+#define MCAN_TXBRP_TRP29_Pos                29                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 29 Position */
+#define MCAN_TXBRP_TRP29_Msk                (_U_(0x1) << MCAN_TXBRP_TRP29_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 29 Mask */
+#define MCAN_TXBRP_TRP29                    MCAN_TXBRP_TRP29_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP29_Msk instead */
+#define MCAN_TXBRP_TRP30_Pos                30                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 30 Position */
+#define MCAN_TXBRP_TRP30_Msk                (_U_(0x1) << MCAN_TXBRP_TRP30_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 30 Mask */
+#define MCAN_TXBRP_TRP30                    MCAN_TXBRP_TRP30_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP30_Msk instead */
+#define MCAN_TXBRP_TRP31_Pos                31                                             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 31 Position */
+#define MCAN_TXBRP_TRP31_Msk                (_U_(0x1) << MCAN_TXBRP_TRP31_Pos)             /**< (MCAN_TXBRP) Transmission Request Pending for Buffer 31 Mask */
+#define MCAN_TXBRP_TRP31                    MCAN_TXBRP_TRP31_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBRP_TRP31_Msk instead */
+#define MCAN_TXBRP_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBRP) Register MASK  (Use MCAN_TXBRP_Msk instead)  */
+#define MCAN_TXBRP_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBRP) Register Mask  */
+
+#define MCAN_TXBRP_TRP_Pos                  0                                              /**< (MCAN_TXBRP Position) Transmission Request Pending for Buffer 3x */
+#define MCAN_TXBRP_TRP_Msk                  (_U_(0xFFFFFFFF) << MCAN_TXBRP_TRP_Pos)        /**< (MCAN_TXBRP Mask) TRP */
+#define MCAN_TXBRP_TRP(value)               (MCAN_TXBRP_TRP_Msk & ((value) << MCAN_TXBRP_TRP_Pos))  
+
+/* -------- MCAN_TXBAR : (MCAN Offset: 0xd0) (R/W 32) Transmit Buffer Add Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AR0:1;                     /**< bit:      0  Add Request for Transmit Buffer 0        */
+    uint32_t AR1:1;                     /**< bit:      1  Add Request for Transmit Buffer 1        */
+    uint32_t AR2:1;                     /**< bit:      2  Add Request for Transmit Buffer 2        */
+    uint32_t AR3:1;                     /**< bit:      3  Add Request for Transmit Buffer 3        */
+    uint32_t AR4:1;                     /**< bit:      4  Add Request for Transmit Buffer 4        */
+    uint32_t AR5:1;                     /**< bit:      5  Add Request for Transmit Buffer 5        */
+    uint32_t AR6:1;                     /**< bit:      6  Add Request for Transmit Buffer 6        */
+    uint32_t AR7:1;                     /**< bit:      7  Add Request for Transmit Buffer 7        */
+    uint32_t AR8:1;                     /**< bit:      8  Add Request for Transmit Buffer 8        */
+    uint32_t AR9:1;                     /**< bit:      9  Add Request for Transmit Buffer 9        */
+    uint32_t AR10:1;                    /**< bit:     10  Add Request for Transmit Buffer 10       */
+    uint32_t AR11:1;                    /**< bit:     11  Add Request for Transmit Buffer 11       */
+    uint32_t AR12:1;                    /**< bit:     12  Add Request for Transmit Buffer 12       */
+    uint32_t AR13:1;                    /**< bit:     13  Add Request for Transmit Buffer 13       */
+    uint32_t AR14:1;                    /**< bit:     14  Add Request for Transmit Buffer 14       */
+    uint32_t AR15:1;                    /**< bit:     15  Add Request for Transmit Buffer 15       */
+    uint32_t AR16:1;                    /**< bit:     16  Add Request for Transmit Buffer 16       */
+    uint32_t AR17:1;                    /**< bit:     17  Add Request for Transmit Buffer 17       */
+    uint32_t AR18:1;                    /**< bit:     18  Add Request for Transmit Buffer 18       */
+    uint32_t AR19:1;                    /**< bit:     19  Add Request for Transmit Buffer 19       */
+    uint32_t AR20:1;                    /**< bit:     20  Add Request for Transmit Buffer 20       */
+    uint32_t AR21:1;                    /**< bit:     21  Add Request for Transmit Buffer 21       */
+    uint32_t AR22:1;                    /**< bit:     22  Add Request for Transmit Buffer 22       */
+    uint32_t AR23:1;                    /**< bit:     23  Add Request for Transmit Buffer 23       */
+    uint32_t AR24:1;                    /**< bit:     24  Add Request for Transmit Buffer 24       */
+    uint32_t AR25:1;                    /**< bit:     25  Add Request for Transmit Buffer 25       */
+    uint32_t AR26:1;                    /**< bit:     26  Add Request for Transmit Buffer 26       */
+    uint32_t AR27:1;                    /**< bit:     27  Add Request for Transmit Buffer 27       */
+    uint32_t AR28:1;                    /**< bit:     28  Add Request for Transmit Buffer 28       */
+    uint32_t AR29:1;                    /**< bit:     29  Add Request for Transmit Buffer 29       */
+    uint32_t AR30:1;                    /**< bit:     30  Add Request for Transmit Buffer 30       */
+    uint32_t AR31:1;                    /**< bit:     31  Add Request for Transmit Buffer 31       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t AR:32;                     /**< bit:  0..31  Add Request for Transmit Buffer 3x       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBAR_OFFSET                   (0xD0)                                        /**<  (MCAN_TXBAR) Transmit Buffer Add Request Register  Offset */
+
+#define MCAN_TXBAR_AR0_Pos                  0                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 0 Position */
+#define MCAN_TXBAR_AR0_Msk                  (_U_(0x1) << MCAN_TXBAR_AR0_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 0 Mask */
+#define MCAN_TXBAR_AR0                      MCAN_TXBAR_AR0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR0_Msk instead */
+#define MCAN_TXBAR_AR1_Pos                  1                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 1 Position */
+#define MCAN_TXBAR_AR1_Msk                  (_U_(0x1) << MCAN_TXBAR_AR1_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 1 Mask */
+#define MCAN_TXBAR_AR1                      MCAN_TXBAR_AR1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR1_Msk instead */
+#define MCAN_TXBAR_AR2_Pos                  2                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 2 Position */
+#define MCAN_TXBAR_AR2_Msk                  (_U_(0x1) << MCAN_TXBAR_AR2_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 2 Mask */
+#define MCAN_TXBAR_AR2                      MCAN_TXBAR_AR2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR2_Msk instead */
+#define MCAN_TXBAR_AR3_Pos                  3                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 3 Position */
+#define MCAN_TXBAR_AR3_Msk                  (_U_(0x1) << MCAN_TXBAR_AR3_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 3 Mask */
+#define MCAN_TXBAR_AR3                      MCAN_TXBAR_AR3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR3_Msk instead */
+#define MCAN_TXBAR_AR4_Pos                  4                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 4 Position */
+#define MCAN_TXBAR_AR4_Msk                  (_U_(0x1) << MCAN_TXBAR_AR4_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 4 Mask */
+#define MCAN_TXBAR_AR4                      MCAN_TXBAR_AR4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR4_Msk instead */
+#define MCAN_TXBAR_AR5_Pos                  5                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 5 Position */
+#define MCAN_TXBAR_AR5_Msk                  (_U_(0x1) << MCAN_TXBAR_AR5_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 5 Mask */
+#define MCAN_TXBAR_AR5                      MCAN_TXBAR_AR5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR5_Msk instead */
+#define MCAN_TXBAR_AR6_Pos                  6                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 6 Position */
+#define MCAN_TXBAR_AR6_Msk                  (_U_(0x1) << MCAN_TXBAR_AR6_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 6 Mask */
+#define MCAN_TXBAR_AR6                      MCAN_TXBAR_AR6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR6_Msk instead */
+#define MCAN_TXBAR_AR7_Pos                  7                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 7 Position */
+#define MCAN_TXBAR_AR7_Msk                  (_U_(0x1) << MCAN_TXBAR_AR7_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 7 Mask */
+#define MCAN_TXBAR_AR7                      MCAN_TXBAR_AR7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR7_Msk instead */
+#define MCAN_TXBAR_AR8_Pos                  8                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 8 Position */
+#define MCAN_TXBAR_AR8_Msk                  (_U_(0x1) << MCAN_TXBAR_AR8_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 8 Mask */
+#define MCAN_TXBAR_AR8                      MCAN_TXBAR_AR8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR8_Msk instead */
+#define MCAN_TXBAR_AR9_Pos                  9                                              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 9 Position */
+#define MCAN_TXBAR_AR9_Msk                  (_U_(0x1) << MCAN_TXBAR_AR9_Pos)               /**< (MCAN_TXBAR) Add Request for Transmit Buffer 9 Mask */
+#define MCAN_TXBAR_AR9                      MCAN_TXBAR_AR9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR9_Msk instead */
+#define MCAN_TXBAR_AR10_Pos                 10                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 10 Position */
+#define MCAN_TXBAR_AR10_Msk                 (_U_(0x1) << MCAN_TXBAR_AR10_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 10 Mask */
+#define MCAN_TXBAR_AR10                     MCAN_TXBAR_AR10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR10_Msk instead */
+#define MCAN_TXBAR_AR11_Pos                 11                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 11 Position */
+#define MCAN_TXBAR_AR11_Msk                 (_U_(0x1) << MCAN_TXBAR_AR11_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 11 Mask */
+#define MCAN_TXBAR_AR11                     MCAN_TXBAR_AR11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR11_Msk instead */
+#define MCAN_TXBAR_AR12_Pos                 12                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 12 Position */
+#define MCAN_TXBAR_AR12_Msk                 (_U_(0x1) << MCAN_TXBAR_AR12_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 12 Mask */
+#define MCAN_TXBAR_AR12                     MCAN_TXBAR_AR12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR12_Msk instead */
+#define MCAN_TXBAR_AR13_Pos                 13                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 13 Position */
+#define MCAN_TXBAR_AR13_Msk                 (_U_(0x1) << MCAN_TXBAR_AR13_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 13 Mask */
+#define MCAN_TXBAR_AR13                     MCAN_TXBAR_AR13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR13_Msk instead */
+#define MCAN_TXBAR_AR14_Pos                 14                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 14 Position */
+#define MCAN_TXBAR_AR14_Msk                 (_U_(0x1) << MCAN_TXBAR_AR14_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 14 Mask */
+#define MCAN_TXBAR_AR14                     MCAN_TXBAR_AR14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR14_Msk instead */
+#define MCAN_TXBAR_AR15_Pos                 15                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 15 Position */
+#define MCAN_TXBAR_AR15_Msk                 (_U_(0x1) << MCAN_TXBAR_AR15_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 15 Mask */
+#define MCAN_TXBAR_AR15                     MCAN_TXBAR_AR15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR15_Msk instead */
+#define MCAN_TXBAR_AR16_Pos                 16                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 16 Position */
+#define MCAN_TXBAR_AR16_Msk                 (_U_(0x1) << MCAN_TXBAR_AR16_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 16 Mask */
+#define MCAN_TXBAR_AR16                     MCAN_TXBAR_AR16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR16_Msk instead */
+#define MCAN_TXBAR_AR17_Pos                 17                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 17 Position */
+#define MCAN_TXBAR_AR17_Msk                 (_U_(0x1) << MCAN_TXBAR_AR17_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 17 Mask */
+#define MCAN_TXBAR_AR17                     MCAN_TXBAR_AR17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR17_Msk instead */
+#define MCAN_TXBAR_AR18_Pos                 18                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 18 Position */
+#define MCAN_TXBAR_AR18_Msk                 (_U_(0x1) << MCAN_TXBAR_AR18_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 18 Mask */
+#define MCAN_TXBAR_AR18                     MCAN_TXBAR_AR18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR18_Msk instead */
+#define MCAN_TXBAR_AR19_Pos                 19                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 19 Position */
+#define MCAN_TXBAR_AR19_Msk                 (_U_(0x1) << MCAN_TXBAR_AR19_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 19 Mask */
+#define MCAN_TXBAR_AR19                     MCAN_TXBAR_AR19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR19_Msk instead */
+#define MCAN_TXBAR_AR20_Pos                 20                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 20 Position */
+#define MCAN_TXBAR_AR20_Msk                 (_U_(0x1) << MCAN_TXBAR_AR20_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 20 Mask */
+#define MCAN_TXBAR_AR20                     MCAN_TXBAR_AR20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR20_Msk instead */
+#define MCAN_TXBAR_AR21_Pos                 21                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 21 Position */
+#define MCAN_TXBAR_AR21_Msk                 (_U_(0x1) << MCAN_TXBAR_AR21_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 21 Mask */
+#define MCAN_TXBAR_AR21                     MCAN_TXBAR_AR21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR21_Msk instead */
+#define MCAN_TXBAR_AR22_Pos                 22                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 22 Position */
+#define MCAN_TXBAR_AR22_Msk                 (_U_(0x1) << MCAN_TXBAR_AR22_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 22 Mask */
+#define MCAN_TXBAR_AR22                     MCAN_TXBAR_AR22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR22_Msk instead */
+#define MCAN_TXBAR_AR23_Pos                 23                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 23 Position */
+#define MCAN_TXBAR_AR23_Msk                 (_U_(0x1) << MCAN_TXBAR_AR23_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 23 Mask */
+#define MCAN_TXBAR_AR23                     MCAN_TXBAR_AR23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR23_Msk instead */
+#define MCAN_TXBAR_AR24_Pos                 24                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 24 Position */
+#define MCAN_TXBAR_AR24_Msk                 (_U_(0x1) << MCAN_TXBAR_AR24_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 24 Mask */
+#define MCAN_TXBAR_AR24                     MCAN_TXBAR_AR24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR24_Msk instead */
+#define MCAN_TXBAR_AR25_Pos                 25                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 25 Position */
+#define MCAN_TXBAR_AR25_Msk                 (_U_(0x1) << MCAN_TXBAR_AR25_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 25 Mask */
+#define MCAN_TXBAR_AR25                     MCAN_TXBAR_AR25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR25_Msk instead */
+#define MCAN_TXBAR_AR26_Pos                 26                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 26 Position */
+#define MCAN_TXBAR_AR26_Msk                 (_U_(0x1) << MCAN_TXBAR_AR26_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 26 Mask */
+#define MCAN_TXBAR_AR26                     MCAN_TXBAR_AR26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR26_Msk instead */
+#define MCAN_TXBAR_AR27_Pos                 27                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 27 Position */
+#define MCAN_TXBAR_AR27_Msk                 (_U_(0x1) << MCAN_TXBAR_AR27_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 27 Mask */
+#define MCAN_TXBAR_AR27                     MCAN_TXBAR_AR27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR27_Msk instead */
+#define MCAN_TXBAR_AR28_Pos                 28                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 28 Position */
+#define MCAN_TXBAR_AR28_Msk                 (_U_(0x1) << MCAN_TXBAR_AR28_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 28 Mask */
+#define MCAN_TXBAR_AR28                     MCAN_TXBAR_AR28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR28_Msk instead */
+#define MCAN_TXBAR_AR29_Pos                 29                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 29 Position */
+#define MCAN_TXBAR_AR29_Msk                 (_U_(0x1) << MCAN_TXBAR_AR29_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 29 Mask */
+#define MCAN_TXBAR_AR29                     MCAN_TXBAR_AR29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR29_Msk instead */
+#define MCAN_TXBAR_AR30_Pos                 30                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 30 Position */
+#define MCAN_TXBAR_AR30_Msk                 (_U_(0x1) << MCAN_TXBAR_AR30_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 30 Mask */
+#define MCAN_TXBAR_AR30                     MCAN_TXBAR_AR30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR30_Msk instead */
+#define MCAN_TXBAR_AR31_Pos                 31                                             /**< (MCAN_TXBAR) Add Request for Transmit Buffer 31 Position */
+#define MCAN_TXBAR_AR31_Msk                 (_U_(0x1) << MCAN_TXBAR_AR31_Pos)              /**< (MCAN_TXBAR) Add Request for Transmit Buffer 31 Mask */
+#define MCAN_TXBAR_AR31                     MCAN_TXBAR_AR31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBAR_AR31_Msk instead */
+#define MCAN_TXBAR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBAR) Register MASK  (Use MCAN_TXBAR_Msk instead)  */
+#define MCAN_TXBAR_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBAR) Register Mask  */
+
+#define MCAN_TXBAR_AR_Pos                   0                                              /**< (MCAN_TXBAR Position) Add Request for Transmit Buffer 3x */
+#define MCAN_TXBAR_AR_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBAR_AR_Pos)         /**< (MCAN_TXBAR Mask) AR */
+#define MCAN_TXBAR_AR(value)                (MCAN_TXBAR_AR_Msk & ((value) << MCAN_TXBAR_AR_Pos))  
+
+/* -------- MCAN_TXBCR : (MCAN Offset: 0xd4) (R/W 32) Transmit Buffer Cancellation Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CR0:1;                     /**< bit:      0  Cancellation Request for Transmit Buffer 0 */
+    uint32_t CR1:1;                     /**< bit:      1  Cancellation Request for Transmit Buffer 1 */
+    uint32_t CR2:1;                     /**< bit:      2  Cancellation Request for Transmit Buffer 2 */
+    uint32_t CR3:1;                     /**< bit:      3  Cancellation Request for Transmit Buffer 3 */
+    uint32_t CR4:1;                     /**< bit:      4  Cancellation Request for Transmit Buffer 4 */
+    uint32_t CR5:1;                     /**< bit:      5  Cancellation Request for Transmit Buffer 5 */
+    uint32_t CR6:1;                     /**< bit:      6  Cancellation Request for Transmit Buffer 6 */
+    uint32_t CR7:1;                     /**< bit:      7  Cancellation Request for Transmit Buffer 7 */
+    uint32_t CR8:1;                     /**< bit:      8  Cancellation Request for Transmit Buffer 8 */
+    uint32_t CR9:1;                     /**< bit:      9  Cancellation Request for Transmit Buffer 9 */
+    uint32_t CR10:1;                    /**< bit:     10  Cancellation Request for Transmit Buffer 10 */
+    uint32_t CR11:1;                    /**< bit:     11  Cancellation Request for Transmit Buffer 11 */
+    uint32_t CR12:1;                    /**< bit:     12  Cancellation Request for Transmit Buffer 12 */
+    uint32_t CR13:1;                    /**< bit:     13  Cancellation Request for Transmit Buffer 13 */
+    uint32_t CR14:1;                    /**< bit:     14  Cancellation Request for Transmit Buffer 14 */
+    uint32_t CR15:1;                    /**< bit:     15  Cancellation Request for Transmit Buffer 15 */
+    uint32_t CR16:1;                    /**< bit:     16  Cancellation Request for Transmit Buffer 16 */
+    uint32_t CR17:1;                    /**< bit:     17  Cancellation Request for Transmit Buffer 17 */
+    uint32_t CR18:1;                    /**< bit:     18  Cancellation Request for Transmit Buffer 18 */
+    uint32_t CR19:1;                    /**< bit:     19  Cancellation Request for Transmit Buffer 19 */
+    uint32_t CR20:1;                    /**< bit:     20  Cancellation Request for Transmit Buffer 20 */
+    uint32_t CR21:1;                    /**< bit:     21  Cancellation Request for Transmit Buffer 21 */
+    uint32_t CR22:1;                    /**< bit:     22  Cancellation Request for Transmit Buffer 22 */
+    uint32_t CR23:1;                    /**< bit:     23  Cancellation Request for Transmit Buffer 23 */
+    uint32_t CR24:1;                    /**< bit:     24  Cancellation Request for Transmit Buffer 24 */
+    uint32_t CR25:1;                    /**< bit:     25  Cancellation Request for Transmit Buffer 25 */
+    uint32_t CR26:1;                    /**< bit:     26  Cancellation Request for Transmit Buffer 26 */
+    uint32_t CR27:1;                    /**< bit:     27  Cancellation Request for Transmit Buffer 27 */
+    uint32_t CR28:1;                    /**< bit:     28  Cancellation Request for Transmit Buffer 28 */
+    uint32_t CR29:1;                    /**< bit:     29  Cancellation Request for Transmit Buffer 29 */
+    uint32_t CR30:1;                    /**< bit:     30  Cancellation Request for Transmit Buffer 30 */
+    uint32_t CR31:1;                    /**< bit:     31  Cancellation Request for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CR:32;                     /**< bit:  0..31  Cancellation Request for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCR_OFFSET                   (0xD4)                                        /**<  (MCAN_TXBCR) Transmit Buffer Cancellation Request Register  Offset */
+
+#define MCAN_TXBCR_CR0_Pos                  0                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 0 Position */
+#define MCAN_TXBCR_CR0_Msk                  (_U_(0x1) << MCAN_TXBCR_CR0_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 0 Mask */
+#define MCAN_TXBCR_CR0                      MCAN_TXBCR_CR0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR0_Msk instead */
+#define MCAN_TXBCR_CR1_Pos                  1                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 1 Position */
+#define MCAN_TXBCR_CR1_Msk                  (_U_(0x1) << MCAN_TXBCR_CR1_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 1 Mask */
+#define MCAN_TXBCR_CR1                      MCAN_TXBCR_CR1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR1_Msk instead */
+#define MCAN_TXBCR_CR2_Pos                  2                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 2 Position */
+#define MCAN_TXBCR_CR2_Msk                  (_U_(0x1) << MCAN_TXBCR_CR2_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 2 Mask */
+#define MCAN_TXBCR_CR2                      MCAN_TXBCR_CR2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR2_Msk instead */
+#define MCAN_TXBCR_CR3_Pos                  3                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 3 Position */
+#define MCAN_TXBCR_CR3_Msk                  (_U_(0x1) << MCAN_TXBCR_CR3_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 3 Mask */
+#define MCAN_TXBCR_CR3                      MCAN_TXBCR_CR3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR3_Msk instead */
+#define MCAN_TXBCR_CR4_Pos                  4                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 4 Position */
+#define MCAN_TXBCR_CR4_Msk                  (_U_(0x1) << MCAN_TXBCR_CR4_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 4 Mask */
+#define MCAN_TXBCR_CR4                      MCAN_TXBCR_CR4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR4_Msk instead */
+#define MCAN_TXBCR_CR5_Pos                  5                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 5 Position */
+#define MCAN_TXBCR_CR5_Msk                  (_U_(0x1) << MCAN_TXBCR_CR5_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 5 Mask */
+#define MCAN_TXBCR_CR5                      MCAN_TXBCR_CR5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR5_Msk instead */
+#define MCAN_TXBCR_CR6_Pos                  6                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 6 Position */
+#define MCAN_TXBCR_CR6_Msk                  (_U_(0x1) << MCAN_TXBCR_CR6_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 6 Mask */
+#define MCAN_TXBCR_CR6                      MCAN_TXBCR_CR6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR6_Msk instead */
+#define MCAN_TXBCR_CR7_Pos                  7                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 7 Position */
+#define MCAN_TXBCR_CR7_Msk                  (_U_(0x1) << MCAN_TXBCR_CR7_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 7 Mask */
+#define MCAN_TXBCR_CR7                      MCAN_TXBCR_CR7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR7_Msk instead */
+#define MCAN_TXBCR_CR8_Pos                  8                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 8 Position */
+#define MCAN_TXBCR_CR8_Msk                  (_U_(0x1) << MCAN_TXBCR_CR8_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 8 Mask */
+#define MCAN_TXBCR_CR8                      MCAN_TXBCR_CR8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR8_Msk instead */
+#define MCAN_TXBCR_CR9_Pos                  9                                              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 9 Position */
+#define MCAN_TXBCR_CR9_Msk                  (_U_(0x1) << MCAN_TXBCR_CR9_Pos)               /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 9 Mask */
+#define MCAN_TXBCR_CR9                      MCAN_TXBCR_CR9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR9_Msk instead */
+#define MCAN_TXBCR_CR10_Pos                 10                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 10 Position */
+#define MCAN_TXBCR_CR10_Msk                 (_U_(0x1) << MCAN_TXBCR_CR10_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 10 Mask */
+#define MCAN_TXBCR_CR10                     MCAN_TXBCR_CR10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR10_Msk instead */
+#define MCAN_TXBCR_CR11_Pos                 11                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 11 Position */
+#define MCAN_TXBCR_CR11_Msk                 (_U_(0x1) << MCAN_TXBCR_CR11_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 11 Mask */
+#define MCAN_TXBCR_CR11                     MCAN_TXBCR_CR11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR11_Msk instead */
+#define MCAN_TXBCR_CR12_Pos                 12                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 12 Position */
+#define MCAN_TXBCR_CR12_Msk                 (_U_(0x1) << MCAN_TXBCR_CR12_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 12 Mask */
+#define MCAN_TXBCR_CR12                     MCAN_TXBCR_CR12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR12_Msk instead */
+#define MCAN_TXBCR_CR13_Pos                 13                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 13 Position */
+#define MCAN_TXBCR_CR13_Msk                 (_U_(0x1) << MCAN_TXBCR_CR13_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 13 Mask */
+#define MCAN_TXBCR_CR13                     MCAN_TXBCR_CR13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR13_Msk instead */
+#define MCAN_TXBCR_CR14_Pos                 14                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 14 Position */
+#define MCAN_TXBCR_CR14_Msk                 (_U_(0x1) << MCAN_TXBCR_CR14_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 14 Mask */
+#define MCAN_TXBCR_CR14                     MCAN_TXBCR_CR14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR14_Msk instead */
+#define MCAN_TXBCR_CR15_Pos                 15                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 15 Position */
+#define MCAN_TXBCR_CR15_Msk                 (_U_(0x1) << MCAN_TXBCR_CR15_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 15 Mask */
+#define MCAN_TXBCR_CR15                     MCAN_TXBCR_CR15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR15_Msk instead */
+#define MCAN_TXBCR_CR16_Pos                 16                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 16 Position */
+#define MCAN_TXBCR_CR16_Msk                 (_U_(0x1) << MCAN_TXBCR_CR16_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 16 Mask */
+#define MCAN_TXBCR_CR16                     MCAN_TXBCR_CR16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR16_Msk instead */
+#define MCAN_TXBCR_CR17_Pos                 17                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 17 Position */
+#define MCAN_TXBCR_CR17_Msk                 (_U_(0x1) << MCAN_TXBCR_CR17_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 17 Mask */
+#define MCAN_TXBCR_CR17                     MCAN_TXBCR_CR17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR17_Msk instead */
+#define MCAN_TXBCR_CR18_Pos                 18                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 18 Position */
+#define MCAN_TXBCR_CR18_Msk                 (_U_(0x1) << MCAN_TXBCR_CR18_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 18 Mask */
+#define MCAN_TXBCR_CR18                     MCAN_TXBCR_CR18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR18_Msk instead */
+#define MCAN_TXBCR_CR19_Pos                 19                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 19 Position */
+#define MCAN_TXBCR_CR19_Msk                 (_U_(0x1) << MCAN_TXBCR_CR19_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 19 Mask */
+#define MCAN_TXBCR_CR19                     MCAN_TXBCR_CR19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR19_Msk instead */
+#define MCAN_TXBCR_CR20_Pos                 20                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 20 Position */
+#define MCAN_TXBCR_CR20_Msk                 (_U_(0x1) << MCAN_TXBCR_CR20_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 20 Mask */
+#define MCAN_TXBCR_CR20                     MCAN_TXBCR_CR20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR20_Msk instead */
+#define MCAN_TXBCR_CR21_Pos                 21                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 21 Position */
+#define MCAN_TXBCR_CR21_Msk                 (_U_(0x1) << MCAN_TXBCR_CR21_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 21 Mask */
+#define MCAN_TXBCR_CR21                     MCAN_TXBCR_CR21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR21_Msk instead */
+#define MCAN_TXBCR_CR22_Pos                 22                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 22 Position */
+#define MCAN_TXBCR_CR22_Msk                 (_U_(0x1) << MCAN_TXBCR_CR22_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 22 Mask */
+#define MCAN_TXBCR_CR22                     MCAN_TXBCR_CR22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR22_Msk instead */
+#define MCAN_TXBCR_CR23_Pos                 23                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 23 Position */
+#define MCAN_TXBCR_CR23_Msk                 (_U_(0x1) << MCAN_TXBCR_CR23_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 23 Mask */
+#define MCAN_TXBCR_CR23                     MCAN_TXBCR_CR23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR23_Msk instead */
+#define MCAN_TXBCR_CR24_Pos                 24                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 24 Position */
+#define MCAN_TXBCR_CR24_Msk                 (_U_(0x1) << MCAN_TXBCR_CR24_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 24 Mask */
+#define MCAN_TXBCR_CR24                     MCAN_TXBCR_CR24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR24_Msk instead */
+#define MCAN_TXBCR_CR25_Pos                 25                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 25 Position */
+#define MCAN_TXBCR_CR25_Msk                 (_U_(0x1) << MCAN_TXBCR_CR25_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 25 Mask */
+#define MCAN_TXBCR_CR25                     MCAN_TXBCR_CR25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR25_Msk instead */
+#define MCAN_TXBCR_CR26_Pos                 26                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 26 Position */
+#define MCAN_TXBCR_CR26_Msk                 (_U_(0x1) << MCAN_TXBCR_CR26_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 26 Mask */
+#define MCAN_TXBCR_CR26                     MCAN_TXBCR_CR26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR26_Msk instead */
+#define MCAN_TXBCR_CR27_Pos                 27                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 27 Position */
+#define MCAN_TXBCR_CR27_Msk                 (_U_(0x1) << MCAN_TXBCR_CR27_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 27 Mask */
+#define MCAN_TXBCR_CR27                     MCAN_TXBCR_CR27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR27_Msk instead */
+#define MCAN_TXBCR_CR28_Pos                 28                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 28 Position */
+#define MCAN_TXBCR_CR28_Msk                 (_U_(0x1) << MCAN_TXBCR_CR28_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 28 Mask */
+#define MCAN_TXBCR_CR28                     MCAN_TXBCR_CR28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR28_Msk instead */
+#define MCAN_TXBCR_CR29_Pos                 29                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 29 Position */
+#define MCAN_TXBCR_CR29_Msk                 (_U_(0x1) << MCAN_TXBCR_CR29_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 29 Mask */
+#define MCAN_TXBCR_CR29                     MCAN_TXBCR_CR29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR29_Msk instead */
+#define MCAN_TXBCR_CR30_Pos                 30                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 30 Position */
+#define MCAN_TXBCR_CR30_Msk                 (_U_(0x1) << MCAN_TXBCR_CR30_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 30 Mask */
+#define MCAN_TXBCR_CR30                     MCAN_TXBCR_CR30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR30_Msk instead */
+#define MCAN_TXBCR_CR31_Pos                 31                                             /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 31 Position */
+#define MCAN_TXBCR_CR31_Msk                 (_U_(0x1) << MCAN_TXBCR_CR31_Pos)              /**< (MCAN_TXBCR) Cancellation Request for Transmit Buffer 31 Mask */
+#define MCAN_TXBCR_CR31                     MCAN_TXBCR_CR31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCR_CR31_Msk instead */
+#define MCAN_TXBCR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCR) Register MASK  (Use MCAN_TXBCR_Msk instead)  */
+#define MCAN_TXBCR_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCR) Register Mask  */
+
+#define MCAN_TXBCR_CR_Pos                   0                                              /**< (MCAN_TXBCR Position) Cancellation Request for Transmit Buffer 3x */
+#define MCAN_TXBCR_CR_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBCR_CR_Pos)         /**< (MCAN_TXBCR Mask) CR */
+#define MCAN_TXBCR_CR(value)                (MCAN_TXBCR_CR_Msk & ((value) << MCAN_TXBCR_CR_Pos))  
+
+/* -------- MCAN_TXBTO : (MCAN Offset: 0xd8) (R/ 32) Transmit Buffer Transmission Occurred Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TO0:1;                     /**< bit:      0  Transmission Occurred for Buffer 0       */
+    uint32_t TO1:1;                     /**< bit:      1  Transmission Occurred for Buffer 1       */
+    uint32_t TO2:1;                     /**< bit:      2  Transmission Occurred for Buffer 2       */
+    uint32_t TO3:1;                     /**< bit:      3  Transmission Occurred for Buffer 3       */
+    uint32_t TO4:1;                     /**< bit:      4  Transmission Occurred for Buffer 4       */
+    uint32_t TO5:1;                     /**< bit:      5  Transmission Occurred for Buffer 5       */
+    uint32_t TO6:1;                     /**< bit:      6  Transmission Occurred for Buffer 6       */
+    uint32_t TO7:1;                     /**< bit:      7  Transmission Occurred for Buffer 7       */
+    uint32_t TO8:1;                     /**< bit:      8  Transmission Occurred for Buffer 8       */
+    uint32_t TO9:1;                     /**< bit:      9  Transmission Occurred for Buffer 9       */
+    uint32_t TO10:1;                    /**< bit:     10  Transmission Occurred for Buffer 10      */
+    uint32_t TO11:1;                    /**< bit:     11  Transmission Occurred for Buffer 11      */
+    uint32_t TO12:1;                    /**< bit:     12  Transmission Occurred for Buffer 12      */
+    uint32_t TO13:1;                    /**< bit:     13  Transmission Occurred for Buffer 13      */
+    uint32_t TO14:1;                    /**< bit:     14  Transmission Occurred for Buffer 14      */
+    uint32_t TO15:1;                    /**< bit:     15  Transmission Occurred for Buffer 15      */
+    uint32_t TO16:1;                    /**< bit:     16  Transmission Occurred for Buffer 16      */
+    uint32_t TO17:1;                    /**< bit:     17  Transmission Occurred for Buffer 17      */
+    uint32_t TO18:1;                    /**< bit:     18  Transmission Occurred for Buffer 18      */
+    uint32_t TO19:1;                    /**< bit:     19  Transmission Occurred for Buffer 19      */
+    uint32_t TO20:1;                    /**< bit:     20  Transmission Occurred for Buffer 20      */
+    uint32_t TO21:1;                    /**< bit:     21  Transmission Occurred for Buffer 21      */
+    uint32_t TO22:1;                    /**< bit:     22  Transmission Occurred for Buffer 22      */
+    uint32_t TO23:1;                    /**< bit:     23  Transmission Occurred for Buffer 23      */
+    uint32_t TO24:1;                    /**< bit:     24  Transmission Occurred for Buffer 24      */
+    uint32_t TO25:1;                    /**< bit:     25  Transmission Occurred for Buffer 25      */
+    uint32_t TO26:1;                    /**< bit:     26  Transmission Occurred for Buffer 26      */
+    uint32_t TO27:1;                    /**< bit:     27  Transmission Occurred for Buffer 27      */
+    uint32_t TO28:1;                    /**< bit:     28  Transmission Occurred for Buffer 28      */
+    uint32_t TO29:1;                    /**< bit:     29  Transmission Occurred for Buffer 29      */
+    uint32_t TO30:1;                    /**< bit:     30  Transmission Occurred for Buffer 30      */
+    uint32_t TO31:1;                    /**< bit:     31  Transmission Occurred for Buffer 31      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TO:32;                     /**< bit:  0..31  Transmission Occurred for Buffer 3x      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBTO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBTO_OFFSET                   (0xD8)                                        /**<  (MCAN_TXBTO) Transmit Buffer Transmission Occurred Register  Offset */
+
+#define MCAN_TXBTO_TO0_Pos                  0                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 0 Position */
+#define MCAN_TXBTO_TO0_Msk                  (_U_(0x1) << MCAN_TXBTO_TO0_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 0 Mask */
+#define MCAN_TXBTO_TO0                      MCAN_TXBTO_TO0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO0_Msk instead */
+#define MCAN_TXBTO_TO1_Pos                  1                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 1 Position */
+#define MCAN_TXBTO_TO1_Msk                  (_U_(0x1) << MCAN_TXBTO_TO1_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 1 Mask */
+#define MCAN_TXBTO_TO1                      MCAN_TXBTO_TO1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO1_Msk instead */
+#define MCAN_TXBTO_TO2_Pos                  2                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 2 Position */
+#define MCAN_TXBTO_TO2_Msk                  (_U_(0x1) << MCAN_TXBTO_TO2_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 2 Mask */
+#define MCAN_TXBTO_TO2                      MCAN_TXBTO_TO2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO2_Msk instead */
+#define MCAN_TXBTO_TO3_Pos                  3                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 3 Position */
+#define MCAN_TXBTO_TO3_Msk                  (_U_(0x1) << MCAN_TXBTO_TO3_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 3 Mask */
+#define MCAN_TXBTO_TO3                      MCAN_TXBTO_TO3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO3_Msk instead */
+#define MCAN_TXBTO_TO4_Pos                  4                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 4 Position */
+#define MCAN_TXBTO_TO4_Msk                  (_U_(0x1) << MCAN_TXBTO_TO4_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 4 Mask */
+#define MCAN_TXBTO_TO4                      MCAN_TXBTO_TO4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO4_Msk instead */
+#define MCAN_TXBTO_TO5_Pos                  5                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 5 Position */
+#define MCAN_TXBTO_TO5_Msk                  (_U_(0x1) << MCAN_TXBTO_TO5_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 5 Mask */
+#define MCAN_TXBTO_TO5                      MCAN_TXBTO_TO5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO5_Msk instead */
+#define MCAN_TXBTO_TO6_Pos                  6                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 6 Position */
+#define MCAN_TXBTO_TO6_Msk                  (_U_(0x1) << MCAN_TXBTO_TO6_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 6 Mask */
+#define MCAN_TXBTO_TO6                      MCAN_TXBTO_TO6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO6_Msk instead */
+#define MCAN_TXBTO_TO7_Pos                  7                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 7 Position */
+#define MCAN_TXBTO_TO7_Msk                  (_U_(0x1) << MCAN_TXBTO_TO7_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 7 Mask */
+#define MCAN_TXBTO_TO7                      MCAN_TXBTO_TO7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO7_Msk instead */
+#define MCAN_TXBTO_TO8_Pos                  8                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 8 Position */
+#define MCAN_TXBTO_TO8_Msk                  (_U_(0x1) << MCAN_TXBTO_TO8_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 8 Mask */
+#define MCAN_TXBTO_TO8                      MCAN_TXBTO_TO8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO8_Msk instead */
+#define MCAN_TXBTO_TO9_Pos                  9                                              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 9 Position */
+#define MCAN_TXBTO_TO9_Msk                  (_U_(0x1) << MCAN_TXBTO_TO9_Pos)               /**< (MCAN_TXBTO) Transmission Occurred for Buffer 9 Mask */
+#define MCAN_TXBTO_TO9                      MCAN_TXBTO_TO9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO9_Msk instead */
+#define MCAN_TXBTO_TO10_Pos                 10                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 10 Position */
+#define MCAN_TXBTO_TO10_Msk                 (_U_(0x1) << MCAN_TXBTO_TO10_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 10 Mask */
+#define MCAN_TXBTO_TO10                     MCAN_TXBTO_TO10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO10_Msk instead */
+#define MCAN_TXBTO_TO11_Pos                 11                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 11 Position */
+#define MCAN_TXBTO_TO11_Msk                 (_U_(0x1) << MCAN_TXBTO_TO11_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 11 Mask */
+#define MCAN_TXBTO_TO11                     MCAN_TXBTO_TO11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO11_Msk instead */
+#define MCAN_TXBTO_TO12_Pos                 12                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 12 Position */
+#define MCAN_TXBTO_TO12_Msk                 (_U_(0x1) << MCAN_TXBTO_TO12_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 12 Mask */
+#define MCAN_TXBTO_TO12                     MCAN_TXBTO_TO12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO12_Msk instead */
+#define MCAN_TXBTO_TO13_Pos                 13                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 13 Position */
+#define MCAN_TXBTO_TO13_Msk                 (_U_(0x1) << MCAN_TXBTO_TO13_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 13 Mask */
+#define MCAN_TXBTO_TO13                     MCAN_TXBTO_TO13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO13_Msk instead */
+#define MCAN_TXBTO_TO14_Pos                 14                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 14 Position */
+#define MCAN_TXBTO_TO14_Msk                 (_U_(0x1) << MCAN_TXBTO_TO14_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 14 Mask */
+#define MCAN_TXBTO_TO14                     MCAN_TXBTO_TO14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO14_Msk instead */
+#define MCAN_TXBTO_TO15_Pos                 15                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 15 Position */
+#define MCAN_TXBTO_TO15_Msk                 (_U_(0x1) << MCAN_TXBTO_TO15_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 15 Mask */
+#define MCAN_TXBTO_TO15                     MCAN_TXBTO_TO15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO15_Msk instead */
+#define MCAN_TXBTO_TO16_Pos                 16                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 16 Position */
+#define MCAN_TXBTO_TO16_Msk                 (_U_(0x1) << MCAN_TXBTO_TO16_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 16 Mask */
+#define MCAN_TXBTO_TO16                     MCAN_TXBTO_TO16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO16_Msk instead */
+#define MCAN_TXBTO_TO17_Pos                 17                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 17 Position */
+#define MCAN_TXBTO_TO17_Msk                 (_U_(0x1) << MCAN_TXBTO_TO17_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 17 Mask */
+#define MCAN_TXBTO_TO17                     MCAN_TXBTO_TO17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO17_Msk instead */
+#define MCAN_TXBTO_TO18_Pos                 18                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 18 Position */
+#define MCAN_TXBTO_TO18_Msk                 (_U_(0x1) << MCAN_TXBTO_TO18_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 18 Mask */
+#define MCAN_TXBTO_TO18                     MCAN_TXBTO_TO18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO18_Msk instead */
+#define MCAN_TXBTO_TO19_Pos                 19                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 19 Position */
+#define MCAN_TXBTO_TO19_Msk                 (_U_(0x1) << MCAN_TXBTO_TO19_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 19 Mask */
+#define MCAN_TXBTO_TO19                     MCAN_TXBTO_TO19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO19_Msk instead */
+#define MCAN_TXBTO_TO20_Pos                 20                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 20 Position */
+#define MCAN_TXBTO_TO20_Msk                 (_U_(0x1) << MCAN_TXBTO_TO20_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 20 Mask */
+#define MCAN_TXBTO_TO20                     MCAN_TXBTO_TO20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO20_Msk instead */
+#define MCAN_TXBTO_TO21_Pos                 21                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 21 Position */
+#define MCAN_TXBTO_TO21_Msk                 (_U_(0x1) << MCAN_TXBTO_TO21_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 21 Mask */
+#define MCAN_TXBTO_TO21                     MCAN_TXBTO_TO21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO21_Msk instead */
+#define MCAN_TXBTO_TO22_Pos                 22                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 22 Position */
+#define MCAN_TXBTO_TO22_Msk                 (_U_(0x1) << MCAN_TXBTO_TO22_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 22 Mask */
+#define MCAN_TXBTO_TO22                     MCAN_TXBTO_TO22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO22_Msk instead */
+#define MCAN_TXBTO_TO23_Pos                 23                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 23 Position */
+#define MCAN_TXBTO_TO23_Msk                 (_U_(0x1) << MCAN_TXBTO_TO23_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 23 Mask */
+#define MCAN_TXBTO_TO23                     MCAN_TXBTO_TO23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO23_Msk instead */
+#define MCAN_TXBTO_TO24_Pos                 24                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 24 Position */
+#define MCAN_TXBTO_TO24_Msk                 (_U_(0x1) << MCAN_TXBTO_TO24_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 24 Mask */
+#define MCAN_TXBTO_TO24                     MCAN_TXBTO_TO24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO24_Msk instead */
+#define MCAN_TXBTO_TO25_Pos                 25                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 25 Position */
+#define MCAN_TXBTO_TO25_Msk                 (_U_(0x1) << MCAN_TXBTO_TO25_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 25 Mask */
+#define MCAN_TXBTO_TO25                     MCAN_TXBTO_TO25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO25_Msk instead */
+#define MCAN_TXBTO_TO26_Pos                 26                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 26 Position */
+#define MCAN_TXBTO_TO26_Msk                 (_U_(0x1) << MCAN_TXBTO_TO26_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 26 Mask */
+#define MCAN_TXBTO_TO26                     MCAN_TXBTO_TO26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO26_Msk instead */
+#define MCAN_TXBTO_TO27_Pos                 27                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 27 Position */
+#define MCAN_TXBTO_TO27_Msk                 (_U_(0x1) << MCAN_TXBTO_TO27_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 27 Mask */
+#define MCAN_TXBTO_TO27                     MCAN_TXBTO_TO27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO27_Msk instead */
+#define MCAN_TXBTO_TO28_Pos                 28                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 28 Position */
+#define MCAN_TXBTO_TO28_Msk                 (_U_(0x1) << MCAN_TXBTO_TO28_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 28 Mask */
+#define MCAN_TXBTO_TO28                     MCAN_TXBTO_TO28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO28_Msk instead */
+#define MCAN_TXBTO_TO29_Pos                 29                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 29 Position */
+#define MCAN_TXBTO_TO29_Msk                 (_U_(0x1) << MCAN_TXBTO_TO29_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 29 Mask */
+#define MCAN_TXBTO_TO29                     MCAN_TXBTO_TO29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO29_Msk instead */
+#define MCAN_TXBTO_TO30_Pos                 30                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 30 Position */
+#define MCAN_TXBTO_TO30_Msk                 (_U_(0x1) << MCAN_TXBTO_TO30_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 30 Mask */
+#define MCAN_TXBTO_TO30                     MCAN_TXBTO_TO30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO30_Msk instead */
+#define MCAN_TXBTO_TO31_Pos                 31                                             /**< (MCAN_TXBTO) Transmission Occurred for Buffer 31 Position */
+#define MCAN_TXBTO_TO31_Msk                 (_U_(0x1) << MCAN_TXBTO_TO31_Pos)              /**< (MCAN_TXBTO) Transmission Occurred for Buffer 31 Mask */
+#define MCAN_TXBTO_TO31                     MCAN_TXBTO_TO31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTO_TO31_Msk instead */
+#define MCAN_TXBTO_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBTO) Register MASK  (Use MCAN_TXBTO_Msk instead)  */
+#define MCAN_TXBTO_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBTO) Register Mask  */
+
+#define MCAN_TXBTO_TO_Pos                   0                                              /**< (MCAN_TXBTO Position) Transmission Occurred for Buffer 3x */
+#define MCAN_TXBTO_TO_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBTO_TO_Pos)         /**< (MCAN_TXBTO Mask) TO */
+#define MCAN_TXBTO_TO(value)                (MCAN_TXBTO_TO_Msk & ((value) << MCAN_TXBTO_TO_Pos))  
+
+/* -------- MCAN_TXBCF : (MCAN Offset: 0xdc) (R/ 32) Transmit Buffer Cancellation Finished Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CF0:1;                     /**< bit:      0  Cancellation Finished for Transmit Buffer 0 */
+    uint32_t CF1:1;                     /**< bit:      1  Cancellation Finished for Transmit Buffer 1 */
+    uint32_t CF2:1;                     /**< bit:      2  Cancellation Finished for Transmit Buffer 2 */
+    uint32_t CF3:1;                     /**< bit:      3  Cancellation Finished for Transmit Buffer 3 */
+    uint32_t CF4:1;                     /**< bit:      4  Cancellation Finished for Transmit Buffer 4 */
+    uint32_t CF5:1;                     /**< bit:      5  Cancellation Finished for Transmit Buffer 5 */
+    uint32_t CF6:1;                     /**< bit:      6  Cancellation Finished for Transmit Buffer 6 */
+    uint32_t CF7:1;                     /**< bit:      7  Cancellation Finished for Transmit Buffer 7 */
+    uint32_t CF8:1;                     /**< bit:      8  Cancellation Finished for Transmit Buffer 8 */
+    uint32_t CF9:1;                     /**< bit:      9  Cancellation Finished for Transmit Buffer 9 */
+    uint32_t CF10:1;                    /**< bit:     10  Cancellation Finished for Transmit Buffer 10 */
+    uint32_t CF11:1;                    /**< bit:     11  Cancellation Finished for Transmit Buffer 11 */
+    uint32_t CF12:1;                    /**< bit:     12  Cancellation Finished for Transmit Buffer 12 */
+    uint32_t CF13:1;                    /**< bit:     13  Cancellation Finished for Transmit Buffer 13 */
+    uint32_t CF14:1;                    /**< bit:     14  Cancellation Finished for Transmit Buffer 14 */
+    uint32_t CF15:1;                    /**< bit:     15  Cancellation Finished for Transmit Buffer 15 */
+    uint32_t CF16:1;                    /**< bit:     16  Cancellation Finished for Transmit Buffer 16 */
+    uint32_t CF17:1;                    /**< bit:     17  Cancellation Finished for Transmit Buffer 17 */
+    uint32_t CF18:1;                    /**< bit:     18  Cancellation Finished for Transmit Buffer 18 */
+    uint32_t CF19:1;                    /**< bit:     19  Cancellation Finished for Transmit Buffer 19 */
+    uint32_t CF20:1;                    /**< bit:     20  Cancellation Finished for Transmit Buffer 20 */
+    uint32_t CF21:1;                    /**< bit:     21  Cancellation Finished for Transmit Buffer 21 */
+    uint32_t CF22:1;                    /**< bit:     22  Cancellation Finished for Transmit Buffer 22 */
+    uint32_t CF23:1;                    /**< bit:     23  Cancellation Finished for Transmit Buffer 23 */
+    uint32_t CF24:1;                    /**< bit:     24  Cancellation Finished for Transmit Buffer 24 */
+    uint32_t CF25:1;                    /**< bit:     25  Cancellation Finished for Transmit Buffer 25 */
+    uint32_t CF26:1;                    /**< bit:     26  Cancellation Finished for Transmit Buffer 26 */
+    uint32_t CF27:1;                    /**< bit:     27  Cancellation Finished for Transmit Buffer 27 */
+    uint32_t CF28:1;                    /**< bit:     28  Cancellation Finished for Transmit Buffer 28 */
+    uint32_t CF29:1;                    /**< bit:     29  Cancellation Finished for Transmit Buffer 29 */
+    uint32_t CF30:1;                    /**< bit:     30  Cancellation Finished for Transmit Buffer 30 */
+    uint32_t CF31:1;                    /**< bit:     31  Cancellation Finished for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CF:32;                     /**< bit:  0..31  Cancellation Finished for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCF_OFFSET                   (0xDC)                                        /**<  (MCAN_TXBCF) Transmit Buffer Cancellation Finished Register  Offset */
+
+#define MCAN_TXBCF_CF0_Pos                  0                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 0 Position */
+#define MCAN_TXBCF_CF0_Msk                  (_U_(0x1) << MCAN_TXBCF_CF0_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 0 Mask */
+#define MCAN_TXBCF_CF0                      MCAN_TXBCF_CF0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF0_Msk instead */
+#define MCAN_TXBCF_CF1_Pos                  1                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 1 Position */
+#define MCAN_TXBCF_CF1_Msk                  (_U_(0x1) << MCAN_TXBCF_CF1_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 1 Mask */
+#define MCAN_TXBCF_CF1                      MCAN_TXBCF_CF1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF1_Msk instead */
+#define MCAN_TXBCF_CF2_Pos                  2                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 2 Position */
+#define MCAN_TXBCF_CF2_Msk                  (_U_(0x1) << MCAN_TXBCF_CF2_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 2 Mask */
+#define MCAN_TXBCF_CF2                      MCAN_TXBCF_CF2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF2_Msk instead */
+#define MCAN_TXBCF_CF3_Pos                  3                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 3 Position */
+#define MCAN_TXBCF_CF3_Msk                  (_U_(0x1) << MCAN_TXBCF_CF3_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 3 Mask */
+#define MCAN_TXBCF_CF3                      MCAN_TXBCF_CF3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF3_Msk instead */
+#define MCAN_TXBCF_CF4_Pos                  4                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 4 Position */
+#define MCAN_TXBCF_CF4_Msk                  (_U_(0x1) << MCAN_TXBCF_CF4_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 4 Mask */
+#define MCAN_TXBCF_CF4                      MCAN_TXBCF_CF4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF4_Msk instead */
+#define MCAN_TXBCF_CF5_Pos                  5                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 5 Position */
+#define MCAN_TXBCF_CF5_Msk                  (_U_(0x1) << MCAN_TXBCF_CF5_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 5 Mask */
+#define MCAN_TXBCF_CF5                      MCAN_TXBCF_CF5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF5_Msk instead */
+#define MCAN_TXBCF_CF6_Pos                  6                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 6 Position */
+#define MCAN_TXBCF_CF6_Msk                  (_U_(0x1) << MCAN_TXBCF_CF6_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 6 Mask */
+#define MCAN_TXBCF_CF6                      MCAN_TXBCF_CF6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF6_Msk instead */
+#define MCAN_TXBCF_CF7_Pos                  7                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 7 Position */
+#define MCAN_TXBCF_CF7_Msk                  (_U_(0x1) << MCAN_TXBCF_CF7_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 7 Mask */
+#define MCAN_TXBCF_CF7                      MCAN_TXBCF_CF7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF7_Msk instead */
+#define MCAN_TXBCF_CF8_Pos                  8                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 8 Position */
+#define MCAN_TXBCF_CF8_Msk                  (_U_(0x1) << MCAN_TXBCF_CF8_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 8 Mask */
+#define MCAN_TXBCF_CF8                      MCAN_TXBCF_CF8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF8_Msk instead */
+#define MCAN_TXBCF_CF9_Pos                  9                                              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 9 Position */
+#define MCAN_TXBCF_CF9_Msk                  (_U_(0x1) << MCAN_TXBCF_CF9_Pos)               /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 9 Mask */
+#define MCAN_TXBCF_CF9                      MCAN_TXBCF_CF9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF9_Msk instead */
+#define MCAN_TXBCF_CF10_Pos                 10                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 10 Position */
+#define MCAN_TXBCF_CF10_Msk                 (_U_(0x1) << MCAN_TXBCF_CF10_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 10 Mask */
+#define MCAN_TXBCF_CF10                     MCAN_TXBCF_CF10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF10_Msk instead */
+#define MCAN_TXBCF_CF11_Pos                 11                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 11 Position */
+#define MCAN_TXBCF_CF11_Msk                 (_U_(0x1) << MCAN_TXBCF_CF11_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 11 Mask */
+#define MCAN_TXBCF_CF11                     MCAN_TXBCF_CF11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF11_Msk instead */
+#define MCAN_TXBCF_CF12_Pos                 12                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 12 Position */
+#define MCAN_TXBCF_CF12_Msk                 (_U_(0x1) << MCAN_TXBCF_CF12_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 12 Mask */
+#define MCAN_TXBCF_CF12                     MCAN_TXBCF_CF12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF12_Msk instead */
+#define MCAN_TXBCF_CF13_Pos                 13                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 13 Position */
+#define MCAN_TXBCF_CF13_Msk                 (_U_(0x1) << MCAN_TXBCF_CF13_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 13 Mask */
+#define MCAN_TXBCF_CF13                     MCAN_TXBCF_CF13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF13_Msk instead */
+#define MCAN_TXBCF_CF14_Pos                 14                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 14 Position */
+#define MCAN_TXBCF_CF14_Msk                 (_U_(0x1) << MCAN_TXBCF_CF14_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 14 Mask */
+#define MCAN_TXBCF_CF14                     MCAN_TXBCF_CF14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF14_Msk instead */
+#define MCAN_TXBCF_CF15_Pos                 15                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 15 Position */
+#define MCAN_TXBCF_CF15_Msk                 (_U_(0x1) << MCAN_TXBCF_CF15_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 15 Mask */
+#define MCAN_TXBCF_CF15                     MCAN_TXBCF_CF15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF15_Msk instead */
+#define MCAN_TXBCF_CF16_Pos                 16                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 16 Position */
+#define MCAN_TXBCF_CF16_Msk                 (_U_(0x1) << MCAN_TXBCF_CF16_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 16 Mask */
+#define MCAN_TXBCF_CF16                     MCAN_TXBCF_CF16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF16_Msk instead */
+#define MCAN_TXBCF_CF17_Pos                 17                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 17 Position */
+#define MCAN_TXBCF_CF17_Msk                 (_U_(0x1) << MCAN_TXBCF_CF17_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 17 Mask */
+#define MCAN_TXBCF_CF17                     MCAN_TXBCF_CF17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF17_Msk instead */
+#define MCAN_TXBCF_CF18_Pos                 18                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 18 Position */
+#define MCAN_TXBCF_CF18_Msk                 (_U_(0x1) << MCAN_TXBCF_CF18_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 18 Mask */
+#define MCAN_TXBCF_CF18                     MCAN_TXBCF_CF18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF18_Msk instead */
+#define MCAN_TXBCF_CF19_Pos                 19                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 19 Position */
+#define MCAN_TXBCF_CF19_Msk                 (_U_(0x1) << MCAN_TXBCF_CF19_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 19 Mask */
+#define MCAN_TXBCF_CF19                     MCAN_TXBCF_CF19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF19_Msk instead */
+#define MCAN_TXBCF_CF20_Pos                 20                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 20 Position */
+#define MCAN_TXBCF_CF20_Msk                 (_U_(0x1) << MCAN_TXBCF_CF20_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 20 Mask */
+#define MCAN_TXBCF_CF20                     MCAN_TXBCF_CF20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF20_Msk instead */
+#define MCAN_TXBCF_CF21_Pos                 21                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 21 Position */
+#define MCAN_TXBCF_CF21_Msk                 (_U_(0x1) << MCAN_TXBCF_CF21_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 21 Mask */
+#define MCAN_TXBCF_CF21                     MCAN_TXBCF_CF21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF21_Msk instead */
+#define MCAN_TXBCF_CF22_Pos                 22                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 22 Position */
+#define MCAN_TXBCF_CF22_Msk                 (_U_(0x1) << MCAN_TXBCF_CF22_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 22 Mask */
+#define MCAN_TXBCF_CF22                     MCAN_TXBCF_CF22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF22_Msk instead */
+#define MCAN_TXBCF_CF23_Pos                 23                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 23 Position */
+#define MCAN_TXBCF_CF23_Msk                 (_U_(0x1) << MCAN_TXBCF_CF23_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 23 Mask */
+#define MCAN_TXBCF_CF23                     MCAN_TXBCF_CF23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF23_Msk instead */
+#define MCAN_TXBCF_CF24_Pos                 24                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 24 Position */
+#define MCAN_TXBCF_CF24_Msk                 (_U_(0x1) << MCAN_TXBCF_CF24_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 24 Mask */
+#define MCAN_TXBCF_CF24                     MCAN_TXBCF_CF24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF24_Msk instead */
+#define MCAN_TXBCF_CF25_Pos                 25                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 25 Position */
+#define MCAN_TXBCF_CF25_Msk                 (_U_(0x1) << MCAN_TXBCF_CF25_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 25 Mask */
+#define MCAN_TXBCF_CF25                     MCAN_TXBCF_CF25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF25_Msk instead */
+#define MCAN_TXBCF_CF26_Pos                 26                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 26 Position */
+#define MCAN_TXBCF_CF26_Msk                 (_U_(0x1) << MCAN_TXBCF_CF26_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 26 Mask */
+#define MCAN_TXBCF_CF26                     MCAN_TXBCF_CF26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF26_Msk instead */
+#define MCAN_TXBCF_CF27_Pos                 27                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 27 Position */
+#define MCAN_TXBCF_CF27_Msk                 (_U_(0x1) << MCAN_TXBCF_CF27_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 27 Mask */
+#define MCAN_TXBCF_CF27                     MCAN_TXBCF_CF27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF27_Msk instead */
+#define MCAN_TXBCF_CF28_Pos                 28                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 28 Position */
+#define MCAN_TXBCF_CF28_Msk                 (_U_(0x1) << MCAN_TXBCF_CF28_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 28 Mask */
+#define MCAN_TXBCF_CF28                     MCAN_TXBCF_CF28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF28_Msk instead */
+#define MCAN_TXBCF_CF29_Pos                 29                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 29 Position */
+#define MCAN_TXBCF_CF29_Msk                 (_U_(0x1) << MCAN_TXBCF_CF29_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 29 Mask */
+#define MCAN_TXBCF_CF29                     MCAN_TXBCF_CF29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF29_Msk instead */
+#define MCAN_TXBCF_CF30_Pos                 30                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 30 Position */
+#define MCAN_TXBCF_CF30_Msk                 (_U_(0x1) << MCAN_TXBCF_CF30_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 30 Mask */
+#define MCAN_TXBCF_CF30                     MCAN_TXBCF_CF30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF30_Msk instead */
+#define MCAN_TXBCF_CF31_Pos                 31                                             /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 31 Position */
+#define MCAN_TXBCF_CF31_Msk                 (_U_(0x1) << MCAN_TXBCF_CF31_Pos)              /**< (MCAN_TXBCF) Cancellation Finished for Transmit Buffer 31 Mask */
+#define MCAN_TXBCF_CF31                     MCAN_TXBCF_CF31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCF_CF31_Msk instead */
+#define MCAN_TXBCF_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCF) Register MASK  (Use MCAN_TXBCF_Msk instead)  */
+#define MCAN_TXBCF_Msk                      _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCF) Register Mask  */
+
+#define MCAN_TXBCF_CF_Pos                   0                                              /**< (MCAN_TXBCF Position) Cancellation Finished for Transmit Buffer 3x */
+#define MCAN_TXBCF_CF_Msk                   (_U_(0xFFFFFFFF) << MCAN_TXBCF_CF_Pos)         /**< (MCAN_TXBCF Mask) CF */
+#define MCAN_TXBCF_CF(value)                (MCAN_TXBCF_CF_Msk & ((value) << MCAN_TXBCF_CF_Pos))  
+
+/* -------- MCAN_TXBTIE : (MCAN Offset: 0xe0) (R/W 32) Transmit Buffer Transmission Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TIE0:1;                    /**< bit:      0  Transmission Interrupt Enable for Buffer 0 */
+    uint32_t TIE1:1;                    /**< bit:      1  Transmission Interrupt Enable for Buffer 1 */
+    uint32_t TIE2:1;                    /**< bit:      2  Transmission Interrupt Enable for Buffer 2 */
+    uint32_t TIE3:1;                    /**< bit:      3  Transmission Interrupt Enable for Buffer 3 */
+    uint32_t TIE4:1;                    /**< bit:      4  Transmission Interrupt Enable for Buffer 4 */
+    uint32_t TIE5:1;                    /**< bit:      5  Transmission Interrupt Enable for Buffer 5 */
+    uint32_t TIE6:1;                    /**< bit:      6  Transmission Interrupt Enable for Buffer 6 */
+    uint32_t TIE7:1;                    /**< bit:      7  Transmission Interrupt Enable for Buffer 7 */
+    uint32_t TIE8:1;                    /**< bit:      8  Transmission Interrupt Enable for Buffer 8 */
+    uint32_t TIE9:1;                    /**< bit:      9  Transmission Interrupt Enable for Buffer 9 */
+    uint32_t TIE10:1;                   /**< bit:     10  Transmission Interrupt Enable for Buffer 10 */
+    uint32_t TIE11:1;                   /**< bit:     11  Transmission Interrupt Enable for Buffer 11 */
+    uint32_t TIE12:1;                   /**< bit:     12  Transmission Interrupt Enable for Buffer 12 */
+    uint32_t TIE13:1;                   /**< bit:     13  Transmission Interrupt Enable for Buffer 13 */
+    uint32_t TIE14:1;                   /**< bit:     14  Transmission Interrupt Enable for Buffer 14 */
+    uint32_t TIE15:1;                   /**< bit:     15  Transmission Interrupt Enable for Buffer 15 */
+    uint32_t TIE16:1;                   /**< bit:     16  Transmission Interrupt Enable for Buffer 16 */
+    uint32_t TIE17:1;                   /**< bit:     17  Transmission Interrupt Enable for Buffer 17 */
+    uint32_t TIE18:1;                   /**< bit:     18  Transmission Interrupt Enable for Buffer 18 */
+    uint32_t TIE19:1;                   /**< bit:     19  Transmission Interrupt Enable for Buffer 19 */
+    uint32_t TIE20:1;                   /**< bit:     20  Transmission Interrupt Enable for Buffer 20 */
+    uint32_t TIE21:1;                   /**< bit:     21  Transmission Interrupt Enable for Buffer 21 */
+    uint32_t TIE22:1;                   /**< bit:     22  Transmission Interrupt Enable for Buffer 22 */
+    uint32_t TIE23:1;                   /**< bit:     23  Transmission Interrupt Enable for Buffer 23 */
+    uint32_t TIE24:1;                   /**< bit:     24  Transmission Interrupt Enable for Buffer 24 */
+    uint32_t TIE25:1;                   /**< bit:     25  Transmission Interrupt Enable for Buffer 25 */
+    uint32_t TIE26:1;                   /**< bit:     26  Transmission Interrupt Enable for Buffer 26 */
+    uint32_t TIE27:1;                   /**< bit:     27  Transmission Interrupt Enable for Buffer 27 */
+    uint32_t TIE28:1;                   /**< bit:     28  Transmission Interrupt Enable for Buffer 28 */
+    uint32_t TIE29:1;                   /**< bit:     29  Transmission Interrupt Enable for Buffer 29 */
+    uint32_t TIE30:1;                   /**< bit:     30  Transmission Interrupt Enable for Buffer 30 */
+    uint32_t TIE31:1;                   /**< bit:     31  Transmission Interrupt Enable for Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t TIE:32;                    /**< bit:  0..31  Transmission Interrupt Enable for Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBTIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBTIE_OFFSET                  (0xE0)                                        /**<  (MCAN_TXBTIE) Transmit Buffer Transmission Interrupt Enable Register  Offset */
+
+#define MCAN_TXBTIE_TIE0_Pos                0                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 0 Position */
+#define MCAN_TXBTIE_TIE0_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE0_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 0 Mask */
+#define MCAN_TXBTIE_TIE0                    MCAN_TXBTIE_TIE0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE0_Msk instead */
+#define MCAN_TXBTIE_TIE1_Pos                1                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 1 Position */
+#define MCAN_TXBTIE_TIE1_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE1_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 1 Mask */
+#define MCAN_TXBTIE_TIE1                    MCAN_TXBTIE_TIE1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE1_Msk instead */
+#define MCAN_TXBTIE_TIE2_Pos                2                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 2 Position */
+#define MCAN_TXBTIE_TIE2_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE2_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 2 Mask */
+#define MCAN_TXBTIE_TIE2                    MCAN_TXBTIE_TIE2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE2_Msk instead */
+#define MCAN_TXBTIE_TIE3_Pos                3                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 3 Position */
+#define MCAN_TXBTIE_TIE3_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE3_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 3 Mask */
+#define MCAN_TXBTIE_TIE3                    MCAN_TXBTIE_TIE3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE3_Msk instead */
+#define MCAN_TXBTIE_TIE4_Pos                4                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 4 Position */
+#define MCAN_TXBTIE_TIE4_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE4_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 4 Mask */
+#define MCAN_TXBTIE_TIE4                    MCAN_TXBTIE_TIE4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE4_Msk instead */
+#define MCAN_TXBTIE_TIE5_Pos                5                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 5 Position */
+#define MCAN_TXBTIE_TIE5_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE5_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 5 Mask */
+#define MCAN_TXBTIE_TIE5                    MCAN_TXBTIE_TIE5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE5_Msk instead */
+#define MCAN_TXBTIE_TIE6_Pos                6                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 6 Position */
+#define MCAN_TXBTIE_TIE6_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE6_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 6 Mask */
+#define MCAN_TXBTIE_TIE6                    MCAN_TXBTIE_TIE6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE6_Msk instead */
+#define MCAN_TXBTIE_TIE7_Pos                7                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 7 Position */
+#define MCAN_TXBTIE_TIE7_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE7_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 7 Mask */
+#define MCAN_TXBTIE_TIE7                    MCAN_TXBTIE_TIE7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE7_Msk instead */
+#define MCAN_TXBTIE_TIE8_Pos                8                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 8 Position */
+#define MCAN_TXBTIE_TIE8_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE8_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 8 Mask */
+#define MCAN_TXBTIE_TIE8                    MCAN_TXBTIE_TIE8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE8_Msk instead */
+#define MCAN_TXBTIE_TIE9_Pos                9                                              /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 9 Position */
+#define MCAN_TXBTIE_TIE9_Msk                (_U_(0x1) << MCAN_TXBTIE_TIE9_Pos)             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 9 Mask */
+#define MCAN_TXBTIE_TIE9                    MCAN_TXBTIE_TIE9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE9_Msk instead */
+#define MCAN_TXBTIE_TIE10_Pos               10                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 10 Position */
+#define MCAN_TXBTIE_TIE10_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE10_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 10 Mask */
+#define MCAN_TXBTIE_TIE10                   MCAN_TXBTIE_TIE10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE10_Msk instead */
+#define MCAN_TXBTIE_TIE11_Pos               11                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 11 Position */
+#define MCAN_TXBTIE_TIE11_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE11_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 11 Mask */
+#define MCAN_TXBTIE_TIE11                   MCAN_TXBTIE_TIE11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE11_Msk instead */
+#define MCAN_TXBTIE_TIE12_Pos               12                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 12 Position */
+#define MCAN_TXBTIE_TIE12_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE12_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 12 Mask */
+#define MCAN_TXBTIE_TIE12                   MCAN_TXBTIE_TIE12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE12_Msk instead */
+#define MCAN_TXBTIE_TIE13_Pos               13                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 13 Position */
+#define MCAN_TXBTIE_TIE13_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE13_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 13 Mask */
+#define MCAN_TXBTIE_TIE13                   MCAN_TXBTIE_TIE13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE13_Msk instead */
+#define MCAN_TXBTIE_TIE14_Pos               14                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 14 Position */
+#define MCAN_TXBTIE_TIE14_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE14_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 14 Mask */
+#define MCAN_TXBTIE_TIE14                   MCAN_TXBTIE_TIE14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE14_Msk instead */
+#define MCAN_TXBTIE_TIE15_Pos               15                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 15 Position */
+#define MCAN_TXBTIE_TIE15_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE15_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 15 Mask */
+#define MCAN_TXBTIE_TIE15                   MCAN_TXBTIE_TIE15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE15_Msk instead */
+#define MCAN_TXBTIE_TIE16_Pos               16                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 16 Position */
+#define MCAN_TXBTIE_TIE16_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE16_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 16 Mask */
+#define MCAN_TXBTIE_TIE16                   MCAN_TXBTIE_TIE16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE16_Msk instead */
+#define MCAN_TXBTIE_TIE17_Pos               17                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 17 Position */
+#define MCAN_TXBTIE_TIE17_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE17_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 17 Mask */
+#define MCAN_TXBTIE_TIE17                   MCAN_TXBTIE_TIE17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE17_Msk instead */
+#define MCAN_TXBTIE_TIE18_Pos               18                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 18 Position */
+#define MCAN_TXBTIE_TIE18_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE18_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 18 Mask */
+#define MCAN_TXBTIE_TIE18                   MCAN_TXBTIE_TIE18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE18_Msk instead */
+#define MCAN_TXBTIE_TIE19_Pos               19                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 19 Position */
+#define MCAN_TXBTIE_TIE19_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE19_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 19 Mask */
+#define MCAN_TXBTIE_TIE19                   MCAN_TXBTIE_TIE19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE19_Msk instead */
+#define MCAN_TXBTIE_TIE20_Pos               20                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 20 Position */
+#define MCAN_TXBTIE_TIE20_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE20_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 20 Mask */
+#define MCAN_TXBTIE_TIE20                   MCAN_TXBTIE_TIE20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE20_Msk instead */
+#define MCAN_TXBTIE_TIE21_Pos               21                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 21 Position */
+#define MCAN_TXBTIE_TIE21_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE21_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 21 Mask */
+#define MCAN_TXBTIE_TIE21                   MCAN_TXBTIE_TIE21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE21_Msk instead */
+#define MCAN_TXBTIE_TIE22_Pos               22                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 22 Position */
+#define MCAN_TXBTIE_TIE22_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE22_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 22 Mask */
+#define MCAN_TXBTIE_TIE22                   MCAN_TXBTIE_TIE22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE22_Msk instead */
+#define MCAN_TXBTIE_TIE23_Pos               23                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 23 Position */
+#define MCAN_TXBTIE_TIE23_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE23_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 23 Mask */
+#define MCAN_TXBTIE_TIE23                   MCAN_TXBTIE_TIE23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE23_Msk instead */
+#define MCAN_TXBTIE_TIE24_Pos               24                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 24 Position */
+#define MCAN_TXBTIE_TIE24_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE24_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 24 Mask */
+#define MCAN_TXBTIE_TIE24                   MCAN_TXBTIE_TIE24_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE24_Msk instead */
+#define MCAN_TXBTIE_TIE25_Pos               25                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 25 Position */
+#define MCAN_TXBTIE_TIE25_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE25_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 25 Mask */
+#define MCAN_TXBTIE_TIE25                   MCAN_TXBTIE_TIE25_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE25_Msk instead */
+#define MCAN_TXBTIE_TIE26_Pos               26                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 26 Position */
+#define MCAN_TXBTIE_TIE26_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE26_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 26 Mask */
+#define MCAN_TXBTIE_TIE26                   MCAN_TXBTIE_TIE26_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE26_Msk instead */
+#define MCAN_TXBTIE_TIE27_Pos               27                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 27 Position */
+#define MCAN_TXBTIE_TIE27_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE27_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 27 Mask */
+#define MCAN_TXBTIE_TIE27                   MCAN_TXBTIE_TIE27_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE27_Msk instead */
+#define MCAN_TXBTIE_TIE28_Pos               28                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 28 Position */
+#define MCAN_TXBTIE_TIE28_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE28_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 28 Mask */
+#define MCAN_TXBTIE_TIE28                   MCAN_TXBTIE_TIE28_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE28_Msk instead */
+#define MCAN_TXBTIE_TIE29_Pos               29                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 29 Position */
+#define MCAN_TXBTIE_TIE29_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE29_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 29 Mask */
+#define MCAN_TXBTIE_TIE29                   MCAN_TXBTIE_TIE29_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE29_Msk instead */
+#define MCAN_TXBTIE_TIE30_Pos               30                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 30 Position */
+#define MCAN_TXBTIE_TIE30_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE30_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 30 Mask */
+#define MCAN_TXBTIE_TIE30                   MCAN_TXBTIE_TIE30_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE30_Msk instead */
+#define MCAN_TXBTIE_TIE31_Pos               31                                             /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 31 Position */
+#define MCAN_TXBTIE_TIE31_Msk               (_U_(0x1) << MCAN_TXBTIE_TIE31_Pos)            /**< (MCAN_TXBTIE) Transmission Interrupt Enable for Buffer 31 Mask */
+#define MCAN_TXBTIE_TIE31                   MCAN_TXBTIE_TIE31_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBTIE_TIE31_Msk instead */
+#define MCAN_TXBTIE_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBTIE) Register MASK  (Use MCAN_TXBTIE_Msk instead)  */
+#define MCAN_TXBTIE_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBTIE) Register Mask  */
+
+#define MCAN_TXBTIE_TIE_Pos                 0                                              /**< (MCAN_TXBTIE Position) Transmission Interrupt Enable for Buffer 3x */
+#define MCAN_TXBTIE_TIE_Msk                 (_U_(0xFFFFFFFF) << MCAN_TXBTIE_TIE_Pos)       /**< (MCAN_TXBTIE Mask) TIE */
+#define MCAN_TXBTIE_TIE(value)              (MCAN_TXBTIE_TIE_Msk & ((value) << MCAN_TXBTIE_TIE_Pos))  
+
+/* -------- MCAN_TXBCIE : (MCAN Offset: 0xe4) (R/W 32) Transmit Buffer Cancellation Finished Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CFIE0:1;                   /**< bit:      0  Cancellation Finished Interrupt Enable for Transmit Buffer 0 */
+    uint32_t CFIE1:1;                   /**< bit:      1  Cancellation Finished Interrupt Enable for Transmit Buffer 1 */
+    uint32_t CFIE2:1;                   /**< bit:      2  Cancellation Finished Interrupt Enable for Transmit Buffer 2 */
+    uint32_t CFIE3:1;                   /**< bit:      3  Cancellation Finished Interrupt Enable for Transmit Buffer 3 */
+    uint32_t CFIE4:1;                   /**< bit:      4  Cancellation Finished Interrupt Enable for Transmit Buffer 4 */
+    uint32_t CFIE5:1;                   /**< bit:      5  Cancellation Finished Interrupt Enable for Transmit Buffer 5 */
+    uint32_t CFIE6:1;                   /**< bit:      6  Cancellation Finished Interrupt Enable for Transmit Buffer 6 */
+    uint32_t CFIE7:1;                   /**< bit:      7  Cancellation Finished Interrupt Enable for Transmit Buffer 7 */
+    uint32_t CFIE8:1;                   /**< bit:      8  Cancellation Finished Interrupt Enable for Transmit Buffer 8 */
+    uint32_t CFIE9:1;                   /**< bit:      9  Cancellation Finished Interrupt Enable for Transmit Buffer 9 */
+    uint32_t CFIE10:1;                  /**< bit:     10  Cancellation Finished Interrupt Enable for Transmit Buffer 10 */
+    uint32_t CFIE11:1;                  /**< bit:     11  Cancellation Finished Interrupt Enable for Transmit Buffer 11 */
+    uint32_t CFIE12:1;                  /**< bit:     12  Cancellation Finished Interrupt Enable for Transmit Buffer 12 */
+    uint32_t CFIE13:1;                  /**< bit:     13  Cancellation Finished Interrupt Enable for Transmit Buffer 13 */
+    uint32_t CFIE14:1;                  /**< bit:     14  Cancellation Finished Interrupt Enable for Transmit Buffer 14 */
+    uint32_t CFIE15:1;                  /**< bit:     15  Cancellation Finished Interrupt Enable for Transmit Buffer 15 */
+    uint32_t CFIE16:1;                  /**< bit:     16  Cancellation Finished Interrupt Enable for Transmit Buffer 16 */
+    uint32_t CFIE17:1;                  /**< bit:     17  Cancellation Finished Interrupt Enable for Transmit Buffer 17 */
+    uint32_t CFIE18:1;                  /**< bit:     18  Cancellation Finished Interrupt Enable for Transmit Buffer 18 */
+    uint32_t CFIE19:1;                  /**< bit:     19  Cancellation Finished Interrupt Enable for Transmit Buffer 19 */
+    uint32_t CFIE20:1;                  /**< bit:     20  Cancellation Finished Interrupt Enable for Transmit Buffer 20 */
+    uint32_t CFIE21:1;                  /**< bit:     21  Cancellation Finished Interrupt Enable for Transmit Buffer 21 */
+    uint32_t CFIE22:1;                  /**< bit:     22  Cancellation Finished Interrupt Enable for Transmit Buffer 22 */
+    uint32_t CFIE23:1;                  /**< bit:     23  Cancellation Finished Interrupt Enable for Transmit Buffer 23 */
+    uint32_t CFIE24:1;                  /**< bit:     24  Cancellation Finished Interrupt Enable for Transmit Buffer 24 */
+    uint32_t CFIE25:1;                  /**< bit:     25  Cancellation Finished Interrupt Enable for Transmit Buffer 25 */
+    uint32_t CFIE26:1;                  /**< bit:     26  Cancellation Finished Interrupt Enable for Transmit Buffer 26 */
+    uint32_t CFIE27:1;                  /**< bit:     27  Cancellation Finished Interrupt Enable for Transmit Buffer 27 */
+    uint32_t CFIE28:1;                  /**< bit:     28  Cancellation Finished Interrupt Enable for Transmit Buffer 28 */
+    uint32_t CFIE29:1;                  /**< bit:     29  Cancellation Finished Interrupt Enable for Transmit Buffer 29 */
+    uint32_t CFIE30:1;                  /**< bit:     30  Cancellation Finished Interrupt Enable for Transmit Buffer 30 */
+    uint32_t CFIE31:1;                  /**< bit:     31  Cancellation Finished Interrupt Enable for Transmit Buffer 31 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CFIE:32;                   /**< bit:  0..31  Cancellation Finished Interrupt Enable for Transmit Buffer 3x */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBCIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBCIE_OFFSET                  (0xE4)                                        /**<  (MCAN_TXBCIE) Transmit Buffer Cancellation Finished Interrupt Enable Register  Offset */
+
+#define MCAN_TXBCIE_CFIE0_Pos               0                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 0 Position */
+#define MCAN_TXBCIE_CFIE0_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE0_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 0 Mask */
+#define MCAN_TXBCIE_CFIE0                   MCAN_TXBCIE_CFIE0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE0_Msk instead */
+#define MCAN_TXBCIE_CFIE1_Pos               1                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 1 Position */
+#define MCAN_TXBCIE_CFIE1_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE1_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 1 Mask */
+#define MCAN_TXBCIE_CFIE1                   MCAN_TXBCIE_CFIE1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE1_Msk instead */
+#define MCAN_TXBCIE_CFIE2_Pos               2                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 2 Position */
+#define MCAN_TXBCIE_CFIE2_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE2_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 2 Mask */
+#define MCAN_TXBCIE_CFIE2                   MCAN_TXBCIE_CFIE2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE2_Msk instead */
+#define MCAN_TXBCIE_CFIE3_Pos               3                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 3 Position */
+#define MCAN_TXBCIE_CFIE3_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE3_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 3 Mask */
+#define MCAN_TXBCIE_CFIE3                   MCAN_TXBCIE_CFIE3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE3_Msk instead */
+#define MCAN_TXBCIE_CFIE4_Pos               4                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 4 Position */
+#define MCAN_TXBCIE_CFIE4_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE4_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 4 Mask */
+#define MCAN_TXBCIE_CFIE4                   MCAN_TXBCIE_CFIE4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE4_Msk instead */
+#define MCAN_TXBCIE_CFIE5_Pos               5                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 5 Position */
+#define MCAN_TXBCIE_CFIE5_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE5_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 5 Mask */
+#define MCAN_TXBCIE_CFIE5                   MCAN_TXBCIE_CFIE5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE5_Msk instead */
+#define MCAN_TXBCIE_CFIE6_Pos               6                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 6 Position */
+#define MCAN_TXBCIE_CFIE6_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE6_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 6 Mask */
+#define MCAN_TXBCIE_CFIE6                   MCAN_TXBCIE_CFIE6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE6_Msk instead */
+#define MCAN_TXBCIE_CFIE7_Pos               7                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 7 Position */
+#define MCAN_TXBCIE_CFIE7_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE7_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 7 Mask */
+#define MCAN_TXBCIE_CFIE7                   MCAN_TXBCIE_CFIE7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE7_Msk instead */
+#define MCAN_TXBCIE_CFIE8_Pos               8                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 8 Position */
+#define MCAN_TXBCIE_CFIE8_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE8_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 8 Mask */
+#define MCAN_TXBCIE_CFIE8                   MCAN_TXBCIE_CFIE8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE8_Msk instead */
+#define MCAN_TXBCIE_CFIE9_Pos               9                                              /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 9 Position */
+#define MCAN_TXBCIE_CFIE9_Msk               (_U_(0x1) << MCAN_TXBCIE_CFIE9_Pos)            /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 9 Mask */
+#define MCAN_TXBCIE_CFIE9                   MCAN_TXBCIE_CFIE9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE9_Msk instead */
+#define MCAN_TXBCIE_CFIE10_Pos              10                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 10 Position */
+#define MCAN_TXBCIE_CFIE10_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE10_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 10 Mask */
+#define MCAN_TXBCIE_CFIE10                  MCAN_TXBCIE_CFIE10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE10_Msk instead */
+#define MCAN_TXBCIE_CFIE11_Pos              11                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 11 Position */
+#define MCAN_TXBCIE_CFIE11_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE11_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 11 Mask */
+#define MCAN_TXBCIE_CFIE11                  MCAN_TXBCIE_CFIE11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE11_Msk instead */
+#define MCAN_TXBCIE_CFIE12_Pos              12                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 12 Position */
+#define MCAN_TXBCIE_CFIE12_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE12_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 12 Mask */
+#define MCAN_TXBCIE_CFIE12                  MCAN_TXBCIE_CFIE12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE12_Msk instead */
+#define MCAN_TXBCIE_CFIE13_Pos              13                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 13 Position */
+#define MCAN_TXBCIE_CFIE13_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE13_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 13 Mask */
+#define MCAN_TXBCIE_CFIE13                  MCAN_TXBCIE_CFIE13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE13_Msk instead */
+#define MCAN_TXBCIE_CFIE14_Pos              14                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 14 Position */
+#define MCAN_TXBCIE_CFIE14_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE14_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 14 Mask */
+#define MCAN_TXBCIE_CFIE14                  MCAN_TXBCIE_CFIE14_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE14_Msk instead */
+#define MCAN_TXBCIE_CFIE15_Pos              15                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 15 Position */
+#define MCAN_TXBCIE_CFIE15_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE15_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 15 Mask */
+#define MCAN_TXBCIE_CFIE15                  MCAN_TXBCIE_CFIE15_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE15_Msk instead */
+#define MCAN_TXBCIE_CFIE16_Pos              16                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 16 Position */
+#define MCAN_TXBCIE_CFIE16_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE16_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 16 Mask */
+#define MCAN_TXBCIE_CFIE16                  MCAN_TXBCIE_CFIE16_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE16_Msk instead */
+#define MCAN_TXBCIE_CFIE17_Pos              17                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 17 Position */
+#define MCAN_TXBCIE_CFIE17_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE17_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 17 Mask */
+#define MCAN_TXBCIE_CFIE17                  MCAN_TXBCIE_CFIE17_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE17_Msk instead */
+#define MCAN_TXBCIE_CFIE18_Pos              18                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 18 Position */
+#define MCAN_TXBCIE_CFIE18_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE18_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 18 Mask */
+#define MCAN_TXBCIE_CFIE18                  MCAN_TXBCIE_CFIE18_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE18_Msk instead */
+#define MCAN_TXBCIE_CFIE19_Pos              19                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 19 Position */
+#define MCAN_TXBCIE_CFIE19_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE19_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 19 Mask */
+#define MCAN_TXBCIE_CFIE19                  MCAN_TXBCIE_CFIE19_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE19_Msk instead */
+#define MCAN_TXBCIE_CFIE20_Pos              20                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 20 Position */
+#define MCAN_TXBCIE_CFIE20_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE20_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 20 Mask */
+#define MCAN_TXBCIE_CFIE20                  MCAN_TXBCIE_CFIE20_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE20_Msk instead */
+#define MCAN_TXBCIE_CFIE21_Pos              21                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 21 Position */
+#define MCAN_TXBCIE_CFIE21_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE21_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 21 Mask */
+#define MCAN_TXBCIE_CFIE21                  MCAN_TXBCIE_CFIE21_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE21_Msk instead */
+#define MCAN_TXBCIE_CFIE22_Pos              22                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 22 Position */
+#define MCAN_TXBCIE_CFIE22_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE22_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 22 Mask */
+#define MCAN_TXBCIE_CFIE22                  MCAN_TXBCIE_CFIE22_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE22_Msk instead */
+#define MCAN_TXBCIE_CFIE23_Pos              23                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 23 Position */
+#define MCAN_TXBCIE_CFIE23_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE23_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 23 Mask */
+#define MCAN_TXBCIE_CFIE23                  MCAN_TXBCIE_CFIE23_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE23_Msk instead */
+#define MCAN_TXBCIE_CFIE24_Pos              24                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 24 Position */
+#define MCAN_TXBCIE_CFIE24_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE24_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 24 Mask */
+#define MCAN_TXBCIE_CFIE24                  MCAN_TXBCIE_CFIE24_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE24_Msk instead */
+#define MCAN_TXBCIE_CFIE25_Pos              25                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 25 Position */
+#define MCAN_TXBCIE_CFIE25_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE25_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 25 Mask */
+#define MCAN_TXBCIE_CFIE25                  MCAN_TXBCIE_CFIE25_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE25_Msk instead */
+#define MCAN_TXBCIE_CFIE26_Pos              26                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 26 Position */
+#define MCAN_TXBCIE_CFIE26_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE26_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 26 Mask */
+#define MCAN_TXBCIE_CFIE26                  MCAN_TXBCIE_CFIE26_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE26_Msk instead */
+#define MCAN_TXBCIE_CFIE27_Pos              27                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 27 Position */
+#define MCAN_TXBCIE_CFIE27_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE27_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 27 Mask */
+#define MCAN_TXBCIE_CFIE27                  MCAN_TXBCIE_CFIE27_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE27_Msk instead */
+#define MCAN_TXBCIE_CFIE28_Pos              28                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 28 Position */
+#define MCAN_TXBCIE_CFIE28_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE28_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 28 Mask */
+#define MCAN_TXBCIE_CFIE28                  MCAN_TXBCIE_CFIE28_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE28_Msk instead */
+#define MCAN_TXBCIE_CFIE29_Pos              29                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 29 Position */
+#define MCAN_TXBCIE_CFIE29_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE29_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 29 Mask */
+#define MCAN_TXBCIE_CFIE29                  MCAN_TXBCIE_CFIE29_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE29_Msk instead */
+#define MCAN_TXBCIE_CFIE30_Pos              30                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 30 Position */
+#define MCAN_TXBCIE_CFIE30_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE30_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 30 Mask */
+#define MCAN_TXBCIE_CFIE30                  MCAN_TXBCIE_CFIE30_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE30_Msk instead */
+#define MCAN_TXBCIE_CFIE31_Pos              31                                             /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 31 Position */
+#define MCAN_TXBCIE_CFIE31_Msk              (_U_(0x1) << MCAN_TXBCIE_CFIE31_Pos)           /**< (MCAN_TXBCIE) Cancellation Finished Interrupt Enable for Transmit Buffer 31 Mask */
+#define MCAN_TXBCIE_CFIE31                  MCAN_TXBCIE_CFIE31_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBCIE_CFIE31_Msk instead */
+#define MCAN_TXBCIE_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBCIE) Register MASK  (Use MCAN_TXBCIE_Msk instead)  */
+#define MCAN_TXBCIE_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBCIE) Register Mask  */
+
+#define MCAN_TXBCIE_CFIE_Pos                0                                              /**< (MCAN_TXBCIE Position) Cancellation Finished Interrupt Enable for Transmit Buffer 3x */
+#define MCAN_TXBCIE_CFIE_Msk                (_U_(0xFFFFFFFF) << MCAN_TXBCIE_CFIE_Pos)      /**< (MCAN_TXBCIE Mask) CFIE */
+#define MCAN_TXBCIE_CFIE(value)             (MCAN_TXBCIE_CFIE_Msk & ((value) << MCAN_TXBCIE_CFIE_Pos))  
+
+/* -------- MCAN_TXEFC : (MCAN Offset: 0xf0) (R/W 32) Transmit Event FIFO Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t EFSA:14;                   /**< bit:  2..15  Event FIFO Start Address                 */
+    uint32_t EFS:6;                     /**< bit: 16..21  Event FIFO Size                          */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t EFWM:6;                    /**< bit: 24..29  Event FIFO Watermark                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFC_OFFSET                   (0xF0)                                        /**<  (MCAN_TXEFC) Transmit Event FIFO Configuration Register  Offset */
+
+#define MCAN_TXEFC_EFSA_Pos                 2                                              /**< (MCAN_TXEFC) Event FIFO Start Address Position */
+#define MCAN_TXEFC_EFSA_Msk                 (_U_(0x3FFF) << MCAN_TXEFC_EFSA_Pos)           /**< (MCAN_TXEFC) Event FIFO Start Address Mask */
+#define MCAN_TXEFC_EFSA(value)              (MCAN_TXEFC_EFSA_Msk & ((value) << MCAN_TXEFC_EFSA_Pos))
+#define MCAN_TXEFC_EFS_Pos                  16                                             /**< (MCAN_TXEFC) Event FIFO Size Position */
+#define MCAN_TXEFC_EFS_Msk                  (_U_(0x3F) << MCAN_TXEFC_EFS_Pos)              /**< (MCAN_TXEFC) Event FIFO Size Mask */
+#define MCAN_TXEFC_EFS(value)               (MCAN_TXEFC_EFS_Msk & ((value) << MCAN_TXEFC_EFS_Pos))
+#define MCAN_TXEFC_EFWM_Pos                 24                                             /**< (MCAN_TXEFC) Event FIFO Watermark Position */
+#define MCAN_TXEFC_EFWM_Msk                 (_U_(0x3F) << MCAN_TXEFC_EFWM_Pos)             /**< (MCAN_TXEFC) Event FIFO Watermark Mask */
+#define MCAN_TXEFC_EFWM(value)              (MCAN_TXEFC_EFWM_Msk & ((value) << MCAN_TXEFC_EFWM_Pos))
+#define MCAN_TXEFC_MASK                     _U_(0x3F3FFFFC)                                /**< \deprecated (MCAN_TXEFC) Register MASK  (Use MCAN_TXEFC_Msk instead)  */
+#define MCAN_TXEFC_Msk                      _U_(0x3F3FFFFC)                                /**< (MCAN_TXEFC) Register Mask  */
+
+
+/* -------- MCAN_TXEFS : (MCAN Offset: 0xf4) (R/ 32) Transmit Event FIFO Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFFL:6;                    /**< bit:   0..5  Event FIFO Fill Level                    */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t EFGI:5;                    /**< bit:  8..12  Event FIFO Get Index                     */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t EFPI:5;                    /**< bit: 16..20  Event FIFO Put Index                     */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t EFF:1;                     /**< bit:     24  Event FIFO Full                          */
+    uint32_t TEFL:1;                    /**< bit:     25  Tx Event FIFO Element Lost               */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFS_OFFSET                   (0xF4)                                        /**<  (MCAN_TXEFS) Transmit Event FIFO Status Register  Offset */
+
+#define MCAN_TXEFS_EFFL_Pos                 0                                              /**< (MCAN_TXEFS) Event FIFO Fill Level Position */
+#define MCAN_TXEFS_EFFL_Msk                 (_U_(0x3F) << MCAN_TXEFS_EFFL_Pos)             /**< (MCAN_TXEFS) Event FIFO Fill Level Mask */
+#define MCAN_TXEFS_EFFL(value)              (MCAN_TXEFS_EFFL_Msk & ((value) << MCAN_TXEFS_EFFL_Pos))
+#define MCAN_TXEFS_EFGI_Pos                 8                                              /**< (MCAN_TXEFS) Event FIFO Get Index Position */
+#define MCAN_TXEFS_EFGI_Msk                 (_U_(0x1F) << MCAN_TXEFS_EFGI_Pos)             /**< (MCAN_TXEFS) Event FIFO Get Index Mask */
+#define MCAN_TXEFS_EFGI(value)              (MCAN_TXEFS_EFGI_Msk & ((value) << MCAN_TXEFS_EFGI_Pos))
+#define MCAN_TXEFS_EFPI_Pos                 16                                             /**< (MCAN_TXEFS) Event FIFO Put Index Position */
+#define MCAN_TXEFS_EFPI_Msk                 (_U_(0x1F) << MCAN_TXEFS_EFPI_Pos)             /**< (MCAN_TXEFS) Event FIFO Put Index Mask */
+#define MCAN_TXEFS_EFPI(value)              (MCAN_TXEFS_EFPI_Msk & ((value) << MCAN_TXEFS_EFPI_Pos))
+#define MCAN_TXEFS_EFF_Pos                  24                                             /**< (MCAN_TXEFS) Event FIFO Full Position */
+#define MCAN_TXEFS_EFF_Msk                  (_U_(0x1) << MCAN_TXEFS_EFF_Pos)               /**< (MCAN_TXEFS) Event FIFO Full Mask */
+#define MCAN_TXEFS_EFF                      MCAN_TXEFS_EFF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFS_EFF_Msk instead */
+#define MCAN_TXEFS_TEFL_Pos                 25                                             /**< (MCAN_TXEFS) Tx Event FIFO Element Lost Position */
+#define MCAN_TXEFS_TEFL_Msk                 (_U_(0x1) << MCAN_TXEFS_TEFL_Pos)              /**< (MCAN_TXEFS) Tx Event FIFO Element Lost Mask */
+#define MCAN_TXEFS_TEFL                     MCAN_TXEFS_TEFL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFS_TEFL_Msk instead */
+#define MCAN_TXEFS_MASK                     _U_(0x31F1F3F)                                 /**< \deprecated (MCAN_TXEFS) Register MASK  (Use MCAN_TXEFS_Msk instead)  */
+#define MCAN_TXEFS_Msk                      _U_(0x31F1F3F)                                 /**< (MCAN_TXEFS) Register Mask  */
+
+
+/* -------- MCAN_TXEFA : (MCAN Offset: 0xf8) (R/W 32) Transmit Event FIFO Acknowledge Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFAI:5;                    /**< bit:   0..4  Event FIFO Acknowledge Index             */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFA_OFFSET                   (0xF8)                                        /**<  (MCAN_TXEFA) Transmit Event FIFO Acknowledge Register  Offset */
+
+#define MCAN_TXEFA_EFAI_Pos                 0                                              /**< (MCAN_TXEFA) Event FIFO Acknowledge Index Position */
+#define MCAN_TXEFA_EFAI_Msk                 (_U_(0x1F) << MCAN_TXEFA_EFAI_Pos)             /**< (MCAN_TXEFA) Event FIFO Acknowledge Index Mask */
+#define MCAN_TXEFA_EFAI(value)              (MCAN_TXEFA_EFAI_Msk & ((value) << MCAN_TXEFA_EFAI_Pos))
+#define MCAN_TXEFA_MASK                     _U_(0x1F)                                      /**< \deprecated (MCAN_TXEFA) Register MASK  (Use MCAN_TXEFA_Msk instead)  */
+#define MCAN_TXEFA_Msk                      _U_(0x1F)                                      /**< (MCAN_TXEFA) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MCAN_RXBE hardware registers */
+typedef struct {  /* Rx Buffer Element */
+  __IO uint32_t MCAN_RXBE_0;    /**< (MCAN_RXBE Offset: 0x00) Rx Buffer Element 0 */
+  __IO uint32_t MCAN_RXBE_1;    /**< (MCAN_RXBE Offset: 0x04) Rx Buffer Element 1 */
+  __IO uint32_t MCAN_RXBE_DATA; /**< (MCAN_RXBE Offset: 0x08) Rx Buffer Element Data */
+} McanRxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF0E hardware registers */
+typedef struct {  /* Rx FIFO 0 Element */
+  __IO uint32_t MCAN_RXF0E_0;   /**< (MCAN_RXF0E Offset: 0x00) Rx FIFO 0 Element 0 */
+  __IO uint32_t MCAN_RXF0E_1;   /**< (MCAN_RXF0E Offset: 0x04) Rx FIFO 0 Element 1 */
+  __IO uint32_t MCAN_RXF0E_DATA; /**< (MCAN_RXF0E Offset: 0x08) Rx FIFO 0 Element Data */
+} McanRxf0e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF1E hardware registers */
+typedef struct {  /* Rx FIFO 1 Element */
+  __IO uint32_t MCAN_RXF1E_0;   /**< (MCAN_RXF1E Offset: 0x00) Rx FIFO 1 Element 0 */
+  __IO uint32_t MCAN_RXF1E_1;   /**< (MCAN_RXF1E Offset: 0x04) Rx FIFO 1 Element 1 */
+  __IO uint32_t MCAN_RXF1E_DATA; /**< (MCAN_RXF1E Offset: 0x08) Rx FIFO 1 Element Data */
+} McanRxf1e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXBE hardware registers */
+typedef struct {  /* Tx Buffer Element */
+  __IO uint32_t MCAN_TXBE_0;    /**< (MCAN_TXBE Offset: 0x00) Tx Buffer Element 0 */
+  __IO uint32_t MCAN_TXBE_1;    /**< (MCAN_TXBE Offset: 0x04) Tx Buffer Element 1 */
+  __IO uint32_t MCAN_TXBE_DATA; /**< (MCAN_TXBE Offset: 0x08) Tx Buffer Element Data */
+} McanTxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXEFE hardware registers */
+typedef struct {  /* Tx Event FIFO Element */
+  __IO uint32_t MCAN_TXEFE_0;   /**< (MCAN_TXEFE Offset: 0x00) Tx Event FIFO Element 0 */
+  __IO uint32_t MCAN_TXEFE_1;   /**< (MCAN_TXEFE Offset: 0x04) Tx Event FIFO Element 1 */
+} McanTxefe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_SIDFE hardware registers */
+typedef struct {  /* Standard Message ID Filter Element */
+  __IO uint32_t MCAN_SIDFE_0;   /**< (MCAN_SIDFE Offset: 0x00) Standard Message ID Filter Element 0 */
+} McanSidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_XIDFE hardware registers */
+typedef struct {  /* Extended Message ID Filter Element */
+  __IO uint32_t MCAN_XIDFE_0;   /**< (MCAN_XIDFE Offset: 0x00) Extended Message ID Filter Element 0 */
+  __IO uint32_t MCAN_XIDFE_1;   /**< (MCAN_XIDFE Offset: 0x04) Extended Message ID Filter Element 1 */
+} McanXidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN hardware registers */
+typedef struct {  
+  __I  uint32_t MCAN_CREL;      /**< (MCAN Offset: 0x00) Core Release Register */
+  __I  uint32_t MCAN_ENDN;      /**< (MCAN Offset: 0x04) Endian Register */
+  __IO uint32_t MCAN_CUST;      /**< (MCAN Offset: 0x08) Customer Register */
+  __IO uint32_t MCAN_DBTP;      /**< (MCAN Offset: 0x0C) Data Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TEST;      /**< (MCAN Offset: 0x10) Test Register */
+  __IO uint32_t MCAN_RWD;       /**< (MCAN Offset: 0x14) RAM Watchdog Register */
+  __IO uint32_t MCAN_CCCR;      /**< (MCAN Offset: 0x18) CC Control Register */
+  __IO uint32_t MCAN_NBTP;      /**< (MCAN Offset: 0x1C) Nominal Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TSCC;      /**< (MCAN Offset: 0x20) Timestamp Counter Configuration Register */
+  __IO uint32_t MCAN_TSCV;      /**< (MCAN Offset: 0x24) Timestamp Counter Value Register */
+  __IO uint32_t MCAN_TOCC;      /**< (MCAN Offset: 0x28) Timeout Counter Configuration Register */
+  __IO uint32_t MCAN_TOCV;      /**< (MCAN Offset: 0x2C) Timeout Counter Value Register */
+  __I  uint8_t                        Reserved1[16];
+  __I  uint32_t MCAN_ECR;       /**< (MCAN Offset: 0x40) Error Counter Register */
+  __I  uint32_t MCAN_PSR;       /**< (MCAN Offset: 0x44) Protocol Status Register */
+  __IO uint32_t MCAN_TDCR;      /**< (MCAN Offset: 0x48) Transmit Delay Compensation Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t MCAN_IR;        /**< (MCAN Offset: 0x50) Interrupt Register */
+  __IO uint32_t MCAN_IE;        /**< (MCAN Offset: 0x54) Interrupt Enable Register */
+  __IO uint32_t MCAN_ILS;       /**< (MCAN Offset: 0x58) Interrupt Line Select Register */
+  __IO uint32_t MCAN_ILE;       /**< (MCAN Offset: 0x5C) Interrupt Line Enable Register */
+  __I  uint8_t                        Reserved3[32];
+  __IO uint32_t MCAN_GFC;       /**< (MCAN Offset: 0x80) Global Filter Configuration Register */
+  __IO uint32_t MCAN_SIDFC;     /**< (MCAN Offset: 0x84) Standard ID Filter Configuration Register */
+  __IO uint32_t MCAN_XIDFC;     /**< (MCAN Offset: 0x88) Extended ID Filter Configuration Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t MCAN_XIDAM;     /**< (MCAN Offset: 0x90) Extended ID AND Mask Register */
+  __I  uint32_t MCAN_HPMS;      /**< (MCAN Offset: 0x94) High Priority Message Status Register */
+  __IO uint32_t MCAN_NDAT1;     /**< (MCAN Offset: 0x98) New Data 1 Register */
+  __IO uint32_t MCAN_NDAT2;     /**< (MCAN Offset: 0x9C) New Data 2 Register */
+  __IO uint32_t MCAN_RXF0C;     /**< (MCAN Offset: 0xA0) Receive FIFO 0 Configuration Register */
+  __I  uint32_t MCAN_RXF0S;     /**< (MCAN Offset: 0xA4) Receive FIFO 0 Status Register */
+  __IO uint32_t MCAN_RXF0A;     /**< (MCAN Offset: 0xA8) Receive FIFO 0 Acknowledge Register */
+  __IO uint32_t MCAN_RXBC;      /**< (MCAN Offset: 0xAC) Receive Rx Buffer Configuration Register */
+  __IO uint32_t MCAN_RXF1C;     /**< (MCAN Offset: 0xB0) Receive FIFO 1 Configuration Register */
+  __I  uint32_t MCAN_RXF1S;     /**< (MCAN Offset: 0xB4) Receive FIFO 1 Status Register */
+  __IO uint32_t MCAN_RXF1A;     /**< (MCAN Offset: 0xB8) Receive FIFO 1 Acknowledge Register */
+  __IO uint32_t MCAN_RXESC;     /**< (MCAN Offset: 0xBC) Receive Buffer / FIFO Element Size Configuration Register */
+  __IO uint32_t MCAN_TXBC;      /**< (MCAN Offset: 0xC0) Transmit Buffer Configuration Register */
+  __I  uint32_t MCAN_TXFQS;     /**< (MCAN Offset: 0xC4) Transmit FIFO/Queue Status Register */
+  __IO uint32_t MCAN_TXESC;     /**< (MCAN Offset: 0xC8) Transmit Buffer Element Size Configuration Register */
+  __I  uint32_t MCAN_TXBRP;     /**< (MCAN Offset: 0xCC) Transmit Buffer Request Pending Register */
+  __IO uint32_t MCAN_TXBAR;     /**< (MCAN Offset: 0xD0) Transmit Buffer Add Request Register */
+  __IO uint32_t MCAN_TXBCR;     /**< (MCAN Offset: 0xD4) Transmit Buffer Cancellation Request Register */
+  __I  uint32_t MCAN_TXBTO;     /**< (MCAN Offset: 0xD8) Transmit Buffer Transmission Occurred Register */
+  __I  uint32_t MCAN_TXBCF;     /**< (MCAN Offset: 0xDC) Transmit Buffer Cancellation Finished Register */
+  __IO uint32_t MCAN_TXBTIE;    /**< (MCAN Offset: 0xE0) Transmit Buffer Transmission Interrupt Enable Register */
+  __IO uint32_t MCAN_TXBCIE;    /**< (MCAN Offset: 0xE4) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[8];
+  __IO uint32_t MCAN_TXEFC;     /**< (MCAN Offset: 0xF0) Transmit Event FIFO Configuration Register */
+  __I  uint32_t MCAN_TXEFS;     /**< (MCAN Offset: 0xF4) Transmit Event FIFO Status Register */
+  __IO uint32_t MCAN_TXEFA;     /**< (MCAN Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
+} Mcan;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MCAN_RXBE hardware registers */
+typedef struct {  /* Rx Buffer Element */
+  __IO MCAN_RXBE_0_Type               MCAN_RXBE_0;    /**< Offset: 0x00 (R/W  32) Rx Buffer Element 0 */
+  __IO MCAN_RXBE_1_Type               MCAN_RXBE_1;    /**< Offset: 0x04 (R/W  32) Rx Buffer Element 1 */
+  __IO MCAN_RXBE_DATA_Type            MCAN_RXBE_DATA; /**< Offset: 0x08 (R/W  32) Rx Buffer Element Data */
+} McanRxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF0E hardware registers */
+typedef struct {  /* Rx FIFO 0 Element */
+  __IO MCAN_RXF0E_0_Type              MCAN_RXF0E_0;   /**< Offset: 0x00 (R/W  32) Rx FIFO 0 Element 0 */
+  __IO MCAN_RXF0E_1_Type              MCAN_RXF0E_1;   /**< Offset: 0x04 (R/W  32) Rx FIFO 0 Element 1 */
+  __IO MCAN_RXF0E_DATA_Type           MCAN_RXF0E_DATA; /**< Offset: 0x08 (R/W  32) Rx FIFO 0 Element Data */
+} McanRxf0e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF1E hardware registers */
+typedef struct {  /* Rx FIFO 1 Element */
+  __IO MCAN_RXF1E_0_Type              MCAN_RXF1E_0;   /**< Offset: 0x00 (R/W  32) Rx FIFO 1 Element 0 */
+  __IO MCAN_RXF1E_1_Type              MCAN_RXF1E_1;   /**< Offset: 0x04 (R/W  32) Rx FIFO 1 Element 1 */
+  __IO MCAN_RXF1E_DATA_Type           MCAN_RXF1E_DATA; /**< Offset: 0x08 (R/W  32) Rx FIFO 1 Element Data */
+} McanRxf1e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXBE hardware registers */
+typedef struct {  /* Tx Buffer Element */
+  __IO MCAN_TXBE_0_Type               MCAN_TXBE_0;    /**< Offset: 0x00 (R/W  32) Tx Buffer Element 0 */
+  __IO MCAN_TXBE_1_Type               MCAN_TXBE_1;    /**< Offset: 0x04 (R/W  32) Tx Buffer Element 1 */
+  __IO MCAN_TXBE_DATA_Type            MCAN_TXBE_DATA; /**< Offset: 0x08 (R/W  32) Tx Buffer Element Data */
+} McanTxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXEFE hardware registers */
+typedef struct {  /* Tx Event FIFO Element */
+  __IO MCAN_TXEFE_0_Type              MCAN_TXEFE_0;   /**< Offset: 0x00 (R/W  32) Tx Event FIFO Element 0 */
+  __IO MCAN_TXEFE_1_Type              MCAN_TXEFE_1;   /**< Offset: 0x04 (R/W  32) Tx Event FIFO Element 1 */
+} McanTxefe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_SIDFE hardware registers */
+typedef struct {  /* Standard Message ID Filter Element */
+  __IO MCAN_SIDFE_0_Type              MCAN_SIDFE_0;   /**< Offset: 0x00 (R/W  32) Standard Message ID Filter Element 0 */
+} McanSidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_XIDFE hardware registers */
+typedef struct {  /* Extended Message ID Filter Element */
+  __IO MCAN_XIDFE_0_Type              MCAN_XIDFE_0;   /**< Offset: 0x00 (R/W  32) Extended Message ID Filter Element 0 */
+  __IO MCAN_XIDFE_1_Type              MCAN_XIDFE_1;   /**< Offset: 0x04 (R/W  32) Extended Message ID Filter Element 1 */
+} McanXidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN hardware registers */
+typedef struct {  
+  __I  MCAN_CREL_Type                 MCAN_CREL;      /**< Offset: 0x00 (R/   32) Core Release Register */
+  __I  MCAN_ENDN_Type                 MCAN_ENDN;      /**< Offset: 0x04 (R/   32) Endian Register */
+  __IO MCAN_CUST_Type                 MCAN_CUST;      /**< Offset: 0x08 (R/W  32) Customer Register */
+  __IO MCAN_DBTP_Type                 MCAN_DBTP;      /**< Offset: 0x0C (R/W  32) Data Bit Timing and Prescaler Register */
+  __IO MCAN_TEST_Type                 MCAN_TEST;      /**< Offset: 0x10 (R/W  32) Test Register */
+  __IO MCAN_RWD_Type                  MCAN_RWD;       /**< Offset: 0x14 (R/W  32) RAM Watchdog Register */
+  __IO MCAN_CCCR_Type                 MCAN_CCCR;      /**< Offset: 0x18 (R/W  32) CC Control Register */
+  __IO MCAN_NBTP_Type                 MCAN_NBTP;      /**< Offset: 0x1C (R/W  32) Nominal Bit Timing and Prescaler Register */
+  __IO MCAN_TSCC_Type                 MCAN_TSCC;      /**< Offset: 0x20 (R/W  32) Timestamp Counter Configuration Register */
+  __IO MCAN_TSCV_Type                 MCAN_TSCV;      /**< Offset: 0x24 (R/W  32) Timestamp Counter Value Register */
+  __IO MCAN_TOCC_Type                 MCAN_TOCC;      /**< Offset: 0x28 (R/W  32) Timeout Counter Configuration Register */
+  __IO MCAN_TOCV_Type                 MCAN_TOCV;      /**< Offset: 0x2C (R/W  32) Timeout Counter Value Register */
+  __I  uint8_t                        Reserved1[16];
+  __I  MCAN_ECR_Type                  MCAN_ECR;       /**< Offset: 0x40 (R/   32) Error Counter Register */
+  __I  MCAN_PSR_Type                  MCAN_PSR;       /**< Offset: 0x44 (R/   32) Protocol Status Register */
+  __IO MCAN_TDCR_Type                 MCAN_TDCR;      /**< Offset: 0x48 (R/W  32) Transmit Delay Compensation Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO MCAN_IR_Type                   MCAN_IR;        /**< Offset: 0x50 (R/W  32) Interrupt Register */
+  __IO MCAN_IE_Type                   MCAN_IE;        /**< Offset: 0x54 (R/W  32) Interrupt Enable Register */
+  __IO MCAN_ILS_Type                  MCAN_ILS;       /**< Offset: 0x58 (R/W  32) Interrupt Line Select Register */
+  __IO MCAN_ILE_Type                  MCAN_ILE;       /**< Offset: 0x5C (R/W  32) Interrupt Line Enable Register */
+  __I  uint8_t                        Reserved3[32];
+  __IO MCAN_GFC_Type                  MCAN_GFC;       /**< Offset: 0x80 (R/W  32) Global Filter Configuration Register */
+  __IO MCAN_SIDFC_Type                MCAN_SIDFC;     /**< Offset: 0x84 (R/W  32) Standard ID Filter Configuration Register */
+  __IO MCAN_XIDFC_Type                MCAN_XIDFC;     /**< Offset: 0x88 (R/W  32) Extended ID Filter Configuration Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO MCAN_XIDAM_Type                MCAN_XIDAM;     /**< Offset: 0x90 (R/W  32) Extended ID AND Mask Register */
+  __I  MCAN_HPMS_Type                 MCAN_HPMS;      /**< Offset: 0x94 (R/   32) High Priority Message Status Register */
+  __IO MCAN_NDAT1_Type                MCAN_NDAT1;     /**< Offset: 0x98 (R/W  32) New Data 1 Register */
+  __IO MCAN_NDAT2_Type                MCAN_NDAT2;     /**< Offset: 0x9C (R/W  32) New Data 2 Register */
+  __IO MCAN_RXF0C_Type                MCAN_RXF0C;     /**< Offset: 0xA0 (R/W  32) Receive FIFO 0 Configuration Register */
+  __I  MCAN_RXF0S_Type                MCAN_RXF0S;     /**< Offset: 0xA4 (R/   32) Receive FIFO 0 Status Register */
+  __IO MCAN_RXF0A_Type                MCAN_RXF0A;     /**< Offset: 0xA8 (R/W  32) Receive FIFO 0 Acknowledge Register */
+  __IO MCAN_RXBC_Type                 MCAN_RXBC;      /**< Offset: 0xAC (R/W  32) Receive Rx Buffer Configuration Register */
+  __IO MCAN_RXF1C_Type                MCAN_RXF1C;     /**< Offset: 0xB0 (R/W  32) Receive FIFO 1 Configuration Register */
+  __I  MCAN_RXF1S_Type                MCAN_RXF1S;     /**< Offset: 0xB4 (R/   32) Receive FIFO 1 Status Register */
+  __IO MCAN_RXF1A_Type                MCAN_RXF1A;     /**< Offset: 0xB8 (R/W  32) Receive FIFO 1 Acknowledge Register */
+  __IO MCAN_RXESC_Type                MCAN_RXESC;     /**< Offset: 0xBC (R/W  32) Receive Buffer / FIFO Element Size Configuration Register */
+  __IO MCAN_TXBC_Type                 MCAN_TXBC;      /**< Offset: 0xC0 (R/W  32) Transmit Buffer Configuration Register */
+  __I  MCAN_TXFQS_Type                MCAN_TXFQS;     /**< Offset: 0xC4 (R/   32) Transmit FIFO/Queue Status Register */
+  __IO MCAN_TXESC_Type                MCAN_TXESC;     /**< Offset: 0xC8 (R/W  32) Transmit Buffer Element Size Configuration Register */
+  __I  MCAN_TXBRP_Type                MCAN_TXBRP;     /**< Offset: 0xCC (R/   32) Transmit Buffer Request Pending Register */
+  __IO MCAN_TXBAR_Type                MCAN_TXBAR;     /**< Offset: 0xD0 (R/W  32) Transmit Buffer Add Request Register */
+  __IO MCAN_TXBCR_Type                MCAN_TXBCR;     /**< Offset: 0xD4 (R/W  32) Transmit Buffer Cancellation Request Register */
+  __I  MCAN_TXBTO_Type                MCAN_TXBTO;     /**< Offset: 0xD8 (R/   32) Transmit Buffer Transmission Occurred Register */
+  __I  MCAN_TXBCF_Type                MCAN_TXBCF;     /**< Offset: 0xDC (R/   32) Transmit Buffer Cancellation Finished Register */
+  __IO MCAN_TXBTIE_Type               MCAN_TXBTIE;    /**< Offset: 0xE0 (R/W  32) Transmit Buffer Transmission Interrupt Enable Register */
+  __IO MCAN_TXBCIE_Type               MCAN_TXBCIE;    /**< Offset: 0xE4 (R/W  32) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[8];
+  __IO MCAN_TXEFC_Type                MCAN_TXEFC;     /**< Offset: 0xF0 (R/W  32) Transmit Event FIFO Configuration Register */
+  __I  MCAN_TXEFS_Type                MCAN_TXEFS;     /**< Offset: 0xF4 (R/   32) Transmit Event FIFO Status Register */
+  __IO MCAN_TXEFA_Type                MCAN_TXEFA;     /**< Offset: 0xF8 (R/W  32) Transmit Event FIFO Acknowledge Register */
+} Mcan;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Controller Area Network */
+
+#endif /* _SAMV71_MCAN_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/mlb.h
+++ b/asf/sam/include/samv71b/component/mlb.h
@@ -1,0 +1,699 @@
+/**
+ * \file
+ *
+ * \brief Component description for MLB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MLB_COMPONENT_H_
+#define _SAMV71_MLB_COMPONENT_H_
+#define _SAMV71_MLB_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 MediaLB
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MLB */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define MLB_11287                      /**< (MLB) Module ID */
+#define REV_MLB E                      /**< (MLB) Module revision */
+
+/* -------- MLB_MLBC0 : (MLB Offset: 0x00) (R/W 32) MediaLB Control 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MLBEN:1;                   /**< bit:      0  MediaLB Enable                           */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t MLBCLK:3;                  /**< bit:   2..4  MLBCLK (MediaLB clock) Speed Select      */
+    uint32_t ZERO:1;                    /**< bit:      5  Must be Written to 0                     */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MLBLK:1;                   /**< bit:      7  MediaLB Lock Status (read-only)          */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t ASYRETRY:1;                /**< bit:     12  Asynchronous Tx Packet Retry             */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CTLRETRY:1;                /**< bit:     14  Control Tx Packet Retry                  */
+    uint32_t FCNT:3;                    /**< bit: 15..17  The number of frames per sub-buffer for synchronous channels */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MLBC0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MLBC0_OFFSET                    (0x00)                                        /**<  (MLB_MLBC0) MediaLB Control 0 Register  Offset */
+
+#define MLB_MLBC0_MLBEN_Pos                 0                                              /**< (MLB_MLBC0) MediaLB Enable Position */
+#define MLB_MLBC0_MLBEN_Msk                 (_U_(0x1) << MLB_MLBC0_MLBEN_Pos)              /**< (MLB_MLBC0) MediaLB Enable Mask */
+#define MLB_MLBC0_MLBEN                     MLB_MLBC0_MLBEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_MLBEN_Msk instead */
+#define MLB_MLBC0_MLBCLK_Pos                2                                              /**< (MLB_MLBC0) MLBCLK (MediaLB clock) Speed Select Position */
+#define MLB_MLBC0_MLBCLK_Msk                (_U_(0x7) << MLB_MLBC0_MLBCLK_Pos)             /**< (MLB_MLBC0) MLBCLK (MediaLB clock) Speed Select Mask */
+#define MLB_MLBC0_MLBCLK(value)             (MLB_MLBC0_MLBCLK_Msk & ((value) << MLB_MLBC0_MLBCLK_Pos))
+#define   MLB_MLBC0_MLBCLK_256_FS_Val       _U_(0x0)                                       /**< (MLB_MLBC0) 256xFs (for MLBPEN = 0)  */
+#define   MLB_MLBC0_MLBCLK_512_FS_Val       _U_(0x1)                                       /**< (MLB_MLBC0) 512xFs (for MLBPEN = 0)  */
+#define   MLB_MLBC0_MLBCLK_1024_FS_Val      _U_(0x2)                                       /**< (MLB_MLBC0) 1024xFs (for MLBPEN = 0)  */
+#define MLB_MLBC0_MLBCLK_256_FS             (MLB_MLBC0_MLBCLK_256_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 256xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_MLBCLK_512_FS             (MLB_MLBC0_MLBCLK_512_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 512xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_MLBCLK_1024_FS            (MLB_MLBC0_MLBCLK_1024_FS_Val << MLB_MLBC0_MLBCLK_Pos)  /**< (MLB_MLBC0) 1024xFs (for MLBPEN = 0) Position  */
+#define MLB_MLBC0_ZERO_Pos                  5                                              /**< (MLB_MLBC0) Must be Written to 0 Position */
+#define MLB_MLBC0_ZERO_Msk                  (_U_(0x1) << MLB_MLBC0_ZERO_Pos)               /**< (MLB_MLBC0) Must be Written to 0 Mask */
+#define MLB_MLBC0_ZERO                      MLB_MLBC0_ZERO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_ZERO_Msk instead */
+#define MLB_MLBC0_MLBLK_Pos                 7                                              /**< (MLB_MLBC0) MediaLB Lock Status (read-only) Position */
+#define MLB_MLBC0_MLBLK_Msk                 (_U_(0x1) << MLB_MLBC0_MLBLK_Pos)              /**< (MLB_MLBC0) MediaLB Lock Status (read-only) Mask */
+#define MLB_MLBC0_MLBLK                     MLB_MLBC0_MLBLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_MLBLK_Msk instead */
+#define MLB_MLBC0_ASYRETRY_Pos              12                                             /**< (MLB_MLBC0) Asynchronous Tx Packet Retry Position */
+#define MLB_MLBC0_ASYRETRY_Msk              (_U_(0x1) << MLB_MLBC0_ASYRETRY_Pos)           /**< (MLB_MLBC0) Asynchronous Tx Packet Retry Mask */
+#define MLB_MLBC0_ASYRETRY                  MLB_MLBC0_ASYRETRY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_ASYRETRY_Msk instead */
+#define MLB_MLBC0_CTLRETRY_Pos              14                                             /**< (MLB_MLBC0) Control Tx Packet Retry Position */
+#define MLB_MLBC0_CTLRETRY_Msk              (_U_(0x1) << MLB_MLBC0_CTLRETRY_Pos)           /**< (MLB_MLBC0) Control Tx Packet Retry Mask */
+#define MLB_MLBC0_CTLRETRY                  MLB_MLBC0_CTLRETRY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC0_CTLRETRY_Msk instead */
+#define MLB_MLBC0_FCNT_Pos                  15                                             /**< (MLB_MLBC0) The number of frames per sub-buffer for synchronous channels Position */
+#define MLB_MLBC0_FCNT_Msk                  (_U_(0x7) << MLB_MLBC0_FCNT_Pos)               /**< (MLB_MLBC0) The number of frames per sub-buffer for synchronous channels Mask */
+#define MLB_MLBC0_FCNT(value)               (MLB_MLBC0_FCNT_Msk & ((value) << MLB_MLBC0_FCNT_Pos))
+#define   MLB_MLBC0_FCNT_1_FRAME_Val        _U_(0x0)                                       /**< (MLB_MLBC0) 1 frame per sub-buffer (Operation is the same as Standard mode.)  */
+#define   MLB_MLBC0_FCNT_2_FRAMES_Val       _U_(0x1)                                       /**< (MLB_MLBC0) 2 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_4_FRAMES_Val       _U_(0x2)                                       /**< (MLB_MLBC0) 4 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_8_FRAMES_Val       _U_(0x3)                                       /**< (MLB_MLBC0) 8 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_16_FRAMES_Val      _U_(0x4)                                       /**< (MLB_MLBC0) 16 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_32_FRAMES_Val      _U_(0x5)                                       /**< (MLB_MLBC0) 32 frames per sub-buffer  */
+#define   MLB_MLBC0_FCNT_64_FRAMES_Val      _U_(0x6)                                       /**< (MLB_MLBC0) 64 frames per sub-buffer  */
+#define MLB_MLBC0_FCNT_1_FRAME              (MLB_MLBC0_FCNT_1_FRAME_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 1 frame per sub-buffer (Operation is the same as Standard mode.) Position  */
+#define MLB_MLBC0_FCNT_2_FRAMES             (MLB_MLBC0_FCNT_2_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 2 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_4_FRAMES             (MLB_MLBC0_FCNT_4_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 4 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_8_FRAMES             (MLB_MLBC0_FCNT_8_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 8 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_16_FRAMES            (MLB_MLBC0_FCNT_16_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 16 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_32_FRAMES            (MLB_MLBC0_FCNT_32_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 32 frames per sub-buffer Position  */
+#define MLB_MLBC0_FCNT_64_FRAMES            (MLB_MLBC0_FCNT_64_FRAMES_Val << MLB_MLBC0_FCNT_Pos)  /**< (MLB_MLBC0) 64 frames per sub-buffer Position  */
+#define MLB_MLBC0_MASK                      _U_(0x3D0BD)                                   /**< \deprecated (MLB_MLBC0) Register MASK  (Use MLB_MLBC0_Msk instead)  */
+#define MLB_MLBC0_Msk                       _U_(0x3D0BD)                                   /**< (MLB_MLBC0) Register Mask  */
+
+
+/* -------- MLB_MS0 : (MLB Offset: 0x0c) (R/W 32) MediaLB Channel Status 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCS:32;                    /**< bit:  0..31  MediaLB Channel Status [31:0] (cleared by writing a 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MS0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MS0_OFFSET                      (0x0C)                                        /**<  (MLB_MS0) MediaLB Channel Status 0 Register  Offset */
+
+#define MLB_MS0_MCS_Pos                     0                                              /**< (MLB_MS0) MediaLB Channel Status [31:0] (cleared by writing a 0) Position */
+#define MLB_MS0_MCS_Msk                     (_U_(0xFFFFFFFF) << MLB_MS0_MCS_Pos)           /**< (MLB_MS0) MediaLB Channel Status [31:0] (cleared by writing a 0) Mask */
+#define MLB_MS0_MCS(value)                  (MLB_MS0_MCS_Msk & ((value) << MLB_MS0_MCS_Pos))
+#define MLB_MS0_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MS0) Register MASK  (Use MLB_MS0_Msk instead)  */
+#define MLB_MS0_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MS0) Register Mask  */
+
+
+/* -------- MLB_MS1 : (MLB Offset: 0x14) (R/W 32) MediaLB Channel Status1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MCS:32;                    /**< bit:  0..31  MediaLB Channel Status [63:32] (cleared by writing a 0) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MS1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MS1_OFFSET                      (0x14)                                        /**<  (MLB_MS1) MediaLB Channel Status1 Register  Offset */
+
+#define MLB_MS1_MCS_Pos                     0                                              /**< (MLB_MS1) MediaLB Channel Status [63:32] (cleared by writing a 0) Position */
+#define MLB_MS1_MCS_Msk                     (_U_(0xFFFFFFFF) << MLB_MS1_MCS_Pos)           /**< (MLB_MS1) MediaLB Channel Status [63:32] (cleared by writing a 0) Mask */
+#define MLB_MS1_MCS(value)                  (MLB_MS1_MCS_Msk & ((value) << MLB_MS1_MCS_Pos))
+#define MLB_MS1_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MS1) Register MASK  (Use MLB_MS1_Msk instead)  */
+#define MLB_MS1_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MS1) Register Mask  */
+
+
+/* -------- MLB_MSS : (MLB Offset: 0x20) (R/W 32) MediaLB System Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSTSYSCMD:1;               /**< bit:      0  Reset System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t LKSYSCMD:1;                /**< bit:      1  Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t ULKSYSCMD:1;               /**< bit:      2  Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t CSSYSCMD:1;                /**< bit:      3  Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t SWSYSCMD:1;                /**< bit:      4  Software System Command Detected in the System Quadlet (cleared by writing a 0) */
+    uint32_t SERVREQ:1;                 /**< bit:      5  Service Request Enabled                  */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MSS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MSS_OFFSET                      (0x20)                                        /**<  (MLB_MSS) MediaLB System Status Register  Offset */
+
+#define MLB_MSS_RSTSYSCMD_Pos               0                                              /**< (MLB_MSS) Reset System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_RSTSYSCMD_Msk               (_U_(0x1) << MLB_MSS_RSTSYSCMD_Pos)            /**< (MLB_MSS) Reset System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_RSTSYSCMD                   MLB_MSS_RSTSYSCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_RSTSYSCMD_Msk instead */
+#define MLB_MSS_LKSYSCMD_Pos                1                                              /**< (MLB_MSS) Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_LKSYSCMD_Msk                (_U_(0x1) << MLB_MSS_LKSYSCMD_Pos)             /**< (MLB_MSS) Network Lock System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_LKSYSCMD                    MLB_MSS_LKSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_LKSYSCMD_Msk instead */
+#define MLB_MSS_ULKSYSCMD_Pos               2                                              /**< (MLB_MSS) Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_ULKSYSCMD_Msk               (_U_(0x1) << MLB_MSS_ULKSYSCMD_Pos)            /**< (MLB_MSS) Network Unlock System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_ULKSYSCMD                   MLB_MSS_ULKSYSCMD_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_ULKSYSCMD_Msk instead */
+#define MLB_MSS_CSSYSCMD_Pos                3                                              /**< (MLB_MSS) Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_CSSYSCMD_Msk                (_U_(0x1) << MLB_MSS_CSSYSCMD_Pos)             /**< (MLB_MSS) Channel Scan System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_CSSYSCMD                    MLB_MSS_CSSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_CSSYSCMD_Msk instead */
+#define MLB_MSS_SWSYSCMD_Pos                4                                              /**< (MLB_MSS) Software System Command Detected in the System Quadlet (cleared by writing a 0) Position */
+#define MLB_MSS_SWSYSCMD_Msk                (_U_(0x1) << MLB_MSS_SWSYSCMD_Pos)             /**< (MLB_MSS) Software System Command Detected in the System Quadlet (cleared by writing a 0) Mask */
+#define MLB_MSS_SWSYSCMD                    MLB_MSS_SWSYSCMD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_SWSYSCMD_Msk instead */
+#define MLB_MSS_SERVREQ_Pos                 5                                              /**< (MLB_MSS) Service Request Enabled Position */
+#define MLB_MSS_SERVREQ_Msk                 (_U_(0x1) << MLB_MSS_SERVREQ_Pos)              /**< (MLB_MSS) Service Request Enabled Mask */
+#define MLB_MSS_SERVREQ                     MLB_MSS_SERVREQ_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MSS_SERVREQ_Msk instead */
+#define MLB_MSS_MASK                        _U_(0x3F)                                      /**< \deprecated (MLB_MSS) Register MASK  (Use MLB_MSS_Msk instead)  */
+#define MLB_MSS_Msk                         _U_(0x3F)                                      /**< (MLB_MSS) Register Mask  */
+
+
+/* -------- MLB_MSD : (MLB Offset: 0x24) (R/ 32) MediaLB System Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SD0:8;                     /**< bit:   0..7  System Data (Byte 0)                     */
+    uint32_t SD1:8;                     /**< bit:  8..15  System Data (Byte 1)                     */
+    uint32_t SD2:8;                     /**< bit: 16..23  System Data (Byte 2)                     */
+    uint32_t SD3:8;                     /**< bit: 24..31  System Data (Byte 3)                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MSD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MSD_OFFSET                      (0x24)                                        /**<  (MLB_MSD) MediaLB System Data Register  Offset */
+
+#define MLB_MSD_SD0_Pos                     0                                              /**< (MLB_MSD) System Data (Byte 0) Position */
+#define MLB_MSD_SD0_Msk                     (_U_(0xFF) << MLB_MSD_SD0_Pos)                 /**< (MLB_MSD) System Data (Byte 0) Mask */
+#define MLB_MSD_SD0(value)                  (MLB_MSD_SD0_Msk & ((value) << MLB_MSD_SD0_Pos))
+#define MLB_MSD_SD1_Pos                     8                                              /**< (MLB_MSD) System Data (Byte 1) Position */
+#define MLB_MSD_SD1_Msk                     (_U_(0xFF) << MLB_MSD_SD1_Pos)                 /**< (MLB_MSD) System Data (Byte 1) Mask */
+#define MLB_MSD_SD1(value)                  (MLB_MSD_SD1_Msk & ((value) << MLB_MSD_SD1_Pos))
+#define MLB_MSD_SD2_Pos                     16                                             /**< (MLB_MSD) System Data (Byte 2) Position */
+#define MLB_MSD_SD2_Msk                     (_U_(0xFF) << MLB_MSD_SD2_Pos)                 /**< (MLB_MSD) System Data (Byte 2) Mask */
+#define MLB_MSD_SD2(value)                  (MLB_MSD_SD2_Msk & ((value) << MLB_MSD_SD2_Pos))
+#define MLB_MSD_SD3_Pos                     24                                             /**< (MLB_MSD) System Data (Byte 3) Position */
+#define MLB_MSD_SD3_Msk                     (_U_(0xFF) << MLB_MSD_SD3_Pos)                 /**< (MLB_MSD) System Data (Byte 3) Mask */
+#define MLB_MSD_SD3(value)                  (MLB_MSD_SD3_Msk & ((value) << MLB_MSD_SD3_Pos))
+#define MLB_MSD_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MSD) Register MASK  (Use MLB_MSD_Msk instead)  */
+#define MLB_MSD_Msk                         _U_(0xFFFFFFFF)                                /**< (MLB_MSD) Register Mask  */
+
+
+/* -------- MLB_MIEN : (MLB Offset: 0x2c) (R/W 32) MediaLB Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ISOC_PE:1;                 /**< bit:      0  Isochronous Rx Protocol Error Enable     */
+    uint32_t ISOC_BUFO:1;               /**< bit:      1  Isochronous Rx Buffer Overflow Enable    */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t SYNC_PE:1;                 /**< bit:     16  Synchronous Protocol Error Enable        */
+    uint32_t ARX_DONE:1;                /**< bit:     17  Asynchronous Rx Done Enable              */
+    uint32_t ARX_PE:1;                  /**< bit:     18  Asynchronous Rx Protocol Error Enable    */
+    uint32_t ARX_BREAK:1;               /**< bit:     19  Asynchronous Rx Break Enable             */
+    uint32_t ATX_DONE:1;                /**< bit:     20  Asynchronous Tx Packet Done Enable       */
+    uint32_t ATX_PE:1;                  /**< bit:     21  Asynchronous Tx Protocol Error Enable    */
+    uint32_t ATX_BREAK:1;               /**< bit:     22  Asynchronous Tx Break Enable             */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t CRX_DONE:1;                /**< bit:     24  Control Rx Packet Done Enable            */
+    uint32_t CRX_PE:1;                  /**< bit:     25  Control Rx Protocol Error Enable         */
+    uint32_t CRX_BREAK:1;               /**< bit:     26  Control Rx Break Enable                  */
+    uint32_t CTX_DONE:1;                /**< bit:     27  Control Tx Packet Done Enable            */
+    uint32_t CTX_PE:1;                  /**< bit:     28  Control Tx Protocol Error Enable         */
+    uint32_t CTX_BREAK:1;               /**< bit:     29  Control Tx Break Enable                  */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MIEN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MIEN_OFFSET                     (0x2C)                                        /**<  (MLB_MIEN) MediaLB Interrupt Enable Register  Offset */
+
+#define MLB_MIEN_ISOC_PE_Pos                0                                              /**< (MLB_MIEN) Isochronous Rx Protocol Error Enable Position */
+#define MLB_MIEN_ISOC_PE_Msk                (_U_(0x1) << MLB_MIEN_ISOC_PE_Pos)             /**< (MLB_MIEN) Isochronous Rx Protocol Error Enable Mask */
+#define MLB_MIEN_ISOC_PE                    MLB_MIEN_ISOC_PE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ISOC_PE_Msk instead */
+#define MLB_MIEN_ISOC_BUFO_Pos              1                                              /**< (MLB_MIEN) Isochronous Rx Buffer Overflow Enable Position */
+#define MLB_MIEN_ISOC_BUFO_Msk              (_U_(0x1) << MLB_MIEN_ISOC_BUFO_Pos)           /**< (MLB_MIEN) Isochronous Rx Buffer Overflow Enable Mask */
+#define MLB_MIEN_ISOC_BUFO                  MLB_MIEN_ISOC_BUFO_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ISOC_BUFO_Msk instead */
+#define MLB_MIEN_SYNC_PE_Pos                16                                             /**< (MLB_MIEN) Synchronous Protocol Error Enable Position */
+#define MLB_MIEN_SYNC_PE_Msk                (_U_(0x1) << MLB_MIEN_SYNC_PE_Pos)             /**< (MLB_MIEN) Synchronous Protocol Error Enable Mask */
+#define MLB_MIEN_SYNC_PE                    MLB_MIEN_SYNC_PE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_SYNC_PE_Msk instead */
+#define MLB_MIEN_ARX_DONE_Pos               17                                             /**< (MLB_MIEN) Asynchronous Rx Done Enable Position */
+#define MLB_MIEN_ARX_DONE_Msk               (_U_(0x1) << MLB_MIEN_ARX_DONE_Pos)            /**< (MLB_MIEN) Asynchronous Rx Done Enable Mask */
+#define MLB_MIEN_ARX_DONE                   MLB_MIEN_ARX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_DONE_Msk instead */
+#define MLB_MIEN_ARX_PE_Pos                 18                                             /**< (MLB_MIEN) Asynchronous Rx Protocol Error Enable Position */
+#define MLB_MIEN_ARX_PE_Msk                 (_U_(0x1) << MLB_MIEN_ARX_PE_Pos)              /**< (MLB_MIEN) Asynchronous Rx Protocol Error Enable Mask */
+#define MLB_MIEN_ARX_PE                     MLB_MIEN_ARX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_PE_Msk instead */
+#define MLB_MIEN_ARX_BREAK_Pos              19                                             /**< (MLB_MIEN) Asynchronous Rx Break Enable Position */
+#define MLB_MIEN_ARX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_ARX_BREAK_Pos)           /**< (MLB_MIEN) Asynchronous Rx Break Enable Mask */
+#define MLB_MIEN_ARX_BREAK                  MLB_MIEN_ARX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ARX_BREAK_Msk instead */
+#define MLB_MIEN_ATX_DONE_Pos               20                                             /**< (MLB_MIEN) Asynchronous Tx Packet Done Enable Position */
+#define MLB_MIEN_ATX_DONE_Msk               (_U_(0x1) << MLB_MIEN_ATX_DONE_Pos)            /**< (MLB_MIEN) Asynchronous Tx Packet Done Enable Mask */
+#define MLB_MIEN_ATX_DONE                   MLB_MIEN_ATX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_DONE_Msk instead */
+#define MLB_MIEN_ATX_PE_Pos                 21                                             /**< (MLB_MIEN) Asynchronous Tx Protocol Error Enable Position */
+#define MLB_MIEN_ATX_PE_Msk                 (_U_(0x1) << MLB_MIEN_ATX_PE_Pos)              /**< (MLB_MIEN) Asynchronous Tx Protocol Error Enable Mask */
+#define MLB_MIEN_ATX_PE                     MLB_MIEN_ATX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_PE_Msk instead */
+#define MLB_MIEN_ATX_BREAK_Pos              22                                             /**< (MLB_MIEN) Asynchronous Tx Break Enable Position */
+#define MLB_MIEN_ATX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_ATX_BREAK_Pos)           /**< (MLB_MIEN) Asynchronous Tx Break Enable Mask */
+#define MLB_MIEN_ATX_BREAK                  MLB_MIEN_ATX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_ATX_BREAK_Msk instead */
+#define MLB_MIEN_CRX_DONE_Pos               24                                             /**< (MLB_MIEN) Control Rx Packet Done Enable Position */
+#define MLB_MIEN_CRX_DONE_Msk               (_U_(0x1) << MLB_MIEN_CRX_DONE_Pos)            /**< (MLB_MIEN) Control Rx Packet Done Enable Mask */
+#define MLB_MIEN_CRX_DONE                   MLB_MIEN_CRX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_DONE_Msk instead */
+#define MLB_MIEN_CRX_PE_Pos                 25                                             /**< (MLB_MIEN) Control Rx Protocol Error Enable Position */
+#define MLB_MIEN_CRX_PE_Msk                 (_U_(0x1) << MLB_MIEN_CRX_PE_Pos)              /**< (MLB_MIEN) Control Rx Protocol Error Enable Mask */
+#define MLB_MIEN_CRX_PE                     MLB_MIEN_CRX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_PE_Msk instead */
+#define MLB_MIEN_CRX_BREAK_Pos              26                                             /**< (MLB_MIEN) Control Rx Break Enable Position */
+#define MLB_MIEN_CRX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_CRX_BREAK_Pos)           /**< (MLB_MIEN) Control Rx Break Enable Mask */
+#define MLB_MIEN_CRX_BREAK                  MLB_MIEN_CRX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CRX_BREAK_Msk instead */
+#define MLB_MIEN_CTX_DONE_Pos               27                                             /**< (MLB_MIEN) Control Tx Packet Done Enable Position */
+#define MLB_MIEN_CTX_DONE_Msk               (_U_(0x1) << MLB_MIEN_CTX_DONE_Pos)            /**< (MLB_MIEN) Control Tx Packet Done Enable Mask */
+#define MLB_MIEN_CTX_DONE                   MLB_MIEN_CTX_DONE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_DONE_Msk instead */
+#define MLB_MIEN_CTX_PE_Pos                 28                                             /**< (MLB_MIEN) Control Tx Protocol Error Enable Position */
+#define MLB_MIEN_CTX_PE_Msk                 (_U_(0x1) << MLB_MIEN_CTX_PE_Pos)              /**< (MLB_MIEN) Control Tx Protocol Error Enable Mask */
+#define MLB_MIEN_CTX_PE                     MLB_MIEN_CTX_PE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_PE_Msk instead */
+#define MLB_MIEN_CTX_BREAK_Pos              29                                             /**< (MLB_MIEN) Control Tx Break Enable Position */
+#define MLB_MIEN_CTX_BREAK_Msk              (_U_(0x1) << MLB_MIEN_CTX_BREAK_Pos)           /**< (MLB_MIEN) Control Tx Break Enable Mask */
+#define MLB_MIEN_CTX_BREAK                  MLB_MIEN_CTX_BREAK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MIEN_CTX_BREAK_Msk instead */
+#define MLB_MIEN_MASK                       _U_(0x3F7F0003)                                /**< \deprecated (MLB_MIEN) Register MASK  (Use MLB_MIEN_Msk instead)  */
+#define MLB_MIEN_Msk                        _U_(0x3F7F0003)                                /**< (MLB_MIEN) Register Mask  */
+
+
+/* -------- MLB_MLBC1 : (MLB Offset: 0x3c) (R/W 32) MediaLB Control 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LOCK:1;                    /**< bit:      6  MediaLB Lock Error Status (cleared by writing a 0) */
+    uint32_t CLKM:1;                    /**< bit:      7  MediaLB Clock Missing Status (cleared by writing a 0) */
+    uint32_t NDA:8;                     /**< bit:  8..15  Node Device Address                      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MLBC1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MLBC1_OFFSET                    (0x3C)                                        /**<  (MLB_MLBC1) MediaLB Control 1 Register  Offset */
+
+#define MLB_MLBC1_LOCK_Pos                  6                                              /**< (MLB_MLBC1) MediaLB Lock Error Status (cleared by writing a 0) Position */
+#define MLB_MLBC1_LOCK_Msk                  (_U_(0x1) << MLB_MLBC1_LOCK_Pos)               /**< (MLB_MLBC1) MediaLB Lock Error Status (cleared by writing a 0) Mask */
+#define MLB_MLBC1_LOCK                      MLB_MLBC1_LOCK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC1_LOCK_Msk instead */
+#define MLB_MLBC1_CLKM_Pos                  7                                              /**< (MLB_MLBC1) MediaLB Clock Missing Status (cleared by writing a 0) Position */
+#define MLB_MLBC1_CLKM_Msk                  (_U_(0x1) << MLB_MLBC1_CLKM_Pos)               /**< (MLB_MLBC1) MediaLB Clock Missing Status (cleared by writing a 0) Mask */
+#define MLB_MLBC1_CLKM                      MLB_MLBC1_CLKM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MLBC1_CLKM_Msk instead */
+#define MLB_MLBC1_NDA_Pos                   8                                              /**< (MLB_MLBC1) Node Device Address Position */
+#define MLB_MLBC1_NDA_Msk                   (_U_(0xFF) << MLB_MLBC1_NDA_Pos)               /**< (MLB_MLBC1) Node Device Address Mask */
+#define MLB_MLBC1_NDA(value)                (MLB_MLBC1_NDA_Msk & ((value) << MLB_MLBC1_NDA_Pos))
+#define MLB_MLBC1_MASK                      _U_(0xFFC0)                                    /**< \deprecated (MLB_MLBC1) Register MASK  (Use MLB_MLBC1_Msk instead)  */
+#define MLB_MLBC1_Msk                       _U_(0xFFC0)                                    /**< (MLB_MLBC1) Register Mask  */
+
+
+/* -------- MLB_HCTL : (MLB Offset: 0x80) (R/W 32) HBI Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RST0:1;                    /**< bit:      0  Address Generation Unit 0 Software Reset */
+    uint32_t RST1:1;                    /**< bit:      1  Address Generation Unit 1 Software Reset */
+    uint32_t :13;                       /**< bit:  2..14  Reserved */
+    uint32_t EN:1;                      /**< bit:     15  HBI Enable                               */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RST:2;                     /**< bit:   0..1  Address Generation Unit x Software Reset */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCTL_OFFSET                     (0x80)                                        /**<  (MLB_HCTL) HBI Control Register  Offset */
+
+#define MLB_HCTL_RST0_Pos                   0                                              /**< (MLB_HCTL) Address Generation Unit 0 Software Reset Position */
+#define MLB_HCTL_RST0_Msk                   (_U_(0x1) << MLB_HCTL_RST0_Pos)                /**< (MLB_HCTL) Address Generation Unit 0 Software Reset Mask */
+#define MLB_HCTL_RST0                       MLB_HCTL_RST0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_RST0_Msk instead */
+#define MLB_HCTL_RST1_Pos                   1                                              /**< (MLB_HCTL) Address Generation Unit 1 Software Reset Position */
+#define MLB_HCTL_RST1_Msk                   (_U_(0x1) << MLB_HCTL_RST1_Pos)                /**< (MLB_HCTL) Address Generation Unit 1 Software Reset Mask */
+#define MLB_HCTL_RST1                       MLB_HCTL_RST1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_RST1_Msk instead */
+#define MLB_HCTL_EN_Pos                     15                                             /**< (MLB_HCTL) HBI Enable Position */
+#define MLB_HCTL_EN_Msk                     (_U_(0x1) << MLB_HCTL_EN_Pos)                  /**< (MLB_HCTL) HBI Enable Mask */
+#define MLB_HCTL_EN                         MLB_HCTL_EN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_HCTL_EN_Msk instead */
+#define MLB_HCTL_MASK                       _U_(0x8003)                                    /**< \deprecated (MLB_HCTL) Register MASK  (Use MLB_HCTL_Msk instead)  */
+#define MLB_HCTL_Msk                        _U_(0x8003)                                    /**< (MLB_HCTL) Register Mask  */
+
+#define MLB_HCTL_RST_Pos                    0                                              /**< (MLB_HCTL Position) Address Generation Unit x Software Reset */
+#define MLB_HCTL_RST_Msk                    (_U_(0x3) << MLB_HCTL_RST_Pos)                 /**< (MLB_HCTL Mask) RST */
+#define MLB_HCTL_RST(value)                 (MLB_HCTL_RST_Msk & ((value) << MLB_HCTL_RST_Pos))  
+
+/* -------- MLB_HCMR : (MLB Offset: 0x88) (R/W 32) HBI Channel Mask 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHM:32;                    /**< bit:  0..31  Bitwise Channel Mask Bit [31:0]          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCMR_OFFSET                     (0x88)                                        /**<  (MLB_HCMR) HBI Channel Mask 0 Register 0  Offset */
+
+#define MLB_HCMR_CHM_Pos                    0                                              /**< (MLB_HCMR) Bitwise Channel Mask Bit [31:0] Position */
+#define MLB_HCMR_CHM_Msk                    (_U_(0xFFFFFFFF) << MLB_HCMR_CHM_Pos)          /**< (MLB_HCMR) Bitwise Channel Mask Bit [31:0] Mask */
+#define MLB_HCMR_CHM(value)                 (MLB_HCMR_CHM_Msk & ((value) << MLB_HCMR_CHM_Pos))
+#define MLB_HCMR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCMR) Register MASK  (Use MLB_HCMR_Msk instead)  */
+#define MLB_HCMR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCMR) Register Mask  */
+
+
+/* -------- MLB_HCER : (MLB Offset: 0x90) (R/ 32) HBI Channel Error 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CERR:32;                   /**< bit:  0..31  Bitwise Channel Error Bit [31:0]         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCER_OFFSET                     (0x90)                                        /**<  (MLB_HCER) HBI Channel Error 0 Register 0  Offset */
+
+#define MLB_HCER_CERR_Pos                   0                                              /**< (MLB_HCER) Bitwise Channel Error Bit [31:0] Position */
+#define MLB_HCER_CERR_Msk                   (_U_(0xFFFFFFFF) << MLB_HCER_CERR_Pos)         /**< (MLB_HCER) Bitwise Channel Error Bit [31:0] Mask */
+#define MLB_HCER_CERR(value)                (MLB_HCER_CERR_Msk & ((value) << MLB_HCER_CERR_Pos))
+#define MLB_HCER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCER) Register MASK  (Use MLB_HCER_Msk instead)  */
+#define MLB_HCER_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCER) Register Mask  */
+
+
+/* -------- MLB_HCBR : (MLB Offset: 0x98) (R/ 32) HBI Channel Busy 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHB:32;                    /**< bit:  0..31  Bitwise Channel Busy Bit [31:0]          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_HCBR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_HCBR_OFFSET                     (0x98)                                        /**<  (MLB_HCBR) HBI Channel Busy 0 Register 0  Offset */
+
+#define MLB_HCBR_CHB_Pos                    0                                              /**< (MLB_HCBR) Bitwise Channel Busy Bit [31:0] Position */
+#define MLB_HCBR_CHB_Msk                    (_U_(0xFFFFFFFF) << MLB_HCBR_CHB_Pos)          /**< (MLB_HCBR) Bitwise Channel Busy Bit [31:0] Mask */
+#define MLB_HCBR_CHB(value)                 (MLB_HCBR_CHB_Msk & ((value) << MLB_HCBR_CHB_Pos))
+#define MLB_HCBR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_HCBR) Register MASK  (Use MLB_HCBR_Msk instead)  */
+#define MLB_HCBR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_HCBR) Register Mask  */
+
+
+/* -------- MLB_MDAT : (MLB Offset: 0xc0) (R/W 32) MIF Data 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATA:32;                   /**< bit:  0..31  CRT or DBR Data                          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MDAT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MDAT_OFFSET                     (0xC0)                                        /**<  (MLB_MDAT) MIF Data 0 Register 0  Offset */
+
+#define MLB_MDAT_DATA_Pos                   0                                              /**< (MLB_MDAT) CRT or DBR Data Position */
+#define MLB_MDAT_DATA_Msk                   (_U_(0xFFFFFFFF) << MLB_MDAT_DATA_Pos)         /**< (MLB_MDAT) CRT or DBR Data Mask */
+#define MLB_MDAT_DATA(value)                (MLB_MDAT_DATA_Msk & ((value) << MLB_MDAT_DATA_Pos))
+#define MLB_MDAT_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_MDAT) Register MASK  (Use MLB_MDAT_Msk instead)  */
+#define MLB_MDAT_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_MDAT) Register Mask  */
+
+
+/* -------- MLB_MDWE : (MLB Offset: 0xd0) (R/W 32) MIF Data Write Enable 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASK:32;                   /**< bit:  0..31  Bitwise Write Enable for CTR Data - bits[31:0] */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MDWE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MDWE_OFFSET                     (0xD0)                                        /**<  (MLB_MDWE) MIF Data Write Enable 0 Register 0  Offset */
+
+#define MLB_MDWE_MASK_Pos                   0                                              /**< (MLB_MDWE) Bitwise Write Enable for CTR Data - bits[31:0] Position */
+#define MLB_MDWE_MASK_Msk                   (_U_(0xFFFFFFFF) << MLB_MDWE_MASK_Pos)         /**< (MLB_MDWE) Bitwise Write Enable for CTR Data - bits[31:0] Mask */
+#define MLB_MDWE_MASK(value)                (MLB_MDWE_MASK_Msk & ((value) << MLB_MDWE_MASK_Pos))
+#define MLB_MDWE_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_MDWE) Register Mask  */
+
+
+/* -------- MLB_MCTL : (MLB Offset: 0xe0) (R/W 32) MIF Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t XCMP:1;                    /**< bit:      0  Transfer Complete (Write 0 to Clear)     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MCTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MCTL_OFFSET                     (0xE0)                                        /**<  (MLB_MCTL) MIF Control Register  Offset */
+
+#define MLB_MCTL_XCMP_Pos                   0                                              /**< (MLB_MCTL) Transfer Complete (Write 0 to Clear) Position */
+#define MLB_MCTL_XCMP_Msk                   (_U_(0x1) << MLB_MCTL_XCMP_Pos)                /**< (MLB_MCTL) Transfer Complete (Write 0 to Clear) Mask */
+#define MLB_MCTL_XCMP                       MLB_MCTL_XCMP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MCTL_XCMP_Msk instead */
+#define MLB_MCTL_MASK                       _U_(0x01)                                      /**< \deprecated (MLB_MCTL) Register MASK  (Use MLB_MCTL_Msk instead)  */
+#define MLB_MCTL_Msk                        _U_(0x01)                                      /**< (MLB_MCTL) Register Mask  */
+
+
+/* -------- MLB_MADR : (MLB Offset: 0xe4) (R/W 32) MIF Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:14;                   /**< bit:  0..13  CTR or DBR Address                       */
+    uint32_t :16;                       /**< bit: 14..29  Reserved */
+    uint32_t TB:1;                      /**< bit:     30  Target Location Bit                      */
+    uint32_t WNR:1;                     /**< bit:     31  Write-Not-Read Selection                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_MADR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_MADR_OFFSET                     (0xE4)                                        /**<  (MLB_MADR) MIF Address Register  Offset */
+
+#define MLB_MADR_ADDR_Pos                   0                                              /**< (MLB_MADR) CTR or DBR Address Position */
+#define MLB_MADR_ADDR_Msk                   (_U_(0x3FFF) << MLB_MADR_ADDR_Pos)             /**< (MLB_MADR) CTR or DBR Address Mask */
+#define MLB_MADR_ADDR(value)                (MLB_MADR_ADDR_Msk & ((value) << MLB_MADR_ADDR_Pos))
+#define MLB_MADR_TB_Pos                     30                                             /**< (MLB_MADR) Target Location Bit Position */
+#define MLB_MADR_TB_Msk                     (_U_(0x1) << MLB_MADR_TB_Pos)                  /**< (MLB_MADR) Target Location Bit Mask */
+#define MLB_MADR_TB                         MLB_MADR_TB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MADR_TB_Msk instead */
+#define   MLB_MADR_TB_CTR_Val               _U_(0x0)                                       /**< (MLB_MADR) Selects CTR  */
+#define   MLB_MADR_TB_DBR_Val               _U_(0x1)                                       /**< (MLB_MADR) Selects DBR  */
+#define MLB_MADR_TB_CTR                     (MLB_MADR_TB_CTR_Val << MLB_MADR_TB_Pos)       /**< (MLB_MADR) Selects CTR Position  */
+#define MLB_MADR_TB_DBR                     (MLB_MADR_TB_DBR_Val << MLB_MADR_TB_Pos)       /**< (MLB_MADR) Selects DBR Position  */
+#define MLB_MADR_WNR_Pos                    31                                             /**< (MLB_MADR) Write-Not-Read Selection Position */
+#define MLB_MADR_WNR_Msk                    (_U_(0x1) << MLB_MADR_WNR_Pos)                 /**< (MLB_MADR) Write-Not-Read Selection Mask */
+#define MLB_MADR_WNR                        MLB_MADR_WNR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_MADR_WNR_Msk instead */
+#define MLB_MADR_MASK                       _U_(0xC0003FFF)                                /**< \deprecated (MLB_MADR) Register MASK  (Use MLB_MADR_Msk instead)  */
+#define MLB_MADR_Msk                        _U_(0xC0003FFF)                                /**< (MLB_MADR) Register Mask  */
+
+
+/* -------- MLB_ACTL : (MLB Offset: 0x3c0) (R/W 32) AHB Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCE:1;                     /**< bit:      0  Software Clear Enable                    */
+    uint32_t SMX:1;                     /**< bit:      1  AHB Interrupt Mux Enable                 */
+    uint32_t DMA_MODE:1;                /**< bit:      2  DMA Mode                                 */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t MPB:1;                     /**< bit:      4  DMA Packet Buffering Mode                */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACTL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACTL_OFFSET                     (0x3C0)                                       /**<  (MLB_ACTL) AHB Control Register  Offset */
+
+#define MLB_ACTL_SCE_Pos                    0                                              /**< (MLB_ACTL) Software Clear Enable Position */
+#define MLB_ACTL_SCE_Msk                    (_U_(0x1) << MLB_ACTL_SCE_Pos)                 /**< (MLB_ACTL) Software Clear Enable Mask */
+#define MLB_ACTL_SCE                        MLB_ACTL_SCE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_SCE_Msk instead */
+#define MLB_ACTL_SMX_Pos                    1                                              /**< (MLB_ACTL) AHB Interrupt Mux Enable Position */
+#define MLB_ACTL_SMX_Msk                    (_U_(0x1) << MLB_ACTL_SMX_Pos)                 /**< (MLB_ACTL) AHB Interrupt Mux Enable Mask */
+#define MLB_ACTL_SMX                        MLB_ACTL_SMX_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_SMX_Msk instead */
+#define MLB_ACTL_DMA_MODE_Pos               2                                              /**< (MLB_ACTL) DMA Mode Position */
+#define MLB_ACTL_DMA_MODE_Msk               (_U_(0x1) << MLB_ACTL_DMA_MODE_Pos)            /**< (MLB_ACTL) DMA Mode Mask */
+#define MLB_ACTL_DMA_MODE                   MLB_ACTL_DMA_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_DMA_MODE_Msk instead */
+#define MLB_ACTL_MPB_Pos                    4                                              /**< (MLB_ACTL) DMA Packet Buffering Mode Position */
+#define MLB_ACTL_MPB_Msk                    (_U_(0x1) << MLB_ACTL_MPB_Pos)                 /**< (MLB_ACTL) DMA Packet Buffering Mode Mask */
+#define MLB_ACTL_MPB                        MLB_ACTL_MPB_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use MLB_ACTL_MPB_Msk instead */
+#define   MLB_ACTL_MPB_SINGLE_PACKET_Val    _U_(0x0)                                       /**< (MLB_ACTL) Single-packet mode  */
+#define   MLB_ACTL_MPB_MULTIPLE_PACKET_Val  _U_(0x1)                                       /**< (MLB_ACTL) Multiple-packet mode  */
+#define MLB_ACTL_MPB_SINGLE_PACKET          (MLB_ACTL_MPB_SINGLE_PACKET_Val << MLB_ACTL_MPB_Pos)  /**< (MLB_ACTL) Single-packet mode Position  */
+#define MLB_ACTL_MPB_MULTIPLE_PACKET        (MLB_ACTL_MPB_MULTIPLE_PACKET_Val << MLB_ACTL_MPB_Pos)  /**< (MLB_ACTL) Multiple-packet mode Position  */
+#define MLB_ACTL_MASK                       _U_(0x17)                                      /**< \deprecated (MLB_ACTL) Register MASK  (Use MLB_ACTL_Msk instead)  */
+#define MLB_ACTL_Msk                        _U_(0x17)                                      /**< (MLB_ACTL) Register Mask  */
+
+
+/* -------- MLB_ACSR : (MLB Offset: 0x3d0) (R/W 32) AHB Channel Status 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHS:32;                    /**< bit:  0..31  Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACSR_OFFSET                     (0x3D0)                                       /**<  (MLB_ACSR) AHB Channel Status 0 Register 0  Offset */
+
+#define MLB_ACSR_CHS_Pos                    0                                              /**< (MLB_ACSR) Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) Position */
+#define MLB_ACSR_CHS_Msk                    (_U_(0xFFFFFFFF) << MLB_ACSR_CHS_Pos)          /**< (MLB_ACSR) Interrupt Status for Logical Channels [31:0] (cleared by writing a 1) Mask */
+#define MLB_ACSR_CHS(value)                 (MLB_ACSR_CHS_Msk & ((value) << MLB_ACSR_CHS_Pos))
+#define MLB_ACSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_ACSR) Register MASK  (Use MLB_ACSR_Msk instead)  */
+#define MLB_ACSR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_ACSR) Register Mask  */
+
+
+/* -------- MLB_ACMR : (MLB Offset: 0x3d8) (R/W 32) AHB Channel Mask 0 Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHM:32;                    /**< bit:  0..31  Bitwise Channel Mask Bits 31 to 0        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MLB_ACMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MLB_ACMR_OFFSET                     (0x3D8)                                       /**<  (MLB_ACMR) AHB Channel Mask 0 Register 0  Offset */
+
+#define MLB_ACMR_CHM_Pos                    0                                              /**< (MLB_ACMR) Bitwise Channel Mask Bits 31 to 0 Position */
+#define MLB_ACMR_CHM_Msk                    (_U_(0xFFFFFFFF) << MLB_ACMR_CHM_Pos)          /**< (MLB_ACMR) Bitwise Channel Mask Bits 31 to 0 Mask */
+#define MLB_ACMR_CHM(value)                 (MLB_ACMR_CHM_Msk & ((value) << MLB_ACMR_CHM_Pos))
+#define MLB_ACMR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (MLB_ACMR) Register MASK  (Use MLB_ACMR_Msk instead)  */
+#define MLB_ACMR_Msk                        _U_(0xFFFFFFFF)                                /**< (MLB_ACMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MLB hardware registers */
+typedef struct {  
+  __IO uint32_t MLB_MLBC0;      /**< (MLB Offset: 0x00) MediaLB Control 0 Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t MLB_MS0;        /**< (MLB Offset: 0x0C) MediaLB Channel Status 0 Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t MLB_MS1;        /**< (MLB Offset: 0x14) MediaLB Channel Status1 Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO uint32_t MLB_MSS;        /**< (MLB Offset: 0x20) MediaLB System Status Register */
+  __I  uint32_t MLB_MSD;        /**< (MLB Offset: 0x24) MediaLB System Data Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t MLB_MIEN;       /**< (MLB Offset: 0x2C) MediaLB Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO uint32_t MLB_MLBC1;      /**< (MLB Offset: 0x3C) MediaLB Control 1 Register */
+  __I  uint8_t                        Reserved6[64];
+  __IO uint32_t MLB_HCTL;       /**< (MLB Offset: 0x80) HBI Control Register */
+  __I  uint8_t                        Reserved7[4];
+  __IO uint32_t MLB_HCMR[2];    /**< (MLB Offset: 0x88) HBI Channel Mask 0 Register 0 */
+  __I  uint32_t MLB_HCER[2];    /**< (MLB Offset: 0x90) HBI Channel Error 0 Register 0 */
+  __I  uint32_t MLB_HCBR[2];    /**< (MLB Offset: 0x98) HBI Channel Busy 0 Register 0 */
+  __I  uint8_t                        Reserved8[32];
+  __IO uint32_t MLB_MDAT[4];    /**< (MLB Offset: 0xC0) MIF Data 0 Register 0 */
+  __IO uint32_t MLB_MDWE[4];    /**< (MLB Offset: 0xD0) MIF Data Write Enable 0 Register 0 */
+  __IO uint32_t MLB_MCTL;       /**< (MLB Offset: 0xE0) MIF Control Register */
+  __IO uint32_t MLB_MADR;       /**< (MLB Offset: 0xE4) MIF Address Register */
+  __I  uint8_t                        Reserved9[728];
+  __IO uint32_t MLB_ACTL;       /**< (MLB Offset: 0x3C0) AHB Control Register */
+  __I  uint8_t                        Reserved10[12];
+  __IO uint32_t MLB_ACSR[2];    /**< (MLB Offset: 0x3D0) AHB Channel Status 0 Register 0 */
+  __IO uint32_t MLB_ACMR[2];    /**< (MLB Offset: 0x3D8) AHB Channel Mask 0 Register 0 */
+} Mlb;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MLB hardware registers */
+typedef struct {  
+  __IO MLB_MLBC0_Type                 MLB_MLBC0;      /**< Offset: 0x00 (R/W  32) MediaLB Control 0 Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO MLB_MS0_Type                   MLB_MS0;        /**< Offset: 0x0C (R/W  32) MediaLB Channel Status 0 Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO MLB_MS1_Type                   MLB_MS1;        /**< Offset: 0x14 (R/W  32) MediaLB Channel Status1 Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO MLB_MSS_Type                   MLB_MSS;        /**< Offset: 0x20 (R/W  32) MediaLB System Status Register */
+  __I  MLB_MSD_Type                   MLB_MSD;        /**< Offset: 0x24 (R/   32) MediaLB System Data Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO MLB_MIEN_Type                  MLB_MIEN;       /**< Offset: 0x2C (R/W  32) MediaLB Interrupt Enable Register */
+  __I  uint8_t                        Reserved5[12];
+  __IO MLB_MLBC1_Type                 MLB_MLBC1;      /**< Offset: 0x3C (R/W  32) MediaLB Control 1 Register */
+  __I  uint8_t                        Reserved6[64];
+  __IO MLB_HCTL_Type                  MLB_HCTL;       /**< Offset: 0x80 (R/W  32) HBI Control Register */
+  __I  uint8_t                        Reserved7[4];
+  __IO MLB_HCMR_Type                  MLB_HCMR[2];    /**< Offset: 0x88 (R/W  32) HBI Channel Mask 0 Register 0 */
+  __I  MLB_HCER_Type                  MLB_HCER[2];    /**< Offset: 0x90 (R/   32) HBI Channel Error 0 Register 0 */
+  __I  MLB_HCBR_Type                  MLB_HCBR[2];    /**< Offset: 0x98 (R/   32) HBI Channel Busy 0 Register 0 */
+  __I  uint8_t                        Reserved8[32];
+  __IO MLB_MDAT_Type                  MLB_MDAT[4];    /**< Offset: 0xC0 (R/W  32) MIF Data 0 Register 0 */
+  __IO MLB_MDWE_Type                  MLB_MDWE[4];    /**< Offset: 0xD0 (R/W  32) MIF Data Write Enable 0 Register 0 */
+  __IO MLB_MCTL_Type                  MLB_MCTL;       /**< Offset: 0xE0 (R/W  32) MIF Control Register */
+  __IO MLB_MADR_Type                  MLB_MADR;       /**< Offset: 0xE4 (R/W  32) MIF Address Register */
+  __I  uint8_t                        Reserved9[728];
+  __IO MLB_ACTL_Type                  MLB_ACTL;       /**< Offset: 0x3C0 (R/W  32) AHB Control Register */
+  __I  uint8_t                        Reserved10[12];
+  __IO MLB_ACSR_Type                  MLB_ACSR[2];    /**< Offset: 0x3D0 (R/W  32) AHB Channel Status 0 Register 0 */
+  __IO MLB_ACMR_Type                  MLB_ACMR[2];    /**< Offset: 0x3D8 (R/W  32) AHB Channel Mask 0 Register 0 */
+} Mlb;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of MediaLB */
+
+#endif /* _SAMV71_MLB_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/pio.h
+++ b/asf/sam/include/samv71b/component/pio.h
@@ -1,0 +1,7397 @@
+/**
+ * \file
+ *
+ * \brief Component description for PIO
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIO_COMPONENT_H_
+#define _SAMV71_PIO_COMPONENT_H_
+#define _SAMV71_PIO_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Parallel Input/Output Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PIO */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PIO_11004                      /**< (PIO) Module ID */
+#define REV_PIO V                      /**< (PIO) Module revision */
+
+/* -------- PIO_PER : (PIO Offset: 0x00) (/W 32) PIO Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Enable                               */
+    uint32_t P1:1;                      /**< bit:      1  PIO Enable                               */
+    uint32_t P2:1;                      /**< bit:      2  PIO Enable                               */
+    uint32_t P3:1;                      /**< bit:      3  PIO Enable                               */
+    uint32_t P4:1;                      /**< bit:      4  PIO Enable                               */
+    uint32_t P5:1;                      /**< bit:      5  PIO Enable                               */
+    uint32_t P6:1;                      /**< bit:      6  PIO Enable                               */
+    uint32_t P7:1;                      /**< bit:      7  PIO Enable                               */
+    uint32_t P8:1;                      /**< bit:      8  PIO Enable                               */
+    uint32_t P9:1;                      /**< bit:      9  PIO Enable                               */
+    uint32_t P10:1;                     /**< bit:     10  PIO Enable                               */
+    uint32_t P11:1;                     /**< bit:     11  PIO Enable                               */
+    uint32_t P12:1;                     /**< bit:     12  PIO Enable                               */
+    uint32_t P13:1;                     /**< bit:     13  PIO Enable                               */
+    uint32_t P14:1;                     /**< bit:     14  PIO Enable                               */
+    uint32_t P15:1;                     /**< bit:     15  PIO Enable                               */
+    uint32_t P16:1;                     /**< bit:     16  PIO Enable                               */
+    uint32_t P17:1;                     /**< bit:     17  PIO Enable                               */
+    uint32_t P18:1;                     /**< bit:     18  PIO Enable                               */
+    uint32_t P19:1;                     /**< bit:     19  PIO Enable                               */
+    uint32_t P20:1;                     /**< bit:     20  PIO Enable                               */
+    uint32_t P21:1;                     /**< bit:     21  PIO Enable                               */
+    uint32_t P22:1;                     /**< bit:     22  PIO Enable                               */
+    uint32_t P23:1;                     /**< bit:     23  PIO Enable                               */
+    uint32_t P24:1;                     /**< bit:     24  PIO Enable                               */
+    uint32_t P25:1;                     /**< bit:     25  PIO Enable                               */
+    uint32_t P26:1;                     /**< bit:     26  PIO Enable                               */
+    uint32_t P27:1;                     /**< bit:     27  PIO Enable                               */
+    uint32_t P28:1;                     /**< bit:     28  PIO Enable                               */
+    uint32_t P29:1;                     /**< bit:     29  PIO Enable                               */
+    uint32_t P30:1;                     /**< bit:     30  PIO Enable                               */
+    uint32_t P31:1;                     /**< bit:     31  PIO Enable                               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Enable                               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PER_OFFSET                      (0x00)                                        /**<  (PIO_PER) PIO Enable Register  Offset */
+
+#define PIO_PER_P0_Pos                      0                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P0_Msk                      (_U_(0x1) << PIO_PER_P0_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P0                          PIO_PER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P0_Msk instead */
+#define PIO_PER_P1_Pos                      1                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P1_Msk                      (_U_(0x1) << PIO_PER_P1_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P1                          PIO_PER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P1_Msk instead */
+#define PIO_PER_P2_Pos                      2                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P2_Msk                      (_U_(0x1) << PIO_PER_P2_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P2                          PIO_PER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P2_Msk instead */
+#define PIO_PER_P3_Pos                      3                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P3_Msk                      (_U_(0x1) << PIO_PER_P3_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P3                          PIO_PER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P3_Msk instead */
+#define PIO_PER_P4_Pos                      4                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P4_Msk                      (_U_(0x1) << PIO_PER_P4_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P4                          PIO_PER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P4_Msk instead */
+#define PIO_PER_P5_Pos                      5                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P5_Msk                      (_U_(0x1) << PIO_PER_P5_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P5                          PIO_PER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P5_Msk instead */
+#define PIO_PER_P6_Pos                      6                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P6_Msk                      (_U_(0x1) << PIO_PER_P6_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P6                          PIO_PER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P6_Msk instead */
+#define PIO_PER_P7_Pos                      7                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P7_Msk                      (_U_(0x1) << PIO_PER_P7_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P7                          PIO_PER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P7_Msk instead */
+#define PIO_PER_P8_Pos                      8                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P8_Msk                      (_U_(0x1) << PIO_PER_P8_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P8                          PIO_PER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P8_Msk instead */
+#define PIO_PER_P9_Pos                      9                                              /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P9_Msk                      (_U_(0x1) << PIO_PER_P9_Pos)                   /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P9                          PIO_PER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P9_Msk instead */
+#define PIO_PER_P10_Pos                     10                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P10_Msk                     (_U_(0x1) << PIO_PER_P10_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P10                         PIO_PER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P10_Msk instead */
+#define PIO_PER_P11_Pos                     11                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P11_Msk                     (_U_(0x1) << PIO_PER_P11_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P11                         PIO_PER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P11_Msk instead */
+#define PIO_PER_P12_Pos                     12                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P12_Msk                     (_U_(0x1) << PIO_PER_P12_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P12                         PIO_PER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P12_Msk instead */
+#define PIO_PER_P13_Pos                     13                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P13_Msk                     (_U_(0x1) << PIO_PER_P13_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P13                         PIO_PER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P13_Msk instead */
+#define PIO_PER_P14_Pos                     14                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P14_Msk                     (_U_(0x1) << PIO_PER_P14_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P14                         PIO_PER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P14_Msk instead */
+#define PIO_PER_P15_Pos                     15                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P15_Msk                     (_U_(0x1) << PIO_PER_P15_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P15                         PIO_PER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P15_Msk instead */
+#define PIO_PER_P16_Pos                     16                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P16_Msk                     (_U_(0x1) << PIO_PER_P16_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P16                         PIO_PER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P16_Msk instead */
+#define PIO_PER_P17_Pos                     17                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P17_Msk                     (_U_(0x1) << PIO_PER_P17_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P17                         PIO_PER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P17_Msk instead */
+#define PIO_PER_P18_Pos                     18                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P18_Msk                     (_U_(0x1) << PIO_PER_P18_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P18                         PIO_PER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P18_Msk instead */
+#define PIO_PER_P19_Pos                     19                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P19_Msk                     (_U_(0x1) << PIO_PER_P19_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P19                         PIO_PER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P19_Msk instead */
+#define PIO_PER_P20_Pos                     20                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P20_Msk                     (_U_(0x1) << PIO_PER_P20_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P20                         PIO_PER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P20_Msk instead */
+#define PIO_PER_P21_Pos                     21                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P21_Msk                     (_U_(0x1) << PIO_PER_P21_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P21                         PIO_PER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P21_Msk instead */
+#define PIO_PER_P22_Pos                     22                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P22_Msk                     (_U_(0x1) << PIO_PER_P22_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P22                         PIO_PER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P22_Msk instead */
+#define PIO_PER_P23_Pos                     23                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P23_Msk                     (_U_(0x1) << PIO_PER_P23_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P23                         PIO_PER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P23_Msk instead */
+#define PIO_PER_P24_Pos                     24                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P24_Msk                     (_U_(0x1) << PIO_PER_P24_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P24                         PIO_PER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P24_Msk instead */
+#define PIO_PER_P25_Pos                     25                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P25_Msk                     (_U_(0x1) << PIO_PER_P25_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P25                         PIO_PER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P25_Msk instead */
+#define PIO_PER_P26_Pos                     26                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P26_Msk                     (_U_(0x1) << PIO_PER_P26_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P26                         PIO_PER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P26_Msk instead */
+#define PIO_PER_P27_Pos                     27                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P27_Msk                     (_U_(0x1) << PIO_PER_P27_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P27                         PIO_PER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P27_Msk instead */
+#define PIO_PER_P28_Pos                     28                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P28_Msk                     (_U_(0x1) << PIO_PER_P28_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P28                         PIO_PER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P28_Msk instead */
+#define PIO_PER_P29_Pos                     29                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P29_Msk                     (_U_(0x1) << PIO_PER_P29_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P29                         PIO_PER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P29_Msk instead */
+#define PIO_PER_P30_Pos                     30                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P30_Msk                     (_U_(0x1) << PIO_PER_P30_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P30                         PIO_PER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P30_Msk instead */
+#define PIO_PER_P31_Pos                     31                                             /**< (PIO_PER) PIO Enable Position */
+#define PIO_PER_P31_Msk                     (_U_(0x1) << PIO_PER_P31_Pos)                  /**< (PIO_PER) PIO Enable Mask */
+#define PIO_PER_P31                         PIO_PER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PER_P31_Msk instead */
+#define PIO_PER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PER) Register MASK  (Use PIO_PER_Msk instead)  */
+#define PIO_PER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PER) Register Mask  */
+
+#define PIO_PER_P_Pos                       0                                              /**< (PIO_PER Position) PIO Enable */
+#define PIO_PER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PER_P_Pos)             /**< (PIO_PER Mask) P */
+#define PIO_PER_P(value)                    (PIO_PER_P_Msk & ((value) << PIO_PER_P_Pos))   
+
+/* -------- PIO_PDR : (PIO Offset: 0x04) (/W 32) PIO Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Disable                              */
+    uint32_t P1:1;                      /**< bit:      1  PIO Disable                              */
+    uint32_t P2:1;                      /**< bit:      2  PIO Disable                              */
+    uint32_t P3:1;                      /**< bit:      3  PIO Disable                              */
+    uint32_t P4:1;                      /**< bit:      4  PIO Disable                              */
+    uint32_t P5:1;                      /**< bit:      5  PIO Disable                              */
+    uint32_t P6:1;                      /**< bit:      6  PIO Disable                              */
+    uint32_t P7:1;                      /**< bit:      7  PIO Disable                              */
+    uint32_t P8:1;                      /**< bit:      8  PIO Disable                              */
+    uint32_t P9:1;                      /**< bit:      9  PIO Disable                              */
+    uint32_t P10:1;                     /**< bit:     10  PIO Disable                              */
+    uint32_t P11:1;                     /**< bit:     11  PIO Disable                              */
+    uint32_t P12:1;                     /**< bit:     12  PIO Disable                              */
+    uint32_t P13:1;                     /**< bit:     13  PIO Disable                              */
+    uint32_t P14:1;                     /**< bit:     14  PIO Disable                              */
+    uint32_t P15:1;                     /**< bit:     15  PIO Disable                              */
+    uint32_t P16:1;                     /**< bit:     16  PIO Disable                              */
+    uint32_t P17:1;                     /**< bit:     17  PIO Disable                              */
+    uint32_t P18:1;                     /**< bit:     18  PIO Disable                              */
+    uint32_t P19:1;                     /**< bit:     19  PIO Disable                              */
+    uint32_t P20:1;                     /**< bit:     20  PIO Disable                              */
+    uint32_t P21:1;                     /**< bit:     21  PIO Disable                              */
+    uint32_t P22:1;                     /**< bit:     22  PIO Disable                              */
+    uint32_t P23:1;                     /**< bit:     23  PIO Disable                              */
+    uint32_t P24:1;                     /**< bit:     24  PIO Disable                              */
+    uint32_t P25:1;                     /**< bit:     25  PIO Disable                              */
+    uint32_t P26:1;                     /**< bit:     26  PIO Disable                              */
+    uint32_t P27:1;                     /**< bit:     27  PIO Disable                              */
+    uint32_t P28:1;                     /**< bit:     28  PIO Disable                              */
+    uint32_t P29:1;                     /**< bit:     29  PIO Disable                              */
+    uint32_t P30:1;                     /**< bit:     30  PIO Disable                              */
+    uint32_t P31:1;                     /**< bit:     31  PIO Disable                              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Disable                              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PDR_OFFSET                      (0x04)                                        /**<  (PIO_PDR) PIO Disable Register  Offset */
+
+#define PIO_PDR_P0_Pos                      0                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P0_Msk                      (_U_(0x1) << PIO_PDR_P0_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P0                          PIO_PDR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P0_Msk instead */
+#define PIO_PDR_P1_Pos                      1                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P1_Msk                      (_U_(0x1) << PIO_PDR_P1_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P1                          PIO_PDR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P1_Msk instead */
+#define PIO_PDR_P2_Pos                      2                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P2_Msk                      (_U_(0x1) << PIO_PDR_P2_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P2                          PIO_PDR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P2_Msk instead */
+#define PIO_PDR_P3_Pos                      3                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P3_Msk                      (_U_(0x1) << PIO_PDR_P3_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P3                          PIO_PDR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P3_Msk instead */
+#define PIO_PDR_P4_Pos                      4                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P4_Msk                      (_U_(0x1) << PIO_PDR_P4_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P4                          PIO_PDR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P4_Msk instead */
+#define PIO_PDR_P5_Pos                      5                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P5_Msk                      (_U_(0x1) << PIO_PDR_P5_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P5                          PIO_PDR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P5_Msk instead */
+#define PIO_PDR_P6_Pos                      6                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P6_Msk                      (_U_(0x1) << PIO_PDR_P6_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P6                          PIO_PDR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P6_Msk instead */
+#define PIO_PDR_P7_Pos                      7                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P7_Msk                      (_U_(0x1) << PIO_PDR_P7_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P7                          PIO_PDR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P7_Msk instead */
+#define PIO_PDR_P8_Pos                      8                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P8_Msk                      (_U_(0x1) << PIO_PDR_P8_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P8                          PIO_PDR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P8_Msk instead */
+#define PIO_PDR_P9_Pos                      9                                              /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P9_Msk                      (_U_(0x1) << PIO_PDR_P9_Pos)                   /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P9                          PIO_PDR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P9_Msk instead */
+#define PIO_PDR_P10_Pos                     10                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P10_Msk                     (_U_(0x1) << PIO_PDR_P10_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P10                         PIO_PDR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P10_Msk instead */
+#define PIO_PDR_P11_Pos                     11                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P11_Msk                     (_U_(0x1) << PIO_PDR_P11_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P11                         PIO_PDR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P11_Msk instead */
+#define PIO_PDR_P12_Pos                     12                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P12_Msk                     (_U_(0x1) << PIO_PDR_P12_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P12                         PIO_PDR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P12_Msk instead */
+#define PIO_PDR_P13_Pos                     13                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P13_Msk                     (_U_(0x1) << PIO_PDR_P13_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P13                         PIO_PDR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P13_Msk instead */
+#define PIO_PDR_P14_Pos                     14                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P14_Msk                     (_U_(0x1) << PIO_PDR_P14_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P14                         PIO_PDR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P14_Msk instead */
+#define PIO_PDR_P15_Pos                     15                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P15_Msk                     (_U_(0x1) << PIO_PDR_P15_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P15                         PIO_PDR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P15_Msk instead */
+#define PIO_PDR_P16_Pos                     16                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P16_Msk                     (_U_(0x1) << PIO_PDR_P16_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P16                         PIO_PDR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P16_Msk instead */
+#define PIO_PDR_P17_Pos                     17                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P17_Msk                     (_U_(0x1) << PIO_PDR_P17_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P17                         PIO_PDR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P17_Msk instead */
+#define PIO_PDR_P18_Pos                     18                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P18_Msk                     (_U_(0x1) << PIO_PDR_P18_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P18                         PIO_PDR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P18_Msk instead */
+#define PIO_PDR_P19_Pos                     19                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P19_Msk                     (_U_(0x1) << PIO_PDR_P19_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P19                         PIO_PDR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P19_Msk instead */
+#define PIO_PDR_P20_Pos                     20                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P20_Msk                     (_U_(0x1) << PIO_PDR_P20_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P20                         PIO_PDR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P20_Msk instead */
+#define PIO_PDR_P21_Pos                     21                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P21_Msk                     (_U_(0x1) << PIO_PDR_P21_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P21                         PIO_PDR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P21_Msk instead */
+#define PIO_PDR_P22_Pos                     22                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P22_Msk                     (_U_(0x1) << PIO_PDR_P22_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P22                         PIO_PDR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P22_Msk instead */
+#define PIO_PDR_P23_Pos                     23                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P23_Msk                     (_U_(0x1) << PIO_PDR_P23_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P23                         PIO_PDR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P23_Msk instead */
+#define PIO_PDR_P24_Pos                     24                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P24_Msk                     (_U_(0x1) << PIO_PDR_P24_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P24                         PIO_PDR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P24_Msk instead */
+#define PIO_PDR_P25_Pos                     25                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P25_Msk                     (_U_(0x1) << PIO_PDR_P25_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P25                         PIO_PDR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P25_Msk instead */
+#define PIO_PDR_P26_Pos                     26                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P26_Msk                     (_U_(0x1) << PIO_PDR_P26_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P26                         PIO_PDR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P26_Msk instead */
+#define PIO_PDR_P27_Pos                     27                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P27_Msk                     (_U_(0x1) << PIO_PDR_P27_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P27                         PIO_PDR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P27_Msk instead */
+#define PIO_PDR_P28_Pos                     28                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P28_Msk                     (_U_(0x1) << PIO_PDR_P28_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P28                         PIO_PDR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P28_Msk instead */
+#define PIO_PDR_P29_Pos                     29                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P29_Msk                     (_U_(0x1) << PIO_PDR_P29_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P29                         PIO_PDR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P29_Msk instead */
+#define PIO_PDR_P30_Pos                     30                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P30_Msk                     (_U_(0x1) << PIO_PDR_P30_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P30                         PIO_PDR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P30_Msk instead */
+#define PIO_PDR_P31_Pos                     31                                             /**< (PIO_PDR) PIO Disable Position */
+#define PIO_PDR_P31_Msk                     (_U_(0x1) << PIO_PDR_P31_Pos)                  /**< (PIO_PDR) PIO Disable Mask */
+#define PIO_PDR_P31                         PIO_PDR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDR_P31_Msk instead */
+#define PIO_PDR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PDR) Register MASK  (Use PIO_PDR_Msk instead)  */
+#define PIO_PDR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PDR) Register Mask  */
+
+#define PIO_PDR_P_Pos                       0                                              /**< (PIO_PDR Position) PIO Disable */
+#define PIO_PDR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PDR_P_Pos)             /**< (PIO_PDR Mask) P */
+#define PIO_PDR_P(value)                    (PIO_PDR_P_Msk & ((value) << PIO_PDR_P_Pos))   
+
+/* -------- PIO_PSR : (PIO Offset: 0x08) (R/ 32) PIO Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  PIO Status                               */
+    uint32_t P1:1;                      /**< bit:      1  PIO Status                               */
+    uint32_t P2:1;                      /**< bit:      2  PIO Status                               */
+    uint32_t P3:1;                      /**< bit:      3  PIO Status                               */
+    uint32_t P4:1;                      /**< bit:      4  PIO Status                               */
+    uint32_t P5:1;                      /**< bit:      5  PIO Status                               */
+    uint32_t P6:1;                      /**< bit:      6  PIO Status                               */
+    uint32_t P7:1;                      /**< bit:      7  PIO Status                               */
+    uint32_t P8:1;                      /**< bit:      8  PIO Status                               */
+    uint32_t P9:1;                      /**< bit:      9  PIO Status                               */
+    uint32_t P10:1;                     /**< bit:     10  PIO Status                               */
+    uint32_t P11:1;                     /**< bit:     11  PIO Status                               */
+    uint32_t P12:1;                     /**< bit:     12  PIO Status                               */
+    uint32_t P13:1;                     /**< bit:     13  PIO Status                               */
+    uint32_t P14:1;                     /**< bit:     14  PIO Status                               */
+    uint32_t P15:1;                     /**< bit:     15  PIO Status                               */
+    uint32_t P16:1;                     /**< bit:     16  PIO Status                               */
+    uint32_t P17:1;                     /**< bit:     17  PIO Status                               */
+    uint32_t P18:1;                     /**< bit:     18  PIO Status                               */
+    uint32_t P19:1;                     /**< bit:     19  PIO Status                               */
+    uint32_t P20:1;                     /**< bit:     20  PIO Status                               */
+    uint32_t P21:1;                     /**< bit:     21  PIO Status                               */
+    uint32_t P22:1;                     /**< bit:     22  PIO Status                               */
+    uint32_t P23:1;                     /**< bit:     23  PIO Status                               */
+    uint32_t P24:1;                     /**< bit:     24  PIO Status                               */
+    uint32_t P25:1;                     /**< bit:     25  PIO Status                               */
+    uint32_t P26:1;                     /**< bit:     26  PIO Status                               */
+    uint32_t P27:1;                     /**< bit:     27  PIO Status                               */
+    uint32_t P28:1;                     /**< bit:     28  PIO Status                               */
+    uint32_t P29:1;                     /**< bit:     29  PIO Status                               */
+    uint32_t P30:1;                     /**< bit:     30  PIO Status                               */
+    uint32_t P31:1;                     /**< bit:     31  PIO Status                               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  PIO Status                               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PSR_OFFSET                      (0x08)                                        /**<  (PIO_PSR) PIO Status Register  Offset */
+
+#define PIO_PSR_P0_Pos                      0                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P0_Msk                      (_U_(0x1) << PIO_PSR_P0_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P0                          PIO_PSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P0_Msk instead */
+#define PIO_PSR_P1_Pos                      1                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P1_Msk                      (_U_(0x1) << PIO_PSR_P1_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P1                          PIO_PSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P1_Msk instead */
+#define PIO_PSR_P2_Pos                      2                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P2_Msk                      (_U_(0x1) << PIO_PSR_P2_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P2                          PIO_PSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P2_Msk instead */
+#define PIO_PSR_P3_Pos                      3                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P3_Msk                      (_U_(0x1) << PIO_PSR_P3_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P3                          PIO_PSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P3_Msk instead */
+#define PIO_PSR_P4_Pos                      4                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P4_Msk                      (_U_(0x1) << PIO_PSR_P4_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P4                          PIO_PSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P4_Msk instead */
+#define PIO_PSR_P5_Pos                      5                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P5_Msk                      (_U_(0x1) << PIO_PSR_P5_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P5                          PIO_PSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P5_Msk instead */
+#define PIO_PSR_P6_Pos                      6                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P6_Msk                      (_U_(0x1) << PIO_PSR_P6_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P6                          PIO_PSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P6_Msk instead */
+#define PIO_PSR_P7_Pos                      7                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P7_Msk                      (_U_(0x1) << PIO_PSR_P7_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P7                          PIO_PSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P7_Msk instead */
+#define PIO_PSR_P8_Pos                      8                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P8_Msk                      (_U_(0x1) << PIO_PSR_P8_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P8                          PIO_PSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P8_Msk instead */
+#define PIO_PSR_P9_Pos                      9                                              /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P9_Msk                      (_U_(0x1) << PIO_PSR_P9_Pos)                   /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P9                          PIO_PSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P9_Msk instead */
+#define PIO_PSR_P10_Pos                     10                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P10_Msk                     (_U_(0x1) << PIO_PSR_P10_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P10                         PIO_PSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P10_Msk instead */
+#define PIO_PSR_P11_Pos                     11                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P11_Msk                     (_U_(0x1) << PIO_PSR_P11_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P11                         PIO_PSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P11_Msk instead */
+#define PIO_PSR_P12_Pos                     12                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P12_Msk                     (_U_(0x1) << PIO_PSR_P12_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P12                         PIO_PSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P12_Msk instead */
+#define PIO_PSR_P13_Pos                     13                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P13_Msk                     (_U_(0x1) << PIO_PSR_P13_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P13                         PIO_PSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P13_Msk instead */
+#define PIO_PSR_P14_Pos                     14                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P14_Msk                     (_U_(0x1) << PIO_PSR_P14_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P14                         PIO_PSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P14_Msk instead */
+#define PIO_PSR_P15_Pos                     15                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P15_Msk                     (_U_(0x1) << PIO_PSR_P15_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P15                         PIO_PSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P15_Msk instead */
+#define PIO_PSR_P16_Pos                     16                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P16_Msk                     (_U_(0x1) << PIO_PSR_P16_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P16                         PIO_PSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P16_Msk instead */
+#define PIO_PSR_P17_Pos                     17                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P17_Msk                     (_U_(0x1) << PIO_PSR_P17_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P17                         PIO_PSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P17_Msk instead */
+#define PIO_PSR_P18_Pos                     18                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P18_Msk                     (_U_(0x1) << PIO_PSR_P18_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P18                         PIO_PSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P18_Msk instead */
+#define PIO_PSR_P19_Pos                     19                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P19_Msk                     (_U_(0x1) << PIO_PSR_P19_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P19                         PIO_PSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P19_Msk instead */
+#define PIO_PSR_P20_Pos                     20                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P20_Msk                     (_U_(0x1) << PIO_PSR_P20_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P20                         PIO_PSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P20_Msk instead */
+#define PIO_PSR_P21_Pos                     21                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P21_Msk                     (_U_(0x1) << PIO_PSR_P21_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P21                         PIO_PSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P21_Msk instead */
+#define PIO_PSR_P22_Pos                     22                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P22_Msk                     (_U_(0x1) << PIO_PSR_P22_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P22                         PIO_PSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P22_Msk instead */
+#define PIO_PSR_P23_Pos                     23                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P23_Msk                     (_U_(0x1) << PIO_PSR_P23_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P23                         PIO_PSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P23_Msk instead */
+#define PIO_PSR_P24_Pos                     24                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P24_Msk                     (_U_(0x1) << PIO_PSR_P24_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P24                         PIO_PSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P24_Msk instead */
+#define PIO_PSR_P25_Pos                     25                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P25_Msk                     (_U_(0x1) << PIO_PSR_P25_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P25                         PIO_PSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P25_Msk instead */
+#define PIO_PSR_P26_Pos                     26                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P26_Msk                     (_U_(0x1) << PIO_PSR_P26_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P26                         PIO_PSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P26_Msk instead */
+#define PIO_PSR_P27_Pos                     27                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P27_Msk                     (_U_(0x1) << PIO_PSR_P27_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P27                         PIO_PSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P27_Msk instead */
+#define PIO_PSR_P28_Pos                     28                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P28_Msk                     (_U_(0x1) << PIO_PSR_P28_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P28                         PIO_PSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P28_Msk instead */
+#define PIO_PSR_P29_Pos                     29                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P29_Msk                     (_U_(0x1) << PIO_PSR_P29_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P29                         PIO_PSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P29_Msk instead */
+#define PIO_PSR_P30_Pos                     30                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P30_Msk                     (_U_(0x1) << PIO_PSR_P30_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P30                         PIO_PSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P30_Msk instead */
+#define PIO_PSR_P31_Pos                     31                                             /**< (PIO_PSR) PIO Status Position */
+#define PIO_PSR_P31_Msk                     (_U_(0x1) << PIO_PSR_P31_Pos)                  /**< (PIO_PSR) PIO Status Mask */
+#define PIO_PSR_P31                         PIO_PSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PSR_P31_Msk instead */
+#define PIO_PSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PSR) Register MASK  (Use PIO_PSR_Msk instead)  */
+#define PIO_PSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_PSR) Register Mask  */
+
+#define PIO_PSR_P_Pos                       0                                              /**< (PIO_PSR Position) PIO Status */
+#define PIO_PSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_PSR_P_Pos)             /**< (PIO_PSR Mask) P */
+#define PIO_PSR_P(value)                    (PIO_PSR_P_Msk & ((value) << PIO_PSR_P_Pos))   
+
+/* -------- PIO_OER : (PIO Offset: 0x10) (/W 32) Output Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Enable                            */
+    uint32_t P1:1;                      /**< bit:      1  Output Enable                            */
+    uint32_t P2:1;                      /**< bit:      2  Output Enable                            */
+    uint32_t P3:1;                      /**< bit:      3  Output Enable                            */
+    uint32_t P4:1;                      /**< bit:      4  Output Enable                            */
+    uint32_t P5:1;                      /**< bit:      5  Output Enable                            */
+    uint32_t P6:1;                      /**< bit:      6  Output Enable                            */
+    uint32_t P7:1;                      /**< bit:      7  Output Enable                            */
+    uint32_t P8:1;                      /**< bit:      8  Output Enable                            */
+    uint32_t P9:1;                      /**< bit:      9  Output Enable                            */
+    uint32_t P10:1;                     /**< bit:     10  Output Enable                            */
+    uint32_t P11:1;                     /**< bit:     11  Output Enable                            */
+    uint32_t P12:1;                     /**< bit:     12  Output Enable                            */
+    uint32_t P13:1;                     /**< bit:     13  Output Enable                            */
+    uint32_t P14:1;                     /**< bit:     14  Output Enable                            */
+    uint32_t P15:1;                     /**< bit:     15  Output Enable                            */
+    uint32_t P16:1;                     /**< bit:     16  Output Enable                            */
+    uint32_t P17:1;                     /**< bit:     17  Output Enable                            */
+    uint32_t P18:1;                     /**< bit:     18  Output Enable                            */
+    uint32_t P19:1;                     /**< bit:     19  Output Enable                            */
+    uint32_t P20:1;                     /**< bit:     20  Output Enable                            */
+    uint32_t P21:1;                     /**< bit:     21  Output Enable                            */
+    uint32_t P22:1;                     /**< bit:     22  Output Enable                            */
+    uint32_t P23:1;                     /**< bit:     23  Output Enable                            */
+    uint32_t P24:1;                     /**< bit:     24  Output Enable                            */
+    uint32_t P25:1;                     /**< bit:     25  Output Enable                            */
+    uint32_t P26:1;                     /**< bit:     26  Output Enable                            */
+    uint32_t P27:1;                     /**< bit:     27  Output Enable                            */
+    uint32_t P28:1;                     /**< bit:     28  Output Enable                            */
+    uint32_t P29:1;                     /**< bit:     29  Output Enable                            */
+    uint32_t P30:1;                     /**< bit:     30  Output Enable                            */
+    uint32_t P31:1;                     /**< bit:     31  Output Enable                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Enable                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OER_OFFSET                      (0x10)                                        /**<  (PIO_OER) Output Enable Register  Offset */
+
+#define PIO_OER_P0_Pos                      0                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P0_Msk                      (_U_(0x1) << PIO_OER_P0_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P0                          PIO_OER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P0_Msk instead */
+#define PIO_OER_P1_Pos                      1                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P1_Msk                      (_U_(0x1) << PIO_OER_P1_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P1                          PIO_OER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P1_Msk instead */
+#define PIO_OER_P2_Pos                      2                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P2_Msk                      (_U_(0x1) << PIO_OER_P2_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P2                          PIO_OER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P2_Msk instead */
+#define PIO_OER_P3_Pos                      3                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P3_Msk                      (_U_(0x1) << PIO_OER_P3_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P3                          PIO_OER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P3_Msk instead */
+#define PIO_OER_P4_Pos                      4                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P4_Msk                      (_U_(0x1) << PIO_OER_P4_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P4                          PIO_OER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P4_Msk instead */
+#define PIO_OER_P5_Pos                      5                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P5_Msk                      (_U_(0x1) << PIO_OER_P5_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P5                          PIO_OER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P5_Msk instead */
+#define PIO_OER_P6_Pos                      6                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P6_Msk                      (_U_(0x1) << PIO_OER_P6_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P6                          PIO_OER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P6_Msk instead */
+#define PIO_OER_P7_Pos                      7                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P7_Msk                      (_U_(0x1) << PIO_OER_P7_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P7                          PIO_OER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P7_Msk instead */
+#define PIO_OER_P8_Pos                      8                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P8_Msk                      (_U_(0x1) << PIO_OER_P8_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P8                          PIO_OER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P8_Msk instead */
+#define PIO_OER_P9_Pos                      9                                              /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P9_Msk                      (_U_(0x1) << PIO_OER_P9_Pos)                   /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P9                          PIO_OER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P9_Msk instead */
+#define PIO_OER_P10_Pos                     10                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P10_Msk                     (_U_(0x1) << PIO_OER_P10_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P10                         PIO_OER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P10_Msk instead */
+#define PIO_OER_P11_Pos                     11                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P11_Msk                     (_U_(0x1) << PIO_OER_P11_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P11                         PIO_OER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P11_Msk instead */
+#define PIO_OER_P12_Pos                     12                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P12_Msk                     (_U_(0x1) << PIO_OER_P12_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P12                         PIO_OER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P12_Msk instead */
+#define PIO_OER_P13_Pos                     13                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P13_Msk                     (_U_(0x1) << PIO_OER_P13_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P13                         PIO_OER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P13_Msk instead */
+#define PIO_OER_P14_Pos                     14                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P14_Msk                     (_U_(0x1) << PIO_OER_P14_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P14                         PIO_OER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P14_Msk instead */
+#define PIO_OER_P15_Pos                     15                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P15_Msk                     (_U_(0x1) << PIO_OER_P15_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P15                         PIO_OER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P15_Msk instead */
+#define PIO_OER_P16_Pos                     16                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P16_Msk                     (_U_(0x1) << PIO_OER_P16_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P16                         PIO_OER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P16_Msk instead */
+#define PIO_OER_P17_Pos                     17                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P17_Msk                     (_U_(0x1) << PIO_OER_P17_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P17                         PIO_OER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P17_Msk instead */
+#define PIO_OER_P18_Pos                     18                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P18_Msk                     (_U_(0x1) << PIO_OER_P18_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P18                         PIO_OER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P18_Msk instead */
+#define PIO_OER_P19_Pos                     19                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P19_Msk                     (_U_(0x1) << PIO_OER_P19_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P19                         PIO_OER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P19_Msk instead */
+#define PIO_OER_P20_Pos                     20                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P20_Msk                     (_U_(0x1) << PIO_OER_P20_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P20                         PIO_OER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P20_Msk instead */
+#define PIO_OER_P21_Pos                     21                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P21_Msk                     (_U_(0x1) << PIO_OER_P21_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P21                         PIO_OER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P21_Msk instead */
+#define PIO_OER_P22_Pos                     22                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P22_Msk                     (_U_(0x1) << PIO_OER_P22_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P22                         PIO_OER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P22_Msk instead */
+#define PIO_OER_P23_Pos                     23                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P23_Msk                     (_U_(0x1) << PIO_OER_P23_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P23                         PIO_OER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P23_Msk instead */
+#define PIO_OER_P24_Pos                     24                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P24_Msk                     (_U_(0x1) << PIO_OER_P24_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P24                         PIO_OER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P24_Msk instead */
+#define PIO_OER_P25_Pos                     25                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P25_Msk                     (_U_(0x1) << PIO_OER_P25_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P25                         PIO_OER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P25_Msk instead */
+#define PIO_OER_P26_Pos                     26                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P26_Msk                     (_U_(0x1) << PIO_OER_P26_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P26                         PIO_OER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P26_Msk instead */
+#define PIO_OER_P27_Pos                     27                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P27_Msk                     (_U_(0x1) << PIO_OER_P27_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P27                         PIO_OER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P27_Msk instead */
+#define PIO_OER_P28_Pos                     28                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P28_Msk                     (_U_(0x1) << PIO_OER_P28_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P28                         PIO_OER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P28_Msk instead */
+#define PIO_OER_P29_Pos                     29                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P29_Msk                     (_U_(0x1) << PIO_OER_P29_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P29                         PIO_OER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P29_Msk instead */
+#define PIO_OER_P30_Pos                     30                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P30_Msk                     (_U_(0x1) << PIO_OER_P30_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P30                         PIO_OER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P30_Msk instead */
+#define PIO_OER_P31_Pos                     31                                             /**< (PIO_OER) Output Enable Position */
+#define PIO_OER_P31_Msk                     (_U_(0x1) << PIO_OER_P31_Pos)                  /**< (PIO_OER) Output Enable Mask */
+#define PIO_OER_P31                         PIO_OER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OER_P31_Msk instead */
+#define PIO_OER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OER) Register MASK  (Use PIO_OER_Msk instead)  */
+#define PIO_OER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_OER) Register Mask  */
+
+#define PIO_OER_P_Pos                       0                                              /**< (PIO_OER Position) Output Enable */
+#define PIO_OER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_OER_P_Pos)             /**< (PIO_OER Mask) P */
+#define PIO_OER_P(value)                    (PIO_OER_P_Msk & ((value) << PIO_OER_P_Pos))   
+
+/* -------- PIO_ODR : (PIO Offset: 0x14) (/W 32) Output Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Disable                           */
+    uint32_t P1:1;                      /**< bit:      1  Output Disable                           */
+    uint32_t P2:1;                      /**< bit:      2  Output Disable                           */
+    uint32_t P3:1;                      /**< bit:      3  Output Disable                           */
+    uint32_t P4:1;                      /**< bit:      4  Output Disable                           */
+    uint32_t P5:1;                      /**< bit:      5  Output Disable                           */
+    uint32_t P6:1;                      /**< bit:      6  Output Disable                           */
+    uint32_t P7:1;                      /**< bit:      7  Output Disable                           */
+    uint32_t P8:1;                      /**< bit:      8  Output Disable                           */
+    uint32_t P9:1;                      /**< bit:      9  Output Disable                           */
+    uint32_t P10:1;                     /**< bit:     10  Output Disable                           */
+    uint32_t P11:1;                     /**< bit:     11  Output Disable                           */
+    uint32_t P12:1;                     /**< bit:     12  Output Disable                           */
+    uint32_t P13:1;                     /**< bit:     13  Output Disable                           */
+    uint32_t P14:1;                     /**< bit:     14  Output Disable                           */
+    uint32_t P15:1;                     /**< bit:     15  Output Disable                           */
+    uint32_t P16:1;                     /**< bit:     16  Output Disable                           */
+    uint32_t P17:1;                     /**< bit:     17  Output Disable                           */
+    uint32_t P18:1;                     /**< bit:     18  Output Disable                           */
+    uint32_t P19:1;                     /**< bit:     19  Output Disable                           */
+    uint32_t P20:1;                     /**< bit:     20  Output Disable                           */
+    uint32_t P21:1;                     /**< bit:     21  Output Disable                           */
+    uint32_t P22:1;                     /**< bit:     22  Output Disable                           */
+    uint32_t P23:1;                     /**< bit:     23  Output Disable                           */
+    uint32_t P24:1;                     /**< bit:     24  Output Disable                           */
+    uint32_t P25:1;                     /**< bit:     25  Output Disable                           */
+    uint32_t P26:1;                     /**< bit:     26  Output Disable                           */
+    uint32_t P27:1;                     /**< bit:     27  Output Disable                           */
+    uint32_t P28:1;                     /**< bit:     28  Output Disable                           */
+    uint32_t P29:1;                     /**< bit:     29  Output Disable                           */
+    uint32_t P30:1;                     /**< bit:     30  Output Disable                           */
+    uint32_t P31:1;                     /**< bit:     31  Output Disable                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Disable                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ODR_OFFSET                      (0x14)                                        /**<  (PIO_ODR) Output Disable Register  Offset */
+
+#define PIO_ODR_P0_Pos                      0                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P0_Msk                      (_U_(0x1) << PIO_ODR_P0_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P0                          PIO_ODR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P0_Msk instead */
+#define PIO_ODR_P1_Pos                      1                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P1_Msk                      (_U_(0x1) << PIO_ODR_P1_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P1                          PIO_ODR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P1_Msk instead */
+#define PIO_ODR_P2_Pos                      2                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P2_Msk                      (_U_(0x1) << PIO_ODR_P2_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P2                          PIO_ODR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P2_Msk instead */
+#define PIO_ODR_P3_Pos                      3                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P3_Msk                      (_U_(0x1) << PIO_ODR_P3_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P3                          PIO_ODR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P3_Msk instead */
+#define PIO_ODR_P4_Pos                      4                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P4_Msk                      (_U_(0x1) << PIO_ODR_P4_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P4                          PIO_ODR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P4_Msk instead */
+#define PIO_ODR_P5_Pos                      5                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P5_Msk                      (_U_(0x1) << PIO_ODR_P5_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P5                          PIO_ODR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P5_Msk instead */
+#define PIO_ODR_P6_Pos                      6                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P6_Msk                      (_U_(0x1) << PIO_ODR_P6_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P6                          PIO_ODR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P6_Msk instead */
+#define PIO_ODR_P7_Pos                      7                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P7_Msk                      (_U_(0x1) << PIO_ODR_P7_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P7                          PIO_ODR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P7_Msk instead */
+#define PIO_ODR_P8_Pos                      8                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P8_Msk                      (_U_(0x1) << PIO_ODR_P8_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P8                          PIO_ODR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P8_Msk instead */
+#define PIO_ODR_P9_Pos                      9                                              /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P9_Msk                      (_U_(0x1) << PIO_ODR_P9_Pos)                   /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P9                          PIO_ODR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P9_Msk instead */
+#define PIO_ODR_P10_Pos                     10                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P10_Msk                     (_U_(0x1) << PIO_ODR_P10_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P10                         PIO_ODR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P10_Msk instead */
+#define PIO_ODR_P11_Pos                     11                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P11_Msk                     (_U_(0x1) << PIO_ODR_P11_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P11                         PIO_ODR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P11_Msk instead */
+#define PIO_ODR_P12_Pos                     12                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P12_Msk                     (_U_(0x1) << PIO_ODR_P12_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P12                         PIO_ODR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P12_Msk instead */
+#define PIO_ODR_P13_Pos                     13                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P13_Msk                     (_U_(0x1) << PIO_ODR_P13_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P13                         PIO_ODR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P13_Msk instead */
+#define PIO_ODR_P14_Pos                     14                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P14_Msk                     (_U_(0x1) << PIO_ODR_P14_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P14                         PIO_ODR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P14_Msk instead */
+#define PIO_ODR_P15_Pos                     15                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P15_Msk                     (_U_(0x1) << PIO_ODR_P15_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P15                         PIO_ODR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P15_Msk instead */
+#define PIO_ODR_P16_Pos                     16                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P16_Msk                     (_U_(0x1) << PIO_ODR_P16_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P16                         PIO_ODR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P16_Msk instead */
+#define PIO_ODR_P17_Pos                     17                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P17_Msk                     (_U_(0x1) << PIO_ODR_P17_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P17                         PIO_ODR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P17_Msk instead */
+#define PIO_ODR_P18_Pos                     18                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P18_Msk                     (_U_(0x1) << PIO_ODR_P18_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P18                         PIO_ODR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P18_Msk instead */
+#define PIO_ODR_P19_Pos                     19                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P19_Msk                     (_U_(0x1) << PIO_ODR_P19_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P19                         PIO_ODR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P19_Msk instead */
+#define PIO_ODR_P20_Pos                     20                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P20_Msk                     (_U_(0x1) << PIO_ODR_P20_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P20                         PIO_ODR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P20_Msk instead */
+#define PIO_ODR_P21_Pos                     21                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P21_Msk                     (_U_(0x1) << PIO_ODR_P21_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P21                         PIO_ODR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P21_Msk instead */
+#define PIO_ODR_P22_Pos                     22                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P22_Msk                     (_U_(0x1) << PIO_ODR_P22_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P22                         PIO_ODR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P22_Msk instead */
+#define PIO_ODR_P23_Pos                     23                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P23_Msk                     (_U_(0x1) << PIO_ODR_P23_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P23                         PIO_ODR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P23_Msk instead */
+#define PIO_ODR_P24_Pos                     24                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P24_Msk                     (_U_(0x1) << PIO_ODR_P24_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P24                         PIO_ODR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P24_Msk instead */
+#define PIO_ODR_P25_Pos                     25                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P25_Msk                     (_U_(0x1) << PIO_ODR_P25_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P25                         PIO_ODR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P25_Msk instead */
+#define PIO_ODR_P26_Pos                     26                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P26_Msk                     (_U_(0x1) << PIO_ODR_P26_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P26                         PIO_ODR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P26_Msk instead */
+#define PIO_ODR_P27_Pos                     27                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P27_Msk                     (_U_(0x1) << PIO_ODR_P27_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P27                         PIO_ODR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P27_Msk instead */
+#define PIO_ODR_P28_Pos                     28                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P28_Msk                     (_U_(0x1) << PIO_ODR_P28_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P28                         PIO_ODR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P28_Msk instead */
+#define PIO_ODR_P29_Pos                     29                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P29_Msk                     (_U_(0x1) << PIO_ODR_P29_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P29                         PIO_ODR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P29_Msk instead */
+#define PIO_ODR_P30_Pos                     30                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P30_Msk                     (_U_(0x1) << PIO_ODR_P30_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P30                         PIO_ODR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P30_Msk instead */
+#define PIO_ODR_P31_Pos                     31                                             /**< (PIO_ODR) Output Disable Position */
+#define PIO_ODR_P31_Msk                     (_U_(0x1) << PIO_ODR_P31_Pos)                  /**< (PIO_ODR) Output Disable Mask */
+#define PIO_ODR_P31                         PIO_ODR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODR_P31_Msk instead */
+#define PIO_ODR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ODR) Register MASK  (Use PIO_ODR_Msk instead)  */
+#define PIO_ODR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ODR) Register Mask  */
+
+#define PIO_ODR_P_Pos                       0                                              /**< (PIO_ODR Position) Output Disable */
+#define PIO_ODR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ODR_P_Pos)             /**< (PIO_ODR Mask) P */
+#define PIO_ODR_P(value)                    (PIO_ODR_P_Msk & ((value) << PIO_ODR_P_Pos))   
+
+/* -------- PIO_OSR : (PIO Offset: 0x18) (R/ 32) Output Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Status                            */
+    uint32_t P1:1;                      /**< bit:      1  Output Status                            */
+    uint32_t P2:1;                      /**< bit:      2  Output Status                            */
+    uint32_t P3:1;                      /**< bit:      3  Output Status                            */
+    uint32_t P4:1;                      /**< bit:      4  Output Status                            */
+    uint32_t P5:1;                      /**< bit:      5  Output Status                            */
+    uint32_t P6:1;                      /**< bit:      6  Output Status                            */
+    uint32_t P7:1;                      /**< bit:      7  Output Status                            */
+    uint32_t P8:1;                      /**< bit:      8  Output Status                            */
+    uint32_t P9:1;                      /**< bit:      9  Output Status                            */
+    uint32_t P10:1;                     /**< bit:     10  Output Status                            */
+    uint32_t P11:1;                     /**< bit:     11  Output Status                            */
+    uint32_t P12:1;                     /**< bit:     12  Output Status                            */
+    uint32_t P13:1;                     /**< bit:     13  Output Status                            */
+    uint32_t P14:1;                     /**< bit:     14  Output Status                            */
+    uint32_t P15:1;                     /**< bit:     15  Output Status                            */
+    uint32_t P16:1;                     /**< bit:     16  Output Status                            */
+    uint32_t P17:1;                     /**< bit:     17  Output Status                            */
+    uint32_t P18:1;                     /**< bit:     18  Output Status                            */
+    uint32_t P19:1;                     /**< bit:     19  Output Status                            */
+    uint32_t P20:1;                     /**< bit:     20  Output Status                            */
+    uint32_t P21:1;                     /**< bit:     21  Output Status                            */
+    uint32_t P22:1;                     /**< bit:     22  Output Status                            */
+    uint32_t P23:1;                     /**< bit:     23  Output Status                            */
+    uint32_t P24:1;                     /**< bit:     24  Output Status                            */
+    uint32_t P25:1;                     /**< bit:     25  Output Status                            */
+    uint32_t P26:1;                     /**< bit:     26  Output Status                            */
+    uint32_t P27:1;                     /**< bit:     27  Output Status                            */
+    uint32_t P28:1;                     /**< bit:     28  Output Status                            */
+    uint32_t P29:1;                     /**< bit:     29  Output Status                            */
+    uint32_t P30:1;                     /**< bit:     30  Output Status                            */
+    uint32_t P31:1;                     /**< bit:     31  Output Status                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Status                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OSR_OFFSET                      (0x18)                                        /**<  (PIO_OSR) Output Status Register  Offset */
+
+#define PIO_OSR_P0_Pos                      0                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P0_Msk                      (_U_(0x1) << PIO_OSR_P0_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P0                          PIO_OSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P0_Msk instead */
+#define PIO_OSR_P1_Pos                      1                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P1_Msk                      (_U_(0x1) << PIO_OSR_P1_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P1                          PIO_OSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P1_Msk instead */
+#define PIO_OSR_P2_Pos                      2                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P2_Msk                      (_U_(0x1) << PIO_OSR_P2_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P2                          PIO_OSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P2_Msk instead */
+#define PIO_OSR_P3_Pos                      3                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P3_Msk                      (_U_(0x1) << PIO_OSR_P3_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P3                          PIO_OSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P3_Msk instead */
+#define PIO_OSR_P4_Pos                      4                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P4_Msk                      (_U_(0x1) << PIO_OSR_P4_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P4                          PIO_OSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P4_Msk instead */
+#define PIO_OSR_P5_Pos                      5                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P5_Msk                      (_U_(0x1) << PIO_OSR_P5_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P5                          PIO_OSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P5_Msk instead */
+#define PIO_OSR_P6_Pos                      6                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P6_Msk                      (_U_(0x1) << PIO_OSR_P6_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P6                          PIO_OSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P6_Msk instead */
+#define PIO_OSR_P7_Pos                      7                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P7_Msk                      (_U_(0x1) << PIO_OSR_P7_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P7                          PIO_OSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P7_Msk instead */
+#define PIO_OSR_P8_Pos                      8                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P8_Msk                      (_U_(0x1) << PIO_OSR_P8_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P8                          PIO_OSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P8_Msk instead */
+#define PIO_OSR_P9_Pos                      9                                              /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P9_Msk                      (_U_(0x1) << PIO_OSR_P9_Pos)                   /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P9                          PIO_OSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P9_Msk instead */
+#define PIO_OSR_P10_Pos                     10                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P10_Msk                     (_U_(0x1) << PIO_OSR_P10_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P10                         PIO_OSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P10_Msk instead */
+#define PIO_OSR_P11_Pos                     11                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P11_Msk                     (_U_(0x1) << PIO_OSR_P11_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P11                         PIO_OSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P11_Msk instead */
+#define PIO_OSR_P12_Pos                     12                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P12_Msk                     (_U_(0x1) << PIO_OSR_P12_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P12                         PIO_OSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P12_Msk instead */
+#define PIO_OSR_P13_Pos                     13                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P13_Msk                     (_U_(0x1) << PIO_OSR_P13_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P13                         PIO_OSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P13_Msk instead */
+#define PIO_OSR_P14_Pos                     14                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P14_Msk                     (_U_(0x1) << PIO_OSR_P14_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P14                         PIO_OSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P14_Msk instead */
+#define PIO_OSR_P15_Pos                     15                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P15_Msk                     (_U_(0x1) << PIO_OSR_P15_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P15                         PIO_OSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P15_Msk instead */
+#define PIO_OSR_P16_Pos                     16                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P16_Msk                     (_U_(0x1) << PIO_OSR_P16_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P16                         PIO_OSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P16_Msk instead */
+#define PIO_OSR_P17_Pos                     17                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P17_Msk                     (_U_(0x1) << PIO_OSR_P17_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P17                         PIO_OSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P17_Msk instead */
+#define PIO_OSR_P18_Pos                     18                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P18_Msk                     (_U_(0x1) << PIO_OSR_P18_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P18                         PIO_OSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P18_Msk instead */
+#define PIO_OSR_P19_Pos                     19                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P19_Msk                     (_U_(0x1) << PIO_OSR_P19_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P19                         PIO_OSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P19_Msk instead */
+#define PIO_OSR_P20_Pos                     20                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P20_Msk                     (_U_(0x1) << PIO_OSR_P20_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P20                         PIO_OSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P20_Msk instead */
+#define PIO_OSR_P21_Pos                     21                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P21_Msk                     (_U_(0x1) << PIO_OSR_P21_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P21                         PIO_OSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P21_Msk instead */
+#define PIO_OSR_P22_Pos                     22                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P22_Msk                     (_U_(0x1) << PIO_OSR_P22_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P22                         PIO_OSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P22_Msk instead */
+#define PIO_OSR_P23_Pos                     23                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P23_Msk                     (_U_(0x1) << PIO_OSR_P23_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P23                         PIO_OSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P23_Msk instead */
+#define PIO_OSR_P24_Pos                     24                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P24_Msk                     (_U_(0x1) << PIO_OSR_P24_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P24                         PIO_OSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P24_Msk instead */
+#define PIO_OSR_P25_Pos                     25                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P25_Msk                     (_U_(0x1) << PIO_OSR_P25_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P25                         PIO_OSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P25_Msk instead */
+#define PIO_OSR_P26_Pos                     26                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P26_Msk                     (_U_(0x1) << PIO_OSR_P26_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P26                         PIO_OSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P26_Msk instead */
+#define PIO_OSR_P27_Pos                     27                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P27_Msk                     (_U_(0x1) << PIO_OSR_P27_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P27                         PIO_OSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P27_Msk instead */
+#define PIO_OSR_P28_Pos                     28                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P28_Msk                     (_U_(0x1) << PIO_OSR_P28_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P28                         PIO_OSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P28_Msk instead */
+#define PIO_OSR_P29_Pos                     29                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P29_Msk                     (_U_(0x1) << PIO_OSR_P29_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P29                         PIO_OSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P29_Msk instead */
+#define PIO_OSR_P30_Pos                     30                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P30_Msk                     (_U_(0x1) << PIO_OSR_P30_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P30                         PIO_OSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P30_Msk instead */
+#define PIO_OSR_P31_Pos                     31                                             /**< (PIO_OSR) Output Status Position */
+#define PIO_OSR_P31_Msk                     (_U_(0x1) << PIO_OSR_P31_Pos)                  /**< (PIO_OSR) Output Status Mask */
+#define PIO_OSR_P31                         PIO_OSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OSR_P31_Msk instead */
+#define PIO_OSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OSR) Register MASK  (Use PIO_OSR_Msk instead)  */
+#define PIO_OSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_OSR) Register Mask  */
+
+#define PIO_OSR_P_Pos                       0                                              /**< (PIO_OSR Position) Output Status */
+#define PIO_OSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_OSR_P_Pos)             /**< (PIO_OSR Mask) P */
+#define PIO_OSR_P(value)                    (PIO_OSR_P_Msk & ((value) << PIO_OSR_P_Pos))   
+
+/* -------- PIO_IFER : (PIO Offset: 0x20) (/W 32) Glitch Input Filter Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Enable                      */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Enable                      */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Enable                      */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Enable                      */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Enable                      */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Enable                      */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Enable                      */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Enable                      */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Enable                      */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Enable                      */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Enable                      */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Enable                      */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Enable                      */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Enable                      */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Enable                      */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Enable                      */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Enable                      */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Enable                      */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Enable                      */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Enable                      */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Enable                      */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Enable                      */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Enable                      */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Enable                      */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Enable                      */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Enable                      */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Enable                      */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Enable                      */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Enable                      */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Enable                      */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Enable                      */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Enable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Enable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFER_OFFSET                     (0x20)                                        /**<  (PIO_IFER) Glitch Input Filter Enable Register  Offset */
+
+#define PIO_IFER_P0_Pos                     0                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P0_Msk                     (_U_(0x1) << PIO_IFER_P0_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P0                         PIO_IFER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P0_Msk instead */
+#define PIO_IFER_P1_Pos                     1                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P1_Msk                     (_U_(0x1) << PIO_IFER_P1_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P1                         PIO_IFER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P1_Msk instead */
+#define PIO_IFER_P2_Pos                     2                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P2_Msk                     (_U_(0x1) << PIO_IFER_P2_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P2                         PIO_IFER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P2_Msk instead */
+#define PIO_IFER_P3_Pos                     3                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P3_Msk                     (_U_(0x1) << PIO_IFER_P3_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P3                         PIO_IFER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P3_Msk instead */
+#define PIO_IFER_P4_Pos                     4                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P4_Msk                     (_U_(0x1) << PIO_IFER_P4_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P4                         PIO_IFER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P4_Msk instead */
+#define PIO_IFER_P5_Pos                     5                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P5_Msk                     (_U_(0x1) << PIO_IFER_P5_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P5                         PIO_IFER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P5_Msk instead */
+#define PIO_IFER_P6_Pos                     6                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P6_Msk                     (_U_(0x1) << PIO_IFER_P6_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P6                         PIO_IFER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P6_Msk instead */
+#define PIO_IFER_P7_Pos                     7                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P7_Msk                     (_U_(0x1) << PIO_IFER_P7_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P7                         PIO_IFER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P7_Msk instead */
+#define PIO_IFER_P8_Pos                     8                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P8_Msk                     (_U_(0x1) << PIO_IFER_P8_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P8                         PIO_IFER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P8_Msk instead */
+#define PIO_IFER_P9_Pos                     9                                              /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P9_Msk                     (_U_(0x1) << PIO_IFER_P9_Pos)                  /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P9                         PIO_IFER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P9_Msk instead */
+#define PIO_IFER_P10_Pos                    10                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P10_Msk                    (_U_(0x1) << PIO_IFER_P10_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P10                        PIO_IFER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P10_Msk instead */
+#define PIO_IFER_P11_Pos                    11                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P11_Msk                    (_U_(0x1) << PIO_IFER_P11_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P11                        PIO_IFER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P11_Msk instead */
+#define PIO_IFER_P12_Pos                    12                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P12_Msk                    (_U_(0x1) << PIO_IFER_P12_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P12                        PIO_IFER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P12_Msk instead */
+#define PIO_IFER_P13_Pos                    13                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P13_Msk                    (_U_(0x1) << PIO_IFER_P13_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P13                        PIO_IFER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P13_Msk instead */
+#define PIO_IFER_P14_Pos                    14                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P14_Msk                    (_U_(0x1) << PIO_IFER_P14_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P14                        PIO_IFER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P14_Msk instead */
+#define PIO_IFER_P15_Pos                    15                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P15_Msk                    (_U_(0x1) << PIO_IFER_P15_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P15                        PIO_IFER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P15_Msk instead */
+#define PIO_IFER_P16_Pos                    16                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P16_Msk                    (_U_(0x1) << PIO_IFER_P16_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P16                        PIO_IFER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P16_Msk instead */
+#define PIO_IFER_P17_Pos                    17                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P17_Msk                    (_U_(0x1) << PIO_IFER_P17_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P17                        PIO_IFER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P17_Msk instead */
+#define PIO_IFER_P18_Pos                    18                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P18_Msk                    (_U_(0x1) << PIO_IFER_P18_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P18                        PIO_IFER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P18_Msk instead */
+#define PIO_IFER_P19_Pos                    19                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P19_Msk                    (_U_(0x1) << PIO_IFER_P19_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P19                        PIO_IFER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P19_Msk instead */
+#define PIO_IFER_P20_Pos                    20                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P20_Msk                    (_U_(0x1) << PIO_IFER_P20_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P20                        PIO_IFER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P20_Msk instead */
+#define PIO_IFER_P21_Pos                    21                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P21_Msk                    (_U_(0x1) << PIO_IFER_P21_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P21                        PIO_IFER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P21_Msk instead */
+#define PIO_IFER_P22_Pos                    22                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P22_Msk                    (_U_(0x1) << PIO_IFER_P22_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P22                        PIO_IFER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P22_Msk instead */
+#define PIO_IFER_P23_Pos                    23                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P23_Msk                    (_U_(0x1) << PIO_IFER_P23_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P23                        PIO_IFER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P23_Msk instead */
+#define PIO_IFER_P24_Pos                    24                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P24_Msk                    (_U_(0x1) << PIO_IFER_P24_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P24                        PIO_IFER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P24_Msk instead */
+#define PIO_IFER_P25_Pos                    25                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P25_Msk                    (_U_(0x1) << PIO_IFER_P25_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P25                        PIO_IFER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P25_Msk instead */
+#define PIO_IFER_P26_Pos                    26                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P26_Msk                    (_U_(0x1) << PIO_IFER_P26_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P26                        PIO_IFER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P26_Msk instead */
+#define PIO_IFER_P27_Pos                    27                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P27_Msk                    (_U_(0x1) << PIO_IFER_P27_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P27                        PIO_IFER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P27_Msk instead */
+#define PIO_IFER_P28_Pos                    28                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P28_Msk                    (_U_(0x1) << PIO_IFER_P28_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P28                        PIO_IFER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P28_Msk instead */
+#define PIO_IFER_P29_Pos                    29                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P29_Msk                    (_U_(0x1) << PIO_IFER_P29_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P29                        PIO_IFER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P29_Msk instead */
+#define PIO_IFER_P30_Pos                    30                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P30_Msk                    (_U_(0x1) << PIO_IFER_P30_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P30                        PIO_IFER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P30_Msk instead */
+#define PIO_IFER_P31_Pos                    31                                             /**< (PIO_IFER) Input Filter Enable Position */
+#define PIO_IFER_P31_Msk                    (_U_(0x1) << PIO_IFER_P31_Pos)                 /**< (PIO_IFER) Input Filter Enable Mask */
+#define PIO_IFER_P31                        PIO_IFER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFER_P31_Msk instead */
+#define PIO_IFER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFER) Register MASK  (Use PIO_IFER_Msk instead)  */
+#define PIO_IFER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFER) Register Mask  */
+
+#define PIO_IFER_P_Pos                      0                                              /**< (PIO_IFER Position) Input Filter Enable */
+#define PIO_IFER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFER_P_Pos)            /**< (PIO_IFER Mask) P */
+#define PIO_IFER_P(value)                   (PIO_IFER_P_Msk & ((value) << PIO_IFER_P_Pos))  
+
+/* -------- PIO_IFDR : (PIO Offset: 0x24) (/W 32) Glitch Input Filter Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Disable                     */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Disable                     */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Disable                     */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Disable                     */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Disable                     */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Disable                     */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Disable                     */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Disable                     */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Disable                     */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Disable                     */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Disable                     */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Disable                     */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Disable                     */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Disable                     */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Disable                     */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Disable                     */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Disable                     */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Disable                     */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Disable                     */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Disable                     */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Disable                     */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Disable                     */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Disable                     */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Disable                     */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Disable                     */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Disable                     */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Disable                     */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Disable                     */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Disable                     */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Disable                     */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Disable                     */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Disable                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Disable                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFDR_OFFSET                     (0x24)                                        /**<  (PIO_IFDR) Glitch Input Filter Disable Register  Offset */
+
+#define PIO_IFDR_P0_Pos                     0                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P0_Msk                     (_U_(0x1) << PIO_IFDR_P0_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P0                         PIO_IFDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P0_Msk instead */
+#define PIO_IFDR_P1_Pos                     1                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P1_Msk                     (_U_(0x1) << PIO_IFDR_P1_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P1                         PIO_IFDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P1_Msk instead */
+#define PIO_IFDR_P2_Pos                     2                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P2_Msk                     (_U_(0x1) << PIO_IFDR_P2_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P2                         PIO_IFDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P2_Msk instead */
+#define PIO_IFDR_P3_Pos                     3                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P3_Msk                     (_U_(0x1) << PIO_IFDR_P3_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P3                         PIO_IFDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P3_Msk instead */
+#define PIO_IFDR_P4_Pos                     4                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P4_Msk                     (_U_(0x1) << PIO_IFDR_P4_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P4                         PIO_IFDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P4_Msk instead */
+#define PIO_IFDR_P5_Pos                     5                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P5_Msk                     (_U_(0x1) << PIO_IFDR_P5_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P5                         PIO_IFDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P5_Msk instead */
+#define PIO_IFDR_P6_Pos                     6                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P6_Msk                     (_U_(0x1) << PIO_IFDR_P6_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P6                         PIO_IFDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P6_Msk instead */
+#define PIO_IFDR_P7_Pos                     7                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P7_Msk                     (_U_(0x1) << PIO_IFDR_P7_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P7                         PIO_IFDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P7_Msk instead */
+#define PIO_IFDR_P8_Pos                     8                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P8_Msk                     (_U_(0x1) << PIO_IFDR_P8_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P8                         PIO_IFDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P8_Msk instead */
+#define PIO_IFDR_P9_Pos                     9                                              /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P9_Msk                     (_U_(0x1) << PIO_IFDR_P9_Pos)                  /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P9                         PIO_IFDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P9_Msk instead */
+#define PIO_IFDR_P10_Pos                    10                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P10_Msk                    (_U_(0x1) << PIO_IFDR_P10_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P10                        PIO_IFDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P10_Msk instead */
+#define PIO_IFDR_P11_Pos                    11                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P11_Msk                    (_U_(0x1) << PIO_IFDR_P11_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P11                        PIO_IFDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P11_Msk instead */
+#define PIO_IFDR_P12_Pos                    12                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P12_Msk                    (_U_(0x1) << PIO_IFDR_P12_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P12                        PIO_IFDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P12_Msk instead */
+#define PIO_IFDR_P13_Pos                    13                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P13_Msk                    (_U_(0x1) << PIO_IFDR_P13_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P13                        PIO_IFDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P13_Msk instead */
+#define PIO_IFDR_P14_Pos                    14                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P14_Msk                    (_U_(0x1) << PIO_IFDR_P14_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P14                        PIO_IFDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P14_Msk instead */
+#define PIO_IFDR_P15_Pos                    15                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P15_Msk                    (_U_(0x1) << PIO_IFDR_P15_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P15                        PIO_IFDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P15_Msk instead */
+#define PIO_IFDR_P16_Pos                    16                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P16_Msk                    (_U_(0x1) << PIO_IFDR_P16_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P16                        PIO_IFDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P16_Msk instead */
+#define PIO_IFDR_P17_Pos                    17                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P17_Msk                    (_U_(0x1) << PIO_IFDR_P17_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P17                        PIO_IFDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P17_Msk instead */
+#define PIO_IFDR_P18_Pos                    18                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P18_Msk                    (_U_(0x1) << PIO_IFDR_P18_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P18                        PIO_IFDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P18_Msk instead */
+#define PIO_IFDR_P19_Pos                    19                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P19_Msk                    (_U_(0x1) << PIO_IFDR_P19_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P19                        PIO_IFDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P19_Msk instead */
+#define PIO_IFDR_P20_Pos                    20                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P20_Msk                    (_U_(0x1) << PIO_IFDR_P20_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P20                        PIO_IFDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P20_Msk instead */
+#define PIO_IFDR_P21_Pos                    21                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P21_Msk                    (_U_(0x1) << PIO_IFDR_P21_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P21                        PIO_IFDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P21_Msk instead */
+#define PIO_IFDR_P22_Pos                    22                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P22_Msk                    (_U_(0x1) << PIO_IFDR_P22_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P22                        PIO_IFDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P22_Msk instead */
+#define PIO_IFDR_P23_Pos                    23                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P23_Msk                    (_U_(0x1) << PIO_IFDR_P23_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P23                        PIO_IFDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P23_Msk instead */
+#define PIO_IFDR_P24_Pos                    24                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P24_Msk                    (_U_(0x1) << PIO_IFDR_P24_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P24                        PIO_IFDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P24_Msk instead */
+#define PIO_IFDR_P25_Pos                    25                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P25_Msk                    (_U_(0x1) << PIO_IFDR_P25_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P25                        PIO_IFDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P25_Msk instead */
+#define PIO_IFDR_P26_Pos                    26                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P26_Msk                    (_U_(0x1) << PIO_IFDR_P26_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P26                        PIO_IFDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P26_Msk instead */
+#define PIO_IFDR_P27_Pos                    27                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P27_Msk                    (_U_(0x1) << PIO_IFDR_P27_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P27                        PIO_IFDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P27_Msk instead */
+#define PIO_IFDR_P28_Pos                    28                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P28_Msk                    (_U_(0x1) << PIO_IFDR_P28_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P28                        PIO_IFDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P28_Msk instead */
+#define PIO_IFDR_P29_Pos                    29                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P29_Msk                    (_U_(0x1) << PIO_IFDR_P29_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P29                        PIO_IFDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P29_Msk instead */
+#define PIO_IFDR_P30_Pos                    30                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P30_Msk                    (_U_(0x1) << PIO_IFDR_P30_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P30                        PIO_IFDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P30_Msk instead */
+#define PIO_IFDR_P31_Pos                    31                                             /**< (PIO_IFDR) Input Filter Disable Position */
+#define PIO_IFDR_P31_Msk                    (_U_(0x1) << PIO_IFDR_P31_Pos)                 /**< (PIO_IFDR) Input Filter Disable Mask */
+#define PIO_IFDR_P31                        PIO_IFDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFDR_P31_Msk instead */
+#define PIO_IFDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFDR) Register MASK  (Use PIO_IFDR_Msk instead)  */
+#define PIO_IFDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFDR) Register Mask  */
+
+#define PIO_IFDR_P_Pos                      0                                              /**< (PIO_IFDR Position) Input Filter Disable */
+#define PIO_IFDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFDR_P_Pos)            /**< (PIO_IFDR Mask) P */
+#define PIO_IFDR_P(value)                   (PIO_IFDR_P_Msk & ((value) << PIO_IFDR_P_Pos))  
+
+/* -------- PIO_IFSR : (PIO Offset: 0x28) (R/ 32) Glitch Input Filter Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Filter Status                      */
+    uint32_t P1:1;                      /**< bit:      1  Input Filter Status                      */
+    uint32_t P2:1;                      /**< bit:      2  Input Filter Status                      */
+    uint32_t P3:1;                      /**< bit:      3  Input Filter Status                      */
+    uint32_t P4:1;                      /**< bit:      4  Input Filter Status                      */
+    uint32_t P5:1;                      /**< bit:      5  Input Filter Status                      */
+    uint32_t P6:1;                      /**< bit:      6  Input Filter Status                      */
+    uint32_t P7:1;                      /**< bit:      7  Input Filter Status                      */
+    uint32_t P8:1;                      /**< bit:      8  Input Filter Status                      */
+    uint32_t P9:1;                      /**< bit:      9  Input Filter Status                      */
+    uint32_t P10:1;                     /**< bit:     10  Input Filter Status                      */
+    uint32_t P11:1;                     /**< bit:     11  Input Filter Status                      */
+    uint32_t P12:1;                     /**< bit:     12  Input Filter Status                      */
+    uint32_t P13:1;                     /**< bit:     13  Input Filter Status                      */
+    uint32_t P14:1;                     /**< bit:     14  Input Filter Status                      */
+    uint32_t P15:1;                     /**< bit:     15  Input Filter Status                      */
+    uint32_t P16:1;                     /**< bit:     16  Input Filter Status                      */
+    uint32_t P17:1;                     /**< bit:     17  Input Filter Status                      */
+    uint32_t P18:1;                     /**< bit:     18  Input Filter Status                      */
+    uint32_t P19:1;                     /**< bit:     19  Input Filter Status                      */
+    uint32_t P20:1;                     /**< bit:     20  Input Filter Status                      */
+    uint32_t P21:1;                     /**< bit:     21  Input Filter Status                      */
+    uint32_t P22:1;                     /**< bit:     22  Input Filter Status                      */
+    uint32_t P23:1;                     /**< bit:     23  Input Filter Status                      */
+    uint32_t P24:1;                     /**< bit:     24  Input Filter Status                      */
+    uint32_t P25:1;                     /**< bit:     25  Input Filter Status                      */
+    uint32_t P26:1;                     /**< bit:     26  Input Filter Status                      */
+    uint32_t P27:1;                     /**< bit:     27  Input Filter Status                      */
+    uint32_t P28:1;                     /**< bit:     28  Input Filter Status                      */
+    uint32_t P29:1;                     /**< bit:     29  Input Filter Status                      */
+    uint32_t P30:1;                     /**< bit:     30  Input Filter Status                      */
+    uint32_t P31:1;                     /**< bit:     31  Input Filter Status                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Filter Status                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSR_OFFSET                     (0x28)                                        /**<  (PIO_IFSR) Glitch Input Filter Status Register  Offset */
+
+#define PIO_IFSR_P0_Pos                     0                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P0_Msk                     (_U_(0x1) << PIO_IFSR_P0_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P0                         PIO_IFSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P0_Msk instead */
+#define PIO_IFSR_P1_Pos                     1                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P1_Msk                     (_U_(0x1) << PIO_IFSR_P1_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P1                         PIO_IFSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P1_Msk instead */
+#define PIO_IFSR_P2_Pos                     2                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P2_Msk                     (_U_(0x1) << PIO_IFSR_P2_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P2                         PIO_IFSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P2_Msk instead */
+#define PIO_IFSR_P3_Pos                     3                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P3_Msk                     (_U_(0x1) << PIO_IFSR_P3_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P3                         PIO_IFSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P3_Msk instead */
+#define PIO_IFSR_P4_Pos                     4                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P4_Msk                     (_U_(0x1) << PIO_IFSR_P4_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P4                         PIO_IFSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P4_Msk instead */
+#define PIO_IFSR_P5_Pos                     5                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P5_Msk                     (_U_(0x1) << PIO_IFSR_P5_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P5                         PIO_IFSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P5_Msk instead */
+#define PIO_IFSR_P6_Pos                     6                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P6_Msk                     (_U_(0x1) << PIO_IFSR_P6_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P6                         PIO_IFSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P6_Msk instead */
+#define PIO_IFSR_P7_Pos                     7                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P7_Msk                     (_U_(0x1) << PIO_IFSR_P7_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P7                         PIO_IFSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P7_Msk instead */
+#define PIO_IFSR_P8_Pos                     8                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P8_Msk                     (_U_(0x1) << PIO_IFSR_P8_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P8                         PIO_IFSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P8_Msk instead */
+#define PIO_IFSR_P9_Pos                     9                                              /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P9_Msk                     (_U_(0x1) << PIO_IFSR_P9_Pos)                  /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P9                         PIO_IFSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P9_Msk instead */
+#define PIO_IFSR_P10_Pos                    10                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P10_Msk                    (_U_(0x1) << PIO_IFSR_P10_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P10                        PIO_IFSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P10_Msk instead */
+#define PIO_IFSR_P11_Pos                    11                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P11_Msk                    (_U_(0x1) << PIO_IFSR_P11_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P11                        PIO_IFSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P11_Msk instead */
+#define PIO_IFSR_P12_Pos                    12                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P12_Msk                    (_U_(0x1) << PIO_IFSR_P12_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P12                        PIO_IFSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P12_Msk instead */
+#define PIO_IFSR_P13_Pos                    13                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P13_Msk                    (_U_(0x1) << PIO_IFSR_P13_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P13                        PIO_IFSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P13_Msk instead */
+#define PIO_IFSR_P14_Pos                    14                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P14_Msk                    (_U_(0x1) << PIO_IFSR_P14_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P14                        PIO_IFSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P14_Msk instead */
+#define PIO_IFSR_P15_Pos                    15                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P15_Msk                    (_U_(0x1) << PIO_IFSR_P15_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P15                        PIO_IFSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P15_Msk instead */
+#define PIO_IFSR_P16_Pos                    16                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P16_Msk                    (_U_(0x1) << PIO_IFSR_P16_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P16                        PIO_IFSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P16_Msk instead */
+#define PIO_IFSR_P17_Pos                    17                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P17_Msk                    (_U_(0x1) << PIO_IFSR_P17_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P17                        PIO_IFSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P17_Msk instead */
+#define PIO_IFSR_P18_Pos                    18                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P18_Msk                    (_U_(0x1) << PIO_IFSR_P18_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P18                        PIO_IFSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P18_Msk instead */
+#define PIO_IFSR_P19_Pos                    19                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P19_Msk                    (_U_(0x1) << PIO_IFSR_P19_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P19                        PIO_IFSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P19_Msk instead */
+#define PIO_IFSR_P20_Pos                    20                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P20_Msk                    (_U_(0x1) << PIO_IFSR_P20_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P20                        PIO_IFSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P20_Msk instead */
+#define PIO_IFSR_P21_Pos                    21                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P21_Msk                    (_U_(0x1) << PIO_IFSR_P21_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P21                        PIO_IFSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P21_Msk instead */
+#define PIO_IFSR_P22_Pos                    22                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P22_Msk                    (_U_(0x1) << PIO_IFSR_P22_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P22                        PIO_IFSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P22_Msk instead */
+#define PIO_IFSR_P23_Pos                    23                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P23_Msk                    (_U_(0x1) << PIO_IFSR_P23_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P23                        PIO_IFSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P23_Msk instead */
+#define PIO_IFSR_P24_Pos                    24                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P24_Msk                    (_U_(0x1) << PIO_IFSR_P24_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P24                        PIO_IFSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P24_Msk instead */
+#define PIO_IFSR_P25_Pos                    25                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P25_Msk                    (_U_(0x1) << PIO_IFSR_P25_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P25                        PIO_IFSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P25_Msk instead */
+#define PIO_IFSR_P26_Pos                    26                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P26_Msk                    (_U_(0x1) << PIO_IFSR_P26_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P26                        PIO_IFSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P26_Msk instead */
+#define PIO_IFSR_P27_Pos                    27                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P27_Msk                    (_U_(0x1) << PIO_IFSR_P27_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P27                        PIO_IFSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P27_Msk instead */
+#define PIO_IFSR_P28_Pos                    28                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P28_Msk                    (_U_(0x1) << PIO_IFSR_P28_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P28                        PIO_IFSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P28_Msk instead */
+#define PIO_IFSR_P29_Pos                    29                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P29_Msk                    (_U_(0x1) << PIO_IFSR_P29_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P29                        PIO_IFSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P29_Msk instead */
+#define PIO_IFSR_P30_Pos                    30                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P30_Msk                    (_U_(0x1) << PIO_IFSR_P30_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P30                        PIO_IFSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P30_Msk instead */
+#define PIO_IFSR_P31_Pos                    31                                             /**< (PIO_IFSR) Input Filter Status Position */
+#define PIO_IFSR_P31_Msk                    (_U_(0x1) << PIO_IFSR_P31_Pos)                 /**< (PIO_IFSR) Input Filter Status Mask */
+#define PIO_IFSR_P31                        PIO_IFSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSR_P31_Msk instead */
+#define PIO_IFSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSR) Register MASK  (Use PIO_IFSR_Msk instead)  */
+#define PIO_IFSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_IFSR) Register Mask  */
+
+#define PIO_IFSR_P_Pos                      0                                              /**< (PIO_IFSR Position) Input Filter Status */
+#define PIO_IFSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_IFSR_P_Pos)            /**< (PIO_IFSR Mask) P */
+#define PIO_IFSR_P(value)                   (PIO_IFSR_P_Msk & ((value) << PIO_IFSR_P_Pos))  
+
+/* -------- PIO_SODR : (PIO Offset: 0x30) (/W 32) Set Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Set Output Data                          */
+    uint32_t P1:1;                      /**< bit:      1  Set Output Data                          */
+    uint32_t P2:1;                      /**< bit:      2  Set Output Data                          */
+    uint32_t P3:1;                      /**< bit:      3  Set Output Data                          */
+    uint32_t P4:1;                      /**< bit:      4  Set Output Data                          */
+    uint32_t P5:1;                      /**< bit:      5  Set Output Data                          */
+    uint32_t P6:1;                      /**< bit:      6  Set Output Data                          */
+    uint32_t P7:1;                      /**< bit:      7  Set Output Data                          */
+    uint32_t P8:1;                      /**< bit:      8  Set Output Data                          */
+    uint32_t P9:1;                      /**< bit:      9  Set Output Data                          */
+    uint32_t P10:1;                     /**< bit:     10  Set Output Data                          */
+    uint32_t P11:1;                     /**< bit:     11  Set Output Data                          */
+    uint32_t P12:1;                     /**< bit:     12  Set Output Data                          */
+    uint32_t P13:1;                     /**< bit:     13  Set Output Data                          */
+    uint32_t P14:1;                     /**< bit:     14  Set Output Data                          */
+    uint32_t P15:1;                     /**< bit:     15  Set Output Data                          */
+    uint32_t P16:1;                     /**< bit:     16  Set Output Data                          */
+    uint32_t P17:1;                     /**< bit:     17  Set Output Data                          */
+    uint32_t P18:1;                     /**< bit:     18  Set Output Data                          */
+    uint32_t P19:1;                     /**< bit:     19  Set Output Data                          */
+    uint32_t P20:1;                     /**< bit:     20  Set Output Data                          */
+    uint32_t P21:1;                     /**< bit:     21  Set Output Data                          */
+    uint32_t P22:1;                     /**< bit:     22  Set Output Data                          */
+    uint32_t P23:1;                     /**< bit:     23  Set Output Data                          */
+    uint32_t P24:1;                     /**< bit:     24  Set Output Data                          */
+    uint32_t P25:1;                     /**< bit:     25  Set Output Data                          */
+    uint32_t P26:1;                     /**< bit:     26  Set Output Data                          */
+    uint32_t P27:1;                     /**< bit:     27  Set Output Data                          */
+    uint32_t P28:1;                     /**< bit:     28  Set Output Data                          */
+    uint32_t P29:1;                     /**< bit:     29  Set Output Data                          */
+    uint32_t P30:1;                     /**< bit:     30  Set Output Data                          */
+    uint32_t P31:1;                     /**< bit:     31  Set Output Data                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Set Output Data                          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SODR_OFFSET                     (0x30)                                        /**<  (PIO_SODR) Set Output Data Register  Offset */
+
+#define PIO_SODR_P0_Pos                     0                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P0_Msk                     (_U_(0x1) << PIO_SODR_P0_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P0                         PIO_SODR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P0_Msk instead */
+#define PIO_SODR_P1_Pos                     1                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P1_Msk                     (_U_(0x1) << PIO_SODR_P1_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P1                         PIO_SODR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P1_Msk instead */
+#define PIO_SODR_P2_Pos                     2                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P2_Msk                     (_U_(0x1) << PIO_SODR_P2_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P2                         PIO_SODR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P2_Msk instead */
+#define PIO_SODR_P3_Pos                     3                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P3_Msk                     (_U_(0x1) << PIO_SODR_P3_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P3                         PIO_SODR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P3_Msk instead */
+#define PIO_SODR_P4_Pos                     4                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P4_Msk                     (_U_(0x1) << PIO_SODR_P4_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P4                         PIO_SODR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P4_Msk instead */
+#define PIO_SODR_P5_Pos                     5                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P5_Msk                     (_U_(0x1) << PIO_SODR_P5_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P5                         PIO_SODR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P5_Msk instead */
+#define PIO_SODR_P6_Pos                     6                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P6_Msk                     (_U_(0x1) << PIO_SODR_P6_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P6                         PIO_SODR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P6_Msk instead */
+#define PIO_SODR_P7_Pos                     7                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P7_Msk                     (_U_(0x1) << PIO_SODR_P7_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P7                         PIO_SODR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P7_Msk instead */
+#define PIO_SODR_P8_Pos                     8                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P8_Msk                     (_U_(0x1) << PIO_SODR_P8_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P8                         PIO_SODR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P8_Msk instead */
+#define PIO_SODR_P9_Pos                     9                                              /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P9_Msk                     (_U_(0x1) << PIO_SODR_P9_Pos)                  /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P9                         PIO_SODR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P9_Msk instead */
+#define PIO_SODR_P10_Pos                    10                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P10_Msk                    (_U_(0x1) << PIO_SODR_P10_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P10                        PIO_SODR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P10_Msk instead */
+#define PIO_SODR_P11_Pos                    11                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P11_Msk                    (_U_(0x1) << PIO_SODR_P11_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P11                        PIO_SODR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P11_Msk instead */
+#define PIO_SODR_P12_Pos                    12                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P12_Msk                    (_U_(0x1) << PIO_SODR_P12_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P12                        PIO_SODR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P12_Msk instead */
+#define PIO_SODR_P13_Pos                    13                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P13_Msk                    (_U_(0x1) << PIO_SODR_P13_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P13                        PIO_SODR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P13_Msk instead */
+#define PIO_SODR_P14_Pos                    14                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P14_Msk                    (_U_(0x1) << PIO_SODR_P14_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P14                        PIO_SODR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P14_Msk instead */
+#define PIO_SODR_P15_Pos                    15                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P15_Msk                    (_U_(0x1) << PIO_SODR_P15_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P15                        PIO_SODR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P15_Msk instead */
+#define PIO_SODR_P16_Pos                    16                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P16_Msk                    (_U_(0x1) << PIO_SODR_P16_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P16                        PIO_SODR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P16_Msk instead */
+#define PIO_SODR_P17_Pos                    17                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P17_Msk                    (_U_(0x1) << PIO_SODR_P17_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P17                        PIO_SODR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P17_Msk instead */
+#define PIO_SODR_P18_Pos                    18                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P18_Msk                    (_U_(0x1) << PIO_SODR_P18_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P18                        PIO_SODR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P18_Msk instead */
+#define PIO_SODR_P19_Pos                    19                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P19_Msk                    (_U_(0x1) << PIO_SODR_P19_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P19                        PIO_SODR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P19_Msk instead */
+#define PIO_SODR_P20_Pos                    20                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P20_Msk                    (_U_(0x1) << PIO_SODR_P20_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P20                        PIO_SODR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P20_Msk instead */
+#define PIO_SODR_P21_Pos                    21                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P21_Msk                    (_U_(0x1) << PIO_SODR_P21_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P21                        PIO_SODR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P21_Msk instead */
+#define PIO_SODR_P22_Pos                    22                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P22_Msk                    (_U_(0x1) << PIO_SODR_P22_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P22                        PIO_SODR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P22_Msk instead */
+#define PIO_SODR_P23_Pos                    23                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P23_Msk                    (_U_(0x1) << PIO_SODR_P23_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P23                        PIO_SODR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P23_Msk instead */
+#define PIO_SODR_P24_Pos                    24                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P24_Msk                    (_U_(0x1) << PIO_SODR_P24_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P24                        PIO_SODR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P24_Msk instead */
+#define PIO_SODR_P25_Pos                    25                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P25_Msk                    (_U_(0x1) << PIO_SODR_P25_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P25                        PIO_SODR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P25_Msk instead */
+#define PIO_SODR_P26_Pos                    26                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P26_Msk                    (_U_(0x1) << PIO_SODR_P26_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P26                        PIO_SODR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P26_Msk instead */
+#define PIO_SODR_P27_Pos                    27                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P27_Msk                    (_U_(0x1) << PIO_SODR_P27_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P27                        PIO_SODR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P27_Msk instead */
+#define PIO_SODR_P28_Pos                    28                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P28_Msk                    (_U_(0x1) << PIO_SODR_P28_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P28                        PIO_SODR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P28_Msk instead */
+#define PIO_SODR_P29_Pos                    29                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P29_Msk                    (_U_(0x1) << PIO_SODR_P29_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P29                        PIO_SODR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P29_Msk instead */
+#define PIO_SODR_P30_Pos                    30                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P30_Msk                    (_U_(0x1) << PIO_SODR_P30_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P30                        PIO_SODR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P30_Msk instead */
+#define PIO_SODR_P31_Pos                    31                                             /**< (PIO_SODR) Set Output Data Position */
+#define PIO_SODR_P31_Msk                    (_U_(0x1) << PIO_SODR_P31_Pos)                 /**< (PIO_SODR) Set Output Data Mask */
+#define PIO_SODR_P31                        PIO_SODR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SODR_P31_Msk instead */
+#define PIO_SODR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_SODR) Register MASK  (Use PIO_SODR_Msk instead)  */
+#define PIO_SODR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_SODR) Register Mask  */
+
+#define PIO_SODR_P_Pos                      0                                              /**< (PIO_SODR Position) Set Output Data */
+#define PIO_SODR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_SODR_P_Pos)            /**< (PIO_SODR Mask) P */
+#define PIO_SODR_P(value)                   (PIO_SODR_P_Msk & ((value) << PIO_SODR_P_Pos))  
+
+/* -------- PIO_CODR : (PIO Offset: 0x34) (/W 32) Clear Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Clear Output Data                        */
+    uint32_t P1:1;                      /**< bit:      1  Clear Output Data                        */
+    uint32_t P2:1;                      /**< bit:      2  Clear Output Data                        */
+    uint32_t P3:1;                      /**< bit:      3  Clear Output Data                        */
+    uint32_t P4:1;                      /**< bit:      4  Clear Output Data                        */
+    uint32_t P5:1;                      /**< bit:      5  Clear Output Data                        */
+    uint32_t P6:1;                      /**< bit:      6  Clear Output Data                        */
+    uint32_t P7:1;                      /**< bit:      7  Clear Output Data                        */
+    uint32_t P8:1;                      /**< bit:      8  Clear Output Data                        */
+    uint32_t P9:1;                      /**< bit:      9  Clear Output Data                        */
+    uint32_t P10:1;                     /**< bit:     10  Clear Output Data                        */
+    uint32_t P11:1;                     /**< bit:     11  Clear Output Data                        */
+    uint32_t P12:1;                     /**< bit:     12  Clear Output Data                        */
+    uint32_t P13:1;                     /**< bit:     13  Clear Output Data                        */
+    uint32_t P14:1;                     /**< bit:     14  Clear Output Data                        */
+    uint32_t P15:1;                     /**< bit:     15  Clear Output Data                        */
+    uint32_t P16:1;                     /**< bit:     16  Clear Output Data                        */
+    uint32_t P17:1;                     /**< bit:     17  Clear Output Data                        */
+    uint32_t P18:1;                     /**< bit:     18  Clear Output Data                        */
+    uint32_t P19:1;                     /**< bit:     19  Clear Output Data                        */
+    uint32_t P20:1;                     /**< bit:     20  Clear Output Data                        */
+    uint32_t P21:1;                     /**< bit:     21  Clear Output Data                        */
+    uint32_t P22:1;                     /**< bit:     22  Clear Output Data                        */
+    uint32_t P23:1;                     /**< bit:     23  Clear Output Data                        */
+    uint32_t P24:1;                     /**< bit:     24  Clear Output Data                        */
+    uint32_t P25:1;                     /**< bit:     25  Clear Output Data                        */
+    uint32_t P26:1;                     /**< bit:     26  Clear Output Data                        */
+    uint32_t P27:1;                     /**< bit:     27  Clear Output Data                        */
+    uint32_t P28:1;                     /**< bit:     28  Clear Output Data                        */
+    uint32_t P29:1;                     /**< bit:     29  Clear Output Data                        */
+    uint32_t P30:1;                     /**< bit:     30  Clear Output Data                        */
+    uint32_t P31:1;                     /**< bit:     31  Clear Output Data                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Clear Output Data                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_CODR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_CODR_OFFSET                     (0x34)                                        /**<  (PIO_CODR) Clear Output Data Register  Offset */
+
+#define PIO_CODR_P0_Pos                     0                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P0_Msk                     (_U_(0x1) << PIO_CODR_P0_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P0                         PIO_CODR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P0_Msk instead */
+#define PIO_CODR_P1_Pos                     1                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P1_Msk                     (_U_(0x1) << PIO_CODR_P1_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P1                         PIO_CODR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P1_Msk instead */
+#define PIO_CODR_P2_Pos                     2                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P2_Msk                     (_U_(0x1) << PIO_CODR_P2_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P2                         PIO_CODR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P2_Msk instead */
+#define PIO_CODR_P3_Pos                     3                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P3_Msk                     (_U_(0x1) << PIO_CODR_P3_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P3                         PIO_CODR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P3_Msk instead */
+#define PIO_CODR_P4_Pos                     4                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P4_Msk                     (_U_(0x1) << PIO_CODR_P4_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P4                         PIO_CODR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P4_Msk instead */
+#define PIO_CODR_P5_Pos                     5                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P5_Msk                     (_U_(0x1) << PIO_CODR_P5_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P5                         PIO_CODR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P5_Msk instead */
+#define PIO_CODR_P6_Pos                     6                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P6_Msk                     (_U_(0x1) << PIO_CODR_P6_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P6                         PIO_CODR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P6_Msk instead */
+#define PIO_CODR_P7_Pos                     7                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P7_Msk                     (_U_(0x1) << PIO_CODR_P7_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P7                         PIO_CODR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P7_Msk instead */
+#define PIO_CODR_P8_Pos                     8                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P8_Msk                     (_U_(0x1) << PIO_CODR_P8_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P8                         PIO_CODR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P8_Msk instead */
+#define PIO_CODR_P9_Pos                     9                                              /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P9_Msk                     (_U_(0x1) << PIO_CODR_P9_Pos)                  /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P9                         PIO_CODR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P9_Msk instead */
+#define PIO_CODR_P10_Pos                    10                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P10_Msk                    (_U_(0x1) << PIO_CODR_P10_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P10                        PIO_CODR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P10_Msk instead */
+#define PIO_CODR_P11_Pos                    11                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P11_Msk                    (_U_(0x1) << PIO_CODR_P11_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P11                        PIO_CODR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P11_Msk instead */
+#define PIO_CODR_P12_Pos                    12                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P12_Msk                    (_U_(0x1) << PIO_CODR_P12_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P12                        PIO_CODR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P12_Msk instead */
+#define PIO_CODR_P13_Pos                    13                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P13_Msk                    (_U_(0x1) << PIO_CODR_P13_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P13                        PIO_CODR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P13_Msk instead */
+#define PIO_CODR_P14_Pos                    14                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P14_Msk                    (_U_(0x1) << PIO_CODR_P14_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P14                        PIO_CODR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P14_Msk instead */
+#define PIO_CODR_P15_Pos                    15                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P15_Msk                    (_U_(0x1) << PIO_CODR_P15_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P15                        PIO_CODR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P15_Msk instead */
+#define PIO_CODR_P16_Pos                    16                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P16_Msk                    (_U_(0x1) << PIO_CODR_P16_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P16                        PIO_CODR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P16_Msk instead */
+#define PIO_CODR_P17_Pos                    17                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P17_Msk                    (_U_(0x1) << PIO_CODR_P17_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P17                        PIO_CODR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P17_Msk instead */
+#define PIO_CODR_P18_Pos                    18                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P18_Msk                    (_U_(0x1) << PIO_CODR_P18_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P18                        PIO_CODR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P18_Msk instead */
+#define PIO_CODR_P19_Pos                    19                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P19_Msk                    (_U_(0x1) << PIO_CODR_P19_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P19                        PIO_CODR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P19_Msk instead */
+#define PIO_CODR_P20_Pos                    20                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P20_Msk                    (_U_(0x1) << PIO_CODR_P20_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P20                        PIO_CODR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P20_Msk instead */
+#define PIO_CODR_P21_Pos                    21                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P21_Msk                    (_U_(0x1) << PIO_CODR_P21_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P21                        PIO_CODR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P21_Msk instead */
+#define PIO_CODR_P22_Pos                    22                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P22_Msk                    (_U_(0x1) << PIO_CODR_P22_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P22                        PIO_CODR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P22_Msk instead */
+#define PIO_CODR_P23_Pos                    23                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P23_Msk                    (_U_(0x1) << PIO_CODR_P23_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P23                        PIO_CODR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P23_Msk instead */
+#define PIO_CODR_P24_Pos                    24                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P24_Msk                    (_U_(0x1) << PIO_CODR_P24_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P24                        PIO_CODR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P24_Msk instead */
+#define PIO_CODR_P25_Pos                    25                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P25_Msk                    (_U_(0x1) << PIO_CODR_P25_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P25                        PIO_CODR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P25_Msk instead */
+#define PIO_CODR_P26_Pos                    26                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P26_Msk                    (_U_(0x1) << PIO_CODR_P26_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P26                        PIO_CODR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P26_Msk instead */
+#define PIO_CODR_P27_Pos                    27                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P27_Msk                    (_U_(0x1) << PIO_CODR_P27_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P27                        PIO_CODR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P27_Msk instead */
+#define PIO_CODR_P28_Pos                    28                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P28_Msk                    (_U_(0x1) << PIO_CODR_P28_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P28                        PIO_CODR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P28_Msk instead */
+#define PIO_CODR_P29_Pos                    29                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P29_Msk                    (_U_(0x1) << PIO_CODR_P29_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P29                        PIO_CODR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P29_Msk instead */
+#define PIO_CODR_P30_Pos                    30                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P30_Msk                    (_U_(0x1) << PIO_CODR_P30_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P30                        PIO_CODR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P30_Msk instead */
+#define PIO_CODR_P31_Pos                    31                                             /**< (PIO_CODR) Clear Output Data Position */
+#define PIO_CODR_P31_Msk                    (_U_(0x1) << PIO_CODR_P31_Pos)                 /**< (PIO_CODR) Clear Output Data Mask */
+#define PIO_CODR_P31                        PIO_CODR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_CODR_P31_Msk instead */
+#define PIO_CODR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_CODR) Register MASK  (Use PIO_CODR_Msk instead)  */
+#define PIO_CODR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_CODR) Register Mask  */
+
+#define PIO_CODR_P_Pos                      0                                              /**< (PIO_CODR Position) Clear Output Data */
+#define PIO_CODR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_CODR_P_Pos)            /**< (PIO_CODR Mask) P */
+#define PIO_CODR_P(value)                   (PIO_CODR_P_Msk & ((value) << PIO_CODR_P_Pos))  
+
+/* -------- PIO_ODSR : (PIO Offset: 0x38) (R/W 32) Output Data Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Output Data Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Output Data Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Output Data Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Output Data Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Output Data Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Output Data Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Output Data Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Output Data Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Output Data Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Output Data Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Output Data Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Output Data Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Output Data Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Output Data Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Output Data Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Output Data Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Output Data Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Output Data Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Output Data Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Output Data Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Output Data Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Output Data Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Output Data Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Output Data Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Output Data Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Output Data Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Output Data Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Output Data Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Output Data Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Output Data Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Output Data Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Data Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ODSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ODSR_OFFSET                     (0x38)                                        /**<  (PIO_ODSR) Output Data Status Register  Offset */
+
+#define PIO_ODSR_P0_Pos                     0                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P0_Msk                     (_U_(0x1) << PIO_ODSR_P0_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P0                         PIO_ODSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P0_Msk instead */
+#define PIO_ODSR_P1_Pos                     1                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P1_Msk                     (_U_(0x1) << PIO_ODSR_P1_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P1                         PIO_ODSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P1_Msk instead */
+#define PIO_ODSR_P2_Pos                     2                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P2_Msk                     (_U_(0x1) << PIO_ODSR_P2_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P2                         PIO_ODSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P2_Msk instead */
+#define PIO_ODSR_P3_Pos                     3                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P3_Msk                     (_U_(0x1) << PIO_ODSR_P3_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P3                         PIO_ODSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P3_Msk instead */
+#define PIO_ODSR_P4_Pos                     4                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P4_Msk                     (_U_(0x1) << PIO_ODSR_P4_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P4                         PIO_ODSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P4_Msk instead */
+#define PIO_ODSR_P5_Pos                     5                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P5_Msk                     (_U_(0x1) << PIO_ODSR_P5_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P5                         PIO_ODSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P5_Msk instead */
+#define PIO_ODSR_P6_Pos                     6                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P6_Msk                     (_U_(0x1) << PIO_ODSR_P6_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P6                         PIO_ODSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P6_Msk instead */
+#define PIO_ODSR_P7_Pos                     7                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P7_Msk                     (_U_(0x1) << PIO_ODSR_P7_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P7                         PIO_ODSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P7_Msk instead */
+#define PIO_ODSR_P8_Pos                     8                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P8_Msk                     (_U_(0x1) << PIO_ODSR_P8_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P8                         PIO_ODSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P8_Msk instead */
+#define PIO_ODSR_P9_Pos                     9                                              /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P9_Msk                     (_U_(0x1) << PIO_ODSR_P9_Pos)                  /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P9                         PIO_ODSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P9_Msk instead */
+#define PIO_ODSR_P10_Pos                    10                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P10_Msk                    (_U_(0x1) << PIO_ODSR_P10_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P10                        PIO_ODSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P10_Msk instead */
+#define PIO_ODSR_P11_Pos                    11                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P11_Msk                    (_U_(0x1) << PIO_ODSR_P11_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P11                        PIO_ODSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P11_Msk instead */
+#define PIO_ODSR_P12_Pos                    12                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P12_Msk                    (_U_(0x1) << PIO_ODSR_P12_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P12                        PIO_ODSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P12_Msk instead */
+#define PIO_ODSR_P13_Pos                    13                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P13_Msk                    (_U_(0x1) << PIO_ODSR_P13_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P13                        PIO_ODSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P13_Msk instead */
+#define PIO_ODSR_P14_Pos                    14                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P14_Msk                    (_U_(0x1) << PIO_ODSR_P14_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P14                        PIO_ODSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P14_Msk instead */
+#define PIO_ODSR_P15_Pos                    15                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P15_Msk                    (_U_(0x1) << PIO_ODSR_P15_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P15                        PIO_ODSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P15_Msk instead */
+#define PIO_ODSR_P16_Pos                    16                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P16_Msk                    (_U_(0x1) << PIO_ODSR_P16_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P16                        PIO_ODSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P16_Msk instead */
+#define PIO_ODSR_P17_Pos                    17                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P17_Msk                    (_U_(0x1) << PIO_ODSR_P17_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P17                        PIO_ODSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P17_Msk instead */
+#define PIO_ODSR_P18_Pos                    18                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P18_Msk                    (_U_(0x1) << PIO_ODSR_P18_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P18                        PIO_ODSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P18_Msk instead */
+#define PIO_ODSR_P19_Pos                    19                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P19_Msk                    (_U_(0x1) << PIO_ODSR_P19_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P19                        PIO_ODSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P19_Msk instead */
+#define PIO_ODSR_P20_Pos                    20                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P20_Msk                    (_U_(0x1) << PIO_ODSR_P20_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P20                        PIO_ODSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P20_Msk instead */
+#define PIO_ODSR_P21_Pos                    21                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P21_Msk                    (_U_(0x1) << PIO_ODSR_P21_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P21                        PIO_ODSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P21_Msk instead */
+#define PIO_ODSR_P22_Pos                    22                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P22_Msk                    (_U_(0x1) << PIO_ODSR_P22_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P22                        PIO_ODSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P22_Msk instead */
+#define PIO_ODSR_P23_Pos                    23                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P23_Msk                    (_U_(0x1) << PIO_ODSR_P23_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P23                        PIO_ODSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P23_Msk instead */
+#define PIO_ODSR_P24_Pos                    24                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P24_Msk                    (_U_(0x1) << PIO_ODSR_P24_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P24                        PIO_ODSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P24_Msk instead */
+#define PIO_ODSR_P25_Pos                    25                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P25_Msk                    (_U_(0x1) << PIO_ODSR_P25_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P25                        PIO_ODSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P25_Msk instead */
+#define PIO_ODSR_P26_Pos                    26                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P26_Msk                    (_U_(0x1) << PIO_ODSR_P26_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P26                        PIO_ODSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P26_Msk instead */
+#define PIO_ODSR_P27_Pos                    27                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P27_Msk                    (_U_(0x1) << PIO_ODSR_P27_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P27                        PIO_ODSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P27_Msk instead */
+#define PIO_ODSR_P28_Pos                    28                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P28_Msk                    (_U_(0x1) << PIO_ODSR_P28_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P28                        PIO_ODSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P28_Msk instead */
+#define PIO_ODSR_P29_Pos                    29                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P29_Msk                    (_U_(0x1) << PIO_ODSR_P29_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P29                        PIO_ODSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P29_Msk instead */
+#define PIO_ODSR_P30_Pos                    30                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P30_Msk                    (_U_(0x1) << PIO_ODSR_P30_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P30                        PIO_ODSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P30_Msk instead */
+#define PIO_ODSR_P31_Pos                    31                                             /**< (PIO_ODSR) Output Data Status Position */
+#define PIO_ODSR_P31_Msk                    (_U_(0x1) << PIO_ODSR_P31_Pos)                 /**< (PIO_ODSR) Output Data Status Mask */
+#define PIO_ODSR_P31                        PIO_ODSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ODSR_P31_Msk instead */
+#define PIO_ODSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ODSR) Register MASK  (Use PIO_ODSR_Msk instead)  */
+#define PIO_ODSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_ODSR) Register Mask  */
+
+#define PIO_ODSR_P_Pos                      0                                              /**< (PIO_ODSR Position) Output Data Status */
+#define PIO_ODSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_ODSR_P_Pos)            /**< (PIO_ODSR Mask) P */
+#define PIO_ODSR_P(value)                   (PIO_ODSR_P_Msk & ((value) << PIO_ODSR_P_Pos))  
+
+/* -------- PIO_PDSR : (PIO Offset: 0x3c) (R/ 32) Pin Data Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Output Data Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Output Data Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Output Data Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Output Data Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Output Data Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Output Data Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Output Data Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Output Data Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Output Data Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Output Data Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Output Data Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Output Data Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Output Data Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Output Data Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Output Data Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Output Data Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Output Data Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Output Data Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Output Data Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Output Data Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Output Data Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Output Data Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Output Data Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Output Data Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Output Data Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Output Data Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Output Data Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Output Data Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Output Data Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Output Data Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Output Data Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Data Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PDSR_OFFSET                     (0x3C)                                        /**<  (PIO_PDSR) Pin Data Status Register  Offset */
+
+#define PIO_PDSR_P0_Pos                     0                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P0_Msk                     (_U_(0x1) << PIO_PDSR_P0_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P0                         PIO_PDSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P0_Msk instead */
+#define PIO_PDSR_P1_Pos                     1                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P1_Msk                     (_U_(0x1) << PIO_PDSR_P1_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P1                         PIO_PDSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P1_Msk instead */
+#define PIO_PDSR_P2_Pos                     2                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P2_Msk                     (_U_(0x1) << PIO_PDSR_P2_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P2                         PIO_PDSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P2_Msk instead */
+#define PIO_PDSR_P3_Pos                     3                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P3_Msk                     (_U_(0x1) << PIO_PDSR_P3_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P3                         PIO_PDSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P3_Msk instead */
+#define PIO_PDSR_P4_Pos                     4                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P4_Msk                     (_U_(0x1) << PIO_PDSR_P4_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P4                         PIO_PDSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P4_Msk instead */
+#define PIO_PDSR_P5_Pos                     5                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P5_Msk                     (_U_(0x1) << PIO_PDSR_P5_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P5                         PIO_PDSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P5_Msk instead */
+#define PIO_PDSR_P6_Pos                     6                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P6_Msk                     (_U_(0x1) << PIO_PDSR_P6_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P6                         PIO_PDSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P6_Msk instead */
+#define PIO_PDSR_P7_Pos                     7                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P7_Msk                     (_U_(0x1) << PIO_PDSR_P7_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P7                         PIO_PDSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P7_Msk instead */
+#define PIO_PDSR_P8_Pos                     8                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P8_Msk                     (_U_(0x1) << PIO_PDSR_P8_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P8                         PIO_PDSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P8_Msk instead */
+#define PIO_PDSR_P9_Pos                     9                                              /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P9_Msk                     (_U_(0x1) << PIO_PDSR_P9_Pos)                  /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P9                         PIO_PDSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P9_Msk instead */
+#define PIO_PDSR_P10_Pos                    10                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P10_Msk                    (_U_(0x1) << PIO_PDSR_P10_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P10                        PIO_PDSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P10_Msk instead */
+#define PIO_PDSR_P11_Pos                    11                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P11_Msk                    (_U_(0x1) << PIO_PDSR_P11_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P11                        PIO_PDSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P11_Msk instead */
+#define PIO_PDSR_P12_Pos                    12                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P12_Msk                    (_U_(0x1) << PIO_PDSR_P12_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P12                        PIO_PDSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P12_Msk instead */
+#define PIO_PDSR_P13_Pos                    13                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P13_Msk                    (_U_(0x1) << PIO_PDSR_P13_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P13                        PIO_PDSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P13_Msk instead */
+#define PIO_PDSR_P14_Pos                    14                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P14_Msk                    (_U_(0x1) << PIO_PDSR_P14_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P14                        PIO_PDSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P14_Msk instead */
+#define PIO_PDSR_P15_Pos                    15                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P15_Msk                    (_U_(0x1) << PIO_PDSR_P15_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P15                        PIO_PDSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P15_Msk instead */
+#define PIO_PDSR_P16_Pos                    16                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P16_Msk                    (_U_(0x1) << PIO_PDSR_P16_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P16                        PIO_PDSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P16_Msk instead */
+#define PIO_PDSR_P17_Pos                    17                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P17_Msk                    (_U_(0x1) << PIO_PDSR_P17_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P17                        PIO_PDSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P17_Msk instead */
+#define PIO_PDSR_P18_Pos                    18                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P18_Msk                    (_U_(0x1) << PIO_PDSR_P18_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P18                        PIO_PDSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P18_Msk instead */
+#define PIO_PDSR_P19_Pos                    19                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P19_Msk                    (_U_(0x1) << PIO_PDSR_P19_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P19                        PIO_PDSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P19_Msk instead */
+#define PIO_PDSR_P20_Pos                    20                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P20_Msk                    (_U_(0x1) << PIO_PDSR_P20_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P20                        PIO_PDSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P20_Msk instead */
+#define PIO_PDSR_P21_Pos                    21                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P21_Msk                    (_U_(0x1) << PIO_PDSR_P21_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P21                        PIO_PDSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P21_Msk instead */
+#define PIO_PDSR_P22_Pos                    22                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P22_Msk                    (_U_(0x1) << PIO_PDSR_P22_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P22                        PIO_PDSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P22_Msk instead */
+#define PIO_PDSR_P23_Pos                    23                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P23_Msk                    (_U_(0x1) << PIO_PDSR_P23_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P23                        PIO_PDSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P23_Msk instead */
+#define PIO_PDSR_P24_Pos                    24                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P24_Msk                    (_U_(0x1) << PIO_PDSR_P24_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P24                        PIO_PDSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P24_Msk instead */
+#define PIO_PDSR_P25_Pos                    25                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P25_Msk                    (_U_(0x1) << PIO_PDSR_P25_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P25                        PIO_PDSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P25_Msk instead */
+#define PIO_PDSR_P26_Pos                    26                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P26_Msk                    (_U_(0x1) << PIO_PDSR_P26_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P26                        PIO_PDSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P26_Msk instead */
+#define PIO_PDSR_P27_Pos                    27                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P27_Msk                    (_U_(0x1) << PIO_PDSR_P27_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P27                        PIO_PDSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P27_Msk instead */
+#define PIO_PDSR_P28_Pos                    28                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P28_Msk                    (_U_(0x1) << PIO_PDSR_P28_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P28                        PIO_PDSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P28_Msk instead */
+#define PIO_PDSR_P29_Pos                    29                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P29_Msk                    (_U_(0x1) << PIO_PDSR_P29_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P29                        PIO_PDSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P29_Msk instead */
+#define PIO_PDSR_P30_Pos                    30                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P30_Msk                    (_U_(0x1) << PIO_PDSR_P30_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P30                        PIO_PDSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P30_Msk instead */
+#define PIO_PDSR_P31_Pos                    31                                             /**< (PIO_PDSR) Output Data Status Position */
+#define PIO_PDSR_P31_Msk                    (_U_(0x1) << PIO_PDSR_P31_Pos)                 /**< (PIO_PDSR) Output Data Status Mask */
+#define PIO_PDSR_P31                        PIO_PDSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PDSR_P31_Msk instead */
+#define PIO_PDSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PDSR) Register MASK  (Use PIO_PDSR_Msk instead)  */
+#define PIO_PDSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PDSR) Register Mask  */
+
+#define PIO_PDSR_P_Pos                      0                                              /**< (PIO_PDSR Position) Output Data Status */
+#define PIO_PDSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PDSR_P_Pos)            /**< (PIO_PDSR Mask) P */
+#define PIO_PDSR_P(value)                   (PIO_PDSR_P_Msk & ((value) << PIO_PDSR_P_Pos))  
+
+/* -------- PIO_IER : (PIO Offset: 0x40) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Enable            */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Enable            */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Enable            */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Enable            */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Enable            */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Enable            */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Enable            */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Enable            */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Enable            */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Enable            */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Enable            */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Enable            */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Enable            */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Enable            */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Enable            */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Enable            */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Enable            */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Enable            */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Enable            */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Enable            */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Enable            */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Enable            */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Enable            */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Enable            */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Enable            */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Enable            */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Enable            */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Enable            */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Enable            */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Enable            */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Enable            */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Enable            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Enable            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IER_OFFSET                      (0x40)                                        /**<  (PIO_IER) Interrupt Enable Register  Offset */
+
+#define PIO_IER_P0_Pos                      0                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P0_Msk                      (_U_(0x1) << PIO_IER_P0_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P0                          PIO_IER_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P0_Msk instead */
+#define PIO_IER_P1_Pos                      1                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P1_Msk                      (_U_(0x1) << PIO_IER_P1_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P1                          PIO_IER_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P1_Msk instead */
+#define PIO_IER_P2_Pos                      2                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P2_Msk                      (_U_(0x1) << PIO_IER_P2_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P2                          PIO_IER_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P2_Msk instead */
+#define PIO_IER_P3_Pos                      3                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P3_Msk                      (_U_(0x1) << PIO_IER_P3_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P3                          PIO_IER_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P3_Msk instead */
+#define PIO_IER_P4_Pos                      4                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P4_Msk                      (_U_(0x1) << PIO_IER_P4_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P4                          PIO_IER_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P4_Msk instead */
+#define PIO_IER_P5_Pos                      5                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P5_Msk                      (_U_(0x1) << PIO_IER_P5_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P5                          PIO_IER_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P5_Msk instead */
+#define PIO_IER_P6_Pos                      6                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P6_Msk                      (_U_(0x1) << PIO_IER_P6_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P6                          PIO_IER_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P6_Msk instead */
+#define PIO_IER_P7_Pos                      7                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P7_Msk                      (_U_(0x1) << PIO_IER_P7_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P7                          PIO_IER_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P7_Msk instead */
+#define PIO_IER_P8_Pos                      8                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P8_Msk                      (_U_(0x1) << PIO_IER_P8_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P8                          PIO_IER_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P8_Msk instead */
+#define PIO_IER_P9_Pos                      9                                              /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P9_Msk                      (_U_(0x1) << PIO_IER_P9_Pos)                   /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P9                          PIO_IER_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P9_Msk instead */
+#define PIO_IER_P10_Pos                     10                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P10_Msk                     (_U_(0x1) << PIO_IER_P10_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P10                         PIO_IER_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P10_Msk instead */
+#define PIO_IER_P11_Pos                     11                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P11_Msk                     (_U_(0x1) << PIO_IER_P11_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P11                         PIO_IER_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P11_Msk instead */
+#define PIO_IER_P12_Pos                     12                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P12_Msk                     (_U_(0x1) << PIO_IER_P12_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P12                         PIO_IER_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P12_Msk instead */
+#define PIO_IER_P13_Pos                     13                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P13_Msk                     (_U_(0x1) << PIO_IER_P13_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P13                         PIO_IER_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P13_Msk instead */
+#define PIO_IER_P14_Pos                     14                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P14_Msk                     (_U_(0x1) << PIO_IER_P14_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P14                         PIO_IER_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P14_Msk instead */
+#define PIO_IER_P15_Pos                     15                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P15_Msk                     (_U_(0x1) << PIO_IER_P15_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P15                         PIO_IER_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P15_Msk instead */
+#define PIO_IER_P16_Pos                     16                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P16_Msk                     (_U_(0x1) << PIO_IER_P16_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P16                         PIO_IER_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P16_Msk instead */
+#define PIO_IER_P17_Pos                     17                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P17_Msk                     (_U_(0x1) << PIO_IER_P17_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P17                         PIO_IER_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P17_Msk instead */
+#define PIO_IER_P18_Pos                     18                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P18_Msk                     (_U_(0x1) << PIO_IER_P18_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P18                         PIO_IER_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P18_Msk instead */
+#define PIO_IER_P19_Pos                     19                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P19_Msk                     (_U_(0x1) << PIO_IER_P19_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P19                         PIO_IER_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P19_Msk instead */
+#define PIO_IER_P20_Pos                     20                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P20_Msk                     (_U_(0x1) << PIO_IER_P20_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P20                         PIO_IER_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P20_Msk instead */
+#define PIO_IER_P21_Pos                     21                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P21_Msk                     (_U_(0x1) << PIO_IER_P21_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P21                         PIO_IER_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P21_Msk instead */
+#define PIO_IER_P22_Pos                     22                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P22_Msk                     (_U_(0x1) << PIO_IER_P22_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P22                         PIO_IER_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P22_Msk instead */
+#define PIO_IER_P23_Pos                     23                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P23_Msk                     (_U_(0x1) << PIO_IER_P23_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P23                         PIO_IER_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P23_Msk instead */
+#define PIO_IER_P24_Pos                     24                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P24_Msk                     (_U_(0x1) << PIO_IER_P24_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P24                         PIO_IER_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P24_Msk instead */
+#define PIO_IER_P25_Pos                     25                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P25_Msk                     (_U_(0x1) << PIO_IER_P25_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P25                         PIO_IER_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P25_Msk instead */
+#define PIO_IER_P26_Pos                     26                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P26_Msk                     (_U_(0x1) << PIO_IER_P26_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P26                         PIO_IER_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P26_Msk instead */
+#define PIO_IER_P27_Pos                     27                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P27_Msk                     (_U_(0x1) << PIO_IER_P27_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P27                         PIO_IER_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P27_Msk instead */
+#define PIO_IER_P28_Pos                     28                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P28_Msk                     (_U_(0x1) << PIO_IER_P28_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P28                         PIO_IER_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P28_Msk instead */
+#define PIO_IER_P29_Pos                     29                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P29_Msk                     (_U_(0x1) << PIO_IER_P29_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P29                         PIO_IER_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P29_Msk instead */
+#define PIO_IER_P30_Pos                     30                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P30_Msk                     (_U_(0x1) << PIO_IER_P30_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P30                         PIO_IER_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P30_Msk instead */
+#define PIO_IER_P31_Pos                     31                                             /**< (PIO_IER) Input Change Interrupt Enable Position */
+#define PIO_IER_P31_Msk                     (_U_(0x1) << PIO_IER_P31_Pos)                  /**< (PIO_IER) Input Change Interrupt Enable Mask */
+#define PIO_IER_P31                         PIO_IER_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IER_P31_Msk instead */
+#define PIO_IER_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IER) Register MASK  (Use PIO_IER_Msk instead)  */
+#define PIO_IER_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IER) Register Mask  */
+
+#define PIO_IER_P_Pos                       0                                              /**< (PIO_IER Position) Input Change Interrupt Enable */
+#define PIO_IER_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IER_P_Pos)             /**< (PIO_IER Mask) P */
+#define PIO_IER_P(value)                    (PIO_IER_P_Msk & ((value) << PIO_IER_P_Pos))   
+
+/* -------- PIO_IDR : (PIO Offset: 0x44) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Disable           */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Disable           */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Disable           */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Disable           */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Disable           */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Disable           */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Disable           */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Disable           */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Disable           */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Disable           */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Disable           */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Disable           */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Disable           */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Disable           */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Disable           */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Disable           */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Disable           */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Disable           */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Disable           */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Disable           */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Disable           */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Disable           */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Disable           */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Disable           */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Disable           */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Disable           */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Disable           */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Disable           */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Disable           */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Disable           */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Disable           */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Disable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Disable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IDR_OFFSET                      (0x44)                                        /**<  (PIO_IDR) Interrupt Disable Register  Offset */
+
+#define PIO_IDR_P0_Pos                      0                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P0_Msk                      (_U_(0x1) << PIO_IDR_P0_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P0                          PIO_IDR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P0_Msk instead */
+#define PIO_IDR_P1_Pos                      1                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P1_Msk                      (_U_(0x1) << PIO_IDR_P1_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P1                          PIO_IDR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P1_Msk instead */
+#define PIO_IDR_P2_Pos                      2                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P2_Msk                      (_U_(0x1) << PIO_IDR_P2_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P2                          PIO_IDR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P2_Msk instead */
+#define PIO_IDR_P3_Pos                      3                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P3_Msk                      (_U_(0x1) << PIO_IDR_P3_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P3                          PIO_IDR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P3_Msk instead */
+#define PIO_IDR_P4_Pos                      4                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P4_Msk                      (_U_(0x1) << PIO_IDR_P4_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P4                          PIO_IDR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P4_Msk instead */
+#define PIO_IDR_P5_Pos                      5                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P5_Msk                      (_U_(0x1) << PIO_IDR_P5_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P5                          PIO_IDR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P5_Msk instead */
+#define PIO_IDR_P6_Pos                      6                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P6_Msk                      (_U_(0x1) << PIO_IDR_P6_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P6                          PIO_IDR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P6_Msk instead */
+#define PIO_IDR_P7_Pos                      7                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P7_Msk                      (_U_(0x1) << PIO_IDR_P7_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P7                          PIO_IDR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P7_Msk instead */
+#define PIO_IDR_P8_Pos                      8                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P8_Msk                      (_U_(0x1) << PIO_IDR_P8_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P8                          PIO_IDR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P8_Msk instead */
+#define PIO_IDR_P9_Pos                      9                                              /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P9_Msk                      (_U_(0x1) << PIO_IDR_P9_Pos)                   /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P9                          PIO_IDR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P9_Msk instead */
+#define PIO_IDR_P10_Pos                     10                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P10_Msk                     (_U_(0x1) << PIO_IDR_P10_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P10                         PIO_IDR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P10_Msk instead */
+#define PIO_IDR_P11_Pos                     11                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P11_Msk                     (_U_(0x1) << PIO_IDR_P11_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P11                         PIO_IDR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P11_Msk instead */
+#define PIO_IDR_P12_Pos                     12                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P12_Msk                     (_U_(0x1) << PIO_IDR_P12_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P12                         PIO_IDR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P12_Msk instead */
+#define PIO_IDR_P13_Pos                     13                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P13_Msk                     (_U_(0x1) << PIO_IDR_P13_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P13                         PIO_IDR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P13_Msk instead */
+#define PIO_IDR_P14_Pos                     14                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P14_Msk                     (_U_(0x1) << PIO_IDR_P14_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P14                         PIO_IDR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P14_Msk instead */
+#define PIO_IDR_P15_Pos                     15                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P15_Msk                     (_U_(0x1) << PIO_IDR_P15_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P15                         PIO_IDR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P15_Msk instead */
+#define PIO_IDR_P16_Pos                     16                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P16_Msk                     (_U_(0x1) << PIO_IDR_P16_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P16                         PIO_IDR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P16_Msk instead */
+#define PIO_IDR_P17_Pos                     17                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P17_Msk                     (_U_(0x1) << PIO_IDR_P17_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P17                         PIO_IDR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P17_Msk instead */
+#define PIO_IDR_P18_Pos                     18                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P18_Msk                     (_U_(0x1) << PIO_IDR_P18_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P18                         PIO_IDR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P18_Msk instead */
+#define PIO_IDR_P19_Pos                     19                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P19_Msk                     (_U_(0x1) << PIO_IDR_P19_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P19                         PIO_IDR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P19_Msk instead */
+#define PIO_IDR_P20_Pos                     20                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P20_Msk                     (_U_(0x1) << PIO_IDR_P20_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P20                         PIO_IDR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P20_Msk instead */
+#define PIO_IDR_P21_Pos                     21                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P21_Msk                     (_U_(0x1) << PIO_IDR_P21_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P21                         PIO_IDR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P21_Msk instead */
+#define PIO_IDR_P22_Pos                     22                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P22_Msk                     (_U_(0x1) << PIO_IDR_P22_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P22                         PIO_IDR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P22_Msk instead */
+#define PIO_IDR_P23_Pos                     23                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P23_Msk                     (_U_(0x1) << PIO_IDR_P23_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P23                         PIO_IDR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P23_Msk instead */
+#define PIO_IDR_P24_Pos                     24                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P24_Msk                     (_U_(0x1) << PIO_IDR_P24_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P24                         PIO_IDR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P24_Msk instead */
+#define PIO_IDR_P25_Pos                     25                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P25_Msk                     (_U_(0x1) << PIO_IDR_P25_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P25                         PIO_IDR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P25_Msk instead */
+#define PIO_IDR_P26_Pos                     26                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P26_Msk                     (_U_(0x1) << PIO_IDR_P26_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P26                         PIO_IDR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P26_Msk instead */
+#define PIO_IDR_P27_Pos                     27                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P27_Msk                     (_U_(0x1) << PIO_IDR_P27_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P27                         PIO_IDR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P27_Msk instead */
+#define PIO_IDR_P28_Pos                     28                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P28_Msk                     (_U_(0x1) << PIO_IDR_P28_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P28                         PIO_IDR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P28_Msk instead */
+#define PIO_IDR_P29_Pos                     29                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P29_Msk                     (_U_(0x1) << PIO_IDR_P29_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P29                         PIO_IDR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P29_Msk instead */
+#define PIO_IDR_P30_Pos                     30                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P30_Msk                     (_U_(0x1) << PIO_IDR_P30_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P30                         PIO_IDR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P30_Msk instead */
+#define PIO_IDR_P31_Pos                     31                                             /**< (PIO_IDR) Input Change Interrupt Disable Position */
+#define PIO_IDR_P31_Msk                     (_U_(0x1) << PIO_IDR_P31_Pos)                  /**< (PIO_IDR) Input Change Interrupt Disable Mask */
+#define PIO_IDR_P31                         PIO_IDR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IDR_P31_Msk instead */
+#define PIO_IDR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IDR) Register MASK  (Use PIO_IDR_Msk instead)  */
+#define PIO_IDR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IDR) Register Mask  */
+
+#define PIO_IDR_P_Pos                       0                                              /**< (PIO_IDR Position) Input Change Interrupt Disable */
+#define PIO_IDR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IDR_P_Pos)             /**< (PIO_IDR Mask) P */
+#define PIO_IDR_P(value)                    (PIO_IDR_P_Msk & ((value) << PIO_IDR_P_Pos))   
+
+/* -------- PIO_IMR : (PIO Offset: 0x48) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Mask              */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Mask              */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Mask              */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Mask              */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Mask              */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Mask              */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Mask              */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Mask              */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Mask              */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Mask              */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Mask              */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Mask              */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Mask              */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Mask              */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Mask              */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Mask              */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Mask              */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Mask              */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Mask              */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Mask              */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Mask              */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Mask              */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Mask              */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Mask              */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Mask              */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Mask              */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Mask              */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Mask              */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Mask              */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Mask              */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Mask              */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Mask              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Mask              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IMR_OFFSET                      (0x48)                                        /**<  (PIO_IMR) Interrupt Mask Register  Offset */
+
+#define PIO_IMR_P0_Pos                      0                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P0_Msk                      (_U_(0x1) << PIO_IMR_P0_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P0                          PIO_IMR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P0_Msk instead */
+#define PIO_IMR_P1_Pos                      1                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P1_Msk                      (_U_(0x1) << PIO_IMR_P1_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P1                          PIO_IMR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P1_Msk instead */
+#define PIO_IMR_P2_Pos                      2                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P2_Msk                      (_U_(0x1) << PIO_IMR_P2_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P2                          PIO_IMR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P2_Msk instead */
+#define PIO_IMR_P3_Pos                      3                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P3_Msk                      (_U_(0x1) << PIO_IMR_P3_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P3                          PIO_IMR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P3_Msk instead */
+#define PIO_IMR_P4_Pos                      4                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P4_Msk                      (_U_(0x1) << PIO_IMR_P4_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P4                          PIO_IMR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P4_Msk instead */
+#define PIO_IMR_P5_Pos                      5                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P5_Msk                      (_U_(0x1) << PIO_IMR_P5_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P5                          PIO_IMR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P5_Msk instead */
+#define PIO_IMR_P6_Pos                      6                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P6_Msk                      (_U_(0x1) << PIO_IMR_P6_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P6                          PIO_IMR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P6_Msk instead */
+#define PIO_IMR_P7_Pos                      7                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P7_Msk                      (_U_(0x1) << PIO_IMR_P7_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P7                          PIO_IMR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P7_Msk instead */
+#define PIO_IMR_P8_Pos                      8                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P8_Msk                      (_U_(0x1) << PIO_IMR_P8_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P8                          PIO_IMR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P8_Msk instead */
+#define PIO_IMR_P9_Pos                      9                                              /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P9_Msk                      (_U_(0x1) << PIO_IMR_P9_Pos)                   /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P9                          PIO_IMR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P9_Msk instead */
+#define PIO_IMR_P10_Pos                     10                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P10_Msk                     (_U_(0x1) << PIO_IMR_P10_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P10                         PIO_IMR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P10_Msk instead */
+#define PIO_IMR_P11_Pos                     11                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P11_Msk                     (_U_(0x1) << PIO_IMR_P11_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P11                         PIO_IMR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P11_Msk instead */
+#define PIO_IMR_P12_Pos                     12                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P12_Msk                     (_U_(0x1) << PIO_IMR_P12_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P12                         PIO_IMR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P12_Msk instead */
+#define PIO_IMR_P13_Pos                     13                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P13_Msk                     (_U_(0x1) << PIO_IMR_P13_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P13                         PIO_IMR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P13_Msk instead */
+#define PIO_IMR_P14_Pos                     14                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P14_Msk                     (_U_(0x1) << PIO_IMR_P14_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P14                         PIO_IMR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P14_Msk instead */
+#define PIO_IMR_P15_Pos                     15                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P15_Msk                     (_U_(0x1) << PIO_IMR_P15_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P15                         PIO_IMR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P15_Msk instead */
+#define PIO_IMR_P16_Pos                     16                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P16_Msk                     (_U_(0x1) << PIO_IMR_P16_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P16                         PIO_IMR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P16_Msk instead */
+#define PIO_IMR_P17_Pos                     17                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P17_Msk                     (_U_(0x1) << PIO_IMR_P17_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P17                         PIO_IMR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P17_Msk instead */
+#define PIO_IMR_P18_Pos                     18                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P18_Msk                     (_U_(0x1) << PIO_IMR_P18_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P18                         PIO_IMR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P18_Msk instead */
+#define PIO_IMR_P19_Pos                     19                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P19_Msk                     (_U_(0x1) << PIO_IMR_P19_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P19                         PIO_IMR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P19_Msk instead */
+#define PIO_IMR_P20_Pos                     20                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P20_Msk                     (_U_(0x1) << PIO_IMR_P20_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P20                         PIO_IMR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P20_Msk instead */
+#define PIO_IMR_P21_Pos                     21                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P21_Msk                     (_U_(0x1) << PIO_IMR_P21_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P21                         PIO_IMR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P21_Msk instead */
+#define PIO_IMR_P22_Pos                     22                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P22_Msk                     (_U_(0x1) << PIO_IMR_P22_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P22                         PIO_IMR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P22_Msk instead */
+#define PIO_IMR_P23_Pos                     23                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P23_Msk                     (_U_(0x1) << PIO_IMR_P23_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P23                         PIO_IMR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P23_Msk instead */
+#define PIO_IMR_P24_Pos                     24                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P24_Msk                     (_U_(0x1) << PIO_IMR_P24_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P24                         PIO_IMR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P24_Msk instead */
+#define PIO_IMR_P25_Pos                     25                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P25_Msk                     (_U_(0x1) << PIO_IMR_P25_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P25                         PIO_IMR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P25_Msk instead */
+#define PIO_IMR_P26_Pos                     26                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P26_Msk                     (_U_(0x1) << PIO_IMR_P26_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P26                         PIO_IMR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P26_Msk instead */
+#define PIO_IMR_P27_Pos                     27                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P27_Msk                     (_U_(0x1) << PIO_IMR_P27_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P27                         PIO_IMR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P27_Msk instead */
+#define PIO_IMR_P28_Pos                     28                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P28_Msk                     (_U_(0x1) << PIO_IMR_P28_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P28                         PIO_IMR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P28_Msk instead */
+#define PIO_IMR_P29_Pos                     29                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P29_Msk                     (_U_(0x1) << PIO_IMR_P29_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P29                         PIO_IMR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P29_Msk instead */
+#define PIO_IMR_P30_Pos                     30                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P30_Msk                     (_U_(0x1) << PIO_IMR_P30_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P30                         PIO_IMR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P30_Msk instead */
+#define PIO_IMR_P31_Pos                     31                                             /**< (PIO_IMR) Input Change Interrupt Mask Position */
+#define PIO_IMR_P31_Msk                     (_U_(0x1) << PIO_IMR_P31_Pos)                  /**< (PIO_IMR) Input Change Interrupt Mask Mask */
+#define PIO_IMR_P31                         PIO_IMR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IMR_P31_Msk instead */
+#define PIO_IMR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IMR) Register MASK  (Use PIO_IMR_Msk instead)  */
+#define PIO_IMR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_IMR) Register Mask  */
+
+#define PIO_IMR_P_Pos                       0                                              /**< (PIO_IMR Position) Input Change Interrupt Mask */
+#define PIO_IMR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_IMR_P_Pos)             /**< (PIO_IMR Mask) P */
+#define PIO_IMR_P(value)                    (PIO_IMR_P_Msk & ((value) << PIO_IMR_P_Pos))   
+
+/* -------- PIO_ISR : (PIO Offset: 0x4c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Status            */
+    uint32_t P1:1;                      /**< bit:      1  Input Change Interrupt Status            */
+    uint32_t P2:1;                      /**< bit:      2  Input Change Interrupt Status            */
+    uint32_t P3:1;                      /**< bit:      3  Input Change Interrupt Status            */
+    uint32_t P4:1;                      /**< bit:      4  Input Change Interrupt Status            */
+    uint32_t P5:1;                      /**< bit:      5  Input Change Interrupt Status            */
+    uint32_t P6:1;                      /**< bit:      6  Input Change Interrupt Status            */
+    uint32_t P7:1;                      /**< bit:      7  Input Change Interrupt Status            */
+    uint32_t P8:1;                      /**< bit:      8  Input Change Interrupt Status            */
+    uint32_t P9:1;                      /**< bit:      9  Input Change Interrupt Status            */
+    uint32_t P10:1;                     /**< bit:     10  Input Change Interrupt Status            */
+    uint32_t P11:1;                     /**< bit:     11  Input Change Interrupt Status            */
+    uint32_t P12:1;                     /**< bit:     12  Input Change Interrupt Status            */
+    uint32_t P13:1;                     /**< bit:     13  Input Change Interrupt Status            */
+    uint32_t P14:1;                     /**< bit:     14  Input Change Interrupt Status            */
+    uint32_t P15:1;                     /**< bit:     15  Input Change Interrupt Status            */
+    uint32_t P16:1;                     /**< bit:     16  Input Change Interrupt Status            */
+    uint32_t P17:1;                     /**< bit:     17  Input Change Interrupt Status            */
+    uint32_t P18:1;                     /**< bit:     18  Input Change Interrupt Status            */
+    uint32_t P19:1;                     /**< bit:     19  Input Change Interrupt Status            */
+    uint32_t P20:1;                     /**< bit:     20  Input Change Interrupt Status            */
+    uint32_t P21:1;                     /**< bit:     21  Input Change Interrupt Status            */
+    uint32_t P22:1;                     /**< bit:     22  Input Change Interrupt Status            */
+    uint32_t P23:1;                     /**< bit:     23  Input Change Interrupt Status            */
+    uint32_t P24:1;                     /**< bit:     24  Input Change Interrupt Status            */
+    uint32_t P25:1;                     /**< bit:     25  Input Change Interrupt Status            */
+    uint32_t P26:1;                     /**< bit:     26  Input Change Interrupt Status            */
+    uint32_t P27:1;                     /**< bit:     27  Input Change Interrupt Status            */
+    uint32_t P28:1;                     /**< bit:     28  Input Change Interrupt Status            */
+    uint32_t P29:1;                     /**< bit:     29  Input Change Interrupt Status            */
+    uint32_t P30:1;                     /**< bit:     30  Input Change Interrupt Status            */
+    uint32_t P31:1;                     /**< bit:     31  Input Change Interrupt Status            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Input Change Interrupt Status            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ISR_OFFSET                      (0x4C)                                        /**<  (PIO_ISR) Interrupt Status Register  Offset */
+
+#define PIO_ISR_P0_Pos                      0                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P0_Msk                      (_U_(0x1) << PIO_ISR_P0_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P0                          PIO_ISR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P0_Msk instead */
+#define PIO_ISR_P1_Pos                      1                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P1_Msk                      (_U_(0x1) << PIO_ISR_P1_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P1                          PIO_ISR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P1_Msk instead */
+#define PIO_ISR_P2_Pos                      2                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P2_Msk                      (_U_(0x1) << PIO_ISR_P2_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P2                          PIO_ISR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P2_Msk instead */
+#define PIO_ISR_P3_Pos                      3                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P3_Msk                      (_U_(0x1) << PIO_ISR_P3_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P3                          PIO_ISR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P3_Msk instead */
+#define PIO_ISR_P4_Pos                      4                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P4_Msk                      (_U_(0x1) << PIO_ISR_P4_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P4                          PIO_ISR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P4_Msk instead */
+#define PIO_ISR_P5_Pos                      5                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P5_Msk                      (_U_(0x1) << PIO_ISR_P5_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P5                          PIO_ISR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P5_Msk instead */
+#define PIO_ISR_P6_Pos                      6                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P6_Msk                      (_U_(0x1) << PIO_ISR_P6_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P6                          PIO_ISR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P6_Msk instead */
+#define PIO_ISR_P7_Pos                      7                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P7_Msk                      (_U_(0x1) << PIO_ISR_P7_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P7                          PIO_ISR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P7_Msk instead */
+#define PIO_ISR_P8_Pos                      8                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P8_Msk                      (_U_(0x1) << PIO_ISR_P8_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P8                          PIO_ISR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P8_Msk instead */
+#define PIO_ISR_P9_Pos                      9                                              /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P9_Msk                      (_U_(0x1) << PIO_ISR_P9_Pos)                   /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P9                          PIO_ISR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P9_Msk instead */
+#define PIO_ISR_P10_Pos                     10                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P10_Msk                     (_U_(0x1) << PIO_ISR_P10_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P10                         PIO_ISR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P10_Msk instead */
+#define PIO_ISR_P11_Pos                     11                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P11_Msk                     (_U_(0x1) << PIO_ISR_P11_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P11                         PIO_ISR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P11_Msk instead */
+#define PIO_ISR_P12_Pos                     12                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P12_Msk                     (_U_(0x1) << PIO_ISR_P12_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P12                         PIO_ISR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P12_Msk instead */
+#define PIO_ISR_P13_Pos                     13                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P13_Msk                     (_U_(0x1) << PIO_ISR_P13_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P13                         PIO_ISR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P13_Msk instead */
+#define PIO_ISR_P14_Pos                     14                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P14_Msk                     (_U_(0x1) << PIO_ISR_P14_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P14                         PIO_ISR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P14_Msk instead */
+#define PIO_ISR_P15_Pos                     15                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P15_Msk                     (_U_(0x1) << PIO_ISR_P15_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P15                         PIO_ISR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P15_Msk instead */
+#define PIO_ISR_P16_Pos                     16                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P16_Msk                     (_U_(0x1) << PIO_ISR_P16_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P16                         PIO_ISR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P16_Msk instead */
+#define PIO_ISR_P17_Pos                     17                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P17_Msk                     (_U_(0x1) << PIO_ISR_P17_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P17                         PIO_ISR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P17_Msk instead */
+#define PIO_ISR_P18_Pos                     18                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P18_Msk                     (_U_(0x1) << PIO_ISR_P18_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P18                         PIO_ISR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P18_Msk instead */
+#define PIO_ISR_P19_Pos                     19                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P19_Msk                     (_U_(0x1) << PIO_ISR_P19_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P19                         PIO_ISR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P19_Msk instead */
+#define PIO_ISR_P20_Pos                     20                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P20_Msk                     (_U_(0x1) << PIO_ISR_P20_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P20                         PIO_ISR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P20_Msk instead */
+#define PIO_ISR_P21_Pos                     21                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P21_Msk                     (_U_(0x1) << PIO_ISR_P21_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P21                         PIO_ISR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P21_Msk instead */
+#define PIO_ISR_P22_Pos                     22                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P22_Msk                     (_U_(0x1) << PIO_ISR_P22_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P22                         PIO_ISR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P22_Msk instead */
+#define PIO_ISR_P23_Pos                     23                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P23_Msk                     (_U_(0x1) << PIO_ISR_P23_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P23                         PIO_ISR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P23_Msk instead */
+#define PIO_ISR_P24_Pos                     24                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P24_Msk                     (_U_(0x1) << PIO_ISR_P24_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P24                         PIO_ISR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P24_Msk instead */
+#define PIO_ISR_P25_Pos                     25                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P25_Msk                     (_U_(0x1) << PIO_ISR_P25_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P25                         PIO_ISR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P25_Msk instead */
+#define PIO_ISR_P26_Pos                     26                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P26_Msk                     (_U_(0x1) << PIO_ISR_P26_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P26                         PIO_ISR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P26_Msk instead */
+#define PIO_ISR_P27_Pos                     27                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P27_Msk                     (_U_(0x1) << PIO_ISR_P27_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P27                         PIO_ISR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P27_Msk instead */
+#define PIO_ISR_P28_Pos                     28                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P28_Msk                     (_U_(0x1) << PIO_ISR_P28_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P28                         PIO_ISR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P28_Msk instead */
+#define PIO_ISR_P29_Pos                     29                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P29_Msk                     (_U_(0x1) << PIO_ISR_P29_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P29                         PIO_ISR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P29_Msk instead */
+#define PIO_ISR_P30_Pos                     30                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P30_Msk                     (_U_(0x1) << PIO_ISR_P30_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P30                         PIO_ISR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P30_Msk instead */
+#define PIO_ISR_P31_Pos                     31                                             /**< (PIO_ISR) Input Change Interrupt Status Position */
+#define PIO_ISR_P31_Msk                     (_U_(0x1) << PIO_ISR_P31_Pos)                  /**< (PIO_ISR) Input Change Interrupt Status Mask */
+#define PIO_ISR_P31                         PIO_ISR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ISR_P31_Msk instead */
+#define PIO_ISR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ISR) Register MASK  (Use PIO_ISR_Msk instead)  */
+#define PIO_ISR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ISR) Register Mask  */
+
+#define PIO_ISR_P_Pos                       0                                              /**< (PIO_ISR Position) Input Change Interrupt Status */
+#define PIO_ISR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ISR_P_Pos)             /**< (PIO_ISR Mask) P */
+#define PIO_ISR_P(value)                    (PIO_ISR_P_Msk & ((value) << PIO_ISR_P_Pos))   
+
+/* -------- PIO_MDER : (PIO Offset: 0x50) (/W 32) Multi-driver Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Enable                       */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Enable                       */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Enable                       */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Enable                       */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Enable                       */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Enable                       */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Enable                       */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Enable                       */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Enable                       */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Enable                       */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Enable                       */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Enable                       */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Enable                       */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Enable                       */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Enable                       */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Enable                       */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Enable                       */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Enable                       */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Enable                       */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Enable                       */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Enable                       */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Enable                       */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Enable                       */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Enable                       */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Enable                       */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Enable                       */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Enable                       */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Enable                       */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Enable                       */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Enable                       */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Enable                       */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Enable                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Enable                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDER_OFFSET                     (0x50)                                        /**<  (PIO_MDER) Multi-driver Enable Register  Offset */
+
+#define PIO_MDER_P0_Pos                     0                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P0_Msk                     (_U_(0x1) << PIO_MDER_P0_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P0                         PIO_MDER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P0_Msk instead */
+#define PIO_MDER_P1_Pos                     1                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P1_Msk                     (_U_(0x1) << PIO_MDER_P1_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P1                         PIO_MDER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P1_Msk instead */
+#define PIO_MDER_P2_Pos                     2                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P2_Msk                     (_U_(0x1) << PIO_MDER_P2_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P2                         PIO_MDER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P2_Msk instead */
+#define PIO_MDER_P3_Pos                     3                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P3_Msk                     (_U_(0x1) << PIO_MDER_P3_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P3                         PIO_MDER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P3_Msk instead */
+#define PIO_MDER_P4_Pos                     4                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P4_Msk                     (_U_(0x1) << PIO_MDER_P4_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P4                         PIO_MDER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P4_Msk instead */
+#define PIO_MDER_P5_Pos                     5                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P5_Msk                     (_U_(0x1) << PIO_MDER_P5_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P5                         PIO_MDER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P5_Msk instead */
+#define PIO_MDER_P6_Pos                     6                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P6_Msk                     (_U_(0x1) << PIO_MDER_P6_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P6                         PIO_MDER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P6_Msk instead */
+#define PIO_MDER_P7_Pos                     7                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P7_Msk                     (_U_(0x1) << PIO_MDER_P7_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P7                         PIO_MDER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P7_Msk instead */
+#define PIO_MDER_P8_Pos                     8                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P8_Msk                     (_U_(0x1) << PIO_MDER_P8_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P8                         PIO_MDER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P8_Msk instead */
+#define PIO_MDER_P9_Pos                     9                                              /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P9_Msk                     (_U_(0x1) << PIO_MDER_P9_Pos)                  /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P9                         PIO_MDER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P9_Msk instead */
+#define PIO_MDER_P10_Pos                    10                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P10_Msk                    (_U_(0x1) << PIO_MDER_P10_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P10                        PIO_MDER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P10_Msk instead */
+#define PIO_MDER_P11_Pos                    11                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P11_Msk                    (_U_(0x1) << PIO_MDER_P11_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P11                        PIO_MDER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P11_Msk instead */
+#define PIO_MDER_P12_Pos                    12                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P12_Msk                    (_U_(0x1) << PIO_MDER_P12_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P12                        PIO_MDER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P12_Msk instead */
+#define PIO_MDER_P13_Pos                    13                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P13_Msk                    (_U_(0x1) << PIO_MDER_P13_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P13                        PIO_MDER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P13_Msk instead */
+#define PIO_MDER_P14_Pos                    14                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P14_Msk                    (_U_(0x1) << PIO_MDER_P14_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P14                        PIO_MDER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P14_Msk instead */
+#define PIO_MDER_P15_Pos                    15                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P15_Msk                    (_U_(0x1) << PIO_MDER_P15_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P15                        PIO_MDER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P15_Msk instead */
+#define PIO_MDER_P16_Pos                    16                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P16_Msk                    (_U_(0x1) << PIO_MDER_P16_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P16                        PIO_MDER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P16_Msk instead */
+#define PIO_MDER_P17_Pos                    17                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P17_Msk                    (_U_(0x1) << PIO_MDER_P17_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P17                        PIO_MDER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P17_Msk instead */
+#define PIO_MDER_P18_Pos                    18                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P18_Msk                    (_U_(0x1) << PIO_MDER_P18_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P18                        PIO_MDER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P18_Msk instead */
+#define PIO_MDER_P19_Pos                    19                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P19_Msk                    (_U_(0x1) << PIO_MDER_P19_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P19                        PIO_MDER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P19_Msk instead */
+#define PIO_MDER_P20_Pos                    20                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P20_Msk                    (_U_(0x1) << PIO_MDER_P20_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P20                        PIO_MDER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P20_Msk instead */
+#define PIO_MDER_P21_Pos                    21                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P21_Msk                    (_U_(0x1) << PIO_MDER_P21_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P21                        PIO_MDER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P21_Msk instead */
+#define PIO_MDER_P22_Pos                    22                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P22_Msk                    (_U_(0x1) << PIO_MDER_P22_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P22                        PIO_MDER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P22_Msk instead */
+#define PIO_MDER_P23_Pos                    23                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P23_Msk                    (_U_(0x1) << PIO_MDER_P23_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P23                        PIO_MDER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P23_Msk instead */
+#define PIO_MDER_P24_Pos                    24                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P24_Msk                    (_U_(0x1) << PIO_MDER_P24_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P24                        PIO_MDER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P24_Msk instead */
+#define PIO_MDER_P25_Pos                    25                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P25_Msk                    (_U_(0x1) << PIO_MDER_P25_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P25                        PIO_MDER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P25_Msk instead */
+#define PIO_MDER_P26_Pos                    26                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P26_Msk                    (_U_(0x1) << PIO_MDER_P26_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P26                        PIO_MDER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P26_Msk instead */
+#define PIO_MDER_P27_Pos                    27                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P27_Msk                    (_U_(0x1) << PIO_MDER_P27_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P27                        PIO_MDER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P27_Msk instead */
+#define PIO_MDER_P28_Pos                    28                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P28_Msk                    (_U_(0x1) << PIO_MDER_P28_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P28                        PIO_MDER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P28_Msk instead */
+#define PIO_MDER_P29_Pos                    29                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P29_Msk                    (_U_(0x1) << PIO_MDER_P29_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P29                        PIO_MDER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P29_Msk instead */
+#define PIO_MDER_P30_Pos                    30                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P30_Msk                    (_U_(0x1) << PIO_MDER_P30_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P30                        PIO_MDER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P30_Msk instead */
+#define PIO_MDER_P31_Pos                    31                                             /**< (PIO_MDER) Multi-drive Enable Position */
+#define PIO_MDER_P31_Msk                    (_U_(0x1) << PIO_MDER_P31_Pos)                 /**< (PIO_MDER) Multi-drive Enable Mask */
+#define PIO_MDER_P31                        PIO_MDER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDER_P31_Msk instead */
+#define PIO_MDER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDER) Register MASK  (Use PIO_MDER_Msk instead)  */
+#define PIO_MDER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDER) Register Mask  */
+
+#define PIO_MDER_P_Pos                      0                                              /**< (PIO_MDER Position) Multi-drive Enable */
+#define PIO_MDER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDER_P_Pos)            /**< (PIO_MDER Mask) P */
+#define PIO_MDER_P(value)                   (PIO_MDER_P_Msk & ((value) << PIO_MDER_P_Pos))  
+
+/* -------- PIO_MDDR : (PIO Offset: 0x54) (/W 32) Multi-driver Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Disable                      */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Disable                      */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Disable                      */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Disable                      */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Disable                      */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Disable                      */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Disable                      */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Disable                      */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Disable                      */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Disable                      */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Disable                      */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Disable                      */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Disable                      */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Disable                      */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Disable                      */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Disable                      */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Disable                      */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Disable                      */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Disable                      */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Disable                      */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Disable                      */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Disable                      */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Disable                      */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Disable                      */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Disable                      */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Disable                      */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Disable                      */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Disable                      */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Disable                      */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Disable                      */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Disable                      */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Disable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Disable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDDR_OFFSET                     (0x54)                                        /**<  (PIO_MDDR) Multi-driver Disable Register  Offset */
+
+#define PIO_MDDR_P0_Pos                     0                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P0_Msk                     (_U_(0x1) << PIO_MDDR_P0_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P0                         PIO_MDDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P0_Msk instead */
+#define PIO_MDDR_P1_Pos                     1                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P1_Msk                     (_U_(0x1) << PIO_MDDR_P1_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P1                         PIO_MDDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P1_Msk instead */
+#define PIO_MDDR_P2_Pos                     2                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P2_Msk                     (_U_(0x1) << PIO_MDDR_P2_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P2                         PIO_MDDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P2_Msk instead */
+#define PIO_MDDR_P3_Pos                     3                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P3_Msk                     (_U_(0x1) << PIO_MDDR_P3_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P3                         PIO_MDDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P3_Msk instead */
+#define PIO_MDDR_P4_Pos                     4                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P4_Msk                     (_U_(0x1) << PIO_MDDR_P4_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P4                         PIO_MDDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P4_Msk instead */
+#define PIO_MDDR_P5_Pos                     5                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P5_Msk                     (_U_(0x1) << PIO_MDDR_P5_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P5                         PIO_MDDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P5_Msk instead */
+#define PIO_MDDR_P6_Pos                     6                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P6_Msk                     (_U_(0x1) << PIO_MDDR_P6_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P6                         PIO_MDDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P6_Msk instead */
+#define PIO_MDDR_P7_Pos                     7                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P7_Msk                     (_U_(0x1) << PIO_MDDR_P7_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P7                         PIO_MDDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P7_Msk instead */
+#define PIO_MDDR_P8_Pos                     8                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P8_Msk                     (_U_(0x1) << PIO_MDDR_P8_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P8                         PIO_MDDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P8_Msk instead */
+#define PIO_MDDR_P9_Pos                     9                                              /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P9_Msk                     (_U_(0x1) << PIO_MDDR_P9_Pos)                  /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P9                         PIO_MDDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P9_Msk instead */
+#define PIO_MDDR_P10_Pos                    10                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P10_Msk                    (_U_(0x1) << PIO_MDDR_P10_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P10                        PIO_MDDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P10_Msk instead */
+#define PIO_MDDR_P11_Pos                    11                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P11_Msk                    (_U_(0x1) << PIO_MDDR_P11_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P11                        PIO_MDDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P11_Msk instead */
+#define PIO_MDDR_P12_Pos                    12                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P12_Msk                    (_U_(0x1) << PIO_MDDR_P12_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P12                        PIO_MDDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P12_Msk instead */
+#define PIO_MDDR_P13_Pos                    13                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P13_Msk                    (_U_(0x1) << PIO_MDDR_P13_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P13                        PIO_MDDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P13_Msk instead */
+#define PIO_MDDR_P14_Pos                    14                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P14_Msk                    (_U_(0x1) << PIO_MDDR_P14_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P14                        PIO_MDDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P14_Msk instead */
+#define PIO_MDDR_P15_Pos                    15                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P15_Msk                    (_U_(0x1) << PIO_MDDR_P15_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P15                        PIO_MDDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P15_Msk instead */
+#define PIO_MDDR_P16_Pos                    16                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P16_Msk                    (_U_(0x1) << PIO_MDDR_P16_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P16                        PIO_MDDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P16_Msk instead */
+#define PIO_MDDR_P17_Pos                    17                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P17_Msk                    (_U_(0x1) << PIO_MDDR_P17_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P17                        PIO_MDDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P17_Msk instead */
+#define PIO_MDDR_P18_Pos                    18                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P18_Msk                    (_U_(0x1) << PIO_MDDR_P18_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P18                        PIO_MDDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P18_Msk instead */
+#define PIO_MDDR_P19_Pos                    19                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P19_Msk                    (_U_(0x1) << PIO_MDDR_P19_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P19                        PIO_MDDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P19_Msk instead */
+#define PIO_MDDR_P20_Pos                    20                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P20_Msk                    (_U_(0x1) << PIO_MDDR_P20_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P20                        PIO_MDDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P20_Msk instead */
+#define PIO_MDDR_P21_Pos                    21                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P21_Msk                    (_U_(0x1) << PIO_MDDR_P21_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P21                        PIO_MDDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P21_Msk instead */
+#define PIO_MDDR_P22_Pos                    22                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P22_Msk                    (_U_(0x1) << PIO_MDDR_P22_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P22                        PIO_MDDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P22_Msk instead */
+#define PIO_MDDR_P23_Pos                    23                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P23_Msk                    (_U_(0x1) << PIO_MDDR_P23_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P23                        PIO_MDDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P23_Msk instead */
+#define PIO_MDDR_P24_Pos                    24                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P24_Msk                    (_U_(0x1) << PIO_MDDR_P24_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P24                        PIO_MDDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P24_Msk instead */
+#define PIO_MDDR_P25_Pos                    25                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P25_Msk                    (_U_(0x1) << PIO_MDDR_P25_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P25                        PIO_MDDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P25_Msk instead */
+#define PIO_MDDR_P26_Pos                    26                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P26_Msk                    (_U_(0x1) << PIO_MDDR_P26_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P26                        PIO_MDDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P26_Msk instead */
+#define PIO_MDDR_P27_Pos                    27                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P27_Msk                    (_U_(0x1) << PIO_MDDR_P27_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P27                        PIO_MDDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P27_Msk instead */
+#define PIO_MDDR_P28_Pos                    28                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P28_Msk                    (_U_(0x1) << PIO_MDDR_P28_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P28                        PIO_MDDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P28_Msk instead */
+#define PIO_MDDR_P29_Pos                    29                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P29_Msk                    (_U_(0x1) << PIO_MDDR_P29_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P29                        PIO_MDDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P29_Msk instead */
+#define PIO_MDDR_P30_Pos                    30                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P30_Msk                    (_U_(0x1) << PIO_MDDR_P30_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P30                        PIO_MDDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P30_Msk instead */
+#define PIO_MDDR_P31_Pos                    31                                             /**< (PIO_MDDR) Multi-drive Disable Position */
+#define PIO_MDDR_P31_Msk                    (_U_(0x1) << PIO_MDDR_P31_Pos)                 /**< (PIO_MDDR) Multi-drive Disable Mask */
+#define PIO_MDDR_P31                        PIO_MDDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDDR_P31_Msk instead */
+#define PIO_MDDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDDR) Register MASK  (Use PIO_MDDR_Msk instead)  */
+#define PIO_MDDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDDR) Register Mask  */
+
+#define PIO_MDDR_P_Pos                      0                                              /**< (PIO_MDDR Position) Multi-drive Disable */
+#define PIO_MDDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDDR_P_Pos)            /**< (PIO_MDDR Mask) P */
+#define PIO_MDDR_P(value)                   (PIO_MDDR_P_Msk & ((value) << PIO_MDDR_P_Pos))  
+
+/* -------- PIO_MDSR : (PIO Offset: 0x58) (R/ 32) Multi-driver Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Multi-drive Status                       */
+    uint32_t P1:1;                      /**< bit:      1  Multi-drive Status                       */
+    uint32_t P2:1;                      /**< bit:      2  Multi-drive Status                       */
+    uint32_t P3:1;                      /**< bit:      3  Multi-drive Status                       */
+    uint32_t P4:1;                      /**< bit:      4  Multi-drive Status                       */
+    uint32_t P5:1;                      /**< bit:      5  Multi-drive Status                       */
+    uint32_t P6:1;                      /**< bit:      6  Multi-drive Status                       */
+    uint32_t P7:1;                      /**< bit:      7  Multi-drive Status                       */
+    uint32_t P8:1;                      /**< bit:      8  Multi-drive Status                       */
+    uint32_t P9:1;                      /**< bit:      9  Multi-drive Status                       */
+    uint32_t P10:1;                     /**< bit:     10  Multi-drive Status                       */
+    uint32_t P11:1;                     /**< bit:     11  Multi-drive Status                       */
+    uint32_t P12:1;                     /**< bit:     12  Multi-drive Status                       */
+    uint32_t P13:1;                     /**< bit:     13  Multi-drive Status                       */
+    uint32_t P14:1;                     /**< bit:     14  Multi-drive Status                       */
+    uint32_t P15:1;                     /**< bit:     15  Multi-drive Status                       */
+    uint32_t P16:1;                     /**< bit:     16  Multi-drive Status                       */
+    uint32_t P17:1;                     /**< bit:     17  Multi-drive Status                       */
+    uint32_t P18:1;                     /**< bit:     18  Multi-drive Status                       */
+    uint32_t P19:1;                     /**< bit:     19  Multi-drive Status                       */
+    uint32_t P20:1;                     /**< bit:     20  Multi-drive Status                       */
+    uint32_t P21:1;                     /**< bit:     21  Multi-drive Status                       */
+    uint32_t P22:1;                     /**< bit:     22  Multi-drive Status                       */
+    uint32_t P23:1;                     /**< bit:     23  Multi-drive Status                       */
+    uint32_t P24:1;                     /**< bit:     24  Multi-drive Status                       */
+    uint32_t P25:1;                     /**< bit:     25  Multi-drive Status                       */
+    uint32_t P26:1;                     /**< bit:     26  Multi-drive Status                       */
+    uint32_t P27:1;                     /**< bit:     27  Multi-drive Status                       */
+    uint32_t P28:1;                     /**< bit:     28  Multi-drive Status                       */
+    uint32_t P29:1;                     /**< bit:     29  Multi-drive Status                       */
+    uint32_t P30:1;                     /**< bit:     30  Multi-drive Status                       */
+    uint32_t P31:1;                     /**< bit:     31  Multi-drive Status                       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Multi-drive Status                       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_MDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_MDSR_OFFSET                     (0x58)                                        /**<  (PIO_MDSR) Multi-driver Status Register  Offset */
+
+#define PIO_MDSR_P0_Pos                     0                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P0_Msk                     (_U_(0x1) << PIO_MDSR_P0_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P0                         PIO_MDSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P0_Msk instead */
+#define PIO_MDSR_P1_Pos                     1                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P1_Msk                     (_U_(0x1) << PIO_MDSR_P1_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P1                         PIO_MDSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P1_Msk instead */
+#define PIO_MDSR_P2_Pos                     2                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P2_Msk                     (_U_(0x1) << PIO_MDSR_P2_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P2                         PIO_MDSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P2_Msk instead */
+#define PIO_MDSR_P3_Pos                     3                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P3_Msk                     (_U_(0x1) << PIO_MDSR_P3_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P3                         PIO_MDSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P3_Msk instead */
+#define PIO_MDSR_P4_Pos                     4                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P4_Msk                     (_U_(0x1) << PIO_MDSR_P4_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P4                         PIO_MDSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P4_Msk instead */
+#define PIO_MDSR_P5_Pos                     5                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P5_Msk                     (_U_(0x1) << PIO_MDSR_P5_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P5                         PIO_MDSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P5_Msk instead */
+#define PIO_MDSR_P6_Pos                     6                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P6_Msk                     (_U_(0x1) << PIO_MDSR_P6_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P6                         PIO_MDSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P6_Msk instead */
+#define PIO_MDSR_P7_Pos                     7                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P7_Msk                     (_U_(0x1) << PIO_MDSR_P7_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P7                         PIO_MDSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P7_Msk instead */
+#define PIO_MDSR_P8_Pos                     8                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P8_Msk                     (_U_(0x1) << PIO_MDSR_P8_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P8                         PIO_MDSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P8_Msk instead */
+#define PIO_MDSR_P9_Pos                     9                                              /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P9_Msk                     (_U_(0x1) << PIO_MDSR_P9_Pos)                  /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P9                         PIO_MDSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P9_Msk instead */
+#define PIO_MDSR_P10_Pos                    10                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P10_Msk                    (_U_(0x1) << PIO_MDSR_P10_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P10                        PIO_MDSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P10_Msk instead */
+#define PIO_MDSR_P11_Pos                    11                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P11_Msk                    (_U_(0x1) << PIO_MDSR_P11_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P11                        PIO_MDSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P11_Msk instead */
+#define PIO_MDSR_P12_Pos                    12                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P12_Msk                    (_U_(0x1) << PIO_MDSR_P12_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P12                        PIO_MDSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P12_Msk instead */
+#define PIO_MDSR_P13_Pos                    13                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P13_Msk                    (_U_(0x1) << PIO_MDSR_P13_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P13                        PIO_MDSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P13_Msk instead */
+#define PIO_MDSR_P14_Pos                    14                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P14_Msk                    (_U_(0x1) << PIO_MDSR_P14_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P14                        PIO_MDSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P14_Msk instead */
+#define PIO_MDSR_P15_Pos                    15                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P15_Msk                    (_U_(0x1) << PIO_MDSR_P15_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P15                        PIO_MDSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P15_Msk instead */
+#define PIO_MDSR_P16_Pos                    16                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P16_Msk                    (_U_(0x1) << PIO_MDSR_P16_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P16                        PIO_MDSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P16_Msk instead */
+#define PIO_MDSR_P17_Pos                    17                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P17_Msk                    (_U_(0x1) << PIO_MDSR_P17_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P17                        PIO_MDSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P17_Msk instead */
+#define PIO_MDSR_P18_Pos                    18                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P18_Msk                    (_U_(0x1) << PIO_MDSR_P18_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P18                        PIO_MDSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P18_Msk instead */
+#define PIO_MDSR_P19_Pos                    19                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P19_Msk                    (_U_(0x1) << PIO_MDSR_P19_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P19                        PIO_MDSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P19_Msk instead */
+#define PIO_MDSR_P20_Pos                    20                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P20_Msk                    (_U_(0x1) << PIO_MDSR_P20_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P20                        PIO_MDSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P20_Msk instead */
+#define PIO_MDSR_P21_Pos                    21                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P21_Msk                    (_U_(0x1) << PIO_MDSR_P21_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P21                        PIO_MDSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P21_Msk instead */
+#define PIO_MDSR_P22_Pos                    22                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P22_Msk                    (_U_(0x1) << PIO_MDSR_P22_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P22                        PIO_MDSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P22_Msk instead */
+#define PIO_MDSR_P23_Pos                    23                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P23_Msk                    (_U_(0x1) << PIO_MDSR_P23_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P23                        PIO_MDSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P23_Msk instead */
+#define PIO_MDSR_P24_Pos                    24                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P24_Msk                    (_U_(0x1) << PIO_MDSR_P24_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P24                        PIO_MDSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P24_Msk instead */
+#define PIO_MDSR_P25_Pos                    25                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P25_Msk                    (_U_(0x1) << PIO_MDSR_P25_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P25                        PIO_MDSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P25_Msk instead */
+#define PIO_MDSR_P26_Pos                    26                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P26_Msk                    (_U_(0x1) << PIO_MDSR_P26_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P26                        PIO_MDSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P26_Msk instead */
+#define PIO_MDSR_P27_Pos                    27                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P27_Msk                    (_U_(0x1) << PIO_MDSR_P27_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P27                        PIO_MDSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P27_Msk instead */
+#define PIO_MDSR_P28_Pos                    28                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P28_Msk                    (_U_(0x1) << PIO_MDSR_P28_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P28                        PIO_MDSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P28_Msk instead */
+#define PIO_MDSR_P29_Pos                    29                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P29_Msk                    (_U_(0x1) << PIO_MDSR_P29_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P29                        PIO_MDSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P29_Msk instead */
+#define PIO_MDSR_P30_Pos                    30                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P30_Msk                    (_U_(0x1) << PIO_MDSR_P30_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P30                        PIO_MDSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P30_Msk instead */
+#define PIO_MDSR_P31_Pos                    31                                             /**< (PIO_MDSR) Multi-drive Status Position */
+#define PIO_MDSR_P31_Msk                    (_U_(0x1) << PIO_MDSR_P31_Pos)                 /**< (PIO_MDSR) Multi-drive Status Mask */
+#define PIO_MDSR_P31                        PIO_MDSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_MDSR_P31_Msk instead */
+#define PIO_MDSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_MDSR) Register MASK  (Use PIO_MDSR_Msk instead)  */
+#define PIO_MDSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_MDSR) Register Mask  */
+
+#define PIO_MDSR_P_Pos                      0                                              /**< (PIO_MDSR Position) Multi-drive Status */
+#define PIO_MDSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_MDSR_P_Pos)            /**< (PIO_MDSR Mask) P */
+#define PIO_MDSR_P(value)                   (PIO_MDSR_P_Msk & ((value) << PIO_MDSR_P_Pos))  
+
+/* -------- PIO_PUDR : (PIO Offset: 0x60) (/W 32) Pull-up Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Disable                          */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Disable                          */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Disable                          */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Disable                          */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Disable                          */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Disable                          */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Disable                          */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Disable                          */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Disable                          */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Disable                          */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Disable                          */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Disable                          */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Disable                          */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Disable                          */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Disable                          */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Disable                          */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Disable                          */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Disable                          */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Disable                          */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Disable                          */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Disable                          */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Disable                          */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Disable                          */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Disable                          */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Disable                          */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Disable                          */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Disable                          */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Disable                          */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Disable                          */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Disable                          */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Disable                          */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Disable                          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Disable                          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUDR_OFFSET                     (0x60)                                        /**<  (PIO_PUDR) Pull-up Disable Register  Offset */
+
+#define PIO_PUDR_P0_Pos                     0                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P0_Msk                     (_U_(0x1) << PIO_PUDR_P0_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P0                         PIO_PUDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P0_Msk instead */
+#define PIO_PUDR_P1_Pos                     1                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P1_Msk                     (_U_(0x1) << PIO_PUDR_P1_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P1                         PIO_PUDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P1_Msk instead */
+#define PIO_PUDR_P2_Pos                     2                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P2_Msk                     (_U_(0x1) << PIO_PUDR_P2_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P2                         PIO_PUDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P2_Msk instead */
+#define PIO_PUDR_P3_Pos                     3                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P3_Msk                     (_U_(0x1) << PIO_PUDR_P3_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P3                         PIO_PUDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P3_Msk instead */
+#define PIO_PUDR_P4_Pos                     4                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P4_Msk                     (_U_(0x1) << PIO_PUDR_P4_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P4                         PIO_PUDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P4_Msk instead */
+#define PIO_PUDR_P5_Pos                     5                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P5_Msk                     (_U_(0x1) << PIO_PUDR_P5_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P5                         PIO_PUDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P5_Msk instead */
+#define PIO_PUDR_P6_Pos                     6                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P6_Msk                     (_U_(0x1) << PIO_PUDR_P6_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P6                         PIO_PUDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P6_Msk instead */
+#define PIO_PUDR_P7_Pos                     7                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P7_Msk                     (_U_(0x1) << PIO_PUDR_P7_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P7                         PIO_PUDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P7_Msk instead */
+#define PIO_PUDR_P8_Pos                     8                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P8_Msk                     (_U_(0x1) << PIO_PUDR_P8_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P8                         PIO_PUDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P8_Msk instead */
+#define PIO_PUDR_P9_Pos                     9                                              /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P9_Msk                     (_U_(0x1) << PIO_PUDR_P9_Pos)                  /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P9                         PIO_PUDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P9_Msk instead */
+#define PIO_PUDR_P10_Pos                    10                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P10_Msk                    (_U_(0x1) << PIO_PUDR_P10_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P10                        PIO_PUDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P10_Msk instead */
+#define PIO_PUDR_P11_Pos                    11                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P11_Msk                    (_U_(0x1) << PIO_PUDR_P11_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P11                        PIO_PUDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P11_Msk instead */
+#define PIO_PUDR_P12_Pos                    12                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P12_Msk                    (_U_(0x1) << PIO_PUDR_P12_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P12                        PIO_PUDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P12_Msk instead */
+#define PIO_PUDR_P13_Pos                    13                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P13_Msk                    (_U_(0x1) << PIO_PUDR_P13_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P13                        PIO_PUDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P13_Msk instead */
+#define PIO_PUDR_P14_Pos                    14                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P14_Msk                    (_U_(0x1) << PIO_PUDR_P14_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P14                        PIO_PUDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P14_Msk instead */
+#define PIO_PUDR_P15_Pos                    15                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P15_Msk                    (_U_(0x1) << PIO_PUDR_P15_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P15                        PIO_PUDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P15_Msk instead */
+#define PIO_PUDR_P16_Pos                    16                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P16_Msk                    (_U_(0x1) << PIO_PUDR_P16_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P16                        PIO_PUDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P16_Msk instead */
+#define PIO_PUDR_P17_Pos                    17                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P17_Msk                    (_U_(0x1) << PIO_PUDR_P17_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P17                        PIO_PUDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P17_Msk instead */
+#define PIO_PUDR_P18_Pos                    18                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P18_Msk                    (_U_(0x1) << PIO_PUDR_P18_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P18                        PIO_PUDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P18_Msk instead */
+#define PIO_PUDR_P19_Pos                    19                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P19_Msk                    (_U_(0x1) << PIO_PUDR_P19_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P19                        PIO_PUDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P19_Msk instead */
+#define PIO_PUDR_P20_Pos                    20                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P20_Msk                    (_U_(0x1) << PIO_PUDR_P20_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P20                        PIO_PUDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P20_Msk instead */
+#define PIO_PUDR_P21_Pos                    21                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P21_Msk                    (_U_(0x1) << PIO_PUDR_P21_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P21                        PIO_PUDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P21_Msk instead */
+#define PIO_PUDR_P22_Pos                    22                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P22_Msk                    (_U_(0x1) << PIO_PUDR_P22_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P22                        PIO_PUDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P22_Msk instead */
+#define PIO_PUDR_P23_Pos                    23                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P23_Msk                    (_U_(0x1) << PIO_PUDR_P23_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P23                        PIO_PUDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P23_Msk instead */
+#define PIO_PUDR_P24_Pos                    24                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P24_Msk                    (_U_(0x1) << PIO_PUDR_P24_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P24                        PIO_PUDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P24_Msk instead */
+#define PIO_PUDR_P25_Pos                    25                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P25_Msk                    (_U_(0x1) << PIO_PUDR_P25_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P25                        PIO_PUDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P25_Msk instead */
+#define PIO_PUDR_P26_Pos                    26                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P26_Msk                    (_U_(0x1) << PIO_PUDR_P26_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P26                        PIO_PUDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P26_Msk instead */
+#define PIO_PUDR_P27_Pos                    27                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P27_Msk                    (_U_(0x1) << PIO_PUDR_P27_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P27                        PIO_PUDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P27_Msk instead */
+#define PIO_PUDR_P28_Pos                    28                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P28_Msk                    (_U_(0x1) << PIO_PUDR_P28_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P28                        PIO_PUDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P28_Msk instead */
+#define PIO_PUDR_P29_Pos                    29                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P29_Msk                    (_U_(0x1) << PIO_PUDR_P29_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P29                        PIO_PUDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P29_Msk instead */
+#define PIO_PUDR_P30_Pos                    30                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P30_Msk                    (_U_(0x1) << PIO_PUDR_P30_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P30                        PIO_PUDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P30_Msk instead */
+#define PIO_PUDR_P31_Pos                    31                                             /**< (PIO_PUDR) Pull-Up Disable Position */
+#define PIO_PUDR_P31_Msk                    (_U_(0x1) << PIO_PUDR_P31_Pos)                 /**< (PIO_PUDR) Pull-Up Disable Mask */
+#define PIO_PUDR_P31                        PIO_PUDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUDR_P31_Msk instead */
+#define PIO_PUDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUDR) Register MASK  (Use PIO_PUDR_Msk instead)  */
+#define PIO_PUDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUDR) Register Mask  */
+
+#define PIO_PUDR_P_Pos                      0                                              /**< (PIO_PUDR Position) Pull-Up Disable */
+#define PIO_PUDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUDR_P_Pos)            /**< (PIO_PUDR Mask) P */
+#define PIO_PUDR_P(value)                   (PIO_PUDR_P_Msk & ((value) << PIO_PUDR_P_Pos))  
+
+/* -------- PIO_PUER : (PIO Offset: 0x64) (/W 32) Pull-up Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Enable                           */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Enable                           */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Enable                           */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Enable                           */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Enable                           */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Enable                           */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Enable                           */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Enable                           */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Enable                           */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Enable                           */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Enable                           */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Enable                           */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Enable                           */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Enable                           */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Enable                           */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Enable                           */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Enable                           */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Enable                           */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Enable                           */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Enable                           */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Enable                           */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Enable                           */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Enable                           */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Enable                           */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Enable                           */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Enable                           */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Enable                           */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Enable                           */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Enable                           */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Enable                           */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Enable                           */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Enable                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Enable                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUER_OFFSET                     (0x64)                                        /**<  (PIO_PUER) Pull-up Enable Register  Offset */
+
+#define PIO_PUER_P0_Pos                     0                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P0_Msk                     (_U_(0x1) << PIO_PUER_P0_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P0                         PIO_PUER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P0_Msk instead */
+#define PIO_PUER_P1_Pos                     1                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P1_Msk                     (_U_(0x1) << PIO_PUER_P1_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P1                         PIO_PUER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P1_Msk instead */
+#define PIO_PUER_P2_Pos                     2                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P2_Msk                     (_U_(0x1) << PIO_PUER_P2_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P2                         PIO_PUER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P2_Msk instead */
+#define PIO_PUER_P3_Pos                     3                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P3_Msk                     (_U_(0x1) << PIO_PUER_P3_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P3                         PIO_PUER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P3_Msk instead */
+#define PIO_PUER_P4_Pos                     4                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P4_Msk                     (_U_(0x1) << PIO_PUER_P4_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P4                         PIO_PUER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P4_Msk instead */
+#define PIO_PUER_P5_Pos                     5                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P5_Msk                     (_U_(0x1) << PIO_PUER_P5_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P5                         PIO_PUER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P5_Msk instead */
+#define PIO_PUER_P6_Pos                     6                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P6_Msk                     (_U_(0x1) << PIO_PUER_P6_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P6                         PIO_PUER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P6_Msk instead */
+#define PIO_PUER_P7_Pos                     7                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P7_Msk                     (_U_(0x1) << PIO_PUER_P7_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P7                         PIO_PUER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P7_Msk instead */
+#define PIO_PUER_P8_Pos                     8                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P8_Msk                     (_U_(0x1) << PIO_PUER_P8_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P8                         PIO_PUER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P8_Msk instead */
+#define PIO_PUER_P9_Pos                     9                                              /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P9_Msk                     (_U_(0x1) << PIO_PUER_P9_Pos)                  /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P9                         PIO_PUER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P9_Msk instead */
+#define PIO_PUER_P10_Pos                    10                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P10_Msk                    (_U_(0x1) << PIO_PUER_P10_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P10                        PIO_PUER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P10_Msk instead */
+#define PIO_PUER_P11_Pos                    11                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P11_Msk                    (_U_(0x1) << PIO_PUER_P11_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P11                        PIO_PUER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P11_Msk instead */
+#define PIO_PUER_P12_Pos                    12                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P12_Msk                    (_U_(0x1) << PIO_PUER_P12_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P12                        PIO_PUER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P12_Msk instead */
+#define PIO_PUER_P13_Pos                    13                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P13_Msk                    (_U_(0x1) << PIO_PUER_P13_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P13                        PIO_PUER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P13_Msk instead */
+#define PIO_PUER_P14_Pos                    14                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P14_Msk                    (_U_(0x1) << PIO_PUER_P14_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P14                        PIO_PUER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P14_Msk instead */
+#define PIO_PUER_P15_Pos                    15                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P15_Msk                    (_U_(0x1) << PIO_PUER_P15_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P15                        PIO_PUER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P15_Msk instead */
+#define PIO_PUER_P16_Pos                    16                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P16_Msk                    (_U_(0x1) << PIO_PUER_P16_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P16                        PIO_PUER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P16_Msk instead */
+#define PIO_PUER_P17_Pos                    17                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P17_Msk                    (_U_(0x1) << PIO_PUER_P17_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P17                        PIO_PUER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P17_Msk instead */
+#define PIO_PUER_P18_Pos                    18                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P18_Msk                    (_U_(0x1) << PIO_PUER_P18_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P18                        PIO_PUER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P18_Msk instead */
+#define PIO_PUER_P19_Pos                    19                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P19_Msk                    (_U_(0x1) << PIO_PUER_P19_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P19                        PIO_PUER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P19_Msk instead */
+#define PIO_PUER_P20_Pos                    20                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P20_Msk                    (_U_(0x1) << PIO_PUER_P20_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P20                        PIO_PUER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P20_Msk instead */
+#define PIO_PUER_P21_Pos                    21                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P21_Msk                    (_U_(0x1) << PIO_PUER_P21_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P21                        PIO_PUER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P21_Msk instead */
+#define PIO_PUER_P22_Pos                    22                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P22_Msk                    (_U_(0x1) << PIO_PUER_P22_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P22                        PIO_PUER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P22_Msk instead */
+#define PIO_PUER_P23_Pos                    23                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P23_Msk                    (_U_(0x1) << PIO_PUER_P23_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P23                        PIO_PUER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P23_Msk instead */
+#define PIO_PUER_P24_Pos                    24                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P24_Msk                    (_U_(0x1) << PIO_PUER_P24_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P24                        PIO_PUER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P24_Msk instead */
+#define PIO_PUER_P25_Pos                    25                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P25_Msk                    (_U_(0x1) << PIO_PUER_P25_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P25                        PIO_PUER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P25_Msk instead */
+#define PIO_PUER_P26_Pos                    26                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P26_Msk                    (_U_(0x1) << PIO_PUER_P26_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P26                        PIO_PUER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P26_Msk instead */
+#define PIO_PUER_P27_Pos                    27                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P27_Msk                    (_U_(0x1) << PIO_PUER_P27_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P27                        PIO_PUER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P27_Msk instead */
+#define PIO_PUER_P28_Pos                    28                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P28_Msk                    (_U_(0x1) << PIO_PUER_P28_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P28                        PIO_PUER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P28_Msk instead */
+#define PIO_PUER_P29_Pos                    29                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P29_Msk                    (_U_(0x1) << PIO_PUER_P29_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P29                        PIO_PUER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P29_Msk instead */
+#define PIO_PUER_P30_Pos                    30                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P30_Msk                    (_U_(0x1) << PIO_PUER_P30_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P30                        PIO_PUER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P30_Msk instead */
+#define PIO_PUER_P31_Pos                    31                                             /**< (PIO_PUER) Pull-Up Enable Position */
+#define PIO_PUER_P31_Msk                    (_U_(0x1) << PIO_PUER_P31_Pos)                 /**< (PIO_PUER) Pull-Up Enable Mask */
+#define PIO_PUER_P31                        PIO_PUER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUER_P31_Msk instead */
+#define PIO_PUER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUER) Register MASK  (Use PIO_PUER_Msk instead)  */
+#define PIO_PUER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUER) Register Mask  */
+
+#define PIO_PUER_P_Pos                      0                                              /**< (PIO_PUER Position) Pull-Up Enable */
+#define PIO_PUER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUER_P_Pos)            /**< (PIO_PUER Mask) P */
+#define PIO_PUER_P(value)                   (PIO_PUER_P_Msk & ((value) << PIO_PUER_P_Pos))  
+
+/* -------- PIO_PUSR : (PIO Offset: 0x68) (R/ 32) Pad Pull-up Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Up Status                           */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Up Status                           */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Up Status                           */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Up Status                           */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Up Status                           */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Up Status                           */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Up Status                           */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Up Status                           */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Up Status                           */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Up Status                           */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Up Status                           */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Up Status                           */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Up Status                           */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Up Status                           */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Up Status                           */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Up Status                           */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Up Status                           */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Up Status                           */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Up Status                           */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Up Status                           */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Up Status                           */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Up Status                           */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Up Status                           */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Up Status                           */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Up Status                           */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Up Status                           */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Up Status                           */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Up Status                           */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Up Status                           */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Up Status                           */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Up Status                           */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Up Status                           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Up Status                           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PUSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PUSR_OFFSET                     (0x68)                                        /**<  (PIO_PUSR) Pad Pull-up Status Register  Offset */
+
+#define PIO_PUSR_P0_Pos                     0                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P0_Msk                     (_U_(0x1) << PIO_PUSR_P0_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P0                         PIO_PUSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P0_Msk instead */
+#define PIO_PUSR_P1_Pos                     1                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P1_Msk                     (_U_(0x1) << PIO_PUSR_P1_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P1                         PIO_PUSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P1_Msk instead */
+#define PIO_PUSR_P2_Pos                     2                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P2_Msk                     (_U_(0x1) << PIO_PUSR_P2_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P2                         PIO_PUSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P2_Msk instead */
+#define PIO_PUSR_P3_Pos                     3                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P3_Msk                     (_U_(0x1) << PIO_PUSR_P3_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P3                         PIO_PUSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P3_Msk instead */
+#define PIO_PUSR_P4_Pos                     4                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P4_Msk                     (_U_(0x1) << PIO_PUSR_P4_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P4                         PIO_PUSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P4_Msk instead */
+#define PIO_PUSR_P5_Pos                     5                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P5_Msk                     (_U_(0x1) << PIO_PUSR_P5_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P5                         PIO_PUSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P5_Msk instead */
+#define PIO_PUSR_P6_Pos                     6                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P6_Msk                     (_U_(0x1) << PIO_PUSR_P6_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P6                         PIO_PUSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P6_Msk instead */
+#define PIO_PUSR_P7_Pos                     7                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P7_Msk                     (_U_(0x1) << PIO_PUSR_P7_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P7                         PIO_PUSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P7_Msk instead */
+#define PIO_PUSR_P8_Pos                     8                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P8_Msk                     (_U_(0x1) << PIO_PUSR_P8_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P8                         PIO_PUSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P8_Msk instead */
+#define PIO_PUSR_P9_Pos                     9                                              /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P9_Msk                     (_U_(0x1) << PIO_PUSR_P9_Pos)                  /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P9                         PIO_PUSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P9_Msk instead */
+#define PIO_PUSR_P10_Pos                    10                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P10_Msk                    (_U_(0x1) << PIO_PUSR_P10_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P10                        PIO_PUSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P10_Msk instead */
+#define PIO_PUSR_P11_Pos                    11                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P11_Msk                    (_U_(0x1) << PIO_PUSR_P11_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P11                        PIO_PUSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P11_Msk instead */
+#define PIO_PUSR_P12_Pos                    12                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P12_Msk                    (_U_(0x1) << PIO_PUSR_P12_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P12                        PIO_PUSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P12_Msk instead */
+#define PIO_PUSR_P13_Pos                    13                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P13_Msk                    (_U_(0x1) << PIO_PUSR_P13_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P13                        PIO_PUSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P13_Msk instead */
+#define PIO_PUSR_P14_Pos                    14                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P14_Msk                    (_U_(0x1) << PIO_PUSR_P14_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P14                        PIO_PUSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P14_Msk instead */
+#define PIO_PUSR_P15_Pos                    15                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P15_Msk                    (_U_(0x1) << PIO_PUSR_P15_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P15                        PIO_PUSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P15_Msk instead */
+#define PIO_PUSR_P16_Pos                    16                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P16_Msk                    (_U_(0x1) << PIO_PUSR_P16_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P16                        PIO_PUSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P16_Msk instead */
+#define PIO_PUSR_P17_Pos                    17                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P17_Msk                    (_U_(0x1) << PIO_PUSR_P17_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P17                        PIO_PUSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P17_Msk instead */
+#define PIO_PUSR_P18_Pos                    18                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P18_Msk                    (_U_(0x1) << PIO_PUSR_P18_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P18                        PIO_PUSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P18_Msk instead */
+#define PIO_PUSR_P19_Pos                    19                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P19_Msk                    (_U_(0x1) << PIO_PUSR_P19_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P19                        PIO_PUSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P19_Msk instead */
+#define PIO_PUSR_P20_Pos                    20                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P20_Msk                    (_U_(0x1) << PIO_PUSR_P20_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P20                        PIO_PUSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P20_Msk instead */
+#define PIO_PUSR_P21_Pos                    21                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P21_Msk                    (_U_(0x1) << PIO_PUSR_P21_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P21                        PIO_PUSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P21_Msk instead */
+#define PIO_PUSR_P22_Pos                    22                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P22_Msk                    (_U_(0x1) << PIO_PUSR_P22_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P22                        PIO_PUSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P22_Msk instead */
+#define PIO_PUSR_P23_Pos                    23                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P23_Msk                    (_U_(0x1) << PIO_PUSR_P23_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P23                        PIO_PUSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P23_Msk instead */
+#define PIO_PUSR_P24_Pos                    24                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P24_Msk                    (_U_(0x1) << PIO_PUSR_P24_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P24                        PIO_PUSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P24_Msk instead */
+#define PIO_PUSR_P25_Pos                    25                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P25_Msk                    (_U_(0x1) << PIO_PUSR_P25_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P25                        PIO_PUSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P25_Msk instead */
+#define PIO_PUSR_P26_Pos                    26                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P26_Msk                    (_U_(0x1) << PIO_PUSR_P26_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P26                        PIO_PUSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P26_Msk instead */
+#define PIO_PUSR_P27_Pos                    27                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P27_Msk                    (_U_(0x1) << PIO_PUSR_P27_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P27                        PIO_PUSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P27_Msk instead */
+#define PIO_PUSR_P28_Pos                    28                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P28_Msk                    (_U_(0x1) << PIO_PUSR_P28_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P28                        PIO_PUSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P28_Msk instead */
+#define PIO_PUSR_P29_Pos                    29                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P29_Msk                    (_U_(0x1) << PIO_PUSR_P29_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P29                        PIO_PUSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P29_Msk instead */
+#define PIO_PUSR_P30_Pos                    30                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P30_Msk                    (_U_(0x1) << PIO_PUSR_P30_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P30                        PIO_PUSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P30_Msk instead */
+#define PIO_PUSR_P31_Pos                    31                                             /**< (PIO_PUSR) Pull-Up Status Position */
+#define PIO_PUSR_P31_Msk                    (_U_(0x1) << PIO_PUSR_P31_Pos)                 /**< (PIO_PUSR) Pull-Up Status Mask */
+#define PIO_PUSR_P31                        PIO_PUSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PUSR_P31_Msk instead */
+#define PIO_PUSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PUSR) Register MASK  (Use PIO_PUSR_Msk instead)  */
+#define PIO_PUSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_PUSR) Register Mask  */
+
+#define PIO_PUSR_P_Pos                      0                                              /**< (PIO_PUSR Position) Pull-Up Status */
+#define PIO_PUSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_PUSR_P_Pos)            /**< (PIO_PUSR Mask) P */
+#define PIO_PUSR_P(value)                   (PIO_PUSR_P_Msk & ((value) << PIO_PUSR_P_Pos))  
+
+/* -------- PIO_ABCDSR : (PIO Offset: 0x70) (R/W 32) Peripheral ABCD Select Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Peripheral Select                        */
+    uint32_t P1:1;                      /**< bit:      1  Peripheral Select                        */
+    uint32_t P2:1;                      /**< bit:      2  Peripheral Select                        */
+    uint32_t P3:1;                      /**< bit:      3  Peripheral Select                        */
+    uint32_t P4:1;                      /**< bit:      4  Peripheral Select                        */
+    uint32_t P5:1;                      /**< bit:      5  Peripheral Select                        */
+    uint32_t P6:1;                      /**< bit:      6  Peripheral Select                        */
+    uint32_t P7:1;                      /**< bit:      7  Peripheral Select                        */
+    uint32_t P8:1;                      /**< bit:      8  Peripheral Select                        */
+    uint32_t P9:1;                      /**< bit:      9  Peripheral Select                        */
+    uint32_t P10:1;                     /**< bit:     10  Peripheral Select                        */
+    uint32_t P11:1;                     /**< bit:     11  Peripheral Select                        */
+    uint32_t P12:1;                     /**< bit:     12  Peripheral Select                        */
+    uint32_t P13:1;                     /**< bit:     13  Peripheral Select                        */
+    uint32_t P14:1;                     /**< bit:     14  Peripheral Select                        */
+    uint32_t P15:1;                     /**< bit:     15  Peripheral Select                        */
+    uint32_t P16:1;                     /**< bit:     16  Peripheral Select                        */
+    uint32_t P17:1;                     /**< bit:     17  Peripheral Select                        */
+    uint32_t P18:1;                     /**< bit:     18  Peripheral Select                        */
+    uint32_t P19:1;                     /**< bit:     19  Peripheral Select                        */
+    uint32_t P20:1;                     /**< bit:     20  Peripheral Select                        */
+    uint32_t P21:1;                     /**< bit:     21  Peripheral Select                        */
+    uint32_t P22:1;                     /**< bit:     22  Peripheral Select                        */
+    uint32_t P23:1;                     /**< bit:     23  Peripheral Select                        */
+    uint32_t P24:1;                     /**< bit:     24  Peripheral Select                        */
+    uint32_t P25:1;                     /**< bit:     25  Peripheral Select                        */
+    uint32_t P26:1;                     /**< bit:     26  Peripheral Select                        */
+    uint32_t P27:1;                     /**< bit:     27  Peripheral Select                        */
+    uint32_t P28:1;                     /**< bit:     28  Peripheral Select                        */
+    uint32_t P29:1;                     /**< bit:     29  Peripheral Select                        */
+    uint32_t P30:1;                     /**< bit:     30  Peripheral Select                        */
+    uint32_t P31:1;                     /**< bit:     31  Peripheral Select                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Peripheral Select                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ABCDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ABCDSR_OFFSET                   (0x70)                                        /**<  (PIO_ABCDSR) Peripheral ABCD Select Register 0  Offset */
+
+#define PIO_ABCDSR_P0_Pos                   0                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P0_Msk                   (_U_(0x1) << PIO_ABCDSR_P0_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P0                       PIO_ABCDSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P0_Msk instead */
+#define PIO_ABCDSR_P1_Pos                   1                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P1_Msk                   (_U_(0x1) << PIO_ABCDSR_P1_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P1                       PIO_ABCDSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P1_Msk instead */
+#define PIO_ABCDSR_P2_Pos                   2                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P2_Msk                   (_U_(0x1) << PIO_ABCDSR_P2_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P2                       PIO_ABCDSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P2_Msk instead */
+#define PIO_ABCDSR_P3_Pos                   3                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P3_Msk                   (_U_(0x1) << PIO_ABCDSR_P3_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P3                       PIO_ABCDSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P3_Msk instead */
+#define PIO_ABCDSR_P4_Pos                   4                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P4_Msk                   (_U_(0x1) << PIO_ABCDSR_P4_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P4                       PIO_ABCDSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P4_Msk instead */
+#define PIO_ABCDSR_P5_Pos                   5                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P5_Msk                   (_U_(0x1) << PIO_ABCDSR_P5_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P5                       PIO_ABCDSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P5_Msk instead */
+#define PIO_ABCDSR_P6_Pos                   6                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P6_Msk                   (_U_(0x1) << PIO_ABCDSR_P6_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P6                       PIO_ABCDSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P6_Msk instead */
+#define PIO_ABCDSR_P7_Pos                   7                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P7_Msk                   (_U_(0x1) << PIO_ABCDSR_P7_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P7                       PIO_ABCDSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P7_Msk instead */
+#define PIO_ABCDSR_P8_Pos                   8                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P8_Msk                   (_U_(0x1) << PIO_ABCDSR_P8_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P8                       PIO_ABCDSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P8_Msk instead */
+#define PIO_ABCDSR_P9_Pos                   9                                              /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P9_Msk                   (_U_(0x1) << PIO_ABCDSR_P9_Pos)                /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P9                       PIO_ABCDSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P9_Msk instead */
+#define PIO_ABCDSR_P10_Pos                  10                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P10_Msk                  (_U_(0x1) << PIO_ABCDSR_P10_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P10                      PIO_ABCDSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P10_Msk instead */
+#define PIO_ABCDSR_P11_Pos                  11                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P11_Msk                  (_U_(0x1) << PIO_ABCDSR_P11_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P11                      PIO_ABCDSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P11_Msk instead */
+#define PIO_ABCDSR_P12_Pos                  12                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P12_Msk                  (_U_(0x1) << PIO_ABCDSR_P12_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P12                      PIO_ABCDSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P12_Msk instead */
+#define PIO_ABCDSR_P13_Pos                  13                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P13_Msk                  (_U_(0x1) << PIO_ABCDSR_P13_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P13                      PIO_ABCDSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P13_Msk instead */
+#define PIO_ABCDSR_P14_Pos                  14                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P14_Msk                  (_U_(0x1) << PIO_ABCDSR_P14_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P14                      PIO_ABCDSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P14_Msk instead */
+#define PIO_ABCDSR_P15_Pos                  15                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P15_Msk                  (_U_(0x1) << PIO_ABCDSR_P15_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P15                      PIO_ABCDSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P15_Msk instead */
+#define PIO_ABCDSR_P16_Pos                  16                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P16_Msk                  (_U_(0x1) << PIO_ABCDSR_P16_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P16                      PIO_ABCDSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P16_Msk instead */
+#define PIO_ABCDSR_P17_Pos                  17                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P17_Msk                  (_U_(0x1) << PIO_ABCDSR_P17_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P17                      PIO_ABCDSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P17_Msk instead */
+#define PIO_ABCDSR_P18_Pos                  18                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P18_Msk                  (_U_(0x1) << PIO_ABCDSR_P18_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P18                      PIO_ABCDSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P18_Msk instead */
+#define PIO_ABCDSR_P19_Pos                  19                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P19_Msk                  (_U_(0x1) << PIO_ABCDSR_P19_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P19                      PIO_ABCDSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P19_Msk instead */
+#define PIO_ABCDSR_P20_Pos                  20                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P20_Msk                  (_U_(0x1) << PIO_ABCDSR_P20_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P20                      PIO_ABCDSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P20_Msk instead */
+#define PIO_ABCDSR_P21_Pos                  21                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P21_Msk                  (_U_(0x1) << PIO_ABCDSR_P21_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P21                      PIO_ABCDSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P21_Msk instead */
+#define PIO_ABCDSR_P22_Pos                  22                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P22_Msk                  (_U_(0x1) << PIO_ABCDSR_P22_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P22                      PIO_ABCDSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P22_Msk instead */
+#define PIO_ABCDSR_P23_Pos                  23                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P23_Msk                  (_U_(0x1) << PIO_ABCDSR_P23_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P23                      PIO_ABCDSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P23_Msk instead */
+#define PIO_ABCDSR_P24_Pos                  24                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P24_Msk                  (_U_(0x1) << PIO_ABCDSR_P24_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P24                      PIO_ABCDSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P24_Msk instead */
+#define PIO_ABCDSR_P25_Pos                  25                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P25_Msk                  (_U_(0x1) << PIO_ABCDSR_P25_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P25                      PIO_ABCDSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P25_Msk instead */
+#define PIO_ABCDSR_P26_Pos                  26                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P26_Msk                  (_U_(0x1) << PIO_ABCDSR_P26_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P26                      PIO_ABCDSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P26_Msk instead */
+#define PIO_ABCDSR_P27_Pos                  27                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P27_Msk                  (_U_(0x1) << PIO_ABCDSR_P27_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P27                      PIO_ABCDSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P27_Msk instead */
+#define PIO_ABCDSR_P28_Pos                  28                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P28_Msk                  (_U_(0x1) << PIO_ABCDSR_P28_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P28                      PIO_ABCDSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P28_Msk instead */
+#define PIO_ABCDSR_P29_Pos                  29                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P29_Msk                  (_U_(0x1) << PIO_ABCDSR_P29_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P29                      PIO_ABCDSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P29_Msk instead */
+#define PIO_ABCDSR_P30_Pos                  30                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P30_Msk                  (_U_(0x1) << PIO_ABCDSR_P30_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P30                      PIO_ABCDSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P30_Msk instead */
+#define PIO_ABCDSR_P31_Pos                  31                                             /**< (PIO_ABCDSR) Peripheral Select Position */
+#define PIO_ABCDSR_P31_Msk                  (_U_(0x1) << PIO_ABCDSR_P31_Pos)               /**< (PIO_ABCDSR) Peripheral Select Mask */
+#define PIO_ABCDSR_P31                      PIO_ABCDSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ABCDSR_P31_Msk instead */
+#define PIO_ABCDSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ABCDSR) Register MASK  (Use PIO_ABCDSR_Msk instead)  */
+#define PIO_ABCDSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_ABCDSR) Register Mask  */
+
+#define PIO_ABCDSR_P_Pos                    0                                              /**< (PIO_ABCDSR Position) Peripheral Select */
+#define PIO_ABCDSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_ABCDSR_P_Pos)          /**< (PIO_ABCDSR Mask) P */
+#define PIO_ABCDSR_P(value)                 (PIO_ABCDSR_P_Msk & ((value) << PIO_ABCDSR_P_Pos))  
+
+/* -------- PIO_IFSCDR : (PIO Offset: 0x80) (/W 32) Input Filter Slow Clock Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Peripheral Clock Glitch Filtering Select */
+    uint32_t P1:1;                      /**< bit:      1  Peripheral Clock Glitch Filtering Select */
+    uint32_t P2:1;                      /**< bit:      2  Peripheral Clock Glitch Filtering Select */
+    uint32_t P3:1;                      /**< bit:      3  Peripheral Clock Glitch Filtering Select */
+    uint32_t P4:1;                      /**< bit:      4  Peripheral Clock Glitch Filtering Select */
+    uint32_t P5:1;                      /**< bit:      5  Peripheral Clock Glitch Filtering Select */
+    uint32_t P6:1;                      /**< bit:      6  Peripheral Clock Glitch Filtering Select */
+    uint32_t P7:1;                      /**< bit:      7  Peripheral Clock Glitch Filtering Select */
+    uint32_t P8:1;                      /**< bit:      8  Peripheral Clock Glitch Filtering Select */
+    uint32_t P9:1;                      /**< bit:      9  Peripheral Clock Glitch Filtering Select */
+    uint32_t P10:1;                     /**< bit:     10  Peripheral Clock Glitch Filtering Select */
+    uint32_t P11:1;                     /**< bit:     11  Peripheral Clock Glitch Filtering Select */
+    uint32_t P12:1;                     /**< bit:     12  Peripheral Clock Glitch Filtering Select */
+    uint32_t P13:1;                     /**< bit:     13  Peripheral Clock Glitch Filtering Select */
+    uint32_t P14:1;                     /**< bit:     14  Peripheral Clock Glitch Filtering Select */
+    uint32_t P15:1;                     /**< bit:     15  Peripheral Clock Glitch Filtering Select */
+    uint32_t P16:1;                     /**< bit:     16  Peripheral Clock Glitch Filtering Select */
+    uint32_t P17:1;                     /**< bit:     17  Peripheral Clock Glitch Filtering Select */
+    uint32_t P18:1;                     /**< bit:     18  Peripheral Clock Glitch Filtering Select */
+    uint32_t P19:1;                     /**< bit:     19  Peripheral Clock Glitch Filtering Select */
+    uint32_t P20:1;                     /**< bit:     20  Peripheral Clock Glitch Filtering Select */
+    uint32_t P21:1;                     /**< bit:     21  Peripheral Clock Glitch Filtering Select */
+    uint32_t P22:1;                     /**< bit:     22  Peripheral Clock Glitch Filtering Select */
+    uint32_t P23:1;                     /**< bit:     23  Peripheral Clock Glitch Filtering Select */
+    uint32_t P24:1;                     /**< bit:     24  Peripheral Clock Glitch Filtering Select */
+    uint32_t P25:1;                     /**< bit:     25  Peripheral Clock Glitch Filtering Select */
+    uint32_t P26:1;                     /**< bit:     26  Peripheral Clock Glitch Filtering Select */
+    uint32_t P27:1;                     /**< bit:     27  Peripheral Clock Glitch Filtering Select */
+    uint32_t P28:1;                     /**< bit:     28  Peripheral Clock Glitch Filtering Select */
+    uint32_t P29:1;                     /**< bit:     29  Peripheral Clock Glitch Filtering Select */
+    uint32_t P30:1;                     /**< bit:     30  Peripheral Clock Glitch Filtering Select */
+    uint32_t P31:1;                     /**< bit:     31  Peripheral Clock Glitch Filtering Select */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Peripheral Clock Glitch Filtering Select */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCDR_OFFSET                   (0x80)                                        /**<  (PIO_IFSCDR) Input Filter Slow Clock Disable Register  Offset */
+
+#define PIO_IFSCDR_P0_Pos                   0                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P0_Msk                   (_U_(0x1) << PIO_IFSCDR_P0_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P0                       PIO_IFSCDR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P0_Msk instead */
+#define PIO_IFSCDR_P1_Pos                   1                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P1_Msk                   (_U_(0x1) << PIO_IFSCDR_P1_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P1                       PIO_IFSCDR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P1_Msk instead */
+#define PIO_IFSCDR_P2_Pos                   2                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P2_Msk                   (_U_(0x1) << PIO_IFSCDR_P2_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P2                       PIO_IFSCDR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P2_Msk instead */
+#define PIO_IFSCDR_P3_Pos                   3                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P3_Msk                   (_U_(0x1) << PIO_IFSCDR_P3_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P3                       PIO_IFSCDR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P3_Msk instead */
+#define PIO_IFSCDR_P4_Pos                   4                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P4_Msk                   (_U_(0x1) << PIO_IFSCDR_P4_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P4                       PIO_IFSCDR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P4_Msk instead */
+#define PIO_IFSCDR_P5_Pos                   5                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P5_Msk                   (_U_(0x1) << PIO_IFSCDR_P5_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P5                       PIO_IFSCDR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P5_Msk instead */
+#define PIO_IFSCDR_P6_Pos                   6                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P6_Msk                   (_U_(0x1) << PIO_IFSCDR_P6_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P6                       PIO_IFSCDR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P6_Msk instead */
+#define PIO_IFSCDR_P7_Pos                   7                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P7_Msk                   (_U_(0x1) << PIO_IFSCDR_P7_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P7                       PIO_IFSCDR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P7_Msk instead */
+#define PIO_IFSCDR_P8_Pos                   8                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P8_Msk                   (_U_(0x1) << PIO_IFSCDR_P8_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P8                       PIO_IFSCDR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P8_Msk instead */
+#define PIO_IFSCDR_P9_Pos                   9                                              /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P9_Msk                   (_U_(0x1) << PIO_IFSCDR_P9_Pos)                /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P9                       PIO_IFSCDR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P9_Msk instead */
+#define PIO_IFSCDR_P10_Pos                  10                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P10_Msk                  (_U_(0x1) << PIO_IFSCDR_P10_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P10                      PIO_IFSCDR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P10_Msk instead */
+#define PIO_IFSCDR_P11_Pos                  11                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P11_Msk                  (_U_(0x1) << PIO_IFSCDR_P11_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P11                      PIO_IFSCDR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P11_Msk instead */
+#define PIO_IFSCDR_P12_Pos                  12                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P12_Msk                  (_U_(0x1) << PIO_IFSCDR_P12_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P12                      PIO_IFSCDR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P12_Msk instead */
+#define PIO_IFSCDR_P13_Pos                  13                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P13_Msk                  (_U_(0x1) << PIO_IFSCDR_P13_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P13                      PIO_IFSCDR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P13_Msk instead */
+#define PIO_IFSCDR_P14_Pos                  14                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P14_Msk                  (_U_(0x1) << PIO_IFSCDR_P14_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P14                      PIO_IFSCDR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P14_Msk instead */
+#define PIO_IFSCDR_P15_Pos                  15                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P15_Msk                  (_U_(0x1) << PIO_IFSCDR_P15_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P15                      PIO_IFSCDR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P15_Msk instead */
+#define PIO_IFSCDR_P16_Pos                  16                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P16_Msk                  (_U_(0x1) << PIO_IFSCDR_P16_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P16                      PIO_IFSCDR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P16_Msk instead */
+#define PIO_IFSCDR_P17_Pos                  17                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P17_Msk                  (_U_(0x1) << PIO_IFSCDR_P17_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P17                      PIO_IFSCDR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P17_Msk instead */
+#define PIO_IFSCDR_P18_Pos                  18                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P18_Msk                  (_U_(0x1) << PIO_IFSCDR_P18_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P18                      PIO_IFSCDR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P18_Msk instead */
+#define PIO_IFSCDR_P19_Pos                  19                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P19_Msk                  (_U_(0x1) << PIO_IFSCDR_P19_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P19                      PIO_IFSCDR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P19_Msk instead */
+#define PIO_IFSCDR_P20_Pos                  20                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P20_Msk                  (_U_(0x1) << PIO_IFSCDR_P20_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P20                      PIO_IFSCDR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P20_Msk instead */
+#define PIO_IFSCDR_P21_Pos                  21                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P21_Msk                  (_U_(0x1) << PIO_IFSCDR_P21_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P21                      PIO_IFSCDR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P21_Msk instead */
+#define PIO_IFSCDR_P22_Pos                  22                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P22_Msk                  (_U_(0x1) << PIO_IFSCDR_P22_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P22                      PIO_IFSCDR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P22_Msk instead */
+#define PIO_IFSCDR_P23_Pos                  23                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P23_Msk                  (_U_(0x1) << PIO_IFSCDR_P23_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P23                      PIO_IFSCDR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P23_Msk instead */
+#define PIO_IFSCDR_P24_Pos                  24                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P24_Msk                  (_U_(0x1) << PIO_IFSCDR_P24_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P24                      PIO_IFSCDR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P24_Msk instead */
+#define PIO_IFSCDR_P25_Pos                  25                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P25_Msk                  (_U_(0x1) << PIO_IFSCDR_P25_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P25                      PIO_IFSCDR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P25_Msk instead */
+#define PIO_IFSCDR_P26_Pos                  26                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P26_Msk                  (_U_(0x1) << PIO_IFSCDR_P26_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P26                      PIO_IFSCDR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P26_Msk instead */
+#define PIO_IFSCDR_P27_Pos                  27                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P27_Msk                  (_U_(0x1) << PIO_IFSCDR_P27_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P27                      PIO_IFSCDR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P27_Msk instead */
+#define PIO_IFSCDR_P28_Pos                  28                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P28_Msk                  (_U_(0x1) << PIO_IFSCDR_P28_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P28                      PIO_IFSCDR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P28_Msk instead */
+#define PIO_IFSCDR_P29_Pos                  29                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P29_Msk                  (_U_(0x1) << PIO_IFSCDR_P29_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P29                      PIO_IFSCDR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P29_Msk instead */
+#define PIO_IFSCDR_P30_Pos                  30                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P30_Msk                  (_U_(0x1) << PIO_IFSCDR_P30_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P30                      PIO_IFSCDR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P30_Msk instead */
+#define PIO_IFSCDR_P31_Pos                  31                                             /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Position */
+#define PIO_IFSCDR_P31_Msk                  (_U_(0x1) << PIO_IFSCDR_P31_Pos)               /**< (PIO_IFSCDR) Peripheral Clock Glitch Filtering Select Mask */
+#define PIO_IFSCDR_P31                      PIO_IFSCDR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCDR_P31_Msk instead */
+#define PIO_IFSCDR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCDR) Register MASK  (Use PIO_IFSCDR_Msk instead)  */
+#define PIO_IFSCDR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCDR) Register Mask  */
+
+#define PIO_IFSCDR_P_Pos                    0                                              /**< (PIO_IFSCDR Position) Peripheral Clock Glitch Filtering Select */
+#define PIO_IFSCDR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCDR_P_Pos)          /**< (PIO_IFSCDR Mask) P */
+#define PIO_IFSCDR_P(value)                 (PIO_IFSCDR_P_Msk & ((value) << PIO_IFSCDR_P_Pos))  
+
+/* -------- PIO_IFSCER : (PIO Offset: 0x84) (/W 32) Input Filter Slow Clock Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Slow Clock Debouncing Filtering Select   */
+    uint32_t P1:1;                      /**< bit:      1  Slow Clock Debouncing Filtering Select   */
+    uint32_t P2:1;                      /**< bit:      2  Slow Clock Debouncing Filtering Select   */
+    uint32_t P3:1;                      /**< bit:      3  Slow Clock Debouncing Filtering Select   */
+    uint32_t P4:1;                      /**< bit:      4  Slow Clock Debouncing Filtering Select   */
+    uint32_t P5:1;                      /**< bit:      5  Slow Clock Debouncing Filtering Select   */
+    uint32_t P6:1;                      /**< bit:      6  Slow Clock Debouncing Filtering Select   */
+    uint32_t P7:1;                      /**< bit:      7  Slow Clock Debouncing Filtering Select   */
+    uint32_t P8:1;                      /**< bit:      8  Slow Clock Debouncing Filtering Select   */
+    uint32_t P9:1;                      /**< bit:      9  Slow Clock Debouncing Filtering Select   */
+    uint32_t P10:1;                     /**< bit:     10  Slow Clock Debouncing Filtering Select   */
+    uint32_t P11:1;                     /**< bit:     11  Slow Clock Debouncing Filtering Select   */
+    uint32_t P12:1;                     /**< bit:     12  Slow Clock Debouncing Filtering Select   */
+    uint32_t P13:1;                     /**< bit:     13  Slow Clock Debouncing Filtering Select   */
+    uint32_t P14:1;                     /**< bit:     14  Slow Clock Debouncing Filtering Select   */
+    uint32_t P15:1;                     /**< bit:     15  Slow Clock Debouncing Filtering Select   */
+    uint32_t P16:1;                     /**< bit:     16  Slow Clock Debouncing Filtering Select   */
+    uint32_t P17:1;                     /**< bit:     17  Slow Clock Debouncing Filtering Select   */
+    uint32_t P18:1;                     /**< bit:     18  Slow Clock Debouncing Filtering Select   */
+    uint32_t P19:1;                     /**< bit:     19  Slow Clock Debouncing Filtering Select   */
+    uint32_t P20:1;                     /**< bit:     20  Slow Clock Debouncing Filtering Select   */
+    uint32_t P21:1;                     /**< bit:     21  Slow Clock Debouncing Filtering Select   */
+    uint32_t P22:1;                     /**< bit:     22  Slow Clock Debouncing Filtering Select   */
+    uint32_t P23:1;                     /**< bit:     23  Slow Clock Debouncing Filtering Select   */
+    uint32_t P24:1;                     /**< bit:     24  Slow Clock Debouncing Filtering Select   */
+    uint32_t P25:1;                     /**< bit:     25  Slow Clock Debouncing Filtering Select   */
+    uint32_t P26:1;                     /**< bit:     26  Slow Clock Debouncing Filtering Select   */
+    uint32_t P27:1;                     /**< bit:     27  Slow Clock Debouncing Filtering Select   */
+    uint32_t P28:1;                     /**< bit:     28  Slow Clock Debouncing Filtering Select   */
+    uint32_t P29:1;                     /**< bit:     29  Slow Clock Debouncing Filtering Select   */
+    uint32_t P30:1;                     /**< bit:     30  Slow Clock Debouncing Filtering Select   */
+    uint32_t P31:1;                     /**< bit:     31  Slow Clock Debouncing Filtering Select   */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Slow Clock Debouncing Filtering Select   */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCER_OFFSET                   (0x84)                                        /**<  (PIO_IFSCER) Input Filter Slow Clock Enable Register  Offset */
+
+#define PIO_IFSCER_P0_Pos                   0                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P0_Msk                   (_U_(0x1) << PIO_IFSCER_P0_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P0                       PIO_IFSCER_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P0_Msk instead */
+#define PIO_IFSCER_P1_Pos                   1                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P1_Msk                   (_U_(0x1) << PIO_IFSCER_P1_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P1                       PIO_IFSCER_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P1_Msk instead */
+#define PIO_IFSCER_P2_Pos                   2                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P2_Msk                   (_U_(0x1) << PIO_IFSCER_P2_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P2                       PIO_IFSCER_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P2_Msk instead */
+#define PIO_IFSCER_P3_Pos                   3                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P3_Msk                   (_U_(0x1) << PIO_IFSCER_P3_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P3                       PIO_IFSCER_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P3_Msk instead */
+#define PIO_IFSCER_P4_Pos                   4                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P4_Msk                   (_U_(0x1) << PIO_IFSCER_P4_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P4                       PIO_IFSCER_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P4_Msk instead */
+#define PIO_IFSCER_P5_Pos                   5                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P5_Msk                   (_U_(0x1) << PIO_IFSCER_P5_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P5                       PIO_IFSCER_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P5_Msk instead */
+#define PIO_IFSCER_P6_Pos                   6                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P6_Msk                   (_U_(0x1) << PIO_IFSCER_P6_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P6                       PIO_IFSCER_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P6_Msk instead */
+#define PIO_IFSCER_P7_Pos                   7                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P7_Msk                   (_U_(0x1) << PIO_IFSCER_P7_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P7                       PIO_IFSCER_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P7_Msk instead */
+#define PIO_IFSCER_P8_Pos                   8                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P8_Msk                   (_U_(0x1) << PIO_IFSCER_P8_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P8                       PIO_IFSCER_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P8_Msk instead */
+#define PIO_IFSCER_P9_Pos                   9                                              /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P9_Msk                   (_U_(0x1) << PIO_IFSCER_P9_Pos)                /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P9                       PIO_IFSCER_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P9_Msk instead */
+#define PIO_IFSCER_P10_Pos                  10                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P10_Msk                  (_U_(0x1) << PIO_IFSCER_P10_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P10                      PIO_IFSCER_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P10_Msk instead */
+#define PIO_IFSCER_P11_Pos                  11                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P11_Msk                  (_U_(0x1) << PIO_IFSCER_P11_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P11                      PIO_IFSCER_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P11_Msk instead */
+#define PIO_IFSCER_P12_Pos                  12                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P12_Msk                  (_U_(0x1) << PIO_IFSCER_P12_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P12                      PIO_IFSCER_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P12_Msk instead */
+#define PIO_IFSCER_P13_Pos                  13                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P13_Msk                  (_U_(0x1) << PIO_IFSCER_P13_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P13                      PIO_IFSCER_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P13_Msk instead */
+#define PIO_IFSCER_P14_Pos                  14                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P14_Msk                  (_U_(0x1) << PIO_IFSCER_P14_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P14                      PIO_IFSCER_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P14_Msk instead */
+#define PIO_IFSCER_P15_Pos                  15                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P15_Msk                  (_U_(0x1) << PIO_IFSCER_P15_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P15                      PIO_IFSCER_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P15_Msk instead */
+#define PIO_IFSCER_P16_Pos                  16                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P16_Msk                  (_U_(0x1) << PIO_IFSCER_P16_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P16                      PIO_IFSCER_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P16_Msk instead */
+#define PIO_IFSCER_P17_Pos                  17                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P17_Msk                  (_U_(0x1) << PIO_IFSCER_P17_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P17                      PIO_IFSCER_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P17_Msk instead */
+#define PIO_IFSCER_P18_Pos                  18                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P18_Msk                  (_U_(0x1) << PIO_IFSCER_P18_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P18                      PIO_IFSCER_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P18_Msk instead */
+#define PIO_IFSCER_P19_Pos                  19                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P19_Msk                  (_U_(0x1) << PIO_IFSCER_P19_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P19                      PIO_IFSCER_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P19_Msk instead */
+#define PIO_IFSCER_P20_Pos                  20                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P20_Msk                  (_U_(0x1) << PIO_IFSCER_P20_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P20                      PIO_IFSCER_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P20_Msk instead */
+#define PIO_IFSCER_P21_Pos                  21                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P21_Msk                  (_U_(0x1) << PIO_IFSCER_P21_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P21                      PIO_IFSCER_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P21_Msk instead */
+#define PIO_IFSCER_P22_Pos                  22                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P22_Msk                  (_U_(0x1) << PIO_IFSCER_P22_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P22                      PIO_IFSCER_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P22_Msk instead */
+#define PIO_IFSCER_P23_Pos                  23                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P23_Msk                  (_U_(0x1) << PIO_IFSCER_P23_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P23                      PIO_IFSCER_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P23_Msk instead */
+#define PIO_IFSCER_P24_Pos                  24                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P24_Msk                  (_U_(0x1) << PIO_IFSCER_P24_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P24                      PIO_IFSCER_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P24_Msk instead */
+#define PIO_IFSCER_P25_Pos                  25                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P25_Msk                  (_U_(0x1) << PIO_IFSCER_P25_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P25                      PIO_IFSCER_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P25_Msk instead */
+#define PIO_IFSCER_P26_Pos                  26                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P26_Msk                  (_U_(0x1) << PIO_IFSCER_P26_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P26                      PIO_IFSCER_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P26_Msk instead */
+#define PIO_IFSCER_P27_Pos                  27                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P27_Msk                  (_U_(0x1) << PIO_IFSCER_P27_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P27                      PIO_IFSCER_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P27_Msk instead */
+#define PIO_IFSCER_P28_Pos                  28                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P28_Msk                  (_U_(0x1) << PIO_IFSCER_P28_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P28                      PIO_IFSCER_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P28_Msk instead */
+#define PIO_IFSCER_P29_Pos                  29                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P29_Msk                  (_U_(0x1) << PIO_IFSCER_P29_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P29                      PIO_IFSCER_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P29_Msk instead */
+#define PIO_IFSCER_P30_Pos                  30                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P30_Msk                  (_U_(0x1) << PIO_IFSCER_P30_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P30                      PIO_IFSCER_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P30_Msk instead */
+#define PIO_IFSCER_P31_Pos                  31                                             /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Position */
+#define PIO_IFSCER_P31_Msk                  (_U_(0x1) << PIO_IFSCER_P31_Pos)               /**< (PIO_IFSCER) Slow Clock Debouncing Filtering Select Mask */
+#define PIO_IFSCER_P31                      PIO_IFSCER_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCER_P31_Msk instead */
+#define PIO_IFSCER_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCER) Register MASK  (Use PIO_IFSCER_Msk instead)  */
+#define PIO_IFSCER_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCER) Register Mask  */
+
+#define PIO_IFSCER_P_Pos                    0                                              /**< (PIO_IFSCER Position) Slow Clock Debouncing Filtering Select */
+#define PIO_IFSCER_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCER_P_Pos)          /**< (PIO_IFSCER Mask) P */
+#define PIO_IFSCER_P(value)                 (PIO_IFSCER_P_Msk & ((value) << PIO_IFSCER_P_Pos))  
+
+/* -------- PIO_IFSCSR : (PIO Offset: 0x88) (R/ 32) Input Filter Slow Clock Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Glitch or Debouncing Filter Selection Status */
+    uint32_t P1:1;                      /**< bit:      1  Glitch or Debouncing Filter Selection Status */
+    uint32_t P2:1;                      /**< bit:      2  Glitch or Debouncing Filter Selection Status */
+    uint32_t P3:1;                      /**< bit:      3  Glitch or Debouncing Filter Selection Status */
+    uint32_t P4:1;                      /**< bit:      4  Glitch or Debouncing Filter Selection Status */
+    uint32_t P5:1;                      /**< bit:      5  Glitch or Debouncing Filter Selection Status */
+    uint32_t P6:1;                      /**< bit:      6  Glitch or Debouncing Filter Selection Status */
+    uint32_t P7:1;                      /**< bit:      7  Glitch or Debouncing Filter Selection Status */
+    uint32_t P8:1;                      /**< bit:      8  Glitch or Debouncing Filter Selection Status */
+    uint32_t P9:1;                      /**< bit:      9  Glitch or Debouncing Filter Selection Status */
+    uint32_t P10:1;                     /**< bit:     10  Glitch or Debouncing Filter Selection Status */
+    uint32_t P11:1;                     /**< bit:     11  Glitch or Debouncing Filter Selection Status */
+    uint32_t P12:1;                     /**< bit:     12  Glitch or Debouncing Filter Selection Status */
+    uint32_t P13:1;                     /**< bit:     13  Glitch or Debouncing Filter Selection Status */
+    uint32_t P14:1;                     /**< bit:     14  Glitch or Debouncing Filter Selection Status */
+    uint32_t P15:1;                     /**< bit:     15  Glitch or Debouncing Filter Selection Status */
+    uint32_t P16:1;                     /**< bit:     16  Glitch or Debouncing Filter Selection Status */
+    uint32_t P17:1;                     /**< bit:     17  Glitch or Debouncing Filter Selection Status */
+    uint32_t P18:1;                     /**< bit:     18  Glitch or Debouncing Filter Selection Status */
+    uint32_t P19:1;                     /**< bit:     19  Glitch or Debouncing Filter Selection Status */
+    uint32_t P20:1;                     /**< bit:     20  Glitch or Debouncing Filter Selection Status */
+    uint32_t P21:1;                     /**< bit:     21  Glitch or Debouncing Filter Selection Status */
+    uint32_t P22:1;                     /**< bit:     22  Glitch or Debouncing Filter Selection Status */
+    uint32_t P23:1;                     /**< bit:     23  Glitch or Debouncing Filter Selection Status */
+    uint32_t P24:1;                     /**< bit:     24  Glitch or Debouncing Filter Selection Status */
+    uint32_t P25:1;                     /**< bit:     25  Glitch or Debouncing Filter Selection Status */
+    uint32_t P26:1;                     /**< bit:     26  Glitch or Debouncing Filter Selection Status */
+    uint32_t P27:1;                     /**< bit:     27  Glitch or Debouncing Filter Selection Status */
+    uint32_t P28:1;                     /**< bit:     28  Glitch or Debouncing Filter Selection Status */
+    uint32_t P29:1;                     /**< bit:     29  Glitch or Debouncing Filter Selection Status */
+    uint32_t P30:1;                     /**< bit:     30  Glitch or Debouncing Filter Selection Status */
+    uint32_t P31:1;                     /**< bit:     31  Glitch or Debouncing Filter Selection Status */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Glitch or Debouncing Filter Selection Status */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_IFSCSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_IFSCSR_OFFSET                   (0x88)                                        /**<  (PIO_IFSCSR) Input Filter Slow Clock Status Register  Offset */
+
+#define PIO_IFSCSR_P0_Pos                   0                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P0_Msk                   (_U_(0x1) << PIO_IFSCSR_P0_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P0                       PIO_IFSCSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P0_Msk instead */
+#define PIO_IFSCSR_P1_Pos                   1                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P1_Msk                   (_U_(0x1) << PIO_IFSCSR_P1_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P1                       PIO_IFSCSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P1_Msk instead */
+#define PIO_IFSCSR_P2_Pos                   2                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P2_Msk                   (_U_(0x1) << PIO_IFSCSR_P2_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P2                       PIO_IFSCSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P2_Msk instead */
+#define PIO_IFSCSR_P3_Pos                   3                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P3_Msk                   (_U_(0x1) << PIO_IFSCSR_P3_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P3                       PIO_IFSCSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P3_Msk instead */
+#define PIO_IFSCSR_P4_Pos                   4                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P4_Msk                   (_U_(0x1) << PIO_IFSCSR_P4_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P4                       PIO_IFSCSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P4_Msk instead */
+#define PIO_IFSCSR_P5_Pos                   5                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P5_Msk                   (_U_(0x1) << PIO_IFSCSR_P5_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P5                       PIO_IFSCSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P5_Msk instead */
+#define PIO_IFSCSR_P6_Pos                   6                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P6_Msk                   (_U_(0x1) << PIO_IFSCSR_P6_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P6                       PIO_IFSCSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P6_Msk instead */
+#define PIO_IFSCSR_P7_Pos                   7                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P7_Msk                   (_U_(0x1) << PIO_IFSCSR_P7_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P7                       PIO_IFSCSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P7_Msk instead */
+#define PIO_IFSCSR_P8_Pos                   8                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P8_Msk                   (_U_(0x1) << PIO_IFSCSR_P8_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P8                       PIO_IFSCSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P8_Msk instead */
+#define PIO_IFSCSR_P9_Pos                   9                                              /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P9_Msk                   (_U_(0x1) << PIO_IFSCSR_P9_Pos)                /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P9                       PIO_IFSCSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P9_Msk instead */
+#define PIO_IFSCSR_P10_Pos                  10                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P10_Msk                  (_U_(0x1) << PIO_IFSCSR_P10_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P10                      PIO_IFSCSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P10_Msk instead */
+#define PIO_IFSCSR_P11_Pos                  11                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P11_Msk                  (_U_(0x1) << PIO_IFSCSR_P11_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P11                      PIO_IFSCSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P11_Msk instead */
+#define PIO_IFSCSR_P12_Pos                  12                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P12_Msk                  (_U_(0x1) << PIO_IFSCSR_P12_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P12                      PIO_IFSCSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P12_Msk instead */
+#define PIO_IFSCSR_P13_Pos                  13                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P13_Msk                  (_U_(0x1) << PIO_IFSCSR_P13_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P13                      PIO_IFSCSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P13_Msk instead */
+#define PIO_IFSCSR_P14_Pos                  14                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P14_Msk                  (_U_(0x1) << PIO_IFSCSR_P14_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P14                      PIO_IFSCSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P14_Msk instead */
+#define PIO_IFSCSR_P15_Pos                  15                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P15_Msk                  (_U_(0x1) << PIO_IFSCSR_P15_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P15                      PIO_IFSCSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P15_Msk instead */
+#define PIO_IFSCSR_P16_Pos                  16                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P16_Msk                  (_U_(0x1) << PIO_IFSCSR_P16_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P16                      PIO_IFSCSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P16_Msk instead */
+#define PIO_IFSCSR_P17_Pos                  17                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P17_Msk                  (_U_(0x1) << PIO_IFSCSR_P17_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P17                      PIO_IFSCSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P17_Msk instead */
+#define PIO_IFSCSR_P18_Pos                  18                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P18_Msk                  (_U_(0x1) << PIO_IFSCSR_P18_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P18                      PIO_IFSCSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P18_Msk instead */
+#define PIO_IFSCSR_P19_Pos                  19                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P19_Msk                  (_U_(0x1) << PIO_IFSCSR_P19_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P19                      PIO_IFSCSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P19_Msk instead */
+#define PIO_IFSCSR_P20_Pos                  20                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P20_Msk                  (_U_(0x1) << PIO_IFSCSR_P20_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P20                      PIO_IFSCSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P20_Msk instead */
+#define PIO_IFSCSR_P21_Pos                  21                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P21_Msk                  (_U_(0x1) << PIO_IFSCSR_P21_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P21                      PIO_IFSCSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P21_Msk instead */
+#define PIO_IFSCSR_P22_Pos                  22                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P22_Msk                  (_U_(0x1) << PIO_IFSCSR_P22_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P22                      PIO_IFSCSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P22_Msk instead */
+#define PIO_IFSCSR_P23_Pos                  23                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P23_Msk                  (_U_(0x1) << PIO_IFSCSR_P23_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P23                      PIO_IFSCSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P23_Msk instead */
+#define PIO_IFSCSR_P24_Pos                  24                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P24_Msk                  (_U_(0x1) << PIO_IFSCSR_P24_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P24                      PIO_IFSCSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P24_Msk instead */
+#define PIO_IFSCSR_P25_Pos                  25                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P25_Msk                  (_U_(0x1) << PIO_IFSCSR_P25_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P25                      PIO_IFSCSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P25_Msk instead */
+#define PIO_IFSCSR_P26_Pos                  26                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P26_Msk                  (_U_(0x1) << PIO_IFSCSR_P26_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P26                      PIO_IFSCSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P26_Msk instead */
+#define PIO_IFSCSR_P27_Pos                  27                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P27_Msk                  (_U_(0x1) << PIO_IFSCSR_P27_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P27                      PIO_IFSCSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P27_Msk instead */
+#define PIO_IFSCSR_P28_Pos                  28                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P28_Msk                  (_U_(0x1) << PIO_IFSCSR_P28_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P28                      PIO_IFSCSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P28_Msk instead */
+#define PIO_IFSCSR_P29_Pos                  29                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P29_Msk                  (_U_(0x1) << PIO_IFSCSR_P29_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P29                      PIO_IFSCSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P29_Msk instead */
+#define PIO_IFSCSR_P30_Pos                  30                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P30_Msk                  (_U_(0x1) << PIO_IFSCSR_P30_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P30                      PIO_IFSCSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P30_Msk instead */
+#define PIO_IFSCSR_P31_Pos                  31                                             /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Position */
+#define PIO_IFSCSR_P31_Msk                  (_U_(0x1) << PIO_IFSCSR_P31_Pos)               /**< (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status Mask */
+#define PIO_IFSCSR_P31                      PIO_IFSCSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_IFSCSR_P31_Msk instead */
+#define PIO_IFSCSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_IFSCSR) Register MASK  (Use PIO_IFSCSR_Msk instead)  */
+#define PIO_IFSCSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_IFSCSR) Register Mask  */
+
+#define PIO_IFSCSR_P_Pos                    0                                              /**< (PIO_IFSCSR Position) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_IFSCSR_P_Pos)          /**< (PIO_IFSCSR Mask) P */
+#define PIO_IFSCSR_P(value)                 (PIO_IFSCSR_P_Msk & ((value) << PIO_IFSCSR_P_Pos))  
+
+/* -------- PIO_SCDR : (PIO Offset: 0x8c) (R/W 32) Slow Clock Divider Debouncing Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIV:14;                    /**< bit:  0..13  Slow Clock Divider Selection for Debouncing */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SCDR_OFFSET                     (0x8C)                                        /**<  (PIO_SCDR) Slow Clock Divider Debouncing Register  Offset */
+
+#define PIO_SCDR_DIV_Pos                    0                                              /**< (PIO_SCDR) Slow Clock Divider Selection for Debouncing Position */
+#define PIO_SCDR_DIV_Msk                    (_U_(0x3FFF) << PIO_SCDR_DIV_Pos)              /**< (PIO_SCDR) Slow Clock Divider Selection for Debouncing Mask */
+#define PIO_SCDR_DIV(value)                 (PIO_SCDR_DIV_Msk & ((value) << PIO_SCDR_DIV_Pos))
+#define PIO_SCDR_MASK                       _U_(0x3FFF)                                    /**< \deprecated (PIO_SCDR) Register MASK  (Use PIO_SCDR_Msk instead)  */
+#define PIO_SCDR_Msk                        _U_(0x3FFF)                                    /**< (PIO_SCDR) Register Mask  */
+
+
+/* -------- PIO_PPDDR : (PIO Offset: 0x90) (/W 32) Pad Pull-down Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Disable                        */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Disable                        */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Disable                        */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Disable                        */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Disable                        */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Disable                        */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Disable                        */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Disable                        */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Disable                        */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Disable                        */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Disable                        */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Disable                        */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Disable                        */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Disable                        */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Disable                        */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Disable                        */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Disable                        */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Disable                        */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Disable                        */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Disable                        */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Disable                        */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Disable                        */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Disable                        */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Disable                        */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Disable                        */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Disable                        */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Disable                        */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Disable                        */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Disable                        */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Disable                        */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Disable                        */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Disable                        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Disable                        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDDR_OFFSET                    (0x90)                                        /**<  (PIO_PPDDR) Pad Pull-down Disable Register  Offset */
+
+#define PIO_PPDDR_P0_Pos                    0                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P0_Msk                    (_U_(0x1) << PIO_PPDDR_P0_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P0                        PIO_PPDDR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P0_Msk instead */
+#define PIO_PPDDR_P1_Pos                    1                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P1_Msk                    (_U_(0x1) << PIO_PPDDR_P1_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P1                        PIO_PPDDR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P1_Msk instead */
+#define PIO_PPDDR_P2_Pos                    2                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P2_Msk                    (_U_(0x1) << PIO_PPDDR_P2_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P2                        PIO_PPDDR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P2_Msk instead */
+#define PIO_PPDDR_P3_Pos                    3                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P3_Msk                    (_U_(0x1) << PIO_PPDDR_P3_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P3                        PIO_PPDDR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P3_Msk instead */
+#define PIO_PPDDR_P4_Pos                    4                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P4_Msk                    (_U_(0x1) << PIO_PPDDR_P4_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P4                        PIO_PPDDR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P4_Msk instead */
+#define PIO_PPDDR_P5_Pos                    5                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P5_Msk                    (_U_(0x1) << PIO_PPDDR_P5_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P5                        PIO_PPDDR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P5_Msk instead */
+#define PIO_PPDDR_P6_Pos                    6                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P6_Msk                    (_U_(0x1) << PIO_PPDDR_P6_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P6                        PIO_PPDDR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P6_Msk instead */
+#define PIO_PPDDR_P7_Pos                    7                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P7_Msk                    (_U_(0x1) << PIO_PPDDR_P7_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P7                        PIO_PPDDR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P7_Msk instead */
+#define PIO_PPDDR_P8_Pos                    8                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P8_Msk                    (_U_(0x1) << PIO_PPDDR_P8_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P8                        PIO_PPDDR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P8_Msk instead */
+#define PIO_PPDDR_P9_Pos                    9                                              /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P9_Msk                    (_U_(0x1) << PIO_PPDDR_P9_Pos)                 /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P9                        PIO_PPDDR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P9_Msk instead */
+#define PIO_PPDDR_P10_Pos                   10                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P10_Msk                   (_U_(0x1) << PIO_PPDDR_P10_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P10                       PIO_PPDDR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P10_Msk instead */
+#define PIO_PPDDR_P11_Pos                   11                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P11_Msk                   (_U_(0x1) << PIO_PPDDR_P11_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P11                       PIO_PPDDR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P11_Msk instead */
+#define PIO_PPDDR_P12_Pos                   12                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P12_Msk                   (_U_(0x1) << PIO_PPDDR_P12_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P12                       PIO_PPDDR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P12_Msk instead */
+#define PIO_PPDDR_P13_Pos                   13                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P13_Msk                   (_U_(0x1) << PIO_PPDDR_P13_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P13                       PIO_PPDDR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P13_Msk instead */
+#define PIO_PPDDR_P14_Pos                   14                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P14_Msk                   (_U_(0x1) << PIO_PPDDR_P14_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P14                       PIO_PPDDR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P14_Msk instead */
+#define PIO_PPDDR_P15_Pos                   15                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P15_Msk                   (_U_(0x1) << PIO_PPDDR_P15_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P15                       PIO_PPDDR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P15_Msk instead */
+#define PIO_PPDDR_P16_Pos                   16                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P16_Msk                   (_U_(0x1) << PIO_PPDDR_P16_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P16                       PIO_PPDDR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P16_Msk instead */
+#define PIO_PPDDR_P17_Pos                   17                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P17_Msk                   (_U_(0x1) << PIO_PPDDR_P17_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P17                       PIO_PPDDR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P17_Msk instead */
+#define PIO_PPDDR_P18_Pos                   18                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P18_Msk                   (_U_(0x1) << PIO_PPDDR_P18_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P18                       PIO_PPDDR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P18_Msk instead */
+#define PIO_PPDDR_P19_Pos                   19                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P19_Msk                   (_U_(0x1) << PIO_PPDDR_P19_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P19                       PIO_PPDDR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P19_Msk instead */
+#define PIO_PPDDR_P20_Pos                   20                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P20_Msk                   (_U_(0x1) << PIO_PPDDR_P20_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P20                       PIO_PPDDR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P20_Msk instead */
+#define PIO_PPDDR_P21_Pos                   21                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P21_Msk                   (_U_(0x1) << PIO_PPDDR_P21_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P21                       PIO_PPDDR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P21_Msk instead */
+#define PIO_PPDDR_P22_Pos                   22                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P22_Msk                   (_U_(0x1) << PIO_PPDDR_P22_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P22                       PIO_PPDDR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P22_Msk instead */
+#define PIO_PPDDR_P23_Pos                   23                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P23_Msk                   (_U_(0x1) << PIO_PPDDR_P23_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P23                       PIO_PPDDR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P23_Msk instead */
+#define PIO_PPDDR_P24_Pos                   24                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P24_Msk                   (_U_(0x1) << PIO_PPDDR_P24_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P24                       PIO_PPDDR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P24_Msk instead */
+#define PIO_PPDDR_P25_Pos                   25                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P25_Msk                   (_U_(0x1) << PIO_PPDDR_P25_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P25                       PIO_PPDDR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P25_Msk instead */
+#define PIO_PPDDR_P26_Pos                   26                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P26_Msk                   (_U_(0x1) << PIO_PPDDR_P26_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P26                       PIO_PPDDR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P26_Msk instead */
+#define PIO_PPDDR_P27_Pos                   27                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P27_Msk                   (_U_(0x1) << PIO_PPDDR_P27_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P27                       PIO_PPDDR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P27_Msk instead */
+#define PIO_PPDDR_P28_Pos                   28                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P28_Msk                   (_U_(0x1) << PIO_PPDDR_P28_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P28                       PIO_PPDDR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P28_Msk instead */
+#define PIO_PPDDR_P29_Pos                   29                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P29_Msk                   (_U_(0x1) << PIO_PPDDR_P29_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P29                       PIO_PPDDR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P29_Msk instead */
+#define PIO_PPDDR_P30_Pos                   30                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P30_Msk                   (_U_(0x1) << PIO_PPDDR_P30_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P30                       PIO_PPDDR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P30_Msk instead */
+#define PIO_PPDDR_P31_Pos                   31                                             /**< (PIO_PPDDR) Pull-Down Disable Position */
+#define PIO_PPDDR_P31_Msk                   (_U_(0x1) << PIO_PPDDR_P31_Pos)                /**< (PIO_PPDDR) Pull-Down Disable Mask */
+#define PIO_PPDDR_P31                       PIO_PPDDR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDDR_P31_Msk instead */
+#define PIO_PPDDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDDR) Register MASK  (Use PIO_PPDDR_Msk instead)  */
+#define PIO_PPDDR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDDR) Register Mask  */
+
+#define PIO_PPDDR_P_Pos                     0                                              /**< (PIO_PPDDR Position) Pull-Down Disable */
+#define PIO_PPDDR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDDR_P_Pos)           /**< (PIO_PPDDR Mask) P */
+#define PIO_PPDDR_P(value)                  (PIO_PPDDR_P_Msk & ((value) << PIO_PPDDR_P_Pos))  
+
+/* -------- PIO_PPDER : (PIO Offset: 0x94) (/W 32) Pad Pull-down Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Enable                         */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Enable                         */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Enable                         */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Enable                         */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Enable                         */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Enable                         */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Enable                         */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Enable                         */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Enable                         */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Enable                         */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Enable                         */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Enable                         */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Enable                         */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Enable                         */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Enable                         */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Enable                         */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Enable                         */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Enable                         */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Enable                         */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Enable                         */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Enable                         */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Enable                         */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Enable                         */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Enable                         */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Enable                         */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Enable                         */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Enable                         */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Enable                         */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Enable                         */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Enable                         */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Enable                         */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Enable                         */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Enable                         */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDER_OFFSET                    (0x94)                                        /**<  (PIO_PPDER) Pad Pull-down Enable Register  Offset */
+
+#define PIO_PPDER_P0_Pos                    0                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P0_Msk                    (_U_(0x1) << PIO_PPDER_P0_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P0                        PIO_PPDER_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P0_Msk instead */
+#define PIO_PPDER_P1_Pos                    1                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P1_Msk                    (_U_(0x1) << PIO_PPDER_P1_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P1                        PIO_PPDER_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P1_Msk instead */
+#define PIO_PPDER_P2_Pos                    2                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P2_Msk                    (_U_(0x1) << PIO_PPDER_P2_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P2                        PIO_PPDER_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P2_Msk instead */
+#define PIO_PPDER_P3_Pos                    3                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P3_Msk                    (_U_(0x1) << PIO_PPDER_P3_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P3                        PIO_PPDER_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P3_Msk instead */
+#define PIO_PPDER_P4_Pos                    4                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P4_Msk                    (_U_(0x1) << PIO_PPDER_P4_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P4                        PIO_PPDER_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P4_Msk instead */
+#define PIO_PPDER_P5_Pos                    5                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P5_Msk                    (_U_(0x1) << PIO_PPDER_P5_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P5                        PIO_PPDER_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P5_Msk instead */
+#define PIO_PPDER_P6_Pos                    6                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P6_Msk                    (_U_(0x1) << PIO_PPDER_P6_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P6                        PIO_PPDER_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P6_Msk instead */
+#define PIO_PPDER_P7_Pos                    7                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P7_Msk                    (_U_(0x1) << PIO_PPDER_P7_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P7                        PIO_PPDER_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P7_Msk instead */
+#define PIO_PPDER_P8_Pos                    8                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P8_Msk                    (_U_(0x1) << PIO_PPDER_P8_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P8                        PIO_PPDER_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P8_Msk instead */
+#define PIO_PPDER_P9_Pos                    9                                              /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P9_Msk                    (_U_(0x1) << PIO_PPDER_P9_Pos)                 /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P9                        PIO_PPDER_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P9_Msk instead */
+#define PIO_PPDER_P10_Pos                   10                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P10_Msk                   (_U_(0x1) << PIO_PPDER_P10_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P10                       PIO_PPDER_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P10_Msk instead */
+#define PIO_PPDER_P11_Pos                   11                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P11_Msk                   (_U_(0x1) << PIO_PPDER_P11_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P11                       PIO_PPDER_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P11_Msk instead */
+#define PIO_PPDER_P12_Pos                   12                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P12_Msk                   (_U_(0x1) << PIO_PPDER_P12_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P12                       PIO_PPDER_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P12_Msk instead */
+#define PIO_PPDER_P13_Pos                   13                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P13_Msk                   (_U_(0x1) << PIO_PPDER_P13_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P13                       PIO_PPDER_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P13_Msk instead */
+#define PIO_PPDER_P14_Pos                   14                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P14_Msk                   (_U_(0x1) << PIO_PPDER_P14_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P14                       PIO_PPDER_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P14_Msk instead */
+#define PIO_PPDER_P15_Pos                   15                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P15_Msk                   (_U_(0x1) << PIO_PPDER_P15_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P15                       PIO_PPDER_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P15_Msk instead */
+#define PIO_PPDER_P16_Pos                   16                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P16_Msk                   (_U_(0x1) << PIO_PPDER_P16_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P16                       PIO_PPDER_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P16_Msk instead */
+#define PIO_PPDER_P17_Pos                   17                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P17_Msk                   (_U_(0x1) << PIO_PPDER_P17_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P17                       PIO_PPDER_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P17_Msk instead */
+#define PIO_PPDER_P18_Pos                   18                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P18_Msk                   (_U_(0x1) << PIO_PPDER_P18_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P18                       PIO_PPDER_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P18_Msk instead */
+#define PIO_PPDER_P19_Pos                   19                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P19_Msk                   (_U_(0x1) << PIO_PPDER_P19_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P19                       PIO_PPDER_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P19_Msk instead */
+#define PIO_PPDER_P20_Pos                   20                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P20_Msk                   (_U_(0x1) << PIO_PPDER_P20_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P20                       PIO_PPDER_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P20_Msk instead */
+#define PIO_PPDER_P21_Pos                   21                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P21_Msk                   (_U_(0x1) << PIO_PPDER_P21_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P21                       PIO_PPDER_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P21_Msk instead */
+#define PIO_PPDER_P22_Pos                   22                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P22_Msk                   (_U_(0x1) << PIO_PPDER_P22_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P22                       PIO_PPDER_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P22_Msk instead */
+#define PIO_PPDER_P23_Pos                   23                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P23_Msk                   (_U_(0x1) << PIO_PPDER_P23_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P23                       PIO_PPDER_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P23_Msk instead */
+#define PIO_PPDER_P24_Pos                   24                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P24_Msk                   (_U_(0x1) << PIO_PPDER_P24_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P24                       PIO_PPDER_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P24_Msk instead */
+#define PIO_PPDER_P25_Pos                   25                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P25_Msk                   (_U_(0x1) << PIO_PPDER_P25_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P25                       PIO_PPDER_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P25_Msk instead */
+#define PIO_PPDER_P26_Pos                   26                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P26_Msk                   (_U_(0x1) << PIO_PPDER_P26_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P26                       PIO_PPDER_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P26_Msk instead */
+#define PIO_PPDER_P27_Pos                   27                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P27_Msk                   (_U_(0x1) << PIO_PPDER_P27_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P27                       PIO_PPDER_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P27_Msk instead */
+#define PIO_PPDER_P28_Pos                   28                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P28_Msk                   (_U_(0x1) << PIO_PPDER_P28_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P28                       PIO_PPDER_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P28_Msk instead */
+#define PIO_PPDER_P29_Pos                   29                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P29_Msk                   (_U_(0x1) << PIO_PPDER_P29_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P29                       PIO_PPDER_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P29_Msk instead */
+#define PIO_PPDER_P30_Pos                   30                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P30_Msk                   (_U_(0x1) << PIO_PPDER_P30_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P30                       PIO_PPDER_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P30_Msk instead */
+#define PIO_PPDER_P31_Pos                   31                                             /**< (PIO_PPDER) Pull-Down Enable Position */
+#define PIO_PPDER_P31_Msk                   (_U_(0x1) << PIO_PPDER_P31_Pos)                /**< (PIO_PPDER) Pull-Down Enable Mask */
+#define PIO_PPDER_P31                       PIO_PPDER_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDER_P31_Msk instead */
+#define PIO_PPDER_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDER) Register MASK  (Use PIO_PPDER_Msk instead)  */
+#define PIO_PPDER_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDER) Register Mask  */
+
+#define PIO_PPDER_P_Pos                     0                                              /**< (PIO_PPDER Position) Pull-Down Enable */
+#define PIO_PPDER_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDER_P_Pos)           /**< (PIO_PPDER Mask) P */
+#define PIO_PPDER_P(value)                  (PIO_PPDER_P_Msk & ((value) << PIO_PPDER_P_Pos))  
+
+/* -------- PIO_PPDSR : (PIO Offset: 0x98) (R/ 32) Pad Pull-down Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Pull-Down Status                         */
+    uint32_t P1:1;                      /**< bit:      1  Pull-Down Status                         */
+    uint32_t P2:1;                      /**< bit:      2  Pull-Down Status                         */
+    uint32_t P3:1;                      /**< bit:      3  Pull-Down Status                         */
+    uint32_t P4:1;                      /**< bit:      4  Pull-Down Status                         */
+    uint32_t P5:1;                      /**< bit:      5  Pull-Down Status                         */
+    uint32_t P6:1;                      /**< bit:      6  Pull-Down Status                         */
+    uint32_t P7:1;                      /**< bit:      7  Pull-Down Status                         */
+    uint32_t P8:1;                      /**< bit:      8  Pull-Down Status                         */
+    uint32_t P9:1;                      /**< bit:      9  Pull-Down Status                         */
+    uint32_t P10:1;                     /**< bit:     10  Pull-Down Status                         */
+    uint32_t P11:1;                     /**< bit:     11  Pull-Down Status                         */
+    uint32_t P12:1;                     /**< bit:     12  Pull-Down Status                         */
+    uint32_t P13:1;                     /**< bit:     13  Pull-Down Status                         */
+    uint32_t P14:1;                     /**< bit:     14  Pull-Down Status                         */
+    uint32_t P15:1;                     /**< bit:     15  Pull-Down Status                         */
+    uint32_t P16:1;                     /**< bit:     16  Pull-Down Status                         */
+    uint32_t P17:1;                     /**< bit:     17  Pull-Down Status                         */
+    uint32_t P18:1;                     /**< bit:     18  Pull-Down Status                         */
+    uint32_t P19:1;                     /**< bit:     19  Pull-Down Status                         */
+    uint32_t P20:1;                     /**< bit:     20  Pull-Down Status                         */
+    uint32_t P21:1;                     /**< bit:     21  Pull-Down Status                         */
+    uint32_t P22:1;                     /**< bit:     22  Pull-Down Status                         */
+    uint32_t P23:1;                     /**< bit:     23  Pull-Down Status                         */
+    uint32_t P24:1;                     /**< bit:     24  Pull-Down Status                         */
+    uint32_t P25:1;                     /**< bit:     25  Pull-Down Status                         */
+    uint32_t P26:1;                     /**< bit:     26  Pull-Down Status                         */
+    uint32_t P27:1;                     /**< bit:     27  Pull-Down Status                         */
+    uint32_t P28:1;                     /**< bit:     28  Pull-Down Status                         */
+    uint32_t P29:1;                     /**< bit:     29  Pull-Down Status                         */
+    uint32_t P30:1;                     /**< bit:     30  Pull-Down Status                         */
+    uint32_t P31:1;                     /**< bit:     31  Pull-Down Status                         */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Pull-Down Status                         */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PPDSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PPDSR_OFFSET                    (0x98)                                        /**<  (PIO_PPDSR) Pad Pull-down Status Register  Offset */
+
+#define PIO_PPDSR_P0_Pos                    0                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P0_Msk                    (_U_(0x1) << PIO_PPDSR_P0_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P0                        PIO_PPDSR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P0_Msk instead */
+#define PIO_PPDSR_P1_Pos                    1                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P1_Msk                    (_U_(0x1) << PIO_PPDSR_P1_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P1                        PIO_PPDSR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P1_Msk instead */
+#define PIO_PPDSR_P2_Pos                    2                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P2_Msk                    (_U_(0x1) << PIO_PPDSR_P2_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P2                        PIO_PPDSR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P2_Msk instead */
+#define PIO_PPDSR_P3_Pos                    3                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P3_Msk                    (_U_(0x1) << PIO_PPDSR_P3_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P3                        PIO_PPDSR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P3_Msk instead */
+#define PIO_PPDSR_P4_Pos                    4                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P4_Msk                    (_U_(0x1) << PIO_PPDSR_P4_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P4                        PIO_PPDSR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P4_Msk instead */
+#define PIO_PPDSR_P5_Pos                    5                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P5_Msk                    (_U_(0x1) << PIO_PPDSR_P5_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P5                        PIO_PPDSR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P5_Msk instead */
+#define PIO_PPDSR_P6_Pos                    6                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P6_Msk                    (_U_(0x1) << PIO_PPDSR_P6_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P6                        PIO_PPDSR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P6_Msk instead */
+#define PIO_PPDSR_P7_Pos                    7                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P7_Msk                    (_U_(0x1) << PIO_PPDSR_P7_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P7                        PIO_PPDSR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P7_Msk instead */
+#define PIO_PPDSR_P8_Pos                    8                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P8_Msk                    (_U_(0x1) << PIO_PPDSR_P8_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P8                        PIO_PPDSR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P8_Msk instead */
+#define PIO_PPDSR_P9_Pos                    9                                              /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P9_Msk                    (_U_(0x1) << PIO_PPDSR_P9_Pos)                 /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P9                        PIO_PPDSR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P9_Msk instead */
+#define PIO_PPDSR_P10_Pos                   10                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P10_Msk                   (_U_(0x1) << PIO_PPDSR_P10_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P10                       PIO_PPDSR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P10_Msk instead */
+#define PIO_PPDSR_P11_Pos                   11                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P11_Msk                   (_U_(0x1) << PIO_PPDSR_P11_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P11                       PIO_PPDSR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P11_Msk instead */
+#define PIO_PPDSR_P12_Pos                   12                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P12_Msk                   (_U_(0x1) << PIO_PPDSR_P12_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P12                       PIO_PPDSR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P12_Msk instead */
+#define PIO_PPDSR_P13_Pos                   13                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P13_Msk                   (_U_(0x1) << PIO_PPDSR_P13_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P13                       PIO_PPDSR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P13_Msk instead */
+#define PIO_PPDSR_P14_Pos                   14                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P14_Msk                   (_U_(0x1) << PIO_PPDSR_P14_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P14                       PIO_PPDSR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P14_Msk instead */
+#define PIO_PPDSR_P15_Pos                   15                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P15_Msk                   (_U_(0x1) << PIO_PPDSR_P15_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P15                       PIO_PPDSR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P15_Msk instead */
+#define PIO_PPDSR_P16_Pos                   16                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P16_Msk                   (_U_(0x1) << PIO_PPDSR_P16_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P16                       PIO_PPDSR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P16_Msk instead */
+#define PIO_PPDSR_P17_Pos                   17                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P17_Msk                   (_U_(0x1) << PIO_PPDSR_P17_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P17                       PIO_PPDSR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P17_Msk instead */
+#define PIO_PPDSR_P18_Pos                   18                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P18_Msk                   (_U_(0x1) << PIO_PPDSR_P18_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P18                       PIO_PPDSR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P18_Msk instead */
+#define PIO_PPDSR_P19_Pos                   19                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P19_Msk                   (_U_(0x1) << PIO_PPDSR_P19_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P19                       PIO_PPDSR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P19_Msk instead */
+#define PIO_PPDSR_P20_Pos                   20                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P20_Msk                   (_U_(0x1) << PIO_PPDSR_P20_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P20                       PIO_PPDSR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P20_Msk instead */
+#define PIO_PPDSR_P21_Pos                   21                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P21_Msk                   (_U_(0x1) << PIO_PPDSR_P21_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P21                       PIO_PPDSR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P21_Msk instead */
+#define PIO_PPDSR_P22_Pos                   22                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P22_Msk                   (_U_(0x1) << PIO_PPDSR_P22_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P22                       PIO_PPDSR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P22_Msk instead */
+#define PIO_PPDSR_P23_Pos                   23                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P23_Msk                   (_U_(0x1) << PIO_PPDSR_P23_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P23                       PIO_PPDSR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P23_Msk instead */
+#define PIO_PPDSR_P24_Pos                   24                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P24_Msk                   (_U_(0x1) << PIO_PPDSR_P24_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P24                       PIO_PPDSR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P24_Msk instead */
+#define PIO_PPDSR_P25_Pos                   25                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P25_Msk                   (_U_(0x1) << PIO_PPDSR_P25_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P25                       PIO_PPDSR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P25_Msk instead */
+#define PIO_PPDSR_P26_Pos                   26                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P26_Msk                   (_U_(0x1) << PIO_PPDSR_P26_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P26                       PIO_PPDSR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P26_Msk instead */
+#define PIO_PPDSR_P27_Pos                   27                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P27_Msk                   (_U_(0x1) << PIO_PPDSR_P27_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P27                       PIO_PPDSR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P27_Msk instead */
+#define PIO_PPDSR_P28_Pos                   28                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P28_Msk                   (_U_(0x1) << PIO_PPDSR_P28_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P28                       PIO_PPDSR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P28_Msk instead */
+#define PIO_PPDSR_P29_Pos                   29                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P29_Msk                   (_U_(0x1) << PIO_PPDSR_P29_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P29                       PIO_PPDSR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P29_Msk instead */
+#define PIO_PPDSR_P30_Pos                   30                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P30_Msk                   (_U_(0x1) << PIO_PPDSR_P30_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P30                       PIO_PPDSR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P30_Msk instead */
+#define PIO_PPDSR_P31_Pos                   31                                             /**< (PIO_PPDSR) Pull-Down Status Position */
+#define PIO_PPDSR_P31_Msk                   (_U_(0x1) << PIO_PPDSR_P31_Pos)                /**< (PIO_PPDSR) Pull-Down Status Mask */
+#define PIO_PPDSR_P31                       PIO_PPDSR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PPDSR_P31_Msk instead */
+#define PIO_PPDSR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PPDSR) Register MASK  (Use PIO_PPDSR_Msk instead)  */
+#define PIO_PPDSR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PPDSR) Register Mask  */
+
+#define PIO_PPDSR_P_Pos                     0                                              /**< (PIO_PPDSR Position) Pull-Down Status */
+#define PIO_PPDSR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_PPDSR_P_Pos)           /**< (PIO_PPDSR Mask) P */
+#define PIO_PPDSR_P(value)                  (PIO_PPDSR_P_Msk & ((value) << PIO_PPDSR_P_Pos))  
+
+/* -------- PIO_OWER : (PIO Offset: 0xa0) (/W 32) Output Write Enable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Enable                      */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Enable                      */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Enable                      */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Enable                      */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Enable                      */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Enable                      */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Enable                      */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Enable                      */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Enable                      */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Enable                      */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Enable                      */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Enable                      */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Enable                      */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Enable                      */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Enable                      */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Enable                      */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Enable                      */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Enable                      */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Enable                      */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Enable                      */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Enable                      */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Enable                      */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Enable                      */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Enable                      */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Enable                      */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Enable                      */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Enable                      */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Enable                      */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Enable                      */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Enable                      */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Enable                      */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Enable                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Enable                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWER_OFFSET                     (0xA0)                                        /**<  (PIO_OWER) Output Write Enable  Offset */
+
+#define PIO_OWER_P0_Pos                     0                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P0_Msk                     (_U_(0x1) << PIO_OWER_P0_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P0                         PIO_OWER_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P0_Msk instead */
+#define PIO_OWER_P1_Pos                     1                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P1_Msk                     (_U_(0x1) << PIO_OWER_P1_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P1                         PIO_OWER_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P1_Msk instead */
+#define PIO_OWER_P2_Pos                     2                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P2_Msk                     (_U_(0x1) << PIO_OWER_P2_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P2                         PIO_OWER_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P2_Msk instead */
+#define PIO_OWER_P3_Pos                     3                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P3_Msk                     (_U_(0x1) << PIO_OWER_P3_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P3                         PIO_OWER_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P3_Msk instead */
+#define PIO_OWER_P4_Pos                     4                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P4_Msk                     (_U_(0x1) << PIO_OWER_P4_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P4                         PIO_OWER_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P4_Msk instead */
+#define PIO_OWER_P5_Pos                     5                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P5_Msk                     (_U_(0x1) << PIO_OWER_P5_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P5                         PIO_OWER_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P5_Msk instead */
+#define PIO_OWER_P6_Pos                     6                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P6_Msk                     (_U_(0x1) << PIO_OWER_P6_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P6                         PIO_OWER_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P6_Msk instead */
+#define PIO_OWER_P7_Pos                     7                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P7_Msk                     (_U_(0x1) << PIO_OWER_P7_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P7                         PIO_OWER_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P7_Msk instead */
+#define PIO_OWER_P8_Pos                     8                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P8_Msk                     (_U_(0x1) << PIO_OWER_P8_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P8                         PIO_OWER_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P8_Msk instead */
+#define PIO_OWER_P9_Pos                     9                                              /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P9_Msk                     (_U_(0x1) << PIO_OWER_P9_Pos)                  /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P9                         PIO_OWER_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P9_Msk instead */
+#define PIO_OWER_P10_Pos                    10                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P10_Msk                    (_U_(0x1) << PIO_OWER_P10_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P10                        PIO_OWER_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P10_Msk instead */
+#define PIO_OWER_P11_Pos                    11                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P11_Msk                    (_U_(0x1) << PIO_OWER_P11_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P11                        PIO_OWER_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P11_Msk instead */
+#define PIO_OWER_P12_Pos                    12                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P12_Msk                    (_U_(0x1) << PIO_OWER_P12_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P12                        PIO_OWER_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P12_Msk instead */
+#define PIO_OWER_P13_Pos                    13                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P13_Msk                    (_U_(0x1) << PIO_OWER_P13_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P13                        PIO_OWER_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P13_Msk instead */
+#define PIO_OWER_P14_Pos                    14                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P14_Msk                    (_U_(0x1) << PIO_OWER_P14_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P14                        PIO_OWER_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P14_Msk instead */
+#define PIO_OWER_P15_Pos                    15                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P15_Msk                    (_U_(0x1) << PIO_OWER_P15_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P15                        PIO_OWER_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P15_Msk instead */
+#define PIO_OWER_P16_Pos                    16                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P16_Msk                    (_U_(0x1) << PIO_OWER_P16_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P16                        PIO_OWER_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P16_Msk instead */
+#define PIO_OWER_P17_Pos                    17                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P17_Msk                    (_U_(0x1) << PIO_OWER_P17_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P17                        PIO_OWER_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P17_Msk instead */
+#define PIO_OWER_P18_Pos                    18                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P18_Msk                    (_U_(0x1) << PIO_OWER_P18_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P18                        PIO_OWER_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P18_Msk instead */
+#define PIO_OWER_P19_Pos                    19                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P19_Msk                    (_U_(0x1) << PIO_OWER_P19_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P19                        PIO_OWER_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P19_Msk instead */
+#define PIO_OWER_P20_Pos                    20                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P20_Msk                    (_U_(0x1) << PIO_OWER_P20_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P20                        PIO_OWER_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P20_Msk instead */
+#define PIO_OWER_P21_Pos                    21                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P21_Msk                    (_U_(0x1) << PIO_OWER_P21_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P21                        PIO_OWER_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P21_Msk instead */
+#define PIO_OWER_P22_Pos                    22                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P22_Msk                    (_U_(0x1) << PIO_OWER_P22_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P22                        PIO_OWER_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P22_Msk instead */
+#define PIO_OWER_P23_Pos                    23                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P23_Msk                    (_U_(0x1) << PIO_OWER_P23_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P23                        PIO_OWER_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P23_Msk instead */
+#define PIO_OWER_P24_Pos                    24                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P24_Msk                    (_U_(0x1) << PIO_OWER_P24_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P24                        PIO_OWER_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P24_Msk instead */
+#define PIO_OWER_P25_Pos                    25                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P25_Msk                    (_U_(0x1) << PIO_OWER_P25_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P25                        PIO_OWER_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P25_Msk instead */
+#define PIO_OWER_P26_Pos                    26                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P26_Msk                    (_U_(0x1) << PIO_OWER_P26_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P26                        PIO_OWER_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P26_Msk instead */
+#define PIO_OWER_P27_Pos                    27                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P27_Msk                    (_U_(0x1) << PIO_OWER_P27_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P27                        PIO_OWER_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P27_Msk instead */
+#define PIO_OWER_P28_Pos                    28                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P28_Msk                    (_U_(0x1) << PIO_OWER_P28_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P28                        PIO_OWER_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P28_Msk instead */
+#define PIO_OWER_P29_Pos                    29                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P29_Msk                    (_U_(0x1) << PIO_OWER_P29_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P29                        PIO_OWER_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P29_Msk instead */
+#define PIO_OWER_P30_Pos                    30                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P30_Msk                    (_U_(0x1) << PIO_OWER_P30_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P30                        PIO_OWER_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P30_Msk instead */
+#define PIO_OWER_P31_Pos                    31                                             /**< (PIO_OWER) Output Write Enable Position */
+#define PIO_OWER_P31_Msk                    (_U_(0x1) << PIO_OWER_P31_Pos)                 /**< (PIO_OWER) Output Write Enable Mask */
+#define PIO_OWER_P31                        PIO_OWER_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWER_P31_Msk instead */
+#define PIO_OWER_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWER) Register MASK  (Use PIO_OWER_Msk instead)  */
+#define PIO_OWER_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWER) Register Mask  */
+
+#define PIO_OWER_P_Pos                      0                                              /**< (PIO_OWER Position) Output Write Enable */
+#define PIO_OWER_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWER_P_Pos)            /**< (PIO_OWER Mask) P */
+#define PIO_OWER_P(value)                   (PIO_OWER_P_Msk & ((value) << PIO_OWER_P_Pos))  
+
+/* -------- PIO_OWDR : (PIO Offset: 0xa4) (/W 32) Output Write Disable -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Disable                     */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Disable                     */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Disable                     */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Disable                     */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Disable                     */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Disable                     */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Disable                     */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Disable                     */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Disable                     */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Disable                     */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Disable                     */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Disable                     */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Disable                     */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Disable                     */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Disable                     */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Disable                     */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Disable                     */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Disable                     */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Disable                     */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Disable                     */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Disable                     */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Disable                     */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Disable                     */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Disable                     */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Disable                     */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Disable                     */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Disable                     */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Disable                     */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Disable                     */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Disable                     */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Disable                     */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Disable                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Disable                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWDR_OFFSET                     (0xA4)                                        /**<  (PIO_OWDR) Output Write Disable  Offset */
+
+#define PIO_OWDR_P0_Pos                     0                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P0_Msk                     (_U_(0x1) << PIO_OWDR_P0_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P0                         PIO_OWDR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P0_Msk instead */
+#define PIO_OWDR_P1_Pos                     1                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P1_Msk                     (_U_(0x1) << PIO_OWDR_P1_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P1                         PIO_OWDR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P1_Msk instead */
+#define PIO_OWDR_P2_Pos                     2                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P2_Msk                     (_U_(0x1) << PIO_OWDR_P2_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P2                         PIO_OWDR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P2_Msk instead */
+#define PIO_OWDR_P3_Pos                     3                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P3_Msk                     (_U_(0x1) << PIO_OWDR_P3_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P3                         PIO_OWDR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P3_Msk instead */
+#define PIO_OWDR_P4_Pos                     4                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P4_Msk                     (_U_(0x1) << PIO_OWDR_P4_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P4                         PIO_OWDR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P4_Msk instead */
+#define PIO_OWDR_P5_Pos                     5                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P5_Msk                     (_U_(0x1) << PIO_OWDR_P5_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P5                         PIO_OWDR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P5_Msk instead */
+#define PIO_OWDR_P6_Pos                     6                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P6_Msk                     (_U_(0x1) << PIO_OWDR_P6_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P6                         PIO_OWDR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P6_Msk instead */
+#define PIO_OWDR_P7_Pos                     7                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P7_Msk                     (_U_(0x1) << PIO_OWDR_P7_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P7                         PIO_OWDR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P7_Msk instead */
+#define PIO_OWDR_P8_Pos                     8                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P8_Msk                     (_U_(0x1) << PIO_OWDR_P8_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P8                         PIO_OWDR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P8_Msk instead */
+#define PIO_OWDR_P9_Pos                     9                                              /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P9_Msk                     (_U_(0x1) << PIO_OWDR_P9_Pos)                  /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P9                         PIO_OWDR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P9_Msk instead */
+#define PIO_OWDR_P10_Pos                    10                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P10_Msk                    (_U_(0x1) << PIO_OWDR_P10_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P10                        PIO_OWDR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P10_Msk instead */
+#define PIO_OWDR_P11_Pos                    11                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P11_Msk                    (_U_(0x1) << PIO_OWDR_P11_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P11                        PIO_OWDR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P11_Msk instead */
+#define PIO_OWDR_P12_Pos                    12                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P12_Msk                    (_U_(0x1) << PIO_OWDR_P12_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P12                        PIO_OWDR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P12_Msk instead */
+#define PIO_OWDR_P13_Pos                    13                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P13_Msk                    (_U_(0x1) << PIO_OWDR_P13_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P13                        PIO_OWDR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P13_Msk instead */
+#define PIO_OWDR_P14_Pos                    14                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P14_Msk                    (_U_(0x1) << PIO_OWDR_P14_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P14                        PIO_OWDR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P14_Msk instead */
+#define PIO_OWDR_P15_Pos                    15                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P15_Msk                    (_U_(0x1) << PIO_OWDR_P15_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P15                        PIO_OWDR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P15_Msk instead */
+#define PIO_OWDR_P16_Pos                    16                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P16_Msk                    (_U_(0x1) << PIO_OWDR_P16_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P16                        PIO_OWDR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P16_Msk instead */
+#define PIO_OWDR_P17_Pos                    17                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P17_Msk                    (_U_(0x1) << PIO_OWDR_P17_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P17                        PIO_OWDR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P17_Msk instead */
+#define PIO_OWDR_P18_Pos                    18                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P18_Msk                    (_U_(0x1) << PIO_OWDR_P18_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P18                        PIO_OWDR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P18_Msk instead */
+#define PIO_OWDR_P19_Pos                    19                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P19_Msk                    (_U_(0x1) << PIO_OWDR_P19_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P19                        PIO_OWDR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P19_Msk instead */
+#define PIO_OWDR_P20_Pos                    20                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P20_Msk                    (_U_(0x1) << PIO_OWDR_P20_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P20                        PIO_OWDR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P20_Msk instead */
+#define PIO_OWDR_P21_Pos                    21                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P21_Msk                    (_U_(0x1) << PIO_OWDR_P21_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P21                        PIO_OWDR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P21_Msk instead */
+#define PIO_OWDR_P22_Pos                    22                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P22_Msk                    (_U_(0x1) << PIO_OWDR_P22_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P22                        PIO_OWDR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P22_Msk instead */
+#define PIO_OWDR_P23_Pos                    23                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P23_Msk                    (_U_(0x1) << PIO_OWDR_P23_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P23                        PIO_OWDR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P23_Msk instead */
+#define PIO_OWDR_P24_Pos                    24                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P24_Msk                    (_U_(0x1) << PIO_OWDR_P24_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P24                        PIO_OWDR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P24_Msk instead */
+#define PIO_OWDR_P25_Pos                    25                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P25_Msk                    (_U_(0x1) << PIO_OWDR_P25_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P25                        PIO_OWDR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P25_Msk instead */
+#define PIO_OWDR_P26_Pos                    26                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P26_Msk                    (_U_(0x1) << PIO_OWDR_P26_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P26                        PIO_OWDR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P26_Msk instead */
+#define PIO_OWDR_P27_Pos                    27                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P27_Msk                    (_U_(0x1) << PIO_OWDR_P27_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P27                        PIO_OWDR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P27_Msk instead */
+#define PIO_OWDR_P28_Pos                    28                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P28_Msk                    (_U_(0x1) << PIO_OWDR_P28_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P28                        PIO_OWDR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P28_Msk instead */
+#define PIO_OWDR_P29_Pos                    29                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P29_Msk                    (_U_(0x1) << PIO_OWDR_P29_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P29                        PIO_OWDR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P29_Msk instead */
+#define PIO_OWDR_P30_Pos                    30                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P30_Msk                    (_U_(0x1) << PIO_OWDR_P30_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P30                        PIO_OWDR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P30_Msk instead */
+#define PIO_OWDR_P31_Pos                    31                                             /**< (PIO_OWDR) Output Write Disable Position */
+#define PIO_OWDR_P31_Msk                    (_U_(0x1) << PIO_OWDR_P31_Pos)                 /**< (PIO_OWDR) Output Write Disable Mask */
+#define PIO_OWDR_P31                        PIO_OWDR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWDR_P31_Msk instead */
+#define PIO_OWDR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWDR) Register MASK  (Use PIO_OWDR_Msk instead)  */
+#define PIO_OWDR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWDR) Register Mask  */
+
+#define PIO_OWDR_P_Pos                      0                                              /**< (PIO_OWDR Position) Output Write Disable */
+#define PIO_OWDR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWDR_P_Pos)            /**< (PIO_OWDR Mask) P */
+#define PIO_OWDR_P(value)                   (PIO_OWDR_P_Msk & ((value) << PIO_OWDR_P_Pos))  
+
+/* -------- PIO_OWSR : (PIO Offset: 0xa8) (R/ 32) Output Write Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Output Write Status                      */
+    uint32_t P1:1;                      /**< bit:      1  Output Write Status                      */
+    uint32_t P2:1;                      /**< bit:      2  Output Write Status                      */
+    uint32_t P3:1;                      /**< bit:      3  Output Write Status                      */
+    uint32_t P4:1;                      /**< bit:      4  Output Write Status                      */
+    uint32_t P5:1;                      /**< bit:      5  Output Write Status                      */
+    uint32_t P6:1;                      /**< bit:      6  Output Write Status                      */
+    uint32_t P7:1;                      /**< bit:      7  Output Write Status                      */
+    uint32_t P8:1;                      /**< bit:      8  Output Write Status                      */
+    uint32_t P9:1;                      /**< bit:      9  Output Write Status                      */
+    uint32_t P10:1;                     /**< bit:     10  Output Write Status                      */
+    uint32_t P11:1;                     /**< bit:     11  Output Write Status                      */
+    uint32_t P12:1;                     /**< bit:     12  Output Write Status                      */
+    uint32_t P13:1;                     /**< bit:     13  Output Write Status                      */
+    uint32_t P14:1;                     /**< bit:     14  Output Write Status                      */
+    uint32_t P15:1;                     /**< bit:     15  Output Write Status                      */
+    uint32_t P16:1;                     /**< bit:     16  Output Write Status                      */
+    uint32_t P17:1;                     /**< bit:     17  Output Write Status                      */
+    uint32_t P18:1;                     /**< bit:     18  Output Write Status                      */
+    uint32_t P19:1;                     /**< bit:     19  Output Write Status                      */
+    uint32_t P20:1;                     /**< bit:     20  Output Write Status                      */
+    uint32_t P21:1;                     /**< bit:     21  Output Write Status                      */
+    uint32_t P22:1;                     /**< bit:     22  Output Write Status                      */
+    uint32_t P23:1;                     /**< bit:     23  Output Write Status                      */
+    uint32_t P24:1;                     /**< bit:     24  Output Write Status                      */
+    uint32_t P25:1;                     /**< bit:     25  Output Write Status                      */
+    uint32_t P26:1;                     /**< bit:     26  Output Write Status                      */
+    uint32_t P27:1;                     /**< bit:     27  Output Write Status                      */
+    uint32_t P28:1;                     /**< bit:     28  Output Write Status                      */
+    uint32_t P29:1;                     /**< bit:     29  Output Write Status                      */
+    uint32_t P30:1;                     /**< bit:     30  Output Write Status                      */
+    uint32_t P31:1;                     /**< bit:     31  Output Write Status                      */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Output Write Status                      */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_OWSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_OWSR_OFFSET                     (0xA8)                                        /**<  (PIO_OWSR) Output Write Status Register  Offset */
+
+#define PIO_OWSR_P0_Pos                     0                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P0_Msk                     (_U_(0x1) << PIO_OWSR_P0_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P0                         PIO_OWSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P0_Msk instead */
+#define PIO_OWSR_P1_Pos                     1                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P1_Msk                     (_U_(0x1) << PIO_OWSR_P1_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P1                         PIO_OWSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P1_Msk instead */
+#define PIO_OWSR_P2_Pos                     2                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P2_Msk                     (_U_(0x1) << PIO_OWSR_P2_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P2                         PIO_OWSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P2_Msk instead */
+#define PIO_OWSR_P3_Pos                     3                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P3_Msk                     (_U_(0x1) << PIO_OWSR_P3_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P3                         PIO_OWSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P3_Msk instead */
+#define PIO_OWSR_P4_Pos                     4                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P4_Msk                     (_U_(0x1) << PIO_OWSR_P4_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P4                         PIO_OWSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P4_Msk instead */
+#define PIO_OWSR_P5_Pos                     5                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P5_Msk                     (_U_(0x1) << PIO_OWSR_P5_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P5                         PIO_OWSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P5_Msk instead */
+#define PIO_OWSR_P6_Pos                     6                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P6_Msk                     (_U_(0x1) << PIO_OWSR_P6_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P6                         PIO_OWSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P6_Msk instead */
+#define PIO_OWSR_P7_Pos                     7                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P7_Msk                     (_U_(0x1) << PIO_OWSR_P7_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P7                         PIO_OWSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P7_Msk instead */
+#define PIO_OWSR_P8_Pos                     8                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P8_Msk                     (_U_(0x1) << PIO_OWSR_P8_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P8                         PIO_OWSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P8_Msk instead */
+#define PIO_OWSR_P9_Pos                     9                                              /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P9_Msk                     (_U_(0x1) << PIO_OWSR_P9_Pos)                  /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P9                         PIO_OWSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P9_Msk instead */
+#define PIO_OWSR_P10_Pos                    10                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P10_Msk                    (_U_(0x1) << PIO_OWSR_P10_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P10                        PIO_OWSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P10_Msk instead */
+#define PIO_OWSR_P11_Pos                    11                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P11_Msk                    (_U_(0x1) << PIO_OWSR_P11_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P11                        PIO_OWSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P11_Msk instead */
+#define PIO_OWSR_P12_Pos                    12                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P12_Msk                    (_U_(0x1) << PIO_OWSR_P12_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P12                        PIO_OWSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P12_Msk instead */
+#define PIO_OWSR_P13_Pos                    13                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P13_Msk                    (_U_(0x1) << PIO_OWSR_P13_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P13                        PIO_OWSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P13_Msk instead */
+#define PIO_OWSR_P14_Pos                    14                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P14_Msk                    (_U_(0x1) << PIO_OWSR_P14_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P14                        PIO_OWSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P14_Msk instead */
+#define PIO_OWSR_P15_Pos                    15                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P15_Msk                    (_U_(0x1) << PIO_OWSR_P15_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P15                        PIO_OWSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P15_Msk instead */
+#define PIO_OWSR_P16_Pos                    16                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P16_Msk                    (_U_(0x1) << PIO_OWSR_P16_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P16                        PIO_OWSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P16_Msk instead */
+#define PIO_OWSR_P17_Pos                    17                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P17_Msk                    (_U_(0x1) << PIO_OWSR_P17_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P17                        PIO_OWSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P17_Msk instead */
+#define PIO_OWSR_P18_Pos                    18                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P18_Msk                    (_U_(0x1) << PIO_OWSR_P18_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P18                        PIO_OWSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P18_Msk instead */
+#define PIO_OWSR_P19_Pos                    19                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P19_Msk                    (_U_(0x1) << PIO_OWSR_P19_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P19                        PIO_OWSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P19_Msk instead */
+#define PIO_OWSR_P20_Pos                    20                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P20_Msk                    (_U_(0x1) << PIO_OWSR_P20_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P20                        PIO_OWSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P20_Msk instead */
+#define PIO_OWSR_P21_Pos                    21                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P21_Msk                    (_U_(0x1) << PIO_OWSR_P21_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P21                        PIO_OWSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P21_Msk instead */
+#define PIO_OWSR_P22_Pos                    22                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P22_Msk                    (_U_(0x1) << PIO_OWSR_P22_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P22                        PIO_OWSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P22_Msk instead */
+#define PIO_OWSR_P23_Pos                    23                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P23_Msk                    (_U_(0x1) << PIO_OWSR_P23_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P23                        PIO_OWSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P23_Msk instead */
+#define PIO_OWSR_P24_Pos                    24                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P24_Msk                    (_U_(0x1) << PIO_OWSR_P24_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P24                        PIO_OWSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P24_Msk instead */
+#define PIO_OWSR_P25_Pos                    25                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P25_Msk                    (_U_(0x1) << PIO_OWSR_P25_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P25                        PIO_OWSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P25_Msk instead */
+#define PIO_OWSR_P26_Pos                    26                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P26_Msk                    (_U_(0x1) << PIO_OWSR_P26_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P26                        PIO_OWSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P26_Msk instead */
+#define PIO_OWSR_P27_Pos                    27                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P27_Msk                    (_U_(0x1) << PIO_OWSR_P27_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P27                        PIO_OWSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P27_Msk instead */
+#define PIO_OWSR_P28_Pos                    28                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P28_Msk                    (_U_(0x1) << PIO_OWSR_P28_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P28                        PIO_OWSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P28_Msk instead */
+#define PIO_OWSR_P29_Pos                    29                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P29_Msk                    (_U_(0x1) << PIO_OWSR_P29_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P29                        PIO_OWSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P29_Msk instead */
+#define PIO_OWSR_P30_Pos                    30                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P30_Msk                    (_U_(0x1) << PIO_OWSR_P30_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P30                        PIO_OWSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P30_Msk instead */
+#define PIO_OWSR_P31_Pos                    31                                             /**< (PIO_OWSR) Output Write Status Position */
+#define PIO_OWSR_P31_Msk                    (_U_(0x1) << PIO_OWSR_P31_Pos)                 /**< (PIO_OWSR) Output Write Status Mask */
+#define PIO_OWSR_P31                        PIO_OWSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_OWSR_P31_Msk instead */
+#define PIO_OWSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_OWSR) Register MASK  (Use PIO_OWSR_Msk instead)  */
+#define PIO_OWSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_OWSR) Register Mask  */
+
+#define PIO_OWSR_P_Pos                      0                                              /**< (PIO_OWSR Position) Output Write Status */
+#define PIO_OWSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_OWSR_P_Pos)            /**< (PIO_OWSR Mask) P */
+#define PIO_OWSR_P(value)                   (PIO_OWSR_P_Msk & ((value) << PIO_OWSR_P_Pos))  
+
+/* -------- PIO_AIMER : (PIO Offset: 0xb0) (/W 32) Additional Interrupt Modes Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Enable        */
+    uint32_t P1:1;                      /**< bit:      1  Additional Interrupt Modes Enable        */
+    uint32_t P2:1;                      /**< bit:      2  Additional Interrupt Modes Enable        */
+    uint32_t P3:1;                      /**< bit:      3  Additional Interrupt Modes Enable        */
+    uint32_t P4:1;                      /**< bit:      4  Additional Interrupt Modes Enable        */
+    uint32_t P5:1;                      /**< bit:      5  Additional Interrupt Modes Enable        */
+    uint32_t P6:1;                      /**< bit:      6  Additional Interrupt Modes Enable        */
+    uint32_t P7:1;                      /**< bit:      7  Additional Interrupt Modes Enable        */
+    uint32_t P8:1;                      /**< bit:      8  Additional Interrupt Modes Enable        */
+    uint32_t P9:1;                      /**< bit:      9  Additional Interrupt Modes Enable        */
+    uint32_t P10:1;                     /**< bit:     10  Additional Interrupt Modes Enable        */
+    uint32_t P11:1;                     /**< bit:     11  Additional Interrupt Modes Enable        */
+    uint32_t P12:1;                     /**< bit:     12  Additional Interrupt Modes Enable        */
+    uint32_t P13:1;                     /**< bit:     13  Additional Interrupt Modes Enable        */
+    uint32_t P14:1;                     /**< bit:     14  Additional Interrupt Modes Enable        */
+    uint32_t P15:1;                     /**< bit:     15  Additional Interrupt Modes Enable        */
+    uint32_t P16:1;                     /**< bit:     16  Additional Interrupt Modes Enable        */
+    uint32_t P17:1;                     /**< bit:     17  Additional Interrupt Modes Enable        */
+    uint32_t P18:1;                     /**< bit:     18  Additional Interrupt Modes Enable        */
+    uint32_t P19:1;                     /**< bit:     19  Additional Interrupt Modes Enable        */
+    uint32_t P20:1;                     /**< bit:     20  Additional Interrupt Modes Enable        */
+    uint32_t P21:1;                     /**< bit:     21  Additional Interrupt Modes Enable        */
+    uint32_t P22:1;                     /**< bit:     22  Additional Interrupt Modes Enable        */
+    uint32_t P23:1;                     /**< bit:     23  Additional Interrupt Modes Enable        */
+    uint32_t P24:1;                     /**< bit:     24  Additional Interrupt Modes Enable        */
+    uint32_t P25:1;                     /**< bit:     25  Additional Interrupt Modes Enable        */
+    uint32_t P26:1;                     /**< bit:     26  Additional Interrupt Modes Enable        */
+    uint32_t P27:1;                     /**< bit:     27  Additional Interrupt Modes Enable        */
+    uint32_t P28:1;                     /**< bit:     28  Additional Interrupt Modes Enable        */
+    uint32_t P29:1;                     /**< bit:     29  Additional Interrupt Modes Enable        */
+    uint32_t P30:1;                     /**< bit:     30  Additional Interrupt Modes Enable        */
+    uint32_t P31:1;                     /**< bit:     31  Additional Interrupt Modes Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Additional Interrupt Modes Enable        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMER_OFFSET                    (0xB0)                                        /**<  (PIO_AIMER) Additional Interrupt Modes Enable Register  Offset */
+
+#define PIO_AIMER_P0_Pos                    0                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P0_Msk                    (_U_(0x1) << PIO_AIMER_P0_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P0                        PIO_AIMER_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P0_Msk instead */
+#define PIO_AIMER_P1_Pos                    1                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P1_Msk                    (_U_(0x1) << PIO_AIMER_P1_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P1                        PIO_AIMER_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P1_Msk instead */
+#define PIO_AIMER_P2_Pos                    2                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P2_Msk                    (_U_(0x1) << PIO_AIMER_P2_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P2                        PIO_AIMER_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P2_Msk instead */
+#define PIO_AIMER_P3_Pos                    3                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P3_Msk                    (_U_(0x1) << PIO_AIMER_P3_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P3                        PIO_AIMER_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P3_Msk instead */
+#define PIO_AIMER_P4_Pos                    4                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P4_Msk                    (_U_(0x1) << PIO_AIMER_P4_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P4                        PIO_AIMER_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P4_Msk instead */
+#define PIO_AIMER_P5_Pos                    5                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P5_Msk                    (_U_(0x1) << PIO_AIMER_P5_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P5                        PIO_AIMER_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P5_Msk instead */
+#define PIO_AIMER_P6_Pos                    6                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P6_Msk                    (_U_(0x1) << PIO_AIMER_P6_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P6                        PIO_AIMER_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P6_Msk instead */
+#define PIO_AIMER_P7_Pos                    7                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P7_Msk                    (_U_(0x1) << PIO_AIMER_P7_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P7                        PIO_AIMER_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P7_Msk instead */
+#define PIO_AIMER_P8_Pos                    8                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P8_Msk                    (_U_(0x1) << PIO_AIMER_P8_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P8                        PIO_AIMER_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P8_Msk instead */
+#define PIO_AIMER_P9_Pos                    9                                              /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P9_Msk                    (_U_(0x1) << PIO_AIMER_P9_Pos)                 /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P9                        PIO_AIMER_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P9_Msk instead */
+#define PIO_AIMER_P10_Pos                   10                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P10_Msk                   (_U_(0x1) << PIO_AIMER_P10_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P10                       PIO_AIMER_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P10_Msk instead */
+#define PIO_AIMER_P11_Pos                   11                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P11_Msk                   (_U_(0x1) << PIO_AIMER_P11_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P11                       PIO_AIMER_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P11_Msk instead */
+#define PIO_AIMER_P12_Pos                   12                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P12_Msk                   (_U_(0x1) << PIO_AIMER_P12_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P12                       PIO_AIMER_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P12_Msk instead */
+#define PIO_AIMER_P13_Pos                   13                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P13_Msk                   (_U_(0x1) << PIO_AIMER_P13_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P13                       PIO_AIMER_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P13_Msk instead */
+#define PIO_AIMER_P14_Pos                   14                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P14_Msk                   (_U_(0x1) << PIO_AIMER_P14_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P14                       PIO_AIMER_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P14_Msk instead */
+#define PIO_AIMER_P15_Pos                   15                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P15_Msk                   (_U_(0x1) << PIO_AIMER_P15_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P15                       PIO_AIMER_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P15_Msk instead */
+#define PIO_AIMER_P16_Pos                   16                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P16_Msk                   (_U_(0x1) << PIO_AIMER_P16_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P16                       PIO_AIMER_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P16_Msk instead */
+#define PIO_AIMER_P17_Pos                   17                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P17_Msk                   (_U_(0x1) << PIO_AIMER_P17_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P17                       PIO_AIMER_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P17_Msk instead */
+#define PIO_AIMER_P18_Pos                   18                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P18_Msk                   (_U_(0x1) << PIO_AIMER_P18_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P18                       PIO_AIMER_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P18_Msk instead */
+#define PIO_AIMER_P19_Pos                   19                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P19_Msk                   (_U_(0x1) << PIO_AIMER_P19_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P19                       PIO_AIMER_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P19_Msk instead */
+#define PIO_AIMER_P20_Pos                   20                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P20_Msk                   (_U_(0x1) << PIO_AIMER_P20_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P20                       PIO_AIMER_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P20_Msk instead */
+#define PIO_AIMER_P21_Pos                   21                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P21_Msk                   (_U_(0x1) << PIO_AIMER_P21_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P21                       PIO_AIMER_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P21_Msk instead */
+#define PIO_AIMER_P22_Pos                   22                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P22_Msk                   (_U_(0x1) << PIO_AIMER_P22_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P22                       PIO_AIMER_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P22_Msk instead */
+#define PIO_AIMER_P23_Pos                   23                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P23_Msk                   (_U_(0x1) << PIO_AIMER_P23_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P23                       PIO_AIMER_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P23_Msk instead */
+#define PIO_AIMER_P24_Pos                   24                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P24_Msk                   (_U_(0x1) << PIO_AIMER_P24_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P24                       PIO_AIMER_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P24_Msk instead */
+#define PIO_AIMER_P25_Pos                   25                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P25_Msk                   (_U_(0x1) << PIO_AIMER_P25_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P25                       PIO_AIMER_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P25_Msk instead */
+#define PIO_AIMER_P26_Pos                   26                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P26_Msk                   (_U_(0x1) << PIO_AIMER_P26_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P26                       PIO_AIMER_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P26_Msk instead */
+#define PIO_AIMER_P27_Pos                   27                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P27_Msk                   (_U_(0x1) << PIO_AIMER_P27_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P27                       PIO_AIMER_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P27_Msk instead */
+#define PIO_AIMER_P28_Pos                   28                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P28_Msk                   (_U_(0x1) << PIO_AIMER_P28_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P28                       PIO_AIMER_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P28_Msk instead */
+#define PIO_AIMER_P29_Pos                   29                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P29_Msk                   (_U_(0x1) << PIO_AIMER_P29_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P29                       PIO_AIMER_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P29_Msk instead */
+#define PIO_AIMER_P30_Pos                   30                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P30_Msk                   (_U_(0x1) << PIO_AIMER_P30_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P30                       PIO_AIMER_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P30_Msk instead */
+#define PIO_AIMER_P31_Pos                   31                                             /**< (PIO_AIMER) Additional Interrupt Modes Enable Position */
+#define PIO_AIMER_P31_Msk                   (_U_(0x1) << PIO_AIMER_P31_Pos)                /**< (PIO_AIMER) Additional Interrupt Modes Enable Mask */
+#define PIO_AIMER_P31                       PIO_AIMER_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMER_P31_Msk instead */
+#define PIO_AIMER_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMER) Register MASK  (Use PIO_AIMER_Msk instead)  */
+#define PIO_AIMER_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMER) Register Mask  */
+
+#define PIO_AIMER_P_Pos                     0                                              /**< (PIO_AIMER Position) Additional Interrupt Modes Enable */
+#define PIO_AIMER_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMER_P_Pos)           /**< (PIO_AIMER Mask) P */
+#define PIO_AIMER_P(value)                  (PIO_AIMER_P_Msk & ((value) << PIO_AIMER_P_Pos))  
+
+/* -------- PIO_AIMDR : (PIO Offset: 0xb4) (/W 32) Additional Interrupt Modes Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Disable       */
+    uint32_t P1:1;                      /**< bit:      1  Additional Interrupt Modes Disable       */
+    uint32_t P2:1;                      /**< bit:      2  Additional Interrupt Modes Disable       */
+    uint32_t P3:1;                      /**< bit:      3  Additional Interrupt Modes Disable       */
+    uint32_t P4:1;                      /**< bit:      4  Additional Interrupt Modes Disable       */
+    uint32_t P5:1;                      /**< bit:      5  Additional Interrupt Modes Disable       */
+    uint32_t P6:1;                      /**< bit:      6  Additional Interrupt Modes Disable       */
+    uint32_t P7:1;                      /**< bit:      7  Additional Interrupt Modes Disable       */
+    uint32_t P8:1;                      /**< bit:      8  Additional Interrupt Modes Disable       */
+    uint32_t P9:1;                      /**< bit:      9  Additional Interrupt Modes Disable       */
+    uint32_t P10:1;                     /**< bit:     10  Additional Interrupt Modes Disable       */
+    uint32_t P11:1;                     /**< bit:     11  Additional Interrupt Modes Disable       */
+    uint32_t P12:1;                     /**< bit:     12  Additional Interrupt Modes Disable       */
+    uint32_t P13:1;                     /**< bit:     13  Additional Interrupt Modes Disable       */
+    uint32_t P14:1;                     /**< bit:     14  Additional Interrupt Modes Disable       */
+    uint32_t P15:1;                     /**< bit:     15  Additional Interrupt Modes Disable       */
+    uint32_t P16:1;                     /**< bit:     16  Additional Interrupt Modes Disable       */
+    uint32_t P17:1;                     /**< bit:     17  Additional Interrupt Modes Disable       */
+    uint32_t P18:1;                     /**< bit:     18  Additional Interrupt Modes Disable       */
+    uint32_t P19:1;                     /**< bit:     19  Additional Interrupt Modes Disable       */
+    uint32_t P20:1;                     /**< bit:     20  Additional Interrupt Modes Disable       */
+    uint32_t P21:1;                     /**< bit:     21  Additional Interrupt Modes Disable       */
+    uint32_t P22:1;                     /**< bit:     22  Additional Interrupt Modes Disable       */
+    uint32_t P23:1;                     /**< bit:     23  Additional Interrupt Modes Disable       */
+    uint32_t P24:1;                     /**< bit:     24  Additional Interrupt Modes Disable       */
+    uint32_t P25:1;                     /**< bit:     25  Additional Interrupt Modes Disable       */
+    uint32_t P26:1;                     /**< bit:     26  Additional Interrupt Modes Disable       */
+    uint32_t P27:1;                     /**< bit:     27  Additional Interrupt Modes Disable       */
+    uint32_t P28:1;                     /**< bit:     28  Additional Interrupt Modes Disable       */
+    uint32_t P29:1;                     /**< bit:     29  Additional Interrupt Modes Disable       */
+    uint32_t P30:1;                     /**< bit:     30  Additional Interrupt Modes Disable       */
+    uint32_t P31:1;                     /**< bit:     31  Additional Interrupt Modes Disable       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Additional Interrupt Modes Disable       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMDR_OFFSET                    (0xB4)                                        /**<  (PIO_AIMDR) Additional Interrupt Modes Disable Register  Offset */
+
+#define PIO_AIMDR_P0_Pos                    0                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P0_Msk                    (_U_(0x1) << PIO_AIMDR_P0_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P0                        PIO_AIMDR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P0_Msk instead */
+#define PIO_AIMDR_P1_Pos                    1                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P1_Msk                    (_U_(0x1) << PIO_AIMDR_P1_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P1                        PIO_AIMDR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P1_Msk instead */
+#define PIO_AIMDR_P2_Pos                    2                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P2_Msk                    (_U_(0x1) << PIO_AIMDR_P2_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P2                        PIO_AIMDR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P2_Msk instead */
+#define PIO_AIMDR_P3_Pos                    3                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P3_Msk                    (_U_(0x1) << PIO_AIMDR_P3_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P3                        PIO_AIMDR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P3_Msk instead */
+#define PIO_AIMDR_P4_Pos                    4                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P4_Msk                    (_U_(0x1) << PIO_AIMDR_P4_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P4                        PIO_AIMDR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P4_Msk instead */
+#define PIO_AIMDR_P5_Pos                    5                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P5_Msk                    (_U_(0x1) << PIO_AIMDR_P5_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P5                        PIO_AIMDR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P5_Msk instead */
+#define PIO_AIMDR_P6_Pos                    6                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P6_Msk                    (_U_(0x1) << PIO_AIMDR_P6_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P6                        PIO_AIMDR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P6_Msk instead */
+#define PIO_AIMDR_P7_Pos                    7                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P7_Msk                    (_U_(0x1) << PIO_AIMDR_P7_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P7                        PIO_AIMDR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P7_Msk instead */
+#define PIO_AIMDR_P8_Pos                    8                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P8_Msk                    (_U_(0x1) << PIO_AIMDR_P8_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P8                        PIO_AIMDR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P8_Msk instead */
+#define PIO_AIMDR_P9_Pos                    9                                              /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P9_Msk                    (_U_(0x1) << PIO_AIMDR_P9_Pos)                 /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P9                        PIO_AIMDR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P9_Msk instead */
+#define PIO_AIMDR_P10_Pos                   10                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P10_Msk                   (_U_(0x1) << PIO_AIMDR_P10_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P10                       PIO_AIMDR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P10_Msk instead */
+#define PIO_AIMDR_P11_Pos                   11                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P11_Msk                   (_U_(0x1) << PIO_AIMDR_P11_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P11                       PIO_AIMDR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P11_Msk instead */
+#define PIO_AIMDR_P12_Pos                   12                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P12_Msk                   (_U_(0x1) << PIO_AIMDR_P12_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P12                       PIO_AIMDR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P12_Msk instead */
+#define PIO_AIMDR_P13_Pos                   13                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P13_Msk                   (_U_(0x1) << PIO_AIMDR_P13_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P13                       PIO_AIMDR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P13_Msk instead */
+#define PIO_AIMDR_P14_Pos                   14                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P14_Msk                   (_U_(0x1) << PIO_AIMDR_P14_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P14                       PIO_AIMDR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P14_Msk instead */
+#define PIO_AIMDR_P15_Pos                   15                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P15_Msk                   (_U_(0x1) << PIO_AIMDR_P15_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P15                       PIO_AIMDR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P15_Msk instead */
+#define PIO_AIMDR_P16_Pos                   16                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P16_Msk                   (_U_(0x1) << PIO_AIMDR_P16_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P16                       PIO_AIMDR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P16_Msk instead */
+#define PIO_AIMDR_P17_Pos                   17                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P17_Msk                   (_U_(0x1) << PIO_AIMDR_P17_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P17                       PIO_AIMDR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P17_Msk instead */
+#define PIO_AIMDR_P18_Pos                   18                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P18_Msk                   (_U_(0x1) << PIO_AIMDR_P18_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P18                       PIO_AIMDR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P18_Msk instead */
+#define PIO_AIMDR_P19_Pos                   19                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P19_Msk                   (_U_(0x1) << PIO_AIMDR_P19_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P19                       PIO_AIMDR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P19_Msk instead */
+#define PIO_AIMDR_P20_Pos                   20                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P20_Msk                   (_U_(0x1) << PIO_AIMDR_P20_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P20                       PIO_AIMDR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P20_Msk instead */
+#define PIO_AIMDR_P21_Pos                   21                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P21_Msk                   (_U_(0x1) << PIO_AIMDR_P21_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P21                       PIO_AIMDR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P21_Msk instead */
+#define PIO_AIMDR_P22_Pos                   22                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P22_Msk                   (_U_(0x1) << PIO_AIMDR_P22_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P22                       PIO_AIMDR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P22_Msk instead */
+#define PIO_AIMDR_P23_Pos                   23                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P23_Msk                   (_U_(0x1) << PIO_AIMDR_P23_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P23                       PIO_AIMDR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P23_Msk instead */
+#define PIO_AIMDR_P24_Pos                   24                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P24_Msk                   (_U_(0x1) << PIO_AIMDR_P24_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P24                       PIO_AIMDR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P24_Msk instead */
+#define PIO_AIMDR_P25_Pos                   25                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P25_Msk                   (_U_(0x1) << PIO_AIMDR_P25_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P25                       PIO_AIMDR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P25_Msk instead */
+#define PIO_AIMDR_P26_Pos                   26                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P26_Msk                   (_U_(0x1) << PIO_AIMDR_P26_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P26                       PIO_AIMDR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P26_Msk instead */
+#define PIO_AIMDR_P27_Pos                   27                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P27_Msk                   (_U_(0x1) << PIO_AIMDR_P27_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P27                       PIO_AIMDR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P27_Msk instead */
+#define PIO_AIMDR_P28_Pos                   28                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P28_Msk                   (_U_(0x1) << PIO_AIMDR_P28_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P28                       PIO_AIMDR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P28_Msk instead */
+#define PIO_AIMDR_P29_Pos                   29                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P29_Msk                   (_U_(0x1) << PIO_AIMDR_P29_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P29                       PIO_AIMDR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P29_Msk instead */
+#define PIO_AIMDR_P30_Pos                   30                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P30_Msk                   (_U_(0x1) << PIO_AIMDR_P30_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P30                       PIO_AIMDR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P30_Msk instead */
+#define PIO_AIMDR_P31_Pos                   31                                             /**< (PIO_AIMDR) Additional Interrupt Modes Disable Position */
+#define PIO_AIMDR_P31_Msk                   (_U_(0x1) << PIO_AIMDR_P31_Pos)                /**< (PIO_AIMDR) Additional Interrupt Modes Disable Mask */
+#define PIO_AIMDR_P31                       PIO_AIMDR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMDR_P31_Msk instead */
+#define PIO_AIMDR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMDR) Register MASK  (Use PIO_AIMDR_Msk instead)  */
+#define PIO_AIMDR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMDR) Register Mask  */
+
+#define PIO_AIMDR_P_Pos                     0                                              /**< (PIO_AIMDR Position) Additional Interrupt Modes Disable */
+#define PIO_AIMDR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMDR_P_Pos)           /**< (PIO_AIMDR Mask) P */
+#define PIO_AIMDR_P(value)                  (PIO_AIMDR_P_Msk & ((value) << PIO_AIMDR_P_Pos))  
+
+/* -------- PIO_AIMMR : (PIO Offset: 0xb8) (R/ 32) Additional Interrupt Modes Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  IO Line Index                            */
+    uint32_t P1:1;                      /**< bit:      1  IO Line Index                            */
+    uint32_t P2:1;                      /**< bit:      2  IO Line Index                            */
+    uint32_t P3:1;                      /**< bit:      3  IO Line Index                            */
+    uint32_t P4:1;                      /**< bit:      4  IO Line Index                            */
+    uint32_t P5:1;                      /**< bit:      5  IO Line Index                            */
+    uint32_t P6:1;                      /**< bit:      6  IO Line Index                            */
+    uint32_t P7:1;                      /**< bit:      7  IO Line Index                            */
+    uint32_t P8:1;                      /**< bit:      8  IO Line Index                            */
+    uint32_t P9:1;                      /**< bit:      9  IO Line Index                            */
+    uint32_t P10:1;                     /**< bit:     10  IO Line Index                            */
+    uint32_t P11:1;                     /**< bit:     11  IO Line Index                            */
+    uint32_t P12:1;                     /**< bit:     12  IO Line Index                            */
+    uint32_t P13:1;                     /**< bit:     13  IO Line Index                            */
+    uint32_t P14:1;                     /**< bit:     14  IO Line Index                            */
+    uint32_t P15:1;                     /**< bit:     15  IO Line Index                            */
+    uint32_t P16:1;                     /**< bit:     16  IO Line Index                            */
+    uint32_t P17:1;                     /**< bit:     17  IO Line Index                            */
+    uint32_t P18:1;                     /**< bit:     18  IO Line Index                            */
+    uint32_t P19:1;                     /**< bit:     19  IO Line Index                            */
+    uint32_t P20:1;                     /**< bit:     20  IO Line Index                            */
+    uint32_t P21:1;                     /**< bit:     21  IO Line Index                            */
+    uint32_t P22:1;                     /**< bit:     22  IO Line Index                            */
+    uint32_t P23:1;                     /**< bit:     23  IO Line Index                            */
+    uint32_t P24:1;                     /**< bit:     24  IO Line Index                            */
+    uint32_t P25:1;                     /**< bit:     25  IO Line Index                            */
+    uint32_t P26:1;                     /**< bit:     26  IO Line Index                            */
+    uint32_t P27:1;                     /**< bit:     27  IO Line Index                            */
+    uint32_t P28:1;                     /**< bit:     28  IO Line Index                            */
+    uint32_t P29:1;                     /**< bit:     29  IO Line Index                            */
+    uint32_t P30:1;                     /**< bit:     30  IO Line Index                            */
+    uint32_t P31:1;                     /**< bit:     31  IO Line Index                            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  IO Line Index                            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_AIMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_AIMMR_OFFSET                    (0xB8)                                        /**<  (PIO_AIMMR) Additional Interrupt Modes Mask Register  Offset */
+
+#define PIO_AIMMR_P0_Pos                    0                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P0_Msk                    (_U_(0x1) << PIO_AIMMR_P0_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P0                        PIO_AIMMR_P0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P0_Msk instead */
+#define PIO_AIMMR_P1_Pos                    1                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P1_Msk                    (_U_(0x1) << PIO_AIMMR_P1_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P1                        PIO_AIMMR_P1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P1_Msk instead */
+#define PIO_AIMMR_P2_Pos                    2                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P2_Msk                    (_U_(0x1) << PIO_AIMMR_P2_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P2                        PIO_AIMMR_P2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P2_Msk instead */
+#define PIO_AIMMR_P3_Pos                    3                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P3_Msk                    (_U_(0x1) << PIO_AIMMR_P3_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P3                        PIO_AIMMR_P3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P3_Msk instead */
+#define PIO_AIMMR_P4_Pos                    4                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P4_Msk                    (_U_(0x1) << PIO_AIMMR_P4_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P4                        PIO_AIMMR_P4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P4_Msk instead */
+#define PIO_AIMMR_P5_Pos                    5                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P5_Msk                    (_U_(0x1) << PIO_AIMMR_P5_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P5                        PIO_AIMMR_P5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P5_Msk instead */
+#define PIO_AIMMR_P6_Pos                    6                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P6_Msk                    (_U_(0x1) << PIO_AIMMR_P6_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P6                        PIO_AIMMR_P6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P6_Msk instead */
+#define PIO_AIMMR_P7_Pos                    7                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P7_Msk                    (_U_(0x1) << PIO_AIMMR_P7_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P7                        PIO_AIMMR_P7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P7_Msk instead */
+#define PIO_AIMMR_P8_Pos                    8                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P8_Msk                    (_U_(0x1) << PIO_AIMMR_P8_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P8                        PIO_AIMMR_P8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P8_Msk instead */
+#define PIO_AIMMR_P9_Pos                    9                                              /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P9_Msk                    (_U_(0x1) << PIO_AIMMR_P9_Pos)                 /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P9                        PIO_AIMMR_P9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P9_Msk instead */
+#define PIO_AIMMR_P10_Pos                   10                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P10_Msk                   (_U_(0x1) << PIO_AIMMR_P10_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P10                       PIO_AIMMR_P10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P10_Msk instead */
+#define PIO_AIMMR_P11_Pos                   11                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P11_Msk                   (_U_(0x1) << PIO_AIMMR_P11_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P11                       PIO_AIMMR_P11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P11_Msk instead */
+#define PIO_AIMMR_P12_Pos                   12                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P12_Msk                   (_U_(0x1) << PIO_AIMMR_P12_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P12                       PIO_AIMMR_P12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P12_Msk instead */
+#define PIO_AIMMR_P13_Pos                   13                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P13_Msk                   (_U_(0x1) << PIO_AIMMR_P13_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P13                       PIO_AIMMR_P13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P13_Msk instead */
+#define PIO_AIMMR_P14_Pos                   14                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P14_Msk                   (_U_(0x1) << PIO_AIMMR_P14_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P14                       PIO_AIMMR_P14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P14_Msk instead */
+#define PIO_AIMMR_P15_Pos                   15                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P15_Msk                   (_U_(0x1) << PIO_AIMMR_P15_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P15                       PIO_AIMMR_P15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P15_Msk instead */
+#define PIO_AIMMR_P16_Pos                   16                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P16_Msk                   (_U_(0x1) << PIO_AIMMR_P16_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P16                       PIO_AIMMR_P16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P16_Msk instead */
+#define PIO_AIMMR_P17_Pos                   17                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P17_Msk                   (_U_(0x1) << PIO_AIMMR_P17_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P17                       PIO_AIMMR_P17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P17_Msk instead */
+#define PIO_AIMMR_P18_Pos                   18                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P18_Msk                   (_U_(0x1) << PIO_AIMMR_P18_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P18                       PIO_AIMMR_P18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P18_Msk instead */
+#define PIO_AIMMR_P19_Pos                   19                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P19_Msk                   (_U_(0x1) << PIO_AIMMR_P19_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P19                       PIO_AIMMR_P19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P19_Msk instead */
+#define PIO_AIMMR_P20_Pos                   20                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P20_Msk                   (_U_(0x1) << PIO_AIMMR_P20_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P20                       PIO_AIMMR_P20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P20_Msk instead */
+#define PIO_AIMMR_P21_Pos                   21                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P21_Msk                   (_U_(0x1) << PIO_AIMMR_P21_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P21                       PIO_AIMMR_P21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P21_Msk instead */
+#define PIO_AIMMR_P22_Pos                   22                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P22_Msk                   (_U_(0x1) << PIO_AIMMR_P22_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P22                       PIO_AIMMR_P22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P22_Msk instead */
+#define PIO_AIMMR_P23_Pos                   23                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P23_Msk                   (_U_(0x1) << PIO_AIMMR_P23_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P23                       PIO_AIMMR_P23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P23_Msk instead */
+#define PIO_AIMMR_P24_Pos                   24                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P24_Msk                   (_U_(0x1) << PIO_AIMMR_P24_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P24                       PIO_AIMMR_P24_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P24_Msk instead */
+#define PIO_AIMMR_P25_Pos                   25                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P25_Msk                   (_U_(0x1) << PIO_AIMMR_P25_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P25                       PIO_AIMMR_P25_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P25_Msk instead */
+#define PIO_AIMMR_P26_Pos                   26                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P26_Msk                   (_U_(0x1) << PIO_AIMMR_P26_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P26                       PIO_AIMMR_P26_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P26_Msk instead */
+#define PIO_AIMMR_P27_Pos                   27                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P27_Msk                   (_U_(0x1) << PIO_AIMMR_P27_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P27                       PIO_AIMMR_P27_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P27_Msk instead */
+#define PIO_AIMMR_P28_Pos                   28                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P28_Msk                   (_U_(0x1) << PIO_AIMMR_P28_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P28                       PIO_AIMMR_P28_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P28_Msk instead */
+#define PIO_AIMMR_P29_Pos                   29                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P29_Msk                   (_U_(0x1) << PIO_AIMMR_P29_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P29                       PIO_AIMMR_P29_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P29_Msk instead */
+#define PIO_AIMMR_P30_Pos                   30                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P30_Msk                   (_U_(0x1) << PIO_AIMMR_P30_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P30                       PIO_AIMMR_P30_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P30_Msk instead */
+#define PIO_AIMMR_P31_Pos                   31                                             /**< (PIO_AIMMR) IO Line Index Position */
+#define PIO_AIMMR_P31_Msk                   (_U_(0x1) << PIO_AIMMR_P31_Pos)                /**< (PIO_AIMMR) IO Line Index Mask */
+#define PIO_AIMMR_P31                       PIO_AIMMR_P31_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_AIMMR_P31_Msk instead */
+#define PIO_AIMMR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_AIMMR) Register MASK  (Use PIO_AIMMR_Msk instead)  */
+#define PIO_AIMMR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_AIMMR) Register Mask  */
+
+#define PIO_AIMMR_P_Pos                     0                                              /**< (PIO_AIMMR Position) IO Line Index */
+#define PIO_AIMMR_P_Msk                     (_U_(0xFFFFFFFF) << PIO_AIMMR_P_Pos)           /**< (PIO_AIMMR Mask) P */
+#define PIO_AIMMR_P(value)                  (PIO_AIMMR_P_Msk & ((value) << PIO_AIMMR_P_Pos))  
+
+/* -------- PIO_ESR : (PIO Offset: 0xc0) (/W 32) Edge Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge Interrupt Selection                 */
+    uint32_t P1:1;                      /**< bit:      1  Edge Interrupt Selection                 */
+    uint32_t P2:1;                      /**< bit:      2  Edge Interrupt Selection                 */
+    uint32_t P3:1;                      /**< bit:      3  Edge Interrupt Selection                 */
+    uint32_t P4:1;                      /**< bit:      4  Edge Interrupt Selection                 */
+    uint32_t P5:1;                      /**< bit:      5  Edge Interrupt Selection                 */
+    uint32_t P6:1;                      /**< bit:      6  Edge Interrupt Selection                 */
+    uint32_t P7:1;                      /**< bit:      7  Edge Interrupt Selection                 */
+    uint32_t P8:1;                      /**< bit:      8  Edge Interrupt Selection                 */
+    uint32_t P9:1;                      /**< bit:      9  Edge Interrupt Selection                 */
+    uint32_t P10:1;                     /**< bit:     10  Edge Interrupt Selection                 */
+    uint32_t P11:1;                     /**< bit:     11  Edge Interrupt Selection                 */
+    uint32_t P12:1;                     /**< bit:     12  Edge Interrupt Selection                 */
+    uint32_t P13:1;                     /**< bit:     13  Edge Interrupt Selection                 */
+    uint32_t P14:1;                     /**< bit:     14  Edge Interrupt Selection                 */
+    uint32_t P15:1;                     /**< bit:     15  Edge Interrupt Selection                 */
+    uint32_t P16:1;                     /**< bit:     16  Edge Interrupt Selection                 */
+    uint32_t P17:1;                     /**< bit:     17  Edge Interrupt Selection                 */
+    uint32_t P18:1;                     /**< bit:     18  Edge Interrupt Selection                 */
+    uint32_t P19:1;                     /**< bit:     19  Edge Interrupt Selection                 */
+    uint32_t P20:1;                     /**< bit:     20  Edge Interrupt Selection                 */
+    uint32_t P21:1;                     /**< bit:     21  Edge Interrupt Selection                 */
+    uint32_t P22:1;                     /**< bit:     22  Edge Interrupt Selection                 */
+    uint32_t P23:1;                     /**< bit:     23  Edge Interrupt Selection                 */
+    uint32_t P24:1;                     /**< bit:     24  Edge Interrupt Selection                 */
+    uint32_t P25:1;                     /**< bit:     25  Edge Interrupt Selection                 */
+    uint32_t P26:1;                     /**< bit:     26  Edge Interrupt Selection                 */
+    uint32_t P27:1;                     /**< bit:     27  Edge Interrupt Selection                 */
+    uint32_t P28:1;                     /**< bit:     28  Edge Interrupt Selection                 */
+    uint32_t P29:1;                     /**< bit:     29  Edge Interrupt Selection                 */
+    uint32_t P30:1;                     /**< bit:     30  Edge Interrupt Selection                 */
+    uint32_t P31:1;                     /**< bit:     31  Edge Interrupt Selection                 */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge Interrupt Selection                 */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ESR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ESR_OFFSET                      (0xC0)                                        /**<  (PIO_ESR) Edge Select Register  Offset */
+
+#define PIO_ESR_P0_Pos                      0                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P0_Msk                      (_U_(0x1) << PIO_ESR_P0_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P0                          PIO_ESR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P0_Msk instead */
+#define PIO_ESR_P1_Pos                      1                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P1_Msk                      (_U_(0x1) << PIO_ESR_P1_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P1                          PIO_ESR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P1_Msk instead */
+#define PIO_ESR_P2_Pos                      2                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P2_Msk                      (_U_(0x1) << PIO_ESR_P2_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P2                          PIO_ESR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P2_Msk instead */
+#define PIO_ESR_P3_Pos                      3                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P3_Msk                      (_U_(0x1) << PIO_ESR_P3_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P3                          PIO_ESR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P3_Msk instead */
+#define PIO_ESR_P4_Pos                      4                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P4_Msk                      (_U_(0x1) << PIO_ESR_P4_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P4                          PIO_ESR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P4_Msk instead */
+#define PIO_ESR_P5_Pos                      5                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P5_Msk                      (_U_(0x1) << PIO_ESR_P5_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P5                          PIO_ESR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P5_Msk instead */
+#define PIO_ESR_P6_Pos                      6                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P6_Msk                      (_U_(0x1) << PIO_ESR_P6_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P6                          PIO_ESR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P6_Msk instead */
+#define PIO_ESR_P7_Pos                      7                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P7_Msk                      (_U_(0x1) << PIO_ESR_P7_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P7                          PIO_ESR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P7_Msk instead */
+#define PIO_ESR_P8_Pos                      8                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P8_Msk                      (_U_(0x1) << PIO_ESR_P8_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P8                          PIO_ESR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P8_Msk instead */
+#define PIO_ESR_P9_Pos                      9                                              /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P9_Msk                      (_U_(0x1) << PIO_ESR_P9_Pos)                   /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P9                          PIO_ESR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P9_Msk instead */
+#define PIO_ESR_P10_Pos                     10                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P10_Msk                     (_U_(0x1) << PIO_ESR_P10_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P10                         PIO_ESR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P10_Msk instead */
+#define PIO_ESR_P11_Pos                     11                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P11_Msk                     (_U_(0x1) << PIO_ESR_P11_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P11                         PIO_ESR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P11_Msk instead */
+#define PIO_ESR_P12_Pos                     12                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P12_Msk                     (_U_(0x1) << PIO_ESR_P12_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P12                         PIO_ESR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P12_Msk instead */
+#define PIO_ESR_P13_Pos                     13                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P13_Msk                     (_U_(0x1) << PIO_ESR_P13_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P13                         PIO_ESR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P13_Msk instead */
+#define PIO_ESR_P14_Pos                     14                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P14_Msk                     (_U_(0x1) << PIO_ESR_P14_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P14                         PIO_ESR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P14_Msk instead */
+#define PIO_ESR_P15_Pos                     15                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P15_Msk                     (_U_(0x1) << PIO_ESR_P15_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P15                         PIO_ESR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P15_Msk instead */
+#define PIO_ESR_P16_Pos                     16                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P16_Msk                     (_U_(0x1) << PIO_ESR_P16_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P16                         PIO_ESR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P16_Msk instead */
+#define PIO_ESR_P17_Pos                     17                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P17_Msk                     (_U_(0x1) << PIO_ESR_P17_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P17                         PIO_ESR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P17_Msk instead */
+#define PIO_ESR_P18_Pos                     18                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P18_Msk                     (_U_(0x1) << PIO_ESR_P18_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P18                         PIO_ESR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P18_Msk instead */
+#define PIO_ESR_P19_Pos                     19                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P19_Msk                     (_U_(0x1) << PIO_ESR_P19_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P19                         PIO_ESR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P19_Msk instead */
+#define PIO_ESR_P20_Pos                     20                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P20_Msk                     (_U_(0x1) << PIO_ESR_P20_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P20                         PIO_ESR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P20_Msk instead */
+#define PIO_ESR_P21_Pos                     21                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P21_Msk                     (_U_(0x1) << PIO_ESR_P21_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P21                         PIO_ESR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P21_Msk instead */
+#define PIO_ESR_P22_Pos                     22                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P22_Msk                     (_U_(0x1) << PIO_ESR_P22_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P22                         PIO_ESR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P22_Msk instead */
+#define PIO_ESR_P23_Pos                     23                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P23_Msk                     (_U_(0x1) << PIO_ESR_P23_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P23                         PIO_ESR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P23_Msk instead */
+#define PIO_ESR_P24_Pos                     24                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P24_Msk                     (_U_(0x1) << PIO_ESR_P24_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P24                         PIO_ESR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P24_Msk instead */
+#define PIO_ESR_P25_Pos                     25                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P25_Msk                     (_U_(0x1) << PIO_ESR_P25_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P25                         PIO_ESR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P25_Msk instead */
+#define PIO_ESR_P26_Pos                     26                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P26_Msk                     (_U_(0x1) << PIO_ESR_P26_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P26                         PIO_ESR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P26_Msk instead */
+#define PIO_ESR_P27_Pos                     27                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P27_Msk                     (_U_(0x1) << PIO_ESR_P27_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P27                         PIO_ESR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P27_Msk instead */
+#define PIO_ESR_P28_Pos                     28                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P28_Msk                     (_U_(0x1) << PIO_ESR_P28_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P28                         PIO_ESR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P28_Msk instead */
+#define PIO_ESR_P29_Pos                     29                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P29_Msk                     (_U_(0x1) << PIO_ESR_P29_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P29                         PIO_ESR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P29_Msk instead */
+#define PIO_ESR_P30_Pos                     30                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P30_Msk                     (_U_(0x1) << PIO_ESR_P30_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P30                         PIO_ESR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P30_Msk instead */
+#define PIO_ESR_P31_Pos                     31                                             /**< (PIO_ESR) Edge Interrupt Selection Position */
+#define PIO_ESR_P31_Msk                     (_U_(0x1) << PIO_ESR_P31_Pos)                  /**< (PIO_ESR) Edge Interrupt Selection Mask */
+#define PIO_ESR_P31                         PIO_ESR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ESR_P31_Msk instead */
+#define PIO_ESR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ESR) Register MASK  (Use PIO_ESR_Msk instead)  */
+#define PIO_ESR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_ESR) Register Mask  */
+
+#define PIO_ESR_P_Pos                       0                                              /**< (PIO_ESR Position) Edge Interrupt Selection */
+#define PIO_ESR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_ESR_P_Pos)             /**< (PIO_ESR Mask) P */
+#define PIO_ESR_P(value)                    (PIO_ESR_P_Msk & ((value) << PIO_ESR_P_Pos))   
+
+/* -------- PIO_LSR : (PIO Offset: 0xc4) (/W 32) Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Level Interrupt Selection                */
+    uint32_t P1:1;                      /**< bit:      1  Level Interrupt Selection                */
+    uint32_t P2:1;                      /**< bit:      2  Level Interrupt Selection                */
+    uint32_t P3:1;                      /**< bit:      3  Level Interrupt Selection                */
+    uint32_t P4:1;                      /**< bit:      4  Level Interrupt Selection                */
+    uint32_t P5:1;                      /**< bit:      5  Level Interrupt Selection                */
+    uint32_t P6:1;                      /**< bit:      6  Level Interrupt Selection                */
+    uint32_t P7:1;                      /**< bit:      7  Level Interrupt Selection                */
+    uint32_t P8:1;                      /**< bit:      8  Level Interrupt Selection                */
+    uint32_t P9:1;                      /**< bit:      9  Level Interrupt Selection                */
+    uint32_t P10:1;                     /**< bit:     10  Level Interrupt Selection                */
+    uint32_t P11:1;                     /**< bit:     11  Level Interrupt Selection                */
+    uint32_t P12:1;                     /**< bit:     12  Level Interrupt Selection                */
+    uint32_t P13:1;                     /**< bit:     13  Level Interrupt Selection                */
+    uint32_t P14:1;                     /**< bit:     14  Level Interrupt Selection                */
+    uint32_t P15:1;                     /**< bit:     15  Level Interrupt Selection                */
+    uint32_t P16:1;                     /**< bit:     16  Level Interrupt Selection                */
+    uint32_t P17:1;                     /**< bit:     17  Level Interrupt Selection                */
+    uint32_t P18:1;                     /**< bit:     18  Level Interrupt Selection                */
+    uint32_t P19:1;                     /**< bit:     19  Level Interrupt Selection                */
+    uint32_t P20:1;                     /**< bit:     20  Level Interrupt Selection                */
+    uint32_t P21:1;                     /**< bit:     21  Level Interrupt Selection                */
+    uint32_t P22:1;                     /**< bit:     22  Level Interrupt Selection                */
+    uint32_t P23:1;                     /**< bit:     23  Level Interrupt Selection                */
+    uint32_t P24:1;                     /**< bit:     24  Level Interrupt Selection                */
+    uint32_t P25:1;                     /**< bit:     25  Level Interrupt Selection                */
+    uint32_t P26:1;                     /**< bit:     26  Level Interrupt Selection                */
+    uint32_t P27:1;                     /**< bit:     27  Level Interrupt Selection                */
+    uint32_t P28:1;                     /**< bit:     28  Level Interrupt Selection                */
+    uint32_t P29:1;                     /**< bit:     29  Level Interrupt Selection                */
+    uint32_t P30:1;                     /**< bit:     30  Level Interrupt Selection                */
+    uint32_t P31:1;                     /**< bit:     31  Level Interrupt Selection                */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Level Interrupt Selection                */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_LSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_LSR_OFFSET                      (0xC4)                                        /**<  (PIO_LSR) Level Select Register  Offset */
+
+#define PIO_LSR_P0_Pos                      0                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P0_Msk                      (_U_(0x1) << PIO_LSR_P0_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P0                          PIO_LSR_P0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P0_Msk instead */
+#define PIO_LSR_P1_Pos                      1                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P1_Msk                      (_U_(0x1) << PIO_LSR_P1_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P1                          PIO_LSR_P1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P1_Msk instead */
+#define PIO_LSR_P2_Pos                      2                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P2_Msk                      (_U_(0x1) << PIO_LSR_P2_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P2                          PIO_LSR_P2_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P2_Msk instead */
+#define PIO_LSR_P3_Pos                      3                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P3_Msk                      (_U_(0x1) << PIO_LSR_P3_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P3                          PIO_LSR_P3_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P3_Msk instead */
+#define PIO_LSR_P4_Pos                      4                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P4_Msk                      (_U_(0x1) << PIO_LSR_P4_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P4                          PIO_LSR_P4_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P4_Msk instead */
+#define PIO_LSR_P5_Pos                      5                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P5_Msk                      (_U_(0x1) << PIO_LSR_P5_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P5                          PIO_LSR_P5_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P5_Msk instead */
+#define PIO_LSR_P6_Pos                      6                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P6_Msk                      (_U_(0x1) << PIO_LSR_P6_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P6                          PIO_LSR_P6_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P6_Msk instead */
+#define PIO_LSR_P7_Pos                      7                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P7_Msk                      (_U_(0x1) << PIO_LSR_P7_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P7                          PIO_LSR_P7_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P7_Msk instead */
+#define PIO_LSR_P8_Pos                      8                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P8_Msk                      (_U_(0x1) << PIO_LSR_P8_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P8                          PIO_LSR_P8_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P8_Msk instead */
+#define PIO_LSR_P9_Pos                      9                                              /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P9_Msk                      (_U_(0x1) << PIO_LSR_P9_Pos)                   /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P9                          PIO_LSR_P9_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P9_Msk instead */
+#define PIO_LSR_P10_Pos                     10                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P10_Msk                     (_U_(0x1) << PIO_LSR_P10_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P10                         PIO_LSR_P10_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P10_Msk instead */
+#define PIO_LSR_P11_Pos                     11                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P11_Msk                     (_U_(0x1) << PIO_LSR_P11_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P11                         PIO_LSR_P11_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P11_Msk instead */
+#define PIO_LSR_P12_Pos                     12                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P12_Msk                     (_U_(0x1) << PIO_LSR_P12_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P12                         PIO_LSR_P12_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P12_Msk instead */
+#define PIO_LSR_P13_Pos                     13                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P13_Msk                     (_U_(0x1) << PIO_LSR_P13_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P13                         PIO_LSR_P13_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P13_Msk instead */
+#define PIO_LSR_P14_Pos                     14                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P14_Msk                     (_U_(0x1) << PIO_LSR_P14_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P14                         PIO_LSR_P14_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P14_Msk instead */
+#define PIO_LSR_P15_Pos                     15                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P15_Msk                     (_U_(0x1) << PIO_LSR_P15_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P15                         PIO_LSR_P15_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P15_Msk instead */
+#define PIO_LSR_P16_Pos                     16                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P16_Msk                     (_U_(0x1) << PIO_LSR_P16_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P16                         PIO_LSR_P16_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P16_Msk instead */
+#define PIO_LSR_P17_Pos                     17                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P17_Msk                     (_U_(0x1) << PIO_LSR_P17_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P17                         PIO_LSR_P17_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P17_Msk instead */
+#define PIO_LSR_P18_Pos                     18                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P18_Msk                     (_U_(0x1) << PIO_LSR_P18_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P18                         PIO_LSR_P18_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P18_Msk instead */
+#define PIO_LSR_P19_Pos                     19                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P19_Msk                     (_U_(0x1) << PIO_LSR_P19_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P19                         PIO_LSR_P19_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P19_Msk instead */
+#define PIO_LSR_P20_Pos                     20                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P20_Msk                     (_U_(0x1) << PIO_LSR_P20_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P20                         PIO_LSR_P20_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P20_Msk instead */
+#define PIO_LSR_P21_Pos                     21                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P21_Msk                     (_U_(0x1) << PIO_LSR_P21_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P21                         PIO_LSR_P21_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P21_Msk instead */
+#define PIO_LSR_P22_Pos                     22                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P22_Msk                     (_U_(0x1) << PIO_LSR_P22_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P22                         PIO_LSR_P22_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P22_Msk instead */
+#define PIO_LSR_P23_Pos                     23                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P23_Msk                     (_U_(0x1) << PIO_LSR_P23_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P23                         PIO_LSR_P23_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P23_Msk instead */
+#define PIO_LSR_P24_Pos                     24                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P24_Msk                     (_U_(0x1) << PIO_LSR_P24_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P24                         PIO_LSR_P24_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P24_Msk instead */
+#define PIO_LSR_P25_Pos                     25                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P25_Msk                     (_U_(0x1) << PIO_LSR_P25_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P25                         PIO_LSR_P25_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P25_Msk instead */
+#define PIO_LSR_P26_Pos                     26                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P26_Msk                     (_U_(0x1) << PIO_LSR_P26_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P26                         PIO_LSR_P26_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P26_Msk instead */
+#define PIO_LSR_P27_Pos                     27                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P27_Msk                     (_U_(0x1) << PIO_LSR_P27_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P27                         PIO_LSR_P27_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P27_Msk instead */
+#define PIO_LSR_P28_Pos                     28                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P28_Msk                     (_U_(0x1) << PIO_LSR_P28_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P28                         PIO_LSR_P28_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P28_Msk instead */
+#define PIO_LSR_P29_Pos                     29                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P29_Msk                     (_U_(0x1) << PIO_LSR_P29_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P29                         PIO_LSR_P29_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P29_Msk instead */
+#define PIO_LSR_P30_Pos                     30                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P30_Msk                     (_U_(0x1) << PIO_LSR_P30_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P30                         PIO_LSR_P30_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P30_Msk instead */
+#define PIO_LSR_P31_Pos                     31                                             /**< (PIO_LSR) Level Interrupt Selection Position */
+#define PIO_LSR_P31_Msk                     (_U_(0x1) << PIO_LSR_P31_Pos)                  /**< (PIO_LSR) Level Interrupt Selection Mask */
+#define PIO_LSR_P31                         PIO_LSR_P31_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LSR_P31_Msk instead */
+#define PIO_LSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_LSR) Register MASK  (Use PIO_LSR_Msk instead)  */
+#define PIO_LSR_Msk                         _U_(0xFFFFFFFF)                                /**< (PIO_LSR) Register Mask  */
+
+#define PIO_LSR_P_Pos                       0                                              /**< (PIO_LSR Position) Level Interrupt Selection */
+#define PIO_LSR_P_Msk                       (_U_(0xFFFFFFFF) << PIO_LSR_P_Pos)             /**< (PIO_LSR Mask) P */
+#define PIO_LSR_P(value)                    (PIO_LSR_P_Msk & ((value) << PIO_LSR_P_Pos))   
+
+/* -------- PIO_ELSR : (PIO Offset: 0xc8) (R/ 32) Edge/Level Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
+    uint32_t P1:1;                      /**< bit:      1  Edge/Level Interrupt Source Selection    */
+    uint32_t P2:1;                      /**< bit:      2  Edge/Level Interrupt Source Selection    */
+    uint32_t P3:1;                      /**< bit:      3  Edge/Level Interrupt Source Selection    */
+    uint32_t P4:1;                      /**< bit:      4  Edge/Level Interrupt Source Selection    */
+    uint32_t P5:1;                      /**< bit:      5  Edge/Level Interrupt Source Selection    */
+    uint32_t P6:1;                      /**< bit:      6  Edge/Level Interrupt Source Selection    */
+    uint32_t P7:1;                      /**< bit:      7  Edge/Level Interrupt Source Selection    */
+    uint32_t P8:1;                      /**< bit:      8  Edge/Level Interrupt Source Selection    */
+    uint32_t P9:1;                      /**< bit:      9  Edge/Level Interrupt Source Selection    */
+    uint32_t P10:1;                     /**< bit:     10  Edge/Level Interrupt Source Selection    */
+    uint32_t P11:1;                     /**< bit:     11  Edge/Level Interrupt Source Selection    */
+    uint32_t P12:1;                     /**< bit:     12  Edge/Level Interrupt Source Selection    */
+    uint32_t P13:1;                     /**< bit:     13  Edge/Level Interrupt Source Selection    */
+    uint32_t P14:1;                     /**< bit:     14  Edge/Level Interrupt Source Selection    */
+    uint32_t P15:1;                     /**< bit:     15  Edge/Level Interrupt Source Selection    */
+    uint32_t P16:1;                     /**< bit:     16  Edge/Level Interrupt Source Selection    */
+    uint32_t P17:1;                     /**< bit:     17  Edge/Level Interrupt Source Selection    */
+    uint32_t P18:1;                     /**< bit:     18  Edge/Level Interrupt Source Selection    */
+    uint32_t P19:1;                     /**< bit:     19  Edge/Level Interrupt Source Selection    */
+    uint32_t P20:1;                     /**< bit:     20  Edge/Level Interrupt Source Selection    */
+    uint32_t P21:1;                     /**< bit:     21  Edge/Level Interrupt Source Selection    */
+    uint32_t P22:1;                     /**< bit:     22  Edge/Level Interrupt Source Selection    */
+    uint32_t P23:1;                     /**< bit:     23  Edge/Level Interrupt Source Selection    */
+    uint32_t P24:1;                     /**< bit:     24  Edge/Level Interrupt Source Selection    */
+    uint32_t P25:1;                     /**< bit:     25  Edge/Level Interrupt Source Selection    */
+    uint32_t P26:1;                     /**< bit:     26  Edge/Level Interrupt Source Selection    */
+    uint32_t P27:1;                     /**< bit:     27  Edge/Level Interrupt Source Selection    */
+    uint32_t P28:1;                     /**< bit:     28  Edge/Level Interrupt Source Selection    */
+    uint32_t P29:1;                     /**< bit:     29  Edge/Level Interrupt Source Selection    */
+    uint32_t P30:1;                     /**< bit:     30  Edge/Level Interrupt Source Selection    */
+    uint32_t P31:1;                     /**< bit:     31  Edge/Level Interrupt Source Selection    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge/Level Interrupt Source Selection    */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_ELSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_ELSR_OFFSET                     (0xC8)                                        /**<  (PIO_ELSR) Edge/Level Status Register  Offset */
+
+#define PIO_ELSR_P0_Pos                     0                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P0_Msk                     (_U_(0x1) << PIO_ELSR_P0_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P0                         PIO_ELSR_P0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P0_Msk instead */
+#define PIO_ELSR_P1_Pos                     1                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P1_Msk                     (_U_(0x1) << PIO_ELSR_P1_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P1                         PIO_ELSR_P1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P1_Msk instead */
+#define PIO_ELSR_P2_Pos                     2                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P2_Msk                     (_U_(0x1) << PIO_ELSR_P2_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P2                         PIO_ELSR_P2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P2_Msk instead */
+#define PIO_ELSR_P3_Pos                     3                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P3_Msk                     (_U_(0x1) << PIO_ELSR_P3_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P3                         PIO_ELSR_P3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P3_Msk instead */
+#define PIO_ELSR_P4_Pos                     4                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P4_Msk                     (_U_(0x1) << PIO_ELSR_P4_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P4                         PIO_ELSR_P4_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P4_Msk instead */
+#define PIO_ELSR_P5_Pos                     5                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P5_Msk                     (_U_(0x1) << PIO_ELSR_P5_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P5                         PIO_ELSR_P5_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P5_Msk instead */
+#define PIO_ELSR_P6_Pos                     6                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P6_Msk                     (_U_(0x1) << PIO_ELSR_P6_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P6                         PIO_ELSR_P6_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P6_Msk instead */
+#define PIO_ELSR_P7_Pos                     7                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P7_Msk                     (_U_(0x1) << PIO_ELSR_P7_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P7                         PIO_ELSR_P7_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P7_Msk instead */
+#define PIO_ELSR_P8_Pos                     8                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P8_Msk                     (_U_(0x1) << PIO_ELSR_P8_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P8                         PIO_ELSR_P8_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P8_Msk instead */
+#define PIO_ELSR_P9_Pos                     9                                              /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P9_Msk                     (_U_(0x1) << PIO_ELSR_P9_Pos)                  /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P9                         PIO_ELSR_P9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P9_Msk instead */
+#define PIO_ELSR_P10_Pos                    10                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P10_Msk                    (_U_(0x1) << PIO_ELSR_P10_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P10                        PIO_ELSR_P10_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P10_Msk instead */
+#define PIO_ELSR_P11_Pos                    11                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P11_Msk                    (_U_(0x1) << PIO_ELSR_P11_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P11                        PIO_ELSR_P11_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P11_Msk instead */
+#define PIO_ELSR_P12_Pos                    12                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P12_Msk                    (_U_(0x1) << PIO_ELSR_P12_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P12                        PIO_ELSR_P12_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P12_Msk instead */
+#define PIO_ELSR_P13_Pos                    13                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P13_Msk                    (_U_(0x1) << PIO_ELSR_P13_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P13                        PIO_ELSR_P13_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P13_Msk instead */
+#define PIO_ELSR_P14_Pos                    14                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P14_Msk                    (_U_(0x1) << PIO_ELSR_P14_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P14                        PIO_ELSR_P14_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P14_Msk instead */
+#define PIO_ELSR_P15_Pos                    15                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P15_Msk                    (_U_(0x1) << PIO_ELSR_P15_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P15                        PIO_ELSR_P15_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P15_Msk instead */
+#define PIO_ELSR_P16_Pos                    16                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P16_Msk                    (_U_(0x1) << PIO_ELSR_P16_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P16                        PIO_ELSR_P16_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P16_Msk instead */
+#define PIO_ELSR_P17_Pos                    17                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P17_Msk                    (_U_(0x1) << PIO_ELSR_P17_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P17                        PIO_ELSR_P17_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P17_Msk instead */
+#define PIO_ELSR_P18_Pos                    18                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P18_Msk                    (_U_(0x1) << PIO_ELSR_P18_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P18                        PIO_ELSR_P18_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P18_Msk instead */
+#define PIO_ELSR_P19_Pos                    19                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P19_Msk                    (_U_(0x1) << PIO_ELSR_P19_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P19                        PIO_ELSR_P19_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P19_Msk instead */
+#define PIO_ELSR_P20_Pos                    20                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P20_Msk                    (_U_(0x1) << PIO_ELSR_P20_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P20                        PIO_ELSR_P20_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P20_Msk instead */
+#define PIO_ELSR_P21_Pos                    21                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P21_Msk                    (_U_(0x1) << PIO_ELSR_P21_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P21                        PIO_ELSR_P21_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P21_Msk instead */
+#define PIO_ELSR_P22_Pos                    22                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P22_Msk                    (_U_(0x1) << PIO_ELSR_P22_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P22                        PIO_ELSR_P22_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P22_Msk instead */
+#define PIO_ELSR_P23_Pos                    23                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P23_Msk                    (_U_(0x1) << PIO_ELSR_P23_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P23                        PIO_ELSR_P23_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P23_Msk instead */
+#define PIO_ELSR_P24_Pos                    24                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P24_Msk                    (_U_(0x1) << PIO_ELSR_P24_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P24                        PIO_ELSR_P24_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P24_Msk instead */
+#define PIO_ELSR_P25_Pos                    25                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P25_Msk                    (_U_(0x1) << PIO_ELSR_P25_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P25                        PIO_ELSR_P25_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P25_Msk instead */
+#define PIO_ELSR_P26_Pos                    26                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P26_Msk                    (_U_(0x1) << PIO_ELSR_P26_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P26                        PIO_ELSR_P26_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P26_Msk instead */
+#define PIO_ELSR_P27_Pos                    27                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P27_Msk                    (_U_(0x1) << PIO_ELSR_P27_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P27                        PIO_ELSR_P27_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P27_Msk instead */
+#define PIO_ELSR_P28_Pos                    28                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P28_Msk                    (_U_(0x1) << PIO_ELSR_P28_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P28                        PIO_ELSR_P28_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P28_Msk instead */
+#define PIO_ELSR_P29_Pos                    29                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P29_Msk                    (_U_(0x1) << PIO_ELSR_P29_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P29                        PIO_ELSR_P29_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P29_Msk instead */
+#define PIO_ELSR_P30_Pos                    30                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P30_Msk                    (_U_(0x1) << PIO_ELSR_P30_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P30                        PIO_ELSR_P30_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P30_Msk instead */
+#define PIO_ELSR_P31_Pos                    31                                             /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_ELSR_P31_Msk                    (_U_(0x1) << PIO_ELSR_P31_Pos)                 /**< (PIO_ELSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_ELSR_P31                        PIO_ELSR_P31_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_ELSR_P31_Msk instead */
+#define PIO_ELSR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_ELSR) Register MASK  (Use PIO_ELSR_Msk instead)  */
+#define PIO_ELSR_Msk                        _U_(0xFFFFFFFF)                                /**< (PIO_ELSR) Register Mask  */
+
+#define PIO_ELSR_P_Pos                      0                                              /**< (PIO_ELSR Position) Edge/Level Interrupt Source Selection */
+#define PIO_ELSR_P_Msk                      (_U_(0xFFFFFFFF) << PIO_ELSR_P_Pos)            /**< (PIO_ELSR Mask) P */
+#define PIO_ELSR_P(value)                   (PIO_ELSR_P_Msk & ((value) << PIO_ELSR_P_Pos))  
+
+/* -------- PIO_FELLSR : (PIO Offset: 0xd0) (/W 32) Falling Edge/Low-Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P1:1;                      /**< bit:      1  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P2:1;                      /**< bit:      2  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P3:1;                      /**< bit:      3  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P4:1;                      /**< bit:      4  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P5:1;                      /**< bit:      5  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P6:1;                      /**< bit:      6  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P7:1;                      /**< bit:      7  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P8:1;                      /**< bit:      8  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P9:1;                      /**< bit:      9  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P10:1;                     /**< bit:     10  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P11:1;                     /**< bit:     11  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P12:1;                     /**< bit:     12  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P13:1;                     /**< bit:     13  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P14:1;                     /**< bit:     14  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P15:1;                     /**< bit:     15  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P16:1;                     /**< bit:     16  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P17:1;                     /**< bit:     17  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P18:1;                     /**< bit:     18  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P19:1;                     /**< bit:     19  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P20:1;                     /**< bit:     20  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P21:1;                     /**< bit:     21  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P22:1;                     /**< bit:     22  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P23:1;                     /**< bit:     23  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P24:1;                     /**< bit:     24  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P25:1;                     /**< bit:     25  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P26:1;                     /**< bit:     26  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P27:1;                     /**< bit:     27  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P28:1;                     /**< bit:     28  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P29:1;                     /**< bit:     29  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P30:1;                     /**< bit:     30  Falling Edge/Low-Level Interrupt Selection */
+    uint32_t P31:1;                     /**< bit:     31  Falling Edge/Low-Level Interrupt Selection */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Falling Edge/Low-Level Interrupt Selection */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_FELLSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_FELLSR_OFFSET                   (0xD0)                                        /**<  (PIO_FELLSR) Falling Edge/Low-Level Select Register  Offset */
+
+#define PIO_FELLSR_P0_Pos                   0                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P0_Msk                   (_U_(0x1) << PIO_FELLSR_P0_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P0                       PIO_FELLSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P0_Msk instead */
+#define PIO_FELLSR_P1_Pos                   1                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P1_Msk                   (_U_(0x1) << PIO_FELLSR_P1_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P1                       PIO_FELLSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P1_Msk instead */
+#define PIO_FELLSR_P2_Pos                   2                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P2_Msk                   (_U_(0x1) << PIO_FELLSR_P2_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P2                       PIO_FELLSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P2_Msk instead */
+#define PIO_FELLSR_P3_Pos                   3                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P3_Msk                   (_U_(0x1) << PIO_FELLSR_P3_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P3                       PIO_FELLSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P3_Msk instead */
+#define PIO_FELLSR_P4_Pos                   4                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P4_Msk                   (_U_(0x1) << PIO_FELLSR_P4_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P4                       PIO_FELLSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P4_Msk instead */
+#define PIO_FELLSR_P5_Pos                   5                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P5_Msk                   (_U_(0x1) << PIO_FELLSR_P5_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P5                       PIO_FELLSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P5_Msk instead */
+#define PIO_FELLSR_P6_Pos                   6                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P6_Msk                   (_U_(0x1) << PIO_FELLSR_P6_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P6                       PIO_FELLSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P6_Msk instead */
+#define PIO_FELLSR_P7_Pos                   7                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P7_Msk                   (_U_(0x1) << PIO_FELLSR_P7_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P7                       PIO_FELLSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P7_Msk instead */
+#define PIO_FELLSR_P8_Pos                   8                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P8_Msk                   (_U_(0x1) << PIO_FELLSR_P8_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P8                       PIO_FELLSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P8_Msk instead */
+#define PIO_FELLSR_P9_Pos                   9                                              /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P9_Msk                   (_U_(0x1) << PIO_FELLSR_P9_Pos)                /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P9                       PIO_FELLSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P9_Msk instead */
+#define PIO_FELLSR_P10_Pos                  10                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P10_Msk                  (_U_(0x1) << PIO_FELLSR_P10_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P10                      PIO_FELLSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P10_Msk instead */
+#define PIO_FELLSR_P11_Pos                  11                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P11_Msk                  (_U_(0x1) << PIO_FELLSR_P11_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P11                      PIO_FELLSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P11_Msk instead */
+#define PIO_FELLSR_P12_Pos                  12                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P12_Msk                  (_U_(0x1) << PIO_FELLSR_P12_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P12                      PIO_FELLSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P12_Msk instead */
+#define PIO_FELLSR_P13_Pos                  13                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P13_Msk                  (_U_(0x1) << PIO_FELLSR_P13_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P13                      PIO_FELLSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P13_Msk instead */
+#define PIO_FELLSR_P14_Pos                  14                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P14_Msk                  (_U_(0x1) << PIO_FELLSR_P14_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P14                      PIO_FELLSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P14_Msk instead */
+#define PIO_FELLSR_P15_Pos                  15                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P15_Msk                  (_U_(0x1) << PIO_FELLSR_P15_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P15                      PIO_FELLSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P15_Msk instead */
+#define PIO_FELLSR_P16_Pos                  16                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P16_Msk                  (_U_(0x1) << PIO_FELLSR_P16_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P16                      PIO_FELLSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P16_Msk instead */
+#define PIO_FELLSR_P17_Pos                  17                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P17_Msk                  (_U_(0x1) << PIO_FELLSR_P17_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P17                      PIO_FELLSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P17_Msk instead */
+#define PIO_FELLSR_P18_Pos                  18                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P18_Msk                  (_U_(0x1) << PIO_FELLSR_P18_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P18                      PIO_FELLSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P18_Msk instead */
+#define PIO_FELLSR_P19_Pos                  19                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P19_Msk                  (_U_(0x1) << PIO_FELLSR_P19_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P19                      PIO_FELLSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P19_Msk instead */
+#define PIO_FELLSR_P20_Pos                  20                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P20_Msk                  (_U_(0x1) << PIO_FELLSR_P20_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P20                      PIO_FELLSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P20_Msk instead */
+#define PIO_FELLSR_P21_Pos                  21                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P21_Msk                  (_U_(0x1) << PIO_FELLSR_P21_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P21                      PIO_FELLSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P21_Msk instead */
+#define PIO_FELLSR_P22_Pos                  22                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P22_Msk                  (_U_(0x1) << PIO_FELLSR_P22_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P22                      PIO_FELLSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P22_Msk instead */
+#define PIO_FELLSR_P23_Pos                  23                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P23_Msk                  (_U_(0x1) << PIO_FELLSR_P23_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P23                      PIO_FELLSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P23_Msk instead */
+#define PIO_FELLSR_P24_Pos                  24                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P24_Msk                  (_U_(0x1) << PIO_FELLSR_P24_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P24                      PIO_FELLSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P24_Msk instead */
+#define PIO_FELLSR_P25_Pos                  25                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P25_Msk                  (_U_(0x1) << PIO_FELLSR_P25_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P25                      PIO_FELLSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P25_Msk instead */
+#define PIO_FELLSR_P26_Pos                  26                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P26_Msk                  (_U_(0x1) << PIO_FELLSR_P26_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P26                      PIO_FELLSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P26_Msk instead */
+#define PIO_FELLSR_P27_Pos                  27                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P27_Msk                  (_U_(0x1) << PIO_FELLSR_P27_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P27                      PIO_FELLSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P27_Msk instead */
+#define PIO_FELLSR_P28_Pos                  28                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P28_Msk                  (_U_(0x1) << PIO_FELLSR_P28_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P28                      PIO_FELLSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P28_Msk instead */
+#define PIO_FELLSR_P29_Pos                  29                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P29_Msk                  (_U_(0x1) << PIO_FELLSR_P29_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P29                      PIO_FELLSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P29_Msk instead */
+#define PIO_FELLSR_P30_Pos                  30                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P30_Msk                  (_U_(0x1) << PIO_FELLSR_P30_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P30                      PIO_FELLSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P30_Msk instead */
+#define PIO_FELLSR_P31_Pos                  31                                             /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Position */
+#define PIO_FELLSR_P31_Msk                  (_U_(0x1) << PIO_FELLSR_P31_Pos)               /**< (PIO_FELLSR) Falling Edge/Low-Level Interrupt Selection Mask */
+#define PIO_FELLSR_P31                      PIO_FELLSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FELLSR_P31_Msk instead */
+#define PIO_FELLSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_FELLSR) Register MASK  (Use PIO_FELLSR_Msk instead)  */
+#define PIO_FELLSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_FELLSR) Register Mask  */
+
+#define PIO_FELLSR_P_Pos                    0                                              /**< (PIO_FELLSR Position) Falling Edge/Low-Level Interrupt Selection */
+#define PIO_FELLSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_FELLSR_P_Pos)          /**< (PIO_FELLSR Mask) P */
+#define PIO_FELLSR_P(value)                 (PIO_FELLSR_P_Msk & ((value) << PIO_FELLSR_P_Pos))  
+
+/* -------- PIO_REHLSR : (PIO Offset: 0xd4) (/W 32) Rising Edge/High-Level Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P1:1;                      /**< bit:      1  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P2:1;                      /**< bit:      2  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P3:1;                      /**< bit:      3  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P4:1;                      /**< bit:      4  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P5:1;                      /**< bit:      5  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P6:1;                      /**< bit:      6  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P7:1;                      /**< bit:      7  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P8:1;                      /**< bit:      8  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P9:1;                      /**< bit:      9  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P10:1;                     /**< bit:     10  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P11:1;                     /**< bit:     11  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P12:1;                     /**< bit:     12  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P13:1;                     /**< bit:     13  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P14:1;                     /**< bit:     14  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P15:1;                     /**< bit:     15  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P16:1;                     /**< bit:     16  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P17:1;                     /**< bit:     17  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P18:1;                     /**< bit:     18  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P19:1;                     /**< bit:     19  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P20:1;                     /**< bit:     20  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P21:1;                     /**< bit:     21  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P22:1;                     /**< bit:     22  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P23:1;                     /**< bit:     23  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P24:1;                     /**< bit:     24  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P25:1;                     /**< bit:     25  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P26:1;                     /**< bit:     26  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P27:1;                     /**< bit:     27  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P28:1;                     /**< bit:     28  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P29:1;                     /**< bit:     29  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P30:1;                     /**< bit:     30  Rising Edge/High-Level Interrupt Selection */
+    uint32_t P31:1;                     /**< bit:     31  Rising Edge/High-Level Interrupt Selection */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Rising Edge/High-Level Interrupt Selection */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_REHLSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_REHLSR_OFFSET                   (0xD4)                                        /**<  (PIO_REHLSR) Rising Edge/High-Level Select Register  Offset */
+
+#define PIO_REHLSR_P0_Pos                   0                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P0_Msk                   (_U_(0x1) << PIO_REHLSR_P0_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P0                       PIO_REHLSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P0_Msk instead */
+#define PIO_REHLSR_P1_Pos                   1                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P1_Msk                   (_U_(0x1) << PIO_REHLSR_P1_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P1                       PIO_REHLSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P1_Msk instead */
+#define PIO_REHLSR_P2_Pos                   2                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P2_Msk                   (_U_(0x1) << PIO_REHLSR_P2_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P2                       PIO_REHLSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P2_Msk instead */
+#define PIO_REHLSR_P3_Pos                   3                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P3_Msk                   (_U_(0x1) << PIO_REHLSR_P3_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P3                       PIO_REHLSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P3_Msk instead */
+#define PIO_REHLSR_P4_Pos                   4                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P4_Msk                   (_U_(0x1) << PIO_REHLSR_P4_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P4                       PIO_REHLSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P4_Msk instead */
+#define PIO_REHLSR_P5_Pos                   5                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P5_Msk                   (_U_(0x1) << PIO_REHLSR_P5_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P5                       PIO_REHLSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P5_Msk instead */
+#define PIO_REHLSR_P6_Pos                   6                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P6_Msk                   (_U_(0x1) << PIO_REHLSR_P6_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P6                       PIO_REHLSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P6_Msk instead */
+#define PIO_REHLSR_P7_Pos                   7                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P7_Msk                   (_U_(0x1) << PIO_REHLSR_P7_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P7                       PIO_REHLSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P7_Msk instead */
+#define PIO_REHLSR_P8_Pos                   8                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P8_Msk                   (_U_(0x1) << PIO_REHLSR_P8_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P8                       PIO_REHLSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P8_Msk instead */
+#define PIO_REHLSR_P9_Pos                   9                                              /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P9_Msk                   (_U_(0x1) << PIO_REHLSR_P9_Pos)                /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P9                       PIO_REHLSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P9_Msk instead */
+#define PIO_REHLSR_P10_Pos                  10                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P10_Msk                  (_U_(0x1) << PIO_REHLSR_P10_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P10                      PIO_REHLSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P10_Msk instead */
+#define PIO_REHLSR_P11_Pos                  11                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P11_Msk                  (_U_(0x1) << PIO_REHLSR_P11_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P11                      PIO_REHLSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P11_Msk instead */
+#define PIO_REHLSR_P12_Pos                  12                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P12_Msk                  (_U_(0x1) << PIO_REHLSR_P12_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P12                      PIO_REHLSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P12_Msk instead */
+#define PIO_REHLSR_P13_Pos                  13                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P13_Msk                  (_U_(0x1) << PIO_REHLSR_P13_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P13                      PIO_REHLSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P13_Msk instead */
+#define PIO_REHLSR_P14_Pos                  14                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P14_Msk                  (_U_(0x1) << PIO_REHLSR_P14_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P14                      PIO_REHLSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P14_Msk instead */
+#define PIO_REHLSR_P15_Pos                  15                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P15_Msk                  (_U_(0x1) << PIO_REHLSR_P15_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P15                      PIO_REHLSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P15_Msk instead */
+#define PIO_REHLSR_P16_Pos                  16                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P16_Msk                  (_U_(0x1) << PIO_REHLSR_P16_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P16                      PIO_REHLSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P16_Msk instead */
+#define PIO_REHLSR_P17_Pos                  17                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P17_Msk                  (_U_(0x1) << PIO_REHLSR_P17_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P17                      PIO_REHLSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P17_Msk instead */
+#define PIO_REHLSR_P18_Pos                  18                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P18_Msk                  (_U_(0x1) << PIO_REHLSR_P18_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P18                      PIO_REHLSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P18_Msk instead */
+#define PIO_REHLSR_P19_Pos                  19                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P19_Msk                  (_U_(0x1) << PIO_REHLSR_P19_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P19                      PIO_REHLSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P19_Msk instead */
+#define PIO_REHLSR_P20_Pos                  20                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P20_Msk                  (_U_(0x1) << PIO_REHLSR_P20_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P20                      PIO_REHLSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P20_Msk instead */
+#define PIO_REHLSR_P21_Pos                  21                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P21_Msk                  (_U_(0x1) << PIO_REHLSR_P21_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P21                      PIO_REHLSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P21_Msk instead */
+#define PIO_REHLSR_P22_Pos                  22                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P22_Msk                  (_U_(0x1) << PIO_REHLSR_P22_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P22                      PIO_REHLSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P22_Msk instead */
+#define PIO_REHLSR_P23_Pos                  23                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P23_Msk                  (_U_(0x1) << PIO_REHLSR_P23_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P23                      PIO_REHLSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P23_Msk instead */
+#define PIO_REHLSR_P24_Pos                  24                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P24_Msk                  (_U_(0x1) << PIO_REHLSR_P24_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P24                      PIO_REHLSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P24_Msk instead */
+#define PIO_REHLSR_P25_Pos                  25                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P25_Msk                  (_U_(0x1) << PIO_REHLSR_P25_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P25                      PIO_REHLSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P25_Msk instead */
+#define PIO_REHLSR_P26_Pos                  26                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P26_Msk                  (_U_(0x1) << PIO_REHLSR_P26_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P26                      PIO_REHLSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P26_Msk instead */
+#define PIO_REHLSR_P27_Pos                  27                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P27_Msk                  (_U_(0x1) << PIO_REHLSR_P27_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P27                      PIO_REHLSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P27_Msk instead */
+#define PIO_REHLSR_P28_Pos                  28                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P28_Msk                  (_U_(0x1) << PIO_REHLSR_P28_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P28                      PIO_REHLSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P28_Msk instead */
+#define PIO_REHLSR_P29_Pos                  29                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P29_Msk                  (_U_(0x1) << PIO_REHLSR_P29_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P29                      PIO_REHLSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P29_Msk instead */
+#define PIO_REHLSR_P30_Pos                  30                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P30_Msk                  (_U_(0x1) << PIO_REHLSR_P30_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P30                      PIO_REHLSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P30_Msk instead */
+#define PIO_REHLSR_P31_Pos                  31                                             /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Position */
+#define PIO_REHLSR_P31_Msk                  (_U_(0x1) << PIO_REHLSR_P31_Pos)               /**< (PIO_REHLSR) Rising Edge/High-Level Interrupt Selection Mask */
+#define PIO_REHLSR_P31                      PIO_REHLSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_REHLSR_P31_Msk instead */
+#define PIO_REHLSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_REHLSR) Register MASK  (Use PIO_REHLSR_Msk instead)  */
+#define PIO_REHLSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_REHLSR) Register Mask  */
+
+#define PIO_REHLSR_P_Pos                    0                                              /**< (PIO_REHLSR Position) Rising Edge/High-Level Interrupt Selection */
+#define PIO_REHLSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_REHLSR_P_Pos)          /**< (PIO_REHLSR Mask) P */
+#define PIO_REHLSR_P(value)                 (PIO_REHLSR_P_Msk & ((value) << PIO_REHLSR_P_Pos))  
+
+/* -------- PIO_FRLHSR : (PIO Offset: 0xd8) (R/ 32) Fall/Rise - Low/High Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
+    uint32_t P1:1;                      /**< bit:      1  Edge/Level Interrupt Source Selection    */
+    uint32_t P2:1;                      /**< bit:      2  Edge/Level Interrupt Source Selection    */
+    uint32_t P3:1;                      /**< bit:      3  Edge/Level Interrupt Source Selection    */
+    uint32_t P4:1;                      /**< bit:      4  Edge/Level Interrupt Source Selection    */
+    uint32_t P5:1;                      /**< bit:      5  Edge/Level Interrupt Source Selection    */
+    uint32_t P6:1;                      /**< bit:      6  Edge/Level Interrupt Source Selection    */
+    uint32_t P7:1;                      /**< bit:      7  Edge/Level Interrupt Source Selection    */
+    uint32_t P8:1;                      /**< bit:      8  Edge/Level Interrupt Source Selection    */
+    uint32_t P9:1;                      /**< bit:      9  Edge/Level Interrupt Source Selection    */
+    uint32_t P10:1;                     /**< bit:     10  Edge/Level Interrupt Source Selection    */
+    uint32_t P11:1;                     /**< bit:     11  Edge/Level Interrupt Source Selection    */
+    uint32_t P12:1;                     /**< bit:     12  Edge/Level Interrupt Source Selection    */
+    uint32_t P13:1;                     /**< bit:     13  Edge/Level Interrupt Source Selection    */
+    uint32_t P14:1;                     /**< bit:     14  Edge/Level Interrupt Source Selection    */
+    uint32_t P15:1;                     /**< bit:     15  Edge/Level Interrupt Source Selection    */
+    uint32_t P16:1;                     /**< bit:     16  Edge/Level Interrupt Source Selection    */
+    uint32_t P17:1;                     /**< bit:     17  Edge/Level Interrupt Source Selection    */
+    uint32_t P18:1;                     /**< bit:     18  Edge/Level Interrupt Source Selection    */
+    uint32_t P19:1;                     /**< bit:     19  Edge/Level Interrupt Source Selection    */
+    uint32_t P20:1;                     /**< bit:     20  Edge/Level Interrupt Source Selection    */
+    uint32_t P21:1;                     /**< bit:     21  Edge/Level Interrupt Source Selection    */
+    uint32_t P22:1;                     /**< bit:     22  Edge/Level Interrupt Source Selection    */
+    uint32_t P23:1;                     /**< bit:     23  Edge/Level Interrupt Source Selection    */
+    uint32_t P24:1;                     /**< bit:     24  Edge/Level Interrupt Source Selection    */
+    uint32_t P25:1;                     /**< bit:     25  Edge/Level Interrupt Source Selection    */
+    uint32_t P26:1;                     /**< bit:     26  Edge/Level Interrupt Source Selection    */
+    uint32_t P27:1;                     /**< bit:     27  Edge/Level Interrupt Source Selection    */
+    uint32_t P28:1;                     /**< bit:     28  Edge/Level Interrupt Source Selection    */
+    uint32_t P29:1;                     /**< bit:     29  Edge/Level Interrupt Source Selection    */
+    uint32_t P30:1;                     /**< bit:     30  Edge/Level Interrupt Source Selection    */
+    uint32_t P31:1;                     /**< bit:     31  Edge/Level Interrupt Source Selection    */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Edge/Level Interrupt Source Selection    */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_FRLHSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_FRLHSR_OFFSET                   (0xD8)                                        /**<  (PIO_FRLHSR) Fall/Rise - Low/High Status Register  Offset */
+
+#define PIO_FRLHSR_P0_Pos                   0                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P0_Msk                   (_U_(0x1) << PIO_FRLHSR_P0_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P0                       PIO_FRLHSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P0_Msk instead */
+#define PIO_FRLHSR_P1_Pos                   1                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P1_Msk                   (_U_(0x1) << PIO_FRLHSR_P1_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P1                       PIO_FRLHSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P1_Msk instead */
+#define PIO_FRLHSR_P2_Pos                   2                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P2_Msk                   (_U_(0x1) << PIO_FRLHSR_P2_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P2                       PIO_FRLHSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P2_Msk instead */
+#define PIO_FRLHSR_P3_Pos                   3                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P3_Msk                   (_U_(0x1) << PIO_FRLHSR_P3_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P3                       PIO_FRLHSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P3_Msk instead */
+#define PIO_FRLHSR_P4_Pos                   4                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P4_Msk                   (_U_(0x1) << PIO_FRLHSR_P4_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P4                       PIO_FRLHSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P4_Msk instead */
+#define PIO_FRLHSR_P5_Pos                   5                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P5_Msk                   (_U_(0x1) << PIO_FRLHSR_P5_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P5                       PIO_FRLHSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P5_Msk instead */
+#define PIO_FRLHSR_P6_Pos                   6                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P6_Msk                   (_U_(0x1) << PIO_FRLHSR_P6_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P6                       PIO_FRLHSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P6_Msk instead */
+#define PIO_FRLHSR_P7_Pos                   7                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P7_Msk                   (_U_(0x1) << PIO_FRLHSR_P7_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P7                       PIO_FRLHSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P7_Msk instead */
+#define PIO_FRLHSR_P8_Pos                   8                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P8_Msk                   (_U_(0x1) << PIO_FRLHSR_P8_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P8                       PIO_FRLHSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P8_Msk instead */
+#define PIO_FRLHSR_P9_Pos                   9                                              /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P9_Msk                   (_U_(0x1) << PIO_FRLHSR_P9_Pos)                /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P9                       PIO_FRLHSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P9_Msk instead */
+#define PIO_FRLHSR_P10_Pos                  10                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P10_Msk                  (_U_(0x1) << PIO_FRLHSR_P10_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P10                      PIO_FRLHSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P10_Msk instead */
+#define PIO_FRLHSR_P11_Pos                  11                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P11_Msk                  (_U_(0x1) << PIO_FRLHSR_P11_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P11                      PIO_FRLHSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P11_Msk instead */
+#define PIO_FRLHSR_P12_Pos                  12                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P12_Msk                  (_U_(0x1) << PIO_FRLHSR_P12_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P12                      PIO_FRLHSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P12_Msk instead */
+#define PIO_FRLHSR_P13_Pos                  13                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P13_Msk                  (_U_(0x1) << PIO_FRLHSR_P13_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P13                      PIO_FRLHSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P13_Msk instead */
+#define PIO_FRLHSR_P14_Pos                  14                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P14_Msk                  (_U_(0x1) << PIO_FRLHSR_P14_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P14                      PIO_FRLHSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P14_Msk instead */
+#define PIO_FRLHSR_P15_Pos                  15                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P15_Msk                  (_U_(0x1) << PIO_FRLHSR_P15_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P15                      PIO_FRLHSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P15_Msk instead */
+#define PIO_FRLHSR_P16_Pos                  16                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P16_Msk                  (_U_(0x1) << PIO_FRLHSR_P16_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P16                      PIO_FRLHSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P16_Msk instead */
+#define PIO_FRLHSR_P17_Pos                  17                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P17_Msk                  (_U_(0x1) << PIO_FRLHSR_P17_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P17                      PIO_FRLHSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P17_Msk instead */
+#define PIO_FRLHSR_P18_Pos                  18                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P18_Msk                  (_U_(0x1) << PIO_FRLHSR_P18_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P18                      PIO_FRLHSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P18_Msk instead */
+#define PIO_FRLHSR_P19_Pos                  19                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P19_Msk                  (_U_(0x1) << PIO_FRLHSR_P19_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P19                      PIO_FRLHSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P19_Msk instead */
+#define PIO_FRLHSR_P20_Pos                  20                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P20_Msk                  (_U_(0x1) << PIO_FRLHSR_P20_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P20                      PIO_FRLHSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P20_Msk instead */
+#define PIO_FRLHSR_P21_Pos                  21                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P21_Msk                  (_U_(0x1) << PIO_FRLHSR_P21_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P21                      PIO_FRLHSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P21_Msk instead */
+#define PIO_FRLHSR_P22_Pos                  22                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P22_Msk                  (_U_(0x1) << PIO_FRLHSR_P22_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P22                      PIO_FRLHSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P22_Msk instead */
+#define PIO_FRLHSR_P23_Pos                  23                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P23_Msk                  (_U_(0x1) << PIO_FRLHSR_P23_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P23                      PIO_FRLHSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P23_Msk instead */
+#define PIO_FRLHSR_P24_Pos                  24                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P24_Msk                  (_U_(0x1) << PIO_FRLHSR_P24_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P24                      PIO_FRLHSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P24_Msk instead */
+#define PIO_FRLHSR_P25_Pos                  25                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P25_Msk                  (_U_(0x1) << PIO_FRLHSR_P25_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P25                      PIO_FRLHSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P25_Msk instead */
+#define PIO_FRLHSR_P26_Pos                  26                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P26_Msk                  (_U_(0x1) << PIO_FRLHSR_P26_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P26                      PIO_FRLHSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P26_Msk instead */
+#define PIO_FRLHSR_P27_Pos                  27                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P27_Msk                  (_U_(0x1) << PIO_FRLHSR_P27_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P27                      PIO_FRLHSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P27_Msk instead */
+#define PIO_FRLHSR_P28_Pos                  28                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P28_Msk                  (_U_(0x1) << PIO_FRLHSR_P28_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P28                      PIO_FRLHSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P28_Msk instead */
+#define PIO_FRLHSR_P29_Pos                  29                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P29_Msk                  (_U_(0x1) << PIO_FRLHSR_P29_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P29                      PIO_FRLHSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P29_Msk instead */
+#define PIO_FRLHSR_P30_Pos                  30                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P30_Msk                  (_U_(0x1) << PIO_FRLHSR_P30_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P30                      PIO_FRLHSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P30_Msk instead */
+#define PIO_FRLHSR_P31_Pos                  31                                             /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Position */
+#define PIO_FRLHSR_P31_Msk                  (_U_(0x1) << PIO_FRLHSR_P31_Pos)               /**< (PIO_FRLHSR) Edge/Level Interrupt Source Selection Mask */
+#define PIO_FRLHSR_P31                      PIO_FRLHSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_FRLHSR_P31_Msk instead */
+#define PIO_FRLHSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_FRLHSR) Register MASK  (Use PIO_FRLHSR_Msk instead)  */
+#define PIO_FRLHSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_FRLHSR) Register Mask  */
+
+#define PIO_FRLHSR_P_Pos                    0                                              /**< (PIO_FRLHSR Position) Edge/Level Interrupt Source Selection */
+#define PIO_FRLHSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_FRLHSR_P_Pos)          /**< (PIO_FRLHSR Mask) P */
+#define PIO_FRLHSR_P(value)                 (PIO_FRLHSR_P_Msk & ((value) << PIO_FRLHSR_P_Pos))  
+
+/* -------- PIO_LOCKSR : (PIO Offset: 0xe0) (R/ 32) Lock Status -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t P0:1;                      /**< bit:      0  Lock Status                              */
+    uint32_t P1:1;                      /**< bit:      1  Lock Status                              */
+    uint32_t P2:1;                      /**< bit:      2  Lock Status                              */
+    uint32_t P3:1;                      /**< bit:      3  Lock Status                              */
+    uint32_t P4:1;                      /**< bit:      4  Lock Status                              */
+    uint32_t P5:1;                      /**< bit:      5  Lock Status                              */
+    uint32_t P6:1;                      /**< bit:      6  Lock Status                              */
+    uint32_t P7:1;                      /**< bit:      7  Lock Status                              */
+    uint32_t P8:1;                      /**< bit:      8  Lock Status                              */
+    uint32_t P9:1;                      /**< bit:      9  Lock Status                              */
+    uint32_t P10:1;                     /**< bit:     10  Lock Status                              */
+    uint32_t P11:1;                     /**< bit:     11  Lock Status                              */
+    uint32_t P12:1;                     /**< bit:     12  Lock Status                              */
+    uint32_t P13:1;                     /**< bit:     13  Lock Status                              */
+    uint32_t P14:1;                     /**< bit:     14  Lock Status                              */
+    uint32_t P15:1;                     /**< bit:     15  Lock Status                              */
+    uint32_t P16:1;                     /**< bit:     16  Lock Status                              */
+    uint32_t P17:1;                     /**< bit:     17  Lock Status                              */
+    uint32_t P18:1;                     /**< bit:     18  Lock Status                              */
+    uint32_t P19:1;                     /**< bit:     19  Lock Status                              */
+    uint32_t P20:1;                     /**< bit:     20  Lock Status                              */
+    uint32_t P21:1;                     /**< bit:     21  Lock Status                              */
+    uint32_t P22:1;                     /**< bit:     22  Lock Status                              */
+    uint32_t P23:1;                     /**< bit:     23  Lock Status                              */
+    uint32_t P24:1;                     /**< bit:     24  Lock Status                              */
+    uint32_t P25:1;                     /**< bit:     25  Lock Status                              */
+    uint32_t P26:1;                     /**< bit:     26  Lock Status                              */
+    uint32_t P27:1;                     /**< bit:     27  Lock Status                              */
+    uint32_t P28:1;                     /**< bit:     28  Lock Status                              */
+    uint32_t P29:1;                     /**< bit:     29  Lock Status                              */
+    uint32_t P30:1;                     /**< bit:     30  Lock Status                              */
+    uint32_t P31:1;                     /**< bit:     31  Lock Status                              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t P:32;                      /**< bit:  0..31  Lock Status                              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_LOCKSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_LOCKSR_OFFSET                   (0xE0)                                        /**<  (PIO_LOCKSR) Lock Status  Offset */
+
+#define PIO_LOCKSR_P0_Pos                   0                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P0_Msk                   (_U_(0x1) << PIO_LOCKSR_P0_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P0                       PIO_LOCKSR_P0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P0_Msk instead */
+#define PIO_LOCKSR_P1_Pos                   1                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P1_Msk                   (_U_(0x1) << PIO_LOCKSR_P1_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P1                       PIO_LOCKSR_P1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P1_Msk instead */
+#define PIO_LOCKSR_P2_Pos                   2                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P2_Msk                   (_U_(0x1) << PIO_LOCKSR_P2_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P2                       PIO_LOCKSR_P2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P2_Msk instead */
+#define PIO_LOCKSR_P3_Pos                   3                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P3_Msk                   (_U_(0x1) << PIO_LOCKSR_P3_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P3                       PIO_LOCKSR_P3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P3_Msk instead */
+#define PIO_LOCKSR_P4_Pos                   4                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P4_Msk                   (_U_(0x1) << PIO_LOCKSR_P4_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P4                       PIO_LOCKSR_P4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P4_Msk instead */
+#define PIO_LOCKSR_P5_Pos                   5                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P5_Msk                   (_U_(0x1) << PIO_LOCKSR_P5_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P5                       PIO_LOCKSR_P5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P5_Msk instead */
+#define PIO_LOCKSR_P6_Pos                   6                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P6_Msk                   (_U_(0x1) << PIO_LOCKSR_P6_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P6                       PIO_LOCKSR_P6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P6_Msk instead */
+#define PIO_LOCKSR_P7_Pos                   7                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P7_Msk                   (_U_(0x1) << PIO_LOCKSR_P7_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P7                       PIO_LOCKSR_P7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P7_Msk instead */
+#define PIO_LOCKSR_P8_Pos                   8                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P8_Msk                   (_U_(0x1) << PIO_LOCKSR_P8_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P8                       PIO_LOCKSR_P8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P8_Msk instead */
+#define PIO_LOCKSR_P9_Pos                   9                                              /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P9_Msk                   (_U_(0x1) << PIO_LOCKSR_P9_Pos)                /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P9                       PIO_LOCKSR_P9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P9_Msk instead */
+#define PIO_LOCKSR_P10_Pos                  10                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P10_Msk                  (_U_(0x1) << PIO_LOCKSR_P10_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P10                      PIO_LOCKSR_P10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P10_Msk instead */
+#define PIO_LOCKSR_P11_Pos                  11                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P11_Msk                  (_U_(0x1) << PIO_LOCKSR_P11_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P11                      PIO_LOCKSR_P11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P11_Msk instead */
+#define PIO_LOCKSR_P12_Pos                  12                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P12_Msk                  (_U_(0x1) << PIO_LOCKSR_P12_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P12                      PIO_LOCKSR_P12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P12_Msk instead */
+#define PIO_LOCKSR_P13_Pos                  13                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P13_Msk                  (_U_(0x1) << PIO_LOCKSR_P13_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P13                      PIO_LOCKSR_P13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P13_Msk instead */
+#define PIO_LOCKSR_P14_Pos                  14                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P14_Msk                  (_U_(0x1) << PIO_LOCKSR_P14_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P14                      PIO_LOCKSR_P14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P14_Msk instead */
+#define PIO_LOCKSR_P15_Pos                  15                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P15_Msk                  (_U_(0x1) << PIO_LOCKSR_P15_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P15                      PIO_LOCKSR_P15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P15_Msk instead */
+#define PIO_LOCKSR_P16_Pos                  16                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P16_Msk                  (_U_(0x1) << PIO_LOCKSR_P16_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P16                      PIO_LOCKSR_P16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P16_Msk instead */
+#define PIO_LOCKSR_P17_Pos                  17                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P17_Msk                  (_U_(0x1) << PIO_LOCKSR_P17_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P17                      PIO_LOCKSR_P17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P17_Msk instead */
+#define PIO_LOCKSR_P18_Pos                  18                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P18_Msk                  (_U_(0x1) << PIO_LOCKSR_P18_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P18                      PIO_LOCKSR_P18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P18_Msk instead */
+#define PIO_LOCKSR_P19_Pos                  19                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P19_Msk                  (_U_(0x1) << PIO_LOCKSR_P19_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P19                      PIO_LOCKSR_P19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P19_Msk instead */
+#define PIO_LOCKSR_P20_Pos                  20                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P20_Msk                  (_U_(0x1) << PIO_LOCKSR_P20_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P20                      PIO_LOCKSR_P20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P20_Msk instead */
+#define PIO_LOCKSR_P21_Pos                  21                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P21_Msk                  (_U_(0x1) << PIO_LOCKSR_P21_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P21                      PIO_LOCKSR_P21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P21_Msk instead */
+#define PIO_LOCKSR_P22_Pos                  22                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P22_Msk                  (_U_(0x1) << PIO_LOCKSR_P22_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P22                      PIO_LOCKSR_P22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P22_Msk instead */
+#define PIO_LOCKSR_P23_Pos                  23                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P23_Msk                  (_U_(0x1) << PIO_LOCKSR_P23_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P23                      PIO_LOCKSR_P23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P23_Msk instead */
+#define PIO_LOCKSR_P24_Pos                  24                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P24_Msk                  (_U_(0x1) << PIO_LOCKSR_P24_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P24                      PIO_LOCKSR_P24_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P24_Msk instead */
+#define PIO_LOCKSR_P25_Pos                  25                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P25_Msk                  (_U_(0x1) << PIO_LOCKSR_P25_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P25                      PIO_LOCKSR_P25_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P25_Msk instead */
+#define PIO_LOCKSR_P26_Pos                  26                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P26_Msk                  (_U_(0x1) << PIO_LOCKSR_P26_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P26                      PIO_LOCKSR_P26_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P26_Msk instead */
+#define PIO_LOCKSR_P27_Pos                  27                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P27_Msk                  (_U_(0x1) << PIO_LOCKSR_P27_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P27                      PIO_LOCKSR_P27_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P27_Msk instead */
+#define PIO_LOCKSR_P28_Pos                  28                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P28_Msk                  (_U_(0x1) << PIO_LOCKSR_P28_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P28                      PIO_LOCKSR_P28_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P28_Msk instead */
+#define PIO_LOCKSR_P29_Pos                  29                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P29_Msk                  (_U_(0x1) << PIO_LOCKSR_P29_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P29                      PIO_LOCKSR_P29_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P29_Msk instead */
+#define PIO_LOCKSR_P30_Pos                  30                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P30_Msk                  (_U_(0x1) << PIO_LOCKSR_P30_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P30                      PIO_LOCKSR_P30_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P30_Msk instead */
+#define PIO_LOCKSR_P31_Pos                  31                                             /**< (PIO_LOCKSR) Lock Status Position */
+#define PIO_LOCKSR_P31_Msk                  (_U_(0x1) << PIO_LOCKSR_P31_Pos)               /**< (PIO_LOCKSR) Lock Status Mask */
+#define PIO_LOCKSR_P31                      PIO_LOCKSR_P31_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_LOCKSR_P31_Msk instead */
+#define PIO_LOCKSR_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_LOCKSR) Register MASK  (Use PIO_LOCKSR_Msk instead)  */
+#define PIO_LOCKSR_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_LOCKSR) Register Mask  */
+
+#define PIO_LOCKSR_P_Pos                    0                                              /**< (PIO_LOCKSR Position) Lock Status */
+#define PIO_LOCKSR_P_Msk                    (_U_(0xFFFFFFFF) << PIO_LOCKSR_P_Pos)          /**< (PIO_LOCKSR Mask) P */
+#define PIO_LOCKSR_P(value)                 (PIO_LOCKSR_P_Msk & ((value) << PIO_LOCKSR_P_Pos))  
+
+/* -------- PIO_WPMR : (PIO Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_WPMR_OFFSET                     (0xE4)                                        /**<  (PIO_WPMR) Write Protection Mode Register  Offset */
+
+#define PIO_WPMR_WPEN_Pos                   0                                              /**< (PIO_WPMR) Write Protection Enable Position */
+#define PIO_WPMR_WPEN_Msk                   (_U_(0x1) << PIO_WPMR_WPEN_Pos)                /**< (PIO_WPMR) Write Protection Enable Mask */
+#define PIO_WPMR_WPEN                       PIO_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_WPMR_WPEN_Msk instead */
+#define PIO_WPMR_WPKEY_Pos                  8                                              /**< (PIO_WPMR) Write Protection Key Position */
+#define PIO_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << PIO_WPMR_WPKEY_Pos)          /**< (PIO_WPMR) Write Protection Key Mask */
+#define PIO_WPMR_WPKEY(value)               (PIO_WPMR_WPKEY_Msk & ((value) << PIO_WPMR_WPKEY_Pos))
+#define   PIO_WPMR_WPKEY_PASSWD_Val         _U_(0x50494F)                                  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define PIO_WPMR_WPKEY_PASSWD               (PIO_WPMR_WPKEY_PASSWD_Val << PIO_WPMR_WPKEY_Pos)  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define PIO_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (PIO_WPMR) Register MASK  (Use PIO_WPMR_Msk instead)  */
+#define PIO_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (PIO_WPMR) Register Mask  */
+
+
+/* -------- PIO_WPSR : (PIO Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_WPSR_OFFSET                     (0xE8)                                        /**<  (PIO_WPSR) Write Protection Status Register  Offset */
+
+#define PIO_WPSR_WPVS_Pos                   0                                              /**< (PIO_WPSR) Write Protection Violation Status Position */
+#define PIO_WPSR_WPVS_Msk                   (_U_(0x1) << PIO_WPSR_WPVS_Pos)                /**< (PIO_WPSR) Write Protection Violation Status Mask */
+#define PIO_WPSR_WPVS                       PIO_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_WPSR_WPVS_Msk instead */
+#define PIO_WPSR_WPVSRC_Pos                 8                                              /**< (PIO_WPSR) Write Protection Violation Source Position */
+#define PIO_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PIO_WPSR_WPVSRC_Pos)           /**< (PIO_WPSR) Write Protection Violation Source Mask */
+#define PIO_WPSR_WPVSRC(value)              (PIO_WPSR_WPVSRC_Msk & ((value) << PIO_WPSR_WPVSRC_Pos))
+#define PIO_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (PIO_WPSR) Register MASK  (Use PIO_WPSR_Msk instead)  */
+#define PIO_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (PIO_WPSR) Register Mask  */
+
+
+/* -------- PIO_SCHMITT : (PIO Offset: 0x100) (R/W 32) Schmitt Trigger Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCHMITT0:1;                /**< bit:      0  Schmitt Trigger Control                  */
+    uint32_t SCHMITT1:1;                /**< bit:      1  Schmitt Trigger Control                  */
+    uint32_t SCHMITT2:1;                /**< bit:      2  Schmitt Trigger Control                  */
+    uint32_t SCHMITT3:1;                /**< bit:      3  Schmitt Trigger Control                  */
+    uint32_t SCHMITT4:1;                /**< bit:      4  Schmitt Trigger Control                  */
+    uint32_t SCHMITT5:1;                /**< bit:      5  Schmitt Trigger Control                  */
+    uint32_t SCHMITT6:1;                /**< bit:      6  Schmitt Trigger Control                  */
+    uint32_t SCHMITT7:1;                /**< bit:      7  Schmitt Trigger Control                  */
+    uint32_t SCHMITT8:1;                /**< bit:      8  Schmitt Trigger Control                  */
+    uint32_t SCHMITT9:1;                /**< bit:      9  Schmitt Trigger Control                  */
+    uint32_t SCHMITT10:1;               /**< bit:     10  Schmitt Trigger Control                  */
+    uint32_t SCHMITT11:1;               /**< bit:     11  Schmitt Trigger Control                  */
+    uint32_t SCHMITT12:1;               /**< bit:     12  Schmitt Trigger Control                  */
+    uint32_t SCHMITT13:1;               /**< bit:     13  Schmitt Trigger Control                  */
+    uint32_t SCHMITT14:1;               /**< bit:     14  Schmitt Trigger Control                  */
+    uint32_t SCHMITT15:1;               /**< bit:     15  Schmitt Trigger Control                  */
+    uint32_t SCHMITT16:1;               /**< bit:     16  Schmitt Trigger Control                  */
+    uint32_t SCHMITT17:1;               /**< bit:     17  Schmitt Trigger Control                  */
+    uint32_t SCHMITT18:1;               /**< bit:     18  Schmitt Trigger Control                  */
+    uint32_t SCHMITT19:1;               /**< bit:     19  Schmitt Trigger Control                  */
+    uint32_t SCHMITT20:1;               /**< bit:     20  Schmitt Trigger Control                  */
+    uint32_t SCHMITT21:1;               /**< bit:     21  Schmitt Trigger Control                  */
+    uint32_t SCHMITT22:1;               /**< bit:     22  Schmitt Trigger Control                  */
+    uint32_t SCHMITT23:1;               /**< bit:     23  Schmitt Trigger Control                  */
+    uint32_t SCHMITT24:1;               /**< bit:     24  Schmitt Trigger Control                  */
+    uint32_t SCHMITT25:1;               /**< bit:     25  Schmitt Trigger Control                  */
+    uint32_t SCHMITT26:1;               /**< bit:     26  Schmitt Trigger Control                  */
+    uint32_t SCHMITT27:1;               /**< bit:     27  Schmitt Trigger Control                  */
+    uint32_t SCHMITT28:1;               /**< bit:     28  Schmitt Trigger Control                  */
+    uint32_t SCHMITT29:1;               /**< bit:     29  Schmitt Trigger Control                  */
+    uint32_t SCHMITT30:1;               /**< bit:     30  Schmitt Trigger Control                  */
+    uint32_t SCHMITT31:1;               /**< bit:     31  Schmitt Trigger Control                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SCHMITT:32;                /**< bit:  0..31  Schmitt Trigger Control                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_SCHMITT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_SCHMITT_OFFSET                  (0x100)                                       /**<  (PIO_SCHMITT) Schmitt Trigger Register  Offset */
+
+#define PIO_SCHMITT_SCHMITT0_Pos            0                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT0_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT0_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT0                PIO_SCHMITT_SCHMITT0_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT0_Msk instead */
+#define PIO_SCHMITT_SCHMITT1_Pos            1                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT1_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT1_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT1                PIO_SCHMITT_SCHMITT1_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT1_Msk instead */
+#define PIO_SCHMITT_SCHMITT2_Pos            2                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT2_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT2_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT2                PIO_SCHMITT_SCHMITT2_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT2_Msk instead */
+#define PIO_SCHMITT_SCHMITT3_Pos            3                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT3_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT3_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT3                PIO_SCHMITT_SCHMITT3_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT3_Msk instead */
+#define PIO_SCHMITT_SCHMITT4_Pos            4                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT4_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT4_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT4                PIO_SCHMITT_SCHMITT4_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT4_Msk instead */
+#define PIO_SCHMITT_SCHMITT5_Pos            5                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT5_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT5_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT5                PIO_SCHMITT_SCHMITT5_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT5_Msk instead */
+#define PIO_SCHMITT_SCHMITT6_Pos            6                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT6_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT6_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT6                PIO_SCHMITT_SCHMITT6_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT6_Msk instead */
+#define PIO_SCHMITT_SCHMITT7_Pos            7                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT7_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT7_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT7                PIO_SCHMITT_SCHMITT7_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT7_Msk instead */
+#define PIO_SCHMITT_SCHMITT8_Pos            8                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT8_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT8_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT8                PIO_SCHMITT_SCHMITT8_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT8_Msk instead */
+#define PIO_SCHMITT_SCHMITT9_Pos            9                                              /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT9_Msk            (_U_(0x1) << PIO_SCHMITT_SCHMITT9_Pos)         /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT9                PIO_SCHMITT_SCHMITT9_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT9_Msk instead */
+#define PIO_SCHMITT_SCHMITT10_Pos           10                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT10_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT10_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT10               PIO_SCHMITT_SCHMITT10_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT10_Msk instead */
+#define PIO_SCHMITT_SCHMITT11_Pos           11                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT11_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT11_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT11               PIO_SCHMITT_SCHMITT11_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT11_Msk instead */
+#define PIO_SCHMITT_SCHMITT12_Pos           12                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT12_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT12_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT12               PIO_SCHMITT_SCHMITT12_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT12_Msk instead */
+#define PIO_SCHMITT_SCHMITT13_Pos           13                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT13_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT13_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT13               PIO_SCHMITT_SCHMITT13_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT13_Msk instead */
+#define PIO_SCHMITT_SCHMITT14_Pos           14                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT14_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT14_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT14               PIO_SCHMITT_SCHMITT14_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT14_Msk instead */
+#define PIO_SCHMITT_SCHMITT15_Pos           15                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT15_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT15_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT15               PIO_SCHMITT_SCHMITT15_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT15_Msk instead */
+#define PIO_SCHMITT_SCHMITT16_Pos           16                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT16_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT16_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT16               PIO_SCHMITT_SCHMITT16_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT16_Msk instead */
+#define PIO_SCHMITT_SCHMITT17_Pos           17                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT17_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT17_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT17               PIO_SCHMITT_SCHMITT17_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT17_Msk instead */
+#define PIO_SCHMITT_SCHMITT18_Pos           18                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT18_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT18_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT18               PIO_SCHMITT_SCHMITT18_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT18_Msk instead */
+#define PIO_SCHMITT_SCHMITT19_Pos           19                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT19_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT19_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT19               PIO_SCHMITT_SCHMITT19_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT19_Msk instead */
+#define PIO_SCHMITT_SCHMITT20_Pos           20                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT20_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT20_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT20               PIO_SCHMITT_SCHMITT20_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT20_Msk instead */
+#define PIO_SCHMITT_SCHMITT21_Pos           21                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT21_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT21_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT21               PIO_SCHMITT_SCHMITT21_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT21_Msk instead */
+#define PIO_SCHMITT_SCHMITT22_Pos           22                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT22_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT22_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT22               PIO_SCHMITT_SCHMITT22_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT22_Msk instead */
+#define PIO_SCHMITT_SCHMITT23_Pos           23                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT23_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT23_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT23               PIO_SCHMITT_SCHMITT23_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT23_Msk instead */
+#define PIO_SCHMITT_SCHMITT24_Pos           24                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT24_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT24_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT24               PIO_SCHMITT_SCHMITT24_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT24_Msk instead */
+#define PIO_SCHMITT_SCHMITT25_Pos           25                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT25_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT25_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT25               PIO_SCHMITT_SCHMITT25_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT25_Msk instead */
+#define PIO_SCHMITT_SCHMITT26_Pos           26                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT26_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT26_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT26               PIO_SCHMITT_SCHMITT26_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT26_Msk instead */
+#define PIO_SCHMITT_SCHMITT27_Pos           27                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT27_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT27_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT27               PIO_SCHMITT_SCHMITT27_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT27_Msk instead */
+#define PIO_SCHMITT_SCHMITT28_Pos           28                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT28_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT28_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT28               PIO_SCHMITT_SCHMITT28_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT28_Msk instead */
+#define PIO_SCHMITT_SCHMITT29_Pos           29                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT29_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT29_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT29               PIO_SCHMITT_SCHMITT29_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT29_Msk instead */
+#define PIO_SCHMITT_SCHMITT30_Pos           30                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT30_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT30_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT30               PIO_SCHMITT_SCHMITT30_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT30_Msk instead */
+#define PIO_SCHMITT_SCHMITT31_Pos           31                                             /**< (PIO_SCHMITT) Schmitt Trigger Control Position */
+#define PIO_SCHMITT_SCHMITT31_Msk           (_U_(0x1) << PIO_SCHMITT_SCHMITT31_Pos)        /**< (PIO_SCHMITT) Schmitt Trigger Control Mask */
+#define PIO_SCHMITT_SCHMITT31               PIO_SCHMITT_SCHMITT31_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_SCHMITT_SCHMITT31_Msk instead */
+#define PIO_SCHMITT_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_SCHMITT) Register MASK  (Use PIO_SCHMITT_Msk instead)  */
+#define PIO_SCHMITT_Msk                     _U_(0xFFFFFFFF)                                /**< (PIO_SCHMITT) Register Mask  */
+
+#define PIO_SCHMITT_SCHMITT_Pos             0                                              /**< (PIO_SCHMITT Position) Schmitt Trigger Control */
+#define PIO_SCHMITT_SCHMITT_Msk             (_U_(0xFFFFFFFF) << PIO_SCHMITT_SCHMITT_Pos)   /**< (PIO_SCHMITT Mask) SCHMITT */
+#define PIO_SCHMITT_SCHMITT(value)          (PIO_SCHMITT_SCHMITT_Msk & ((value) << PIO_SCHMITT_SCHMITT_Pos))  
+
+/* -------- PIO_DRIVER : (PIO Offset: 0x118) (R/W 32) I/O Drive Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LINE0:1;                   /**< bit:      0  Drive of PIO Line 0                      */
+    uint32_t LINE1:1;                   /**< bit:      1  Drive of PIO Line 1                      */
+    uint32_t LINE2:1;                   /**< bit:      2  Drive of PIO Line 2                      */
+    uint32_t LINE3:1;                   /**< bit:      3  Drive of PIO Line 3                      */
+    uint32_t LINE4:1;                   /**< bit:      4  Drive of PIO Line 4                      */
+    uint32_t LINE5:1;                   /**< bit:      5  Drive of PIO Line 5                      */
+    uint32_t LINE6:1;                   /**< bit:      6  Drive of PIO Line 6                      */
+    uint32_t LINE7:1;                   /**< bit:      7  Drive of PIO Line 7                      */
+    uint32_t LINE8:1;                   /**< bit:      8  Drive of PIO Line 8                      */
+    uint32_t LINE9:1;                   /**< bit:      9  Drive of PIO Line 9                      */
+    uint32_t LINE10:1;                  /**< bit:     10  Drive of PIO Line 10                     */
+    uint32_t LINE11:1;                  /**< bit:     11  Drive of PIO Line 11                     */
+    uint32_t LINE12:1;                  /**< bit:     12  Drive of PIO Line 12                     */
+    uint32_t LINE13:1;                  /**< bit:     13  Drive of PIO Line 13                     */
+    uint32_t LINE14:1;                  /**< bit:     14  Drive of PIO Line 14                     */
+    uint32_t LINE15:1;                  /**< bit:     15  Drive of PIO Line 15                     */
+    uint32_t LINE16:1;                  /**< bit:     16  Drive of PIO Line 16                     */
+    uint32_t LINE17:1;                  /**< bit:     17  Drive of PIO Line 17                     */
+    uint32_t LINE18:1;                  /**< bit:     18  Drive of PIO Line 18                     */
+    uint32_t LINE19:1;                  /**< bit:     19  Drive of PIO Line 19                     */
+    uint32_t LINE20:1;                  /**< bit:     20  Drive of PIO Line 20                     */
+    uint32_t LINE21:1;                  /**< bit:     21  Drive of PIO Line 21                     */
+    uint32_t LINE22:1;                  /**< bit:     22  Drive of PIO Line 22                     */
+    uint32_t LINE23:1;                  /**< bit:     23  Drive of PIO Line 23                     */
+    uint32_t LINE24:1;                  /**< bit:     24  Drive of PIO Line 24                     */
+    uint32_t LINE25:1;                  /**< bit:     25  Drive of PIO Line 25                     */
+    uint32_t LINE26:1;                  /**< bit:     26  Drive of PIO Line 26                     */
+    uint32_t LINE27:1;                  /**< bit:     27  Drive of PIO Line 27                     */
+    uint32_t LINE28:1;                  /**< bit:     28  Drive of PIO Line 28                     */
+    uint32_t LINE29:1;                  /**< bit:     29  Drive of PIO Line 29                     */
+    uint32_t LINE30:1;                  /**< bit:     30  Drive of PIO Line 30                     */
+    uint32_t LINE31:1;                  /**< bit:     31  Drive of PIO Line 31                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t LINE:32;                   /**< bit:  0..31  Drive of PIO Line 3x                     */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_DRIVER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_DRIVER_OFFSET                   (0x118)                                       /**<  (PIO_DRIVER) I/O Drive Register  Offset */
+
+#define PIO_DRIVER_LINE0_Pos                0                                              /**< (PIO_DRIVER) Drive of PIO Line 0 Position */
+#define PIO_DRIVER_LINE0_Msk                (_U_(0x1) << PIO_DRIVER_LINE0_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 0 Mask */
+#define PIO_DRIVER_LINE0                    PIO_DRIVER_LINE0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE0_Msk instead */
+#define   PIO_DRIVER_LINE0_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE0_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE0_LOW_DRIVE          (PIO_DRIVER_LINE0_LOW_DRIVE_Val << PIO_DRIVER_LINE0_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE0_HIGH_DRIVE         (PIO_DRIVER_LINE0_HIGH_DRIVE_Val << PIO_DRIVER_LINE0_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE1_Pos                1                                              /**< (PIO_DRIVER) Drive of PIO Line 1 Position */
+#define PIO_DRIVER_LINE1_Msk                (_U_(0x1) << PIO_DRIVER_LINE1_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 1 Mask */
+#define PIO_DRIVER_LINE1                    PIO_DRIVER_LINE1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE1_Msk instead */
+#define   PIO_DRIVER_LINE1_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE1_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE1_LOW_DRIVE          (PIO_DRIVER_LINE1_LOW_DRIVE_Val << PIO_DRIVER_LINE1_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE1_HIGH_DRIVE         (PIO_DRIVER_LINE1_HIGH_DRIVE_Val << PIO_DRIVER_LINE1_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE2_Pos                2                                              /**< (PIO_DRIVER) Drive of PIO Line 2 Position */
+#define PIO_DRIVER_LINE2_Msk                (_U_(0x1) << PIO_DRIVER_LINE2_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 2 Mask */
+#define PIO_DRIVER_LINE2                    PIO_DRIVER_LINE2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE2_Msk instead */
+#define   PIO_DRIVER_LINE2_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE2_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE2_LOW_DRIVE          (PIO_DRIVER_LINE2_LOW_DRIVE_Val << PIO_DRIVER_LINE2_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE2_HIGH_DRIVE         (PIO_DRIVER_LINE2_HIGH_DRIVE_Val << PIO_DRIVER_LINE2_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE3_Pos                3                                              /**< (PIO_DRIVER) Drive of PIO Line 3 Position */
+#define PIO_DRIVER_LINE3_Msk                (_U_(0x1) << PIO_DRIVER_LINE3_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 3 Mask */
+#define PIO_DRIVER_LINE3                    PIO_DRIVER_LINE3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE3_Msk instead */
+#define   PIO_DRIVER_LINE3_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE3_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE3_LOW_DRIVE          (PIO_DRIVER_LINE3_LOW_DRIVE_Val << PIO_DRIVER_LINE3_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE3_HIGH_DRIVE         (PIO_DRIVER_LINE3_HIGH_DRIVE_Val << PIO_DRIVER_LINE3_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE4_Pos                4                                              /**< (PIO_DRIVER) Drive of PIO Line 4 Position */
+#define PIO_DRIVER_LINE4_Msk                (_U_(0x1) << PIO_DRIVER_LINE4_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 4 Mask */
+#define PIO_DRIVER_LINE4                    PIO_DRIVER_LINE4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE4_Msk instead */
+#define   PIO_DRIVER_LINE4_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE4_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE4_LOW_DRIVE          (PIO_DRIVER_LINE4_LOW_DRIVE_Val << PIO_DRIVER_LINE4_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE4_HIGH_DRIVE         (PIO_DRIVER_LINE4_HIGH_DRIVE_Val << PIO_DRIVER_LINE4_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE5_Pos                5                                              /**< (PIO_DRIVER) Drive of PIO Line 5 Position */
+#define PIO_DRIVER_LINE5_Msk                (_U_(0x1) << PIO_DRIVER_LINE5_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 5 Mask */
+#define PIO_DRIVER_LINE5                    PIO_DRIVER_LINE5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE5_Msk instead */
+#define   PIO_DRIVER_LINE5_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE5_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE5_LOW_DRIVE          (PIO_DRIVER_LINE5_LOW_DRIVE_Val << PIO_DRIVER_LINE5_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE5_HIGH_DRIVE         (PIO_DRIVER_LINE5_HIGH_DRIVE_Val << PIO_DRIVER_LINE5_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE6_Pos                6                                              /**< (PIO_DRIVER) Drive of PIO Line 6 Position */
+#define PIO_DRIVER_LINE6_Msk                (_U_(0x1) << PIO_DRIVER_LINE6_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 6 Mask */
+#define PIO_DRIVER_LINE6                    PIO_DRIVER_LINE6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE6_Msk instead */
+#define   PIO_DRIVER_LINE6_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE6_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE6_LOW_DRIVE          (PIO_DRIVER_LINE6_LOW_DRIVE_Val << PIO_DRIVER_LINE6_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE6_HIGH_DRIVE         (PIO_DRIVER_LINE6_HIGH_DRIVE_Val << PIO_DRIVER_LINE6_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE7_Pos                7                                              /**< (PIO_DRIVER) Drive of PIO Line 7 Position */
+#define PIO_DRIVER_LINE7_Msk                (_U_(0x1) << PIO_DRIVER_LINE7_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 7 Mask */
+#define PIO_DRIVER_LINE7                    PIO_DRIVER_LINE7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE7_Msk instead */
+#define   PIO_DRIVER_LINE7_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE7_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE7_LOW_DRIVE          (PIO_DRIVER_LINE7_LOW_DRIVE_Val << PIO_DRIVER_LINE7_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE7_HIGH_DRIVE         (PIO_DRIVER_LINE7_HIGH_DRIVE_Val << PIO_DRIVER_LINE7_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE8_Pos                8                                              /**< (PIO_DRIVER) Drive of PIO Line 8 Position */
+#define PIO_DRIVER_LINE8_Msk                (_U_(0x1) << PIO_DRIVER_LINE8_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 8 Mask */
+#define PIO_DRIVER_LINE8                    PIO_DRIVER_LINE8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE8_Msk instead */
+#define   PIO_DRIVER_LINE8_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE8_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE8_LOW_DRIVE          (PIO_DRIVER_LINE8_LOW_DRIVE_Val << PIO_DRIVER_LINE8_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE8_HIGH_DRIVE         (PIO_DRIVER_LINE8_HIGH_DRIVE_Val << PIO_DRIVER_LINE8_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE9_Pos                9                                              /**< (PIO_DRIVER) Drive of PIO Line 9 Position */
+#define PIO_DRIVER_LINE9_Msk                (_U_(0x1) << PIO_DRIVER_LINE9_Pos)             /**< (PIO_DRIVER) Drive of PIO Line 9 Mask */
+#define PIO_DRIVER_LINE9                    PIO_DRIVER_LINE9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE9_Msk instead */
+#define   PIO_DRIVER_LINE9_LOW_DRIVE_Val    _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE9_HIGH_DRIVE_Val   _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE9_LOW_DRIVE          (PIO_DRIVER_LINE9_LOW_DRIVE_Val << PIO_DRIVER_LINE9_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE9_HIGH_DRIVE         (PIO_DRIVER_LINE9_HIGH_DRIVE_Val << PIO_DRIVER_LINE9_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE10_Pos               10                                             /**< (PIO_DRIVER) Drive of PIO Line 10 Position */
+#define PIO_DRIVER_LINE10_Msk               (_U_(0x1) << PIO_DRIVER_LINE10_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 10 Mask */
+#define PIO_DRIVER_LINE10                   PIO_DRIVER_LINE10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE10_Msk instead */
+#define   PIO_DRIVER_LINE10_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE10_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE10_LOW_DRIVE         (PIO_DRIVER_LINE10_LOW_DRIVE_Val << PIO_DRIVER_LINE10_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE10_HIGH_DRIVE        (PIO_DRIVER_LINE10_HIGH_DRIVE_Val << PIO_DRIVER_LINE10_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE11_Pos               11                                             /**< (PIO_DRIVER) Drive of PIO Line 11 Position */
+#define PIO_DRIVER_LINE11_Msk               (_U_(0x1) << PIO_DRIVER_LINE11_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 11 Mask */
+#define PIO_DRIVER_LINE11                   PIO_DRIVER_LINE11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE11_Msk instead */
+#define   PIO_DRIVER_LINE11_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE11_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE11_LOW_DRIVE         (PIO_DRIVER_LINE11_LOW_DRIVE_Val << PIO_DRIVER_LINE11_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE11_HIGH_DRIVE        (PIO_DRIVER_LINE11_HIGH_DRIVE_Val << PIO_DRIVER_LINE11_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE12_Pos               12                                             /**< (PIO_DRIVER) Drive of PIO Line 12 Position */
+#define PIO_DRIVER_LINE12_Msk               (_U_(0x1) << PIO_DRIVER_LINE12_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 12 Mask */
+#define PIO_DRIVER_LINE12                   PIO_DRIVER_LINE12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE12_Msk instead */
+#define   PIO_DRIVER_LINE12_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE12_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE12_LOW_DRIVE         (PIO_DRIVER_LINE12_LOW_DRIVE_Val << PIO_DRIVER_LINE12_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE12_HIGH_DRIVE        (PIO_DRIVER_LINE12_HIGH_DRIVE_Val << PIO_DRIVER_LINE12_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE13_Pos               13                                             /**< (PIO_DRIVER) Drive of PIO Line 13 Position */
+#define PIO_DRIVER_LINE13_Msk               (_U_(0x1) << PIO_DRIVER_LINE13_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 13 Mask */
+#define PIO_DRIVER_LINE13                   PIO_DRIVER_LINE13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE13_Msk instead */
+#define   PIO_DRIVER_LINE13_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE13_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE13_LOW_DRIVE         (PIO_DRIVER_LINE13_LOW_DRIVE_Val << PIO_DRIVER_LINE13_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE13_HIGH_DRIVE        (PIO_DRIVER_LINE13_HIGH_DRIVE_Val << PIO_DRIVER_LINE13_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE14_Pos               14                                             /**< (PIO_DRIVER) Drive of PIO Line 14 Position */
+#define PIO_DRIVER_LINE14_Msk               (_U_(0x1) << PIO_DRIVER_LINE14_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 14 Mask */
+#define PIO_DRIVER_LINE14                   PIO_DRIVER_LINE14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE14_Msk instead */
+#define   PIO_DRIVER_LINE14_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE14_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE14_LOW_DRIVE         (PIO_DRIVER_LINE14_LOW_DRIVE_Val << PIO_DRIVER_LINE14_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE14_HIGH_DRIVE        (PIO_DRIVER_LINE14_HIGH_DRIVE_Val << PIO_DRIVER_LINE14_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE15_Pos               15                                             /**< (PIO_DRIVER) Drive of PIO Line 15 Position */
+#define PIO_DRIVER_LINE15_Msk               (_U_(0x1) << PIO_DRIVER_LINE15_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 15 Mask */
+#define PIO_DRIVER_LINE15                   PIO_DRIVER_LINE15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE15_Msk instead */
+#define   PIO_DRIVER_LINE15_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE15_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE15_LOW_DRIVE         (PIO_DRIVER_LINE15_LOW_DRIVE_Val << PIO_DRIVER_LINE15_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE15_HIGH_DRIVE        (PIO_DRIVER_LINE15_HIGH_DRIVE_Val << PIO_DRIVER_LINE15_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE16_Pos               16                                             /**< (PIO_DRIVER) Drive of PIO Line 16 Position */
+#define PIO_DRIVER_LINE16_Msk               (_U_(0x1) << PIO_DRIVER_LINE16_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 16 Mask */
+#define PIO_DRIVER_LINE16                   PIO_DRIVER_LINE16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE16_Msk instead */
+#define   PIO_DRIVER_LINE16_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE16_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE16_LOW_DRIVE         (PIO_DRIVER_LINE16_LOW_DRIVE_Val << PIO_DRIVER_LINE16_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE16_HIGH_DRIVE        (PIO_DRIVER_LINE16_HIGH_DRIVE_Val << PIO_DRIVER_LINE16_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE17_Pos               17                                             /**< (PIO_DRIVER) Drive of PIO Line 17 Position */
+#define PIO_DRIVER_LINE17_Msk               (_U_(0x1) << PIO_DRIVER_LINE17_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 17 Mask */
+#define PIO_DRIVER_LINE17                   PIO_DRIVER_LINE17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE17_Msk instead */
+#define   PIO_DRIVER_LINE17_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE17_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE17_LOW_DRIVE         (PIO_DRIVER_LINE17_LOW_DRIVE_Val << PIO_DRIVER_LINE17_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE17_HIGH_DRIVE        (PIO_DRIVER_LINE17_HIGH_DRIVE_Val << PIO_DRIVER_LINE17_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE18_Pos               18                                             /**< (PIO_DRIVER) Drive of PIO Line 18 Position */
+#define PIO_DRIVER_LINE18_Msk               (_U_(0x1) << PIO_DRIVER_LINE18_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 18 Mask */
+#define PIO_DRIVER_LINE18                   PIO_DRIVER_LINE18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE18_Msk instead */
+#define   PIO_DRIVER_LINE18_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE18_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE18_LOW_DRIVE         (PIO_DRIVER_LINE18_LOW_DRIVE_Val << PIO_DRIVER_LINE18_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE18_HIGH_DRIVE        (PIO_DRIVER_LINE18_HIGH_DRIVE_Val << PIO_DRIVER_LINE18_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE19_Pos               19                                             /**< (PIO_DRIVER) Drive of PIO Line 19 Position */
+#define PIO_DRIVER_LINE19_Msk               (_U_(0x1) << PIO_DRIVER_LINE19_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 19 Mask */
+#define PIO_DRIVER_LINE19                   PIO_DRIVER_LINE19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE19_Msk instead */
+#define   PIO_DRIVER_LINE19_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE19_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE19_LOW_DRIVE         (PIO_DRIVER_LINE19_LOW_DRIVE_Val << PIO_DRIVER_LINE19_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE19_HIGH_DRIVE        (PIO_DRIVER_LINE19_HIGH_DRIVE_Val << PIO_DRIVER_LINE19_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE20_Pos               20                                             /**< (PIO_DRIVER) Drive of PIO Line 20 Position */
+#define PIO_DRIVER_LINE20_Msk               (_U_(0x1) << PIO_DRIVER_LINE20_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 20 Mask */
+#define PIO_DRIVER_LINE20                   PIO_DRIVER_LINE20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE20_Msk instead */
+#define   PIO_DRIVER_LINE20_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE20_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE20_LOW_DRIVE         (PIO_DRIVER_LINE20_LOW_DRIVE_Val << PIO_DRIVER_LINE20_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE20_HIGH_DRIVE        (PIO_DRIVER_LINE20_HIGH_DRIVE_Val << PIO_DRIVER_LINE20_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE21_Pos               21                                             /**< (PIO_DRIVER) Drive of PIO Line 21 Position */
+#define PIO_DRIVER_LINE21_Msk               (_U_(0x1) << PIO_DRIVER_LINE21_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 21 Mask */
+#define PIO_DRIVER_LINE21                   PIO_DRIVER_LINE21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE21_Msk instead */
+#define   PIO_DRIVER_LINE21_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE21_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE21_LOW_DRIVE         (PIO_DRIVER_LINE21_LOW_DRIVE_Val << PIO_DRIVER_LINE21_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE21_HIGH_DRIVE        (PIO_DRIVER_LINE21_HIGH_DRIVE_Val << PIO_DRIVER_LINE21_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE22_Pos               22                                             /**< (PIO_DRIVER) Drive of PIO Line 22 Position */
+#define PIO_DRIVER_LINE22_Msk               (_U_(0x1) << PIO_DRIVER_LINE22_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 22 Mask */
+#define PIO_DRIVER_LINE22                   PIO_DRIVER_LINE22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE22_Msk instead */
+#define   PIO_DRIVER_LINE22_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE22_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE22_LOW_DRIVE         (PIO_DRIVER_LINE22_LOW_DRIVE_Val << PIO_DRIVER_LINE22_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE22_HIGH_DRIVE        (PIO_DRIVER_LINE22_HIGH_DRIVE_Val << PIO_DRIVER_LINE22_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE23_Pos               23                                             /**< (PIO_DRIVER) Drive of PIO Line 23 Position */
+#define PIO_DRIVER_LINE23_Msk               (_U_(0x1) << PIO_DRIVER_LINE23_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 23 Mask */
+#define PIO_DRIVER_LINE23                   PIO_DRIVER_LINE23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE23_Msk instead */
+#define   PIO_DRIVER_LINE23_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE23_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE23_LOW_DRIVE         (PIO_DRIVER_LINE23_LOW_DRIVE_Val << PIO_DRIVER_LINE23_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE23_HIGH_DRIVE        (PIO_DRIVER_LINE23_HIGH_DRIVE_Val << PIO_DRIVER_LINE23_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE24_Pos               24                                             /**< (PIO_DRIVER) Drive of PIO Line 24 Position */
+#define PIO_DRIVER_LINE24_Msk               (_U_(0x1) << PIO_DRIVER_LINE24_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 24 Mask */
+#define PIO_DRIVER_LINE24                   PIO_DRIVER_LINE24_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE24_Msk instead */
+#define   PIO_DRIVER_LINE24_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE24_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE24_LOW_DRIVE         (PIO_DRIVER_LINE24_LOW_DRIVE_Val << PIO_DRIVER_LINE24_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE24_HIGH_DRIVE        (PIO_DRIVER_LINE24_HIGH_DRIVE_Val << PIO_DRIVER_LINE24_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE25_Pos               25                                             /**< (PIO_DRIVER) Drive of PIO Line 25 Position */
+#define PIO_DRIVER_LINE25_Msk               (_U_(0x1) << PIO_DRIVER_LINE25_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 25 Mask */
+#define PIO_DRIVER_LINE25                   PIO_DRIVER_LINE25_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE25_Msk instead */
+#define   PIO_DRIVER_LINE25_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE25_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE25_LOW_DRIVE         (PIO_DRIVER_LINE25_LOW_DRIVE_Val << PIO_DRIVER_LINE25_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE25_HIGH_DRIVE        (PIO_DRIVER_LINE25_HIGH_DRIVE_Val << PIO_DRIVER_LINE25_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE26_Pos               26                                             /**< (PIO_DRIVER) Drive of PIO Line 26 Position */
+#define PIO_DRIVER_LINE26_Msk               (_U_(0x1) << PIO_DRIVER_LINE26_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 26 Mask */
+#define PIO_DRIVER_LINE26                   PIO_DRIVER_LINE26_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE26_Msk instead */
+#define   PIO_DRIVER_LINE26_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE26_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE26_LOW_DRIVE         (PIO_DRIVER_LINE26_LOW_DRIVE_Val << PIO_DRIVER_LINE26_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE26_HIGH_DRIVE        (PIO_DRIVER_LINE26_HIGH_DRIVE_Val << PIO_DRIVER_LINE26_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE27_Pos               27                                             /**< (PIO_DRIVER) Drive of PIO Line 27 Position */
+#define PIO_DRIVER_LINE27_Msk               (_U_(0x1) << PIO_DRIVER_LINE27_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 27 Mask */
+#define PIO_DRIVER_LINE27                   PIO_DRIVER_LINE27_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE27_Msk instead */
+#define   PIO_DRIVER_LINE27_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE27_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE27_LOW_DRIVE         (PIO_DRIVER_LINE27_LOW_DRIVE_Val << PIO_DRIVER_LINE27_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE27_HIGH_DRIVE        (PIO_DRIVER_LINE27_HIGH_DRIVE_Val << PIO_DRIVER_LINE27_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE28_Pos               28                                             /**< (PIO_DRIVER) Drive of PIO Line 28 Position */
+#define PIO_DRIVER_LINE28_Msk               (_U_(0x1) << PIO_DRIVER_LINE28_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 28 Mask */
+#define PIO_DRIVER_LINE28                   PIO_DRIVER_LINE28_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE28_Msk instead */
+#define   PIO_DRIVER_LINE28_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE28_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE28_LOW_DRIVE         (PIO_DRIVER_LINE28_LOW_DRIVE_Val << PIO_DRIVER_LINE28_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE28_HIGH_DRIVE        (PIO_DRIVER_LINE28_HIGH_DRIVE_Val << PIO_DRIVER_LINE28_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE29_Pos               29                                             /**< (PIO_DRIVER) Drive of PIO Line 29 Position */
+#define PIO_DRIVER_LINE29_Msk               (_U_(0x1) << PIO_DRIVER_LINE29_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 29 Mask */
+#define PIO_DRIVER_LINE29                   PIO_DRIVER_LINE29_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE29_Msk instead */
+#define   PIO_DRIVER_LINE29_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE29_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE29_LOW_DRIVE         (PIO_DRIVER_LINE29_LOW_DRIVE_Val << PIO_DRIVER_LINE29_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE29_HIGH_DRIVE        (PIO_DRIVER_LINE29_HIGH_DRIVE_Val << PIO_DRIVER_LINE29_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE30_Pos               30                                             /**< (PIO_DRIVER) Drive of PIO Line 30 Position */
+#define PIO_DRIVER_LINE30_Msk               (_U_(0x1) << PIO_DRIVER_LINE30_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 30 Mask */
+#define PIO_DRIVER_LINE30                   PIO_DRIVER_LINE30_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE30_Msk instead */
+#define   PIO_DRIVER_LINE30_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE30_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE30_LOW_DRIVE         (PIO_DRIVER_LINE30_LOW_DRIVE_Val << PIO_DRIVER_LINE30_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE30_HIGH_DRIVE        (PIO_DRIVER_LINE30_HIGH_DRIVE_Val << PIO_DRIVER_LINE30_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_LINE31_Pos               31                                             /**< (PIO_DRIVER) Drive of PIO Line 31 Position */
+#define PIO_DRIVER_LINE31_Msk               (_U_(0x1) << PIO_DRIVER_LINE31_Pos)            /**< (PIO_DRIVER) Drive of PIO Line 31 Mask */
+#define PIO_DRIVER_LINE31                   PIO_DRIVER_LINE31_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_DRIVER_LINE31_Msk instead */
+#define   PIO_DRIVER_LINE31_LOW_DRIVE_Val   _U_(0x0)                                       /**< (PIO_DRIVER) Lowest drive  */
+#define   PIO_DRIVER_LINE31_HIGH_DRIVE_Val  _U_(0x1)                                       /**< (PIO_DRIVER) Highest drive  */
+#define PIO_DRIVER_LINE31_LOW_DRIVE         (PIO_DRIVER_LINE31_LOW_DRIVE_Val << PIO_DRIVER_LINE31_Pos)  /**< (PIO_DRIVER) Lowest drive Position  */
+#define PIO_DRIVER_LINE31_HIGH_DRIVE        (PIO_DRIVER_LINE31_HIGH_DRIVE_Val << PIO_DRIVER_LINE31_Pos)  /**< (PIO_DRIVER) Highest drive Position  */
+#define PIO_DRIVER_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_DRIVER) Register MASK  (Use PIO_DRIVER_Msk instead)  */
+#define PIO_DRIVER_Msk                      _U_(0xFFFFFFFF)                                /**< (PIO_DRIVER) Register Mask  */
+
+#define PIO_DRIVER_LINE_Pos                 0                                              /**< (PIO_DRIVER Position) Drive of PIO Line 3x */
+#define PIO_DRIVER_LINE_Msk                 (_U_(0xFFFFFFFF) << PIO_DRIVER_LINE_Pos)       /**< (PIO_DRIVER Mask) LINE */
+#define PIO_DRIVER_LINE(value)              (PIO_DRIVER_LINE_Msk & ((value) << PIO_DRIVER_LINE_Pos))  
+
+/* -------- PIO_PCMR : (PIO Offset: 0x150) (R/W 32) Parallel Capture Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PCEN:1;                    /**< bit:      0  Parallel Capture Mode Enable             */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t DSIZE:2;                   /**< bit:   4..5  Parallel Capture Mode Data Size          */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t ALWYS:1;                   /**< bit:      9  Parallel Capture Mode Always Sampling    */
+    uint32_t HALFS:1;                   /**< bit:     10  Parallel Capture Mode Half Sampling      */
+    uint32_t FRSTS:1;                   /**< bit:     11  Parallel Capture Mode First Sample       */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCMR_OFFSET                     (0x150)                                       /**<  (PIO_PCMR) Parallel Capture Mode Register  Offset */
+
+#define PIO_PCMR_PCEN_Pos                   0                                              /**< (PIO_PCMR) Parallel Capture Mode Enable Position */
+#define PIO_PCMR_PCEN_Msk                   (_U_(0x1) << PIO_PCMR_PCEN_Pos)                /**< (PIO_PCMR) Parallel Capture Mode Enable Mask */
+#define PIO_PCMR_PCEN                       PIO_PCMR_PCEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_PCEN_Msk instead */
+#define PIO_PCMR_DSIZE_Pos                  4                                              /**< (PIO_PCMR) Parallel Capture Mode Data Size Position */
+#define PIO_PCMR_DSIZE_Msk                  (_U_(0x3) << PIO_PCMR_DSIZE_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Data Size Mask */
+#define PIO_PCMR_DSIZE(value)               (PIO_PCMR_DSIZE_Msk & ((value) << PIO_PCMR_DSIZE_Pos))
+#define   PIO_PCMR_DSIZE_BYTE_Val           _U_(0x0)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a byte (8-bit)  */
+#define   PIO_PCMR_DSIZE_HALFWORD_Val       _U_(0x1)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a half-word (16-bit)  */
+#define   PIO_PCMR_DSIZE_WORD_Val           _U_(0x2)                                       /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a word (32-bit)  */
+#define PIO_PCMR_DSIZE_BYTE                 (PIO_PCMR_DSIZE_BYTE_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a byte (8-bit) Position  */
+#define PIO_PCMR_DSIZE_HALFWORD             (PIO_PCMR_DSIZE_HALFWORD_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a half-word (16-bit) Position  */
+#define PIO_PCMR_DSIZE_WORD                 (PIO_PCMR_DSIZE_WORD_Val << PIO_PCMR_DSIZE_Pos)  /**< (PIO_PCMR) The reception data in the PIO_PCRHR is a word (32-bit) Position  */
+#define PIO_PCMR_ALWYS_Pos                  9                                              /**< (PIO_PCMR) Parallel Capture Mode Always Sampling Position */
+#define PIO_PCMR_ALWYS_Msk                  (_U_(0x1) << PIO_PCMR_ALWYS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Always Sampling Mask */
+#define PIO_PCMR_ALWYS                      PIO_PCMR_ALWYS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_ALWYS_Msk instead */
+#define PIO_PCMR_HALFS_Pos                  10                                             /**< (PIO_PCMR) Parallel Capture Mode Half Sampling Position */
+#define PIO_PCMR_HALFS_Msk                  (_U_(0x1) << PIO_PCMR_HALFS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode Half Sampling Mask */
+#define PIO_PCMR_HALFS                      PIO_PCMR_HALFS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_HALFS_Msk instead */
+#define PIO_PCMR_FRSTS_Pos                  11                                             /**< (PIO_PCMR) Parallel Capture Mode First Sample Position */
+#define PIO_PCMR_FRSTS_Msk                  (_U_(0x1) << PIO_PCMR_FRSTS_Pos)               /**< (PIO_PCMR) Parallel Capture Mode First Sample Mask */
+#define PIO_PCMR_FRSTS                      PIO_PCMR_FRSTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCMR_FRSTS_Msk instead */
+#define PIO_PCMR_MASK                       _U_(0xE31)                                     /**< \deprecated (PIO_PCMR) Register MASK  (Use PIO_PCMR_Msk instead)  */
+#define PIO_PCMR_Msk                        _U_(0xE31)                                     /**< (PIO_PCMR) Register Mask  */
+
+
+/* -------- PIO_PCIER : (PIO Offset: 0x154) (/W 32) Parallel Capture Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Enable */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Enable */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Enable */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Enable   */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIER_OFFSET                    (0x154)                                       /**<  (PIO_PCIER) Parallel Capture Interrupt Enable Register  Offset */
+
+#define PIO_PCIER_DRDY_Pos                  0                                              /**< (PIO_PCIER) Parallel Capture Mode Data Ready Interrupt Enable Position */
+#define PIO_PCIER_DRDY_Msk                  (_U_(0x1) << PIO_PCIER_DRDY_Pos)               /**< (PIO_PCIER) Parallel Capture Mode Data Ready Interrupt Enable Mask */
+#define PIO_PCIER_DRDY                      PIO_PCIER_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_DRDY_Msk instead */
+#define PIO_PCIER_OVRE_Pos                  1                                              /**< (PIO_PCIER) Parallel Capture Mode Overrun Error Interrupt Enable Position */
+#define PIO_PCIER_OVRE_Msk                  (_U_(0x1) << PIO_PCIER_OVRE_Pos)               /**< (PIO_PCIER) Parallel Capture Mode Overrun Error Interrupt Enable Mask */
+#define PIO_PCIER_OVRE                      PIO_PCIER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_OVRE_Msk instead */
+#define PIO_PCIER_ENDRX_Pos                 2                                              /**< (PIO_PCIER) End of Reception Transfer Interrupt Enable Position */
+#define PIO_PCIER_ENDRX_Msk                 (_U_(0x1) << PIO_PCIER_ENDRX_Pos)              /**< (PIO_PCIER) End of Reception Transfer Interrupt Enable Mask */
+#define PIO_PCIER_ENDRX                     PIO_PCIER_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_ENDRX_Msk instead */
+#define PIO_PCIER_RXBUFF_Pos                3                                              /**< (PIO_PCIER) Reception Buffer Full Interrupt Enable Position */
+#define PIO_PCIER_RXBUFF_Msk                (_U_(0x1) << PIO_PCIER_RXBUFF_Pos)             /**< (PIO_PCIER) Reception Buffer Full Interrupt Enable Mask */
+#define PIO_PCIER_RXBUFF                    PIO_PCIER_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIER_RXBUFF_Msk instead */
+#define PIO_PCIER_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIER) Register MASK  (Use PIO_PCIER_Msk instead)  */
+#define PIO_PCIER_Msk                       _U_(0x0F)                                      /**< (PIO_PCIER) Register Mask  */
+
+
+/* -------- PIO_PCIDR : (PIO Offset: 0x158) (/W 32) Parallel Capture Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Disable */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Disable */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Disable */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Disable  */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIDR_OFFSET                    (0x158)                                       /**<  (PIO_PCIDR) Parallel Capture Interrupt Disable Register  Offset */
+
+#define PIO_PCIDR_DRDY_Pos                  0                                              /**< (PIO_PCIDR) Parallel Capture Mode Data Ready Interrupt Disable Position */
+#define PIO_PCIDR_DRDY_Msk                  (_U_(0x1) << PIO_PCIDR_DRDY_Pos)               /**< (PIO_PCIDR) Parallel Capture Mode Data Ready Interrupt Disable Mask */
+#define PIO_PCIDR_DRDY                      PIO_PCIDR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_DRDY_Msk instead */
+#define PIO_PCIDR_OVRE_Pos                  1                                              /**< (PIO_PCIDR) Parallel Capture Mode Overrun Error Interrupt Disable Position */
+#define PIO_PCIDR_OVRE_Msk                  (_U_(0x1) << PIO_PCIDR_OVRE_Pos)               /**< (PIO_PCIDR) Parallel Capture Mode Overrun Error Interrupt Disable Mask */
+#define PIO_PCIDR_OVRE                      PIO_PCIDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_OVRE_Msk instead */
+#define PIO_PCIDR_ENDRX_Pos                 2                                              /**< (PIO_PCIDR) End of Reception Transfer Interrupt Disable Position */
+#define PIO_PCIDR_ENDRX_Msk                 (_U_(0x1) << PIO_PCIDR_ENDRX_Pos)              /**< (PIO_PCIDR) End of Reception Transfer Interrupt Disable Mask */
+#define PIO_PCIDR_ENDRX                     PIO_PCIDR_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_ENDRX_Msk instead */
+#define PIO_PCIDR_RXBUFF_Pos                3                                              /**< (PIO_PCIDR) Reception Buffer Full Interrupt Disable Position */
+#define PIO_PCIDR_RXBUFF_Msk                (_U_(0x1) << PIO_PCIDR_RXBUFF_Pos)             /**< (PIO_PCIDR) Reception Buffer Full Interrupt Disable Mask */
+#define PIO_PCIDR_RXBUFF                    PIO_PCIDR_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIDR_RXBUFF_Msk instead */
+#define PIO_PCIDR_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIDR) Register MASK  (Use PIO_PCIDR_Msk instead)  */
+#define PIO_PCIDR_Msk                       _U_(0x0F)                                      /**< (PIO_PCIDR) Register Mask  */
+
+
+/* -------- PIO_PCIMR : (PIO Offset: 0x15c) (R/ 32) Parallel Capture Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Mask */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error Interrupt Mask */
+    uint32_t ENDRX:1;                   /**< bit:      2  End of Reception Transfer Interrupt Mask */
+    uint32_t RXBUFF:1;                  /**< bit:      3  Reception Buffer Full Interrupt Mask     */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCIMR_OFFSET                    (0x15C)                                       /**<  (PIO_PCIMR) Parallel Capture Interrupt Mask Register  Offset */
+
+#define PIO_PCIMR_DRDY_Pos                  0                                              /**< (PIO_PCIMR) Parallel Capture Mode Data Ready Interrupt Mask Position */
+#define PIO_PCIMR_DRDY_Msk                  (_U_(0x1) << PIO_PCIMR_DRDY_Pos)               /**< (PIO_PCIMR) Parallel Capture Mode Data Ready Interrupt Mask Mask */
+#define PIO_PCIMR_DRDY                      PIO_PCIMR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_DRDY_Msk instead */
+#define PIO_PCIMR_OVRE_Pos                  1                                              /**< (PIO_PCIMR) Parallel Capture Mode Overrun Error Interrupt Mask Position */
+#define PIO_PCIMR_OVRE_Msk                  (_U_(0x1) << PIO_PCIMR_OVRE_Pos)               /**< (PIO_PCIMR) Parallel Capture Mode Overrun Error Interrupt Mask Mask */
+#define PIO_PCIMR_OVRE                      PIO_PCIMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_OVRE_Msk instead */
+#define PIO_PCIMR_ENDRX_Pos                 2                                              /**< (PIO_PCIMR) End of Reception Transfer Interrupt Mask Position */
+#define PIO_PCIMR_ENDRX_Msk                 (_U_(0x1) << PIO_PCIMR_ENDRX_Pos)              /**< (PIO_PCIMR) End of Reception Transfer Interrupt Mask Mask */
+#define PIO_PCIMR_ENDRX                     PIO_PCIMR_ENDRX_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_ENDRX_Msk instead */
+#define PIO_PCIMR_RXBUFF_Pos                3                                              /**< (PIO_PCIMR) Reception Buffer Full Interrupt Mask Position */
+#define PIO_PCIMR_RXBUFF_Msk                (_U_(0x1) << PIO_PCIMR_RXBUFF_Pos)             /**< (PIO_PCIMR) Reception Buffer Full Interrupt Mask Mask */
+#define PIO_PCIMR_RXBUFF                    PIO_PCIMR_RXBUFF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCIMR_RXBUFF_Msk instead */
+#define PIO_PCIMR_MASK                      _U_(0x0F)                                      /**< \deprecated (PIO_PCIMR) Register MASK  (Use PIO_PCIMR_Msk instead)  */
+#define PIO_PCIMR_Msk                       _U_(0x0F)                                      /**< (PIO_PCIMR) Register Mask  */
+
+
+/* -------- PIO_PCISR : (PIO Offset: 0x160) (R/ 32) Parallel Capture Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready         */
+    uint32_t OVRE:1;                    /**< bit:      1  Parallel Capture Mode Overrun Error      */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCISR_OFFSET                    (0x160)                                       /**<  (PIO_PCISR) Parallel Capture Interrupt Status Register  Offset */
+
+#define PIO_PCISR_DRDY_Pos                  0                                              /**< (PIO_PCISR) Parallel Capture Mode Data Ready Position */
+#define PIO_PCISR_DRDY_Msk                  (_U_(0x1) << PIO_PCISR_DRDY_Pos)               /**< (PIO_PCISR) Parallel Capture Mode Data Ready Mask */
+#define PIO_PCISR_DRDY                      PIO_PCISR_DRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCISR_DRDY_Msk instead */
+#define PIO_PCISR_OVRE_Pos                  1                                              /**< (PIO_PCISR) Parallel Capture Mode Overrun Error Position */
+#define PIO_PCISR_OVRE_Msk                  (_U_(0x1) << PIO_PCISR_OVRE_Pos)               /**< (PIO_PCISR) Parallel Capture Mode Overrun Error Mask */
+#define PIO_PCISR_OVRE                      PIO_PCISR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PIO_PCISR_OVRE_Msk instead */
+#define PIO_PCISR_MASK                      _U_(0x03)                                      /**< \deprecated (PIO_PCISR) Register MASK  (Use PIO_PCISR_Msk instead)  */
+#define PIO_PCISR_Msk                       _U_(0x03)                                      /**< (PIO_PCISR) Register Mask  */
+
+
+/* -------- PIO_PCRHR : (PIO Offset: 0x164) (R/ 32) Parallel Capture Reception Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDATA:32;                  /**< bit:  0..31  Parallel Capture Mode Reception Data     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PIO_PCRHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PIO_PCRHR_OFFSET                    (0x164)                                       /**<  (PIO_PCRHR) Parallel Capture Reception Holding Register  Offset */
+
+#define PIO_PCRHR_RDATA_Pos                 0                                              /**< (PIO_PCRHR) Parallel Capture Mode Reception Data Position */
+#define PIO_PCRHR_RDATA_Msk                 (_U_(0xFFFFFFFF) << PIO_PCRHR_RDATA_Pos)       /**< (PIO_PCRHR) Parallel Capture Mode Reception Data Mask */
+#define PIO_PCRHR_RDATA(value)              (PIO_PCRHR_RDATA_Msk & ((value) << PIO_PCRHR_RDATA_Pos))
+#define PIO_PCRHR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PIO_PCRHR) Register MASK  (Use PIO_PCRHR_Msk instead)  */
+#define PIO_PCRHR_Msk                       _U_(0xFFFFFFFF)                                /**< (PIO_PCRHR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PIO hardware registers */
+typedef struct {  
+  __O  uint32_t PIO_PER;        /**< (PIO Offset: 0x00) PIO Enable Register */
+  __O  uint32_t PIO_PDR;        /**< (PIO Offset: 0x04) PIO Disable Register */
+  __I  uint32_t PIO_PSR;        /**< (PIO Offset: 0x08) PIO Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t PIO_OER;        /**< (PIO Offset: 0x10) Output Enable Register */
+  __O  uint32_t PIO_ODR;        /**< (PIO Offset: 0x14) Output Disable Register */
+  __I  uint32_t PIO_OSR;        /**< (PIO Offset: 0x18) Output Status Register */
+  __I  uint8_t                        Reserved2[4];
+  __O  uint32_t PIO_IFER;       /**< (PIO Offset: 0x20) Glitch Input Filter Enable Register */
+  __O  uint32_t PIO_IFDR;       /**< (PIO Offset: 0x24) Glitch Input Filter Disable Register */
+  __I  uint32_t PIO_IFSR;       /**< (PIO Offset: 0x28) Glitch Input Filter Status Register */
+  __I  uint8_t                        Reserved3[4];
+  __O  uint32_t PIO_SODR;       /**< (PIO Offset: 0x30) Set Output Data Register */
+  __O  uint32_t PIO_CODR;       /**< (PIO Offset: 0x34) Clear Output Data Register */
+  __IO uint32_t PIO_ODSR;       /**< (PIO Offset: 0x38) Output Data Status Register */
+  __I  uint32_t PIO_PDSR;       /**< (PIO Offset: 0x3C) Pin Data Status Register */
+  __O  uint32_t PIO_IER;        /**< (PIO Offset: 0x40) Interrupt Enable Register */
+  __O  uint32_t PIO_IDR;        /**< (PIO Offset: 0x44) Interrupt Disable Register */
+  __I  uint32_t PIO_IMR;        /**< (PIO Offset: 0x48) Interrupt Mask Register */
+  __I  uint32_t PIO_ISR;        /**< (PIO Offset: 0x4C) Interrupt Status Register */
+  __O  uint32_t PIO_MDER;       /**< (PIO Offset: 0x50) Multi-driver Enable Register */
+  __O  uint32_t PIO_MDDR;       /**< (PIO Offset: 0x54) Multi-driver Disable Register */
+  __I  uint32_t PIO_MDSR;       /**< (PIO Offset: 0x58) Multi-driver Status Register */
+  __I  uint8_t                        Reserved4[4];
+  __O  uint32_t PIO_PUDR;       /**< (PIO Offset: 0x60) Pull-up Disable Register */
+  __O  uint32_t PIO_PUER;       /**< (PIO Offset: 0x64) Pull-up Enable Register */
+  __I  uint32_t PIO_PUSR;       /**< (PIO Offset: 0x68) Pad Pull-up Status Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO uint32_t PIO_ABCDSR[2];  /**< (PIO Offset: 0x70) Peripheral ABCD Select Register 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  uint32_t PIO_IFSCDR;     /**< (PIO Offset: 0x80) Input Filter Slow Clock Disable Register */
+  __O  uint32_t PIO_IFSCER;     /**< (PIO Offset: 0x84) Input Filter Slow Clock Enable Register */
+  __I  uint32_t PIO_IFSCSR;     /**< (PIO Offset: 0x88) Input Filter Slow Clock Status Register */
+  __IO uint32_t PIO_SCDR;       /**< (PIO Offset: 0x8C) Slow Clock Divider Debouncing Register */
+  __O  uint32_t PIO_PPDDR;      /**< (PIO Offset: 0x90) Pad Pull-down Disable Register */
+  __O  uint32_t PIO_PPDER;      /**< (PIO Offset: 0x94) Pad Pull-down Enable Register */
+  __I  uint32_t PIO_PPDSR;      /**< (PIO Offset: 0x98) Pad Pull-down Status Register */
+  __I  uint8_t                        Reserved7[4];
+  __O  uint32_t PIO_OWER;       /**< (PIO Offset: 0xA0) Output Write Enable */
+  __O  uint32_t PIO_OWDR;       /**< (PIO Offset: 0xA4) Output Write Disable */
+  __I  uint32_t PIO_OWSR;       /**< (PIO Offset: 0xA8) Output Write Status Register */
+  __I  uint8_t                        Reserved8[4];
+  __O  uint32_t PIO_AIMER;      /**< (PIO Offset: 0xB0) Additional Interrupt Modes Enable Register */
+  __O  uint32_t PIO_AIMDR;      /**< (PIO Offset: 0xB4) Additional Interrupt Modes Disable Register */
+  __I  uint32_t PIO_AIMMR;      /**< (PIO Offset: 0xB8) Additional Interrupt Modes Mask Register */
+  __I  uint8_t                        Reserved9[4];
+  __O  uint32_t PIO_ESR;        /**< (PIO Offset: 0xC0) Edge Select Register */
+  __O  uint32_t PIO_LSR;        /**< (PIO Offset: 0xC4) Level Select Register */
+  __I  uint32_t PIO_ELSR;       /**< (PIO Offset: 0xC8) Edge/Level Status Register */
+  __I  uint8_t                        Reserved10[4];
+  __O  uint32_t PIO_FELLSR;     /**< (PIO Offset: 0xD0) Falling Edge/Low-Level Select Register */
+  __O  uint32_t PIO_REHLSR;     /**< (PIO Offset: 0xD4) Rising Edge/High-Level Select Register */
+  __I  uint32_t PIO_FRLHSR;     /**< (PIO Offset: 0xD8) Fall/Rise - Low/High Status Register */
+  __I  uint8_t                        Reserved11[4];
+  __I  uint32_t PIO_LOCKSR;     /**< (PIO Offset: 0xE0) Lock Status */
+  __IO uint32_t PIO_WPMR;       /**< (PIO Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t PIO_WPSR;       /**< (PIO Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved12[20];
+  __IO uint32_t PIO_SCHMITT;    /**< (PIO Offset: 0x100) Schmitt Trigger Register */
+  __I  uint8_t                        Reserved13[20];
+  __IO uint32_t PIO_DRIVER;     /**< (PIO Offset: 0x118) I/O Drive Register */
+  __I  uint8_t                        Reserved14[52];
+  __IO uint32_t PIO_PCMR;       /**< (PIO Offset: 0x150) Parallel Capture Mode Register */
+  __O  uint32_t PIO_PCIER;      /**< (PIO Offset: 0x154) Parallel Capture Interrupt Enable Register */
+  __O  uint32_t PIO_PCIDR;      /**< (PIO Offset: 0x158) Parallel Capture Interrupt Disable Register */
+  __I  uint32_t PIO_PCIMR;      /**< (PIO Offset: 0x15C) Parallel Capture Interrupt Mask Register */
+  __I  uint32_t PIO_PCISR;      /**< (PIO Offset: 0x160) Parallel Capture Interrupt Status Register */
+  __I  uint32_t PIO_PCRHR;      /**< (PIO Offset: 0x164) Parallel Capture Reception Holding Register */
+} Pio;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PIO hardware registers */
+typedef struct {  
+  __O  PIO_PER_Type                   PIO_PER;        /**< Offset: 0x00 ( /W  32) PIO Enable Register */
+  __O  PIO_PDR_Type                   PIO_PDR;        /**< Offset: 0x04 ( /W  32) PIO Disable Register */
+  __I  PIO_PSR_Type                   PIO_PSR;        /**< Offset: 0x08 (R/   32) PIO Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  PIO_OER_Type                   PIO_OER;        /**< Offset: 0x10 ( /W  32) Output Enable Register */
+  __O  PIO_ODR_Type                   PIO_ODR;        /**< Offset: 0x14 ( /W  32) Output Disable Register */
+  __I  PIO_OSR_Type                   PIO_OSR;        /**< Offset: 0x18 (R/   32) Output Status Register */
+  __I  uint8_t                        Reserved2[4];
+  __O  PIO_IFER_Type                  PIO_IFER;       /**< Offset: 0x20 ( /W  32) Glitch Input Filter Enable Register */
+  __O  PIO_IFDR_Type                  PIO_IFDR;       /**< Offset: 0x24 ( /W  32) Glitch Input Filter Disable Register */
+  __I  PIO_IFSR_Type                  PIO_IFSR;       /**< Offset: 0x28 (R/   32) Glitch Input Filter Status Register */
+  __I  uint8_t                        Reserved3[4];
+  __O  PIO_SODR_Type                  PIO_SODR;       /**< Offset: 0x30 ( /W  32) Set Output Data Register */
+  __O  PIO_CODR_Type                  PIO_CODR;       /**< Offset: 0x34 ( /W  32) Clear Output Data Register */
+  __IO PIO_ODSR_Type                  PIO_ODSR;       /**< Offset: 0x38 (R/W  32) Output Data Status Register */
+  __I  PIO_PDSR_Type                  PIO_PDSR;       /**< Offset: 0x3C (R/   32) Pin Data Status Register */
+  __O  PIO_IER_Type                   PIO_IER;        /**< Offset: 0x40 ( /W  32) Interrupt Enable Register */
+  __O  PIO_IDR_Type                   PIO_IDR;        /**< Offset: 0x44 ( /W  32) Interrupt Disable Register */
+  __I  PIO_IMR_Type                   PIO_IMR;        /**< Offset: 0x48 (R/   32) Interrupt Mask Register */
+  __I  PIO_ISR_Type                   PIO_ISR;        /**< Offset: 0x4C (R/   32) Interrupt Status Register */
+  __O  PIO_MDER_Type                  PIO_MDER;       /**< Offset: 0x50 ( /W  32) Multi-driver Enable Register */
+  __O  PIO_MDDR_Type                  PIO_MDDR;       /**< Offset: 0x54 ( /W  32) Multi-driver Disable Register */
+  __I  PIO_MDSR_Type                  PIO_MDSR;       /**< Offset: 0x58 (R/   32) Multi-driver Status Register */
+  __I  uint8_t                        Reserved4[4];
+  __O  PIO_PUDR_Type                  PIO_PUDR;       /**< Offset: 0x60 ( /W  32) Pull-up Disable Register */
+  __O  PIO_PUER_Type                  PIO_PUER;       /**< Offset: 0x64 ( /W  32) Pull-up Enable Register */
+  __I  PIO_PUSR_Type                  PIO_PUSR;       /**< Offset: 0x68 (R/   32) Pad Pull-up Status Register */
+  __I  uint8_t                        Reserved5[4];
+  __IO PIO_ABCDSR_Type                PIO_ABCDSR[2];  /**< Offset: 0x70 (R/W  32) Peripheral ABCD Select Register 0 */
+  __I  uint8_t                        Reserved6[8];
+  __O  PIO_IFSCDR_Type                PIO_IFSCDR;     /**< Offset: 0x80 ( /W  32) Input Filter Slow Clock Disable Register */
+  __O  PIO_IFSCER_Type                PIO_IFSCER;     /**< Offset: 0x84 ( /W  32) Input Filter Slow Clock Enable Register */
+  __I  PIO_IFSCSR_Type                PIO_IFSCSR;     /**< Offset: 0x88 (R/   32) Input Filter Slow Clock Status Register */
+  __IO PIO_SCDR_Type                  PIO_SCDR;       /**< Offset: 0x8C (R/W  32) Slow Clock Divider Debouncing Register */
+  __O  PIO_PPDDR_Type                 PIO_PPDDR;      /**< Offset: 0x90 ( /W  32) Pad Pull-down Disable Register */
+  __O  PIO_PPDER_Type                 PIO_PPDER;      /**< Offset: 0x94 ( /W  32) Pad Pull-down Enable Register */
+  __I  PIO_PPDSR_Type                 PIO_PPDSR;      /**< Offset: 0x98 (R/   32) Pad Pull-down Status Register */
+  __I  uint8_t                        Reserved7[4];
+  __O  PIO_OWER_Type                  PIO_OWER;       /**< Offset: 0xA0 ( /W  32) Output Write Enable */
+  __O  PIO_OWDR_Type                  PIO_OWDR;       /**< Offset: 0xA4 ( /W  32) Output Write Disable */
+  __I  PIO_OWSR_Type                  PIO_OWSR;       /**< Offset: 0xA8 (R/   32) Output Write Status Register */
+  __I  uint8_t                        Reserved8[4];
+  __O  PIO_AIMER_Type                 PIO_AIMER;      /**< Offset: 0xB0 ( /W  32) Additional Interrupt Modes Enable Register */
+  __O  PIO_AIMDR_Type                 PIO_AIMDR;      /**< Offset: 0xB4 ( /W  32) Additional Interrupt Modes Disable Register */
+  __I  PIO_AIMMR_Type                 PIO_AIMMR;      /**< Offset: 0xB8 (R/   32) Additional Interrupt Modes Mask Register */
+  __I  uint8_t                        Reserved9[4];
+  __O  PIO_ESR_Type                   PIO_ESR;        /**< Offset: 0xC0 ( /W  32) Edge Select Register */
+  __O  PIO_LSR_Type                   PIO_LSR;        /**< Offset: 0xC4 ( /W  32) Level Select Register */
+  __I  PIO_ELSR_Type                  PIO_ELSR;       /**< Offset: 0xC8 (R/   32) Edge/Level Status Register */
+  __I  uint8_t                        Reserved10[4];
+  __O  PIO_FELLSR_Type                PIO_FELLSR;     /**< Offset: 0xD0 ( /W  32) Falling Edge/Low-Level Select Register */
+  __O  PIO_REHLSR_Type                PIO_REHLSR;     /**< Offset: 0xD4 ( /W  32) Rising Edge/High-Level Select Register */
+  __I  PIO_FRLHSR_Type                PIO_FRLHSR;     /**< Offset: 0xD8 (R/   32) Fall/Rise - Low/High Status Register */
+  __I  uint8_t                        Reserved11[4];
+  __I  PIO_LOCKSR_Type                PIO_LOCKSR;     /**< Offset: 0xE0 (R/   32) Lock Status */
+  __IO PIO_WPMR_Type                  PIO_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  PIO_WPSR_Type                  PIO_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved12[20];
+  __IO PIO_SCHMITT_Type               PIO_SCHMITT;    /**< Offset: 0x100 (R/W  32) Schmitt Trigger Register */
+  __I  uint8_t                        Reserved13[20];
+  __IO PIO_DRIVER_Type                PIO_DRIVER;     /**< Offset: 0x118 (R/W  32) I/O Drive Register */
+  __I  uint8_t                        Reserved14[52];
+  __IO PIO_PCMR_Type                  PIO_PCMR;       /**< Offset: 0x150 (R/W  32) Parallel Capture Mode Register */
+  __O  PIO_PCIER_Type                 PIO_PCIER;      /**< Offset: 0x154 ( /W  32) Parallel Capture Interrupt Enable Register */
+  __O  PIO_PCIDR_Type                 PIO_PCIDR;      /**< Offset: 0x158 ( /W  32) Parallel Capture Interrupt Disable Register */
+  __I  PIO_PCIMR_Type                 PIO_PCIMR;      /**< Offset: 0x15C (R/   32) Parallel Capture Interrupt Mask Register */
+  __I  PIO_PCISR_Type                 PIO_PCISR;      /**< Offset: 0x160 (R/   32) Parallel Capture Interrupt Status Register */
+  __I  PIO_PCRHR_Type                 PIO_PCRHR;      /**< Offset: 0x164 (R/   32) Parallel Capture Reception Holding Register */
+} Pio;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Parallel Input/Output Controller */
+
+#endif /* _SAMV71_PIO_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/pmc.h
+++ b/asf/sam/include/samv71b/component/pmc.h
@@ -1,0 +1,3246 @@
+/**
+ * \file
+ *
+ * \brief Component description for PMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PMC_COMPONENT_H_
+#define _SAMV71_PMC_COMPONENT_H_
+#define _SAMV71_PMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Power Management Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PMC_44006                      /**< (PMC) Module ID */
+#define REV_PMC P                      /**< (PMC) Module revision */
+
+/* -------- PMC_SCER : (PMC Offset: 0x00) (/W 32) System Clock Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  Enable USB FS Clock                      */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Enable       */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Enable       */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Enable       */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Enable       */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Enable       */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Enable       */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Enable       */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Enable       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Enable       */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCER_OFFSET                     (0x00)                                        /**<  (PMC_SCER) System Clock Enable Register  Offset */
+
+#define PMC_SCER_USBCLK_Pos                 5                                              /**< (PMC_SCER) Enable USB FS Clock Position */
+#define PMC_SCER_USBCLK_Msk                 (_U_(0x1) << PMC_SCER_USBCLK_Pos)              /**< (PMC_SCER) Enable USB FS Clock Mask */
+#define PMC_SCER_USBCLK                     PMC_SCER_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_USBCLK_Msk instead */
+#define PMC_SCER_PCK0_Pos                   8                                              /**< (PMC_SCER) Programmable Clock 0 Output Enable Position */
+#define PMC_SCER_PCK0_Msk                   (_U_(0x1) << PMC_SCER_PCK0_Pos)                /**< (PMC_SCER) Programmable Clock 0 Output Enable Mask */
+#define PMC_SCER_PCK0                       PMC_SCER_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK0_Msk instead */
+#define PMC_SCER_PCK1_Pos                   9                                              /**< (PMC_SCER) Programmable Clock 1 Output Enable Position */
+#define PMC_SCER_PCK1_Msk                   (_U_(0x1) << PMC_SCER_PCK1_Pos)                /**< (PMC_SCER) Programmable Clock 1 Output Enable Mask */
+#define PMC_SCER_PCK1                       PMC_SCER_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK1_Msk instead */
+#define PMC_SCER_PCK2_Pos                   10                                             /**< (PMC_SCER) Programmable Clock 2 Output Enable Position */
+#define PMC_SCER_PCK2_Msk                   (_U_(0x1) << PMC_SCER_PCK2_Pos)                /**< (PMC_SCER) Programmable Clock 2 Output Enable Mask */
+#define PMC_SCER_PCK2                       PMC_SCER_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK2_Msk instead */
+#define PMC_SCER_PCK3_Pos                   11                                             /**< (PMC_SCER) Programmable Clock 3 Output Enable Position */
+#define PMC_SCER_PCK3_Msk                   (_U_(0x1) << PMC_SCER_PCK3_Pos)                /**< (PMC_SCER) Programmable Clock 3 Output Enable Mask */
+#define PMC_SCER_PCK3                       PMC_SCER_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK3_Msk instead */
+#define PMC_SCER_PCK4_Pos                   12                                             /**< (PMC_SCER) Programmable Clock 4 Output Enable Position */
+#define PMC_SCER_PCK4_Msk                   (_U_(0x1) << PMC_SCER_PCK4_Pos)                /**< (PMC_SCER) Programmable Clock 4 Output Enable Mask */
+#define PMC_SCER_PCK4                       PMC_SCER_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK4_Msk instead */
+#define PMC_SCER_PCK5_Pos                   13                                             /**< (PMC_SCER) Programmable Clock 5 Output Enable Position */
+#define PMC_SCER_PCK5_Msk                   (_U_(0x1) << PMC_SCER_PCK5_Pos)                /**< (PMC_SCER) Programmable Clock 5 Output Enable Mask */
+#define PMC_SCER_PCK5                       PMC_SCER_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK5_Msk instead */
+#define PMC_SCER_PCK6_Pos                   14                                             /**< (PMC_SCER) Programmable Clock 6 Output Enable Position */
+#define PMC_SCER_PCK6_Msk                   (_U_(0x1) << PMC_SCER_PCK6_Pos)                /**< (PMC_SCER) Programmable Clock 6 Output Enable Mask */
+#define PMC_SCER_PCK6                       PMC_SCER_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK6_Msk instead */
+#define PMC_SCER_PCK7_Pos                   15                                             /**< (PMC_SCER) Programmable Clock 7 Output Enable Position */
+#define PMC_SCER_PCK7_Msk                   (_U_(0x1) << PMC_SCER_PCK7_Pos)                /**< (PMC_SCER) Programmable Clock 7 Output Enable Mask */
+#define PMC_SCER_PCK7                       PMC_SCER_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK7_Msk instead */
+#define PMC_SCER_MASK                       _U_(0xFF20)                                    /**< \deprecated (PMC_SCER) Register MASK  (Use PMC_SCER_Msk instead)  */
+#define PMC_SCER_Msk                        _U_(0xFF20)                                    /**< (PMC_SCER) Register Mask  */
+
+#define PMC_SCER_PCK_Pos                    8                                              /**< (PMC_SCER Position) Programmable Clock 7 Output Enable */
+#define PMC_SCER_PCK_Msk                    (_U_(0xFF) << PMC_SCER_PCK_Pos)                /**< (PMC_SCER Mask) PCK */
+#define PMC_SCER_PCK(value)                 (PMC_SCER_PCK_Msk & ((value) << PMC_SCER_PCK_Pos))  
+
+/* -------- PMC_SCDR : (PMC Offset: 0x04) (/W 32) System Clock Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  Disable USB FS Clock                     */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Disable      */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Disable      */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Disable      */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Disable      */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Disable      */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Disable      */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Disable      */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Disable      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Disable      */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCDR_OFFSET                     (0x04)                                        /**<  (PMC_SCDR) System Clock Disable Register  Offset */
+
+#define PMC_SCDR_USBCLK_Pos                 5                                              /**< (PMC_SCDR) Disable USB FS Clock Position */
+#define PMC_SCDR_USBCLK_Msk                 (_U_(0x1) << PMC_SCDR_USBCLK_Pos)              /**< (PMC_SCDR) Disable USB FS Clock Mask */
+#define PMC_SCDR_USBCLK                     PMC_SCDR_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_USBCLK_Msk instead */
+#define PMC_SCDR_PCK0_Pos                   8                                              /**< (PMC_SCDR) Programmable Clock 0 Output Disable Position */
+#define PMC_SCDR_PCK0_Msk                   (_U_(0x1) << PMC_SCDR_PCK0_Pos)                /**< (PMC_SCDR) Programmable Clock 0 Output Disable Mask */
+#define PMC_SCDR_PCK0                       PMC_SCDR_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK0_Msk instead */
+#define PMC_SCDR_PCK1_Pos                   9                                              /**< (PMC_SCDR) Programmable Clock 1 Output Disable Position */
+#define PMC_SCDR_PCK1_Msk                   (_U_(0x1) << PMC_SCDR_PCK1_Pos)                /**< (PMC_SCDR) Programmable Clock 1 Output Disable Mask */
+#define PMC_SCDR_PCK1                       PMC_SCDR_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK1_Msk instead */
+#define PMC_SCDR_PCK2_Pos                   10                                             /**< (PMC_SCDR) Programmable Clock 2 Output Disable Position */
+#define PMC_SCDR_PCK2_Msk                   (_U_(0x1) << PMC_SCDR_PCK2_Pos)                /**< (PMC_SCDR) Programmable Clock 2 Output Disable Mask */
+#define PMC_SCDR_PCK2                       PMC_SCDR_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK2_Msk instead */
+#define PMC_SCDR_PCK3_Pos                   11                                             /**< (PMC_SCDR) Programmable Clock 3 Output Disable Position */
+#define PMC_SCDR_PCK3_Msk                   (_U_(0x1) << PMC_SCDR_PCK3_Pos)                /**< (PMC_SCDR) Programmable Clock 3 Output Disable Mask */
+#define PMC_SCDR_PCK3                       PMC_SCDR_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK3_Msk instead */
+#define PMC_SCDR_PCK4_Pos                   12                                             /**< (PMC_SCDR) Programmable Clock 4 Output Disable Position */
+#define PMC_SCDR_PCK4_Msk                   (_U_(0x1) << PMC_SCDR_PCK4_Pos)                /**< (PMC_SCDR) Programmable Clock 4 Output Disable Mask */
+#define PMC_SCDR_PCK4                       PMC_SCDR_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK4_Msk instead */
+#define PMC_SCDR_PCK5_Pos                   13                                             /**< (PMC_SCDR) Programmable Clock 5 Output Disable Position */
+#define PMC_SCDR_PCK5_Msk                   (_U_(0x1) << PMC_SCDR_PCK5_Pos)                /**< (PMC_SCDR) Programmable Clock 5 Output Disable Mask */
+#define PMC_SCDR_PCK5                       PMC_SCDR_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK5_Msk instead */
+#define PMC_SCDR_PCK6_Pos                   14                                             /**< (PMC_SCDR) Programmable Clock 6 Output Disable Position */
+#define PMC_SCDR_PCK6_Msk                   (_U_(0x1) << PMC_SCDR_PCK6_Pos)                /**< (PMC_SCDR) Programmable Clock 6 Output Disable Mask */
+#define PMC_SCDR_PCK6                       PMC_SCDR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK6_Msk instead */
+#define PMC_SCDR_PCK7_Pos                   15                                             /**< (PMC_SCDR) Programmable Clock 7 Output Disable Position */
+#define PMC_SCDR_PCK7_Msk                   (_U_(0x1) << PMC_SCDR_PCK7_Pos)                /**< (PMC_SCDR) Programmable Clock 7 Output Disable Mask */
+#define PMC_SCDR_PCK7                       PMC_SCDR_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK7_Msk instead */
+#define PMC_SCDR_MASK                       _U_(0xFF20)                                    /**< \deprecated (PMC_SCDR) Register MASK  (Use PMC_SCDR_Msk instead)  */
+#define PMC_SCDR_Msk                        _U_(0xFF20)                                    /**< (PMC_SCDR) Register Mask  */
+
+#define PMC_SCDR_PCK_Pos                    8                                              /**< (PMC_SCDR Position) Programmable Clock 7 Output Disable */
+#define PMC_SCDR_PCK_Msk                    (_U_(0xFF) << PMC_SCDR_PCK_Pos)                /**< (PMC_SCDR Mask) PCK */
+#define PMC_SCDR_PCK(value)                 (PMC_SCDR_PCK_Msk & ((value) << PMC_SCDR_PCK_Pos))  
+
+/* -------- PMC_SCSR : (PMC Offset: 0x08) (R/ 32) System Clock Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HCLKS:1;                   /**< bit:      0  HCLK Status                              */
+    uint32_t :4;                        /**< bit:   1..4  Reserved */
+    uint32_t USBCLK:1;                  /**< bit:      5  USB FS Clock Status                      */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t PCK0:1;                    /**< bit:      8  Programmable Clock 0 Output Status       */
+    uint32_t PCK1:1;                    /**< bit:      9  Programmable Clock 1 Output Status       */
+    uint32_t PCK2:1;                    /**< bit:     10  Programmable Clock 2 Output Status       */
+    uint32_t PCK3:1;                    /**< bit:     11  Programmable Clock 3 Output Status       */
+    uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Status       */
+    uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Status       */
+    uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Status       */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Status       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Status       */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SCSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SCSR_OFFSET                     (0x08)                                        /**<  (PMC_SCSR) System Clock Status Register  Offset */
+
+#define PMC_SCSR_HCLKS_Pos                  0                                              /**< (PMC_SCSR) HCLK Status Position */
+#define PMC_SCSR_HCLKS_Msk                  (_U_(0x1) << PMC_SCSR_HCLKS_Pos)               /**< (PMC_SCSR) HCLK Status Mask */
+#define PMC_SCSR_HCLKS                      PMC_SCSR_HCLKS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_HCLKS_Msk instead */
+#define PMC_SCSR_USBCLK_Pos                 5                                              /**< (PMC_SCSR) USB FS Clock Status Position */
+#define PMC_SCSR_USBCLK_Msk                 (_U_(0x1) << PMC_SCSR_USBCLK_Pos)              /**< (PMC_SCSR) USB FS Clock Status Mask */
+#define PMC_SCSR_USBCLK                     PMC_SCSR_USBCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_USBCLK_Msk instead */
+#define PMC_SCSR_PCK0_Pos                   8                                              /**< (PMC_SCSR) Programmable Clock 0 Output Status Position */
+#define PMC_SCSR_PCK0_Msk                   (_U_(0x1) << PMC_SCSR_PCK0_Pos)                /**< (PMC_SCSR) Programmable Clock 0 Output Status Mask */
+#define PMC_SCSR_PCK0                       PMC_SCSR_PCK0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK0_Msk instead */
+#define PMC_SCSR_PCK1_Pos                   9                                              /**< (PMC_SCSR) Programmable Clock 1 Output Status Position */
+#define PMC_SCSR_PCK1_Msk                   (_U_(0x1) << PMC_SCSR_PCK1_Pos)                /**< (PMC_SCSR) Programmable Clock 1 Output Status Mask */
+#define PMC_SCSR_PCK1                       PMC_SCSR_PCK1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK1_Msk instead */
+#define PMC_SCSR_PCK2_Pos                   10                                             /**< (PMC_SCSR) Programmable Clock 2 Output Status Position */
+#define PMC_SCSR_PCK2_Msk                   (_U_(0x1) << PMC_SCSR_PCK2_Pos)                /**< (PMC_SCSR) Programmable Clock 2 Output Status Mask */
+#define PMC_SCSR_PCK2                       PMC_SCSR_PCK2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK2_Msk instead */
+#define PMC_SCSR_PCK3_Pos                   11                                             /**< (PMC_SCSR) Programmable Clock 3 Output Status Position */
+#define PMC_SCSR_PCK3_Msk                   (_U_(0x1) << PMC_SCSR_PCK3_Pos)                /**< (PMC_SCSR) Programmable Clock 3 Output Status Mask */
+#define PMC_SCSR_PCK3                       PMC_SCSR_PCK3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK3_Msk instead */
+#define PMC_SCSR_PCK4_Pos                   12                                             /**< (PMC_SCSR) Programmable Clock 4 Output Status Position */
+#define PMC_SCSR_PCK4_Msk                   (_U_(0x1) << PMC_SCSR_PCK4_Pos)                /**< (PMC_SCSR) Programmable Clock 4 Output Status Mask */
+#define PMC_SCSR_PCK4                       PMC_SCSR_PCK4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK4_Msk instead */
+#define PMC_SCSR_PCK5_Pos                   13                                             /**< (PMC_SCSR) Programmable Clock 5 Output Status Position */
+#define PMC_SCSR_PCK5_Msk                   (_U_(0x1) << PMC_SCSR_PCK5_Pos)                /**< (PMC_SCSR) Programmable Clock 5 Output Status Mask */
+#define PMC_SCSR_PCK5                       PMC_SCSR_PCK5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK5_Msk instead */
+#define PMC_SCSR_PCK6_Pos                   14                                             /**< (PMC_SCSR) Programmable Clock 6 Output Status Position */
+#define PMC_SCSR_PCK6_Msk                   (_U_(0x1) << PMC_SCSR_PCK6_Pos)                /**< (PMC_SCSR) Programmable Clock 6 Output Status Mask */
+#define PMC_SCSR_PCK6                       PMC_SCSR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK6_Msk instead */
+#define PMC_SCSR_PCK7_Pos                   15                                             /**< (PMC_SCSR) Programmable Clock 7 Output Status Position */
+#define PMC_SCSR_PCK7_Msk                   (_U_(0x1) << PMC_SCSR_PCK7_Pos)                /**< (PMC_SCSR) Programmable Clock 7 Output Status Mask */
+#define PMC_SCSR_PCK7                       PMC_SCSR_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK7_Msk instead */
+#define PMC_SCSR_MASK                       _U_(0xFF21)                                    /**< \deprecated (PMC_SCSR) Register MASK  (Use PMC_SCSR_Msk instead)  */
+#define PMC_SCSR_Msk                        _U_(0xFF21)                                    /**< (PMC_SCSR) Register Mask  */
+
+#define PMC_SCSR_PCK_Pos                    8                                              /**< (PMC_SCSR Position) Programmable Clock 7 Output Status */
+#define PMC_SCSR_PCK_Msk                    (_U_(0xFF) << PMC_SCSR_PCK_Pos)                /**< (PMC_SCSR Mask) PCK */
+#define PMC_SCSR_PCK(value)                 (PMC_SCSR_PCK_Msk & ((value) << PMC_SCSR_PCK_Pos))  
+
+/* -------- PMC_PCER0 : (PMC Offset: 0x10) (/W 32) Peripheral Clock Enable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Enable                */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Enable                */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Enable                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Enable               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Enable               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Enable               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Enable               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Enable               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Enable               */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Enable               */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Enable               */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Enable               */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Enable               */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Enable               */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Enable               */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Enable               */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Enable               */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Enable               */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Enable               */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Enable               */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Enable               */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Enable               */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Enable               */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Enable               */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Enable               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Enable               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCER0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCER0_OFFSET                    (0x10)                                        /**<  (PMC_PCER0) Peripheral Clock Enable Register 0  Offset */
+
+#define PMC_PCER0_PID7_Pos                  7                                              /**< (PMC_PCER0) Peripheral Clock 7 Enable Position */
+#define PMC_PCER0_PID7_Msk                  (_U_(0x1) << PMC_PCER0_PID7_Pos)               /**< (PMC_PCER0) Peripheral Clock 7 Enable Mask */
+#define PMC_PCER0_PID7                      PMC_PCER0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID7_Msk instead */
+#define PMC_PCER0_PID8_Pos                  8                                              /**< (PMC_PCER0) Peripheral Clock 8 Enable Position */
+#define PMC_PCER0_PID8_Msk                  (_U_(0x1) << PMC_PCER0_PID8_Pos)               /**< (PMC_PCER0) Peripheral Clock 8 Enable Mask */
+#define PMC_PCER0_PID8                      PMC_PCER0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID8_Msk instead */
+#define PMC_PCER0_PID9_Pos                  9                                              /**< (PMC_PCER0) Peripheral Clock 9 Enable Position */
+#define PMC_PCER0_PID9_Msk                  (_U_(0x1) << PMC_PCER0_PID9_Pos)               /**< (PMC_PCER0) Peripheral Clock 9 Enable Mask */
+#define PMC_PCER0_PID9                      PMC_PCER0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID9_Msk instead */
+#define PMC_PCER0_PID10_Pos                 10                                             /**< (PMC_PCER0) Peripheral Clock 10 Enable Position */
+#define PMC_PCER0_PID10_Msk                 (_U_(0x1) << PMC_PCER0_PID10_Pos)              /**< (PMC_PCER0) Peripheral Clock 10 Enable Mask */
+#define PMC_PCER0_PID10                     PMC_PCER0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID10_Msk instead */
+#define PMC_PCER0_PID11_Pos                 11                                             /**< (PMC_PCER0) Peripheral Clock 11 Enable Position */
+#define PMC_PCER0_PID11_Msk                 (_U_(0x1) << PMC_PCER0_PID11_Pos)              /**< (PMC_PCER0) Peripheral Clock 11 Enable Mask */
+#define PMC_PCER0_PID11                     PMC_PCER0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID11_Msk instead */
+#define PMC_PCER0_PID12_Pos                 12                                             /**< (PMC_PCER0) Peripheral Clock 12 Enable Position */
+#define PMC_PCER0_PID12_Msk                 (_U_(0x1) << PMC_PCER0_PID12_Pos)              /**< (PMC_PCER0) Peripheral Clock 12 Enable Mask */
+#define PMC_PCER0_PID12                     PMC_PCER0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID12_Msk instead */
+#define PMC_PCER0_PID13_Pos                 13                                             /**< (PMC_PCER0) Peripheral Clock 13 Enable Position */
+#define PMC_PCER0_PID13_Msk                 (_U_(0x1) << PMC_PCER0_PID13_Pos)              /**< (PMC_PCER0) Peripheral Clock 13 Enable Mask */
+#define PMC_PCER0_PID13                     PMC_PCER0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID13_Msk instead */
+#define PMC_PCER0_PID14_Pos                 14                                             /**< (PMC_PCER0) Peripheral Clock 14 Enable Position */
+#define PMC_PCER0_PID14_Msk                 (_U_(0x1) << PMC_PCER0_PID14_Pos)              /**< (PMC_PCER0) Peripheral Clock 14 Enable Mask */
+#define PMC_PCER0_PID14                     PMC_PCER0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID14_Msk instead */
+#define PMC_PCER0_PID15_Pos                 15                                             /**< (PMC_PCER0) Peripheral Clock 15 Enable Position */
+#define PMC_PCER0_PID15_Msk                 (_U_(0x1) << PMC_PCER0_PID15_Pos)              /**< (PMC_PCER0) Peripheral Clock 15 Enable Mask */
+#define PMC_PCER0_PID15                     PMC_PCER0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID15_Msk instead */
+#define PMC_PCER0_PID16_Pos                 16                                             /**< (PMC_PCER0) Peripheral Clock 16 Enable Position */
+#define PMC_PCER0_PID16_Msk                 (_U_(0x1) << PMC_PCER0_PID16_Pos)              /**< (PMC_PCER0) Peripheral Clock 16 Enable Mask */
+#define PMC_PCER0_PID16                     PMC_PCER0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID16_Msk instead */
+#define PMC_PCER0_PID17_Pos                 17                                             /**< (PMC_PCER0) Peripheral Clock 17 Enable Position */
+#define PMC_PCER0_PID17_Msk                 (_U_(0x1) << PMC_PCER0_PID17_Pos)              /**< (PMC_PCER0) Peripheral Clock 17 Enable Mask */
+#define PMC_PCER0_PID17                     PMC_PCER0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID17_Msk instead */
+#define PMC_PCER0_PID18_Pos                 18                                             /**< (PMC_PCER0) Peripheral Clock 18 Enable Position */
+#define PMC_PCER0_PID18_Msk                 (_U_(0x1) << PMC_PCER0_PID18_Pos)              /**< (PMC_PCER0) Peripheral Clock 18 Enable Mask */
+#define PMC_PCER0_PID18                     PMC_PCER0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID18_Msk instead */
+#define PMC_PCER0_PID19_Pos                 19                                             /**< (PMC_PCER0) Peripheral Clock 19 Enable Position */
+#define PMC_PCER0_PID19_Msk                 (_U_(0x1) << PMC_PCER0_PID19_Pos)              /**< (PMC_PCER0) Peripheral Clock 19 Enable Mask */
+#define PMC_PCER0_PID19                     PMC_PCER0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID19_Msk instead */
+#define PMC_PCER0_PID20_Pos                 20                                             /**< (PMC_PCER0) Peripheral Clock 20 Enable Position */
+#define PMC_PCER0_PID20_Msk                 (_U_(0x1) << PMC_PCER0_PID20_Pos)              /**< (PMC_PCER0) Peripheral Clock 20 Enable Mask */
+#define PMC_PCER0_PID20                     PMC_PCER0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID20_Msk instead */
+#define PMC_PCER0_PID21_Pos                 21                                             /**< (PMC_PCER0) Peripheral Clock 21 Enable Position */
+#define PMC_PCER0_PID21_Msk                 (_U_(0x1) << PMC_PCER0_PID21_Pos)              /**< (PMC_PCER0) Peripheral Clock 21 Enable Mask */
+#define PMC_PCER0_PID21                     PMC_PCER0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID21_Msk instead */
+#define PMC_PCER0_PID22_Pos                 22                                             /**< (PMC_PCER0) Peripheral Clock 22 Enable Position */
+#define PMC_PCER0_PID22_Msk                 (_U_(0x1) << PMC_PCER0_PID22_Pos)              /**< (PMC_PCER0) Peripheral Clock 22 Enable Mask */
+#define PMC_PCER0_PID22                     PMC_PCER0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID22_Msk instead */
+#define PMC_PCER0_PID23_Pos                 23                                             /**< (PMC_PCER0) Peripheral Clock 23 Enable Position */
+#define PMC_PCER0_PID23_Msk                 (_U_(0x1) << PMC_PCER0_PID23_Pos)              /**< (PMC_PCER0) Peripheral Clock 23 Enable Mask */
+#define PMC_PCER0_PID23                     PMC_PCER0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID23_Msk instead */
+#define PMC_PCER0_PID24_Pos                 24                                             /**< (PMC_PCER0) Peripheral Clock 24 Enable Position */
+#define PMC_PCER0_PID24_Msk                 (_U_(0x1) << PMC_PCER0_PID24_Pos)              /**< (PMC_PCER0) Peripheral Clock 24 Enable Mask */
+#define PMC_PCER0_PID24                     PMC_PCER0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID24_Msk instead */
+#define PMC_PCER0_PID25_Pos                 25                                             /**< (PMC_PCER0) Peripheral Clock 25 Enable Position */
+#define PMC_PCER0_PID25_Msk                 (_U_(0x1) << PMC_PCER0_PID25_Pos)              /**< (PMC_PCER0) Peripheral Clock 25 Enable Mask */
+#define PMC_PCER0_PID25                     PMC_PCER0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID25_Msk instead */
+#define PMC_PCER0_PID26_Pos                 26                                             /**< (PMC_PCER0) Peripheral Clock 26 Enable Position */
+#define PMC_PCER0_PID26_Msk                 (_U_(0x1) << PMC_PCER0_PID26_Pos)              /**< (PMC_PCER0) Peripheral Clock 26 Enable Mask */
+#define PMC_PCER0_PID26                     PMC_PCER0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID26_Msk instead */
+#define PMC_PCER0_PID27_Pos                 27                                             /**< (PMC_PCER0) Peripheral Clock 27 Enable Position */
+#define PMC_PCER0_PID27_Msk                 (_U_(0x1) << PMC_PCER0_PID27_Pos)              /**< (PMC_PCER0) Peripheral Clock 27 Enable Mask */
+#define PMC_PCER0_PID27                     PMC_PCER0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID27_Msk instead */
+#define PMC_PCER0_PID28_Pos                 28                                             /**< (PMC_PCER0) Peripheral Clock 28 Enable Position */
+#define PMC_PCER0_PID28_Msk                 (_U_(0x1) << PMC_PCER0_PID28_Pos)              /**< (PMC_PCER0) Peripheral Clock 28 Enable Mask */
+#define PMC_PCER0_PID28                     PMC_PCER0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID28_Msk instead */
+#define PMC_PCER0_PID29_Pos                 29                                             /**< (PMC_PCER0) Peripheral Clock 29 Enable Position */
+#define PMC_PCER0_PID29_Msk                 (_U_(0x1) << PMC_PCER0_PID29_Pos)              /**< (PMC_PCER0) Peripheral Clock 29 Enable Mask */
+#define PMC_PCER0_PID29                     PMC_PCER0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID29_Msk instead */
+#define PMC_PCER0_PID30_Pos                 30                                             /**< (PMC_PCER0) Peripheral Clock 30 Enable Position */
+#define PMC_PCER0_PID30_Msk                 (_U_(0x1) << PMC_PCER0_PID30_Pos)              /**< (PMC_PCER0) Peripheral Clock 30 Enable Mask */
+#define PMC_PCER0_PID30                     PMC_PCER0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID30_Msk instead */
+#define PMC_PCER0_PID31_Pos                 31                                             /**< (PMC_PCER0) Peripheral Clock 31 Enable Position */
+#define PMC_PCER0_PID31_Msk                 (_U_(0x1) << PMC_PCER0_PID31_Pos)              /**< (PMC_PCER0) Peripheral Clock 31 Enable Mask */
+#define PMC_PCER0_PID31                     PMC_PCER0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID31_Msk instead */
+#define PMC_PCER0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
+#define PMC_PCER0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCER0) Register Mask  */
+
+#define PMC_PCER0_PID_Pos                   7                                              /**< (PMC_PCER0 Position) Peripheral Clock 3x Enable */
+#define PMC_PCER0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER0_PID_Pos)          /**< (PMC_PCER0 Mask) PID */
+#define PMC_PCER0_PID(value)                (PMC_PCER0_PID_Msk & ((value) << PMC_PCER0_PID_Pos))  
+
+/* -------- PMC_PCDR0 : (PMC Offset: 0x14) (/W 32) Peripheral Clock Disable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Disable               */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Disable               */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Disable               */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Disable              */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Disable              */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Disable              */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Disable              */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Disable              */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Disable              */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Disable              */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Disable              */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Disable              */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Disable              */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Disable              */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Disable              */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Disable              */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Disable              */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Disable              */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Disable              */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Disable              */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Disable              */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Disable              */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Disable              */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Disable              */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Disable              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Disable              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCDR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCDR0_OFFSET                    (0x14)                                        /**<  (PMC_PCDR0) Peripheral Clock Disable Register 0  Offset */
+
+#define PMC_PCDR0_PID7_Pos                  7                                              /**< (PMC_PCDR0) Peripheral Clock 7 Disable Position */
+#define PMC_PCDR0_PID7_Msk                  (_U_(0x1) << PMC_PCDR0_PID7_Pos)               /**< (PMC_PCDR0) Peripheral Clock 7 Disable Mask */
+#define PMC_PCDR0_PID7                      PMC_PCDR0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID7_Msk instead */
+#define PMC_PCDR0_PID8_Pos                  8                                              /**< (PMC_PCDR0) Peripheral Clock 8 Disable Position */
+#define PMC_PCDR0_PID8_Msk                  (_U_(0x1) << PMC_PCDR0_PID8_Pos)               /**< (PMC_PCDR0) Peripheral Clock 8 Disable Mask */
+#define PMC_PCDR0_PID8                      PMC_PCDR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID8_Msk instead */
+#define PMC_PCDR0_PID9_Pos                  9                                              /**< (PMC_PCDR0) Peripheral Clock 9 Disable Position */
+#define PMC_PCDR0_PID9_Msk                  (_U_(0x1) << PMC_PCDR0_PID9_Pos)               /**< (PMC_PCDR0) Peripheral Clock 9 Disable Mask */
+#define PMC_PCDR0_PID9                      PMC_PCDR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID9_Msk instead */
+#define PMC_PCDR0_PID10_Pos                 10                                             /**< (PMC_PCDR0) Peripheral Clock 10 Disable Position */
+#define PMC_PCDR0_PID10_Msk                 (_U_(0x1) << PMC_PCDR0_PID10_Pos)              /**< (PMC_PCDR0) Peripheral Clock 10 Disable Mask */
+#define PMC_PCDR0_PID10                     PMC_PCDR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID10_Msk instead */
+#define PMC_PCDR0_PID11_Pos                 11                                             /**< (PMC_PCDR0) Peripheral Clock 11 Disable Position */
+#define PMC_PCDR0_PID11_Msk                 (_U_(0x1) << PMC_PCDR0_PID11_Pos)              /**< (PMC_PCDR0) Peripheral Clock 11 Disable Mask */
+#define PMC_PCDR0_PID11                     PMC_PCDR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID11_Msk instead */
+#define PMC_PCDR0_PID12_Pos                 12                                             /**< (PMC_PCDR0) Peripheral Clock 12 Disable Position */
+#define PMC_PCDR0_PID12_Msk                 (_U_(0x1) << PMC_PCDR0_PID12_Pos)              /**< (PMC_PCDR0) Peripheral Clock 12 Disable Mask */
+#define PMC_PCDR0_PID12                     PMC_PCDR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID12_Msk instead */
+#define PMC_PCDR0_PID13_Pos                 13                                             /**< (PMC_PCDR0) Peripheral Clock 13 Disable Position */
+#define PMC_PCDR0_PID13_Msk                 (_U_(0x1) << PMC_PCDR0_PID13_Pos)              /**< (PMC_PCDR0) Peripheral Clock 13 Disable Mask */
+#define PMC_PCDR0_PID13                     PMC_PCDR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID13_Msk instead */
+#define PMC_PCDR0_PID14_Pos                 14                                             /**< (PMC_PCDR0) Peripheral Clock 14 Disable Position */
+#define PMC_PCDR0_PID14_Msk                 (_U_(0x1) << PMC_PCDR0_PID14_Pos)              /**< (PMC_PCDR0) Peripheral Clock 14 Disable Mask */
+#define PMC_PCDR0_PID14                     PMC_PCDR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID14_Msk instead */
+#define PMC_PCDR0_PID15_Pos                 15                                             /**< (PMC_PCDR0) Peripheral Clock 15 Disable Position */
+#define PMC_PCDR0_PID15_Msk                 (_U_(0x1) << PMC_PCDR0_PID15_Pos)              /**< (PMC_PCDR0) Peripheral Clock 15 Disable Mask */
+#define PMC_PCDR0_PID15                     PMC_PCDR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID15_Msk instead */
+#define PMC_PCDR0_PID16_Pos                 16                                             /**< (PMC_PCDR0) Peripheral Clock 16 Disable Position */
+#define PMC_PCDR0_PID16_Msk                 (_U_(0x1) << PMC_PCDR0_PID16_Pos)              /**< (PMC_PCDR0) Peripheral Clock 16 Disable Mask */
+#define PMC_PCDR0_PID16                     PMC_PCDR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID16_Msk instead */
+#define PMC_PCDR0_PID17_Pos                 17                                             /**< (PMC_PCDR0) Peripheral Clock 17 Disable Position */
+#define PMC_PCDR0_PID17_Msk                 (_U_(0x1) << PMC_PCDR0_PID17_Pos)              /**< (PMC_PCDR0) Peripheral Clock 17 Disable Mask */
+#define PMC_PCDR0_PID17                     PMC_PCDR0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID17_Msk instead */
+#define PMC_PCDR0_PID18_Pos                 18                                             /**< (PMC_PCDR0) Peripheral Clock 18 Disable Position */
+#define PMC_PCDR0_PID18_Msk                 (_U_(0x1) << PMC_PCDR0_PID18_Pos)              /**< (PMC_PCDR0) Peripheral Clock 18 Disable Mask */
+#define PMC_PCDR0_PID18                     PMC_PCDR0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID18_Msk instead */
+#define PMC_PCDR0_PID19_Pos                 19                                             /**< (PMC_PCDR0) Peripheral Clock 19 Disable Position */
+#define PMC_PCDR0_PID19_Msk                 (_U_(0x1) << PMC_PCDR0_PID19_Pos)              /**< (PMC_PCDR0) Peripheral Clock 19 Disable Mask */
+#define PMC_PCDR0_PID19                     PMC_PCDR0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID19_Msk instead */
+#define PMC_PCDR0_PID20_Pos                 20                                             /**< (PMC_PCDR0) Peripheral Clock 20 Disable Position */
+#define PMC_PCDR0_PID20_Msk                 (_U_(0x1) << PMC_PCDR0_PID20_Pos)              /**< (PMC_PCDR0) Peripheral Clock 20 Disable Mask */
+#define PMC_PCDR0_PID20                     PMC_PCDR0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID20_Msk instead */
+#define PMC_PCDR0_PID21_Pos                 21                                             /**< (PMC_PCDR0) Peripheral Clock 21 Disable Position */
+#define PMC_PCDR0_PID21_Msk                 (_U_(0x1) << PMC_PCDR0_PID21_Pos)              /**< (PMC_PCDR0) Peripheral Clock 21 Disable Mask */
+#define PMC_PCDR0_PID21                     PMC_PCDR0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID21_Msk instead */
+#define PMC_PCDR0_PID22_Pos                 22                                             /**< (PMC_PCDR0) Peripheral Clock 22 Disable Position */
+#define PMC_PCDR0_PID22_Msk                 (_U_(0x1) << PMC_PCDR0_PID22_Pos)              /**< (PMC_PCDR0) Peripheral Clock 22 Disable Mask */
+#define PMC_PCDR0_PID22                     PMC_PCDR0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID22_Msk instead */
+#define PMC_PCDR0_PID23_Pos                 23                                             /**< (PMC_PCDR0) Peripheral Clock 23 Disable Position */
+#define PMC_PCDR0_PID23_Msk                 (_U_(0x1) << PMC_PCDR0_PID23_Pos)              /**< (PMC_PCDR0) Peripheral Clock 23 Disable Mask */
+#define PMC_PCDR0_PID23                     PMC_PCDR0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID23_Msk instead */
+#define PMC_PCDR0_PID24_Pos                 24                                             /**< (PMC_PCDR0) Peripheral Clock 24 Disable Position */
+#define PMC_PCDR0_PID24_Msk                 (_U_(0x1) << PMC_PCDR0_PID24_Pos)              /**< (PMC_PCDR0) Peripheral Clock 24 Disable Mask */
+#define PMC_PCDR0_PID24                     PMC_PCDR0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID24_Msk instead */
+#define PMC_PCDR0_PID25_Pos                 25                                             /**< (PMC_PCDR0) Peripheral Clock 25 Disable Position */
+#define PMC_PCDR0_PID25_Msk                 (_U_(0x1) << PMC_PCDR0_PID25_Pos)              /**< (PMC_PCDR0) Peripheral Clock 25 Disable Mask */
+#define PMC_PCDR0_PID25                     PMC_PCDR0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID25_Msk instead */
+#define PMC_PCDR0_PID26_Pos                 26                                             /**< (PMC_PCDR0) Peripheral Clock 26 Disable Position */
+#define PMC_PCDR0_PID26_Msk                 (_U_(0x1) << PMC_PCDR0_PID26_Pos)              /**< (PMC_PCDR0) Peripheral Clock 26 Disable Mask */
+#define PMC_PCDR0_PID26                     PMC_PCDR0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID26_Msk instead */
+#define PMC_PCDR0_PID27_Pos                 27                                             /**< (PMC_PCDR0) Peripheral Clock 27 Disable Position */
+#define PMC_PCDR0_PID27_Msk                 (_U_(0x1) << PMC_PCDR0_PID27_Pos)              /**< (PMC_PCDR0) Peripheral Clock 27 Disable Mask */
+#define PMC_PCDR0_PID27                     PMC_PCDR0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID27_Msk instead */
+#define PMC_PCDR0_PID28_Pos                 28                                             /**< (PMC_PCDR0) Peripheral Clock 28 Disable Position */
+#define PMC_PCDR0_PID28_Msk                 (_U_(0x1) << PMC_PCDR0_PID28_Pos)              /**< (PMC_PCDR0) Peripheral Clock 28 Disable Mask */
+#define PMC_PCDR0_PID28                     PMC_PCDR0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID28_Msk instead */
+#define PMC_PCDR0_PID29_Pos                 29                                             /**< (PMC_PCDR0) Peripheral Clock 29 Disable Position */
+#define PMC_PCDR0_PID29_Msk                 (_U_(0x1) << PMC_PCDR0_PID29_Pos)              /**< (PMC_PCDR0) Peripheral Clock 29 Disable Mask */
+#define PMC_PCDR0_PID29                     PMC_PCDR0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID29_Msk instead */
+#define PMC_PCDR0_PID30_Pos                 30                                             /**< (PMC_PCDR0) Peripheral Clock 30 Disable Position */
+#define PMC_PCDR0_PID30_Msk                 (_U_(0x1) << PMC_PCDR0_PID30_Pos)              /**< (PMC_PCDR0) Peripheral Clock 30 Disable Mask */
+#define PMC_PCDR0_PID30                     PMC_PCDR0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID30_Msk instead */
+#define PMC_PCDR0_PID31_Pos                 31                                             /**< (PMC_PCDR0) Peripheral Clock 31 Disable Position */
+#define PMC_PCDR0_PID31_Msk                 (_U_(0x1) << PMC_PCDR0_PID31_Pos)              /**< (PMC_PCDR0) Peripheral Clock 31 Disable Mask */
+#define PMC_PCDR0_PID31                     PMC_PCDR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID31_Msk instead */
+#define PMC_PCDR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
+#define PMC_PCDR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCDR0) Register Mask  */
+
+#define PMC_PCDR0_PID_Pos                   7                                              /**< (PMC_PCDR0 Position) Peripheral Clock 3x Disable */
+#define PMC_PCDR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR0_PID_Pos)          /**< (PMC_PCDR0 Mask) PID */
+#define PMC_PCDR0_PID(value)                (PMC_PCDR0_PID_Msk & ((value) << PMC_PCDR0_PID_Pos))  
+
+/* -------- PMC_PCSR0 : (PMC Offset: 0x18) (R/ 32) Peripheral Clock Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Status                */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Status                */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Status                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Status               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Status               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Status               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Status               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Status               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Status               */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Status               */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Status               */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Status               */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral Clock 19 Status               */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral Clock 20 Status               */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral Clock 21 Status               */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral Clock 22 Status               */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral Clock 23 Status               */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral Clock 24 Status               */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral Clock 25 Status               */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral Clock 26 Status               */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral Clock 27 Status               */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral Clock 28 Status               */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral Clock 29 Status               */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral Clock 30 Status               */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral Clock 31 Status               */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Status               */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCSR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCSR0_OFFSET                    (0x18)                                        /**<  (PMC_PCSR0) Peripheral Clock Status Register 0  Offset */
+
+#define PMC_PCSR0_PID7_Pos                  7                                              /**< (PMC_PCSR0) Peripheral Clock 7 Status Position */
+#define PMC_PCSR0_PID7_Msk                  (_U_(0x1) << PMC_PCSR0_PID7_Pos)               /**< (PMC_PCSR0) Peripheral Clock 7 Status Mask */
+#define PMC_PCSR0_PID7                      PMC_PCSR0_PID7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID7_Msk instead */
+#define PMC_PCSR0_PID8_Pos                  8                                              /**< (PMC_PCSR0) Peripheral Clock 8 Status Position */
+#define PMC_PCSR0_PID8_Msk                  (_U_(0x1) << PMC_PCSR0_PID8_Pos)               /**< (PMC_PCSR0) Peripheral Clock 8 Status Mask */
+#define PMC_PCSR0_PID8                      PMC_PCSR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID8_Msk instead */
+#define PMC_PCSR0_PID9_Pos                  9                                              /**< (PMC_PCSR0) Peripheral Clock 9 Status Position */
+#define PMC_PCSR0_PID9_Msk                  (_U_(0x1) << PMC_PCSR0_PID9_Pos)               /**< (PMC_PCSR0) Peripheral Clock 9 Status Mask */
+#define PMC_PCSR0_PID9                      PMC_PCSR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID9_Msk instead */
+#define PMC_PCSR0_PID10_Pos                 10                                             /**< (PMC_PCSR0) Peripheral Clock 10 Status Position */
+#define PMC_PCSR0_PID10_Msk                 (_U_(0x1) << PMC_PCSR0_PID10_Pos)              /**< (PMC_PCSR0) Peripheral Clock 10 Status Mask */
+#define PMC_PCSR0_PID10                     PMC_PCSR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID10_Msk instead */
+#define PMC_PCSR0_PID11_Pos                 11                                             /**< (PMC_PCSR0) Peripheral Clock 11 Status Position */
+#define PMC_PCSR0_PID11_Msk                 (_U_(0x1) << PMC_PCSR0_PID11_Pos)              /**< (PMC_PCSR0) Peripheral Clock 11 Status Mask */
+#define PMC_PCSR0_PID11                     PMC_PCSR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID11_Msk instead */
+#define PMC_PCSR0_PID12_Pos                 12                                             /**< (PMC_PCSR0) Peripheral Clock 12 Status Position */
+#define PMC_PCSR0_PID12_Msk                 (_U_(0x1) << PMC_PCSR0_PID12_Pos)              /**< (PMC_PCSR0) Peripheral Clock 12 Status Mask */
+#define PMC_PCSR0_PID12                     PMC_PCSR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID12_Msk instead */
+#define PMC_PCSR0_PID13_Pos                 13                                             /**< (PMC_PCSR0) Peripheral Clock 13 Status Position */
+#define PMC_PCSR0_PID13_Msk                 (_U_(0x1) << PMC_PCSR0_PID13_Pos)              /**< (PMC_PCSR0) Peripheral Clock 13 Status Mask */
+#define PMC_PCSR0_PID13                     PMC_PCSR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID13_Msk instead */
+#define PMC_PCSR0_PID14_Pos                 14                                             /**< (PMC_PCSR0) Peripheral Clock 14 Status Position */
+#define PMC_PCSR0_PID14_Msk                 (_U_(0x1) << PMC_PCSR0_PID14_Pos)              /**< (PMC_PCSR0) Peripheral Clock 14 Status Mask */
+#define PMC_PCSR0_PID14                     PMC_PCSR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID14_Msk instead */
+#define PMC_PCSR0_PID15_Pos                 15                                             /**< (PMC_PCSR0) Peripheral Clock 15 Status Position */
+#define PMC_PCSR0_PID15_Msk                 (_U_(0x1) << PMC_PCSR0_PID15_Pos)              /**< (PMC_PCSR0) Peripheral Clock 15 Status Mask */
+#define PMC_PCSR0_PID15                     PMC_PCSR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID15_Msk instead */
+#define PMC_PCSR0_PID16_Pos                 16                                             /**< (PMC_PCSR0) Peripheral Clock 16 Status Position */
+#define PMC_PCSR0_PID16_Msk                 (_U_(0x1) << PMC_PCSR0_PID16_Pos)              /**< (PMC_PCSR0) Peripheral Clock 16 Status Mask */
+#define PMC_PCSR0_PID16                     PMC_PCSR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID16_Msk instead */
+#define PMC_PCSR0_PID17_Pos                 17                                             /**< (PMC_PCSR0) Peripheral Clock 17 Status Position */
+#define PMC_PCSR0_PID17_Msk                 (_U_(0x1) << PMC_PCSR0_PID17_Pos)              /**< (PMC_PCSR0) Peripheral Clock 17 Status Mask */
+#define PMC_PCSR0_PID17                     PMC_PCSR0_PID17_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID17_Msk instead */
+#define PMC_PCSR0_PID18_Pos                 18                                             /**< (PMC_PCSR0) Peripheral Clock 18 Status Position */
+#define PMC_PCSR0_PID18_Msk                 (_U_(0x1) << PMC_PCSR0_PID18_Pos)              /**< (PMC_PCSR0) Peripheral Clock 18 Status Mask */
+#define PMC_PCSR0_PID18                     PMC_PCSR0_PID18_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID18_Msk instead */
+#define PMC_PCSR0_PID19_Pos                 19                                             /**< (PMC_PCSR0) Peripheral Clock 19 Status Position */
+#define PMC_PCSR0_PID19_Msk                 (_U_(0x1) << PMC_PCSR0_PID19_Pos)              /**< (PMC_PCSR0) Peripheral Clock 19 Status Mask */
+#define PMC_PCSR0_PID19                     PMC_PCSR0_PID19_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID19_Msk instead */
+#define PMC_PCSR0_PID20_Pos                 20                                             /**< (PMC_PCSR0) Peripheral Clock 20 Status Position */
+#define PMC_PCSR0_PID20_Msk                 (_U_(0x1) << PMC_PCSR0_PID20_Pos)              /**< (PMC_PCSR0) Peripheral Clock 20 Status Mask */
+#define PMC_PCSR0_PID20                     PMC_PCSR0_PID20_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID20_Msk instead */
+#define PMC_PCSR0_PID21_Pos                 21                                             /**< (PMC_PCSR0) Peripheral Clock 21 Status Position */
+#define PMC_PCSR0_PID21_Msk                 (_U_(0x1) << PMC_PCSR0_PID21_Pos)              /**< (PMC_PCSR0) Peripheral Clock 21 Status Mask */
+#define PMC_PCSR0_PID21                     PMC_PCSR0_PID21_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID21_Msk instead */
+#define PMC_PCSR0_PID22_Pos                 22                                             /**< (PMC_PCSR0) Peripheral Clock 22 Status Position */
+#define PMC_PCSR0_PID22_Msk                 (_U_(0x1) << PMC_PCSR0_PID22_Pos)              /**< (PMC_PCSR0) Peripheral Clock 22 Status Mask */
+#define PMC_PCSR0_PID22                     PMC_PCSR0_PID22_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID22_Msk instead */
+#define PMC_PCSR0_PID23_Pos                 23                                             /**< (PMC_PCSR0) Peripheral Clock 23 Status Position */
+#define PMC_PCSR0_PID23_Msk                 (_U_(0x1) << PMC_PCSR0_PID23_Pos)              /**< (PMC_PCSR0) Peripheral Clock 23 Status Mask */
+#define PMC_PCSR0_PID23                     PMC_PCSR0_PID23_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID23_Msk instead */
+#define PMC_PCSR0_PID24_Pos                 24                                             /**< (PMC_PCSR0) Peripheral Clock 24 Status Position */
+#define PMC_PCSR0_PID24_Msk                 (_U_(0x1) << PMC_PCSR0_PID24_Pos)              /**< (PMC_PCSR0) Peripheral Clock 24 Status Mask */
+#define PMC_PCSR0_PID24                     PMC_PCSR0_PID24_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID24_Msk instead */
+#define PMC_PCSR0_PID25_Pos                 25                                             /**< (PMC_PCSR0) Peripheral Clock 25 Status Position */
+#define PMC_PCSR0_PID25_Msk                 (_U_(0x1) << PMC_PCSR0_PID25_Pos)              /**< (PMC_PCSR0) Peripheral Clock 25 Status Mask */
+#define PMC_PCSR0_PID25                     PMC_PCSR0_PID25_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID25_Msk instead */
+#define PMC_PCSR0_PID26_Pos                 26                                             /**< (PMC_PCSR0) Peripheral Clock 26 Status Position */
+#define PMC_PCSR0_PID26_Msk                 (_U_(0x1) << PMC_PCSR0_PID26_Pos)              /**< (PMC_PCSR0) Peripheral Clock 26 Status Mask */
+#define PMC_PCSR0_PID26                     PMC_PCSR0_PID26_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID26_Msk instead */
+#define PMC_PCSR0_PID27_Pos                 27                                             /**< (PMC_PCSR0) Peripheral Clock 27 Status Position */
+#define PMC_PCSR0_PID27_Msk                 (_U_(0x1) << PMC_PCSR0_PID27_Pos)              /**< (PMC_PCSR0) Peripheral Clock 27 Status Mask */
+#define PMC_PCSR0_PID27                     PMC_PCSR0_PID27_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID27_Msk instead */
+#define PMC_PCSR0_PID28_Pos                 28                                             /**< (PMC_PCSR0) Peripheral Clock 28 Status Position */
+#define PMC_PCSR0_PID28_Msk                 (_U_(0x1) << PMC_PCSR0_PID28_Pos)              /**< (PMC_PCSR0) Peripheral Clock 28 Status Mask */
+#define PMC_PCSR0_PID28                     PMC_PCSR0_PID28_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID28_Msk instead */
+#define PMC_PCSR0_PID29_Pos                 29                                             /**< (PMC_PCSR0) Peripheral Clock 29 Status Position */
+#define PMC_PCSR0_PID29_Msk                 (_U_(0x1) << PMC_PCSR0_PID29_Pos)              /**< (PMC_PCSR0) Peripheral Clock 29 Status Mask */
+#define PMC_PCSR0_PID29                     PMC_PCSR0_PID29_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID29_Msk instead */
+#define PMC_PCSR0_PID30_Pos                 30                                             /**< (PMC_PCSR0) Peripheral Clock 30 Status Position */
+#define PMC_PCSR0_PID30_Msk                 (_U_(0x1) << PMC_PCSR0_PID30_Pos)              /**< (PMC_PCSR0) Peripheral Clock 30 Status Mask */
+#define PMC_PCSR0_PID30                     PMC_PCSR0_PID30_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID30_Msk instead */
+#define PMC_PCSR0_PID31_Pos                 31                                             /**< (PMC_PCSR0) Peripheral Clock 31 Status Position */
+#define PMC_PCSR0_PID31_Msk                 (_U_(0x1) << PMC_PCSR0_PID31_Pos)              /**< (PMC_PCSR0) Peripheral Clock 31 Status Mask */
+#define PMC_PCSR0_PID31                     PMC_PCSR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID31_Msk instead */
+#define PMC_PCSR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
+#define PMC_PCSR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCSR0) Register Mask  */
+
+#define PMC_PCSR0_PID_Pos                   7                                              /**< (PMC_PCSR0 Position) Peripheral Clock 3x Status */
+#define PMC_PCSR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR0_PID_Pos)          /**< (PMC_PCSR0 Mask) PID */
+#define PMC_PCSR0_PID(value)                (PMC_PCSR0_PID_Msk & ((value) << PMC_PCSR0_PID_Pos))  
+
+/* -------- CKGR_UCKR : (PMC Offset: 0x1c) (R/W 32) UTMI Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t UPLLEN:1;                  /**< bit:     16  UTMI PLL Enable                          */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t UPLLCOUNT:4;               /**< bit: 20..23  UTMI PLL Start-up Time                   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_UCKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_UCKR_OFFSET                    (0x1C)                                        /**<  (CKGR_UCKR) UTMI Clock Register  Offset */
+
+#define CKGR_UCKR_UPLLEN_Pos                16                                             /**< (CKGR_UCKR) UTMI PLL Enable Position */
+#define CKGR_UCKR_UPLLEN_Msk                (_U_(0x1) << CKGR_UCKR_UPLLEN_Pos)             /**< (CKGR_UCKR) UTMI PLL Enable Mask */
+#define CKGR_UCKR_UPLLEN                    CKGR_UCKR_UPLLEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_UCKR_UPLLEN_Msk instead */
+#define CKGR_UCKR_UPLLCOUNT_Pos             20                                             /**< (CKGR_UCKR) UTMI PLL Start-up Time Position */
+#define CKGR_UCKR_UPLLCOUNT_Msk             (_U_(0xF) << CKGR_UCKR_UPLLCOUNT_Pos)          /**< (CKGR_UCKR) UTMI PLL Start-up Time Mask */
+#define CKGR_UCKR_UPLLCOUNT(value)          (CKGR_UCKR_UPLLCOUNT_Msk & ((value) << CKGR_UCKR_UPLLCOUNT_Pos))
+#define CKGR_UCKR_MASK                      _U_(0xF10000)                                  /**< \deprecated (CKGR_UCKR) Register MASK  (Use CKGR_UCKR_Msk instead)  */
+#define CKGR_UCKR_Msk                       _U_(0xF10000)                                  /**< (CKGR_UCKR) Register Mask  */
+
+
+/* -------- CKGR_MOR : (PMC Offset: 0x20) (R/W 32) Main Oscillator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTEN:1;                /**< bit:      0  Main Crystal Oscillator Enable           */
+    uint32_t MOSCXTBY:1;                /**< bit:      1  Main Crystal Oscillator Bypass           */
+    uint32_t WAITMODE:1;                /**< bit:      2  Wait Mode Command (Write-only)           */
+    uint32_t MOSCRCEN:1;                /**< bit:      3  Main RC Oscillator Enable                */
+    uint32_t MOSCRCF:3;                 /**< bit:   4..6  Main RC Oscillator Frequency Selection   */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MOSCXTST:8;                /**< bit:  8..15  Main Crystal Oscillator Startup Time     */
+    uint32_t KEY:8;                     /**< bit: 16..23  Write Access Password                    */
+    uint32_t MOSCSEL:1;                 /**< bit:     24  Main Clock Oscillator Selection          */
+    uint32_t CFDEN:1;                   /**< bit:     25  Clock Failure Detector Enable            */
+    uint32_t XT32KFME:1;                /**< bit:     26  32.768 kHz Crystal Oscillator Frequency Monitoring Enable */
+    uint32_t :5;                        /**< bit: 27..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_MOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_MOR_OFFSET                     (0x20)                                        /**<  (CKGR_MOR) Main Oscillator Register  Offset */
+
+#define CKGR_MOR_MOSCXTEN_Pos               0                                              /**< (CKGR_MOR) Main Crystal Oscillator Enable Position */
+#define CKGR_MOR_MOSCXTEN_Msk               (_U_(0x1) << CKGR_MOR_MOSCXTEN_Pos)            /**< (CKGR_MOR) Main Crystal Oscillator Enable Mask */
+#define CKGR_MOR_MOSCXTEN                   CKGR_MOR_MOSCXTEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCXTEN_Msk instead */
+#define CKGR_MOR_MOSCXTBY_Pos               1                                              /**< (CKGR_MOR) Main Crystal Oscillator Bypass Position */
+#define CKGR_MOR_MOSCXTBY_Msk               (_U_(0x1) << CKGR_MOR_MOSCXTBY_Pos)            /**< (CKGR_MOR) Main Crystal Oscillator Bypass Mask */
+#define CKGR_MOR_MOSCXTBY                   CKGR_MOR_MOSCXTBY_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCXTBY_Msk instead */
+#define CKGR_MOR_WAITMODE_Pos               2                                              /**< (CKGR_MOR) Wait Mode Command (Write-only) Position */
+#define CKGR_MOR_WAITMODE_Msk               (_U_(0x1) << CKGR_MOR_WAITMODE_Pos)            /**< (CKGR_MOR) Wait Mode Command (Write-only) Mask */
+#define CKGR_MOR_WAITMODE                   CKGR_MOR_WAITMODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_WAITMODE_Msk instead */
+#define CKGR_MOR_MOSCRCEN_Pos               3                                              /**< (CKGR_MOR) Main RC Oscillator Enable Position */
+#define CKGR_MOR_MOSCRCEN_Msk               (_U_(0x1) << CKGR_MOR_MOSCRCEN_Pos)            /**< (CKGR_MOR) Main RC Oscillator Enable Mask */
+#define CKGR_MOR_MOSCRCEN                   CKGR_MOR_MOSCRCEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCRCEN_Msk instead */
+#define CKGR_MOR_MOSCRCF_Pos                4                                              /**< (CKGR_MOR) Main RC Oscillator Frequency Selection Position */
+#define CKGR_MOR_MOSCRCF_Msk                (_U_(0x7) << CKGR_MOR_MOSCRCF_Pos)             /**< (CKGR_MOR) Main RC Oscillator Frequency Selection Mask */
+#define CKGR_MOR_MOSCRCF(value)             (CKGR_MOR_MOSCRCF_Msk & ((value) << CKGR_MOR_MOSCRCF_Pos))
+#define   CKGR_MOR_MOSCRCF_4_MHz_Val        _U_(0x0)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 4 MHz  */
+#define   CKGR_MOR_MOSCRCF_8_MHz_Val        _U_(0x1)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 8 MHz  */
+#define   CKGR_MOR_MOSCRCF_12_MHz_Val       _U_(0x2)                                       /**< (CKGR_MOR) The RC oscillator frequency is at 12 MHz  */
+#define CKGR_MOR_MOSCRCF_4_MHz              (CKGR_MOR_MOSCRCF_4_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 4 MHz Position  */
+#define CKGR_MOR_MOSCRCF_8_MHz              (CKGR_MOR_MOSCRCF_8_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 8 MHz Position  */
+#define CKGR_MOR_MOSCRCF_12_MHz             (CKGR_MOR_MOSCRCF_12_MHz_Val << CKGR_MOR_MOSCRCF_Pos)  /**< (CKGR_MOR) The RC oscillator frequency is at 12 MHz Position  */
+#define CKGR_MOR_MOSCXTST_Pos               8                                              /**< (CKGR_MOR) Main Crystal Oscillator Startup Time Position */
+#define CKGR_MOR_MOSCXTST_Msk               (_U_(0xFF) << CKGR_MOR_MOSCXTST_Pos)           /**< (CKGR_MOR) Main Crystal Oscillator Startup Time Mask */
+#define CKGR_MOR_MOSCXTST(value)            (CKGR_MOR_MOSCXTST_Msk & ((value) << CKGR_MOR_MOSCXTST_Pos))
+#define CKGR_MOR_KEY_Pos                    16                                             /**< (CKGR_MOR) Write Access Password Position */
+#define CKGR_MOR_KEY_Msk                    (_U_(0xFF) << CKGR_MOR_KEY_Pos)                /**< (CKGR_MOR) Write Access Password Mask */
+#define CKGR_MOR_KEY(value)                 (CKGR_MOR_KEY_Msk & ((value) << CKGR_MOR_KEY_Pos))
+#define   CKGR_MOR_KEY_PASSWD_Val           _U_(0x37)                                      /**< (CKGR_MOR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define CKGR_MOR_KEY_PASSWD                 (CKGR_MOR_KEY_PASSWD_Val << CKGR_MOR_KEY_Pos)  /**< (CKGR_MOR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define CKGR_MOR_MOSCSEL_Pos                24                                             /**< (CKGR_MOR) Main Clock Oscillator Selection Position */
+#define CKGR_MOR_MOSCSEL_Msk                (_U_(0x1) << CKGR_MOR_MOSCSEL_Pos)             /**< (CKGR_MOR) Main Clock Oscillator Selection Mask */
+#define CKGR_MOR_MOSCSEL                    CKGR_MOR_MOSCSEL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_MOSCSEL_Msk instead */
+#define CKGR_MOR_CFDEN_Pos                  25                                             /**< (CKGR_MOR) Clock Failure Detector Enable Position */
+#define CKGR_MOR_CFDEN_Msk                  (_U_(0x1) << CKGR_MOR_CFDEN_Pos)               /**< (CKGR_MOR) Clock Failure Detector Enable Mask */
+#define CKGR_MOR_CFDEN                      CKGR_MOR_CFDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_CFDEN_Msk instead */
+#define CKGR_MOR_XT32KFME_Pos               26                                             /**< (CKGR_MOR) 32.768 kHz Crystal Oscillator Frequency Monitoring Enable Position */
+#define CKGR_MOR_XT32KFME_Msk               (_U_(0x1) << CKGR_MOR_XT32KFME_Pos)            /**< (CKGR_MOR) 32.768 kHz Crystal Oscillator Frequency Monitoring Enable Mask */
+#define CKGR_MOR_XT32KFME                   CKGR_MOR_XT32KFME_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MOR_XT32KFME_Msk instead */
+#define CKGR_MOR_MASK                       _U_(0x7FFFF7F)                                 /**< \deprecated (CKGR_MOR) Register MASK  (Use CKGR_MOR_Msk instead)  */
+#define CKGR_MOR_Msk                        _U_(0x7FFFF7F)                                 /**< (CKGR_MOR) Register Mask  */
+
+
+/* -------- CKGR_MCFR : (PMC Offset: 0x24) (R/W 32) Main Clock Frequency Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAINF:16;                  /**< bit:  0..15  Main Clock Frequency                     */
+    uint32_t MAINFRDY:1;                /**< bit:     16  Main Clock Frequency Measure Ready       */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t RCMEAS:1;                  /**< bit:     20  RC Oscillator Frequency Measure (write-only) */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t CCSS:1;                    /**< bit:     24  Counter Clock Source Selection           */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_MCFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_MCFR_OFFSET                    (0x24)                                        /**<  (CKGR_MCFR) Main Clock Frequency Register  Offset */
+
+#define CKGR_MCFR_MAINF_Pos                 0                                              /**< (CKGR_MCFR) Main Clock Frequency Position */
+#define CKGR_MCFR_MAINF_Msk                 (_U_(0xFFFF) << CKGR_MCFR_MAINF_Pos)           /**< (CKGR_MCFR) Main Clock Frequency Mask */
+#define CKGR_MCFR_MAINF(value)              (CKGR_MCFR_MAINF_Msk & ((value) << CKGR_MCFR_MAINF_Pos))
+#define CKGR_MCFR_MAINFRDY_Pos              16                                             /**< (CKGR_MCFR) Main Clock Frequency Measure Ready Position */
+#define CKGR_MCFR_MAINFRDY_Msk              (_U_(0x1) << CKGR_MCFR_MAINFRDY_Pos)           /**< (CKGR_MCFR) Main Clock Frequency Measure Ready Mask */
+#define CKGR_MCFR_MAINFRDY                  CKGR_MCFR_MAINFRDY_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_MAINFRDY_Msk instead */
+#define CKGR_MCFR_RCMEAS_Pos                20                                             /**< (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) Position */
+#define CKGR_MCFR_RCMEAS_Msk                (_U_(0x1) << CKGR_MCFR_RCMEAS_Pos)             /**< (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) Mask */
+#define CKGR_MCFR_RCMEAS                    CKGR_MCFR_RCMEAS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_RCMEAS_Msk instead */
+#define CKGR_MCFR_CCSS_Pos                  24                                             /**< (CKGR_MCFR) Counter Clock Source Selection Position */
+#define CKGR_MCFR_CCSS_Msk                  (_U_(0x1) << CKGR_MCFR_CCSS_Pos)               /**< (CKGR_MCFR) Counter Clock Source Selection Mask */
+#define CKGR_MCFR_CCSS                      CKGR_MCFR_CCSS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_MCFR_CCSS_Msk instead */
+#define CKGR_MCFR_MASK                      _U_(0x111FFFF)                                 /**< \deprecated (CKGR_MCFR) Register MASK  (Use CKGR_MCFR_Msk instead)  */
+#define CKGR_MCFR_Msk                       _U_(0x111FFFF)                                 /**< (CKGR_MCFR) Register Mask  */
+
+
+/* -------- CKGR_PLLAR : (PMC Offset: 0x28) (R/W 32) PLLA Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIVA:8;                    /**< bit:   0..7  PLLA Front End Divider                   */
+    uint32_t PLLACOUNT:6;               /**< bit:  8..13  PLLA Counter                             */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t MULA:11;                   /**< bit: 16..26  PLLA Multiplier                          */
+    uint32_t :2;                        /**< bit: 27..28  Reserved */
+    uint32_t ONE:1;                     /**< bit:     29  Must Be Set to 1                         */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} CKGR_PLLAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CKGR_PLLAR_OFFSET                   (0x28)                                        /**<  (CKGR_PLLAR) PLLA Register  Offset */
+
+#define CKGR_PLLAR_DIVA_Pos                 0                                              /**< (CKGR_PLLAR) PLLA Front End Divider Position */
+#define CKGR_PLLAR_DIVA_Msk                 (_U_(0xFF) << CKGR_PLLAR_DIVA_Pos)             /**< (CKGR_PLLAR) PLLA Front End Divider Mask */
+#define CKGR_PLLAR_DIVA(value)              (CKGR_PLLAR_DIVA_Msk & ((value) << CKGR_PLLAR_DIVA_Pos))
+#define   CKGR_PLLAR_DIVA_0_Val             _U_(0x0)                                       /**< (CKGR_PLLAR) Divider output is 0 and PLLA is disabled.  */
+#define   CKGR_PLLAR_DIVA_BYPASS_Val        _U_(0x1)                                       /**< (CKGR_PLLAR) Divider is bypassed (divide by 1) and PLLA is enabled.  */
+#define CKGR_PLLAR_DIVA_0                   (CKGR_PLLAR_DIVA_0_Val << CKGR_PLLAR_DIVA_Pos)  /**< (CKGR_PLLAR) Divider output is 0 and PLLA is disabled. Position  */
+#define CKGR_PLLAR_DIVA_BYPASS              (CKGR_PLLAR_DIVA_BYPASS_Val << CKGR_PLLAR_DIVA_Pos)  /**< (CKGR_PLLAR) Divider is bypassed (divide by 1) and PLLA is enabled. Position  */
+#define CKGR_PLLAR_PLLACOUNT_Pos            8                                              /**< (CKGR_PLLAR) PLLA Counter Position */
+#define CKGR_PLLAR_PLLACOUNT_Msk            (_U_(0x3F) << CKGR_PLLAR_PLLACOUNT_Pos)        /**< (CKGR_PLLAR) PLLA Counter Mask */
+#define CKGR_PLLAR_PLLACOUNT(value)         (CKGR_PLLAR_PLLACOUNT_Msk & ((value) << CKGR_PLLAR_PLLACOUNT_Pos))
+#define CKGR_PLLAR_MULA_Pos                 16                                             /**< (CKGR_PLLAR) PLLA Multiplier Position */
+#define CKGR_PLLAR_MULA_Msk                 (_U_(0x7FF) << CKGR_PLLAR_MULA_Pos)            /**< (CKGR_PLLAR) PLLA Multiplier Mask */
+#define CKGR_PLLAR_MULA(value)              (CKGR_PLLAR_MULA_Msk & ((value) << CKGR_PLLAR_MULA_Pos))
+#define CKGR_PLLAR_ONE_Pos                  29                                             /**< (CKGR_PLLAR) Must Be Set to 1 Position */
+#define CKGR_PLLAR_ONE_Msk                  (_U_(0x1) << CKGR_PLLAR_ONE_Pos)               /**< (CKGR_PLLAR) Must Be Set to 1 Mask */
+#define CKGR_PLLAR_ONE                      CKGR_PLLAR_ONE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use CKGR_PLLAR_ONE_Msk instead */
+#define CKGR_PLLAR_MASK                     _U_(0x27FF3FFF)                                /**< \deprecated (CKGR_PLLAR) Register MASK  (Use CKGR_PLLAR_Msk instead)  */
+#define CKGR_PLLAR_Msk                      _U_(0x27FF3FFF)                                /**< (CKGR_PLLAR) Register Mask  */
+
+
+/* -------- PMC_MCKR : (PMC Offset: 0x30) (R/W 32) Master Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSS:2;                     /**< bit:   0..1  Master Clock Source Selection            */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t PRES:3;                    /**< bit:   4..6  Processor Clock Prescaler                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDIV:2;                    /**< bit:   8..9  Master Clock Division                    */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t UPLLDIV2:1;                /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t UPLLDIV:1;                 /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_MCKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_MCKR_OFFSET                     (0x30)                                        /**<  (PMC_MCKR) Master Clock Register  Offset */
+
+#define PMC_MCKR_CSS_Pos                    0                                              /**< (PMC_MCKR) Master Clock Source Selection Position */
+#define PMC_MCKR_CSS_Msk                    (_U_(0x3) << PMC_MCKR_CSS_Pos)                 /**< (PMC_MCKR) Master Clock Source Selection Mask */
+#define PMC_MCKR_CSS(value)                 (PMC_MCKR_CSS_Msk & ((value) << PMC_MCKR_CSS_Pos))
+#define   PMC_MCKR_CSS_SLOW_CLK_Val         _U_(0x0)                                       /**< (PMC_MCKR) Slow Clock is selected  */
+#define   PMC_MCKR_CSS_MAIN_CLK_Val         _U_(0x1)                                       /**< (PMC_MCKR) Main Clock is selected  */
+#define   PMC_MCKR_CSS_PLLA_CLK_Val         _U_(0x2)                                       /**< (PMC_MCKR) PLLA Clock is selected  */
+#define   PMC_MCKR_CSS_UPLL_CLK_Val         _U_(0x3)                                       /**< (PMC_MCKR) Divided UPLL Clock is selected  */
+#define PMC_MCKR_CSS_SLOW_CLK               (PMC_MCKR_CSS_SLOW_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) Slow Clock is selected Position  */
+#define PMC_MCKR_CSS_MAIN_CLK               (PMC_MCKR_CSS_MAIN_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) Main Clock is selected Position  */
+#define PMC_MCKR_CSS_PLLA_CLK               (PMC_MCKR_CSS_PLLA_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) PLLA Clock is selected Position  */
+#define PMC_MCKR_CSS_UPLL_CLK               (PMC_MCKR_CSS_UPLL_CLK_Val << PMC_MCKR_CSS_Pos)  /**< (PMC_MCKR) Divided UPLL Clock is selected Position  */
+#define PMC_MCKR_PRES_Pos                   4                                              /**< (PMC_MCKR) Processor Clock Prescaler Position */
+#define PMC_MCKR_PRES_Msk                   (_U_(0x7) << PMC_MCKR_PRES_Pos)                /**< (PMC_MCKR) Processor Clock Prescaler Mask */
+#define PMC_MCKR_PRES(value)                (PMC_MCKR_PRES_Msk & ((value) << PMC_MCKR_PRES_Pos))
+#define   PMC_MCKR_PRES_CLK_1_Val           _U_(0x0)                                       /**< (PMC_MCKR) Selected clock  */
+#define   PMC_MCKR_PRES_CLK_2_Val           _U_(0x1)                                       /**< (PMC_MCKR) Selected clock divided by 2  */
+#define   PMC_MCKR_PRES_CLK_4_Val           _U_(0x2)                                       /**< (PMC_MCKR) Selected clock divided by 4  */
+#define   PMC_MCKR_PRES_CLK_8_Val           _U_(0x3)                                       /**< (PMC_MCKR) Selected clock divided by 8  */
+#define   PMC_MCKR_PRES_CLK_16_Val          _U_(0x4)                                       /**< (PMC_MCKR) Selected clock divided by 16  */
+#define   PMC_MCKR_PRES_CLK_32_Val          _U_(0x5)                                       /**< (PMC_MCKR) Selected clock divided by 32  */
+#define   PMC_MCKR_PRES_CLK_64_Val          _U_(0x6)                                       /**< (PMC_MCKR) Selected clock divided by 64  */
+#define   PMC_MCKR_PRES_CLK_3_Val           _U_(0x7)                                       /**< (PMC_MCKR) Selected clock divided by 3  */
+#define PMC_MCKR_PRES_CLK_1                 (PMC_MCKR_PRES_CLK_1_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock Position  */
+#define PMC_MCKR_PRES_CLK_2                 (PMC_MCKR_PRES_CLK_2_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 2 Position  */
+#define PMC_MCKR_PRES_CLK_4                 (PMC_MCKR_PRES_CLK_4_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 4 Position  */
+#define PMC_MCKR_PRES_CLK_8                 (PMC_MCKR_PRES_CLK_8_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 8 Position  */
+#define PMC_MCKR_PRES_CLK_16                (PMC_MCKR_PRES_CLK_16_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 16 Position  */
+#define PMC_MCKR_PRES_CLK_32                (PMC_MCKR_PRES_CLK_32_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 32 Position  */
+#define PMC_MCKR_PRES_CLK_64                (PMC_MCKR_PRES_CLK_64_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 64 Position  */
+#define PMC_MCKR_PRES_CLK_3                 (PMC_MCKR_PRES_CLK_3_Val << PMC_MCKR_PRES_Pos)  /**< (PMC_MCKR) Selected clock divided by 3 Position  */
+#define PMC_MCKR_MDIV_Pos                   8                                              /**< (PMC_MCKR) Master Clock Division Position */
+#define PMC_MCKR_MDIV_Msk                   (_U_(0x3) << PMC_MCKR_MDIV_Pos)                /**< (PMC_MCKR) Master Clock Division Mask */
+#define PMC_MCKR_MDIV(value)                (PMC_MCKR_MDIV_Msk & ((value) << PMC_MCKR_MDIV_Pos))
+#define   PMC_MCKR_MDIV_EQ_PCK_Val          _U_(0x0)                                       /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 1.  */
+#define   PMC_MCKR_MDIV_PCK_DIV2_Val        _U_(0x1)                                       /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 2.  */
+#define   PMC_MCKR_MDIV_PCK_DIV4_Val        _U_(0x2)                                       /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 4.  */
+#define   PMC_MCKR_MDIV_PCK_DIV3_Val        _U_(0x3)                                       /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 3.  */
+#define PMC_MCKR_MDIV_EQ_PCK                (PMC_MCKR_MDIV_EQ_PCK_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 1. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV2              (PMC_MCKR_MDIV_PCK_DIV2_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 2. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV4              (PMC_MCKR_MDIV_PCK_DIV4_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 4. Position  */
+#define PMC_MCKR_MDIV_PCK_DIV3              (PMC_MCKR_MDIV_PCK_DIV3_Val << PMC_MCKR_MDIV_Pos)  /**< (PMC_MCKR) Master Clock is Prescaler Output Clock divided by 3. Position  */
+#define PMC_MCKR_UPLLDIV2_Pos               13                                             /**< (PMC_MCKR) UPLL Divider by 2 Position */
+#define PMC_MCKR_UPLLDIV2_Msk               (_U_(0x1) << PMC_MCKR_UPLLDIV2_Pos)            /**< (PMC_MCKR) UPLL Divider by 2 Mask */
+#define PMC_MCKR_UPLLDIV2                   PMC_MCKR_UPLLDIV2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_MCKR_UPLLDIV2_Msk instead */
+#define PMC_MCKR_MASK                       _U_(0x2373)                                    /**< \deprecated (PMC_MCKR) Register MASK  (Use PMC_MCKR_Msk instead)  */
+#define PMC_MCKR_Msk                        _U_(0x2373)                                    /**< (PMC_MCKR) Register Mask  */
+
+#define PMC_MCKR_UPLLDIV_Pos                13                                             /**< (PMC_MCKR Position) UPLL Divider by 2 */
+#define PMC_MCKR_UPLLDIV_Msk                (_U_(0x1) << PMC_MCKR_UPLLDIV_Pos)             /**< (PMC_MCKR Mask) UPLLDIV */
+#define PMC_MCKR_UPLLDIV(value)             (PMC_MCKR_UPLLDIV_Msk & ((value) << PMC_MCKR_UPLLDIV_Pos))  
+
+/* -------- PMC_USB : (PMC Offset: 0x38) (R/W 32) USB Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USBS:1;                    /**< bit:      0  USB Input Clock Selection                */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t USBDIV:4;                  /**< bit:  8..11  Divider for USB_48M                      */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_USB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_USB_OFFSET                      (0x38)                                        /**<  (PMC_USB) USB Clock Register  Offset */
+
+#define PMC_USB_USBS_Pos                    0                                              /**< (PMC_USB) USB Input Clock Selection Position */
+#define PMC_USB_USBS_Msk                    (_U_(0x1) << PMC_USB_USBS_Pos)                 /**< (PMC_USB) USB Input Clock Selection Mask */
+#define PMC_USB_USBS                        PMC_USB_USBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_USB_USBS_Msk instead */
+#define PMC_USB_USBDIV_Pos                  8                                              /**< (PMC_USB) Divider for USB_48M Position */
+#define PMC_USB_USBDIV_Msk                  (_U_(0xF) << PMC_USB_USBDIV_Pos)               /**< (PMC_USB) Divider for USB_48M Mask */
+#define PMC_USB_USBDIV(value)               (PMC_USB_USBDIV_Msk & ((value) << PMC_USB_USBDIV_Pos))
+#define PMC_USB_MASK                        _U_(0xF01)                                     /**< \deprecated (PMC_USB) Register MASK  (Use PMC_USB_Msk instead)  */
+#define PMC_USB_Msk                         _U_(0xF01)                                     /**< (PMC_USB) Register Mask  */
+
+
+/* -------- PMC_PCK : (PMC Offset: 0x40) (R/W 32) Programmable Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSS:3;                     /**< bit:   0..2  Programmable Clock Source Selection      */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t PRES:8;                    /**< bit:  4..11  Programmable Clock Prescaler             */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCK_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCK_OFFSET                      (0x40)                                        /**<  (PMC_PCK) Programmable Clock Register  Offset */
+
+#define PMC_PCK_CSS_Pos                     0                                              /**< (PMC_PCK) Programmable Clock Source Selection Position */
+#define PMC_PCK_CSS_Msk                     (_U_(0x7) << PMC_PCK_CSS_Pos)                  /**< (PMC_PCK) Programmable Clock Source Selection Mask */
+#define PMC_PCK_CSS(value)                  (PMC_PCK_CSS_Msk & ((value) << PMC_PCK_CSS_Pos))
+#define   PMC_PCK_CSS_SLOW_CLK_Val          _U_(0x0)                                       /**< (PMC_PCK) SLCK is selected  */
+#define   PMC_PCK_CSS_MAIN_CLK_Val          _U_(0x1)                                       /**< (PMC_PCK) MAINCK is selected  */
+#define   PMC_PCK_CSS_PLLA_CLK_Val          _U_(0x2)                                       /**< (PMC_PCK) PLLACK is selected  */
+#define   PMC_PCK_CSS_UPLL_CLK_Val          _U_(0x3)                                       /**< (PMC_PCK) UPLLCKDIV is selected  */
+#define   PMC_PCK_CSS_MCK_Val               _U_(0x4)                                       /**< (PMC_PCK) MCK is selected  */
+#define PMC_PCK_CSS_SLOW_CLK                (PMC_PCK_CSS_SLOW_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) SLCK is selected Position  */
+#define PMC_PCK_CSS_MAIN_CLK                (PMC_PCK_CSS_MAIN_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) MAINCK is selected Position  */
+#define PMC_PCK_CSS_PLLA_CLK                (PMC_PCK_CSS_PLLA_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) PLLACK is selected Position  */
+#define PMC_PCK_CSS_UPLL_CLK                (PMC_PCK_CSS_UPLL_CLK_Val << PMC_PCK_CSS_Pos)  /**< (PMC_PCK) UPLLCKDIV is selected Position  */
+#define PMC_PCK_CSS_MCK                     (PMC_PCK_CSS_MCK_Val << PMC_PCK_CSS_Pos)       /**< (PMC_PCK) MCK is selected Position  */
+#define PMC_PCK_PRES_Pos                    4                                              /**< (PMC_PCK) Programmable Clock Prescaler Position */
+#define PMC_PCK_PRES_Msk                    (_U_(0xFF) << PMC_PCK_PRES_Pos)                /**< (PMC_PCK) Programmable Clock Prescaler Mask */
+#define PMC_PCK_PRES(value)                 (PMC_PCK_PRES_Msk & ((value) << PMC_PCK_PRES_Pos))
+#define PMC_PCK_MASK                        _U_(0xFF7)                                     /**< \deprecated (PMC_PCK) Register MASK  (Use PMC_PCK_Msk instead)  */
+#define PMC_PCK_Msk                         _U_(0xFF7)                                     /**< (PMC_PCK) Register Mask  */
+
+
+/* -------- PMC_IER : (PMC Offset: 0x60) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Enable */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Enable               */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Enable      */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Enable           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Enable */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Enable */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Enable */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Enable */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Enable */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Enable */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Enable */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Enable */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Enable */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status Interrupt Enable */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Enable */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Enable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Enable */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IER_OFFSET                      (0x60)                                        /**<  (PMC_IER) Interrupt Enable Register  Offset */
+
+#define PMC_IER_MOSCXTS_Pos                 0                                              /**< (PMC_IER) Main Crystal Oscillator Status Interrupt Enable Position */
+#define PMC_IER_MOSCXTS_Msk                 (_U_(0x1) << PMC_IER_MOSCXTS_Pos)              /**< (PMC_IER) Main Crystal Oscillator Status Interrupt Enable Mask */
+#define PMC_IER_MOSCXTS                     PMC_IER_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCXTS_Msk instead */
+#define PMC_IER_LOCKA_Pos                   1                                              /**< (PMC_IER) PLLA Lock Interrupt Enable Position */
+#define PMC_IER_LOCKA_Msk                   (_U_(0x1) << PMC_IER_LOCKA_Pos)                /**< (PMC_IER) PLLA Lock Interrupt Enable Mask */
+#define PMC_IER_LOCKA                       PMC_IER_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_LOCKA_Msk instead */
+#define PMC_IER_MCKRDY_Pos                  3                                              /**< (PMC_IER) Master Clock Ready Interrupt Enable Position */
+#define PMC_IER_MCKRDY_Msk                  (_U_(0x1) << PMC_IER_MCKRDY_Pos)               /**< (PMC_IER) Master Clock Ready Interrupt Enable Mask */
+#define PMC_IER_MCKRDY                      PMC_IER_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MCKRDY_Msk instead */
+#define PMC_IER_LOCKU_Pos                   6                                              /**< (PMC_IER) UTMI PLL Lock Interrupt Enable Position */
+#define PMC_IER_LOCKU_Msk                   (_U_(0x1) << PMC_IER_LOCKU_Pos)                /**< (PMC_IER) UTMI PLL Lock Interrupt Enable Mask */
+#define PMC_IER_LOCKU                       PMC_IER_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_LOCKU_Msk instead */
+#define PMC_IER_PCKRDY0_Pos                 8                                              /**< (PMC_IER) Programmable Clock Ready 0 Interrupt Enable Position */
+#define PMC_IER_PCKRDY0_Msk                 (_U_(0x1) << PMC_IER_PCKRDY0_Pos)              /**< (PMC_IER) Programmable Clock Ready 0 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY0                     PMC_IER_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY0_Msk instead */
+#define PMC_IER_PCKRDY1_Pos                 9                                              /**< (PMC_IER) Programmable Clock Ready 1 Interrupt Enable Position */
+#define PMC_IER_PCKRDY1_Msk                 (_U_(0x1) << PMC_IER_PCKRDY1_Pos)              /**< (PMC_IER) Programmable Clock Ready 1 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY1                     PMC_IER_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY1_Msk instead */
+#define PMC_IER_PCKRDY2_Pos                 10                                             /**< (PMC_IER) Programmable Clock Ready 2 Interrupt Enable Position */
+#define PMC_IER_PCKRDY2_Msk                 (_U_(0x1) << PMC_IER_PCKRDY2_Pos)              /**< (PMC_IER) Programmable Clock Ready 2 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY2                     PMC_IER_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY2_Msk instead */
+#define PMC_IER_PCKRDY3_Pos                 11                                             /**< (PMC_IER) Programmable Clock Ready 3 Interrupt Enable Position */
+#define PMC_IER_PCKRDY3_Msk                 (_U_(0x1) << PMC_IER_PCKRDY3_Pos)              /**< (PMC_IER) Programmable Clock Ready 3 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY3                     PMC_IER_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY3_Msk instead */
+#define PMC_IER_PCKRDY4_Pos                 12                                             /**< (PMC_IER) Programmable Clock Ready 4 Interrupt Enable Position */
+#define PMC_IER_PCKRDY4_Msk                 (_U_(0x1) << PMC_IER_PCKRDY4_Pos)              /**< (PMC_IER) Programmable Clock Ready 4 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY4                     PMC_IER_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY4_Msk instead */
+#define PMC_IER_PCKRDY5_Pos                 13                                             /**< (PMC_IER) Programmable Clock Ready 5 Interrupt Enable Position */
+#define PMC_IER_PCKRDY5_Msk                 (_U_(0x1) << PMC_IER_PCKRDY5_Pos)              /**< (PMC_IER) Programmable Clock Ready 5 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY5                     PMC_IER_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY5_Msk instead */
+#define PMC_IER_PCKRDY6_Pos                 14                                             /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Position */
+#define PMC_IER_PCKRDY6_Msk                 (_U_(0x1) << PMC_IER_PCKRDY6_Pos)              /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY6                     PMC_IER_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY6_Msk instead */
+#define PMC_IER_PCKRDY7_Pos                 15                                             /**< (PMC_IER) Programmable Clock Ready 7 Interrupt Enable Position */
+#define PMC_IER_PCKRDY7_Msk                 (_U_(0x1) << PMC_IER_PCKRDY7_Pos)              /**< (PMC_IER) Programmable Clock Ready 7 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY7                     PMC_IER_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY7_Msk instead */
+#define PMC_IER_MOSCSELS_Pos                16                                             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Position */
+#define PMC_IER_MOSCSELS_Msk                (_U_(0x1) << PMC_IER_MOSCSELS_Pos)             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Mask */
+#define PMC_IER_MOSCSELS                    PMC_IER_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCSELS_Msk instead */
+#define PMC_IER_MOSCRCS_Pos                 17                                             /**< (PMC_IER) Main RC Oscillator Status Interrupt Enable Position */
+#define PMC_IER_MOSCRCS_Msk                 (_U_(0x1) << PMC_IER_MOSCRCS_Pos)              /**< (PMC_IER) Main RC Oscillator Status Interrupt Enable Mask */
+#define PMC_IER_MOSCRCS                     PMC_IER_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCRCS_Msk instead */
+#define PMC_IER_CFDEV_Pos                   18                                             /**< (PMC_IER) Clock Failure Detector Event Interrupt Enable Position */
+#define PMC_IER_CFDEV_Msk                   (_U_(0x1) << PMC_IER_CFDEV_Pos)                /**< (PMC_IER) Clock Failure Detector Event Interrupt Enable Mask */
+#define PMC_IER_CFDEV                       PMC_IER_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_CFDEV_Msk instead */
+#define PMC_IER_XT32KERR_Pos                21                                             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Position */
+#define PMC_IER_XT32KERR_Msk                (_U_(0x1) << PMC_IER_XT32KERR_Pos)             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Mask */
+#define PMC_IER_XT32KERR                    PMC_IER_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_XT32KERR_Msk instead */
+#define PMC_IER_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IER) Register MASK  (Use PMC_IER_Msk instead)  */
+#define PMC_IER_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IER) Register Mask  */
+
+#define PMC_IER_PCKRDY_Pos                  8                                              /**< (PMC_IER Position) Programmable Clock Ready x Interrupt Enable */
+#define PMC_IER_PCKRDY_Msk                  (_U_(0xFF) << PMC_IER_PCKRDY_Pos)              /**< (PMC_IER Mask) PCKRDY */
+#define PMC_IER_PCKRDY(value)               (PMC_IER_PCKRDY_Msk & ((value) << PMC_IER_PCKRDY_Pos))  
+
+/* -------- PMC_IDR : (PMC Offset: 0x64) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Disable */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Disable              */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Disable     */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Disable          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Disable */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Disable */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Disable */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Disable */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Disable */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Disable */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Disable */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Disable */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Disable */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Disable         */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Disable */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Disable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Disable */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IDR_OFFSET                      (0x64)                                        /**<  (PMC_IDR) Interrupt Disable Register  Offset */
+
+#define PMC_IDR_MOSCXTS_Pos                 0                                              /**< (PMC_IDR) Main Crystal Oscillator Status Interrupt Disable Position */
+#define PMC_IDR_MOSCXTS_Msk                 (_U_(0x1) << PMC_IDR_MOSCXTS_Pos)              /**< (PMC_IDR) Main Crystal Oscillator Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCXTS                     PMC_IDR_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCXTS_Msk instead */
+#define PMC_IDR_LOCKA_Pos                   1                                              /**< (PMC_IDR) PLLA Lock Interrupt Disable Position */
+#define PMC_IDR_LOCKA_Msk                   (_U_(0x1) << PMC_IDR_LOCKA_Pos)                /**< (PMC_IDR) PLLA Lock Interrupt Disable Mask */
+#define PMC_IDR_LOCKA                       PMC_IDR_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_LOCKA_Msk instead */
+#define PMC_IDR_MCKRDY_Pos                  3                                              /**< (PMC_IDR) Master Clock Ready Interrupt Disable Position */
+#define PMC_IDR_MCKRDY_Msk                  (_U_(0x1) << PMC_IDR_MCKRDY_Pos)               /**< (PMC_IDR) Master Clock Ready Interrupt Disable Mask */
+#define PMC_IDR_MCKRDY                      PMC_IDR_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MCKRDY_Msk instead */
+#define PMC_IDR_LOCKU_Pos                   6                                              /**< (PMC_IDR) UTMI PLL Lock Interrupt Disable Position */
+#define PMC_IDR_LOCKU_Msk                   (_U_(0x1) << PMC_IDR_LOCKU_Pos)                /**< (PMC_IDR) UTMI PLL Lock Interrupt Disable Mask */
+#define PMC_IDR_LOCKU                       PMC_IDR_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_LOCKU_Msk instead */
+#define PMC_IDR_PCKRDY0_Pos                 8                                              /**< (PMC_IDR) Programmable Clock Ready 0 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY0_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY0_Pos)              /**< (PMC_IDR) Programmable Clock Ready 0 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY0                     PMC_IDR_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY0_Msk instead */
+#define PMC_IDR_PCKRDY1_Pos                 9                                              /**< (PMC_IDR) Programmable Clock Ready 1 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY1_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY1_Pos)              /**< (PMC_IDR) Programmable Clock Ready 1 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY1                     PMC_IDR_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY1_Msk instead */
+#define PMC_IDR_PCKRDY2_Pos                 10                                             /**< (PMC_IDR) Programmable Clock Ready 2 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY2_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY2_Pos)              /**< (PMC_IDR) Programmable Clock Ready 2 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY2                     PMC_IDR_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY2_Msk instead */
+#define PMC_IDR_PCKRDY3_Pos                 11                                             /**< (PMC_IDR) Programmable Clock Ready 3 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY3_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY3_Pos)              /**< (PMC_IDR) Programmable Clock Ready 3 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY3                     PMC_IDR_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY3_Msk instead */
+#define PMC_IDR_PCKRDY4_Pos                 12                                             /**< (PMC_IDR) Programmable Clock Ready 4 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY4_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY4_Pos)              /**< (PMC_IDR) Programmable Clock Ready 4 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY4                     PMC_IDR_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY4_Msk instead */
+#define PMC_IDR_PCKRDY5_Pos                 13                                             /**< (PMC_IDR) Programmable Clock Ready 5 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY5_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY5_Pos)              /**< (PMC_IDR) Programmable Clock Ready 5 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY5                     PMC_IDR_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY5_Msk instead */
+#define PMC_IDR_PCKRDY6_Pos                 14                                             /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY6_Pos)              /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY6                     PMC_IDR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY6_Msk instead */
+#define PMC_IDR_PCKRDY7_Pos                 15                                             /**< (PMC_IDR) Programmable Clock Ready 7 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY7_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY7_Pos)              /**< (PMC_IDR) Programmable Clock Ready 7 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY7                     PMC_IDR_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY7_Msk instead */
+#define PMC_IDR_MOSCSELS_Pos                16                                             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Position */
+#define PMC_IDR_MOSCSELS_Msk                (_U_(0x1) << PMC_IDR_MOSCSELS_Pos)             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCSELS                    PMC_IDR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCSELS_Msk instead */
+#define PMC_IDR_MOSCRCS_Pos                 17                                             /**< (PMC_IDR) Main RC Status Interrupt Disable Position */
+#define PMC_IDR_MOSCRCS_Msk                 (_U_(0x1) << PMC_IDR_MOSCRCS_Pos)              /**< (PMC_IDR) Main RC Status Interrupt Disable Mask */
+#define PMC_IDR_MOSCRCS                     PMC_IDR_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCRCS_Msk instead */
+#define PMC_IDR_CFDEV_Pos                   18                                             /**< (PMC_IDR) Clock Failure Detector Event Interrupt Disable Position */
+#define PMC_IDR_CFDEV_Msk                   (_U_(0x1) << PMC_IDR_CFDEV_Pos)                /**< (PMC_IDR) Clock Failure Detector Event Interrupt Disable Mask */
+#define PMC_IDR_CFDEV                       PMC_IDR_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_CFDEV_Msk instead */
+#define PMC_IDR_XT32KERR_Pos                21                                             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Position */
+#define PMC_IDR_XT32KERR_Msk                (_U_(0x1) << PMC_IDR_XT32KERR_Pos)             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Mask */
+#define PMC_IDR_XT32KERR                    PMC_IDR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_XT32KERR_Msk instead */
+#define PMC_IDR_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IDR) Register MASK  (Use PMC_IDR_Msk instead)  */
+#define PMC_IDR_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IDR) Register Mask  */
+
+#define PMC_IDR_PCKRDY_Pos                  8                                              /**< (PMC_IDR Position) Programmable Clock Ready x Interrupt Disable */
+#define PMC_IDR_PCKRDY_Msk                  (_U_(0xFF) << PMC_IDR_PCKRDY_Pos)              /**< (PMC_IDR Mask) PCKRDY */
+#define PMC_IDR_PCKRDY(value)               (PMC_IDR_PCKRDY_Msk & ((value) << PMC_IDR_PCKRDY_Pos))  
+
+/* -------- PMC_SR : (PMC Offset: 0x68) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status           */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Status                         */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Status                      */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Status                     */
+    uint32_t OSCSELS:1;                 /**< bit:      7  Slow Clock Source Oscillator Selection   */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Status        */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Status        */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Status        */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Status        */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Status        */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Status        */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Status        */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Status        */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status                */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event             */
+    uint32_t CFDS:1;                    /**< bit:     19  Clock Failure Detector Status            */
+    uint32_t FOS:1;                     /**< bit:     20  Clock Failure Detector Fault Output Status */
+    uint32_t XT32KERR:1;                /**< bit:     21  Slow Crystal Oscillator Error            */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Status        */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SR_OFFSET                       (0x68)                                        /**<  (PMC_SR) Status Register  Offset */
+
+#define PMC_SR_MOSCXTS_Pos                  0                                              /**< (PMC_SR) Main Crystal Oscillator Status Position */
+#define PMC_SR_MOSCXTS_Msk                  (_U_(0x1) << PMC_SR_MOSCXTS_Pos)               /**< (PMC_SR) Main Crystal Oscillator Status Mask */
+#define PMC_SR_MOSCXTS                      PMC_SR_MOSCXTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCXTS_Msk instead */
+#define PMC_SR_LOCKA_Pos                    1                                              /**< (PMC_SR) PLLA Lock Status Position */
+#define PMC_SR_LOCKA_Msk                    (_U_(0x1) << PMC_SR_LOCKA_Pos)                 /**< (PMC_SR) PLLA Lock Status Mask */
+#define PMC_SR_LOCKA                        PMC_SR_LOCKA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_LOCKA_Msk instead */
+#define PMC_SR_MCKRDY_Pos                   3                                              /**< (PMC_SR) Master Clock Status Position */
+#define PMC_SR_MCKRDY_Msk                   (_U_(0x1) << PMC_SR_MCKRDY_Pos)                /**< (PMC_SR) Master Clock Status Mask */
+#define PMC_SR_MCKRDY                       PMC_SR_MCKRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MCKRDY_Msk instead */
+#define PMC_SR_LOCKU_Pos                    6                                              /**< (PMC_SR) UTMI PLL Lock Status Position */
+#define PMC_SR_LOCKU_Msk                    (_U_(0x1) << PMC_SR_LOCKU_Pos)                 /**< (PMC_SR) UTMI PLL Lock Status Mask */
+#define PMC_SR_LOCKU                        PMC_SR_LOCKU_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_LOCKU_Msk instead */
+#define PMC_SR_OSCSELS_Pos                  7                                              /**< (PMC_SR) Slow Clock Source Oscillator Selection Position */
+#define PMC_SR_OSCSELS_Msk                  (_U_(0x1) << PMC_SR_OSCSELS_Pos)               /**< (PMC_SR) Slow Clock Source Oscillator Selection Mask */
+#define PMC_SR_OSCSELS                      PMC_SR_OSCSELS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_OSCSELS_Msk instead */
+#define PMC_SR_PCKRDY0_Pos                  8                                              /**< (PMC_SR) Programmable Clock Ready 0 Status Position */
+#define PMC_SR_PCKRDY0_Msk                  (_U_(0x1) << PMC_SR_PCKRDY0_Pos)               /**< (PMC_SR) Programmable Clock Ready 0 Status Mask */
+#define PMC_SR_PCKRDY0                      PMC_SR_PCKRDY0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY0_Msk instead */
+#define PMC_SR_PCKRDY1_Pos                  9                                              /**< (PMC_SR) Programmable Clock Ready 1 Status Position */
+#define PMC_SR_PCKRDY1_Msk                  (_U_(0x1) << PMC_SR_PCKRDY1_Pos)               /**< (PMC_SR) Programmable Clock Ready 1 Status Mask */
+#define PMC_SR_PCKRDY1                      PMC_SR_PCKRDY1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY1_Msk instead */
+#define PMC_SR_PCKRDY2_Pos                  10                                             /**< (PMC_SR) Programmable Clock Ready 2 Status Position */
+#define PMC_SR_PCKRDY2_Msk                  (_U_(0x1) << PMC_SR_PCKRDY2_Pos)               /**< (PMC_SR) Programmable Clock Ready 2 Status Mask */
+#define PMC_SR_PCKRDY2                      PMC_SR_PCKRDY2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY2_Msk instead */
+#define PMC_SR_PCKRDY3_Pos                  11                                             /**< (PMC_SR) Programmable Clock Ready 3 Status Position */
+#define PMC_SR_PCKRDY3_Msk                  (_U_(0x1) << PMC_SR_PCKRDY3_Pos)               /**< (PMC_SR) Programmable Clock Ready 3 Status Mask */
+#define PMC_SR_PCKRDY3                      PMC_SR_PCKRDY3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY3_Msk instead */
+#define PMC_SR_PCKRDY4_Pos                  12                                             /**< (PMC_SR) Programmable Clock Ready 4 Status Position */
+#define PMC_SR_PCKRDY4_Msk                  (_U_(0x1) << PMC_SR_PCKRDY4_Pos)               /**< (PMC_SR) Programmable Clock Ready 4 Status Mask */
+#define PMC_SR_PCKRDY4                      PMC_SR_PCKRDY4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY4_Msk instead */
+#define PMC_SR_PCKRDY5_Pos                  13                                             /**< (PMC_SR) Programmable Clock Ready 5 Status Position */
+#define PMC_SR_PCKRDY5_Msk                  (_U_(0x1) << PMC_SR_PCKRDY5_Pos)               /**< (PMC_SR) Programmable Clock Ready 5 Status Mask */
+#define PMC_SR_PCKRDY5                      PMC_SR_PCKRDY5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY5_Msk instead */
+#define PMC_SR_PCKRDY6_Pos                  14                                             /**< (PMC_SR) Programmable Clock Ready 6 Status Position */
+#define PMC_SR_PCKRDY6_Msk                  (_U_(0x1) << PMC_SR_PCKRDY6_Pos)               /**< (PMC_SR) Programmable Clock Ready 6 Status Mask */
+#define PMC_SR_PCKRDY6                      PMC_SR_PCKRDY6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY6_Msk instead */
+#define PMC_SR_PCKRDY7_Pos                  15                                             /**< (PMC_SR) Programmable Clock Ready 7 Status Position */
+#define PMC_SR_PCKRDY7_Msk                  (_U_(0x1) << PMC_SR_PCKRDY7_Pos)               /**< (PMC_SR) Programmable Clock Ready 7 Status Mask */
+#define PMC_SR_PCKRDY7                      PMC_SR_PCKRDY7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY7_Msk instead */
+#define PMC_SR_MOSCSELS_Pos                 16                                             /**< (PMC_SR) Main Clock Source Oscillator Selection Status Position */
+#define PMC_SR_MOSCSELS_Msk                 (_U_(0x1) << PMC_SR_MOSCSELS_Pos)              /**< (PMC_SR) Main Clock Source Oscillator Selection Status Mask */
+#define PMC_SR_MOSCSELS                     PMC_SR_MOSCSELS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCSELS_Msk instead */
+#define PMC_SR_MOSCRCS_Pos                  17                                             /**< (PMC_SR) Main RC Oscillator Status Position */
+#define PMC_SR_MOSCRCS_Msk                  (_U_(0x1) << PMC_SR_MOSCRCS_Pos)               /**< (PMC_SR) Main RC Oscillator Status Mask */
+#define PMC_SR_MOSCRCS                      PMC_SR_MOSCRCS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCRCS_Msk instead */
+#define PMC_SR_CFDEV_Pos                    18                                             /**< (PMC_SR) Clock Failure Detector Event Position */
+#define PMC_SR_CFDEV_Msk                    (_U_(0x1) << PMC_SR_CFDEV_Pos)                 /**< (PMC_SR) Clock Failure Detector Event Mask */
+#define PMC_SR_CFDEV                        PMC_SR_CFDEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_CFDEV_Msk instead */
+#define PMC_SR_CFDS_Pos                     19                                             /**< (PMC_SR) Clock Failure Detector Status Position */
+#define PMC_SR_CFDS_Msk                     (_U_(0x1) << PMC_SR_CFDS_Pos)                  /**< (PMC_SR) Clock Failure Detector Status Mask */
+#define PMC_SR_CFDS                         PMC_SR_CFDS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_CFDS_Msk instead */
+#define PMC_SR_FOS_Pos                      20                                             /**< (PMC_SR) Clock Failure Detector Fault Output Status Position */
+#define PMC_SR_FOS_Msk                      (_U_(0x1) << PMC_SR_FOS_Pos)                   /**< (PMC_SR) Clock Failure Detector Fault Output Status Mask */
+#define PMC_SR_FOS                          PMC_SR_FOS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_FOS_Msk instead */
+#define PMC_SR_XT32KERR_Pos                 21                                             /**< (PMC_SR) Slow Crystal Oscillator Error Position */
+#define PMC_SR_XT32KERR_Msk                 (_U_(0x1) << PMC_SR_XT32KERR_Pos)              /**< (PMC_SR) Slow Crystal Oscillator Error Mask */
+#define PMC_SR_XT32KERR                     PMC_SR_XT32KERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_XT32KERR_Msk instead */
+#define PMC_SR_MASK                         _U_(0x3FFFCB)                                  /**< \deprecated (PMC_SR) Register MASK  (Use PMC_SR_Msk instead)  */
+#define PMC_SR_Msk                          _U_(0x3FFFCB)                                  /**< (PMC_SR) Register Mask  */
+
+#define PMC_SR_PCKRDY_Pos                   8                                              /**< (PMC_SR Position) Programmable Clock Ready x Status */
+#define PMC_SR_PCKRDY_Msk                   (_U_(0xFF) << PMC_SR_PCKRDY_Pos)               /**< (PMC_SR Mask) PCKRDY */
+#define PMC_SR_PCKRDY(value)                (PMC_SR_PCKRDY_Msk & ((value) << PMC_SR_PCKRDY_Pos))  
+
+/* -------- PMC_IMR : (PMC Offset: 0x6c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Mask */
+    uint32_t LOCKA:1;                   /**< bit:      1  PLLA Lock Interrupt Mask                 */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t MCKRDY:1;                  /**< bit:      3  Master Clock Ready Interrupt Mask        */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t LOCKU:1;                   /**< bit:      6  UTMI PLL Lock Interrupt Mask             */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PCKRDY0:1;                 /**< bit:      8  Programmable Clock Ready 0 Interrupt Mask */
+    uint32_t PCKRDY1:1;                 /**< bit:      9  Programmable Clock Ready 1 Interrupt Mask */
+    uint32_t PCKRDY2:1;                 /**< bit:     10  Programmable Clock Ready 2 Interrupt Mask */
+    uint32_t PCKRDY3:1;                 /**< bit:     11  Programmable Clock Ready 3 Interrupt Mask */
+    uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Mask */
+    uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Mask */
+    uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Mask */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Mask */
+    uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Mask */
+    uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Mask            */
+    uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Mask */
+    uint32_t :2;                        /**< bit: 19..20  Reserved */
+    uint32_t XT32KERR:1;                /**< bit:     21  32.768 kHz Crystal Oscillator Error Interrupt Mask */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Mask */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_IMR_OFFSET                      (0x6C)                                        /**<  (PMC_IMR) Interrupt Mask Register  Offset */
+
+#define PMC_IMR_MOSCXTS_Pos                 0                                              /**< (PMC_IMR) Main Crystal Oscillator Status Interrupt Mask Position */
+#define PMC_IMR_MOSCXTS_Msk                 (_U_(0x1) << PMC_IMR_MOSCXTS_Pos)              /**< (PMC_IMR) Main Crystal Oscillator Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCXTS                     PMC_IMR_MOSCXTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCXTS_Msk instead */
+#define PMC_IMR_LOCKA_Pos                   1                                              /**< (PMC_IMR) PLLA Lock Interrupt Mask Position */
+#define PMC_IMR_LOCKA_Msk                   (_U_(0x1) << PMC_IMR_LOCKA_Pos)                /**< (PMC_IMR) PLLA Lock Interrupt Mask Mask */
+#define PMC_IMR_LOCKA                       PMC_IMR_LOCKA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_LOCKA_Msk instead */
+#define PMC_IMR_MCKRDY_Pos                  3                                              /**< (PMC_IMR) Master Clock Ready Interrupt Mask Position */
+#define PMC_IMR_MCKRDY_Msk                  (_U_(0x1) << PMC_IMR_MCKRDY_Pos)               /**< (PMC_IMR) Master Clock Ready Interrupt Mask Mask */
+#define PMC_IMR_MCKRDY                      PMC_IMR_MCKRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MCKRDY_Msk instead */
+#define PMC_IMR_LOCKU_Pos                   6                                              /**< (PMC_IMR) UTMI PLL Lock Interrupt Mask Position */
+#define PMC_IMR_LOCKU_Msk                   (_U_(0x1) << PMC_IMR_LOCKU_Pos)                /**< (PMC_IMR) UTMI PLL Lock Interrupt Mask Mask */
+#define PMC_IMR_LOCKU                       PMC_IMR_LOCKU_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_LOCKU_Msk instead */
+#define PMC_IMR_PCKRDY0_Pos                 8                                              /**< (PMC_IMR) Programmable Clock Ready 0 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY0_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY0_Pos)              /**< (PMC_IMR) Programmable Clock Ready 0 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY0                     PMC_IMR_PCKRDY0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY0_Msk instead */
+#define PMC_IMR_PCKRDY1_Pos                 9                                              /**< (PMC_IMR) Programmable Clock Ready 1 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY1_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY1_Pos)              /**< (PMC_IMR) Programmable Clock Ready 1 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY1                     PMC_IMR_PCKRDY1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY1_Msk instead */
+#define PMC_IMR_PCKRDY2_Pos                 10                                             /**< (PMC_IMR) Programmable Clock Ready 2 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY2_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY2_Pos)              /**< (PMC_IMR) Programmable Clock Ready 2 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY2                     PMC_IMR_PCKRDY2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY2_Msk instead */
+#define PMC_IMR_PCKRDY3_Pos                 11                                             /**< (PMC_IMR) Programmable Clock Ready 3 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY3_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY3_Pos)              /**< (PMC_IMR) Programmable Clock Ready 3 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY3                     PMC_IMR_PCKRDY3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY3_Msk instead */
+#define PMC_IMR_PCKRDY4_Pos                 12                                             /**< (PMC_IMR) Programmable Clock Ready 4 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY4_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY4_Pos)              /**< (PMC_IMR) Programmable Clock Ready 4 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY4                     PMC_IMR_PCKRDY4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY4_Msk instead */
+#define PMC_IMR_PCKRDY5_Pos                 13                                             /**< (PMC_IMR) Programmable Clock Ready 5 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY5_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY5_Pos)              /**< (PMC_IMR) Programmable Clock Ready 5 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY5                     PMC_IMR_PCKRDY5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY5_Msk instead */
+#define PMC_IMR_PCKRDY6_Pos                 14                                             /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY6_Pos)              /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY6                     PMC_IMR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY6_Msk instead */
+#define PMC_IMR_PCKRDY7_Pos                 15                                             /**< (PMC_IMR) Programmable Clock Ready 7 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY7_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY7_Pos)              /**< (PMC_IMR) Programmable Clock Ready 7 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY7                     PMC_IMR_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY7_Msk instead */
+#define PMC_IMR_MOSCSELS_Pos                16                                             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Position */
+#define PMC_IMR_MOSCSELS_Msk                (_U_(0x1) << PMC_IMR_MOSCSELS_Pos)             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCSELS                    PMC_IMR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCSELS_Msk instead */
+#define PMC_IMR_MOSCRCS_Pos                 17                                             /**< (PMC_IMR) Main RC Status Interrupt Mask Position */
+#define PMC_IMR_MOSCRCS_Msk                 (_U_(0x1) << PMC_IMR_MOSCRCS_Pos)              /**< (PMC_IMR) Main RC Status Interrupt Mask Mask */
+#define PMC_IMR_MOSCRCS                     PMC_IMR_MOSCRCS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCRCS_Msk instead */
+#define PMC_IMR_CFDEV_Pos                   18                                             /**< (PMC_IMR) Clock Failure Detector Event Interrupt Mask Position */
+#define PMC_IMR_CFDEV_Msk                   (_U_(0x1) << PMC_IMR_CFDEV_Pos)                /**< (PMC_IMR) Clock Failure Detector Event Interrupt Mask Mask */
+#define PMC_IMR_CFDEV                       PMC_IMR_CFDEV_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_CFDEV_Msk instead */
+#define PMC_IMR_XT32KERR_Pos                21                                             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Position */
+#define PMC_IMR_XT32KERR_Msk                (_U_(0x1) << PMC_IMR_XT32KERR_Pos)             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Mask */
+#define PMC_IMR_XT32KERR                    PMC_IMR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_XT32KERR_Msk instead */
+#define PMC_IMR_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IMR) Register MASK  (Use PMC_IMR_Msk instead)  */
+#define PMC_IMR_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IMR) Register Mask  */
+
+#define PMC_IMR_PCKRDY_Pos                  8                                              /**< (PMC_IMR Position) Programmable Clock Ready x Interrupt Mask */
+#define PMC_IMR_PCKRDY_Msk                  (_U_(0xFF) << PMC_IMR_PCKRDY_Pos)              /**< (PMC_IMR Mask) PCKRDY */
+#define PMC_IMR_PCKRDY(value)               (PMC_IMR_PCKRDY_Msk & ((value) << PMC_IMR_PCKRDY_Pos))  
+
+/* -------- PMC_FSMR : (PMC Offset: 0x70) (R/W 32) Fast Startup Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FSTT0:1;                   /**< bit:      0  Fast Startup Input Enable 0              */
+    uint32_t FSTT1:1;                   /**< bit:      1  Fast Startup Input Enable 1              */
+    uint32_t FSTT2:1;                   /**< bit:      2  Fast Startup Input Enable 2              */
+    uint32_t FSTT3:1;                   /**< bit:      3  Fast Startup Input Enable 3              */
+    uint32_t FSTT4:1;                   /**< bit:      4  Fast Startup Input Enable 4              */
+    uint32_t FSTT5:1;                   /**< bit:      5  Fast Startup Input Enable 5              */
+    uint32_t FSTT6:1;                   /**< bit:      6  Fast Startup Input Enable 6              */
+    uint32_t FSTT7:1;                   /**< bit:      7  Fast Startup Input Enable 7              */
+    uint32_t FSTT8:1;                   /**< bit:      8  Fast Startup Input Enable 8              */
+    uint32_t FSTT9:1;                   /**< bit:      9  Fast Startup Input Enable 9              */
+    uint32_t FSTT10:1;                  /**< bit:     10  Fast Startup Input Enable 10             */
+    uint32_t FSTT11:1;                  /**< bit:     11  Fast Startup Input Enable 11             */
+    uint32_t FSTT12:1;                  /**< bit:     12  Fast Startup Input Enable 12             */
+    uint32_t FSTT13:1;                  /**< bit:     13  Fast Startup Input Enable 13             */
+    uint32_t FSTT14:1;                  /**< bit:     14  Fast Startup Input Enable 14             */
+    uint32_t FSTT15:1;                  /**< bit:     15  Fast Startup Input Enable 15             */
+    uint32_t RTTAL:1;                   /**< bit:     16  RTT Alarm Enable                         */
+    uint32_t RTCAL:1;                   /**< bit:     17  RTC Alarm Enable                         */
+    uint32_t USBAL:1;                   /**< bit:     18  USB Alarm Enable                         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t LPM:1;                     /**< bit:     20  Low-power Mode                           */
+    uint32_t FLPM:2;                    /**< bit: 21..22  Flash Low-power Mode                     */
+    uint32_t FFLPM:1;                   /**< bit:     23  Force Flash Low-power Mode               */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FSTT:16;                   /**< bit:  0..15  Fast Startup Input Enable x              */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FSMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FSMR_OFFSET                     (0x70)                                        /**<  (PMC_FSMR) Fast Startup Mode Register  Offset */
+
+#define PMC_FSMR_FSTT0_Pos                  0                                              /**< (PMC_FSMR) Fast Startup Input Enable 0 Position */
+#define PMC_FSMR_FSTT0_Msk                  (_U_(0x1) << PMC_FSMR_FSTT0_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 0 Mask */
+#define PMC_FSMR_FSTT0                      PMC_FSMR_FSTT0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT0_Msk instead */
+#define PMC_FSMR_FSTT1_Pos                  1                                              /**< (PMC_FSMR) Fast Startup Input Enable 1 Position */
+#define PMC_FSMR_FSTT1_Msk                  (_U_(0x1) << PMC_FSMR_FSTT1_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 1 Mask */
+#define PMC_FSMR_FSTT1                      PMC_FSMR_FSTT1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT1_Msk instead */
+#define PMC_FSMR_FSTT2_Pos                  2                                              /**< (PMC_FSMR) Fast Startup Input Enable 2 Position */
+#define PMC_FSMR_FSTT2_Msk                  (_U_(0x1) << PMC_FSMR_FSTT2_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 2 Mask */
+#define PMC_FSMR_FSTT2                      PMC_FSMR_FSTT2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT2_Msk instead */
+#define PMC_FSMR_FSTT3_Pos                  3                                              /**< (PMC_FSMR) Fast Startup Input Enable 3 Position */
+#define PMC_FSMR_FSTT3_Msk                  (_U_(0x1) << PMC_FSMR_FSTT3_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 3 Mask */
+#define PMC_FSMR_FSTT3                      PMC_FSMR_FSTT3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT3_Msk instead */
+#define PMC_FSMR_FSTT4_Pos                  4                                              /**< (PMC_FSMR) Fast Startup Input Enable 4 Position */
+#define PMC_FSMR_FSTT4_Msk                  (_U_(0x1) << PMC_FSMR_FSTT4_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 4 Mask */
+#define PMC_FSMR_FSTT4                      PMC_FSMR_FSTT4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT4_Msk instead */
+#define PMC_FSMR_FSTT5_Pos                  5                                              /**< (PMC_FSMR) Fast Startup Input Enable 5 Position */
+#define PMC_FSMR_FSTT5_Msk                  (_U_(0x1) << PMC_FSMR_FSTT5_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 5 Mask */
+#define PMC_FSMR_FSTT5                      PMC_FSMR_FSTT5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT5_Msk instead */
+#define PMC_FSMR_FSTT6_Pos                  6                                              /**< (PMC_FSMR) Fast Startup Input Enable 6 Position */
+#define PMC_FSMR_FSTT6_Msk                  (_U_(0x1) << PMC_FSMR_FSTT6_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 6 Mask */
+#define PMC_FSMR_FSTT6                      PMC_FSMR_FSTT6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT6_Msk instead */
+#define PMC_FSMR_FSTT7_Pos                  7                                              /**< (PMC_FSMR) Fast Startup Input Enable 7 Position */
+#define PMC_FSMR_FSTT7_Msk                  (_U_(0x1) << PMC_FSMR_FSTT7_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 7 Mask */
+#define PMC_FSMR_FSTT7                      PMC_FSMR_FSTT7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT7_Msk instead */
+#define PMC_FSMR_FSTT8_Pos                  8                                              /**< (PMC_FSMR) Fast Startup Input Enable 8 Position */
+#define PMC_FSMR_FSTT8_Msk                  (_U_(0x1) << PMC_FSMR_FSTT8_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 8 Mask */
+#define PMC_FSMR_FSTT8                      PMC_FSMR_FSTT8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT8_Msk instead */
+#define PMC_FSMR_FSTT9_Pos                  9                                              /**< (PMC_FSMR) Fast Startup Input Enable 9 Position */
+#define PMC_FSMR_FSTT9_Msk                  (_U_(0x1) << PMC_FSMR_FSTT9_Pos)               /**< (PMC_FSMR) Fast Startup Input Enable 9 Mask */
+#define PMC_FSMR_FSTT9                      PMC_FSMR_FSTT9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT9_Msk instead */
+#define PMC_FSMR_FSTT10_Pos                 10                                             /**< (PMC_FSMR) Fast Startup Input Enable 10 Position */
+#define PMC_FSMR_FSTT10_Msk                 (_U_(0x1) << PMC_FSMR_FSTT10_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 10 Mask */
+#define PMC_FSMR_FSTT10                     PMC_FSMR_FSTT10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT10_Msk instead */
+#define PMC_FSMR_FSTT11_Pos                 11                                             /**< (PMC_FSMR) Fast Startup Input Enable 11 Position */
+#define PMC_FSMR_FSTT11_Msk                 (_U_(0x1) << PMC_FSMR_FSTT11_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 11 Mask */
+#define PMC_FSMR_FSTT11                     PMC_FSMR_FSTT11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT11_Msk instead */
+#define PMC_FSMR_FSTT12_Pos                 12                                             /**< (PMC_FSMR) Fast Startup Input Enable 12 Position */
+#define PMC_FSMR_FSTT12_Msk                 (_U_(0x1) << PMC_FSMR_FSTT12_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 12 Mask */
+#define PMC_FSMR_FSTT12                     PMC_FSMR_FSTT12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT12_Msk instead */
+#define PMC_FSMR_FSTT13_Pos                 13                                             /**< (PMC_FSMR) Fast Startup Input Enable 13 Position */
+#define PMC_FSMR_FSTT13_Msk                 (_U_(0x1) << PMC_FSMR_FSTT13_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 13 Mask */
+#define PMC_FSMR_FSTT13                     PMC_FSMR_FSTT13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT13_Msk instead */
+#define PMC_FSMR_FSTT14_Pos                 14                                             /**< (PMC_FSMR) Fast Startup Input Enable 14 Position */
+#define PMC_FSMR_FSTT14_Msk                 (_U_(0x1) << PMC_FSMR_FSTT14_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 14 Mask */
+#define PMC_FSMR_FSTT14                     PMC_FSMR_FSTT14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT14_Msk instead */
+#define PMC_FSMR_FSTT15_Pos                 15                                             /**< (PMC_FSMR) Fast Startup Input Enable 15 Position */
+#define PMC_FSMR_FSTT15_Msk                 (_U_(0x1) << PMC_FSMR_FSTT15_Pos)              /**< (PMC_FSMR) Fast Startup Input Enable 15 Mask */
+#define PMC_FSMR_FSTT15                     PMC_FSMR_FSTT15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FSTT15_Msk instead */
+#define PMC_FSMR_RTTAL_Pos                  16                                             /**< (PMC_FSMR) RTT Alarm Enable Position */
+#define PMC_FSMR_RTTAL_Msk                  (_U_(0x1) << PMC_FSMR_RTTAL_Pos)               /**< (PMC_FSMR) RTT Alarm Enable Mask */
+#define PMC_FSMR_RTTAL                      PMC_FSMR_RTTAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_RTTAL_Msk instead */
+#define PMC_FSMR_RTCAL_Pos                  17                                             /**< (PMC_FSMR) RTC Alarm Enable Position */
+#define PMC_FSMR_RTCAL_Msk                  (_U_(0x1) << PMC_FSMR_RTCAL_Pos)               /**< (PMC_FSMR) RTC Alarm Enable Mask */
+#define PMC_FSMR_RTCAL                      PMC_FSMR_RTCAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_RTCAL_Msk instead */
+#define PMC_FSMR_USBAL_Pos                  18                                             /**< (PMC_FSMR) USB Alarm Enable Position */
+#define PMC_FSMR_USBAL_Msk                  (_U_(0x1) << PMC_FSMR_USBAL_Pos)               /**< (PMC_FSMR) USB Alarm Enable Mask */
+#define PMC_FSMR_USBAL                      PMC_FSMR_USBAL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_USBAL_Msk instead */
+#define PMC_FSMR_LPM_Pos                    20                                             /**< (PMC_FSMR) Low-power Mode Position */
+#define PMC_FSMR_LPM_Msk                    (_U_(0x1) << PMC_FSMR_LPM_Pos)                 /**< (PMC_FSMR) Low-power Mode Mask */
+#define PMC_FSMR_LPM                        PMC_FSMR_LPM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_LPM_Msk instead */
+#define PMC_FSMR_FLPM_Pos                   21                                             /**< (PMC_FSMR) Flash Low-power Mode Position */
+#define PMC_FSMR_FLPM_Msk                   (_U_(0x3) << PMC_FSMR_FLPM_Pos)                /**< (PMC_FSMR) Flash Low-power Mode Mask */
+#define PMC_FSMR_FLPM(value)                (PMC_FSMR_FLPM_Msk & ((value) << PMC_FSMR_FLPM_Pos))
+#define   PMC_FSMR_FLPM_FLASH_STANDBY_Val   _U_(0x0)                                       /**< (PMC_FSMR) Flash is in Standby Mode when system enters Wait Mode  */
+#define   PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN_Val _U_(0x1)                                       /**< (PMC_FSMR) Flash is in Deep-power-down mode when system enters Wait Mode  */
+#define   PMC_FSMR_FLPM_FLASH_IDLE_Val      _U_(0x2)                                       /**< (PMC_FSMR) Idle mode  */
+#define PMC_FSMR_FLPM_FLASH_STANDBY         (PMC_FSMR_FLPM_FLASH_STANDBY_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Flash is in Standby Mode when system enters Wait Mode Position  */
+#define PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN  (PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Flash is in Deep-power-down mode when system enters Wait Mode Position  */
+#define PMC_FSMR_FLPM_FLASH_IDLE            (PMC_FSMR_FLPM_FLASH_IDLE_Val << PMC_FSMR_FLPM_Pos)  /**< (PMC_FSMR) Idle mode Position  */
+#define PMC_FSMR_FFLPM_Pos                  23                                             /**< (PMC_FSMR) Force Flash Low-power Mode Position */
+#define PMC_FSMR_FFLPM_Msk                  (_U_(0x1) << PMC_FSMR_FFLPM_Pos)               /**< (PMC_FSMR) Force Flash Low-power Mode Mask */
+#define PMC_FSMR_FFLPM                      PMC_FSMR_FFLPM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSMR_FFLPM_Msk instead */
+#define PMC_FSMR_MASK                       _U_(0xF7FFFF)                                  /**< \deprecated (PMC_FSMR) Register MASK  (Use PMC_FSMR_Msk instead)  */
+#define PMC_FSMR_Msk                        _U_(0xF7FFFF)                                  /**< (PMC_FSMR) Register Mask  */
+
+#define PMC_FSMR_FSTT_Pos                   0                                              /**< (PMC_FSMR Position) Fast Startup Input Enable x */
+#define PMC_FSMR_FSTT_Msk                   (_U_(0xFFFF) << PMC_FSMR_FSTT_Pos)             /**< (PMC_FSMR Mask) FSTT */
+#define PMC_FSMR_FSTT(value)                (PMC_FSMR_FSTT_Msk & ((value) << PMC_FSMR_FSTT_Pos))  
+
+/* -------- PMC_FSPR : (PMC Offset: 0x74) (R/W 32) Fast Startup Polarity Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FSTP0:1;                   /**< bit:      0  Fast Startup Input Polarity 0            */
+    uint32_t FSTP1:1;                   /**< bit:      1  Fast Startup Input Polarity 1            */
+    uint32_t FSTP2:1;                   /**< bit:      2  Fast Startup Input Polarity 2            */
+    uint32_t FSTP3:1;                   /**< bit:      3  Fast Startup Input Polarity 3            */
+    uint32_t FSTP4:1;                   /**< bit:      4  Fast Startup Input Polarity 4            */
+    uint32_t FSTP5:1;                   /**< bit:      5  Fast Startup Input Polarity 5            */
+    uint32_t FSTP6:1;                   /**< bit:      6  Fast Startup Input Polarity 6            */
+    uint32_t FSTP7:1;                   /**< bit:      7  Fast Startup Input Polarity 7            */
+    uint32_t FSTP8:1;                   /**< bit:      8  Fast Startup Input Polarity 8            */
+    uint32_t FSTP9:1;                   /**< bit:      9  Fast Startup Input Polarity 9            */
+    uint32_t FSTP10:1;                  /**< bit:     10  Fast Startup Input Polarity 10           */
+    uint32_t FSTP11:1;                  /**< bit:     11  Fast Startup Input Polarity 11           */
+    uint32_t FSTP12:1;                  /**< bit:     12  Fast Startup Input Polarity 12           */
+    uint32_t FSTP13:1;                  /**< bit:     13  Fast Startup Input Polarity 13           */
+    uint32_t FSTP14:1;                  /**< bit:     14  Fast Startup Input Polarity 14           */
+    uint32_t FSTP15:1;                  /**< bit:     15  Fast Startup Input Polarity 15           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FSTP:16;                   /**< bit:  0..15  Fast Startup Input Polarity x5           */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FSPR_OFFSET                     (0x74)                                        /**<  (PMC_FSPR) Fast Startup Polarity Register  Offset */
+
+#define PMC_FSPR_FSTP0_Pos                  0                                              /**< (PMC_FSPR) Fast Startup Input Polarity 0 Position */
+#define PMC_FSPR_FSTP0_Msk                  (_U_(0x1) << PMC_FSPR_FSTP0_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 0 Mask */
+#define PMC_FSPR_FSTP0                      PMC_FSPR_FSTP0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP0_Msk instead */
+#define PMC_FSPR_FSTP1_Pos                  1                                              /**< (PMC_FSPR) Fast Startup Input Polarity 1 Position */
+#define PMC_FSPR_FSTP1_Msk                  (_U_(0x1) << PMC_FSPR_FSTP1_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 1 Mask */
+#define PMC_FSPR_FSTP1                      PMC_FSPR_FSTP1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP1_Msk instead */
+#define PMC_FSPR_FSTP2_Pos                  2                                              /**< (PMC_FSPR) Fast Startup Input Polarity 2 Position */
+#define PMC_FSPR_FSTP2_Msk                  (_U_(0x1) << PMC_FSPR_FSTP2_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 2 Mask */
+#define PMC_FSPR_FSTP2                      PMC_FSPR_FSTP2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP2_Msk instead */
+#define PMC_FSPR_FSTP3_Pos                  3                                              /**< (PMC_FSPR) Fast Startup Input Polarity 3 Position */
+#define PMC_FSPR_FSTP3_Msk                  (_U_(0x1) << PMC_FSPR_FSTP3_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 3 Mask */
+#define PMC_FSPR_FSTP3                      PMC_FSPR_FSTP3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP3_Msk instead */
+#define PMC_FSPR_FSTP4_Pos                  4                                              /**< (PMC_FSPR) Fast Startup Input Polarity 4 Position */
+#define PMC_FSPR_FSTP4_Msk                  (_U_(0x1) << PMC_FSPR_FSTP4_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 4 Mask */
+#define PMC_FSPR_FSTP4                      PMC_FSPR_FSTP4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP4_Msk instead */
+#define PMC_FSPR_FSTP5_Pos                  5                                              /**< (PMC_FSPR) Fast Startup Input Polarity 5 Position */
+#define PMC_FSPR_FSTP5_Msk                  (_U_(0x1) << PMC_FSPR_FSTP5_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 5 Mask */
+#define PMC_FSPR_FSTP5                      PMC_FSPR_FSTP5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP5_Msk instead */
+#define PMC_FSPR_FSTP6_Pos                  6                                              /**< (PMC_FSPR) Fast Startup Input Polarity 6 Position */
+#define PMC_FSPR_FSTP6_Msk                  (_U_(0x1) << PMC_FSPR_FSTP6_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 6 Mask */
+#define PMC_FSPR_FSTP6                      PMC_FSPR_FSTP6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP6_Msk instead */
+#define PMC_FSPR_FSTP7_Pos                  7                                              /**< (PMC_FSPR) Fast Startup Input Polarity 7 Position */
+#define PMC_FSPR_FSTP7_Msk                  (_U_(0x1) << PMC_FSPR_FSTP7_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 7 Mask */
+#define PMC_FSPR_FSTP7                      PMC_FSPR_FSTP7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP7_Msk instead */
+#define PMC_FSPR_FSTP8_Pos                  8                                              /**< (PMC_FSPR) Fast Startup Input Polarity 8 Position */
+#define PMC_FSPR_FSTP8_Msk                  (_U_(0x1) << PMC_FSPR_FSTP8_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 8 Mask */
+#define PMC_FSPR_FSTP8                      PMC_FSPR_FSTP8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP8_Msk instead */
+#define PMC_FSPR_FSTP9_Pos                  9                                              /**< (PMC_FSPR) Fast Startup Input Polarity 9 Position */
+#define PMC_FSPR_FSTP9_Msk                  (_U_(0x1) << PMC_FSPR_FSTP9_Pos)               /**< (PMC_FSPR) Fast Startup Input Polarity 9 Mask */
+#define PMC_FSPR_FSTP9                      PMC_FSPR_FSTP9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP9_Msk instead */
+#define PMC_FSPR_FSTP10_Pos                 10                                             /**< (PMC_FSPR) Fast Startup Input Polarity 10 Position */
+#define PMC_FSPR_FSTP10_Msk                 (_U_(0x1) << PMC_FSPR_FSTP10_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 10 Mask */
+#define PMC_FSPR_FSTP10                     PMC_FSPR_FSTP10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP10_Msk instead */
+#define PMC_FSPR_FSTP11_Pos                 11                                             /**< (PMC_FSPR) Fast Startup Input Polarity 11 Position */
+#define PMC_FSPR_FSTP11_Msk                 (_U_(0x1) << PMC_FSPR_FSTP11_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 11 Mask */
+#define PMC_FSPR_FSTP11                     PMC_FSPR_FSTP11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP11_Msk instead */
+#define PMC_FSPR_FSTP12_Pos                 12                                             /**< (PMC_FSPR) Fast Startup Input Polarity 12 Position */
+#define PMC_FSPR_FSTP12_Msk                 (_U_(0x1) << PMC_FSPR_FSTP12_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 12 Mask */
+#define PMC_FSPR_FSTP12                     PMC_FSPR_FSTP12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP12_Msk instead */
+#define PMC_FSPR_FSTP13_Pos                 13                                             /**< (PMC_FSPR) Fast Startup Input Polarity 13 Position */
+#define PMC_FSPR_FSTP13_Msk                 (_U_(0x1) << PMC_FSPR_FSTP13_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 13 Mask */
+#define PMC_FSPR_FSTP13                     PMC_FSPR_FSTP13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP13_Msk instead */
+#define PMC_FSPR_FSTP14_Pos                 14                                             /**< (PMC_FSPR) Fast Startup Input Polarity 14 Position */
+#define PMC_FSPR_FSTP14_Msk                 (_U_(0x1) << PMC_FSPR_FSTP14_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 14 Mask */
+#define PMC_FSPR_FSTP14                     PMC_FSPR_FSTP14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP14_Msk instead */
+#define PMC_FSPR_FSTP15_Pos                 15                                             /**< (PMC_FSPR) Fast Startup Input Polarity 15 Position */
+#define PMC_FSPR_FSTP15_Msk                 (_U_(0x1) << PMC_FSPR_FSTP15_Pos)              /**< (PMC_FSPR) Fast Startup Input Polarity 15 Mask */
+#define PMC_FSPR_FSTP15                     PMC_FSPR_FSTP15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FSPR_FSTP15_Msk instead */
+#define PMC_FSPR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (PMC_FSPR) Register MASK  (Use PMC_FSPR_Msk instead)  */
+#define PMC_FSPR_Msk                        _U_(0xFFFF)                                    /**< (PMC_FSPR) Register Mask  */
+
+#define PMC_FSPR_FSTP_Pos                   0                                              /**< (PMC_FSPR Position) Fast Startup Input Polarity x5 */
+#define PMC_FSPR_FSTP_Msk                   (_U_(0xFFFF) << PMC_FSPR_FSTP_Pos)             /**< (PMC_FSPR Mask) FSTP */
+#define PMC_FSPR_FSTP(value)                (PMC_FSPR_FSTP_Msk & ((value) << PMC_FSPR_FSTP_Pos))  
+
+/* -------- PMC_FOCR : (PMC Offset: 0x78) (/W 32) Fault Output Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FOCLR:1;                   /**< bit:      0  Fault Output Clear                       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_FOCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_FOCR_OFFSET                     (0x78)                                        /**<  (PMC_FOCR) Fault Output Clear Register  Offset */
+
+#define PMC_FOCR_FOCLR_Pos                  0                                              /**< (PMC_FOCR) Fault Output Clear Position */
+#define PMC_FOCR_FOCLR_Msk                  (_U_(0x1) << PMC_FOCR_FOCLR_Pos)               /**< (PMC_FOCR) Fault Output Clear Mask */
+#define PMC_FOCR_FOCLR                      PMC_FOCR_FOCLR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_FOCR_FOCLR_Msk instead */
+#define PMC_FOCR_MASK                       _U_(0x01)                                      /**< \deprecated (PMC_FOCR) Register MASK  (Use PMC_FOCR_Msk instead)  */
+#define PMC_FOCR_Msk                        _U_(0x01)                                      /**< (PMC_FOCR) Register Mask  */
+
+
+/* -------- PMC_WPMR : (PMC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_WPMR_OFFSET                     (0xE4)                                        /**<  (PMC_WPMR) Write Protection Mode Register  Offset */
+
+#define PMC_WPMR_WPEN_Pos                   0                                              /**< (PMC_WPMR) Write Protection Enable Position */
+#define PMC_WPMR_WPEN_Msk                   (_U_(0x1) << PMC_WPMR_WPEN_Pos)                /**< (PMC_WPMR) Write Protection Enable Mask */
+#define PMC_WPMR_WPEN                       PMC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_WPMR_WPEN_Msk instead */
+#define PMC_WPMR_WPKEY_Pos                  8                                              /**< (PMC_WPMR) Write Protection Key Position */
+#define PMC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << PMC_WPMR_WPKEY_Pos)          /**< (PMC_WPMR) Write Protection Key Mask */
+#define PMC_WPMR_WPKEY(value)               (PMC_WPMR_WPKEY_Msk & ((value) << PMC_WPMR_WPKEY_Pos))
+#define   PMC_WPMR_WPKEY_PASSWD_Val         _U_(0x504D43)                                  /**< (PMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define PMC_WPMR_WPKEY_PASSWD               (PMC_WPMR_WPKEY_PASSWD_Val << PMC_WPMR_WPKEY_Pos)  /**< (PMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define PMC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (PMC_WPMR) Register MASK  (Use PMC_WPMR_Msk instead)  */
+#define PMC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (PMC_WPMR) Register Mask  */
+
+
+/* -------- PMC_WPSR : (PMC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_WPSR_OFFSET                     (0xE8)                                        /**<  (PMC_WPSR) Write Protection Status Register  Offset */
+
+#define PMC_WPSR_WPVS_Pos                   0                                              /**< (PMC_WPSR) Write Protection Violation Status Position */
+#define PMC_WPSR_WPVS_Msk                   (_U_(0x1) << PMC_WPSR_WPVS_Pos)                /**< (PMC_WPSR) Write Protection Violation Status Mask */
+#define PMC_WPSR_WPVS                       PMC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_WPSR_WPVS_Msk instead */
+#define PMC_WPSR_WPVSRC_Pos                 8                                              /**< (PMC_WPSR) Write Protection Violation Source Position */
+#define PMC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PMC_WPSR_WPVSRC_Pos)           /**< (PMC_WPSR) Write Protection Violation Source Mask */
+#define PMC_WPSR_WPVSRC(value)              (PMC_WPSR_WPVSRC_Msk & ((value) << PMC_WPSR_WPVSRC_Pos))
+#define PMC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (PMC_WPSR) Register MASK  (Use PMC_WPSR_Msk instead)  */
+#define PMC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (PMC_WPSR) Register Mask  */
+
+
+/* -------- PMC_PCER1 : (PMC Offset: 0x100) (/W 32) Peripheral Clock Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Enable               */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Enable               */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Enable               */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Enable               */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Enable               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Enable               */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Enable               */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Enable               */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Enable               */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Enable               */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Enable               */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Enable               */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Enable               */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Enable               */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Enable               */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Enable               */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Enable               */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Enable               */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Enable               */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Enable               */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Enable               */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Enable               */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Enable               */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Enable               */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Enable               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Enable               */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCER1_OFFSET                    (0x100)                                       /**<  (PMC_PCER1) Peripheral Clock Enable Register 1  Offset */
+
+#define PMC_PCER1_PID32_Pos                 0                                              /**< (PMC_PCER1) Peripheral Clock 32 Enable Position */
+#define PMC_PCER1_PID32_Msk                 (_U_(0x1) << PMC_PCER1_PID32_Pos)              /**< (PMC_PCER1) Peripheral Clock 32 Enable Mask */
+#define PMC_PCER1_PID32                     PMC_PCER1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID32_Msk instead */
+#define PMC_PCER1_PID33_Pos                 1                                              /**< (PMC_PCER1) Peripheral Clock 33 Enable Position */
+#define PMC_PCER1_PID33_Msk                 (_U_(0x1) << PMC_PCER1_PID33_Pos)              /**< (PMC_PCER1) Peripheral Clock 33 Enable Mask */
+#define PMC_PCER1_PID33                     PMC_PCER1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID33_Msk instead */
+#define PMC_PCER1_PID34_Pos                 2                                              /**< (PMC_PCER1) Peripheral Clock 34 Enable Position */
+#define PMC_PCER1_PID34_Msk                 (_U_(0x1) << PMC_PCER1_PID34_Pos)              /**< (PMC_PCER1) Peripheral Clock 34 Enable Mask */
+#define PMC_PCER1_PID34                     PMC_PCER1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID34_Msk instead */
+#define PMC_PCER1_PID35_Pos                 3                                              /**< (PMC_PCER1) Peripheral Clock 35 Enable Position */
+#define PMC_PCER1_PID35_Msk                 (_U_(0x1) << PMC_PCER1_PID35_Pos)              /**< (PMC_PCER1) Peripheral Clock 35 Enable Mask */
+#define PMC_PCER1_PID35                     PMC_PCER1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID35_Msk instead */
+#define PMC_PCER1_PID37_Pos                 5                                              /**< (PMC_PCER1) Peripheral Clock 37 Enable Position */
+#define PMC_PCER1_PID37_Msk                 (_U_(0x1) << PMC_PCER1_PID37_Pos)              /**< (PMC_PCER1) Peripheral Clock 37 Enable Mask */
+#define PMC_PCER1_PID37                     PMC_PCER1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID37_Msk instead */
+#define PMC_PCER1_PID39_Pos                 7                                              /**< (PMC_PCER1) Peripheral Clock 39 Enable Position */
+#define PMC_PCER1_PID39_Msk                 (_U_(0x1) << PMC_PCER1_PID39_Pos)              /**< (PMC_PCER1) Peripheral Clock 39 Enable Mask */
+#define PMC_PCER1_PID39                     PMC_PCER1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID39_Msk instead */
+#define PMC_PCER1_PID40_Pos                 8                                              /**< (PMC_PCER1) Peripheral Clock 40 Enable Position */
+#define PMC_PCER1_PID40_Msk                 (_U_(0x1) << PMC_PCER1_PID40_Pos)              /**< (PMC_PCER1) Peripheral Clock 40 Enable Mask */
+#define PMC_PCER1_PID40                     PMC_PCER1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID40_Msk instead */
+#define PMC_PCER1_PID41_Pos                 9                                              /**< (PMC_PCER1) Peripheral Clock 41 Enable Position */
+#define PMC_PCER1_PID41_Msk                 (_U_(0x1) << PMC_PCER1_PID41_Pos)              /**< (PMC_PCER1) Peripheral Clock 41 Enable Mask */
+#define PMC_PCER1_PID41                     PMC_PCER1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID41_Msk instead */
+#define PMC_PCER1_PID42_Pos                 10                                             /**< (PMC_PCER1) Peripheral Clock 42 Enable Position */
+#define PMC_PCER1_PID42_Msk                 (_U_(0x1) << PMC_PCER1_PID42_Pos)              /**< (PMC_PCER1) Peripheral Clock 42 Enable Mask */
+#define PMC_PCER1_PID42                     PMC_PCER1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID42_Msk instead */
+#define PMC_PCER1_PID43_Pos                 11                                             /**< (PMC_PCER1) Peripheral Clock 43 Enable Position */
+#define PMC_PCER1_PID43_Msk                 (_U_(0x1) << PMC_PCER1_PID43_Pos)              /**< (PMC_PCER1) Peripheral Clock 43 Enable Mask */
+#define PMC_PCER1_PID43                     PMC_PCER1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID43_Msk instead */
+#define PMC_PCER1_PID44_Pos                 12                                             /**< (PMC_PCER1) Peripheral Clock 44 Enable Position */
+#define PMC_PCER1_PID44_Msk                 (_U_(0x1) << PMC_PCER1_PID44_Pos)              /**< (PMC_PCER1) Peripheral Clock 44 Enable Mask */
+#define PMC_PCER1_PID44                     PMC_PCER1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID44_Msk instead */
+#define PMC_PCER1_PID45_Pos                 13                                             /**< (PMC_PCER1) Peripheral Clock 45 Enable Position */
+#define PMC_PCER1_PID45_Msk                 (_U_(0x1) << PMC_PCER1_PID45_Pos)              /**< (PMC_PCER1) Peripheral Clock 45 Enable Mask */
+#define PMC_PCER1_PID45                     PMC_PCER1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID45_Msk instead */
+#define PMC_PCER1_PID46_Pos                 14                                             /**< (PMC_PCER1) Peripheral Clock 46 Enable Position */
+#define PMC_PCER1_PID46_Msk                 (_U_(0x1) << PMC_PCER1_PID46_Pos)              /**< (PMC_PCER1) Peripheral Clock 46 Enable Mask */
+#define PMC_PCER1_PID46                     PMC_PCER1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID46_Msk instead */
+#define PMC_PCER1_PID47_Pos                 15                                             /**< (PMC_PCER1) Peripheral Clock 47 Enable Position */
+#define PMC_PCER1_PID47_Msk                 (_U_(0x1) << PMC_PCER1_PID47_Pos)              /**< (PMC_PCER1) Peripheral Clock 47 Enable Mask */
+#define PMC_PCER1_PID47                     PMC_PCER1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID47_Msk instead */
+#define PMC_PCER1_PID48_Pos                 16                                             /**< (PMC_PCER1) Peripheral Clock 48 Enable Position */
+#define PMC_PCER1_PID48_Msk                 (_U_(0x1) << PMC_PCER1_PID48_Pos)              /**< (PMC_PCER1) Peripheral Clock 48 Enable Mask */
+#define PMC_PCER1_PID48                     PMC_PCER1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID48_Msk instead */
+#define PMC_PCER1_PID49_Pos                 17                                             /**< (PMC_PCER1) Peripheral Clock 49 Enable Position */
+#define PMC_PCER1_PID49_Msk                 (_U_(0x1) << PMC_PCER1_PID49_Pos)              /**< (PMC_PCER1) Peripheral Clock 49 Enable Mask */
+#define PMC_PCER1_PID49                     PMC_PCER1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID49_Msk instead */
+#define PMC_PCER1_PID50_Pos                 18                                             /**< (PMC_PCER1) Peripheral Clock 50 Enable Position */
+#define PMC_PCER1_PID50_Msk                 (_U_(0x1) << PMC_PCER1_PID50_Pos)              /**< (PMC_PCER1) Peripheral Clock 50 Enable Mask */
+#define PMC_PCER1_PID50                     PMC_PCER1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID50_Msk instead */
+#define PMC_PCER1_PID51_Pos                 19                                             /**< (PMC_PCER1) Peripheral Clock 51 Enable Position */
+#define PMC_PCER1_PID51_Msk                 (_U_(0x1) << PMC_PCER1_PID51_Pos)              /**< (PMC_PCER1) Peripheral Clock 51 Enable Mask */
+#define PMC_PCER1_PID51                     PMC_PCER1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID51_Msk instead */
+#define PMC_PCER1_PID52_Pos                 20                                             /**< (PMC_PCER1) Peripheral Clock 52 Enable Position */
+#define PMC_PCER1_PID52_Msk                 (_U_(0x1) << PMC_PCER1_PID52_Pos)              /**< (PMC_PCER1) Peripheral Clock 52 Enable Mask */
+#define PMC_PCER1_PID52                     PMC_PCER1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID52_Msk instead */
+#define PMC_PCER1_PID53_Pos                 21                                             /**< (PMC_PCER1) Peripheral Clock 53 Enable Position */
+#define PMC_PCER1_PID53_Msk                 (_U_(0x1) << PMC_PCER1_PID53_Pos)              /**< (PMC_PCER1) Peripheral Clock 53 Enable Mask */
+#define PMC_PCER1_PID53                     PMC_PCER1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID53_Msk instead */
+#define PMC_PCER1_PID56_Pos                 24                                             /**< (PMC_PCER1) Peripheral Clock 56 Enable Position */
+#define PMC_PCER1_PID56_Msk                 (_U_(0x1) << PMC_PCER1_PID56_Pos)              /**< (PMC_PCER1) Peripheral Clock 56 Enable Mask */
+#define PMC_PCER1_PID56                     PMC_PCER1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID56_Msk instead */
+#define PMC_PCER1_PID57_Pos                 25                                             /**< (PMC_PCER1) Peripheral Clock 57 Enable Position */
+#define PMC_PCER1_PID57_Msk                 (_U_(0x1) << PMC_PCER1_PID57_Pos)              /**< (PMC_PCER1) Peripheral Clock 57 Enable Mask */
+#define PMC_PCER1_PID57                     PMC_PCER1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID57_Msk instead */
+#define PMC_PCER1_PID58_Pos                 26                                             /**< (PMC_PCER1) Peripheral Clock 58 Enable Position */
+#define PMC_PCER1_PID58_Msk                 (_U_(0x1) << PMC_PCER1_PID58_Pos)              /**< (PMC_PCER1) Peripheral Clock 58 Enable Mask */
+#define PMC_PCER1_PID58                     PMC_PCER1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID58_Msk instead */
+#define PMC_PCER1_PID59_Pos                 27                                             /**< (PMC_PCER1) Peripheral Clock 59 Enable Position */
+#define PMC_PCER1_PID59_Msk                 (_U_(0x1) << PMC_PCER1_PID59_Pos)              /**< (PMC_PCER1) Peripheral Clock 59 Enable Mask */
+#define PMC_PCER1_PID59                     PMC_PCER1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID59_Msk instead */
+#define PMC_PCER1_PID60_Pos                 28                                             /**< (PMC_PCER1) Peripheral Clock 60 Enable Position */
+#define PMC_PCER1_PID60_Msk                 (_U_(0x1) << PMC_PCER1_PID60_Pos)              /**< (PMC_PCER1) Peripheral Clock 60 Enable Mask */
+#define PMC_PCER1_PID60                     PMC_PCER1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID60_Msk instead */
+#define PMC_PCER1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCER1) Register MASK  (Use PMC_PCER1_Msk instead)  */
+#define PMC_PCER1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCER1) Register Mask  */
+
+#define PMC_PCER1_PID_Pos                   0                                              /**< (PMC_PCER1 Position) Peripheral Clock 6x Enable */
+#define PMC_PCER1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER1_PID_Pos)          /**< (PMC_PCER1 Mask) PID */
+#define PMC_PCER1_PID(value)                (PMC_PCER1_PID_Msk & ((value) << PMC_PCER1_PID_Pos))  
+
+/* -------- PMC_PCDR1 : (PMC Offset: 0x104) (/W 32) Peripheral Clock Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Disable              */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Disable              */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Disable              */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Disable              */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Disable              */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Disable              */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Disable              */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Disable              */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Disable              */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Disable              */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Disable              */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Disable              */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Disable              */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Disable              */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Disable              */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Disable              */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Disable              */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Disable              */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Disable              */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Disable              */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Disable              */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Disable              */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Disable              */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Disable              */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Disable              */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Disable              */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCDR1_OFFSET                    (0x104)                                       /**<  (PMC_PCDR1) Peripheral Clock Disable Register 1  Offset */
+
+#define PMC_PCDR1_PID32_Pos                 0                                              /**< (PMC_PCDR1) Peripheral Clock 32 Disable Position */
+#define PMC_PCDR1_PID32_Msk                 (_U_(0x1) << PMC_PCDR1_PID32_Pos)              /**< (PMC_PCDR1) Peripheral Clock 32 Disable Mask */
+#define PMC_PCDR1_PID32                     PMC_PCDR1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID32_Msk instead */
+#define PMC_PCDR1_PID33_Pos                 1                                              /**< (PMC_PCDR1) Peripheral Clock 33 Disable Position */
+#define PMC_PCDR1_PID33_Msk                 (_U_(0x1) << PMC_PCDR1_PID33_Pos)              /**< (PMC_PCDR1) Peripheral Clock 33 Disable Mask */
+#define PMC_PCDR1_PID33                     PMC_PCDR1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID33_Msk instead */
+#define PMC_PCDR1_PID34_Pos                 2                                              /**< (PMC_PCDR1) Peripheral Clock 34 Disable Position */
+#define PMC_PCDR1_PID34_Msk                 (_U_(0x1) << PMC_PCDR1_PID34_Pos)              /**< (PMC_PCDR1) Peripheral Clock 34 Disable Mask */
+#define PMC_PCDR1_PID34                     PMC_PCDR1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID34_Msk instead */
+#define PMC_PCDR1_PID35_Pos                 3                                              /**< (PMC_PCDR1) Peripheral Clock 35 Disable Position */
+#define PMC_PCDR1_PID35_Msk                 (_U_(0x1) << PMC_PCDR1_PID35_Pos)              /**< (PMC_PCDR1) Peripheral Clock 35 Disable Mask */
+#define PMC_PCDR1_PID35                     PMC_PCDR1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID35_Msk instead */
+#define PMC_PCDR1_PID37_Pos                 5                                              /**< (PMC_PCDR1) Peripheral Clock 37 Disable Position */
+#define PMC_PCDR1_PID37_Msk                 (_U_(0x1) << PMC_PCDR1_PID37_Pos)              /**< (PMC_PCDR1) Peripheral Clock 37 Disable Mask */
+#define PMC_PCDR1_PID37                     PMC_PCDR1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID37_Msk instead */
+#define PMC_PCDR1_PID39_Pos                 7                                              /**< (PMC_PCDR1) Peripheral Clock 39 Disable Position */
+#define PMC_PCDR1_PID39_Msk                 (_U_(0x1) << PMC_PCDR1_PID39_Pos)              /**< (PMC_PCDR1) Peripheral Clock 39 Disable Mask */
+#define PMC_PCDR1_PID39                     PMC_PCDR1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID39_Msk instead */
+#define PMC_PCDR1_PID40_Pos                 8                                              /**< (PMC_PCDR1) Peripheral Clock 40 Disable Position */
+#define PMC_PCDR1_PID40_Msk                 (_U_(0x1) << PMC_PCDR1_PID40_Pos)              /**< (PMC_PCDR1) Peripheral Clock 40 Disable Mask */
+#define PMC_PCDR1_PID40                     PMC_PCDR1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID40_Msk instead */
+#define PMC_PCDR1_PID41_Pos                 9                                              /**< (PMC_PCDR1) Peripheral Clock 41 Disable Position */
+#define PMC_PCDR1_PID41_Msk                 (_U_(0x1) << PMC_PCDR1_PID41_Pos)              /**< (PMC_PCDR1) Peripheral Clock 41 Disable Mask */
+#define PMC_PCDR1_PID41                     PMC_PCDR1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID41_Msk instead */
+#define PMC_PCDR1_PID42_Pos                 10                                             /**< (PMC_PCDR1) Peripheral Clock 42 Disable Position */
+#define PMC_PCDR1_PID42_Msk                 (_U_(0x1) << PMC_PCDR1_PID42_Pos)              /**< (PMC_PCDR1) Peripheral Clock 42 Disable Mask */
+#define PMC_PCDR1_PID42                     PMC_PCDR1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID42_Msk instead */
+#define PMC_PCDR1_PID43_Pos                 11                                             /**< (PMC_PCDR1) Peripheral Clock 43 Disable Position */
+#define PMC_PCDR1_PID43_Msk                 (_U_(0x1) << PMC_PCDR1_PID43_Pos)              /**< (PMC_PCDR1) Peripheral Clock 43 Disable Mask */
+#define PMC_PCDR1_PID43                     PMC_PCDR1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID43_Msk instead */
+#define PMC_PCDR1_PID44_Pos                 12                                             /**< (PMC_PCDR1) Peripheral Clock 44 Disable Position */
+#define PMC_PCDR1_PID44_Msk                 (_U_(0x1) << PMC_PCDR1_PID44_Pos)              /**< (PMC_PCDR1) Peripheral Clock 44 Disable Mask */
+#define PMC_PCDR1_PID44                     PMC_PCDR1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID44_Msk instead */
+#define PMC_PCDR1_PID45_Pos                 13                                             /**< (PMC_PCDR1) Peripheral Clock 45 Disable Position */
+#define PMC_PCDR1_PID45_Msk                 (_U_(0x1) << PMC_PCDR1_PID45_Pos)              /**< (PMC_PCDR1) Peripheral Clock 45 Disable Mask */
+#define PMC_PCDR1_PID45                     PMC_PCDR1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID45_Msk instead */
+#define PMC_PCDR1_PID46_Pos                 14                                             /**< (PMC_PCDR1) Peripheral Clock 46 Disable Position */
+#define PMC_PCDR1_PID46_Msk                 (_U_(0x1) << PMC_PCDR1_PID46_Pos)              /**< (PMC_PCDR1) Peripheral Clock 46 Disable Mask */
+#define PMC_PCDR1_PID46                     PMC_PCDR1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID46_Msk instead */
+#define PMC_PCDR1_PID47_Pos                 15                                             /**< (PMC_PCDR1) Peripheral Clock 47 Disable Position */
+#define PMC_PCDR1_PID47_Msk                 (_U_(0x1) << PMC_PCDR1_PID47_Pos)              /**< (PMC_PCDR1) Peripheral Clock 47 Disable Mask */
+#define PMC_PCDR1_PID47                     PMC_PCDR1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID47_Msk instead */
+#define PMC_PCDR1_PID48_Pos                 16                                             /**< (PMC_PCDR1) Peripheral Clock 48 Disable Position */
+#define PMC_PCDR1_PID48_Msk                 (_U_(0x1) << PMC_PCDR1_PID48_Pos)              /**< (PMC_PCDR1) Peripheral Clock 48 Disable Mask */
+#define PMC_PCDR1_PID48                     PMC_PCDR1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID48_Msk instead */
+#define PMC_PCDR1_PID49_Pos                 17                                             /**< (PMC_PCDR1) Peripheral Clock 49 Disable Position */
+#define PMC_PCDR1_PID49_Msk                 (_U_(0x1) << PMC_PCDR1_PID49_Pos)              /**< (PMC_PCDR1) Peripheral Clock 49 Disable Mask */
+#define PMC_PCDR1_PID49                     PMC_PCDR1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID49_Msk instead */
+#define PMC_PCDR1_PID50_Pos                 18                                             /**< (PMC_PCDR1) Peripheral Clock 50 Disable Position */
+#define PMC_PCDR1_PID50_Msk                 (_U_(0x1) << PMC_PCDR1_PID50_Pos)              /**< (PMC_PCDR1) Peripheral Clock 50 Disable Mask */
+#define PMC_PCDR1_PID50                     PMC_PCDR1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID50_Msk instead */
+#define PMC_PCDR1_PID51_Pos                 19                                             /**< (PMC_PCDR1) Peripheral Clock 51 Disable Position */
+#define PMC_PCDR1_PID51_Msk                 (_U_(0x1) << PMC_PCDR1_PID51_Pos)              /**< (PMC_PCDR1) Peripheral Clock 51 Disable Mask */
+#define PMC_PCDR1_PID51                     PMC_PCDR1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID51_Msk instead */
+#define PMC_PCDR1_PID52_Pos                 20                                             /**< (PMC_PCDR1) Peripheral Clock 52 Disable Position */
+#define PMC_PCDR1_PID52_Msk                 (_U_(0x1) << PMC_PCDR1_PID52_Pos)              /**< (PMC_PCDR1) Peripheral Clock 52 Disable Mask */
+#define PMC_PCDR1_PID52                     PMC_PCDR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID52_Msk instead */
+#define PMC_PCDR1_PID53_Pos                 21                                             /**< (PMC_PCDR1) Peripheral Clock 53 Disable Position */
+#define PMC_PCDR1_PID53_Msk                 (_U_(0x1) << PMC_PCDR1_PID53_Pos)              /**< (PMC_PCDR1) Peripheral Clock 53 Disable Mask */
+#define PMC_PCDR1_PID53                     PMC_PCDR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID53_Msk instead */
+#define PMC_PCDR1_PID56_Pos                 24                                             /**< (PMC_PCDR1) Peripheral Clock 56 Disable Position */
+#define PMC_PCDR1_PID56_Msk                 (_U_(0x1) << PMC_PCDR1_PID56_Pos)              /**< (PMC_PCDR1) Peripheral Clock 56 Disable Mask */
+#define PMC_PCDR1_PID56                     PMC_PCDR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID56_Msk instead */
+#define PMC_PCDR1_PID57_Pos                 25                                             /**< (PMC_PCDR1) Peripheral Clock 57 Disable Position */
+#define PMC_PCDR1_PID57_Msk                 (_U_(0x1) << PMC_PCDR1_PID57_Pos)              /**< (PMC_PCDR1) Peripheral Clock 57 Disable Mask */
+#define PMC_PCDR1_PID57                     PMC_PCDR1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID57_Msk instead */
+#define PMC_PCDR1_PID58_Pos                 26                                             /**< (PMC_PCDR1) Peripheral Clock 58 Disable Position */
+#define PMC_PCDR1_PID58_Msk                 (_U_(0x1) << PMC_PCDR1_PID58_Pos)              /**< (PMC_PCDR1) Peripheral Clock 58 Disable Mask */
+#define PMC_PCDR1_PID58                     PMC_PCDR1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID58_Msk instead */
+#define PMC_PCDR1_PID59_Pos                 27                                             /**< (PMC_PCDR1) Peripheral Clock 59 Disable Position */
+#define PMC_PCDR1_PID59_Msk                 (_U_(0x1) << PMC_PCDR1_PID59_Pos)              /**< (PMC_PCDR1) Peripheral Clock 59 Disable Mask */
+#define PMC_PCDR1_PID59                     PMC_PCDR1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID59_Msk instead */
+#define PMC_PCDR1_PID60_Pos                 28                                             /**< (PMC_PCDR1) Peripheral Clock 60 Disable Position */
+#define PMC_PCDR1_PID60_Msk                 (_U_(0x1) << PMC_PCDR1_PID60_Pos)              /**< (PMC_PCDR1) Peripheral Clock 60 Disable Mask */
+#define PMC_PCDR1_PID60                     PMC_PCDR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID60_Msk instead */
+#define PMC_PCDR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCDR1) Register MASK  (Use PMC_PCDR1_Msk instead)  */
+#define PMC_PCDR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCDR1) Register Mask  */
+
+#define PMC_PCDR1_PID_Pos                   0                                              /**< (PMC_PCDR1 Position) Peripheral Clock 6x Disable */
+#define PMC_PCDR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR1_PID_Pos)          /**< (PMC_PCDR1 Mask) PID */
+#define PMC_PCDR1_PID(value)                (PMC_PCDR1_PID_Msk & ((value) << PMC_PCDR1_PID_Pos))  
+
+/* -------- PMC_PCSR1 : (PMC Offset: 0x108) (R/ 32) Peripheral Clock Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Status               */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral Clock 33 Status               */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral Clock 34 Status               */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral Clock 35 Status               */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral Clock 37 Status               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral Clock 39 Status               */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral Clock 40 Status               */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral Clock 41 Status               */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral Clock 42 Status               */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral Clock 43 Status               */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral Clock 44 Status               */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral Clock 45 Status               */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral Clock 46 Status               */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral Clock 47 Status               */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral Clock 48 Status               */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral Clock 49 Status               */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Status               */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Status               */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Status               */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Status               */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Status               */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Status               */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Status               */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral Clock 59 Status               */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral Clock 60 Status               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Status               */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCSR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCSR1_OFFSET                    (0x108)                                       /**<  (PMC_PCSR1) Peripheral Clock Status Register 1  Offset */
+
+#define PMC_PCSR1_PID32_Pos                 0                                              /**< (PMC_PCSR1) Peripheral Clock 32 Status Position */
+#define PMC_PCSR1_PID32_Msk                 (_U_(0x1) << PMC_PCSR1_PID32_Pos)              /**< (PMC_PCSR1) Peripheral Clock 32 Status Mask */
+#define PMC_PCSR1_PID32                     PMC_PCSR1_PID32_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID32_Msk instead */
+#define PMC_PCSR1_PID33_Pos                 1                                              /**< (PMC_PCSR1) Peripheral Clock 33 Status Position */
+#define PMC_PCSR1_PID33_Msk                 (_U_(0x1) << PMC_PCSR1_PID33_Pos)              /**< (PMC_PCSR1) Peripheral Clock 33 Status Mask */
+#define PMC_PCSR1_PID33                     PMC_PCSR1_PID33_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID33_Msk instead */
+#define PMC_PCSR1_PID34_Pos                 2                                              /**< (PMC_PCSR1) Peripheral Clock 34 Status Position */
+#define PMC_PCSR1_PID34_Msk                 (_U_(0x1) << PMC_PCSR1_PID34_Pos)              /**< (PMC_PCSR1) Peripheral Clock 34 Status Mask */
+#define PMC_PCSR1_PID34                     PMC_PCSR1_PID34_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID34_Msk instead */
+#define PMC_PCSR1_PID35_Pos                 3                                              /**< (PMC_PCSR1) Peripheral Clock 35 Status Position */
+#define PMC_PCSR1_PID35_Msk                 (_U_(0x1) << PMC_PCSR1_PID35_Pos)              /**< (PMC_PCSR1) Peripheral Clock 35 Status Mask */
+#define PMC_PCSR1_PID35                     PMC_PCSR1_PID35_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID35_Msk instead */
+#define PMC_PCSR1_PID37_Pos                 5                                              /**< (PMC_PCSR1) Peripheral Clock 37 Status Position */
+#define PMC_PCSR1_PID37_Msk                 (_U_(0x1) << PMC_PCSR1_PID37_Pos)              /**< (PMC_PCSR1) Peripheral Clock 37 Status Mask */
+#define PMC_PCSR1_PID37                     PMC_PCSR1_PID37_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID37_Msk instead */
+#define PMC_PCSR1_PID39_Pos                 7                                              /**< (PMC_PCSR1) Peripheral Clock 39 Status Position */
+#define PMC_PCSR1_PID39_Msk                 (_U_(0x1) << PMC_PCSR1_PID39_Pos)              /**< (PMC_PCSR1) Peripheral Clock 39 Status Mask */
+#define PMC_PCSR1_PID39                     PMC_PCSR1_PID39_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID39_Msk instead */
+#define PMC_PCSR1_PID40_Pos                 8                                              /**< (PMC_PCSR1) Peripheral Clock 40 Status Position */
+#define PMC_PCSR1_PID40_Msk                 (_U_(0x1) << PMC_PCSR1_PID40_Pos)              /**< (PMC_PCSR1) Peripheral Clock 40 Status Mask */
+#define PMC_PCSR1_PID40                     PMC_PCSR1_PID40_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID40_Msk instead */
+#define PMC_PCSR1_PID41_Pos                 9                                              /**< (PMC_PCSR1) Peripheral Clock 41 Status Position */
+#define PMC_PCSR1_PID41_Msk                 (_U_(0x1) << PMC_PCSR1_PID41_Pos)              /**< (PMC_PCSR1) Peripheral Clock 41 Status Mask */
+#define PMC_PCSR1_PID41                     PMC_PCSR1_PID41_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID41_Msk instead */
+#define PMC_PCSR1_PID42_Pos                 10                                             /**< (PMC_PCSR1) Peripheral Clock 42 Status Position */
+#define PMC_PCSR1_PID42_Msk                 (_U_(0x1) << PMC_PCSR1_PID42_Pos)              /**< (PMC_PCSR1) Peripheral Clock 42 Status Mask */
+#define PMC_PCSR1_PID42                     PMC_PCSR1_PID42_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID42_Msk instead */
+#define PMC_PCSR1_PID43_Pos                 11                                             /**< (PMC_PCSR1) Peripheral Clock 43 Status Position */
+#define PMC_PCSR1_PID43_Msk                 (_U_(0x1) << PMC_PCSR1_PID43_Pos)              /**< (PMC_PCSR1) Peripheral Clock 43 Status Mask */
+#define PMC_PCSR1_PID43                     PMC_PCSR1_PID43_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID43_Msk instead */
+#define PMC_PCSR1_PID44_Pos                 12                                             /**< (PMC_PCSR1) Peripheral Clock 44 Status Position */
+#define PMC_PCSR1_PID44_Msk                 (_U_(0x1) << PMC_PCSR1_PID44_Pos)              /**< (PMC_PCSR1) Peripheral Clock 44 Status Mask */
+#define PMC_PCSR1_PID44                     PMC_PCSR1_PID44_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID44_Msk instead */
+#define PMC_PCSR1_PID45_Pos                 13                                             /**< (PMC_PCSR1) Peripheral Clock 45 Status Position */
+#define PMC_PCSR1_PID45_Msk                 (_U_(0x1) << PMC_PCSR1_PID45_Pos)              /**< (PMC_PCSR1) Peripheral Clock 45 Status Mask */
+#define PMC_PCSR1_PID45                     PMC_PCSR1_PID45_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID45_Msk instead */
+#define PMC_PCSR1_PID46_Pos                 14                                             /**< (PMC_PCSR1) Peripheral Clock 46 Status Position */
+#define PMC_PCSR1_PID46_Msk                 (_U_(0x1) << PMC_PCSR1_PID46_Pos)              /**< (PMC_PCSR1) Peripheral Clock 46 Status Mask */
+#define PMC_PCSR1_PID46                     PMC_PCSR1_PID46_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID46_Msk instead */
+#define PMC_PCSR1_PID47_Pos                 15                                             /**< (PMC_PCSR1) Peripheral Clock 47 Status Position */
+#define PMC_PCSR1_PID47_Msk                 (_U_(0x1) << PMC_PCSR1_PID47_Pos)              /**< (PMC_PCSR1) Peripheral Clock 47 Status Mask */
+#define PMC_PCSR1_PID47                     PMC_PCSR1_PID47_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID47_Msk instead */
+#define PMC_PCSR1_PID48_Pos                 16                                             /**< (PMC_PCSR1) Peripheral Clock 48 Status Position */
+#define PMC_PCSR1_PID48_Msk                 (_U_(0x1) << PMC_PCSR1_PID48_Pos)              /**< (PMC_PCSR1) Peripheral Clock 48 Status Mask */
+#define PMC_PCSR1_PID48                     PMC_PCSR1_PID48_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID48_Msk instead */
+#define PMC_PCSR1_PID49_Pos                 17                                             /**< (PMC_PCSR1) Peripheral Clock 49 Status Position */
+#define PMC_PCSR1_PID49_Msk                 (_U_(0x1) << PMC_PCSR1_PID49_Pos)              /**< (PMC_PCSR1) Peripheral Clock 49 Status Mask */
+#define PMC_PCSR1_PID49                     PMC_PCSR1_PID49_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID49_Msk instead */
+#define PMC_PCSR1_PID50_Pos                 18                                             /**< (PMC_PCSR1) Peripheral Clock 50 Status Position */
+#define PMC_PCSR1_PID50_Msk                 (_U_(0x1) << PMC_PCSR1_PID50_Pos)              /**< (PMC_PCSR1) Peripheral Clock 50 Status Mask */
+#define PMC_PCSR1_PID50                     PMC_PCSR1_PID50_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID50_Msk instead */
+#define PMC_PCSR1_PID51_Pos                 19                                             /**< (PMC_PCSR1) Peripheral Clock 51 Status Position */
+#define PMC_PCSR1_PID51_Msk                 (_U_(0x1) << PMC_PCSR1_PID51_Pos)              /**< (PMC_PCSR1) Peripheral Clock 51 Status Mask */
+#define PMC_PCSR1_PID51                     PMC_PCSR1_PID51_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID51_Msk instead */
+#define PMC_PCSR1_PID52_Pos                 20                                             /**< (PMC_PCSR1) Peripheral Clock 52 Status Position */
+#define PMC_PCSR1_PID52_Msk                 (_U_(0x1) << PMC_PCSR1_PID52_Pos)              /**< (PMC_PCSR1) Peripheral Clock 52 Status Mask */
+#define PMC_PCSR1_PID52                     PMC_PCSR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID52_Msk instead */
+#define PMC_PCSR1_PID53_Pos                 21                                             /**< (PMC_PCSR1) Peripheral Clock 53 Status Position */
+#define PMC_PCSR1_PID53_Msk                 (_U_(0x1) << PMC_PCSR1_PID53_Pos)              /**< (PMC_PCSR1) Peripheral Clock 53 Status Mask */
+#define PMC_PCSR1_PID53                     PMC_PCSR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID53_Msk instead */
+#define PMC_PCSR1_PID56_Pos                 24                                             /**< (PMC_PCSR1) Peripheral Clock 56 Status Position */
+#define PMC_PCSR1_PID56_Msk                 (_U_(0x1) << PMC_PCSR1_PID56_Pos)              /**< (PMC_PCSR1) Peripheral Clock 56 Status Mask */
+#define PMC_PCSR1_PID56                     PMC_PCSR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID56_Msk instead */
+#define PMC_PCSR1_PID57_Pos                 25                                             /**< (PMC_PCSR1) Peripheral Clock 57 Status Position */
+#define PMC_PCSR1_PID57_Msk                 (_U_(0x1) << PMC_PCSR1_PID57_Pos)              /**< (PMC_PCSR1) Peripheral Clock 57 Status Mask */
+#define PMC_PCSR1_PID57                     PMC_PCSR1_PID57_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID57_Msk instead */
+#define PMC_PCSR1_PID58_Pos                 26                                             /**< (PMC_PCSR1) Peripheral Clock 58 Status Position */
+#define PMC_PCSR1_PID58_Msk                 (_U_(0x1) << PMC_PCSR1_PID58_Pos)              /**< (PMC_PCSR1) Peripheral Clock 58 Status Mask */
+#define PMC_PCSR1_PID58                     PMC_PCSR1_PID58_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID58_Msk instead */
+#define PMC_PCSR1_PID59_Pos                 27                                             /**< (PMC_PCSR1) Peripheral Clock 59 Status Position */
+#define PMC_PCSR1_PID59_Msk                 (_U_(0x1) << PMC_PCSR1_PID59_Pos)              /**< (PMC_PCSR1) Peripheral Clock 59 Status Mask */
+#define PMC_PCSR1_PID59                     PMC_PCSR1_PID59_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID59_Msk instead */
+#define PMC_PCSR1_PID60_Pos                 28                                             /**< (PMC_PCSR1) Peripheral Clock 60 Status Position */
+#define PMC_PCSR1_PID60_Msk                 (_U_(0x1) << PMC_PCSR1_PID60_Pos)              /**< (PMC_PCSR1) Peripheral Clock 60 Status Mask */
+#define PMC_PCSR1_PID60                     PMC_PCSR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID60_Msk instead */
+#define PMC_PCSR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCSR1) Register MASK  (Use PMC_PCSR1_Msk instead)  */
+#define PMC_PCSR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCSR1) Register Mask  */
+
+#define PMC_PCSR1_PID_Pos                   0                                              /**< (PMC_PCSR1 Position) Peripheral Clock 6x Status */
+#define PMC_PCSR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR1_PID_Pos)          /**< (PMC_PCSR1 Mask) PID */
+#define PMC_PCSR1_PID(value)                (PMC_PCSR1_PID_Msk & ((value) << PMC_PCSR1_PID_Pos))  
+
+/* -------- PMC_PCR : (PMC Offset: 0x10c) (R/W 32) Peripheral Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID:7;                     /**< bit:   0..6  Peripheral ID                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t GCLKCSS:3;                 /**< bit:  8..10  Generic Clock Source Selection           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t CMD:1;                     /**< bit:     12  Command                                  */
+    uint32_t :7;                        /**< bit: 13..19  Reserved */
+    uint32_t GCLKDIV:8;                 /**< bit: 20..27  Generic Clock Division Ratio             */
+    uint32_t EN:1;                      /**< bit:     28  Enable                                   */
+    uint32_t GCLKEN:1;                  /**< bit:     29  Generic Clock Enable                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PCR_OFFSET                      (0x10C)                                       /**<  (PMC_PCR) Peripheral Control Register  Offset */
+
+#define PMC_PCR_PID_Pos                     0                                              /**< (PMC_PCR) Peripheral ID Position */
+#define PMC_PCR_PID_Msk                     (_U_(0x7F) << PMC_PCR_PID_Pos)                 /**< (PMC_PCR) Peripheral ID Mask */
+#define PMC_PCR_PID(value)                  (PMC_PCR_PID_Msk & ((value) << PMC_PCR_PID_Pos))
+#define PMC_PCR_GCLKCSS_Pos                 8                                              /**< (PMC_PCR) Generic Clock Source Selection Position */
+#define PMC_PCR_GCLKCSS_Msk                 (_U_(0x7) << PMC_PCR_GCLKCSS_Pos)              /**< (PMC_PCR) Generic Clock Source Selection Mask */
+#define PMC_PCR_GCLKCSS(value)              (PMC_PCR_GCLKCSS_Msk & ((value) << PMC_PCR_GCLKCSS_Pos))
+#define   PMC_PCR_GCLKCSS_SLOW_CLK_Val      _U_(0x0)                                       /**< (PMC_PCR) Slow clock is selected  */
+#define   PMC_PCR_GCLKCSS_MAIN_CLK_Val      _U_(0x1)                                       /**< (PMC_PCR) Main clock is selected  */
+#define   PMC_PCR_GCLKCSS_PLLA_CLK_Val      _U_(0x2)                                       /**< (PMC_PCR) PLLACK is selected  */
+#define   PMC_PCR_GCLKCSS_UPLL_CLK_Val      _U_(0x3)                                       /**< (PMC_PCR) UPLL Clock is selected  */
+#define   PMC_PCR_GCLKCSS_MCK_CLK_Val       _U_(0x4)                                       /**< (PMC_PCR) Master Clock is selected  */
+#define PMC_PCR_GCLKCSS_SLOW_CLK            (PMC_PCR_GCLKCSS_SLOW_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) Slow clock is selected Position  */
+#define PMC_PCR_GCLKCSS_MAIN_CLK            (PMC_PCR_GCLKCSS_MAIN_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) Main clock is selected Position  */
+#define PMC_PCR_GCLKCSS_PLLA_CLK            (PMC_PCR_GCLKCSS_PLLA_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) PLLACK is selected Position  */
+#define PMC_PCR_GCLKCSS_UPLL_CLK            (PMC_PCR_GCLKCSS_UPLL_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) UPLL Clock is selected Position  */
+#define PMC_PCR_GCLKCSS_MCK_CLK             (PMC_PCR_GCLKCSS_MCK_CLK_Val << PMC_PCR_GCLKCSS_Pos)  /**< (PMC_PCR) Master Clock is selected Position  */
+#define PMC_PCR_CMD_Pos                     12                                             /**< (PMC_PCR) Command Position */
+#define PMC_PCR_CMD_Msk                     (_U_(0x1) << PMC_PCR_CMD_Pos)                  /**< (PMC_PCR) Command Mask */
+#define PMC_PCR_CMD                         PMC_PCR_CMD_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_CMD_Msk instead */
+#define PMC_PCR_GCLKDIV_Pos                 20                                             /**< (PMC_PCR) Generic Clock Division Ratio Position */
+#define PMC_PCR_GCLKDIV_Msk                 (_U_(0xFF) << PMC_PCR_GCLKDIV_Pos)             /**< (PMC_PCR) Generic Clock Division Ratio Mask */
+#define PMC_PCR_GCLKDIV(value)              (PMC_PCR_GCLKDIV_Msk & ((value) << PMC_PCR_GCLKDIV_Pos))
+#define PMC_PCR_EN_Pos                      28                                             /**< (PMC_PCR) Enable Position */
+#define PMC_PCR_EN_Msk                      (_U_(0x1) << PMC_PCR_EN_Pos)                   /**< (PMC_PCR) Enable Mask */
+#define PMC_PCR_EN                          PMC_PCR_EN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_EN_Msk instead */
+#define PMC_PCR_GCLKEN_Pos                  29                                             /**< (PMC_PCR) Generic Clock Enable Position */
+#define PMC_PCR_GCLKEN_Msk                  (_U_(0x1) << PMC_PCR_GCLKEN_Pos)               /**< (PMC_PCR) Generic Clock Enable Mask */
+#define PMC_PCR_GCLKEN                      PMC_PCR_GCLKEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCR_GCLKEN_Msk instead */
+#define PMC_PCR_MASK                        _U_(0x3FF0177F)                                /**< \deprecated (PMC_PCR) Register MASK  (Use PMC_PCR_Msk instead)  */
+#define PMC_PCR_Msk                         _U_(0x3FF0177F)                                /**< (PMC_PCR) Register Mask  */
+
+
+/* -------- PMC_OCR : (PMC Offset: 0x110) (R/W 32) Oscillator Calibration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CAL4:7;                    /**< bit:   0..6  Main RC Oscillator Calibration Bits for 4 MHz */
+    uint32_t SEL4:1;                    /**< bit:      7  Selection of Main RC Oscillator Calibration Bits for 4 MHz */
+    uint32_t CAL8:7;                    /**< bit:  8..14  Main RC Oscillator Calibration Bits for 8 MHz */
+    uint32_t SEL8:1;                    /**< bit:     15  Selection of Main RC Oscillator Calibration Bits for 8 MHz */
+    uint32_t CAL12:7;                   /**< bit: 16..22  Main RC Oscillator Calibration Bits for 12 MHz */
+    uint32_t SEL12:1;                   /**< bit:     23  Selection of Main RC Oscillator Calibration Bits for 12 MHz */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_OCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_OCR_OFFSET                      (0x110)                                       /**<  (PMC_OCR) Oscillator Calibration Register  Offset */
+
+#define PMC_OCR_CAL4_Pos                    0                                              /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 4 MHz Position */
+#define PMC_OCR_CAL4_Msk                    (_U_(0x7F) << PMC_OCR_CAL4_Pos)                /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 4 MHz Mask */
+#define PMC_OCR_CAL4(value)                 (PMC_OCR_CAL4_Msk & ((value) << PMC_OCR_CAL4_Pos))
+#define PMC_OCR_SEL4_Pos                    7                                              /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 4 MHz Position */
+#define PMC_OCR_SEL4_Msk                    (_U_(0x1) << PMC_OCR_SEL4_Pos)                 /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 4 MHz Mask */
+#define PMC_OCR_SEL4                        PMC_OCR_SEL4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL4_Msk instead */
+#define PMC_OCR_CAL8_Pos                    8                                              /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 8 MHz Position */
+#define PMC_OCR_CAL8_Msk                    (_U_(0x7F) << PMC_OCR_CAL8_Pos)                /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 8 MHz Mask */
+#define PMC_OCR_CAL8(value)                 (PMC_OCR_CAL8_Msk & ((value) << PMC_OCR_CAL8_Pos))
+#define PMC_OCR_SEL8_Pos                    15                                             /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 8 MHz Position */
+#define PMC_OCR_SEL8_Msk                    (_U_(0x1) << PMC_OCR_SEL8_Pos)                 /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 8 MHz Mask */
+#define PMC_OCR_SEL8                        PMC_OCR_SEL8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL8_Msk instead */
+#define PMC_OCR_CAL12_Pos                   16                                             /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 12 MHz Position */
+#define PMC_OCR_CAL12_Msk                   (_U_(0x7F) << PMC_OCR_CAL12_Pos)               /**< (PMC_OCR) Main RC Oscillator Calibration Bits for 12 MHz Mask */
+#define PMC_OCR_CAL12(value)                (PMC_OCR_CAL12_Msk & ((value) << PMC_OCR_CAL12_Pos))
+#define PMC_OCR_SEL12_Pos                   23                                             /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 12 MHz Position */
+#define PMC_OCR_SEL12_Msk                   (_U_(0x1) << PMC_OCR_SEL12_Pos)                /**< (PMC_OCR) Selection of Main RC Oscillator Calibration Bits for 12 MHz Mask */
+#define PMC_OCR_SEL12                       PMC_OCR_SEL12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_OCR_SEL12_Msk instead */
+#define PMC_OCR_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (PMC_OCR) Register MASK  (Use PMC_OCR_Msk instead)  */
+#define PMC_OCR_Msk                         _U_(0xFFFFFF)                                  /**< (PMC_OCR) Register Mask  */
+
+
+/* -------- PMC_SLPWK_ER0 : (PMC Offset: 0x114) (/W 32) SleepWalking Enable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Enable         */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Enable         */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Enable         */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Enable        */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Enable        */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Enable        */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Enable        */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Enable        */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Enable        */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Enable        */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Enable        */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Enable        */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Enable        */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Enable        */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Enable        */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Enable        */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Enable        */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Enable        */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Enable        */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Enable        */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Enable        */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Enable        */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Enable        */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Enable        */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Enable        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Enable        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ER0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ER0_OFFSET                (0x114)                                       /**<  (PMC_SLPWK_ER0) SleepWalking Enable Register 0  Offset */
+
+#define PMC_SLPWK_ER0_PID7_Pos              7                                              /**< (PMC_SLPWK_ER0) Peripheral 7 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID7_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 7 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID7                  PMC_SLPWK_ER0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID7_Msk instead */
+#define PMC_SLPWK_ER0_PID8_Pos              8                                              /**< (PMC_SLPWK_ER0) Peripheral 8 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID8_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 8 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID8                  PMC_SLPWK_ER0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID8_Msk instead */
+#define PMC_SLPWK_ER0_PID9_Pos              9                                              /**< (PMC_SLPWK_ER0) Peripheral 9 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_ER0_PID9_Pos)           /**< (PMC_SLPWK_ER0) Peripheral 9 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID9                  PMC_SLPWK_ER0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID9_Msk instead */
+#define PMC_SLPWK_ER0_PID10_Pos             10                                             /**< (PMC_SLPWK_ER0) Peripheral 10 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID10_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 10 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID10                 PMC_SLPWK_ER0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID10_Msk instead */
+#define PMC_SLPWK_ER0_PID11_Pos             11                                             /**< (PMC_SLPWK_ER0) Peripheral 11 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID11_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 11 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID11                 PMC_SLPWK_ER0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID11_Msk instead */
+#define PMC_SLPWK_ER0_PID12_Pos             12                                             /**< (PMC_SLPWK_ER0) Peripheral 12 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID12_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 12 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID12                 PMC_SLPWK_ER0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID12_Msk instead */
+#define PMC_SLPWK_ER0_PID13_Pos             13                                             /**< (PMC_SLPWK_ER0) Peripheral 13 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID13_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 13 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID13                 PMC_SLPWK_ER0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID13_Msk instead */
+#define PMC_SLPWK_ER0_PID14_Pos             14                                             /**< (PMC_SLPWK_ER0) Peripheral 14 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID14_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 14 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID14                 PMC_SLPWK_ER0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID14_Msk instead */
+#define PMC_SLPWK_ER0_PID15_Pos             15                                             /**< (PMC_SLPWK_ER0) Peripheral 15 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID15_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 15 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID15                 PMC_SLPWK_ER0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID15_Msk instead */
+#define PMC_SLPWK_ER0_PID16_Pos             16                                             /**< (PMC_SLPWK_ER0) Peripheral 16 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID16_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 16 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID16                 PMC_SLPWK_ER0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID16_Msk instead */
+#define PMC_SLPWK_ER0_PID17_Pos             17                                             /**< (PMC_SLPWK_ER0) Peripheral 17 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID17_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 17 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID17                 PMC_SLPWK_ER0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID17_Msk instead */
+#define PMC_SLPWK_ER0_PID18_Pos             18                                             /**< (PMC_SLPWK_ER0) Peripheral 18 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID18_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 18 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID18                 PMC_SLPWK_ER0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID18_Msk instead */
+#define PMC_SLPWK_ER0_PID19_Pos             19                                             /**< (PMC_SLPWK_ER0) Peripheral 19 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID19_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 19 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID19                 PMC_SLPWK_ER0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID19_Msk instead */
+#define PMC_SLPWK_ER0_PID20_Pos             20                                             /**< (PMC_SLPWK_ER0) Peripheral 20 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID20_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 20 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID20                 PMC_SLPWK_ER0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID20_Msk instead */
+#define PMC_SLPWK_ER0_PID21_Pos             21                                             /**< (PMC_SLPWK_ER0) Peripheral 21 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID21_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 21 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID21                 PMC_SLPWK_ER0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID21_Msk instead */
+#define PMC_SLPWK_ER0_PID22_Pos             22                                             /**< (PMC_SLPWK_ER0) Peripheral 22 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID22_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 22 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID22                 PMC_SLPWK_ER0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID22_Msk instead */
+#define PMC_SLPWK_ER0_PID23_Pos             23                                             /**< (PMC_SLPWK_ER0) Peripheral 23 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID23_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 23 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID23                 PMC_SLPWK_ER0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID23_Msk instead */
+#define PMC_SLPWK_ER0_PID24_Pos             24                                             /**< (PMC_SLPWK_ER0) Peripheral 24 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID24_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 24 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID24                 PMC_SLPWK_ER0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID24_Msk instead */
+#define PMC_SLPWK_ER0_PID25_Pos             25                                             /**< (PMC_SLPWK_ER0) Peripheral 25 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID25_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 25 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID25                 PMC_SLPWK_ER0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID25_Msk instead */
+#define PMC_SLPWK_ER0_PID26_Pos             26                                             /**< (PMC_SLPWK_ER0) Peripheral 26 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID26_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 26 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID26                 PMC_SLPWK_ER0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID26_Msk instead */
+#define PMC_SLPWK_ER0_PID27_Pos             27                                             /**< (PMC_SLPWK_ER0) Peripheral 27 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID27_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 27 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID27                 PMC_SLPWK_ER0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID27_Msk instead */
+#define PMC_SLPWK_ER0_PID28_Pos             28                                             /**< (PMC_SLPWK_ER0) Peripheral 28 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID28_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 28 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID28                 PMC_SLPWK_ER0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID28_Msk instead */
+#define PMC_SLPWK_ER0_PID29_Pos             29                                             /**< (PMC_SLPWK_ER0) Peripheral 29 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID29_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 29 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID29                 PMC_SLPWK_ER0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID29_Msk instead */
+#define PMC_SLPWK_ER0_PID30_Pos             30                                             /**< (PMC_SLPWK_ER0) Peripheral 30 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID30_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 30 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID30                 PMC_SLPWK_ER0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID30_Msk instead */
+#define PMC_SLPWK_ER0_PID31_Pos             31                                             /**< (PMC_SLPWK_ER0) Peripheral 31 SleepWalking Enable Position */
+#define PMC_SLPWK_ER0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_ER0_PID31_Pos)          /**< (PMC_SLPWK_ER0) Peripheral 31 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER0_PID31                 PMC_SLPWK_ER0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER0_PID31_Msk instead */
+#define PMC_SLPWK_ER0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_ER0) Register MASK  (Use PMC_SLPWK_ER0_Msk instead)  */
+#define PMC_SLPWK_ER0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_ER0) Register Mask  */
+
+#define PMC_SLPWK_ER0_PID_Pos               7                                              /**< (PMC_SLPWK_ER0 Position) Peripheral 3x SleepWalking Enable */
+#define PMC_SLPWK_ER0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_ER0_PID_Pos)      /**< (PMC_SLPWK_ER0 Mask) PID */
+#define PMC_SLPWK_ER0_PID(value)            (PMC_SLPWK_ER0_PID_Msk & ((value) << PMC_SLPWK_ER0_PID_Pos))  
+
+/* -------- PMC_SLPWK_DR0 : (PMC Offset: 0x118) (/W 32) SleepWalking Disable Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Disable        */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Disable        */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Disable        */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Disable       */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Disable       */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Disable       */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Disable       */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Disable       */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Disable       */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Disable       */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Disable       */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Disable       */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Disable       */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Disable       */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Disable       */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Disable       */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Disable       */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Disable       */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Disable       */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Disable       */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Disable       */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Disable       */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Disable       */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Disable       */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Disable       */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Disable       */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_DR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_DR0_OFFSET                (0x118)                                       /**<  (PMC_SLPWK_DR0) SleepWalking Disable Register 0  Offset */
+
+#define PMC_SLPWK_DR0_PID7_Pos              7                                              /**< (PMC_SLPWK_DR0) Peripheral 7 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID7_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 7 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID7                  PMC_SLPWK_DR0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID7_Msk instead */
+#define PMC_SLPWK_DR0_PID8_Pos              8                                              /**< (PMC_SLPWK_DR0) Peripheral 8 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID8_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 8 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID8                  PMC_SLPWK_DR0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID8_Msk instead */
+#define PMC_SLPWK_DR0_PID9_Pos              9                                              /**< (PMC_SLPWK_DR0) Peripheral 9 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_DR0_PID9_Pos)           /**< (PMC_SLPWK_DR0) Peripheral 9 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID9                  PMC_SLPWK_DR0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID9_Msk instead */
+#define PMC_SLPWK_DR0_PID10_Pos             10                                             /**< (PMC_SLPWK_DR0) Peripheral 10 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID10_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 10 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID10                 PMC_SLPWK_DR0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID10_Msk instead */
+#define PMC_SLPWK_DR0_PID11_Pos             11                                             /**< (PMC_SLPWK_DR0) Peripheral 11 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID11_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 11 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID11                 PMC_SLPWK_DR0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID11_Msk instead */
+#define PMC_SLPWK_DR0_PID12_Pos             12                                             /**< (PMC_SLPWK_DR0) Peripheral 12 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID12_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 12 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID12                 PMC_SLPWK_DR0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID12_Msk instead */
+#define PMC_SLPWK_DR0_PID13_Pos             13                                             /**< (PMC_SLPWK_DR0) Peripheral 13 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID13_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 13 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID13                 PMC_SLPWK_DR0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID13_Msk instead */
+#define PMC_SLPWK_DR0_PID14_Pos             14                                             /**< (PMC_SLPWK_DR0) Peripheral 14 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID14_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 14 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID14                 PMC_SLPWK_DR0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID14_Msk instead */
+#define PMC_SLPWK_DR0_PID15_Pos             15                                             /**< (PMC_SLPWK_DR0) Peripheral 15 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID15_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 15 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID15                 PMC_SLPWK_DR0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID15_Msk instead */
+#define PMC_SLPWK_DR0_PID16_Pos             16                                             /**< (PMC_SLPWK_DR0) Peripheral 16 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID16_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 16 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID16                 PMC_SLPWK_DR0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID16_Msk instead */
+#define PMC_SLPWK_DR0_PID17_Pos             17                                             /**< (PMC_SLPWK_DR0) Peripheral 17 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID17_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 17 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID17                 PMC_SLPWK_DR0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID17_Msk instead */
+#define PMC_SLPWK_DR0_PID18_Pos             18                                             /**< (PMC_SLPWK_DR0) Peripheral 18 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID18_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 18 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID18                 PMC_SLPWK_DR0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID18_Msk instead */
+#define PMC_SLPWK_DR0_PID19_Pos             19                                             /**< (PMC_SLPWK_DR0) Peripheral 19 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID19_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 19 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID19                 PMC_SLPWK_DR0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID19_Msk instead */
+#define PMC_SLPWK_DR0_PID20_Pos             20                                             /**< (PMC_SLPWK_DR0) Peripheral 20 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID20_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 20 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID20                 PMC_SLPWK_DR0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID20_Msk instead */
+#define PMC_SLPWK_DR0_PID21_Pos             21                                             /**< (PMC_SLPWK_DR0) Peripheral 21 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID21_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 21 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID21                 PMC_SLPWK_DR0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID21_Msk instead */
+#define PMC_SLPWK_DR0_PID22_Pos             22                                             /**< (PMC_SLPWK_DR0) Peripheral 22 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID22_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 22 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID22                 PMC_SLPWK_DR0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID22_Msk instead */
+#define PMC_SLPWK_DR0_PID23_Pos             23                                             /**< (PMC_SLPWK_DR0) Peripheral 23 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID23_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 23 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID23                 PMC_SLPWK_DR0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID23_Msk instead */
+#define PMC_SLPWK_DR0_PID24_Pos             24                                             /**< (PMC_SLPWK_DR0) Peripheral 24 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID24_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 24 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID24                 PMC_SLPWK_DR0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID24_Msk instead */
+#define PMC_SLPWK_DR0_PID25_Pos             25                                             /**< (PMC_SLPWK_DR0) Peripheral 25 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID25_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 25 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID25                 PMC_SLPWK_DR0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID25_Msk instead */
+#define PMC_SLPWK_DR0_PID26_Pos             26                                             /**< (PMC_SLPWK_DR0) Peripheral 26 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID26_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 26 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID26                 PMC_SLPWK_DR0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID26_Msk instead */
+#define PMC_SLPWK_DR0_PID27_Pos             27                                             /**< (PMC_SLPWK_DR0) Peripheral 27 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID27_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 27 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID27                 PMC_SLPWK_DR0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID27_Msk instead */
+#define PMC_SLPWK_DR0_PID28_Pos             28                                             /**< (PMC_SLPWK_DR0) Peripheral 28 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID28_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 28 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID28                 PMC_SLPWK_DR0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID28_Msk instead */
+#define PMC_SLPWK_DR0_PID29_Pos             29                                             /**< (PMC_SLPWK_DR0) Peripheral 29 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID29_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 29 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID29                 PMC_SLPWK_DR0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID29_Msk instead */
+#define PMC_SLPWK_DR0_PID30_Pos             30                                             /**< (PMC_SLPWK_DR0) Peripheral 30 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID30_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 30 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID30                 PMC_SLPWK_DR0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID30_Msk instead */
+#define PMC_SLPWK_DR0_PID31_Pos             31                                             /**< (PMC_SLPWK_DR0) Peripheral 31 SleepWalking Disable Position */
+#define PMC_SLPWK_DR0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_DR0_PID31_Pos)          /**< (PMC_SLPWK_DR0) Peripheral 31 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR0_PID31                 PMC_SLPWK_DR0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR0_PID31_Msk instead */
+#define PMC_SLPWK_DR0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_DR0) Register MASK  (Use PMC_SLPWK_DR0_Msk instead)  */
+#define PMC_SLPWK_DR0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_DR0) Register Mask  */
+
+#define PMC_SLPWK_DR0_PID_Pos               7                                              /**< (PMC_SLPWK_DR0 Position) Peripheral 3x SleepWalking Disable */
+#define PMC_SLPWK_DR0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_DR0_PID_Pos)      /**< (PMC_SLPWK_DR0 Mask) PID */
+#define PMC_SLPWK_DR0_PID(value)            (PMC_SLPWK_DR0_PID_Msk & ((value) << PMC_SLPWK_DR0_PID_Pos))  
+
+/* -------- PMC_SLPWK_SR0 : (PMC Offset: 0x11c) (R/ 32) SleepWalking Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 SleepWalking Status         */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 SleepWalking Status         */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 SleepWalking Status         */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 SleepWalking Status        */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 SleepWalking Status        */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 SleepWalking Status        */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 SleepWalking Status        */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 SleepWalking Status        */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 SleepWalking Status        */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 SleepWalking Status        */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 SleepWalking Status        */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 SleepWalking Status        */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 SleepWalking Status        */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 SleepWalking Status        */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 SleepWalking Status        */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 SleepWalking Status        */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 SleepWalking Status        */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 SleepWalking Status        */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 SleepWalking Status        */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 SleepWalking Status        */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 SleepWalking Status        */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 SleepWalking Status        */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 SleepWalking Status        */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 SleepWalking Status        */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 SleepWalking Status        */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x SleepWalking Status        */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_SR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_SR0_OFFSET                (0x11C)                                       /**<  (PMC_SLPWK_SR0) SleepWalking Status Register 0  Offset */
+
+#define PMC_SLPWK_SR0_PID7_Pos              7                                              /**< (PMC_SLPWK_SR0) Peripheral 7 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID7_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID7_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 7 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID7                  PMC_SLPWK_SR0_PID7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID7_Msk instead */
+#define PMC_SLPWK_SR0_PID8_Pos              8                                              /**< (PMC_SLPWK_SR0) Peripheral 8 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID8_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID8_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 8 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID8                  PMC_SLPWK_SR0_PID8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID8_Msk instead */
+#define PMC_SLPWK_SR0_PID9_Pos              9                                              /**< (PMC_SLPWK_SR0) Peripheral 9 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID9_Msk              (_U_(0x1) << PMC_SLPWK_SR0_PID9_Pos)           /**< (PMC_SLPWK_SR0) Peripheral 9 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID9                  PMC_SLPWK_SR0_PID9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID9_Msk instead */
+#define PMC_SLPWK_SR0_PID10_Pos             10                                             /**< (PMC_SLPWK_SR0) Peripheral 10 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID10_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID10_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 10 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID10                 PMC_SLPWK_SR0_PID10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID10_Msk instead */
+#define PMC_SLPWK_SR0_PID11_Pos             11                                             /**< (PMC_SLPWK_SR0) Peripheral 11 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID11_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID11_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 11 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID11                 PMC_SLPWK_SR0_PID11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID11_Msk instead */
+#define PMC_SLPWK_SR0_PID12_Pos             12                                             /**< (PMC_SLPWK_SR0) Peripheral 12 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID12_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID12_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 12 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID12                 PMC_SLPWK_SR0_PID12_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID12_Msk instead */
+#define PMC_SLPWK_SR0_PID13_Pos             13                                             /**< (PMC_SLPWK_SR0) Peripheral 13 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID13_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID13_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 13 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID13                 PMC_SLPWK_SR0_PID13_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID13_Msk instead */
+#define PMC_SLPWK_SR0_PID14_Pos             14                                             /**< (PMC_SLPWK_SR0) Peripheral 14 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID14_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID14_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 14 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID14                 PMC_SLPWK_SR0_PID14_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID14_Msk instead */
+#define PMC_SLPWK_SR0_PID15_Pos             15                                             /**< (PMC_SLPWK_SR0) Peripheral 15 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID15_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID15_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 15 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID15                 PMC_SLPWK_SR0_PID15_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID15_Msk instead */
+#define PMC_SLPWK_SR0_PID16_Pos             16                                             /**< (PMC_SLPWK_SR0) Peripheral 16 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID16_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID16_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 16 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID16                 PMC_SLPWK_SR0_PID16_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID16_Msk instead */
+#define PMC_SLPWK_SR0_PID17_Pos             17                                             /**< (PMC_SLPWK_SR0) Peripheral 17 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID17_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID17_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 17 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID17                 PMC_SLPWK_SR0_PID17_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID17_Msk instead */
+#define PMC_SLPWK_SR0_PID18_Pos             18                                             /**< (PMC_SLPWK_SR0) Peripheral 18 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID18_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID18_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 18 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID18                 PMC_SLPWK_SR0_PID18_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID18_Msk instead */
+#define PMC_SLPWK_SR0_PID19_Pos             19                                             /**< (PMC_SLPWK_SR0) Peripheral 19 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID19_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID19_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 19 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID19                 PMC_SLPWK_SR0_PID19_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID19_Msk instead */
+#define PMC_SLPWK_SR0_PID20_Pos             20                                             /**< (PMC_SLPWK_SR0) Peripheral 20 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID20_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID20_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 20 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID20                 PMC_SLPWK_SR0_PID20_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID20_Msk instead */
+#define PMC_SLPWK_SR0_PID21_Pos             21                                             /**< (PMC_SLPWK_SR0) Peripheral 21 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID21_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID21_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 21 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID21                 PMC_SLPWK_SR0_PID21_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID21_Msk instead */
+#define PMC_SLPWK_SR0_PID22_Pos             22                                             /**< (PMC_SLPWK_SR0) Peripheral 22 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID22_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID22_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 22 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID22                 PMC_SLPWK_SR0_PID22_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID22_Msk instead */
+#define PMC_SLPWK_SR0_PID23_Pos             23                                             /**< (PMC_SLPWK_SR0) Peripheral 23 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID23_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID23_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 23 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID23                 PMC_SLPWK_SR0_PID23_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID23_Msk instead */
+#define PMC_SLPWK_SR0_PID24_Pos             24                                             /**< (PMC_SLPWK_SR0) Peripheral 24 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID24_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID24_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 24 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID24                 PMC_SLPWK_SR0_PID24_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID24_Msk instead */
+#define PMC_SLPWK_SR0_PID25_Pos             25                                             /**< (PMC_SLPWK_SR0) Peripheral 25 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID25_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID25_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 25 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID25                 PMC_SLPWK_SR0_PID25_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID25_Msk instead */
+#define PMC_SLPWK_SR0_PID26_Pos             26                                             /**< (PMC_SLPWK_SR0) Peripheral 26 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID26_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID26_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 26 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID26                 PMC_SLPWK_SR0_PID26_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID26_Msk instead */
+#define PMC_SLPWK_SR0_PID27_Pos             27                                             /**< (PMC_SLPWK_SR0) Peripheral 27 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID27_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID27_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 27 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID27                 PMC_SLPWK_SR0_PID27_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID27_Msk instead */
+#define PMC_SLPWK_SR0_PID28_Pos             28                                             /**< (PMC_SLPWK_SR0) Peripheral 28 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID28_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID28_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 28 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID28                 PMC_SLPWK_SR0_PID28_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID28_Msk instead */
+#define PMC_SLPWK_SR0_PID29_Pos             29                                             /**< (PMC_SLPWK_SR0) Peripheral 29 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID29_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID29_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 29 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID29                 PMC_SLPWK_SR0_PID29_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID29_Msk instead */
+#define PMC_SLPWK_SR0_PID30_Pos             30                                             /**< (PMC_SLPWK_SR0) Peripheral 30 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID30_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID30_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 30 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID30                 PMC_SLPWK_SR0_PID30_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID30_Msk instead */
+#define PMC_SLPWK_SR0_PID31_Pos             31                                             /**< (PMC_SLPWK_SR0) Peripheral 31 SleepWalking Status Position */
+#define PMC_SLPWK_SR0_PID31_Msk             (_U_(0x1) << PMC_SLPWK_SR0_PID31_Pos)          /**< (PMC_SLPWK_SR0) Peripheral 31 SleepWalking Status Mask */
+#define PMC_SLPWK_SR0_PID31                 PMC_SLPWK_SR0_PID31_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR0_PID31_Msk instead */
+#define PMC_SLPWK_SR0_MASK                  _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_SR0) Register MASK  (Use PMC_SLPWK_SR0_Msk instead)  */
+#define PMC_SLPWK_SR0_Msk                   _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_SR0) Register Mask  */
+
+#define PMC_SLPWK_SR0_PID_Pos               7                                              /**< (PMC_SLPWK_SR0 Position) Peripheral 3x SleepWalking Status */
+#define PMC_SLPWK_SR0_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_SR0_PID_Pos)      /**< (PMC_SLPWK_SR0 Mask) PID */
+#define PMC_SLPWK_SR0_PID(value)            (PMC_SLPWK_SR0_PID_Msk & ((value) << PMC_SLPWK_SR0_PID_Pos))  
+
+/* -------- PMC_SLPWK_ASR0 : (PMC Offset: 0x120) (R/ 32) SleepWalking Activity Status Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID7:1;                    /**< bit:      7  Peripheral 7 Activity Status             */
+    uint32_t PID8:1;                    /**< bit:      8  Peripheral 8 Activity Status             */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral 9 Activity Status             */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral 10 Activity Status            */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral 11 Activity Status            */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral 12 Activity Status            */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral 13 Activity Status            */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral 14 Activity Status            */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral 15 Activity Status            */
+    uint32_t PID16:1;                   /**< bit:     16  Peripheral 16 Activity Status            */
+    uint32_t PID17:1;                   /**< bit:     17  Peripheral 17 Activity Status            */
+    uint32_t PID18:1;                   /**< bit:     18  Peripheral 18 Activity Status            */
+    uint32_t PID19:1;                   /**< bit:     19  Peripheral 19 Activity Status            */
+    uint32_t PID20:1;                   /**< bit:     20  Peripheral 20 Activity Status            */
+    uint32_t PID21:1;                   /**< bit:     21  Peripheral 21 Activity Status            */
+    uint32_t PID22:1;                   /**< bit:     22  Peripheral 22 Activity Status            */
+    uint32_t PID23:1;                   /**< bit:     23  Peripheral 23 Activity Status            */
+    uint32_t PID24:1;                   /**< bit:     24  Peripheral 24 Activity Status            */
+    uint32_t PID25:1;                   /**< bit:     25  Peripheral 25 Activity Status            */
+    uint32_t PID26:1;                   /**< bit:     26  Peripheral 26 Activity Status            */
+    uint32_t PID27:1;                   /**< bit:     27  Peripheral 27 Activity Status            */
+    uint32_t PID28:1;                   /**< bit:     28  Peripheral 28 Activity Status            */
+    uint32_t PID29:1;                   /**< bit:     29  Peripheral 29 Activity Status            */
+    uint32_t PID30:1;                   /**< bit:     30  Peripheral 30 Activity Status            */
+    uint32_t PID31:1;                   /**< bit:     31  Peripheral 31 Activity Status            */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :7;                        /**< bit:   0..6  Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral 3x Activity Status            */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ASR0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ASR0_OFFSET               (0x120)                                       /**<  (PMC_SLPWK_ASR0) SleepWalking Activity Status Register 0  Offset */
+
+#define PMC_SLPWK_ASR0_PID7_Pos             7                                              /**< (PMC_SLPWK_ASR0) Peripheral 7 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID7_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID7_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 7 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID7                 PMC_SLPWK_ASR0_PID7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID7_Msk instead */
+#define PMC_SLPWK_ASR0_PID8_Pos             8                                              /**< (PMC_SLPWK_ASR0) Peripheral 8 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID8_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID8_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 8 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID8                 PMC_SLPWK_ASR0_PID8_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID8_Msk instead */
+#define PMC_SLPWK_ASR0_PID9_Pos             9                                              /**< (PMC_SLPWK_ASR0) Peripheral 9 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID9_Msk             (_U_(0x1) << PMC_SLPWK_ASR0_PID9_Pos)          /**< (PMC_SLPWK_ASR0) Peripheral 9 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID9                 PMC_SLPWK_ASR0_PID9_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID9_Msk instead */
+#define PMC_SLPWK_ASR0_PID10_Pos            10                                             /**< (PMC_SLPWK_ASR0) Peripheral 10 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID10_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID10_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 10 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID10                PMC_SLPWK_ASR0_PID10_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID10_Msk instead */
+#define PMC_SLPWK_ASR0_PID11_Pos            11                                             /**< (PMC_SLPWK_ASR0) Peripheral 11 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID11_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID11_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 11 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID11                PMC_SLPWK_ASR0_PID11_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID11_Msk instead */
+#define PMC_SLPWK_ASR0_PID12_Pos            12                                             /**< (PMC_SLPWK_ASR0) Peripheral 12 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID12_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID12_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 12 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID12                PMC_SLPWK_ASR0_PID12_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID12_Msk instead */
+#define PMC_SLPWK_ASR0_PID13_Pos            13                                             /**< (PMC_SLPWK_ASR0) Peripheral 13 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID13_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID13_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 13 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID13                PMC_SLPWK_ASR0_PID13_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID13_Msk instead */
+#define PMC_SLPWK_ASR0_PID14_Pos            14                                             /**< (PMC_SLPWK_ASR0) Peripheral 14 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID14_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID14_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 14 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID14                PMC_SLPWK_ASR0_PID14_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID14_Msk instead */
+#define PMC_SLPWK_ASR0_PID15_Pos            15                                             /**< (PMC_SLPWK_ASR0) Peripheral 15 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID15_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID15_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 15 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID15                PMC_SLPWK_ASR0_PID15_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID15_Msk instead */
+#define PMC_SLPWK_ASR0_PID16_Pos            16                                             /**< (PMC_SLPWK_ASR0) Peripheral 16 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID16_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID16_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 16 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID16                PMC_SLPWK_ASR0_PID16_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID16_Msk instead */
+#define PMC_SLPWK_ASR0_PID17_Pos            17                                             /**< (PMC_SLPWK_ASR0) Peripheral 17 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID17_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID17_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 17 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID17                PMC_SLPWK_ASR0_PID17_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID17_Msk instead */
+#define PMC_SLPWK_ASR0_PID18_Pos            18                                             /**< (PMC_SLPWK_ASR0) Peripheral 18 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID18_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID18_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 18 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID18                PMC_SLPWK_ASR0_PID18_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID18_Msk instead */
+#define PMC_SLPWK_ASR0_PID19_Pos            19                                             /**< (PMC_SLPWK_ASR0) Peripheral 19 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID19_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID19_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 19 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID19                PMC_SLPWK_ASR0_PID19_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID19_Msk instead */
+#define PMC_SLPWK_ASR0_PID20_Pos            20                                             /**< (PMC_SLPWK_ASR0) Peripheral 20 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID20_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID20_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 20 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID20                PMC_SLPWK_ASR0_PID20_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID20_Msk instead */
+#define PMC_SLPWK_ASR0_PID21_Pos            21                                             /**< (PMC_SLPWK_ASR0) Peripheral 21 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID21_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID21_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 21 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID21                PMC_SLPWK_ASR0_PID21_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID21_Msk instead */
+#define PMC_SLPWK_ASR0_PID22_Pos            22                                             /**< (PMC_SLPWK_ASR0) Peripheral 22 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID22_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID22_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 22 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID22                PMC_SLPWK_ASR0_PID22_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID22_Msk instead */
+#define PMC_SLPWK_ASR0_PID23_Pos            23                                             /**< (PMC_SLPWK_ASR0) Peripheral 23 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID23_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID23_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 23 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID23                PMC_SLPWK_ASR0_PID23_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID23_Msk instead */
+#define PMC_SLPWK_ASR0_PID24_Pos            24                                             /**< (PMC_SLPWK_ASR0) Peripheral 24 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID24_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID24_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 24 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID24                PMC_SLPWK_ASR0_PID24_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID24_Msk instead */
+#define PMC_SLPWK_ASR0_PID25_Pos            25                                             /**< (PMC_SLPWK_ASR0) Peripheral 25 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID25_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID25_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 25 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID25                PMC_SLPWK_ASR0_PID25_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID25_Msk instead */
+#define PMC_SLPWK_ASR0_PID26_Pos            26                                             /**< (PMC_SLPWK_ASR0) Peripheral 26 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID26_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID26_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 26 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID26                PMC_SLPWK_ASR0_PID26_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID26_Msk instead */
+#define PMC_SLPWK_ASR0_PID27_Pos            27                                             /**< (PMC_SLPWK_ASR0) Peripheral 27 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID27_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID27_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 27 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID27                PMC_SLPWK_ASR0_PID27_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID27_Msk instead */
+#define PMC_SLPWK_ASR0_PID28_Pos            28                                             /**< (PMC_SLPWK_ASR0) Peripheral 28 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID28_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID28_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 28 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID28                PMC_SLPWK_ASR0_PID28_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID28_Msk instead */
+#define PMC_SLPWK_ASR0_PID29_Pos            29                                             /**< (PMC_SLPWK_ASR0) Peripheral 29 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID29_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID29_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 29 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID29                PMC_SLPWK_ASR0_PID29_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID29_Msk instead */
+#define PMC_SLPWK_ASR0_PID30_Pos            30                                             /**< (PMC_SLPWK_ASR0) Peripheral 30 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID30_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID30_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 30 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID30                PMC_SLPWK_ASR0_PID30_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID30_Msk instead */
+#define PMC_SLPWK_ASR0_PID31_Pos            31                                             /**< (PMC_SLPWK_ASR0) Peripheral 31 Activity Status Position */
+#define PMC_SLPWK_ASR0_PID31_Msk            (_U_(0x1) << PMC_SLPWK_ASR0_PID31_Pos)         /**< (PMC_SLPWK_ASR0) Peripheral 31 Activity Status Mask */
+#define PMC_SLPWK_ASR0_PID31                PMC_SLPWK_ASR0_PID31_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR0_PID31_Msk instead */
+#define PMC_SLPWK_ASR0_MASK                 _U_(0xFFFFFF80)                                /**< \deprecated (PMC_SLPWK_ASR0) Register MASK  (Use PMC_SLPWK_ASR0_Msk instead)  */
+#define PMC_SLPWK_ASR0_Msk                  _U_(0xFFFFFF80)                                /**< (PMC_SLPWK_ASR0) Register Mask  */
+
+#define PMC_SLPWK_ASR0_PID_Pos              7                                              /**< (PMC_SLPWK_ASR0 Position) Peripheral 3x Activity Status */
+#define PMC_SLPWK_ASR0_PID_Msk              (_U_(0x1FFFFFF) << PMC_SLPWK_ASR0_PID_Pos)     /**< (PMC_SLPWK_ASR0 Mask) PID */
+#define PMC_SLPWK_ASR0_PID(value)           (PMC_SLPWK_ASR0_PID_Msk & ((value) << PMC_SLPWK_ASR0_PID_Pos))  
+
+/* -------- PMC_PMMR : (PMC Offset: 0x130) (R/W 32) PLL Maximum Multiplier Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PLLA_MMAX:11;              /**< bit:  0..10  PLLA Maximum Allowed Multiplier Value    */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_PMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_PMMR_OFFSET                     (0x130)                                       /**<  (PMC_PMMR) PLL Maximum Multiplier Value Register  Offset */
+
+#define PMC_PMMR_PLLA_MMAX_Pos              0                                              /**< (PMC_PMMR) PLLA Maximum Allowed Multiplier Value Position */
+#define PMC_PMMR_PLLA_MMAX_Msk              (_U_(0x7FF) << PMC_PMMR_PLLA_MMAX_Pos)         /**< (PMC_PMMR) PLLA Maximum Allowed Multiplier Value Mask */
+#define PMC_PMMR_PLLA_MMAX(value)           (PMC_PMMR_PLLA_MMAX_Msk & ((value) << PMC_PMMR_PLLA_MMAX_Pos))
+#define PMC_PMMR_MASK                       _U_(0x7FF)                                     /**< \deprecated (PMC_PMMR) Register MASK  (Use PMC_PMMR_Msk instead)  */
+#define PMC_PMMR_Msk                        _U_(0x7FF)                                     /**< (PMC_PMMR) Register Mask  */
+
+
+/* -------- PMC_SLPWK_ER1 : (PMC Offset: 0x134) (/W 32) SleepWalking Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Enable        */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Enable        */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Enable        */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Enable        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Enable        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Enable        */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Enable        */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Enable        */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Enable        */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Enable        */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Enable        */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Enable        */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Enable        */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Enable        */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Enable        */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Enable        */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Enable        */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Enable        */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Enable        */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Enable        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Enable        */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Enable        */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Enable        */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Enable        */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Enable        */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Enable        */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ER1_OFFSET                (0x134)                                       /**<  (PMC_SLPWK_ER1) SleepWalking Enable Register 1  Offset */
+
+#define PMC_SLPWK_ER1_PID32_Pos             0                                              /**< (PMC_SLPWK_ER1) Peripheral 32 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID32_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 32 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID32                 PMC_SLPWK_ER1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID32_Msk instead */
+#define PMC_SLPWK_ER1_PID33_Pos             1                                              /**< (PMC_SLPWK_ER1) Peripheral 33 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID33_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 33 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID33                 PMC_SLPWK_ER1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID33_Msk instead */
+#define PMC_SLPWK_ER1_PID34_Pos             2                                              /**< (PMC_SLPWK_ER1) Peripheral 34 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID34_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 34 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID34                 PMC_SLPWK_ER1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID34_Msk instead */
+#define PMC_SLPWK_ER1_PID35_Pos             3                                              /**< (PMC_SLPWK_ER1) Peripheral 35 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID35_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 35 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID35                 PMC_SLPWK_ER1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID35_Msk instead */
+#define PMC_SLPWK_ER1_PID37_Pos             5                                              /**< (PMC_SLPWK_ER1) Peripheral 37 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID37_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 37 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID37                 PMC_SLPWK_ER1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID37_Msk instead */
+#define PMC_SLPWK_ER1_PID39_Pos             7                                              /**< (PMC_SLPWK_ER1) Peripheral 39 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID39_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 39 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID39                 PMC_SLPWK_ER1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID39_Msk instead */
+#define PMC_SLPWK_ER1_PID40_Pos             8                                              /**< (PMC_SLPWK_ER1) Peripheral 40 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID40_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 40 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID40                 PMC_SLPWK_ER1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID40_Msk instead */
+#define PMC_SLPWK_ER1_PID41_Pos             9                                              /**< (PMC_SLPWK_ER1) Peripheral 41 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID41_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 41 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID41                 PMC_SLPWK_ER1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID41_Msk instead */
+#define PMC_SLPWK_ER1_PID42_Pos             10                                             /**< (PMC_SLPWK_ER1) Peripheral 42 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID42_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 42 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID42                 PMC_SLPWK_ER1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID42_Msk instead */
+#define PMC_SLPWK_ER1_PID43_Pos             11                                             /**< (PMC_SLPWK_ER1) Peripheral 43 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID43_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 43 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID43                 PMC_SLPWK_ER1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID43_Msk instead */
+#define PMC_SLPWK_ER1_PID44_Pos             12                                             /**< (PMC_SLPWK_ER1) Peripheral 44 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID44_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 44 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID44                 PMC_SLPWK_ER1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID44_Msk instead */
+#define PMC_SLPWK_ER1_PID45_Pos             13                                             /**< (PMC_SLPWK_ER1) Peripheral 45 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID45_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 45 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID45                 PMC_SLPWK_ER1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID45_Msk instead */
+#define PMC_SLPWK_ER1_PID46_Pos             14                                             /**< (PMC_SLPWK_ER1) Peripheral 46 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID46_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 46 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID46                 PMC_SLPWK_ER1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID46_Msk instead */
+#define PMC_SLPWK_ER1_PID47_Pos             15                                             /**< (PMC_SLPWK_ER1) Peripheral 47 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID47_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 47 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID47                 PMC_SLPWK_ER1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID47_Msk instead */
+#define PMC_SLPWK_ER1_PID48_Pos             16                                             /**< (PMC_SLPWK_ER1) Peripheral 48 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID48_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 48 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID48                 PMC_SLPWK_ER1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID48_Msk instead */
+#define PMC_SLPWK_ER1_PID49_Pos             17                                             /**< (PMC_SLPWK_ER1) Peripheral 49 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID49_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 49 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID49                 PMC_SLPWK_ER1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID49_Msk instead */
+#define PMC_SLPWK_ER1_PID50_Pos             18                                             /**< (PMC_SLPWK_ER1) Peripheral 50 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID50_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 50 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID50                 PMC_SLPWK_ER1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID50_Msk instead */
+#define PMC_SLPWK_ER1_PID51_Pos             19                                             /**< (PMC_SLPWK_ER1) Peripheral 51 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID51_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 51 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID51                 PMC_SLPWK_ER1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID51_Msk instead */
+#define PMC_SLPWK_ER1_PID52_Pos             20                                             /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID52_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID52                 PMC_SLPWK_ER1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID52_Msk instead */
+#define PMC_SLPWK_ER1_PID53_Pos             21                                             /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID53_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID53                 PMC_SLPWK_ER1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID53_Msk instead */
+#define PMC_SLPWK_ER1_PID56_Pos             24                                             /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID56_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID56                 PMC_SLPWK_ER1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID56_Msk instead */
+#define PMC_SLPWK_ER1_PID57_Pos             25                                             /**< (PMC_SLPWK_ER1) Peripheral 57 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID57_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 57 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID57                 PMC_SLPWK_ER1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID57_Msk instead */
+#define PMC_SLPWK_ER1_PID58_Pos             26                                             /**< (PMC_SLPWK_ER1) Peripheral 58 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID58_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 58 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID58                 PMC_SLPWK_ER1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID58_Msk instead */
+#define PMC_SLPWK_ER1_PID59_Pos             27                                             /**< (PMC_SLPWK_ER1) Peripheral 59 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID59_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 59 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID59                 PMC_SLPWK_ER1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID59_Msk instead */
+#define PMC_SLPWK_ER1_PID60_Pos             28                                             /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Position */
+#define PMC_SLPWK_ER1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID60_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Mask */
+#define PMC_SLPWK_ER1_PID60                 PMC_SLPWK_ER1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID60_Msk instead */
+#define PMC_SLPWK_ER1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ER1) Register MASK  (Use PMC_SLPWK_ER1_Msk instead)  */
+#define PMC_SLPWK_ER1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ER1) Register Mask  */
+
+#define PMC_SLPWK_ER1_PID_Pos               0                                              /**< (PMC_SLPWK_ER1 Position) Peripheral 6x SleepWalking Enable */
+#define PMC_SLPWK_ER1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_ER1_PID_Pos)      /**< (PMC_SLPWK_ER1 Mask) PID */
+#define PMC_SLPWK_ER1_PID(value)            (PMC_SLPWK_ER1_PID_Msk & ((value) << PMC_SLPWK_ER1_PID_Pos))  
+
+/* -------- PMC_SLPWK_DR1 : (PMC Offset: 0x138) (/W 32) SleepWalking Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Disable       */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Disable       */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Disable       */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Disable       */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Disable       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Disable       */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Disable       */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Disable       */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Disable       */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Disable       */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Disable       */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Disable       */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Disable       */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Disable       */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Disable       */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Disable       */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Disable       */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Disable       */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Disable       */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Disable       */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Disable       */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Disable       */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Disable       */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Disable       */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Disable       */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Disable       */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_DR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_DR1_OFFSET                (0x138)                                       /**<  (PMC_SLPWK_DR1) SleepWalking Disable Register 1  Offset */
+
+#define PMC_SLPWK_DR1_PID32_Pos             0                                              /**< (PMC_SLPWK_DR1) Peripheral 32 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID32_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 32 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID32                 PMC_SLPWK_DR1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID32_Msk instead */
+#define PMC_SLPWK_DR1_PID33_Pos             1                                              /**< (PMC_SLPWK_DR1) Peripheral 33 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID33_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 33 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID33                 PMC_SLPWK_DR1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID33_Msk instead */
+#define PMC_SLPWK_DR1_PID34_Pos             2                                              /**< (PMC_SLPWK_DR1) Peripheral 34 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID34_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 34 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID34                 PMC_SLPWK_DR1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID34_Msk instead */
+#define PMC_SLPWK_DR1_PID35_Pos             3                                              /**< (PMC_SLPWK_DR1) Peripheral 35 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID35_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 35 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID35                 PMC_SLPWK_DR1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID35_Msk instead */
+#define PMC_SLPWK_DR1_PID37_Pos             5                                              /**< (PMC_SLPWK_DR1) Peripheral 37 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID37_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 37 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID37                 PMC_SLPWK_DR1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID37_Msk instead */
+#define PMC_SLPWK_DR1_PID39_Pos             7                                              /**< (PMC_SLPWK_DR1) Peripheral 39 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID39_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 39 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID39                 PMC_SLPWK_DR1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID39_Msk instead */
+#define PMC_SLPWK_DR1_PID40_Pos             8                                              /**< (PMC_SLPWK_DR1) Peripheral 40 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID40_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 40 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID40                 PMC_SLPWK_DR1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID40_Msk instead */
+#define PMC_SLPWK_DR1_PID41_Pos             9                                              /**< (PMC_SLPWK_DR1) Peripheral 41 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID41_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 41 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID41                 PMC_SLPWK_DR1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID41_Msk instead */
+#define PMC_SLPWK_DR1_PID42_Pos             10                                             /**< (PMC_SLPWK_DR1) Peripheral 42 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID42_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 42 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID42                 PMC_SLPWK_DR1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID42_Msk instead */
+#define PMC_SLPWK_DR1_PID43_Pos             11                                             /**< (PMC_SLPWK_DR1) Peripheral 43 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID43_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 43 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID43                 PMC_SLPWK_DR1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID43_Msk instead */
+#define PMC_SLPWK_DR1_PID44_Pos             12                                             /**< (PMC_SLPWK_DR1) Peripheral 44 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID44_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 44 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID44                 PMC_SLPWK_DR1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID44_Msk instead */
+#define PMC_SLPWK_DR1_PID45_Pos             13                                             /**< (PMC_SLPWK_DR1) Peripheral 45 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID45_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 45 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID45                 PMC_SLPWK_DR1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID45_Msk instead */
+#define PMC_SLPWK_DR1_PID46_Pos             14                                             /**< (PMC_SLPWK_DR1) Peripheral 46 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID46_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 46 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID46                 PMC_SLPWK_DR1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID46_Msk instead */
+#define PMC_SLPWK_DR1_PID47_Pos             15                                             /**< (PMC_SLPWK_DR1) Peripheral 47 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID47_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 47 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID47                 PMC_SLPWK_DR1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID47_Msk instead */
+#define PMC_SLPWK_DR1_PID48_Pos             16                                             /**< (PMC_SLPWK_DR1) Peripheral 48 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID48_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 48 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID48                 PMC_SLPWK_DR1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID48_Msk instead */
+#define PMC_SLPWK_DR1_PID49_Pos             17                                             /**< (PMC_SLPWK_DR1) Peripheral 49 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID49_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 49 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID49                 PMC_SLPWK_DR1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID49_Msk instead */
+#define PMC_SLPWK_DR1_PID50_Pos             18                                             /**< (PMC_SLPWK_DR1) Peripheral 50 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID50_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 50 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID50                 PMC_SLPWK_DR1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID50_Msk instead */
+#define PMC_SLPWK_DR1_PID51_Pos             19                                             /**< (PMC_SLPWK_DR1) Peripheral 51 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID51_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 51 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID51                 PMC_SLPWK_DR1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID51_Msk instead */
+#define PMC_SLPWK_DR1_PID52_Pos             20                                             /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID52_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID52                 PMC_SLPWK_DR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID52_Msk instead */
+#define PMC_SLPWK_DR1_PID53_Pos             21                                             /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID53_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID53                 PMC_SLPWK_DR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID53_Msk instead */
+#define PMC_SLPWK_DR1_PID56_Pos             24                                             /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID56_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID56                 PMC_SLPWK_DR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID56_Msk instead */
+#define PMC_SLPWK_DR1_PID57_Pos             25                                             /**< (PMC_SLPWK_DR1) Peripheral 57 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID57_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 57 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID57                 PMC_SLPWK_DR1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID57_Msk instead */
+#define PMC_SLPWK_DR1_PID58_Pos             26                                             /**< (PMC_SLPWK_DR1) Peripheral 58 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID58_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 58 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID58                 PMC_SLPWK_DR1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID58_Msk instead */
+#define PMC_SLPWK_DR1_PID59_Pos             27                                             /**< (PMC_SLPWK_DR1) Peripheral 59 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID59_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 59 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID59                 PMC_SLPWK_DR1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID59_Msk instead */
+#define PMC_SLPWK_DR1_PID60_Pos             28                                             /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Position */
+#define PMC_SLPWK_DR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID60_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Mask */
+#define PMC_SLPWK_DR1_PID60                 PMC_SLPWK_DR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID60_Msk instead */
+#define PMC_SLPWK_DR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_DR1) Register MASK  (Use PMC_SLPWK_DR1_Msk instead)  */
+#define PMC_SLPWK_DR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_DR1) Register Mask  */
+
+#define PMC_SLPWK_DR1_PID_Pos               0                                              /**< (PMC_SLPWK_DR1 Position) Peripheral 6x SleepWalking Disable */
+#define PMC_SLPWK_DR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_DR1_PID_Pos)      /**< (PMC_SLPWK_DR1 Mask) PID */
+#define PMC_SLPWK_DR1_PID(value)            (PMC_SLPWK_DR1_PID_Msk & ((value) << PMC_SLPWK_DR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_SR1 : (PMC Offset: 0x13c) (R/ 32) SleepWalking Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Status        */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 SleepWalking Status        */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 SleepWalking Status        */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 SleepWalking Status        */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 SleepWalking Status        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 SleepWalking Status        */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 SleepWalking Status        */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 SleepWalking Status        */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 SleepWalking Status        */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 SleepWalking Status        */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 SleepWalking Status        */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 SleepWalking Status        */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 SleepWalking Status        */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 SleepWalking Status        */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 SleepWalking Status        */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 SleepWalking Status        */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Status        */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Status        */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Status        */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Status        */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Status        */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Status        */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Status        */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 SleepWalking Status        */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 SleepWalking Status        */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Status        */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_SR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_SR1_OFFSET                (0x13C)                                       /**<  (PMC_SLPWK_SR1) SleepWalking Status Register 1  Offset */
+
+#define PMC_SLPWK_SR1_PID32_Pos             0                                              /**< (PMC_SLPWK_SR1) Peripheral 32 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID32_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID32_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 32 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID32                 PMC_SLPWK_SR1_PID32_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID32_Msk instead */
+#define PMC_SLPWK_SR1_PID33_Pos             1                                              /**< (PMC_SLPWK_SR1) Peripheral 33 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID33_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID33_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 33 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID33                 PMC_SLPWK_SR1_PID33_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID33_Msk instead */
+#define PMC_SLPWK_SR1_PID34_Pos             2                                              /**< (PMC_SLPWK_SR1) Peripheral 34 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID34_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID34_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 34 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID34                 PMC_SLPWK_SR1_PID34_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID34_Msk instead */
+#define PMC_SLPWK_SR1_PID35_Pos             3                                              /**< (PMC_SLPWK_SR1) Peripheral 35 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID35_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID35_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 35 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID35                 PMC_SLPWK_SR1_PID35_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID35_Msk instead */
+#define PMC_SLPWK_SR1_PID37_Pos             5                                              /**< (PMC_SLPWK_SR1) Peripheral 37 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID37_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID37_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 37 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID37                 PMC_SLPWK_SR1_PID37_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID37_Msk instead */
+#define PMC_SLPWK_SR1_PID39_Pos             7                                              /**< (PMC_SLPWK_SR1) Peripheral 39 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID39_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID39_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 39 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID39                 PMC_SLPWK_SR1_PID39_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID39_Msk instead */
+#define PMC_SLPWK_SR1_PID40_Pos             8                                              /**< (PMC_SLPWK_SR1) Peripheral 40 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID40_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID40_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 40 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID40                 PMC_SLPWK_SR1_PID40_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID40_Msk instead */
+#define PMC_SLPWK_SR1_PID41_Pos             9                                              /**< (PMC_SLPWK_SR1) Peripheral 41 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID41_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID41_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 41 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID41                 PMC_SLPWK_SR1_PID41_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID41_Msk instead */
+#define PMC_SLPWK_SR1_PID42_Pos             10                                             /**< (PMC_SLPWK_SR1) Peripheral 42 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID42_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID42_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 42 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID42                 PMC_SLPWK_SR1_PID42_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID42_Msk instead */
+#define PMC_SLPWK_SR1_PID43_Pos             11                                             /**< (PMC_SLPWK_SR1) Peripheral 43 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID43_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID43_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 43 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID43                 PMC_SLPWK_SR1_PID43_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID43_Msk instead */
+#define PMC_SLPWK_SR1_PID44_Pos             12                                             /**< (PMC_SLPWK_SR1) Peripheral 44 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID44_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID44_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 44 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID44                 PMC_SLPWK_SR1_PID44_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID44_Msk instead */
+#define PMC_SLPWK_SR1_PID45_Pos             13                                             /**< (PMC_SLPWK_SR1) Peripheral 45 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID45_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID45_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 45 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID45                 PMC_SLPWK_SR1_PID45_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID45_Msk instead */
+#define PMC_SLPWK_SR1_PID46_Pos             14                                             /**< (PMC_SLPWK_SR1) Peripheral 46 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID46_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID46_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 46 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID46                 PMC_SLPWK_SR1_PID46_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID46_Msk instead */
+#define PMC_SLPWK_SR1_PID47_Pos             15                                             /**< (PMC_SLPWK_SR1) Peripheral 47 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID47_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID47_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 47 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID47                 PMC_SLPWK_SR1_PID47_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID47_Msk instead */
+#define PMC_SLPWK_SR1_PID48_Pos             16                                             /**< (PMC_SLPWK_SR1) Peripheral 48 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID48_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID48_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 48 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID48                 PMC_SLPWK_SR1_PID48_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID48_Msk instead */
+#define PMC_SLPWK_SR1_PID49_Pos             17                                             /**< (PMC_SLPWK_SR1) Peripheral 49 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID49_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID49_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 49 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID49                 PMC_SLPWK_SR1_PID49_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID49_Msk instead */
+#define PMC_SLPWK_SR1_PID50_Pos             18                                             /**< (PMC_SLPWK_SR1) Peripheral 50 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID50_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID50_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 50 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID50                 PMC_SLPWK_SR1_PID50_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID50_Msk instead */
+#define PMC_SLPWK_SR1_PID51_Pos             19                                             /**< (PMC_SLPWK_SR1) Peripheral 51 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID51_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID51_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 51 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID51                 PMC_SLPWK_SR1_PID51_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID51_Msk instead */
+#define PMC_SLPWK_SR1_PID52_Pos             20                                             /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID52_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID52                 PMC_SLPWK_SR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID52_Msk instead */
+#define PMC_SLPWK_SR1_PID53_Pos             21                                             /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID53_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID53                 PMC_SLPWK_SR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID53_Msk instead */
+#define PMC_SLPWK_SR1_PID56_Pos             24                                             /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID56_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID56                 PMC_SLPWK_SR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID56_Msk instead */
+#define PMC_SLPWK_SR1_PID57_Pos             25                                             /**< (PMC_SLPWK_SR1) Peripheral 57 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID57_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID57_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 57 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID57                 PMC_SLPWK_SR1_PID57_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID57_Msk instead */
+#define PMC_SLPWK_SR1_PID58_Pos             26                                             /**< (PMC_SLPWK_SR1) Peripheral 58 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID58_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID58_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 58 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID58                 PMC_SLPWK_SR1_PID58_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID58_Msk instead */
+#define PMC_SLPWK_SR1_PID59_Pos             27                                             /**< (PMC_SLPWK_SR1) Peripheral 59 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID59_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID59_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 59 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID59                 PMC_SLPWK_SR1_PID59_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID59_Msk instead */
+#define PMC_SLPWK_SR1_PID60_Pos             28                                             /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Position */
+#define PMC_SLPWK_SR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID60_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Mask */
+#define PMC_SLPWK_SR1_PID60                 PMC_SLPWK_SR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID60_Msk instead */
+#define PMC_SLPWK_SR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_SR1) Register MASK  (Use PMC_SLPWK_SR1_Msk instead)  */
+#define PMC_SLPWK_SR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_SR1) Register Mask  */
+
+#define PMC_SLPWK_SR1_PID_Pos               0                                              /**< (PMC_SLPWK_SR1 Position) Peripheral 6x SleepWalking Status */
+#define PMC_SLPWK_SR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_SR1_PID_Pos)      /**< (PMC_SLPWK_SR1 Mask) PID */
+#define PMC_SLPWK_SR1_PID(value)            (PMC_SLPWK_SR1_PID_Msk & ((value) << PMC_SLPWK_SR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_ASR1 : (PMC Offset: 0x140) (R/ 32) SleepWalking Activity Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 Activity Status            */
+    uint32_t PID33:1;                   /**< bit:      1  Peripheral 33 Activity Status            */
+    uint32_t PID34:1;                   /**< bit:      2  Peripheral 34 Activity Status            */
+    uint32_t PID35:1;                   /**< bit:      3  Peripheral 35 Activity Status            */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t PID37:1;                   /**< bit:      5  Peripheral 37 Activity Status            */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t PID39:1;                   /**< bit:      7  Peripheral 39 Activity Status            */
+    uint32_t PID40:1;                   /**< bit:      8  Peripheral 40 Activity Status            */
+    uint32_t PID41:1;                   /**< bit:      9  Peripheral 41 Activity Status            */
+    uint32_t PID42:1;                   /**< bit:     10  Peripheral 42 Activity Status            */
+    uint32_t PID43:1;                   /**< bit:     11  Peripheral 43 Activity Status            */
+    uint32_t PID44:1;                   /**< bit:     12  Peripheral 44 Activity Status            */
+    uint32_t PID45:1;                   /**< bit:     13  Peripheral 45 Activity Status            */
+    uint32_t PID46:1;                   /**< bit:     14  Peripheral 46 Activity Status            */
+    uint32_t PID47:1;                   /**< bit:     15  Peripheral 47 Activity Status            */
+    uint32_t PID48:1;                   /**< bit:     16  Peripheral 48 Activity Status            */
+    uint32_t PID49:1;                   /**< bit:     17  Peripheral 49 Activity Status            */
+    uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 Activity Status            */
+    uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 Activity Status            */
+    uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 Activity Status            */
+    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 Activity Status            */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 Activity Status            */
+    uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 Activity Status            */
+    uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 Activity Status            */
+    uint32_t PID59:1;                   /**< bit:     27  Peripheral 59 Activity Status            */
+    uint32_t PID60:1;                   /**< bit:     28  Peripheral 60 Activity Status            */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x Activity Status            */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_ASR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_ASR1_OFFSET               (0x140)                                       /**<  (PMC_SLPWK_ASR1) SleepWalking Activity Status Register 1  Offset */
+
+#define PMC_SLPWK_ASR1_PID32_Pos            0                                              /**< (PMC_SLPWK_ASR1) Peripheral 32 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID32_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID32_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 32 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID32                PMC_SLPWK_ASR1_PID32_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID32_Msk instead */
+#define PMC_SLPWK_ASR1_PID33_Pos            1                                              /**< (PMC_SLPWK_ASR1) Peripheral 33 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID33_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID33_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 33 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID33                PMC_SLPWK_ASR1_PID33_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID33_Msk instead */
+#define PMC_SLPWK_ASR1_PID34_Pos            2                                              /**< (PMC_SLPWK_ASR1) Peripheral 34 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID34_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID34_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 34 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID34                PMC_SLPWK_ASR1_PID34_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID34_Msk instead */
+#define PMC_SLPWK_ASR1_PID35_Pos            3                                              /**< (PMC_SLPWK_ASR1) Peripheral 35 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID35_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID35_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 35 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID35                PMC_SLPWK_ASR1_PID35_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID35_Msk instead */
+#define PMC_SLPWK_ASR1_PID37_Pos            5                                              /**< (PMC_SLPWK_ASR1) Peripheral 37 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID37_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID37_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 37 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID37                PMC_SLPWK_ASR1_PID37_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID37_Msk instead */
+#define PMC_SLPWK_ASR1_PID39_Pos            7                                              /**< (PMC_SLPWK_ASR1) Peripheral 39 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID39_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID39_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 39 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID39                PMC_SLPWK_ASR1_PID39_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID39_Msk instead */
+#define PMC_SLPWK_ASR1_PID40_Pos            8                                              /**< (PMC_SLPWK_ASR1) Peripheral 40 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID40_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID40_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 40 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID40                PMC_SLPWK_ASR1_PID40_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID40_Msk instead */
+#define PMC_SLPWK_ASR1_PID41_Pos            9                                              /**< (PMC_SLPWK_ASR1) Peripheral 41 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID41_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID41_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 41 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID41                PMC_SLPWK_ASR1_PID41_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID41_Msk instead */
+#define PMC_SLPWK_ASR1_PID42_Pos            10                                             /**< (PMC_SLPWK_ASR1) Peripheral 42 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID42_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID42_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 42 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID42                PMC_SLPWK_ASR1_PID42_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID42_Msk instead */
+#define PMC_SLPWK_ASR1_PID43_Pos            11                                             /**< (PMC_SLPWK_ASR1) Peripheral 43 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID43_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID43_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 43 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID43                PMC_SLPWK_ASR1_PID43_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID43_Msk instead */
+#define PMC_SLPWK_ASR1_PID44_Pos            12                                             /**< (PMC_SLPWK_ASR1) Peripheral 44 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID44_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID44_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 44 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID44                PMC_SLPWK_ASR1_PID44_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID44_Msk instead */
+#define PMC_SLPWK_ASR1_PID45_Pos            13                                             /**< (PMC_SLPWK_ASR1) Peripheral 45 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID45_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID45_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 45 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID45                PMC_SLPWK_ASR1_PID45_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID45_Msk instead */
+#define PMC_SLPWK_ASR1_PID46_Pos            14                                             /**< (PMC_SLPWK_ASR1) Peripheral 46 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID46_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID46_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 46 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID46                PMC_SLPWK_ASR1_PID46_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID46_Msk instead */
+#define PMC_SLPWK_ASR1_PID47_Pos            15                                             /**< (PMC_SLPWK_ASR1) Peripheral 47 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID47_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID47_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 47 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID47                PMC_SLPWK_ASR1_PID47_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID47_Msk instead */
+#define PMC_SLPWK_ASR1_PID48_Pos            16                                             /**< (PMC_SLPWK_ASR1) Peripheral 48 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID48_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID48_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 48 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID48                PMC_SLPWK_ASR1_PID48_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID48_Msk instead */
+#define PMC_SLPWK_ASR1_PID49_Pos            17                                             /**< (PMC_SLPWK_ASR1) Peripheral 49 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID49_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID49_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 49 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID49                PMC_SLPWK_ASR1_PID49_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID49_Msk instead */
+#define PMC_SLPWK_ASR1_PID50_Pos            18                                             /**< (PMC_SLPWK_ASR1) Peripheral 50 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID50_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID50_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 50 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID50                PMC_SLPWK_ASR1_PID50_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID50_Msk instead */
+#define PMC_SLPWK_ASR1_PID51_Pos            19                                             /**< (PMC_SLPWK_ASR1) Peripheral 51 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID51_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID51_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 51 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID51                PMC_SLPWK_ASR1_PID51_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID51_Msk instead */
+#define PMC_SLPWK_ASR1_PID52_Pos            20                                             /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID52_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID52_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID52                PMC_SLPWK_ASR1_PID52_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID52_Msk instead */
+#define PMC_SLPWK_ASR1_PID53_Pos            21                                             /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID53_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID53_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID53                PMC_SLPWK_ASR1_PID53_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID53_Msk instead */
+#define PMC_SLPWK_ASR1_PID56_Pos            24                                             /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID56_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID56_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID56                PMC_SLPWK_ASR1_PID56_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID56_Msk instead */
+#define PMC_SLPWK_ASR1_PID57_Pos            25                                             /**< (PMC_SLPWK_ASR1) Peripheral 57 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID57_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID57_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 57 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID57                PMC_SLPWK_ASR1_PID57_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID57_Msk instead */
+#define PMC_SLPWK_ASR1_PID58_Pos            26                                             /**< (PMC_SLPWK_ASR1) Peripheral 58 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID58_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID58_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 58 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID58                PMC_SLPWK_ASR1_PID58_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID58_Msk instead */
+#define PMC_SLPWK_ASR1_PID59_Pos            27                                             /**< (PMC_SLPWK_ASR1) Peripheral 59 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID59_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID59_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 59 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID59                PMC_SLPWK_ASR1_PID59_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID59_Msk instead */
+#define PMC_SLPWK_ASR1_PID60_Pos            28                                             /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Position */
+#define PMC_SLPWK_ASR1_PID60_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID60_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Mask */
+#define PMC_SLPWK_ASR1_PID60                PMC_SLPWK_ASR1_PID60_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID60_Msk instead */
+#define PMC_SLPWK_ASR1_MASK                 _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ASR1) Register MASK  (Use PMC_SLPWK_ASR1_Msk instead)  */
+#define PMC_SLPWK_ASR1_Msk                  _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ASR1) Register Mask  */
+
+#define PMC_SLPWK_ASR1_PID_Pos              0                                              /**< (PMC_SLPWK_ASR1 Position) Peripheral 6x Activity Status */
+#define PMC_SLPWK_ASR1_PID_Msk              (_U_(0x1FFFFFF) << PMC_SLPWK_ASR1_PID_Pos)     /**< (PMC_SLPWK_ASR1 Mask) PID */
+#define PMC_SLPWK_ASR1_PID(value)           (PMC_SLPWK_ASR1_PID_Msk & ((value) << PMC_SLPWK_ASR1_PID_Pos))  
+
+/* -------- PMC_SLPWK_AIPR : (PMC Offset: 0x144) (R/ 32) SleepWalking Activity In Progress Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t AIP:1;                     /**< bit:      0  Activity In Progress                     */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PMC_SLPWK_AIPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PMC_SLPWK_AIPR_OFFSET               (0x144)                                       /**<  (PMC_SLPWK_AIPR) SleepWalking Activity In Progress Register  Offset */
+
+#define PMC_SLPWK_AIPR_AIP_Pos              0                                              /**< (PMC_SLPWK_AIPR) Activity In Progress Position */
+#define PMC_SLPWK_AIPR_AIP_Msk              (_U_(0x1) << PMC_SLPWK_AIPR_AIP_Pos)           /**< (PMC_SLPWK_AIPR) Activity In Progress Mask */
+#define PMC_SLPWK_AIPR_AIP                  PMC_SLPWK_AIPR_AIP_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_AIPR_AIP_Msk instead */
+#define PMC_SLPWK_AIPR_MASK                 _U_(0x01)                                      /**< \deprecated (PMC_SLPWK_AIPR) Register MASK  (Use PMC_SLPWK_AIPR_Msk instead)  */
+#define PMC_SLPWK_AIPR_Msk                  _U_(0x01)                                      /**< (PMC_SLPWK_AIPR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PMC hardware registers */
+typedef struct {  
+  __O  uint32_t PMC_SCER;       /**< (PMC Offset: 0x00) System Clock Enable Register */
+  __O  uint32_t PMC_SCDR;       /**< (PMC Offset: 0x04) System Clock Disable Register */
+  __I  uint32_t PMC_SCSR;       /**< (PMC Offset: 0x08) System Clock Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  uint32_t PMC_PCER0;      /**< (PMC Offset: 0x10) Peripheral Clock Enable Register 0 */
+  __O  uint32_t PMC_PCDR0;      /**< (PMC Offset: 0x14) Peripheral Clock Disable Register 0 */
+  __I  uint32_t PMC_PCSR0;      /**< (PMC Offset: 0x18) Peripheral Clock Status Register 0 */
+  __IO uint32_t CKGR_UCKR;      /**< (PMC Offset: 0x1C) UTMI Clock Register */
+  __IO uint32_t CKGR_MOR;       /**< (PMC Offset: 0x20) Main Oscillator Register */
+  __IO uint32_t CKGR_MCFR;      /**< (PMC Offset: 0x24) Main Clock Frequency Register */
+  __IO uint32_t CKGR_PLLAR;     /**< (PMC Offset: 0x28) PLLA Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t PMC_MCKR;       /**< (PMC Offset: 0x30) Master Clock Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO uint32_t PMC_USB;        /**< (PMC Offset: 0x38) USB Clock Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO uint32_t PMC_PCK[8];     /**< (PMC Offset: 0x40) Programmable Clock Register */
+  __O  uint32_t PMC_IER;        /**< (PMC Offset: 0x60) Interrupt Enable Register */
+  __O  uint32_t PMC_IDR;        /**< (PMC Offset: 0x64) Interrupt Disable Register */
+  __I  uint32_t PMC_SR;         /**< (PMC Offset: 0x68) Status Register */
+  __I  uint32_t PMC_IMR;        /**< (PMC Offset: 0x6C) Interrupt Mask Register */
+  __IO uint32_t PMC_FSMR;       /**< (PMC Offset: 0x70) Fast Startup Mode Register */
+  __IO uint32_t PMC_FSPR;       /**< (PMC Offset: 0x74) Fast Startup Polarity Register */
+  __O  uint32_t PMC_FOCR;       /**< (PMC Offset: 0x78) Fault Output Clear Register */
+  __I  uint8_t                        Reserved5[104];
+  __IO uint32_t PMC_WPMR;       /**< (PMC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t PMC_WPSR;       /**< (PMC Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[20];
+  __O  uint32_t PMC_PCER1;      /**< (PMC Offset: 0x100) Peripheral Clock Enable Register 1 */
+  __O  uint32_t PMC_PCDR1;      /**< (PMC Offset: 0x104) Peripheral Clock Disable Register 1 */
+  __I  uint32_t PMC_PCSR1;      /**< (PMC Offset: 0x108) Peripheral Clock Status Register 1 */
+  __IO uint32_t PMC_PCR;        /**< (PMC Offset: 0x10C) Peripheral Control Register */
+  __IO uint32_t PMC_OCR;        /**< (PMC Offset: 0x110) Oscillator Calibration Register */
+  __O  uint32_t PMC_SLPWK_ER0;  /**< (PMC Offset: 0x114) SleepWalking Enable Register 0 */
+  __O  uint32_t PMC_SLPWK_DR0;  /**< (PMC Offset: 0x118) SleepWalking Disable Register 0 */
+  __I  uint32_t PMC_SLPWK_SR0;  /**< (PMC Offset: 0x11C) SleepWalking Status Register 0 */
+  __I  uint32_t PMC_SLPWK_ASR0; /**< (PMC Offset: 0x120) SleepWalking Activity Status Register 0 */
+  __I  uint8_t                        Reserved7[12];
+  __IO uint32_t PMC_PMMR;       /**< (PMC Offset: 0x130) PLL Maximum Multiplier Value Register */
+  __O  uint32_t PMC_SLPWK_ER1;  /**< (PMC Offset: 0x134) SleepWalking Enable Register 1 */
+  __O  uint32_t PMC_SLPWK_DR1;  /**< (PMC Offset: 0x138) SleepWalking Disable Register 1 */
+  __I  uint32_t PMC_SLPWK_SR1;  /**< (PMC Offset: 0x13C) SleepWalking Status Register 1 */
+  __I  uint32_t PMC_SLPWK_ASR1; /**< (PMC Offset: 0x140) SleepWalking Activity Status Register 1 */
+  __I  uint32_t PMC_SLPWK_AIPR; /**< (PMC Offset: 0x144) SleepWalking Activity In Progress Register */
+} Pmc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PMC hardware registers */
+typedef struct {  
+  __O  PMC_SCER_Type                  PMC_SCER;       /**< Offset: 0x00 ( /W  32) System Clock Enable Register */
+  __O  PMC_SCDR_Type                  PMC_SCDR;       /**< Offset: 0x04 ( /W  32) System Clock Disable Register */
+  __I  PMC_SCSR_Type                  PMC_SCSR;       /**< Offset: 0x08 (R/   32) System Clock Status Register */
+  __I  uint8_t                        Reserved1[4];
+  __O  PMC_PCER0_Type                 PMC_PCER0;      /**< Offset: 0x10 ( /W  32) Peripheral Clock Enable Register 0 */
+  __O  PMC_PCDR0_Type                 PMC_PCDR0;      /**< Offset: 0x14 ( /W  32) Peripheral Clock Disable Register 0 */
+  __I  PMC_PCSR0_Type                 PMC_PCSR0;      /**< Offset: 0x18 (R/   32) Peripheral Clock Status Register 0 */
+  __IO CKGR_UCKR_Type                 CKGR_UCKR;      /**< Offset: 0x1C (R/W  32) UTMI Clock Register */
+  __IO CKGR_MOR_Type                  CKGR_MOR;       /**< Offset: 0x20 (R/W  32) Main Oscillator Register */
+  __IO CKGR_MCFR_Type                 CKGR_MCFR;      /**< Offset: 0x24 (R/W  32) Main Clock Frequency Register */
+  __IO CKGR_PLLAR_Type                CKGR_PLLAR;     /**< Offset: 0x28 (R/W  32) PLLA Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO PMC_MCKR_Type                  PMC_MCKR;       /**< Offset: 0x30 (R/W  32) Master Clock Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO PMC_USB_Type                   PMC_USB;        /**< Offset: 0x38 (R/W  32) USB Clock Register */
+  __I  uint8_t                        Reserved4[4];
+  __IO PMC_PCK_Type                   PMC_PCK[8];     /**< Offset: 0x40 (R/W  32) Programmable Clock Register */
+  __O  PMC_IER_Type                   PMC_IER;        /**< Offset: 0x60 ( /W  32) Interrupt Enable Register */
+  __O  PMC_IDR_Type                   PMC_IDR;        /**< Offset: 0x64 ( /W  32) Interrupt Disable Register */
+  __I  PMC_SR_Type                    PMC_SR;         /**< Offset: 0x68 (R/   32) Status Register */
+  __I  PMC_IMR_Type                   PMC_IMR;        /**< Offset: 0x6C (R/   32) Interrupt Mask Register */
+  __IO PMC_FSMR_Type                  PMC_FSMR;       /**< Offset: 0x70 (R/W  32) Fast Startup Mode Register */
+  __IO PMC_FSPR_Type                  PMC_FSPR;       /**< Offset: 0x74 (R/W  32) Fast Startup Polarity Register */
+  __O  PMC_FOCR_Type                  PMC_FOCR;       /**< Offset: 0x78 ( /W  32) Fault Output Clear Register */
+  __I  uint8_t                        Reserved5[104];
+  __IO PMC_WPMR_Type                  PMC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  PMC_WPSR_Type                  PMC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+  __I  uint8_t                        Reserved6[20];
+  __O  PMC_PCER1_Type                 PMC_PCER1;      /**< Offset: 0x100 ( /W  32) Peripheral Clock Enable Register 1 */
+  __O  PMC_PCDR1_Type                 PMC_PCDR1;      /**< Offset: 0x104 ( /W  32) Peripheral Clock Disable Register 1 */
+  __I  PMC_PCSR1_Type                 PMC_PCSR1;      /**< Offset: 0x108 (R/   32) Peripheral Clock Status Register 1 */
+  __IO PMC_PCR_Type                   PMC_PCR;        /**< Offset: 0x10C (R/W  32) Peripheral Control Register */
+  __IO PMC_OCR_Type                   PMC_OCR;        /**< Offset: 0x110 (R/W  32) Oscillator Calibration Register */
+  __O  PMC_SLPWK_ER0_Type             PMC_SLPWK_ER0;  /**< Offset: 0x114 ( /W  32) SleepWalking Enable Register 0 */
+  __O  PMC_SLPWK_DR0_Type             PMC_SLPWK_DR0;  /**< Offset: 0x118 ( /W  32) SleepWalking Disable Register 0 */
+  __I  PMC_SLPWK_SR0_Type             PMC_SLPWK_SR0;  /**< Offset: 0x11C (R/   32) SleepWalking Status Register 0 */
+  __I  PMC_SLPWK_ASR0_Type            PMC_SLPWK_ASR0; /**< Offset: 0x120 (R/   32) SleepWalking Activity Status Register 0 */
+  __I  uint8_t                        Reserved7[12];
+  __IO PMC_PMMR_Type                  PMC_PMMR;       /**< Offset: 0x130 (R/W  32) PLL Maximum Multiplier Value Register */
+  __O  PMC_SLPWK_ER1_Type             PMC_SLPWK_ER1;  /**< Offset: 0x134 ( /W  32) SleepWalking Enable Register 1 */
+  __O  PMC_SLPWK_DR1_Type             PMC_SLPWK_DR1;  /**< Offset: 0x138 ( /W  32) SleepWalking Disable Register 1 */
+  __I  PMC_SLPWK_SR1_Type             PMC_SLPWK_SR1;  /**< Offset: 0x13C (R/   32) SleepWalking Status Register 1 */
+  __I  PMC_SLPWK_ASR1_Type            PMC_SLPWK_ASR1; /**< Offset: 0x140 (R/   32) SleepWalking Activity Status Register 1 */
+  __I  PMC_SLPWK_AIPR_Type            PMC_SLPWK_AIPR; /**< Offset: 0x144 (R/   32) SleepWalking Activity In Progress Register */
+} Pmc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Power Management Controller */
+
+#endif /* _SAMV71_PMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/pwm.h
+++ b/asf/sam/include/samv71b/component/pwm.h
@@ -1,0 +1,2873 @@
+/**
+ * \file
+ *
+ * \brief Component description for PWM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PWM_COMPONENT_H_
+#define _SAMV71_PWM_COMPONENT_H_
+#define _SAMV71_PWM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Pulse Width Modulation Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PWM */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define PWM_6343                       /**< (PWM) Module ID */
+#define REV_PWM Y                      /**< (PWM) Module revision */
+
+/* -------- PWM_CMR : (PWM Offset: 0x00) (R/W 32) PWM Channel Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRE:4;                    /**< bit:   0..3  Channel Pre-scaler                       */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CALG:1;                    /**< bit:      8  Channel Alignment                        */
+    uint32_t CPOL:1;                    /**< bit:      9  Channel Polarity                         */
+    uint32_t CES:1;                     /**< bit:     10  Counter Event Selection                  */
+    uint32_t UPDS:1;                    /**< bit:     11  Update Selection                         */
+    uint32_t DPOLI:1;                   /**< bit:     12  Disabled Polarity Inverted               */
+    uint32_t TCTS:1;                    /**< bit:     13  Timer Counter Trigger Selection          */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t DTE:1;                     /**< bit:     16  Dead-Time Generator Enable               */
+    uint32_t DTHI:1;                    /**< bit:     17  Dead-Time PWMHx Output Inverted          */
+    uint32_t DTLI:1;                    /**< bit:     18  Dead-Time PWMLx Output Inverted          */
+    uint32_t PPM:1;                     /**< bit:     19  Push-Pull Mode                           */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMR_OFFSET                      (0x00)                                        /**<  (PWM_CMR) PWM Channel Mode Register  Offset */
+
+#define PWM_CMR_CPRE_Pos                    0                                              /**< (PWM_CMR) Channel Pre-scaler Position */
+#define PWM_CMR_CPRE_Msk                    (_U_(0xF) << PWM_CMR_CPRE_Pos)                 /**< (PWM_CMR) Channel Pre-scaler Mask */
+#define PWM_CMR_CPRE(value)                 (PWM_CMR_CPRE_Msk & ((value) << PWM_CMR_CPRE_Pos))
+#define   PWM_CMR_CPRE_MCK_Val              _U_(0x0)                                       /**< (PWM_CMR) Peripheral clock  */
+#define   PWM_CMR_CPRE_MCK_DIV_2_Val        _U_(0x1)                                       /**< (PWM_CMR) Peripheral clock/2  */
+#define   PWM_CMR_CPRE_MCK_DIV_4_Val        _U_(0x2)                                       /**< (PWM_CMR) Peripheral clock/4  */
+#define   PWM_CMR_CPRE_MCK_DIV_8_Val        _U_(0x3)                                       /**< (PWM_CMR) Peripheral clock/8  */
+#define   PWM_CMR_CPRE_MCK_DIV_16_Val       _U_(0x4)                                       /**< (PWM_CMR) Peripheral clock/16  */
+#define   PWM_CMR_CPRE_MCK_DIV_32_Val       _U_(0x5)                                       /**< (PWM_CMR) Peripheral clock/32  */
+#define   PWM_CMR_CPRE_MCK_DIV_64_Val       _U_(0x6)                                       /**< (PWM_CMR) Peripheral clock/64  */
+#define   PWM_CMR_CPRE_MCK_DIV_128_Val      _U_(0x7)                                       /**< (PWM_CMR) Peripheral clock/128  */
+#define   PWM_CMR_CPRE_MCK_DIV_256_Val      _U_(0x8)                                       /**< (PWM_CMR) Peripheral clock/256  */
+#define   PWM_CMR_CPRE_MCK_DIV_512_Val      _U_(0x9)                                       /**< (PWM_CMR) Peripheral clock/512  */
+#define   PWM_CMR_CPRE_MCK_DIV_1024_Val     _U_(0xA)                                       /**< (PWM_CMR) Peripheral clock/1024  */
+#define   PWM_CMR_CPRE_CLKA_Val             _U_(0xB)                                       /**< (PWM_CMR) Clock A  */
+#define   PWM_CMR_CPRE_CLKB_Val             _U_(0xC)                                       /**< (PWM_CMR) Clock B  */
+#define PWM_CMR_CPRE_MCK                    (PWM_CMR_CPRE_MCK_Val << PWM_CMR_CPRE_Pos)     /**< (PWM_CMR) Peripheral clock Position  */
+#define PWM_CMR_CPRE_MCK_DIV_2              (PWM_CMR_CPRE_MCK_DIV_2_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/2 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_4              (PWM_CMR_CPRE_MCK_DIV_4_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/4 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_8              (PWM_CMR_CPRE_MCK_DIV_8_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/8 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_16             (PWM_CMR_CPRE_MCK_DIV_16_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/16 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_32             (PWM_CMR_CPRE_MCK_DIV_32_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/32 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_64             (PWM_CMR_CPRE_MCK_DIV_64_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/64 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_128            (PWM_CMR_CPRE_MCK_DIV_128_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/128 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_256            (PWM_CMR_CPRE_MCK_DIV_256_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/256 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_512            (PWM_CMR_CPRE_MCK_DIV_512_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/512 Position  */
+#define PWM_CMR_CPRE_MCK_DIV_1024           (PWM_CMR_CPRE_MCK_DIV_1024_Val << PWM_CMR_CPRE_Pos)  /**< (PWM_CMR) Peripheral clock/1024 Position  */
+#define PWM_CMR_CPRE_CLKA                   (PWM_CMR_CPRE_CLKA_Val << PWM_CMR_CPRE_Pos)    /**< (PWM_CMR) Clock A Position  */
+#define PWM_CMR_CPRE_CLKB                   (PWM_CMR_CPRE_CLKB_Val << PWM_CMR_CPRE_Pos)    /**< (PWM_CMR) Clock B Position  */
+#define PWM_CMR_CALG_Pos                    8                                              /**< (PWM_CMR) Channel Alignment Position */
+#define PWM_CMR_CALG_Msk                    (_U_(0x1) << PWM_CMR_CALG_Pos)                 /**< (PWM_CMR) Channel Alignment Mask */
+#define PWM_CMR_CALG                        PWM_CMR_CALG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CALG_Msk instead */
+#define   PWM_CMR_CALG_LEFT_ALIGNED_Val     _U_(0x0)                                       /**< (PWM_CMR) Left aligned  */
+#define   PWM_CMR_CALG_CENTER_ALIGNED_Val   _U_(0x1)                                       /**< (PWM_CMR) Center aligned  */
+#define PWM_CMR_CALG_LEFT_ALIGNED           (PWM_CMR_CALG_LEFT_ALIGNED_Val << PWM_CMR_CALG_Pos)  /**< (PWM_CMR) Left aligned Position  */
+#define PWM_CMR_CALG_CENTER_ALIGNED         (PWM_CMR_CALG_CENTER_ALIGNED_Val << PWM_CMR_CALG_Pos)  /**< (PWM_CMR) Center aligned Position  */
+#define PWM_CMR_CPOL_Pos                    9                                              /**< (PWM_CMR) Channel Polarity Position */
+#define PWM_CMR_CPOL_Msk                    (_U_(0x1) << PWM_CMR_CPOL_Pos)                 /**< (PWM_CMR) Channel Polarity Mask */
+#define PWM_CMR_CPOL                        PWM_CMR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CPOL_Msk instead */
+#define   PWM_CMR_CPOL_LOW_POLARITY_Val     _U_(0x0)                                       /**< (PWM_CMR) Waveform starts at low level  */
+#define   PWM_CMR_CPOL_HIGH_POLARITY_Val    _U_(0x1)                                       /**< (PWM_CMR) Waveform starts at high level  */
+#define PWM_CMR_CPOL_LOW_POLARITY           (PWM_CMR_CPOL_LOW_POLARITY_Val << PWM_CMR_CPOL_Pos)  /**< (PWM_CMR) Waveform starts at low level Position  */
+#define PWM_CMR_CPOL_HIGH_POLARITY          (PWM_CMR_CPOL_HIGH_POLARITY_Val << PWM_CMR_CPOL_Pos)  /**< (PWM_CMR) Waveform starts at high level Position  */
+#define PWM_CMR_CES_Pos                     10                                             /**< (PWM_CMR) Counter Event Selection Position */
+#define PWM_CMR_CES_Msk                     (_U_(0x1) << PWM_CMR_CES_Pos)                  /**< (PWM_CMR) Counter Event Selection Mask */
+#define PWM_CMR_CES                         PWM_CMR_CES_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CES_Msk instead */
+#define   PWM_CMR_CES_SINGLE_EVENT_Val      _U_(0x0)                                       /**< (PWM_CMR) At the end of PWM period  */
+#define   PWM_CMR_CES_DOUBLE_EVENT_Val      _U_(0x1)                                       /**< (PWM_CMR) At half of PWM period AND at the end of PWM period  */
+#define PWM_CMR_CES_SINGLE_EVENT            (PWM_CMR_CES_SINGLE_EVENT_Val << PWM_CMR_CES_Pos)  /**< (PWM_CMR) At the end of PWM period Position  */
+#define PWM_CMR_CES_DOUBLE_EVENT            (PWM_CMR_CES_DOUBLE_EVENT_Val << PWM_CMR_CES_Pos)  /**< (PWM_CMR) At half of PWM period AND at the end of PWM period Position  */
+#define PWM_CMR_UPDS_Pos                    11                                             /**< (PWM_CMR) Update Selection Position */
+#define PWM_CMR_UPDS_Msk                    (_U_(0x1) << PWM_CMR_UPDS_Pos)                 /**< (PWM_CMR) Update Selection Mask */
+#define PWM_CMR_UPDS                        PWM_CMR_UPDS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_UPDS_Msk instead */
+#define   PWM_CMR_UPDS_UPDATE_AT_PERIOD_Val _U_(0x0)                                       /**< (PWM_CMR) At the next end of PWM period  */
+#define   PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD_Val _U_(0x1)                                       /**< (PWM_CMR) At the next end of Half PWM period  */
+#define PWM_CMR_UPDS_UPDATE_AT_PERIOD       (PWM_CMR_UPDS_UPDATE_AT_PERIOD_Val << PWM_CMR_UPDS_Pos)  /**< (PWM_CMR) At the next end of PWM period Position  */
+#define PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD  (PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD_Val << PWM_CMR_UPDS_Pos)  /**< (PWM_CMR) At the next end of Half PWM period Position  */
+#define PWM_CMR_DPOLI_Pos                   12                                             /**< (PWM_CMR) Disabled Polarity Inverted Position */
+#define PWM_CMR_DPOLI_Msk                   (_U_(0x1) << PWM_CMR_DPOLI_Pos)                /**< (PWM_CMR) Disabled Polarity Inverted Mask */
+#define PWM_CMR_DPOLI                       PWM_CMR_DPOLI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DPOLI_Msk instead */
+#define PWM_CMR_TCTS_Pos                    13                                             /**< (PWM_CMR) Timer Counter Trigger Selection Position */
+#define PWM_CMR_TCTS_Msk                    (_U_(0x1) << PWM_CMR_TCTS_Pos)                 /**< (PWM_CMR) Timer Counter Trigger Selection Mask */
+#define PWM_CMR_TCTS                        PWM_CMR_TCTS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_TCTS_Msk instead */
+#define PWM_CMR_DTE_Pos                     16                                             /**< (PWM_CMR) Dead-Time Generator Enable Position */
+#define PWM_CMR_DTE_Msk                     (_U_(0x1) << PWM_CMR_DTE_Pos)                  /**< (PWM_CMR) Dead-Time Generator Enable Mask */
+#define PWM_CMR_DTE                         PWM_CMR_DTE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTE_Msk instead */
+#define PWM_CMR_DTHI_Pos                    17                                             /**< (PWM_CMR) Dead-Time PWMHx Output Inverted Position */
+#define PWM_CMR_DTHI_Msk                    (_U_(0x1) << PWM_CMR_DTHI_Pos)                 /**< (PWM_CMR) Dead-Time PWMHx Output Inverted Mask */
+#define PWM_CMR_DTHI                        PWM_CMR_DTHI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTHI_Msk instead */
+#define PWM_CMR_DTLI_Pos                    18                                             /**< (PWM_CMR) Dead-Time PWMLx Output Inverted Position */
+#define PWM_CMR_DTLI_Msk                    (_U_(0x1) << PWM_CMR_DTLI_Pos)                 /**< (PWM_CMR) Dead-Time PWMLx Output Inverted Mask */
+#define PWM_CMR_DTLI                        PWM_CMR_DTLI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DTLI_Msk instead */
+#define PWM_CMR_PPM_Pos                     19                                             /**< (PWM_CMR) Push-Pull Mode Position */
+#define PWM_CMR_PPM_Msk                     (_U_(0x1) << PWM_CMR_PPM_Pos)                  /**< (PWM_CMR) Push-Pull Mode Mask */
+#define PWM_CMR_PPM                         PWM_CMR_PPM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_PPM_Msk instead */
+#define PWM_CMR_MASK                        _U_(0xF3F0F)                                   /**< \deprecated (PWM_CMR) Register MASK  (Use PWM_CMR_Msk instead)  */
+#define PWM_CMR_Msk                         _U_(0xF3F0F)                                   /**< (PWM_CMR) Register Mask  */
+
+
+/* -------- PWM_CDTY : (PWM Offset: 0x04) (R/W 32) PWM Channel Duty Cycle Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CDTY:24;                   /**< bit:  0..23  Channel Duty-Cycle                       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CDTY_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CDTY_OFFSET                     (0x04)                                        /**<  (PWM_CDTY) PWM Channel Duty Cycle Register  Offset */
+
+#define PWM_CDTY_CDTY_Pos                   0                                              /**< (PWM_CDTY) Channel Duty-Cycle Position */
+#define PWM_CDTY_CDTY_Msk                   (_U_(0xFFFFFF) << PWM_CDTY_CDTY_Pos)           /**< (PWM_CDTY) Channel Duty-Cycle Mask */
+#define PWM_CDTY_CDTY(value)                (PWM_CDTY_CDTY_Msk & ((value) << PWM_CDTY_CDTY_Pos))
+#define PWM_CDTY_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CDTY) Register MASK  (Use PWM_CDTY_Msk instead)  */
+#define PWM_CDTY_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CDTY) Register Mask  */
+
+
+/* -------- PWM_CDTYUPD : (PWM Offset: 0x08) (/W 32) PWM Channel Duty Cycle Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CDTYUPD:24;                /**< bit:  0..23  Channel Duty-Cycle Update                */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CDTYUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CDTYUPD_OFFSET                  (0x08)                                        /**<  (PWM_CDTYUPD) PWM Channel Duty Cycle Update Register  Offset */
+
+#define PWM_CDTYUPD_CDTYUPD_Pos             0                                              /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Position */
+#define PWM_CDTYUPD_CDTYUPD_Msk             (_U_(0xFFFFFF) << PWM_CDTYUPD_CDTYUPD_Pos)     /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Mask */
+#define PWM_CDTYUPD_CDTYUPD(value)          (PWM_CDTYUPD_CDTYUPD_Msk & ((value) << PWM_CDTYUPD_CDTYUPD_Pos))
+#define PWM_CDTYUPD_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CDTYUPD) Register MASK  (Use PWM_CDTYUPD_Msk instead)  */
+#define PWM_CDTYUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CDTYUPD) Register Mask  */
+
+
+/* -------- PWM_CPRD : (PWM Offset: 0x0c) (R/W 32) PWM Channel Period Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRD:24;                   /**< bit:  0..23  Channel Period                           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CPRD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CPRD_OFFSET                     (0x0C)                                        /**<  (PWM_CPRD) PWM Channel Period Register  Offset */
+
+#define PWM_CPRD_CPRD_Pos                   0                                              /**< (PWM_CPRD) Channel Period Position */
+#define PWM_CPRD_CPRD_Msk                   (_U_(0xFFFFFF) << PWM_CPRD_CPRD_Pos)           /**< (PWM_CPRD) Channel Period Mask */
+#define PWM_CPRD_CPRD(value)                (PWM_CPRD_CPRD_Msk & ((value) << PWM_CPRD_CPRD_Pos))
+#define PWM_CPRD_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CPRD) Register MASK  (Use PWM_CPRD_Msk instead)  */
+#define PWM_CPRD_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CPRD) Register Mask  */
+
+
+/* -------- PWM_CPRDUPD : (PWM Offset: 0x10) (/W 32) PWM Channel Period Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPRDUPD:24;                /**< bit:  0..23  Channel Period Update                    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CPRDUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CPRDUPD_OFFSET                  (0x10)                                        /**<  (PWM_CPRDUPD) PWM Channel Period Update Register  Offset */
+
+#define PWM_CPRDUPD_CPRDUPD_Pos             0                                              /**< (PWM_CPRDUPD) Channel Period Update Position */
+#define PWM_CPRDUPD_CPRDUPD_Msk             (_U_(0xFFFFFF) << PWM_CPRDUPD_CPRDUPD_Pos)     /**< (PWM_CPRDUPD) Channel Period Update Mask */
+#define PWM_CPRDUPD_CPRDUPD(value)          (PWM_CPRDUPD_CPRDUPD_Msk & ((value) << PWM_CPRDUPD_CPRDUPD_Pos))
+#define PWM_CPRDUPD_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CPRDUPD) Register MASK  (Use PWM_CPRDUPD_Msk instead)  */
+#define PWM_CPRDUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CPRDUPD) Register Mask  */
+
+
+/* -------- PWM_CCNT : (PWM Offset: 0x14) (R/ 32) PWM Channel Counter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CNT:24;                    /**< bit:  0..23  Channel Counter Register                 */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CCNT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CCNT_OFFSET                     (0x14)                                        /**<  (PWM_CCNT) PWM Channel Counter Register  Offset */
+
+#define PWM_CCNT_CNT_Pos                    0                                              /**< (PWM_CCNT) Channel Counter Register Position */
+#define PWM_CCNT_CNT_Msk                    (_U_(0xFFFFFF) << PWM_CCNT_CNT_Pos)            /**< (PWM_CCNT) Channel Counter Register Mask */
+#define PWM_CCNT_CNT(value)                 (PWM_CCNT_CNT_Msk & ((value) << PWM_CCNT_CNT_Pos))
+#define PWM_CCNT_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_CCNT) Register MASK  (Use PWM_CCNT_Msk instead)  */
+#define PWM_CCNT_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CCNT) Register Mask  */
+
+
+/* -------- PWM_DT : (PWM Offset: 0x18) (R/W 32) PWM Channel Dead Time Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTH:16;                    /**< bit:  0..15  Dead-Time Value for PWMHx Output         */
+    uint32_t DTL:16;                    /**< bit: 16..31  Dead-Time Value for PWMLx Output         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DT_OFFSET                       (0x18)                                        /**<  (PWM_DT) PWM Channel Dead Time Register  Offset */
+
+#define PWM_DT_DTH_Pos                      0                                              /**< (PWM_DT) Dead-Time Value for PWMHx Output Position */
+#define PWM_DT_DTH_Msk                      (_U_(0xFFFF) << PWM_DT_DTH_Pos)                /**< (PWM_DT) Dead-Time Value for PWMHx Output Mask */
+#define PWM_DT_DTH(value)                   (PWM_DT_DTH_Msk & ((value) << PWM_DT_DTH_Pos))
+#define PWM_DT_DTL_Pos                      16                                             /**< (PWM_DT) Dead-Time Value for PWMLx Output Position */
+#define PWM_DT_DTL_Msk                      (_U_(0xFFFF) << PWM_DT_DTL_Pos)                /**< (PWM_DT) Dead-Time Value for PWMLx Output Mask */
+#define PWM_DT_DTL(value)                   (PWM_DT_DTL_Msk & ((value) << PWM_DT_DTL_Pos))
+#define PWM_DT_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_DT) Register MASK  (Use PWM_DT_Msk instead)  */
+#define PWM_DT_Msk                          _U_(0xFFFFFFFF)                                /**< (PWM_DT) Register Mask  */
+
+
+/* -------- PWM_DTUPD : (PWM Offset: 0x1c) (/W 32) PWM Channel Dead Time Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DTHUPD:16;                 /**< bit:  0..15  Dead-Time Value Update for PWMHx Output  */
+    uint32_t DTLUPD:16;                 /**< bit: 16..31  Dead-Time Value Update for PWMLx Output  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DTUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DTUPD_OFFSET                    (0x1C)                                        /**<  (PWM_DTUPD) PWM Channel Dead Time Update Register  Offset */
+
+#define PWM_DTUPD_DTHUPD_Pos                0                                              /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Position */
+#define PWM_DTUPD_DTHUPD_Msk                (_U_(0xFFFF) << PWM_DTUPD_DTHUPD_Pos)          /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Mask */
+#define PWM_DTUPD_DTHUPD(value)             (PWM_DTUPD_DTHUPD_Msk & ((value) << PWM_DTUPD_DTHUPD_Pos))
+#define PWM_DTUPD_DTLUPD_Pos                16                                             /**< (PWM_DTUPD) Dead-Time Value Update for PWMLx Output Position */
+#define PWM_DTUPD_DTLUPD_Msk                (_U_(0xFFFF) << PWM_DTUPD_DTLUPD_Pos)          /**< (PWM_DTUPD) Dead-Time Value Update for PWMLx Output Mask */
+#define PWM_DTUPD_DTLUPD(value)             (PWM_DTUPD_DTLUPD_Msk & ((value) << PWM_DTUPD_DTLUPD_Pos))
+#define PWM_DTUPD_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_DTUPD) Register MASK  (Use PWM_DTUPD_Msk instead)  */
+#define PWM_DTUPD_Msk                       _U_(0xFFFFFFFF)                                /**< (PWM_DTUPD) Register Mask  */
+
+
+/* -------- PWM_CMPV : (PWM Offset: 0x00) (R/W 32) PWM Comparison 0 Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CV:24;                     /**< bit:  0..23  Comparison x Value                       */
+    uint32_t CVM:1;                     /**< bit:     24  Comparison x Value Mode                  */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPV_OFFSET                     (0x00)                                        /**<  (PWM_CMPV) PWM Comparison 0 Value Register  Offset */
+
+#define PWM_CMPV_CV_Pos                     0                                              /**< (PWM_CMPV) Comparison x Value Position */
+#define PWM_CMPV_CV_Msk                     (_U_(0xFFFFFF) << PWM_CMPV_CV_Pos)             /**< (PWM_CMPV) Comparison x Value Mask */
+#define PWM_CMPV_CV(value)                  (PWM_CMPV_CV_Msk & ((value) << PWM_CMPV_CV_Pos))
+#define PWM_CMPV_CVM_Pos                    24                                             /**< (PWM_CMPV) Comparison x Value Mode Position */
+#define PWM_CMPV_CVM_Msk                    (_U_(0x1) << PWM_CMPV_CVM_Pos)                 /**< (PWM_CMPV) Comparison x Value Mode Mask */
+#define PWM_CMPV_CVM                        PWM_CMPV_CVM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPV_CVM_Msk instead */
+#define   PWM_CMPV_CVM_COMPARE_AT_INCREMENT_Val _U_(0x0)                                       /**< (PWM_CMPV) Compare when counter is incrementing  */
+#define   PWM_CMPV_CVM_COMPARE_AT_DECREMENT_Val _U_(0x1)                                       /**< (PWM_CMPV) Compare when counter is decrementing  */
+#define PWM_CMPV_CVM_COMPARE_AT_INCREMENT   (PWM_CMPV_CVM_COMPARE_AT_INCREMENT_Val << PWM_CMPV_CVM_Pos)  /**< (PWM_CMPV) Compare when counter is incrementing Position  */
+#define PWM_CMPV_CVM_COMPARE_AT_DECREMENT   (PWM_CMPV_CVM_COMPARE_AT_DECREMENT_Val << PWM_CMPV_CVM_Pos)  /**< (PWM_CMPV) Compare when counter is decrementing Position  */
+#define PWM_CMPV_MASK                       _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_CMPV) Register MASK  (Use PWM_CMPV_Msk instead)  */
+#define PWM_CMPV_Msk                        _U_(0x1FFFFFF)                                 /**< (PWM_CMPV) Register Mask  */
+
+
+/* -------- PWM_CMPVUPD : (PWM Offset: 0x04) (/W 32) PWM Comparison 0 Value Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CVUPD:24;                  /**< bit:  0..23  Comparison x Value Update                */
+    uint32_t CVMUPD:1;                  /**< bit:     24  Comparison x Value Mode Update           */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPVUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPVUPD_OFFSET                  (0x04)                                        /**<  (PWM_CMPVUPD) PWM Comparison 0 Value Update Register  Offset */
+
+#define PWM_CMPVUPD_CVUPD_Pos               0                                              /**< (PWM_CMPVUPD) Comparison x Value Update Position */
+#define PWM_CMPVUPD_CVUPD_Msk               (_U_(0xFFFFFF) << PWM_CMPVUPD_CVUPD_Pos)       /**< (PWM_CMPVUPD) Comparison x Value Update Mask */
+#define PWM_CMPVUPD_CVUPD(value)            (PWM_CMPVUPD_CVUPD_Msk & ((value) << PWM_CMPVUPD_CVUPD_Pos))
+#define PWM_CMPVUPD_CVMUPD_Pos              24                                             /**< (PWM_CMPVUPD) Comparison x Value Mode Update Position */
+#define PWM_CMPVUPD_CVMUPD_Msk              (_U_(0x1) << PWM_CMPVUPD_CVMUPD_Pos)           /**< (PWM_CMPVUPD) Comparison x Value Mode Update Mask */
+#define PWM_CMPVUPD_CVMUPD                  PWM_CMPVUPD_CVMUPD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPVUPD_CVMUPD_Msk instead */
+#define PWM_CMPVUPD_MASK                    _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_CMPVUPD) Register MASK  (Use PWM_CMPVUPD_Msk instead)  */
+#define PWM_CMPVUPD_Msk                     _U_(0x1FFFFFF)                                 /**< (PWM_CMPVUPD) Register Mask  */
+
+
+/* -------- PWM_CMPM : (PWM Offset: 0x08) (R/W 32) PWM Comparison 0 Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CEN:1;                     /**< bit:      0  Comparison x Enable                      */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t CTR:4;                     /**< bit:   4..7  Comparison x Trigger                     */
+    uint32_t CPR:4;                     /**< bit:  8..11  Comparison x Period                      */
+    uint32_t CPRCNT:4;                  /**< bit: 12..15  Comparison x Period Counter              */
+    uint32_t CUPR:4;                    /**< bit: 16..19  Comparison x Update Period               */
+    uint32_t CUPRCNT:4;                 /**< bit: 20..23  Comparison x Update Period Counter       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPM_OFFSET                     (0x08)                                        /**<  (PWM_CMPM) PWM Comparison 0 Mode Register  Offset */
+
+#define PWM_CMPM_CEN_Pos                    0                                              /**< (PWM_CMPM) Comparison x Enable Position */
+#define PWM_CMPM_CEN_Msk                    (_U_(0x1) << PWM_CMPM_CEN_Pos)                 /**< (PWM_CMPM) Comparison x Enable Mask */
+#define PWM_CMPM_CEN                        PWM_CMPM_CEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPM_CEN_Msk instead */
+#define PWM_CMPM_CTR_Pos                    4                                              /**< (PWM_CMPM) Comparison x Trigger Position */
+#define PWM_CMPM_CTR_Msk                    (_U_(0xF) << PWM_CMPM_CTR_Pos)                 /**< (PWM_CMPM) Comparison x Trigger Mask */
+#define PWM_CMPM_CTR(value)                 (PWM_CMPM_CTR_Msk & ((value) << PWM_CMPM_CTR_Pos))
+#define PWM_CMPM_CPR_Pos                    8                                              /**< (PWM_CMPM) Comparison x Period Position */
+#define PWM_CMPM_CPR_Msk                    (_U_(0xF) << PWM_CMPM_CPR_Pos)                 /**< (PWM_CMPM) Comparison x Period Mask */
+#define PWM_CMPM_CPR(value)                 (PWM_CMPM_CPR_Msk & ((value) << PWM_CMPM_CPR_Pos))
+#define PWM_CMPM_CPRCNT_Pos                 12                                             /**< (PWM_CMPM) Comparison x Period Counter Position */
+#define PWM_CMPM_CPRCNT_Msk                 (_U_(0xF) << PWM_CMPM_CPRCNT_Pos)              /**< (PWM_CMPM) Comparison x Period Counter Mask */
+#define PWM_CMPM_CPRCNT(value)              (PWM_CMPM_CPRCNT_Msk & ((value) << PWM_CMPM_CPRCNT_Pos))
+#define PWM_CMPM_CUPR_Pos                   16                                             /**< (PWM_CMPM) Comparison x Update Period Position */
+#define PWM_CMPM_CUPR_Msk                   (_U_(0xF) << PWM_CMPM_CUPR_Pos)                /**< (PWM_CMPM) Comparison x Update Period Mask */
+#define PWM_CMPM_CUPR(value)                (PWM_CMPM_CUPR_Msk & ((value) << PWM_CMPM_CUPR_Pos))
+#define PWM_CMPM_CUPRCNT_Pos                20                                             /**< (PWM_CMPM) Comparison x Update Period Counter Position */
+#define PWM_CMPM_CUPRCNT_Msk                (_U_(0xF) << PWM_CMPM_CUPRCNT_Pos)             /**< (PWM_CMPM) Comparison x Update Period Counter Mask */
+#define PWM_CMPM_CUPRCNT(value)             (PWM_CMPM_CUPRCNT_Msk & ((value) << PWM_CMPM_CUPRCNT_Pos))
+#define PWM_CMPM_MASK                       _U_(0xFFFFF1)                                  /**< \deprecated (PWM_CMPM) Register MASK  (Use PWM_CMPM_Msk instead)  */
+#define PWM_CMPM_Msk                        _U_(0xFFFFF1)                                  /**< (PWM_CMPM) Register Mask  */
+
+
+/* -------- PWM_CMPMUPD : (PWM Offset: 0x0c) (/W 32) PWM Comparison 0 Mode Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CENUPD:1;                  /**< bit:      0  Comparison x Enable Update               */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t CTRUPD:4;                  /**< bit:   4..7  Comparison x Trigger Update              */
+    uint32_t CPRUPD:4;                  /**< bit:  8..11  Comparison x Period Update               */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t CUPRUPD:4;                 /**< bit: 16..19  Comparison x Update Period Update        */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMPMUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMPMUPD_OFFSET                  (0x0C)                                        /**<  (PWM_CMPMUPD) PWM Comparison 0 Mode Update Register  Offset */
+
+#define PWM_CMPMUPD_CENUPD_Pos              0                                              /**< (PWM_CMPMUPD) Comparison x Enable Update Position */
+#define PWM_CMPMUPD_CENUPD_Msk              (_U_(0x1) << PWM_CMPMUPD_CENUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Enable Update Mask */
+#define PWM_CMPMUPD_CENUPD                  PWM_CMPMUPD_CENUPD_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPMUPD_CENUPD_Msk instead */
+#define PWM_CMPMUPD_CTRUPD_Pos              4                                              /**< (PWM_CMPMUPD) Comparison x Trigger Update Position */
+#define PWM_CMPMUPD_CTRUPD_Msk              (_U_(0xF) << PWM_CMPMUPD_CTRUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Trigger Update Mask */
+#define PWM_CMPMUPD_CTRUPD(value)           (PWM_CMPMUPD_CTRUPD_Msk & ((value) << PWM_CMPMUPD_CTRUPD_Pos))
+#define PWM_CMPMUPD_CPRUPD_Pos              8                                              /**< (PWM_CMPMUPD) Comparison x Period Update Position */
+#define PWM_CMPMUPD_CPRUPD_Msk              (_U_(0xF) << PWM_CMPMUPD_CPRUPD_Pos)           /**< (PWM_CMPMUPD) Comparison x Period Update Mask */
+#define PWM_CMPMUPD_CPRUPD(value)           (PWM_CMPMUPD_CPRUPD_Msk & ((value) << PWM_CMPMUPD_CPRUPD_Pos))
+#define PWM_CMPMUPD_CUPRUPD_Pos             16                                             /**< (PWM_CMPMUPD) Comparison x Update Period Update Position */
+#define PWM_CMPMUPD_CUPRUPD_Msk             (_U_(0xF) << PWM_CMPMUPD_CUPRUPD_Pos)          /**< (PWM_CMPMUPD) Comparison x Update Period Update Mask */
+#define PWM_CMPMUPD_CUPRUPD(value)          (PWM_CMPMUPD_CUPRUPD_Msk & ((value) << PWM_CMPMUPD_CUPRUPD_Pos))
+#define PWM_CMPMUPD_MASK                    _U_(0xF0FF1)                                   /**< \deprecated (PWM_CMPMUPD) Register MASK  (Use PWM_CMPMUPD_Msk instead)  */
+#define PWM_CMPMUPD_Msk                     _U_(0xF0FF1)                                   /**< (PWM_CMPMUPD) Register Mask  */
+
+
+/* -------- PWM_CLK : (PWM Offset: 0x00) (R/W 32) PWM Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIVA:8;                    /**< bit:   0..7  CLKA Divide Factor                       */
+    uint32_t PREA:4;                    /**< bit:  8..11  CLKA Source Clock Selection              */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DIVB:8;                    /**< bit: 16..23  CLKB Divide Factor                       */
+    uint32_t PREB:4;                    /**< bit: 24..27  CLKB Source Clock Selection              */
+    uint32_t :4;                        /**< bit: 28..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CLK_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CLK_OFFSET                      (0x00)                                        /**<  (PWM_CLK) PWM Clock Register  Offset */
+
+#define PWM_CLK_DIVA_Pos                    0                                              /**< (PWM_CLK) CLKA Divide Factor Position */
+#define PWM_CLK_DIVA_Msk                    (_U_(0xFF) << PWM_CLK_DIVA_Pos)                /**< (PWM_CLK) CLKA Divide Factor Mask */
+#define PWM_CLK_DIVA(value)                 (PWM_CLK_DIVA_Msk & ((value) << PWM_CLK_DIVA_Pos))
+#define   PWM_CLK_DIVA_CLKA_POFF_Val        _U_(0x0)                                       /**< (PWM_CLK) CLKA clock is turned off  */
+#define   PWM_CLK_DIVA_PREA_Val             _U_(0x1)                                       /**< (PWM_CLK) CLKA clock is clock selected by PREA  */
+#define PWM_CLK_DIVA_CLKA_POFF              (PWM_CLK_DIVA_CLKA_POFF_Val << PWM_CLK_DIVA_Pos)  /**< (PWM_CLK) CLKA clock is turned off Position  */
+#define PWM_CLK_DIVA_PREA                   (PWM_CLK_DIVA_PREA_Val << PWM_CLK_DIVA_Pos)    /**< (PWM_CLK) CLKA clock is clock selected by PREA Position  */
+#define PWM_CLK_PREA_Pos                    8                                              /**< (PWM_CLK) CLKA Source Clock Selection Position */
+#define PWM_CLK_PREA_Msk                    (_U_(0xF) << PWM_CLK_PREA_Pos)                 /**< (PWM_CLK) CLKA Source Clock Selection Mask */
+#define PWM_CLK_PREA(value)                 (PWM_CLK_PREA_Msk & ((value) << PWM_CLK_PREA_Pos))
+#define   PWM_CLK_PREA_CLK_Val              _U_(0x0)                                       /**< (PWM_CLK) Peripheral clock  */
+#define   PWM_CLK_PREA_CLK_DIV2_Val         _U_(0x1)                                       /**< (PWM_CLK) Peripheral clock/2  */
+#define   PWM_CLK_PREA_CLK_DIV4_Val         _U_(0x2)                                       /**< (PWM_CLK) Peripheral clock/4  */
+#define   PWM_CLK_PREA_CLK_DIV8_Val         _U_(0x3)                                       /**< (PWM_CLK) Peripheral clock/8  */
+#define   PWM_CLK_PREA_CLK_DIV16_Val        _U_(0x4)                                       /**< (PWM_CLK) Peripheral clock/16  */
+#define   PWM_CLK_PREA_CLK_DIV32_Val        _U_(0x5)                                       /**< (PWM_CLK) Peripheral clock/32  */
+#define   PWM_CLK_PREA_CLK_DIV64_Val        _U_(0x6)                                       /**< (PWM_CLK) Peripheral clock/64  */
+#define   PWM_CLK_PREA_CLK_DIV128_Val       _U_(0x7)                                       /**< (PWM_CLK) Peripheral clock/128  */
+#define   PWM_CLK_PREA_CLK_DIV256_Val       _U_(0x8)                                       /**< (PWM_CLK) Peripheral clock/256  */
+#define   PWM_CLK_PREA_CLK_DIV512_Val       _U_(0x9)                                       /**< (PWM_CLK) Peripheral clock/512  */
+#define   PWM_CLK_PREA_CLK_DIV1024_Val      _U_(0xA)                                       /**< (PWM_CLK) Peripheral clock/1024  */
+#define PWM_CLK_PREA_CLK                    (PWM_CLK_PREA_CLK_Val << PWM_CLK_PREA_Pos)     /**< (PWM_CLK) Peripheral clock Position  */
+#define PWM_CLK_PREA_CLK_DIV2               (PWM_CLK_PREA_CLK_DIV2_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/2 Position  */
+#define PWM_CLK_PREA_CLK_DIV4               (PWM_CLK_PREA_CLK_DIV4_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/4 Position  */
+#define PWM_CLK_PREA_CLK_DIV8               (PWM_CLK_PREA_CLK_DIV8_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/8 Position  */
+#define PWM_CLK_PREA_CLK_DIV16              (PWM_CLK_PREA_CLK_DIV16_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/16 Position  */
+#define PWM_CLK_PREA_CLK_DIV32              (PWM_CLK_PREA_CLK_DIV32_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/32 Position  */
+#define PWM_CLK_PREA_CLK_DIV64              (PWM_CLK_PREA_CLK_DIV64_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/64 Position  */
+#define PWM_CLK_PREA_CLK_DIV128             (PWM_CLK_PREA_CLK_DIV128_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/128 Position  */
+#define PWM_CLK_PREA_CLK_DIV256             (PWM_CLK_PREA_CLK_DIV256_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/256 Position  */
+#define PWM_CLK_PREA_CLK_DIV512             (PWM_CLK_PREA_CLK_DIV512_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/512 Position  */
+#define PWM_CLK_PREA_CLK_DIV1024            (PWM_CLK_PREA_CLK_DIV1024_Val << PWM_CLK_PREA_Pos)  /**< (PWM_CLK) Peripheral clock/1024 Position  */
+#define PWM_CLK_DIVB_Pos                    16                                             /**< (PWM_CLK) CLKB Divide Factor Position */
+#define PWM_CLK_DIVB_Msk                    (_U_(0xFF) << PWM_CLK_DIVB_Pos)                /**< (PWM_CLK) CLKB Divide Factor Mask */
+#define PWM_CLK_DIVB(value)                 (PWM_CLK_DIVB_Msk & ((value) << PWM_CLK_DIVB_Pos))
+#define   PWM_CLK_DIVB_CLKB_POFF_Val        _U_(0x0)                                       /**< (PWM_CLK) CLKB clock is turned off  */
+#define   PWM_CLK_DIVB_PREB_Val             _U_(0x1)                                       /**< (PWM_CLK) CLKB clock is clock selected by PREB  */
+#define PWM_CLK_DIVB_CLKB_POFF              (PWM_CLK_DIVB_CLKB_POFF_Val << PWM_CLK_DIVB_Pos)  /**< (PWM_CLK) CLKB clock is turned off Position  */
+#define PWM_CLK_DIVB_PREB                   (PWM_CLK_DIVB_PREB_Val << PWM_CLK_DIVB_Pos)    /**< (PWM_CLK) CLKB clock is clock selected by PREB Position  */
+#define PWM_CLK_PREB_Pos                    24                                             /**< (PWM_CLK) CLKB Source Clock Selection Position */
+#define PWM_CLK_PREB_Msk                    (_U_(0xF) << PWM_CLK_PREB_Pos)                 /**< (PWM_CLK) CLKB Source Clock Selection Mask */
+#define PWM_CLK_PREB(value)                 (PWM_CLK_PREB_Msk & ((value) << PWM_CLK_PREB_Pos))
+#define   PWM_CLK_PREB_CLK_Val              _U_(0x0)                                       /**< (PWM_CLK) Peripheral clock  */
+#define   PWM_CLK_PREB_CLK_DIV2_Val         _U_(0x1)                                       /**< (PWM_CLK) Peripheral clock/2  */
+#define   PWM_CLK_PREB_CLK_DIV4_Val         _U_(0x2)                                       /**< (PWM_CLK) Peripheral clock/4  */
+#define   PWM_CLK_PREB_CLK_DIV8_Val         _U_(0x3)                                       /**< (PWM_CLK) Peripheral clock/8  */
+#define   PWM_CLK_PREB_CLK_DIV16_Val        _U_(0x4)                                       /**< (PWM_CLK) Peripheral clock/16  */
+#define   PWM_CLK_PREB_CLK_DIV32_Val        _U_(0x5)                                       /**< (PWM_CLK) Peripheral clock/32  */
+#define   PWM_CLK_PREB_CLK_DIV64_Val        _U_(0x6)                                       /**< (PWM_CLK) Peripheral clock/64  */
+#define   PWM_CLK_PREB_CLK_DIV128_Val       _U_(0x7)                                       /**< (PWM_CLK) Peripheral clock/128  */
+#define   PWM_CLK_PREB_CLK_DIV256_Val       _U_(0x8)                                       /**< (PWM_CLK) Peripheral clock/256  */
+#define   PWM_CLK_PREB_CLK_DIV512_Val       _U_(0x9)                                       /**< (PWM_CLK) Peripheral clock/512  */
+#define   PWM_CLK_PREB_CLK_DIV1024_Val      _U_(0xA)                                       /**< (PWM_CLK) Peripheral clock/1024  */
+#define PWM_CLK_PREB_CLK                    (PWM_CLK_PREB_CLK_Val << PWM_CLK_PREB_Pos)     /**< (PWM_CLK) Peripheral clock Position  */
+#define PWM_CLK_PREB_CLK_DIV2               (PWM_CLK_PREB_CLK_DIV2_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/2 Position  */
+#define PWM_CLK_PREB_CLK_DIV4               (PWM_CLK_PREB_CLK_DIV4_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/4 Position  */
+#define PWM_CLK_PREB_CLK_DIV8               (PWM_CLK_PREB_CLK_DIV8_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/8 Position  */
+#define PWM_CLK_PREB_CLK_DIV16              (PWM_CLK_PREB_CLK_DIV16_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/16 Position  */
+#define PWM_CLK_PREB_CLK_DIV32              (PWM_CLK_PREB_CLK_DIV32_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/32 Position  */
+#define PWM_CLK_PREB_CLK_DIV64              (PWM_CLK_PREB_CLK_DIV64_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/64 Position  */
+#define PWM_CLK_PREB_CLK_DIV128             (PWM_CLK_PREB_CLK_DIV128_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/128 Position  */
+#define PWM_CLK_PREB_CLK_DIV256             (PWM_CLK_PREB_CLK_DIV256_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/256 Position  */
+#define PWM_CLK_PREB_CLK_DIV512             (PWM_CLK_PREB_CLK_DIV512_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/512 Position  */
+#define PWM_CLK_PREB_CLK_DIV1024            (PWM_CLK_PREB_CLK_DIV1024_Val << PWM_CLK_PREB_Pos)  /**< (PWM_CLK) Peripheral clock/1024 Position  */
+#define PWM_CLK_MASK                        _U_(0xFFF0FFF)                                 /**< \deprecated (PWM_CLK) Register MASK  (Use PWM_CLK_Msk instead)  */
+#define PWM_CLK_Msk                         _U_(0xFFF0FFF)                                 /**< (PWM_CLK) Register Mask  */
+
+
+/* -------- PWM_ENA : (PWM Offset: 0x04) (/W 32) PWM Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ENA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ENA_OFFSET                      (0x04)                                        /**<  (PWM_ENA) PWM Enable Register  Offset */
+
+#define PWM_ENA_CHID0_Pos                   0                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID0_Msk                   (_U_(0x1) << PWM_ENA_CHID0_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID0                       PWM_ENA_CHID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID0_Msk instead */
+#define PWM_ENA_CHID1_Pos                   1                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID1_Msk                   (_U_(0x1) << PWM_ENA_CHID1_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID1                       PWM_ENA_CHID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID1_Msk instead */
+#define PWM_ENA_CHID2_Pos                   2                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID2_Msk                   (_U_(0x1) << PWM_ENA_CHID2_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID2                       PWM_ENA_CHID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID2_Msk instead */
+#define PWM_ENA_CHID3_Pos                   3                                              /**< (PWM_ENA) Channel ID Position */
+#define PWM_ENA_CHID3_Msk                   (_U_(0x1) << PWM_ENA_CHID3_Pos)                /**< (PWM_ENA) Channel ID Mask */
+#define PWM_ENA_CHID3                       PWM_ENA_CHID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ENA_CHID3_Msk instead */
+#define PWM_ENA_MASK                        _U_(0x0F)                                      /**< \deprecated (PWM_ENA) Register MASK  (Use PWM_ENA_Msk instead)  */
+#define PWM_ENA_Msk                         _U_(0x0F)                                      /**< (PWM_ENA) Register Mask  */
+
+#define PWM_ENA_CHID_Pos                    0                                              /**< (PWM_ENA Position) Channel ID */
+#define PWM_ENA_CHID_Msk                    (_U_(0xF) << PWM_ENA_CHID_Pos)                 /**< (PWM_ENA Mask) CHID */
+#define PWM_ENA_CHID(value)                 (PWM_ENA_CHID_Msk & ((value) << PWM_ENA_CHID_Pos))  
+
+/* -------- PWM_DIS : (PWM Offset: 0x08) (/W 32) PWM Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DIS_OFFSET                      (0x08)                                        /**<  (PWM_DIS) PWM Disable Register  Offset */
+
+#define PWM_DIS_CHID0_Pos                   0                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID0_Msk                   (_U_(0x1) << PWM_DIS_CHID0_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID0                       PWM_DIS_CHID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID0_Msk instead */
+#define PWM_DIS_CHID1_Pos                   1                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID1_Msk                   (_U_(0x1) << PWM_DIS_CHID1_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID1                       PWM_DIS_CHID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID1_Msk instead */
+#define PWM_DIS_CHID2_Pos                   2                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID2_Msk                   (_U_(0x1) << PWM_DIS_CHID2_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID2                       PWM_DIS_CHID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID2_Msk instead */
+#define PWM_DIS_CHID3_Pos                   3                                              /**< (PWM_DIS) Channel ID Position */
+#define PWM_DIS_CHID3_Msk                   (_U_(0x1) << PWM_DIS_CHID3_Pos)                /**< (PWM_DIS) Channel ID Mask */
+#define PWM_DIS_CHID3                       PWM_DIS_CHID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_DIS_CHID3_Msk instead */
+#define PWM_DIS_MASK                        _U_(0x0F)                                      /**< \deprecated (PWM_DIS) Register MASK  (Use PWM_DIS_Msk instead)  */
+#define PWM_DIS_Msk                         _U_(0x0F)                                      /**< (PWM_DIS) Register Mask  */
+
+#define PWM_DIS_CHID_Pos                    0                                              /**< (PWM_DIS Position) Channel ID */
+#define PWM_DIS_CHID_Msk                    (_U_(0xF) << PWM_DIS_CHID_Pos)                 /**< (PWM_DIS Mask) CHID */
+#define PWM_DIS_CHID(value)                 (PWM_DIS_CHID_Msk & ((value) << PWM_DIS_CHID_Pos))  
+
+/* -------- PWM_SR : (PWM Offset: 0x0c) (R/ 32) PWM Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
+    uint32_t CHID1:1;                   /**< bit:      1  Channel ID                               */
+    uint32_t CHID2:1;                   /**< bit:      2  Channel ID                               */
+    uint32_t CHID3:1;                   /**< bit:      3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Channel ID                               */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SR_OFFSET                       (0x0C)                                        /**<  (PWM_SR) PWM Status Register  Offset */
+
+#define PWM_SR_CHID0_Pos                    0                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID0_Msk                    (_U_(0x1) << PWM_SR_CHID0_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID0                        PWM_SR_CHID0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID0_Msk instead */
+#define PWM_SR_CHID1_Pos                    1                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID1_Msk                    (_U_(0x1) << PWM_SR_CHID1_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID1                        PWM_SR_CHID1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID1_Msk instead */
+#define PWM_SR_CHID2_Pos                    2                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID2_Msk                    (_U_(0x1) << PWM_SR_CHID2_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID2                        PWM_SR_CHID2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID2_Msk instead */
+#define PWM_SR_CHID3_Pos                    3                                              /**< (PWM_SR) Channel ID Position */
+#define PWM_SR_CHID3_Msk                    (_U_(0x1) << PWM_SR_CHID3_Pos)                 /**< (PWM_SR) Channel ID Mask */
+#define PWM_SR_CHID3                        PWM_SR_CHID3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SR_CHID3_Msk instead */
+#define PWM_SR_MASK                         _U_(0x0F)                                      /**< \deprecated (PWM_SR) Register MASK  (Use PWM_SR_Msk instead)  */
+#define PWM_SR_Msk                          _U_(0x0F)                                      /**< (PWM_SR) Register Mask  */
+
+#define PWM_SR_CHID_Pos                     0                                              /**< (PWM_SR Position) Channel ID */
+#define PWM_SR_CHID_Msk                     (_U_(0xF) << PWM_SR_CHID_Pos)                  /**< (PWM_SR Mask) CHID */
+#define PWM_SR_CHID(value)                  (PWM_SR_CHID_Msk & ((value) << PWM_SR_CHID_Pos))  
+
+/* -------- PWM_IER1 : (PWM Offset: 0x10) (/W 32) PWM Interrupt Enable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Enable */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Enable */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Enable */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Enable */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Enable */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Enable */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Enable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Enable */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IER1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IER1_OFFSET                     (0x10)                                        /**<  (PWM_IER1) PWM Interrupt Enable Register 1  Offset */
+
+#define PWM_IER1_CHID0_Pos                  0                                              /**< (PWM_IER1) Counter Event on Channel 0 Interrupt Enable Position */
+#define PWM_IER1_CHID0_Msk                  (_U_(0x1) << PWM_IER1_CHID0_Pos)               /**< (PWM_IER1) Counter Event on Channel 0 Interrupt Enable Mask */
+#define PWM_IER1_CHID0                      PWM_IER1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID0_Msk instead */
+#define PWM_IER1_CHID1_Pos                  1                                              /**< (PWM_IER1) Counter Event on Channel 1 Interrupt Enable Position */
+#define PWM_IER1_CHID1_Msk                  (_U_(0x1) << PWM_IER1_CHID1_Pos)               /**< (PWM_IER1) Counter Event on Channel 1 Interrupt Enable Mask */
+#define PWM_IER1_CHID1                      PWM_IER1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID1_Msk instead */
+#define PWM_IER1_CHID2_Pos                  2                                              /**< (PWM_IER1) Counter Event on Channel 2 Interrupt Enable Position */
+#define PWM_IER1_CHID2_Msk                  (_U_(0x1) << PWM_IER1_CHID2_Pos)               /**< (PWM_IER1) Counter Event on Channel 2 Interrupt Enable Mask */
+#define PWM_IER1_CHID2                      PWM_IER1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID2_Msk instead */
+#define PWM_IER1_CHID3_Pos                  3                                              /**< (PWM_IER1) Counter Event on Channel 3 Interrupt Enable Position */
+#define PWM_IER1_CHID3_Msk                  (_U_(0x1) << PWM_IER1_CHID3_Pos)               /**< (PWM_IER1) Counter Event on Channel 3 Interrupt Enable Mask */
+#define PWM_IER1_CHID3                      PWM_IER1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_CHID3_Msk instead */
+#define PWM_IER1_FCHID0_Pos                 16                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 0 Interrupt Enable Position */
+#define PWM_IER1_FCHID0_Msk                 (_U_(0x1) << PWM_IER1_FCHID0_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 0 Interrupt Enable Mask */
+#define PWM_IER1_FCHID0                     PWM_IER1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID0_Msk instead */
+#define PWM_IER1_FCHID1_Pos                 17                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 1 Interrupt Enable Position */
+#define PWM_IER1_FCHID1_Msk                 (_U_(0x1) << PWM_IER1_FCHID1_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 1 Interrupt Enable Mask */
+#define PWM_IER1_FCHID1                     PWM_IER1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID1_Msk instead */
+#define PWM_IER1_FCHID2_Pos                 18                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 2 Interrupt Enable Position */
+#define PWM_IER1_FCHID2_Msk                 (_U_(0x1) << PWM_IER1_FCHID2_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 2 Interrupt Enable Mask */
+#define PWM_IER1_FCHID2                     PWM_IER1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID2_Msk instead */
+#define PWM_IER1_FCHID3_Pos                 19                                             /**< (PWM_IER1) Fault Protection Trigger on Channel 3 Interrupt Enable Position */
+#define PWM_IER1_FCHID3_Msk                 (_U_(0x1) << PWM_IER1_FCHID3_Pos)              /**< (PWM_IER1) Fault Protection Trigger on Channel 3 Interrupt Enable Mask */
+#define PWM_IER1_FCHID3                     PWM_IER1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER1_FCHID3_Msk instead */
+#define PWM_IER1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IER1) Register MASK  (Use PWM_IER1_Msk instead)  */
+#define PWM_IER1_Msk                        _U_(0xF000F)                                   /**< (PWM_IER1) Register Mask  */
+
+#define PWM_IER1_CHID_Pos                   0                                              /**< (PWM_IER1 Position) Counter Event on Channel x Interrupt Enable */
+#define PWM_IER1_CHID_Msk                   (_U_(0xF) << PWM_IER1_CHID_Pos)                /**< (PWM_IER1 Mask) CHID */
+#define PWM_IER1_CHID(value)                (PWM_IER1_CHID_Msk & ((value) << PWM_IER1_CHID_Pos))  
+#define PWM_IER1_FCHID_Pos                  16                                             /**< (PWM_IER1 Position) Fault Protection Trigger on Channel 3 Interrupt Enable */
+#define PWM_IER1_FCHID_Msk                  (_U_(0xF) << PWM_IER1_FCHID_Pos)               /**< (PWM_IER1 Mask) FCHID */
+#define PWM_IER1_FCHID(value)               (PWM_IER1_FCHID_Msk & ((value) << PWM_IER1_FCHID_Pos))  
+
+/* -------- PWM_IDR1 : (PWM Offset: 0x14) (/W 32) PWM Interrupt Disable Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Disable */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Disable */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Disable */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Disable */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Disable */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Disable */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Disable */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Disable */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IDR1_OFFSET                     (0x14)                                        /**<  (PWM_IDR1) PWM Interrupt Disable Register 1  Offset */
+
+#define PWM_IDR1_CHID0_Pos                  0                                              /**< (PWM_IDR1) Counter Event on Channel 0 Interrupt Disable Position */
+#define PWM_IDR1_CHID0_Msk                  (_U_(0x1) << PWM_IDR1_CHID0_Pos)               /**< (PWM_IDR1) Counter Event on Channel 0 Interrupt Disable Mask */
+#define PWM_IDR1_CHID0                      PWM_IDR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID0_Msk instead */
+#define PWM_IDR1_CHID1_Pos                  1                                              /**< (PWM_IDR1) Counter Event on Channel 1 Interrupt Disable Position */
+#define PWM_IDR1_CHID1_Msk                  (_U_(0x1) << PWM_IDR1_CHID1_Pos)               /**< (PWM_IDR1) Counter Event on Channel 1 Interrupt Disable Mask */
+#define PWM_IDR1_CHID1                      PWM_IDR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID1_Msk instead */
+#define PWM_IDR1_CHID2_Pos                  2                                              /**< (PWM_IDR1) Counter Event on Channel 2 Interrupt Disable Position */
+#define PWM_IDR1_CHID2_Msk                  (_U_(0x1) << PWM_IDR1_CHID2_Pos)               /**< (PWM_IDR1) Counter Event on Channel 2 Interrupt Disable Mask */
+#define PWM_IDR1_CHID2                      PWM_IDR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID2_Msk instead */
+#define PWM_IDR1_CHID3_Pos                  3                                              /**< (PWM_IDR1) Counter Event on Channel 3 Interrupt Disable Position */
+#define PWM_IDR1_CHID3_Msk                  (_U_(0x1) << PWM_IDR1_CHID3_Pos)               /**< (PWM_IDR1) Counter Event on Channel 3 Interrupt Disable Mask */
+#define PWM_IDR1_CHID3                      PWM_IDR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_CHID3_Msk instead */
+#define PWM_IDR1_FCHID0_Pos                 16                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 0 Interrupt Disable Position */
+#define PWM_IDR1_FCHID0_Msk                 (_U_(0x1) << PWM_IDR1_FCHID0_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 0 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID0                     PWM_IDR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID0_Msk instead */
+#define PWM_IDR1_FCHID1_Pos                 17                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 1 Interrupt Disable Position */
+#define PWM_IDR1_FCHID1_Msk                 (_U_(0x1) << PWM_IDR1_FCHID1_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 1 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID1                     PWM_IDR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID1_Msk instead */
+#define PWM_IDR1_FCHID2_Pos                 18                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 2 Interrupt Disable Position */
+#define PWM_IDR1_FCHID2_Msk                 (_U_(0x1) << PWM_IDR1_FCHID2_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 2 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID2                     PWM_IDR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID2_Msk instead */
+#define PWM_IDR1_FCHID3_Pos                 19                                             /**< (PWM_IDR1) Fault Protection Trigger on Channel 3 Interrupt Disable Position */
+#define PWM_IDR1_FCHID3_Msk                 (_U_(0x1) << PWM_IDR1_FCHID3_Pos)              /**< (PWM_IDR1) Fault Protection Trigger on Channel 3 Interrupt Disable Mask */
+#define PWM_IDR1_FCHID3                     PWM_IDR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR1_FCHID3_Msk instead */
+#define PWM_IDR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IDR1) Register MASK  (Use PWM_IDR1_Msk instead)  */
+#define PWM_IDR1_Msk                        _U_(0xF000F)                                   /**< (PWM_IDR1) Register Mask  */
+
+#define PWM_IDR1_CHID_Pos                   0                                              /**< (PWM_IDR1 Position) Counter Event on Channel x Interrupt Disable */
+#define PWM_IDR1_CHID_Msk                   (_U_(0xF) << PWM_IDR1_CHID_Pos)                /**< (PWM_IDR1 Mask) CHID */
+#define PWM_IDR1_CHID(value)                (PWM_IDR1_CHID_Msk & ((value) << PWM_IDR1_CHID_Pos))  
+#define PWM_IDR1_FCHID_Pos                  16                                             /**< (PWM_IDR1 Position) Fault Protection Trigger on Channel 3 Interrupt Disable */
+#define PWM_IDR1_FCHID_Msk                  (_U_(0xF) << PWM_IDR1_FCHID_Pos)               /**< (PWM_IDR1 Mask) FCHID */
+#define PWM_IDR1_FCHID(value)               (PWM_IDR1_FCHID_Msk & ((value) << PWM_IDR1_FCHID_Pos))  
+
+/* -------- PWM_IMR1 : (PWM Offset: 0x18) (R/ 32) PWM Interrupt Mask Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Mask */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1 Interrupt Mask */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2 Interrupt Mask */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0 Interrupt Mask */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1 Interrupt Mask */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2 Interrupt Mask */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x Interrupt Mask */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3 Interrupt Mask */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IMR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IMR1_OFFSET                     (0x18)                                        /**<  (PWM_IMR1) PWM Interrupt Mask Register 1  Offset */
+
+#define PWM_IMR1_CHID0_Pos                  0                                              /**< (PWM_IMR1) Counter Event on Channel 0 Interrupt Mask Position */
+#define PWM_IMR1_CHID0_Msk                  (_U_(0x1) << PWM_IMR1_CHID0_Pos)               /**< (PWM_IMR1) Counter Event on Channel 0 Interrupt Mask Mask */
+#define PWM_IMR1_CHID0                      PWM_IMR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID0_Msk instead */
+#define PWM_IMR1_CHID1_Pos                  1                                              /**< (PWM_IMR1) Counter Event on Channel 1 Interrupt Mask Position */
+#define PWM_IMR1_CHID1_Msk                  (_U_(0x1) << PWM_IMR1_CHID1_Pos)               /**< (PWM_IMR1) Counter Event on Channel 1 Interrupt Mask Mask */
+#define PWM_IMR1_CHID1                      PWM_IMR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID1_Msk instead */
+#define PWM_IMR1_CHID2_Pos                  2                                              /**< (PWM_IMR1) Counter Event on Channel 2 Interrupt Mask Position */
+#define PWM_IMR1_CHID2_Msk                  (_U_(0x1) << PWM_IMR1_CHID2_Pos)               /**< (PWM_IMR1) Counter Event on Channel 2 Interrupt Mask Mask */
+#define PWM_IMR1_CHID2                      PWM_IMR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID2_Msk instead */
+#define PWM_IMR1_CHID3_Pos                  3                                              /**< (PWM_IMR1) Counter Event on Channel 3 Interrupt Mask Position */
+#define PWM_IMR1_CHID3_Msk                  (_U_(0x1) << PWM_IMR1_CHID3_Pos)               /**< (PWM_IMR1) Counter Event on Channel 3 Interrupt Mask Mask */
+#define PWM_IMR1_CHID3                      PWM_IMR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_CHID3_Msk instead */
+#define PWM_IMR1_FCHID0_Pos                 16                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 0 Interrupt Mask Position */
+#define PWM_IMR1_FCHID0_Msk                 (_U_(0x1) << PWM_IMR1_FCHID0_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 0 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID0                     PWM_IMR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID0_Msk instead */
+#define PWM_IMR1_FCHID1_Pos                 17                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 1 Interrupt Mask Position */
+#define PWM_IMR1_FCHID1_Msk                 (_U_(0x1) << PWM_IMR1_FCHID1_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 1 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID1                     PWM_IMR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID1_Msk instead */
+#define PWM_IMR1_FCHID2_Pos                 18                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 2 Interrupt Mask Position */
+#define PWM_IMR1_FCHID2_Msk                 (_U_(0x1) << PWM_IMR1_FCHID2_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 2 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID2                     PWM_IMR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID2_Msk instead */
+#define PWM_IMR1_FCHID3_Pos                 19                                             /**< (PWM_IMR1) Fault Protection Trigger on Channel 3 Interrupt Mask Position */
+#define PWM_IMR1_FCHID3_Msk                 (_U_(0x1) << PWM_IMR1_FCHID3_Pos)              /**< (PWM_IMR1) Fault Protection Trigger on Channel 3 Interrupt Mask Mask */
+#define PWM_IMR1_FCHID3                     PWM_IMR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR1_FCHID3_Msk instead */
+#define PWM_IMR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_IMR1) Register MASK  (Use PWM_IMR1_Msk instead)  */
+#define PWM_IMR1_Msk                        _U_(0xF000F)                                   /**< (PWM_IMR1) Register Mask  */
+
+#define PWM_IMR1_CHID_Pos                   0                                              /**< (PWM_IMR1 Position) Counter Event on Channel x Interrupt Mask */
+#define PWM_IMR1_CHID_Msk                   (_U_(0xF) << PWM_IMR1_CHID_Pos)                /**< (PWM_IMR1 Mask) CHID */
+#define PWM_IMR1_CHID(value)                (PWM_IMR1_CHID_Msk & ((value) << PWM_IMR1_CHID_Pos))  
+#define PWM_IMR1_FCHID_Pos                  16                                             /**< (PWM_IMR1 Position) Fault Protection Trigger on Channel 3 Interrupt Mask */
+#define PWM_IMR1_FCHID_Msk                  (_U_(0xF) << PWM_IMR1_FCHID_Pos)               /**< (PWM_IMR1 Mask) FCHID */
+#define PWM_IMR1_FCHID(value)               (PWM_IMR1_FCHID_Msk & ((value) << PWM_IMR1_FCHID_Pos))  
+
+/* -------- PWM_ISR1 : (PWM Offset: 0x1c) (R/ 32) PWM Interrupt Status Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0               */
+    uint32_t CHID1:1;                   /**< bit:      1  Counter Event on Channel 1               */
+    uint32_t CHID2:1;                   /**< bit:      2  Counter Event on Channel 2               */
+    uint32_t CHID3:1;                   /**< bit:      3  Counter Event on Channel 3               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID0:1;                  /**< bit:     16  Fault Protection Trigger on Channel 0    */
+    uint32_t FCHID1:1;                  /**< bit:     17  Fault Protection Trigger on Channel 1    */
+    uint32_t FCHID2:1;                  /**< bit:     18  Fault Protection Trigger on Channel 2    */
+    uint32_t FCHID3:1;                  /**< bit:     19  Fault Protection Trigger on Channel 3    */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CHID:4;                    /**< bit:   0..3  Counter Event on Channel x               */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FCHID:4;                   /**< bit: 16..19  Fault Protection Trigger on Channel 3    */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ISR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ISR1_OFFSET                     (0x1C)                                        /**<  (PWM_ISR1) PWM Interrupt Status Register 1  Offset */
+
+#define PWM_ISR1_CHID0_Pos                  0                                              /**< (PWM_ISR1) Counter Event on Channel 0 Position */
+#define PWM_ISR1_CHID0_Msk                  (_U_(0x1) << PWM_ISR1_CHID0_Pos)               /**< (PWM_ISR1) Counter Event on Channel 0 Mask */
+#define PWM_ISR1_CHID0                      PWM_ISR1_CHID0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID0_Msk instead */
+#define PWM_ISR1_CHID1_Pos                  1                                              /**< (PWM_ISR1) Counter Event on Channel 1 Position */
+#define PWM_ISR1_CHID1_Msk                  (_U_(0x1) << PWM_ISR1_CHID1_Pos)               /**< (PWM_ISR1) Counter Event on Channel 1 Mask */
+#define PWM_ISR1_CHID1                      PWM_ISR1_CHID1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID1_Msk instead */
+#define PWM_ISR1_CHID2_Pos                  2                                              /**< (PWM_ISR1) Counter Event on Channel 2 Position */
+#define PWM_ISR1_CHID2_Msk                  (_U_(0x1) << PWM_ISR1_CHID2_Pos)               /**< (PWM_ISR1) Counter Event on Channel 2 Mask */
+#define PWM_ISR1_CHID2                      PWM_ISR1_CHID2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID2_Msk instead */
+#define PWM_ISR1_CHID3_Pos                  3                                              /**< (PWM_ISR1) Counter Event on Channel 3 Position */
+#define PWM_ISR1_CHID3_Msk                  (_U_(0x1) << PWM_ISR1_CHID3_Pos)               /**< (PWM_ISR1) Counter Event on Channel 3 Mask */
+#define PWM_ISR1_CHID3                      PWM_ISR1_CHID3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_CHID3_Msk instead */
+#define PWM_ISR1_FCHID0_Pos                 16                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 0 Position */
+#define PWM_ISR1_FCHID0_Msk                 (_U_(0x1) << PWM_ISR1_FCHID0_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 0 Mask */
+#define PWM_ISR1_FCHID0                     PWM_ISR1_FCHID0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID0_Msk instead */
+#define PWM_ISR1_FCHID1_Pos                 17                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 1 Position */
+#define PWM_ISR1_FCHID1_Msk                 (_U_(0x1) << PWM_ISR1_FCHID1_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 1 Mask */
+#define PWM_ISR1_FCHID1                     PWM_ISR1_FCHID1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID1_Msk instead */
+#define PWM_ISR1_FCHID2_Pos                 18                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 2 Position */
+#define PWM_ISR1_FCHID2_Msk                 (_U_(0x1) << PWM_ISR1_FCHID2_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 2 Mask */
+#define PWM_ISR1_FCHID2                     PWM_ISR1_FCHID2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID2_Msk instead */
+#define PWM_ISR1_FCHID3_Pos                 19                                             /**< (PWM_ISR1) Fault Protection Trigger on Channel 3 Position */
+#define PWM_ISR1_FCHID3_Msk                 (_U_(0x1) << PWM_ISR1_FCHID3_Pos)              /**< (PWM_ISR1) Fault Protection Trigger on Channel 3 Mask */
+#define PWM_ISR1_FCHID3                     PWM_ISR1_FCHID3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR1_FCHID3_Msk instead */
+#define PWM_ISR1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_ISR1) Register MASK  (Use PWM_ISR1_Msk instead)  */
+#define PWM_ISR1_Msk                        _U_(0xF000F)                                   /**< (PWM_ISR1) Register Mask  */
+
+#define PWM_ISR1_CHID_Pos                   0                                              /**< (PWM_ISR1 Position) Counter Event on Channel x */
+#define PWM_ISR1_CHID_Msk                   (_U_(0xF) << PWM_ISR1_CHID_Pos)                /**< (PWM_ISR1 Mask) CHID */
+#define PWM_ISR1_CHID(value)                (PWM_ISR1_CHID_Msk & ((value) << PWM_ISR1_CHID_Pos))  
+#define PWM_ISR1_FCHID_Pos                  16                                             /**< (PWM_ISR1 Position) Fault Protection Trigger on Channel 3 */
+#define PWM_ISR1_FCHID_Msk                  (_U_(0xF) << PWM_ISR1_FCHID_Pos)               /**< (PWM_ISR1 Mask) FCHID */
+#define PWM_ISR1_FCHID(value)               (PWM_ISR1_FCHID_Msk & ((value) << PWM_ISR1_FCHID_Pos))  
+
+/* -------- PWM_SCM : (PWM Offset: 0x20) (R/W 32) PWM Sync Channels Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SYNC0:1;                   /**< bit:      0  Synchronous Channel 0                    */
+    uint32_t SYNC1:1;                   /**< bit:      1  Synchronous Channel 1                    */
+    uint32_t SYNC2:1;                   /**< bit:      2  Synchronous Channel 2                    */
+    uint32_t SYNC3:1;                   /**< bit:      3  Synchronous Channel 3                    */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t UPDM:2;                    /**< bit: 16..17  Synchronous Channels Update Mode         */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t PTRM:1;                    /**< bit:     20  DMA Controller Transfer Request Mode     */
+    uint32_t PTRCS:3;                   /**< bit: 21..23  DMA Controller Transfer Request Comparison Selection */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SYNC:4;                    /**< bit:   0..3  Synchronous Channel x                    */
+    uint32_t :28;                       /**< bit:  4..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCM_OFFSET                      (0x20)                                        /**<  (PWM_SCM) PWM Sync Channels Mode Register  Offset */
+
+#define PWM_SCM_SYNC0_Pos                   0                                              /**< (PWM_SCM) Synchronous Channel 0 Position */
+#define PWM_SCM_SYNC0_Msk                   (_U_(0x1) << PWM_SCM_SYNC0_Pos)                /**< (PWM_SCM) Synchronous Channel 0 Mask */
+#define PWM_SCM_SYNC0                       PWM_SCM_SYNC0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC0_Msk instead */
+#define PWM_SCM_SYNC1_Pos                   1                                              /**< (PWM_SCM) Synchronous Channel 1 Position */
+#define PWM_SCM_SYNC1_Msk                   (_U_(0x1) << PWM_SCM_SYNC1_Pos)                /**< (PWM_SCM) Synchronous Channel 1 Mask */
+#define PWM_SCM_SYNC1                       PWM_SCM_SYNC1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC1_Msk instead */
+#define PWM_SCM_SYNC2_Pos                   2                                              /**< (PWM_SCM) Synchronous Channel 2 Position */
+#define PWM_SCM_SYNC2_Msk                   (_U_(0x1) << PWM_SCM_SYNC2_Pos)                /**< (PWM_SCM) Synchronous Channel 2 Mask */
+#define PWM_SCM_SYNC2                       PWM_SCM_SYNC2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC2_Msk instead */
+#define PWM_SCM_SYNC3_Pos                   3                                              /**< (PWM_SCM) Synchronous Channel 3 Position */
+#define PWM_SCM_SYNC3_Msk                   (_U_(0x1) << PWM_SCM_SYNC3_Pos)                /**< (PWM_SCM) Synchronous Channel 3 Mask */
+#define PWM_SCM_SYNC3                       PWM_SCM_SYNC3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_SYNC3_Msk instead */
+#define PWM_SCM_UPDM_Pos                    16                                             /**< (PWM_SCM) Synchronous Channels Update Mode Position */
+#define PWM_SCM_UPDM_Msk                    (_U_(0x3) << PWM_SCM_UPDM_Pos)                 /**< (PWM_SCM) Synchronous Channels Update Mode Mask */
+#define PWM_SCM_UPDM(value)                 (PWM_SCM_UPDM_Msk & ((value) << PWM_SCM_UPDM_Pos))
+#define   PWM_SCM_UPDM_MODE0_Val            _U_(0x0)                                       /**< (PWM_SCM) Manual write of double buffer registers and manual update of synchronous channels  */
+#define   PWM_SCM_UPDM_MODE1_Val            _U_(0x1)                                       /**< (PWM_SCM) Manual write of double buffer registers and automatic update of synchronous channels  */
+#define   PWM_SCM_UPDM_MODE2_Val            _U_(0x2)                                       /**< (PWM_SCM) Automatic write of duty-cycle update registers by the DMA Controller and automatic update of synchronous channels  */
+#define PWM_SCM_UPDM_MODE0                  (PWM_SCM_UPDM_MODE0_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Manual write of double buffer registers and manual update of synchronous channels Position  */
+#define PWM_SCM_UPDM_MODE1                  (PWM_SCM_UPDM_MODE1_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Manual write of double buffer registers and automatic update of synchronous channels Position  */
+#define PWM_SCM_UPDM_MODE2                  (PWM_SCM_UPDM_MODE2_Val << PWM_SCM_UPDM_Pos)   /**< (PWM_SCM) Automatic write of duty-cycle update registers by the DMA Controller and automatic update of synchronous channels Position  */
+#define PWM_SCM_PTRM_Pos                    20                                             /**< (PWM_SCM) DMA Controller Transfer Request Mode Position */
+#define PWM_SCM_PTRM_Msk                    (_U_(0x1) << PWM_SCM_PTRM_Pos)                 /**< (PWM_SCM) DMA Controller Transfer Request Mode Mask */
+#define PWM_SCM_PTRM                        PWM_SCM_PTRM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCM_PTRM_Msk instead */
+#define PWM_SCM_PTRCS_Pos                   21                                             /**< (PWM_SCM) DMA Controller Transfer Request Comparison Selection Position */
+#define PWM_SCM_PTRCS_Msk                   (_U_(0x7) << PWM_SCM_PTRCS_Pos)                /**< (PWM_SCM) DMA Controller Transfer Request Comparison Selection Mask */
+#define PWM_SCM_PTRCS(value)                (PWM_SCM_PTRCS_Msk & ((value) << PWM_SCM_PTRCS_Pos))
+#define PWM_SCM_MASK                        _U_(0xF3000F)                                  /**< \deprecated (PWM_SCM) Register MASK  (Use PWM_SCM_Msk instead)  */
+#define PWM_SCM_Msk                         _U_(0xF3000F)                                  /**< (PWM_SCM) Register Mask  */
+
+#define PWM_SCM_SYNC_Pos                    0                                              /**< (PWM_SCM Position) Synchronous Channel x */
+#define PWM_SCM_SYNC_Msk                    (_U_(0xF) << PWM_SCM_SYNC_Pos)                 /**< (PWM_SCM Mask) SYNC */
+#define PWM_SCM_SYNC(value)                 (PWM_SCM_SYNC_Msk & ((value) << PWM_SCM_SYNC_Pos))  
+
+/* -------- PWM_DMAR : (PWM Offset: 0x24) (/W 32) PWM DMA Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DMADUTY:24;                /**< bit:  0..23  Duty-Cycle Holding Register for DMA Access */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_DMAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_DMAR_OFFSET                     (0x24)                                        /**<  (PWM_DMAR) PWM DMA Register  Offset */
+
+#define PWM_DMAR_DMADUTY_Pos                0                                              /**< (PWM_DMAR) Duty-Cycle Holding Register for DMA Access Position */
+#define PWM_DMAR_DMADUTY_Msk                (_U_(0xFFFFFF) << PWM_DMAR_DMADUTY_Pos)        /**< (PWM_DMAR) Duty-Cycle Holding Register for DMA Access Mask */
+#define PWM_DMAR_DMADUTY(value)             (PWM_DMAR_DMADUTY_Msk & ((value) << PWM_DMAR_DMADUTY_Pos))
+#define PWM_DMAR_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (PWM_DMAR) Register MASK  (Use PWM_DMAR_Msk instead)  */
+#define PWM_DMAR_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_DMAR) Register Mask  */
+
+
+/* -------- PWM_SCUC : (PWM Offset: 0x28) (R/W 32) PWM Sync Channels Update Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPDULOCK:1;                /**< bit:      0  Synchronous Channels Update Unlock       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUC_OFFSET                     (0x28)                                        /**<  (PWM_SCUC) PWM Sync Channels Update Control Register  Offset */
+
+#define PWM_SCUC_UPDULOCK_Pos               0                                              /**< (PWM_SCUC) Synchronous Channels Update Unlock Position */
+#define PWM_SCUC_UPDULOCK_Msk               (_U_(0x1) << PWM_SCUC_UPDULOCK_Pos)            /**< (PWM_SCUC) Synchronous Channels Update Unlock Mask */
+#define PWM_SCUC_UPDULOCK                   PWM_SCUC_UPDULOCK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SCUC_UPDULOCK_Msk instead */
+#define PWM_SCUC_MASK                       _U_(0x01)                                      /**< \deprecated (PWM_SCUC) Register MASK  (Use PWM_SCUC_Msk instead)  */
+#define PWM_SCUC_Msk                        _U_(0x01)                                      /**< (PWM_SCUC) Register Mask  */
+
+
+/* -------- PWM_SCUP : (PWM Offset: 0x2c) (R/W 32) PWM Sync Channels Update Period Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPR:4;                     /**< bit:   0..3  Update Period                            */
+    uint32_t UPRCNT:4;                  /**< bit:   4..7  Update Period Counter                    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUP_OFFSET                     (0x2C)                                        /**<  (PWM_SCUP) PWM Sync Channels Update Period Register  Offset */
+
+#define PWM_SCUP_UPR_Pos                    0                                              /**< (PWM_SCUP) Update Period Position */
+#define PWM_SCUP_UPR_Msk                    (_U_(0xF) << PWM_SCUP_UPR_Pos)                 /**< (PWM_SCUP) Update Period Mask */
+#define PWM_SCUP_UPR(value)                 (PWM_SCUP_UPR_Msk & ((value) << PWM_SCUP_UPR_Pos))
+#define PWM_SCUP_UPRCNT_Pos                 4                                              /**< (PWM_SCUP) Update Period Counter Position */
+#define PWM_SCUP_UPRCNT_Msk                 (_U_(0xF) << PWM_SCUP_UPRCNT_Pos)              /**< (PWM_SCUP) Update Period Counter Mask */
+#define PWM_SCUP_UPRCNT(value)              (PWM_SCUP_UPRCNT_Msk & ((value) << PWM_SCUP_UPRCNT_Pos))
+#define PWM_SCUP_MASK                       _U_(0xFF)                                      /**< \deprecated (PWM_SCUP) Register MASK  (Use PWM_SCUP_Msk instead)  */
+#define PWM_SCUP_Msk                        _U_(0xFF)                                      /**< (PWM_SCUP) Register Mask  */
+
+
+/* -------- PWM_SCUPUPD : (PWM Offset: 0x30) (/W 32) PWM Sync Channels Update Period Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPRUPD:4;                  /**< bit:   0..3  Update Period Update                     */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SCUPUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SCUPUPD_OFFSET                  (0x30)                                        /**<  (PWM_SCUPUPD) PWM Sync Channels Update Period Update Register  Offset */
+
+#define PWM_SCUPUPD_UPRUPD_Pos              0                                              /**< (PWM_SCUPUPD) Update Period Update Position */
+#define PWM_SCUPUPD_UPRUPD_Msk              (_U_(0xF) << PWM_SCUPUPD_UPRUPD_Pos)           /**< (PWM_SCUPUPD) Update Period Update Mask */
+#define PWM_SCUPUPD_UPRUPD(value)           (PWM_SCUPUPD_UPRUPD_Msk & ((value) << PWM_SCUPUPD_UPRUPD_Pos))
+#define PWM_SCUPUPD_MASK                    _U_(0x0F)                                      /**< \deprecated (PWM_SCUPUPD) Register MASK  (Use PWM_SCUPUPD_Msk instead)  */
+#define PWM_SCUPUPD_Msk                     _U_(0x0F)                                      /**< (PWM_SCUPUPD) Register Mask  */
+
+
+/* -------- PWM_IER2 : (PWM Offset: 0x34) (/W 32) PWM Interrupt Enable Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Enable */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Enable */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Enable      */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Enable      */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Enable      */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Enable      */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Enable      */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Enable      */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Enable      */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Enable      */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Enable     */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Enable     */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Enable     */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Enable     */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Enable     */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Enable     */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Enable     */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Enable     */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Enable      */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Enable     */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IER2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IER2_OFFSET                     (0x34)                                        /**<  (PWM_IER2) PWM Interrupt Enable Register 2  Offset */
+
+#define PWM_IER2_WRDY_Pos                   0                                              /**< (PWM_IER2) Write Ready for Synchronous Channels Update Interrupt Enable Position */
+#define PWM_IER2_WRDY_Msk                   (_U_(0x1) << PWM_IER2_WRDY_Pos)                /**< (PWM_IER2) Write Ready for Synchronous Channels Update Interrupt Enable Mask */
+#define PWM_IER2_WRDY                       PWM_IER2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_WRDY_Msk instead */
+#define PWM_IER2_UNRE_Pos                   3                                              /**< (PWM_IER2) Synchronous Channels Update Underrun Error Interrupt Enable Position */
+#define PWM_IER2_UNRE_Msk                   (_U_(0x1) << PWM_IER2_UNRE_Pos)                /**< (PWM_IER2) Synchronous Channels Update Underrun Error Interrupt Enable Mask */
+#define PWM_IER2_UNRE                       PWM_IER2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_UNRE_Msk instead */
+#define PWM_IER2_CMPM0_Pos                  8                                              /**< (PWM_IER2) Comparison 0 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM0_Msk                  (_U_(0x1) << PWM_IER2_CMPM0_Pos)               /**< (PWM_IER2) Comparison 0 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM0                      PWM_IER2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM0_Msk instead */
+#define PWM_IER2_CMPM1_Pos                  9                                              /**< (PWM_IER2) Comparison 1 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM1_Msk                  (_U_(0x1) << PWM_IER2_CMPM1_Pos)               /**< (PWM_IER2) Comparison 1 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM1                      PWM_IER2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM1_Msk instead */
+#define PWM_IER2_CMPM2_Pos                  10                                             /**< (PWM_IER2) Comparison 2 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM2_Msk                  (_U_(0x1) << PWM_IER2_CMPM2_Pos)               /**< (PWM_IER2) Comparison 2 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM2                      PWM_IER2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM2_Msk instead */
+#define PWM_IER2_CMPM3_Pos                  11                                             /**< (PWM_IER2) Comparison 3 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM3_Msk                  (_U_(0x1) << PWM_IER2_CMPM3_Pos)               /**< (PWM_IER2) Comparison 3 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM3                      PWM_IER2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM3_Msk instead */
+#define PWM_IER2_CMPM4_Pos                  12                                             /**< (PWM_IER2) Comparison 4 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM4_Msk                  (_U_(0x1) << PWM_IER2_CMPM4_Pos)               /**< (PWM_IER2) Comparison 4 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM4                      PWM_IER2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM4_Msk instead */
+#define PWM_IER2_CMPM5_Pos                  13                                             /**< (PWM_IER2) Comparison 5 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM5_Msk                  (_U_(0x1) << PWM_IER2_CMPM5_Pos)               /**< (PWM_IER2) Comparison 5 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM5                      PWM_IER2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM5_Msk instead */
+#define PWM_IER2_CMPM6_Pos                  14                                             /**< (PWM_IER2) Comparison 6 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM6_Msk                  (_U_(0x1) << PWM_IER2_CMPM6_Pos)               /**< (PWM_IER2) Comparison 6 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM6                      PWM_IER2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM6_Msk instead */
+#define PWM_IER2_CMPM7_Pos                  15                                             /**< (PWM_IER2) Comparison 7 Match Interrupt Enable Position */
+#define PWM_IER2_CMPM7_Msk                  (_U_(0x1) << PWM_IER2_CMPM7_Pos)               /**< (PWM_IER2) Comparison 7 Match Interrupt Enable Mask */
+#define PWM_IER2_CMPM7                      PWM_IER2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPM7_Msk instead */
+#define PWM_IER2_CMPU0_Pos                  16                                             /**< (PWM_IER2) Comparison 0 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU0_Msk                  (_U_(0x1) << PWM_IER2_CMPU0_Pos)               /**< (PWM_IER2) Comparison 0 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU0                      PWM_IER2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU0_Msk instead */
+#define PWM_IER2_CMPU1_Pos                  17                                             /**< (PWM_IER2) Comparison 1 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU1_Msk                  (_U_(0x1) << PWM_IER2_CMPU1_Pos)               /**< (PWM_IER2) Comparison 1 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU1                      PWM_IER2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU1_Msk instead */
+#define PWM_IER2_CMPU2_Pos                  18                                             /**< (PWM_IER2) Comparison 2 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU2_Msk                  (_U_(0x1) << PWM_IER2_CMPU2_Pos)               /**< (PWM_IER2) Comparison 2 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU2                      PWM_IER2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU2_Msk instead */
+#define PWM_IER2_CMPU3_Pos                  19                                             /**< (PWM_IER2) Comparison 3 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU3_Msk                  (_U_(0x1) << PWM_IER2_CMPU3_Pos)               /**< (PWM_IER2) Comparison 3 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU3                      PWM_IER2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU3_Msk instead */
+#define PWM_IER2_CMPU4_Pos                  20                                             /**< (PWM_IER2) Comparison 4 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU4_Msk                  (_U_(0x1) << PWM_IER2_CMPU4_Pos)               /**< (PWM_IER2) Comparison 4 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU4                      PWM_IER2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU4_Msk instead */
+#define PWM_IER2_CMPU5_Pos                  21                                             /**< (PWM_IER2) Comparison 5 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU5_Msk                  (_U_(0x1) << PWM_IER2_CMPU5_Pos)               /**< (PWM_IER2) Comparison 5 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU5                      PWM_IER2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU5_Msk instead */
+#define PWM_IER2_CMPU6_Pos                  22                                             /**< (PWM_IER2) Comparison 6 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU6_Msk                  (_U_(0x1) << PWM_IER2_CMPU6_Pos)               /**< (PWM_IER2) Comparison 6 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU6                      PWM_IER2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU6_Msk instead */
+#define PWM_IER2_CMPU7_Pos                  23                                             /**< (PWM_IER2) Comparison 7 Update Interrupt Enable Position */
+#define PWM_IER2_CMPU7_Msk                  (_U_(0x1) << PWM_IER2_CMPU7_Pos)               /**< (PWM_IER2) Comparison 7 Update Interrupt Enable Mask */
+#define PWM_IER2_CMPU7                      PWM_IER2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IER2_CMPU7_Msk instead */
+#define PWM_IER2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IER2) Register MASK  (Use PWM_IER2_Msk instead)  */
+#define PWM_IER2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IER2) Register Mask  */
+
+#define PWM_IER2_CMPM_Pos                   8                                              /**< (PWM_IER2 Position) Comparison x Match Interrupt Enable */
+#define PWM_IER2_CMPM_Msk                   (_U_(0xFF) << PWM_IER2_CMPM_Pos)               /**< (PWM_IER2 Mask) CMPM */
+#define PWM_IER2_CMPM(value)                (PWM_IER2_CMPM_Msk & ((value) << PWM_IER2_CMPM_Pos))  
+#define PWM_IER2_CMPU_Pos                   16                                             /**< (PWM_IER2 Position) Comparison 7 Update Interrupt Enable */
+#define PWM_IER2_CMPU_Msk                   (_U_(0xFF) << PWM_IER2_CMPU_Pos)               /**< (PWM_IER2 Mask) CMPU */
+#define PWM_IER2_CMPU(value)                (PWM_IER2_CMPU_Msk & ((value) << PWM_IER2_CMPU_Pos))  
+
+/* -------- PWM_IDR2 : (PWM Offset: 0x38) (/W 32) PWM Interrupt Disable Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Disable */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Disable */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Disable     */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Disable     */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Disable     */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Disable     */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Disable     */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Disable     */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Disable     */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Disable     */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Disable    */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Disable    */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Disable    */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Disable    */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Disable    */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Disable    */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Disable    */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Disable    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Disable     */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Disable    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IDR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IDR2_OFFSET                     (0x38)                                        /**<  (PWM_IDR2) PWM Interrupt Disable Register 2  Offset */
+
+#define PWM_IDR2_WRDY_Pos                   0                                              /**< (PWM_IDR2) Write Ready for Synchronous Channels Update Interrupt Disable Position */
+#define PWM_IDR2_WRDY_Msk                   (_U_(0x1) << PWM_IDR2_WRDY_Pos)                /**< (PWM_IDR2) Write Ready for Synchronous Channels Update Interrupt Disable Mask */
+#define PWM_IDR2_WRDY                       PWM_IDR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_WRDY_Msk instead */
+#define PWM_IDR2_UNRE_Pos                   3                                              /**< (PWM_IDR2) Synchronous Channels Update Underrun Error Interrupt Disable Position */
+#define PWM_IDR2_UNRE_Msk                   (_U_(0x1) << PWM_IDR2_UNRE_Pos)                /**< (PWM_IDR2) Synchronous Channels Update Underrun Error Interrupt Disable Mask */
+#define PWM_IDR2_UNRE                       PWM_IDR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_UNRE_Msk instead */
+#define PWM_IDR2_CMPM0_Pos                  8                                              /**< (PWM_IDR2) Comparison 0 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM0_Msk                  (_U_(0x1) << PWM_IDR2_CMPM0_Pos)               /**< (PWM_IDR2) Comparison 0 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM0                      PWM_IDR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM0_Msk instead */
+#define PWM_IDR2_CMPM1_Pos                  9                                              /**< (PWM_IDR2) Comparison 1 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM1_Msk                  (_U_(0x1) << PWM_IDR2_CMPM1_Pos)               /**< (PWM_IDR2) Comparison 1 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM1                      PWM_IDR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM1_Msk instead */
+#define PWM_IDR2_CMPM2_Pos                  10                                             /**< (PWM_IDR2) Comparison 2 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM2_Msk                  (_U_(0x1) << PWM_IDR2_CMPM2_Pos)               /**< (PWM_IDR2) Comparison 2 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM2                      PWM_IDR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM2_Msk instead */
+#define PWM_IDR2_CMPM3_Pos                  11                                             /**< (PWM_IDR2) Comparison 3 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM3_Msk                  (_U_(0x1) << PWM_IDR2_CMPM3_Pos)               /**< (PWM_IDR2) Comparison 3 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM3                      PWM_IDR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM3_Msk instead */
+#define PWM_IDR2_CMPM4_Pos                  12                                             /**< (PWM_IDR2) Comparison 4 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM4_Msk                  (_U_(0x1) << PWM_IDR2_CMPM4_Pos)               /**< (PWM_IDR2) Comparison 4 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM4                      PWM_IDR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM4_Msk instead */
+#define PWM_IDR2_CMPM5_Pos                  13                                             /**< (PWM_IDR2) Comparison 5 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM5_Msk                  (_U_(0x1) << PWM_IDR2_CMPM5_Pos)               /**< (PWM_IDR2) Comparison 5 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM5                      PWM_IDR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM5_Msk instead */
+#define PWM_IDR2_CMPM6_Pos                  14                                             /**< (PWM_IDR2) Comparison 6 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM6_Msk                  (_U_(0x1) << PWM_IDR2_CMPM6_Pos)               /**< (PWM_IDR2) Comparison 6 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM6                      PWM_IDR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM6_Msk instead */
+#define PWM_IDR2_CMPM7_Pos                  15                                             /**< (PWM_IDR2) Comparison 7 Match Interrupt Disable Position */
+#define PWM_IDR2_CMPM7_Msk                  (_U_(0x1) << PWM_IDR2_CMPM7_Pos)               /**< (PWM_IDR2) Comparison 7 Match Interrupt Disable Mask */
+#define PWM_IDR2_CMPM7                      PWM_IDR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPM7_Msk instead */
+#define PWM_IDR2_CMPU0_Pos                  16                                             /**< (PWM_IDR2) Comparison 0 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU0_Msk                  (_U_(0x1) << PWM_IDR2_CMPU0_Pos)               /**< (PWM_IDR2) Comparison 0 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU0                      PWM_IDR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU0_Msk instead */
+#define PWM_IDR2_CMPU1_Pos                  17                                             /**< (PWM_IDR2) Comparison 1 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU1_Msk                  (_U_(0x1) << PWM_IDR2_CMPU1_Pos)               /**< (PWM_IDR2) Comparison 1 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU1                      PWM_IDR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU1_Msk instead */
+#define PWM_IDR2_CMPU2_Pos                  18                                             /**< (PWM_IDR2) Comparison 2 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU2_Msk                  (_U_(0x1) << PWM_IDR2_CMPU2_Pos)               /**< (PWM_IDR2) Comparison 2 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU2                      PWM_IDR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU2_Msk instead */
+#define PWM_IDR2_CMPU3_Pos                  19                                             /**< (PWM_IDR2) Comparison 3 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU3_Msk                  (_U_(0x1) << PWM_IDR2_CMPU3_Pos)               /**< (PWM_IDR2) Comparison 3 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU3                      PWM_IDR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU3_Msk instead */
+#define PWM_IDR2_CMPU4_Pos                  20                                             /**< (PWM_IDR2) Comparison 4 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU4_Msk                  (_U_(0x1) << PWM_IDR2_CMPU4_Pos)               /**< (PWM_IDR2) Comparison 4 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU4                      PWM_IDR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU4_Msk instead */
+#define PWM_IDR2_CMPU5_Pos                  21                                             /**< (PWM_IDR2) Comparison 5 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU5_Msk                  (_U_(0x1) << PWM_IDR2_CMPU5_Pos)               /**< (PWM_IDR2) Comparison 5 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU5                      PWM_IDR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU5_Msk instead */
+#define PWM_IDR2_CMPU6_Pos                  22                                             /**< (PWM_IDR2) Comparison 6 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU6_Msk                  (_U_(0x1) << PWM_IDR2_CMPU6_Pos)               /**< (PWM_IDR2) Comparison 6 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU6                      PWM_IDR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU6_Msk instead */
+#define PWM_IDR2_CMPU7_Pos                  23                                             /**< (PWM_IDR2) Comparison 7 Update Interrupt Disable Position */
+#define PWM_IDR2_CMPU7_Msk                  (_U_(0x1) << PWM_IDR2_CMPU7_Pos)               /**< (PWM_IDR2) Comparison 7 Update Interrupt Disable Mask */
+#define PWM_IDR2_CMPU7                      PWM_IDR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IDR2_CMPU7_Msk instead */
+#define PWM_IDR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IDR2) Register MASK  (Use PWM_IDR2_Msk instead)  */
+#define PWM_IDR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IDR2) Register Mask  */
+
+#define PWM_IDR2_CMPM_Pos                   8                                              /**< (PWM_IDR2 Position) Comparison x Match Interrupt Disable */
+#define PWM_IDR2_CMPM_Msk                   (_U_(0xFF) << PWM_IDR2_CMPM_Pos)               /**< (PWM_IDR2 Mask) CMPM */
+#define PWM_IDR2_CMPM(value)                (PWM_IDR2_CMPM_Msk & ((value) << PWM_IDR2_CMPM_Pos))  
+#define PWM_IDR2_CMPU_Pos                   16                                             /**< (PWM_IDR2 Position) Comparison 7 Update Interrupt Disable */
+#define PWM_IDR2_CMPU_Msk                   (_U_(0xFF) << PWM_IDR2_CMPU_Pos)               /**< (PWM_IDR2 Mask) CMPU */
+#define PWM_IDR2_CMPU(value)                (PWM_IDR2_CMPU_Msk & ((value) << PWM_IDR2_CMPU_Pos))  
+
+/* -------- PWM_IMR2 : (PWM Offset: 0x3c) (R/ 32) PWM Interrupt Mask Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Mask */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error Interrupt Mask */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match Interrupt Mask        */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match Interrupt Mask        */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match Interrupt Mask        */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match Interrupt Mask        */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match Interrupt Mask        */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match Interrupt Mask        */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match Interrupt Mask        */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match Interrupt Mask        */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update Interrupt Mask       */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update Interrupt Mask       */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update Interrupt Mask       */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update Interrupt Mask       */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update Interrupt Mask       */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update Interrupt Mask       */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update Interrupt Mask       */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update Interrupt Mask       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match Interrupt Mask        */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update Interrupt Mask       */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_IMR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_IMR2_OFFSET                     (0x3C)                                        /**<  (PWM_IMR2) PWM Interrupt Mask Register 2  Offset */
+
+#define PWM_IMR2_WRDY_Pos                   0                                              /**< (PWM_IMR2) Write Ready for Synchronous Channels Update Interrupt Mask Position */
+#define PWM_IMR2_WRDY_Msk                   (_U_(0x1) << PWM_IMR2_WRDY_Pos)                /**< (PWM_IMR2) Write Ready for Synchronous Channels Update Interrupt Mask Mask */
+#define PWM_IMR2_WRDY                       PWM_IMR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_WRDY_Msk instead */
+#define PWM_IMR2_UNRE_Pos                   3                                              /**< (PWM_IMR2) Synchronous Channels Update Underrun Error Interrupt Mask Position */
+#define PWM_IMR2_UNRE_Msk                   (_U_(0x1) << PWM_IMR2_UNRE_Pos)                /**< (PWM_IMR2) Synchronous Channels Update Underrun Error Interrupt Mask Mask */
+#define PWM_IMR2_UNRE                       PWM_IMR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_UNRE_Msk instead */
+#define PWM_IMR2_CMPM0_Pos                  8                                              /**< (PWM_IMR2) Comparison 0 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM0_Msk                  (_U_(0x1) << PWM_IMR2_CMPM0_Pos)               /**< (PWM_IMR2) Comparison 0 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM0                      PWM_IMR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM0_Msk instead */
+#define PWM_IMR2_CMPM1_Pos                  9                                              /**< (PWM_IMR2) Comparison 1 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM1_Msk                  (_U_(0x1) << PWM_IMR2_CMPM1_Pos)               /**< (PWM_IMR2) Comparison 1 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM1                      PWM_IMR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM1_Msk instead */
+#define PWM_IMR2_CMPM2_Pos                  10                                             /**< (PWM_IMR2) Comparison 2 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM2_Msk                  (_U_(0x1) << PWM_IMR2_CMPM2_Pos)               /**< (PWM_IMR2) Comparison 2 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM2                      PWM_IMR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM2_Msk instead */
+#define PWM_IMR2_CMPM3_Pos                  11                                             /**< (PWM_IMR2) Comparison 3 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM3_Msk                  (_U_(0x1) << PWM_IMR2_CMPM3_Pos)               /**< (PWM_IMR2) Comparison 3 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM3                      PWM_IMR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM3_Msk instead */
+#define PWM_IMR2_CMPM4_Pos                  12                                             /**< (PWM_IMR2) Comparison 4 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM4_Msk                  (_U_(0x1) << PWM_IMR2_CMPM4_Pos)               /**< (PWM_IMR2) Comparison 4 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM4                      PWM_IMR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM4_Msk instead */
+#define PWM_IMR2_CMPM5_Pos                  13                                             /**< (PWM_IMR2) Comparison 5 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM5_Msk                  (_U_(0x1) << PWM_IMR2_CMPM5_Pos)               /**< (PWM_IMR2) Comparison 5 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM5                      PWM_IMR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM5_Msk instead */
+#define PWM_IMR2_CMPM6_Pos                  14                                             /**< (PWM_IMR2) Comparison 6 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM6_Msk                  (_U_(0x1) << PWM_IMR2_CMPM6_Pos)               /**< (PWM_IMR2) Comparison 6 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM6                      PWM_IMR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM6_Msk instead */
+#define PWM_IMR2_CMPM7_Pos                  15                                             /**< (PWM_IMR2) Comparison 7 Match Interrupt Mask Position */
+#define PWM_IMR2_CMPM7_Msk                  (_U_(0x1) << PWM_IMR2_CMPM7_Pos)               /**< (PWM_IMR2) Comparison 7 Match Interrupt Mask Mask */
+#define PWM_IMR2_CMPM7                      PWM_IMR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPM7_Msk instead */
+#define PWM_IMR2_CMPU0_Pos                  16                                             /**< (PWM_IMR2) Comparison 0 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU0_Msk                  (_U_(0x1) << PWM_IMR2_CMPU0_Pos)               /**< (PWM_IMR2) Comparison 0 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU0                      PWM_IMR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU0_Msk instead */
+#define PWM_IMR2_CMPU1_Pos                  17                                             /**< (PWM_IMR2) Comparison 1 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU1_Msk                  (_U_(0x1) << PWM_IMR2_CMPU1_Pos)               /**< (PWM_IMR2) Comparison 1 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU1                      PWM_IMR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU1_Msk instead */
+#define PWM_IMR2_CMPU2_Pos                  18                                             /**< (PWM_IMR2) Comparison 2 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU2_Msk                  (_U_(0x1) << PWM_IMR2_CMPU2_Pos)               /**< (PWM_IMR2) Comparison 2 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU2                      PWM_IMR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU2_Msk instead */
+#define PWM_IMR2_CMPU3_Pos                  19                                             /**< (PWM_IMR2) Comparison 3 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU3_Msk                  (_U_(0x1) << PWM_IMR2_CMPU3_Pos)               /**< (PWM_IMR2) Comparison 3 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU3                      PWM_IMR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU3_Msk instead */
+#define PWM_IMR2_CMPU4_Pos                  20                                             /**< (PWM_IMR2) Comparison 4 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU4_Msk                  (_U_(0x1) << PWM_IMR2_CMPU4_Pos)               /**< (PWM_IMR2) Comparison 4 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU4                      PWM_IMR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU4_Msk instead */
+#define PWM_IMR2_CMPU5_Pos                  21                                             /**< (PWM_IMR2) Comparison 5 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU5_Msk                  (_U_(0x1) << PWM_IMR2_CMPU5_Pos)               /**< (PWM_IMR2) Comparison 5 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU5                      PWM_IMR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU5_Msk instead */
+#define PWM_IMR2_CMPU6_Pos                  22                                             /**< (PWM_IMR2) Comparison 6 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU6_Msk                  (_U_(0x1) << PWM_IMR2_CMPU6_Pos)               /**< (PWM_IMR2) Comparison 6 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU6                      PWM_IMR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU6_Msk instead */
+#define PWM_IMR2_CMPU7_Pos                  23                                             /**< (PWM_IMR2) Comparison 7 Update Interrupt Mask Position */
+#define PWM_IMR2_CMPU7_Msk                  (_U_(0x1) << PWM_IMR2_CMPU7_Pos)               /**< (PWM_IMR2) Comparison 7 Update Interrupt Mask Mask */
+#define PWM_IMR2_CMPU7                      PWM_IMR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_IMR2_CMPU7_Msk instead */
+#define PWM_IMR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_IMR2) Register MASK  (Use PWM_IMR2_Msk instead)  */
+#define PWM_IMR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_IMR2) Register Mask  */
+
+#define PWM_IMR2_CMPM_Pos                   8                                              /**< (PWM_IMR2 Position) Comparison x Match Interrupt Mask */
+#define PWM_IMR2_CMPM_Msk                   (_U_(0xFF) << PWM_IMR2_CMPM_Pos)               /**< (PWM_IMR2 Mask) CMPM */
+#define PWM_IMR2_CMPM(value)                (PWM_IMR2_CMPM_Msk & ((value) << PWM_IMR2_CMPM_Pos))  
+#define PWM_IMR2_CMPU_Pos                   16                                             /**< (PWM_IMR2 Position) Comparison 7 Update Interrupt Mask */
+#define PWM_IMR2_CMPU_Msk                   (_U_(0xFF) << PWM_IMR2_CMPU_Pos)               /**< (PWM_IMR2 Mask) CMPU */
+#define PWM_IMR2_CMPU(value)                (PWM_IMR2_CMPU_Msk & ((value) << PWM_IMR2_CMPU_Pos))  
+
+/* -------- PWM_ISR2 : (PWM Offset: 0x40) (R/ 32) PWM Interrupt Status Register 2 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t UNRE:1;                    /**< bit:      3  Synchronous Channels Update Underrun Error */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CMPM0:1;                   /**< bit:      8  Comparison 0 Match                       */
+    uint32_t CMPM1:1;                   /**< bit:      9  Comparison 1 Match                       */
+    uint32_t CMPM2:1;                   /**< bit:     10  Comparison 2 Match                       */
+    uint32_t CMPM3:1;                   /**< bit:     11  Comparison 3 Match                       */
+    uint32_t CMPM4:1;                   /**< bit:     12  Comparison 4 Match                       */
+    uint32_t CMPM5:1;                   /**< bit:     13  Comparison 5 Match                       */
+    uint32_t CMPM6:1;                   /**< bit:     14  Comparison 6 Match                       */
+    uint32_t CMPM7:1;                   /**< bit:     15  Comparison 7 Match                       */
+    uint32_t CMPU0:1;                   /**< bit:     16  Comparison 0 Update                      */
+    uint32_t CMPU1:1;                   /**< bit:     17  Comparison 1 Update                      */
+    uint32_t CMPU2:1;                   /**< bit:     18  Comparison 2 Update                      */
+    uint32_t CMPU3:1;                   /**< bit:     19  Comparison 3 Update                      */
+    uint32_t CMPU4:1;                   /**< bit:     20  Comparison 4 Update                      */
+    uint32_t CMPU5:1;                   /**< bit:     21  Comparison 5 Update                      */
+    uint32_t CMPU6:1;                   /**< bit:     22  Comparison 6 Update                      */
+    uint32_t CMPU7:1;                   /**< bit:     23  Comparison 7 Update                      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CMPM:8;                    /**< bit:  8..15  Comparison x Match                       */
+    uint32_t CMPU:8;                    /**< bit: 16..23  Comparison 7 Update                      */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ISR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ISR2_OFFSET                     (0x40)                                        /**<  (PWM_ISR2) PWM Interrupt Status Register 2  Offset */
+
+#define PWM_ISR2_WRDY_Pos                   0                                              /**< (PWM_ISR2) Write Ready for Synchronous Channels Update Position */
+#define PWM_ISR2_WRDY_Msk                   (_U_(0x1) << PWM_ISR2_WRDY_Pos)                /**< (PWM_ISR2) Write Ready for Synchronous Channels Update Mask */
+#define PWM_ISR2_WRDY                       PWM_ISR2_WRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_WRDY_Msk instead */
+#define PWM_ISR2_UNRE_Pos                   3                                              /**< (PWM_ISR2) Synchronous Channels Update Underrun Error Position */
+#define PWM_ISR2_UNRE_Msk                   (_U_(0x1) << PWM_ISR2_UNRE_Pos)                /**< (PWM_ISR2) Synchronous Channels Update Underrun Error Mask */
+#define PWM_ISR2_UNRE                       PWM_ISR2_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_UNRE_Msk instead */
+#define PWM_ISR2_CMPM0_Pos                  8                                              /**< (PWM_ISR2) Comparison 0 Match Position */
+#define PWM_ISR2_CMPM0_Msk                  (_U_(0x1) << PWM_ISR2_CMPM0_Pos)               /**< (PWM_ISR2) Comparison 0 Match Mask */
+#define PWM_ISR2_CMPM0                      PWM_ISR2_CMPM0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM0_Msk instead */
+#define PWM_ISR2_CMPM1_Pos                  9                                              /**< (PWM_ISR2) Comparison 1 Match Position */
+#define PWM_ISR2_CMPM1_Msk                  (_U_(0x1) << PWM_ISR2_CMPM1_Pos)               /**< (PWM_ISR2) Comparison 1 Match Mask */
+#define PWM_ISR2_CMPM1                      PWM_ISR2_CMPM1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM1_Msk instead */
+#define PWM_ISR2_CMPM2_Pos                  10                                             /**< (PWM_ISR2) Comparison 2 Match Position */
+#define PWM_ISR2_CMPM2_Msk                  (_U_(0x1) << PWM_ISR2_CMPM2_Pos)               /**< (PWM_ISR2) Comparison 2 Match Mask */
+#define PWM_ISR2_CMPM2                      PWM_ISR2_CMPM2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM2_Msk instead */
+#define PWM_ISR2_CMPM3_Pos                  11                                             /**< (PWM_ISR2) Comparison 3 Match Position */
+#define PWM_ISR2_CMPM3_Msk                  (_U_(0x1) << PWM_ISR2_CMPM3_Pos)               /**< (PWM_ISR2) Comparison 3 Match Mask */
+#define PWM_ISR2_CMPM3                      PWM_ISR2_CMPM3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM3_Msk instead */
+#define PWM_ISR2_CMPM4_Pos                  12                                             /**< (PWM_ISR2) Comparison 4 Match Position */
+#define PWM_ISR2_CMPM4_Msk                  (_U_(0x1) << PWM_ISR2_CMPM4_Pos)               /**< (PWM_ISR2) Comparison 4 Match Mask */
+#define PWM_ISR2_CMPM4                      PWM_ISR2_CMPM4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM4_Msk instead */
+#define PWM_ISR2_CMPM5_Pos                  13                                             /**< (PWM_ISR2) Comparison 5 Match Position */
+#define PWM_ISR2_CMPM5_Msk                  (_U_(0x1) << PWM_ISR2_CMPM5_Pos)               /**< (PWM_ISR2) Comparison 5 Match Mask */
+#define PWM_ISR2_CMPM5                      PWM_ISR2_CMPM5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM5_Msk instead */
+#define PWM_ISR2_CMPM6_Pos                  14                                             /**< (PWM_ISR2) Comparison 6 Match Position */
+#define PWM_ISR2_CMPM6_Msk                  (_U_(0x1) << PWM_ISR2_CMPM6_Pos)               /**< (PWM_ISR2) Comparison 6 Match Mask */
+#define PWM_ISR2_CMPM6                      PWM_ISR2_CMPM6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM6_Msk instead */
+#define PWM_ISR2_CMPM7_Pos                  15                                             /**< (PWM_ISR2) Comparison 7 Match Position */
+#define PWM_ISR2_CMPM7_Msk                  (_U_(0x1) << PWM_ISR2_CMPM7_Pos)               /**< (PWM_ISR2) Comparison 7 Match Mask */
+#define PWM_ISR2_CMPM7                      PWM_ISR2_CMPM7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPM7_Msk instead */
+#define PWM_ISR2_CMPU0_Pos                  16                                             /**< (PWM_ISR2) Comparison 0 Update Position */
+#define PWM_ISR2_CMPU0_Msk                  (_U_(0x1) << PWM_ISR2_CMPU0_Pos)               /**< (PWM_ISR2) Comparison 0 Update Mask */
+#define PWM_ISR2_CMPU0                      PWM_ISR2_CMPU0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU0_Msk instead */
+#define PWM_ISR2_CMPU1_Pos                  17                                             /**< (PWM_ISR2) Comparison 1 Update Position */
+#define PWM_ISR2_CMPU1_Msk                  (_U_(0x1) << PWM_ISR2_CMPU1_Pos)               /**< (PWM_ISR2) Comparison 1 Update Mask */
+#define PWM_ISR2_CMPU1                      PWM_ISR2_CMPU1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU1_Msk instead */
+#define PWM_ISR2_CMPU2_Pos                  18                                             /**< (PWM_ISR2) Comparison 2 Update Position */
+#define PWM_ISR2_CMPU2_Msk                  (_U_(0x1) << PWM_ISR2_CMPU2_Pos)               /**< (PWM_ISR2) Comparison 2 Update Mask */
+#define PWM_ISR2_CMPU2                      PWM_ISR2_CMPU2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU2_Msk instead */
+#define PWM_ISR2_CMPU3_Pos                  19                                             /**< (PWM_ISR2) Comparison 3 Update Position */
+#define PWM_ISR2_CMPU3_Msk                  (_U_(0x1) << PWM_ISR2_CMPU3_Pos)               /**< (PWM_ISR2) Comparison 3 Update Mask */
+#define PWM_ISR2_CMPU3                      PWM_ISR2_CMPU3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU3_Msk instead */
+#define PWM_ISR2_CMPU4_Pos                  20                                             /**< (PWM_ISR2) Comparison 4 Update Position */
+#define PWM_ISR2_CMPU4_Msk                  (_U_(0x1) << PWM_ISR2_CMPU4_Pos)               /**< (PWM_ISR2) Comparison 4 Update Mask */
+#define PWM_ISR2_CMPU4                      PWM_ISR2_CMPU4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU4_Msk instead */
+#define PWM_ISR2_CMPU5_Pos                  21                                             /**< (PWM_ISR2) Comparison 5 Update Position */
+#define PWM_ISR2_CMPU5_Msk                  (_U_(0x1) << PWM_ISR2_CMPU5_Pos)               /**< (PWM_ISR2) Comparison 5 Update Mask */
+#define PWM_ISR2_CMPU5                      PWM_ISR2_CMPU5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU5_Msk instead */
+#define PWM_ISR2_CMPU6_Pos                  22                                             /**< (PWM_ISR2) Comparison 6 Update Position */
+#define PWM_ISR2_CMPU6_Msk                  (_U_(0x1) << PWM_ISR2_CMPU6_Pos)               /**< (PWM_ISR2) Comparison 6 Update Mask */
+#define PWM_ISR2_CMPU6                      PWM_ISR2_CMPU6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU6_Msk instead */
+#define PWM_ISR2_CMPU7_Pos                  23                                             /**< (PWM_ISR2) Comparison 7 Update Position */
+#define PWM_ISR2_CMPU7_Msk                  (_U_(0x1) << PWM_ISR2_CMPU7_Pos)               /**< (PWM_ISR2) Comparison 7 Update Mask */
+#define PWM_ISR2_CMPU7                      PWM_ISR2_CMPU7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ISR2_CMPU7_Msk instead */
+#define PWM_ISR2_MASK                       _U_(0xFFFF09)                                  /**< \deprecated (PWM_ISR2) Register MASK  (Use PWM_ISR2_Msk instead)  */
+#define PWM_ISR2_Msk                        _U_(0xFFFF09)                                  /**< (PWM_ISR2) Register Mask  */
+
+#define PWM_ISR2_CMPM_Pos                   8                                              /**< (PWM_ISR2 Position) Comparison x Match */
+#define PWM_ISR2_CMPM_Msk                   (_U_(0xFF) << PWM_ISR2_CMPM_Pos)               /**< (PWM_ISR2 Mask) CMPM */
+#define PWM_ISR2_CMPM(value)                (PWM_ISR2_CMPM_Msk & ((value) << PWM_ISR2_CMPM_Pos))  
+#define PWM_ISR2_CMPU_Pos                   16                                             /**< (PWM_ISR2 Position) Comparison 7 Update */
+#define PWM_ISR2_CMPU_Msk                   (_U_(0xFF) << PWM_ISR2_CMPU_Pos)               /**< (PWM_ISR2 Mask) CMPU */
+#define PWM_ISR2_CMPU(value)                (PWM_ISR2_CMPU_Msk & ((value) << PWM_ISR2_CMPU_Pos))  
+
+/* -------- PWM_OOV : (PWM Offset: 0x44) (R/W 32) PWM Output Override Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OOVH0:1;                   /**< bit:      0  Output Override Value for PWMH output of the channel 0 */
+    uint32_t OOVH1:1;                   /**< bit:      1  Output Override Value for PWMH output of the channel 1 */
+    uint32_t OOVH2:1;                   /**< bit:      2  Output Override Value for PWMH output of the channel 2 */
+    uint32_t OOVH3:1;                   /**< bit:      3  Output Override Value for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OOVL0:1;                   /**< bit:     16  Output Override Value for PWML output of the channel 0 */
+    uint32_t OOVL1:1;                   /**< bit:     17  Output Override Value for PWML output of the channel 1 */
+    uint32_t OOVL2:1;                   /**< bit:     18  Output Override Value for PWML output of the channel 2 */
+    uint32_t OOVL3:1;                   /**< bit:     19  Output Override Value for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OOVH:4;                    /**< bit:   0..3  Output Override Value for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OOVL:4;                    /**< bit: 16..19  Output Override Value for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OOV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OOV_OFFSET                      (0x44)                                        /**<  (PWM_OOV) PWM Output Override Value Register  Offset */
+
+#define PWM_OOV_OOVH0_Pos                   0                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 0 Position */
+#define PWM_OOV_OOVH0_Msk                   (_U_(0x1) << PWM_OOV_OOVH0_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 0 Mask */
+#define PWM_OOV_OOVH0                       PWM_OOV_OOVH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH0_Msk instead */
+#define PWM_OOV_OOVH1_Pos                   1                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 1 Position */
+#define PWM_OOV_OOVH1_Msk                   (_U_(0x1) << PWM_OOV_OOVH1_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 1 Mask */
+#define PWM_OOV_OOVH1                       PWM_OOV_OOVH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH1_Msk instead */
+#define PWM_OOV_OOVH2_Pos                   2                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 2 Position */
+#define PWM_OOV_OOVH2_Msk                   (_U_(0x1) << PWM_OOV_OOVH2_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 2 Mask */
+#define PWM_OOV_OOVH2                       PWM_OOV_OOVH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH2_Msk instead */
+#define PWM_OOV_OOVH3_Pos                   3                                              /**< (PWM_OOV) Output Override Value for PWMH output of the channel 3 Position */
+#define PWM_OOV_OOVH3_Msk                   (_U_(0x1) << PWM_OOV_OOVH3_Pos)                /**< (PWM_OOV) Output Override Value for PWMH output of the channel 3 Mask */
+#define PWM_OOV_OOVH3                       PWM_OOV_OOVH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVH3_Msk instead */
+#define PWM_OOV_OOVL0_Pos                   16                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 0 Position */
+#define PWM_OOV_OOVL0_Msk                   (_U_(0x1) << PWM_OOV_OOVL0_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 0 Mask */
+#define PWM_OOV_OOVL0                       PWM_OOV_OOVL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL0_Msk instead */
+#define PWM_OOV_OOVL1_Pos                   17                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 1 Position */
+#define PWM_OOV_OOVL1_Msk                   (_U_(0x1) << PWM_OOV_OOVL1_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 1 Mask */
+#define PWM_OOV_OOVL1                       PWM_OOV_OOVL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL1_Msk instead */
+#define PWM_OOV_OOVL2_Pos                   18                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 2 Position */
+#define PWM_OOV_OOVL2_Msk                   (_U_(0x1) << PWM_OOV_OOVL2_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 2 Mask */
+#define PWM_OOV_OOVL2                       PWM_OOV_OOVL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL2_Msk instead */
+#define PWM_OOV_OOVL3_Pos                   19                                             /**< (PWM_OOV) Output Override Value for PWML output of the channel 3 Position */
+#define PWM_OOV_OOVL3_Msk                   (_U_(0x1) << PWM_OOV_OOVL3_Pos)                /**< (PWM_OOV) Output Override Value for PWML output of the channel 3 Mask */
+#define PWM_OOV_OOVL3                       PWM_OOV_OOVL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OOV_OOVL3_Msk instead */
+#define PWM_OOV_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OOV) Register MASK  (Use PWM_OOV_Msk instead)  */
+#define PWM_OOV_Msk                         _U_(0xF000F)                                   /**< (PWM_OOV) Register Mask  */
+
+#define PWM_OOV_OOVH_Pos                    0                                              /**< (PWM_OOV Position) Output Override Value for PWMH output of the channel x */
+#define PWM_OOV_OOVH_Msk                    (_U_(0xF) << PWM_OOV_OOVH_Pos)                 /**< (PWM_OOV Mask) OOVH */
+#define PWM_OOV_OOVH(value)                 (PWM_OOV_OOVH_Msk & ((value) << PWM_OOV_OOVH_Pos))  
+#define PWM_OOV_OOVL_Pos                    16                                             /**< (PWM_OOV Position) Output Override Value for PWML output of the channel 3 */
+#define PWM_OOV_OOVL_Msk                    (_U_(0xF) << PWM_OOV_OOVL_Pos)                 /**< (PWM_OOV Mask) OOVL */
+#define PWM_OOV_OOVL(value)                 (PWM_OOV_OOVL_Msk & ((value) << PWM_OOV_OOVL_Pos))  
+
+/* -------- PWM_OS : (PWM Offset: 0x48) (R/W 32) PWM Output Selection Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSH0:1;                    /**< bit:      0  Output Selection for PWMH output of the channel 0 */
+    uint32_t OSH1:1;                    /**< bit:      1  Output Selection for PWMH output of the channel 1 */
+    uint32_t OSH2:1;                    /**< bit:      2  Output Selection for PWMH output of the channel 2 */
+    uint32_t OSH3:1;                    /**< bit:      3  Output Selection for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSL0:1;                    /**< bit:     16  Output Selection for PWML output of the channel 0 */
+    uint32_t OSL1:1;                    /**< bit:     17  Output Selection for PWML output of the channel 1 */
+    uint32_t OSL2:1;                    /**< bit:     18  Output Selection for PWML output of the channel 2 */
+    uint32_t OSL3:1;                    /**< bit:     19  Output Selection for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSH:4;                     /**< bit:   0..3  Output Selection for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSL:4;                     /**< bit: 16..19  Output Selection for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OS_OFFSET                       (0x48)                                        /**<  (PWM_OS) PWM Output Selection Register  Offset */
+
+#define PWM_OS_OSH0_Pos                     0                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 0 Position */
+#define PWM_OS_OSH0_Msk                     (_U_(0x1) << PWM_OS_OSH0_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 0 Mask */
+#define PWM_OS_OSH0                         PWM_OS_OSH0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH0_Msk instead */
+#define PWM_OS_OSH1_Pos                     1                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 1 Position */
+#define PWM_OS_OSH1_Msk                     (_U_(0x1) << PWM_OS_OSH1_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 1 Mask */
+#define PWM_OS_OSH1                         PWM_OS_OSH1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH1_Msk instead */
+#define PWM_OS_OSH2_Pos                     2                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 2 Position */
+#define PWM_OS_OSH2_Msk                     (_U_(0x1) << PWM_OS_OSH2_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 2 Mask */
+#define PWM_OS_OSH2                         PWM_OS_OSH2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH2_Msk instead */
+#define PWM_OS_OSH3_Pos                     3                                              /**< (PWM_OS) Output Selection for PWMH output of the channel 3 Position */
+#define PWM_OS_OSH3_Msk                     (_U_(0x1) << PWM_OS_OSH3_Pos)                  /**< (PWM_OS) Output Selection for PWMH output of the channel 3 Mask */
+#define PWM_OS_OSH3                         PWM_OS_OSH3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSH3_Msk instead */
+#define PWM_OS_OSL0_Pos                     16                                             /**< (PWM_OS) Output Selection for PWML output of the channel 0 Position */
+#define PWM_OS_OSL0_Msk                     (_U_(0x1) << PWM_OS_OSL0_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 0 Mask */
+#define PWM_OS_OSL0                         PWM_OS_OSL0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL0_Msk instead */
+#define PWM_OS_OSL1_Pos                     17                                             /**< (PWM_OS) Output Selection for PWML output of the channel 1 Position */
+#define PWM_OS_OSL1_Msk                     (_U_(0x1) << PWM_OS_OSL1_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 1 Mask */
+#define PWM_OS_OSL1                         PWM_OS_OSL1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL1_Msk instead */
+#define PWM_OS_OSL2_Pos                     18                                             /**< (PWM_OS) Output Selection for PWML output of the channel 2 Position */
+#define PWM_OS_OSL2_Msk                     (_U_(0x1) << PWM_OS_OSL2_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 2 Mask */
+#define PWM_OS_OSL2                         PWM_OS_OSL2_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL2_Msk instead */
+#define PWM_OS_OSL3_Pos                     19                                             /**< (PWM_OS) Output Selection for PWML output of the channel 3 Position */
+#define PWM_OS_OSL3_Msk                     (_U_(0x1) << PWM_OS_OSL3_Pos)                  /**< (PWM_OS) Output Selection for PWML output of the channel 3 Mask */
+#define PWM_OS_OSL3                         PWM_OS_OSL3_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OS_OSL3_Msk instead */
+#define PWM_OS_MASK                         _U_(0xF000F)                                   /**< \deprecated (PWM_OS) Register MASK  (Use PWM_OS_Msk instead)  */
+#define PWM_OS_Msk                          _U_(0xF000F)                                   /**< (PWM_OS) Register Mask  */
+
+#define PWM_OS_OSH_Pos                      0                                              /**< (PWM_OS Position) Output Selection for PWMH output of the channel x */
+#define PWM_OS_OSH_Msk                      (_U_(0xF) << PWM_OS_OSH_Pos)                   /**< (PWM_OS Mask) OSH */
+#define PWM_OS_OSH(value)                   (PWM_OS_OSH_Msk & ((value) << PWM_OS_OSH_Pos))  
+#define PWM_OS_OSL_Pos                      16                                             /**< (PWM_OS Position) Output Selection for PWML output of the channel 3 */
+#define PWM_OS_OSL_Msk                      (_U_(0xF) << PWM_OS_OSL_Pos)                   /**< (PWM_OS Mask) OSL */
+#define PWM_OS_OSL(value)                   (PWM_OS_OSL_Msk & ((value) << PWM_OS_OSL_Pos))  
+
+/* -------- PWM_OSS : (PWM Offset: 0x4c) (/W 32) PWM Output Selection Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSSH0:1;                   /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
+    uint32_t OSSH1:1;                   /**< bit:      1  Output Selection Set for PWMH output of the channel 1 */
+    uint32_t OSSH2:1;                   /**< bit:      2  Output Selection Set for PWMH output of the channel 2 */
+    uint32_t OSSH3:1;                   /**< bit:      3  Output Selection Set for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSL0:1;                   /**< bit:     16  Output Selection Set for PWML output of the channel 0 */
+    uint32_t OSSL1:1;                   /**< bit:     17  Output Selection Set for PWML output of the channel 1 */
+    uint32_t OSSL2:1;                   /**< bit:     18  Output Selection Set for PWML output of the channel 2 */
+    uint32_t OSSL3:1;                   /**< bit:     19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSSH:4;                    /**< bit:   0..3  Output Selection Set for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSL:4;                    /**< bit: 16..19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSS_OFFSET                      (0x4C)                                        /**<  (PWM_OSS) PWM Output Selection Set Register  Offset */
+
+#define PWM_OSS_OSSH0_Pos                   0                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 0 Position */
+#define PWM_OSS_OSSH0_Msk                   (_U_(0x1) << PWM_OSS_OSSH0_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 0 Mask */
+#define PWM_OSS_OSSH0                       PWM_OSS_OSSH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH0_Msk instead */
+#define PWM_OSS_OSSH1_Pos                   1                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 1 Position */
+#define PWM_OSS_OSSH1_Msk                   (_U_(0x1) << PWM_OSS_OSSH1_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 1 Mask */
+#define PWM_OSS_OSSH1                       PWM_OSS_OSSH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH1_Msk instead */
+#define PWM_OSS_OSSH2_Pos                   2                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 2 Position */
+#define PWM_OSS_OSSH2_Msk                   (_U_(0x1) << PWM_OSS_OSSH2_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 2 Mask */
+#define PWM_OSS_OSSH2                       PWM_OSS_OSSH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH2_Msk instead */
+#define PWM_OSS_OSSH3_Pos                   3                                              /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 3 Position */
+#define PWM_OSS_OSSH3_Msk                   (_U_(0x1) << PWM_OSS_OSSH3_Pos)                /**< (PWM_OSS) Output Selection Set for PWMH output of the channel 3 Mask */
+#define PWM_OSS_OSSH3                       PWM_OSS_OSSH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSH3_Msk instead */
+#define PWM_OSS_OSSL0_Pos                   16                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 0 Position */
+#define PWM_OSS_OSSL0_Msk                   (_U_(0x1) << PWM_OSS_OSSL0_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 0 Mask */
+#define PWM_OSS_OSSL0                       PWM_OSS_OSSL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL0_Msk instead */
+#define PWM_OSS_OSSL1_Pos                   17                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 1 Position */
+#define PWM_OSS_OSSL1_Msk                   (_U_(0x1) << PWM_OSS_OSSL1_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 1 Mask */
+#define PWM_OSS_OSSL1                       PWM_OSS_OSSL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL1_Msk instead */
+#define PWM_OSS_OSSL2_Pos                   18                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 2 Position */
+#define PWM_OSS_OSSL2_Msk                   (_U_(0x1) << PWM_OSS_OSSL2_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 2 Mask */
+#define PWM_OSS_OSSL2                       PWM_OSS_OSSL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL2_Msk instead */
+#define PWM_OSS_OSSL3_Pos                   19                                             /**< (PWM_OSS) Output Selection Set for PWML output of the channel 3 Position */
+#define PWM_OSS_OSSL3_Msk                   (_U_(0x1) << PWM_OSS_OSSL3_Pos)                /**< (PWM_OSS) Output Selection Set for PWML output of the channel 3 Mask */
+#define PWM_OSS_OSSL3                       PWM_OSS_OSSL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSS_OSSL3_Msk instead */
+#define PWM_OSS_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OSS) Register MASK  (Use PWM_OSS_Msk instead)  */
+#define PWM_OSS_Msk                         _U_(0xF000F)                                   /**< (PWM_OSS) Register Mask  */
+
+#define PWM_OSS_OSSH_Pos                    0                                              /**< (PWM_OSS Position) Output Selection Set for PWMH output of the channel x */
+#define PWM_OSS_OSSH_Msk                    (_U_(0xF) << PWM_OSS_OSSH_Pos)                 /**< (PWM_OSS Mask) OSSH */
+#define PWM_OSS_OSSH(value)                 (PWM_OSS_OSSH_Msk & ((value) << PWM_OSS_OSSH_Pos))  
+#define PWM_OSS_OSSL_Pos                    16                                             /**< (PWM_OSS Position) Output Selection Set for PWML output of the channel 3 */
+#define PWM_OSS_OSSL_Msk                    (_U_(0xF) << PWM_OSS_OSSL_Pos)                 /**< (PWM_OSS Mask) OSSL */
+#define PWM_OSS_OSSL(value)                 (PWM_OSS_OSSL_Msk & ((value) << PWM_OSS_OSSL_Pos))  
+
+/* -------- PWM_OSC : (PWM Offset: 0x50) (/W 32) PWM Output Selection Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSCH0:1;                   /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
+    uint32_t OSCH1:1;                   /**< bit:      1  Output Selection Clear for PWMH output of the channel 1 */
+    uint32_t OSCH2:1;                   /**< bit:      2  Output Selection Clear for PWMH output of the channel 2 */
+    uint32_t OSCH3:1;                   /**< bit:      3  Output Selection Clear for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCL0:1;                   /**< bit:     16  Output Selection Clear for PWML output of the channel 0 */
+    uint32_t OSCL1:1;                   /**< bit:     17  Output Selection Clear for PWML output of the channel 1 */
+    uint32_t OSCL2:1;                   /**< bit:     18  Output Selection Clear for PWML output of the channel 2 */
+    uint32_t OSCL3:1;                   /**< bit:     19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSCH:4;                    /**< bit:   0..3  Output Selection Clear for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCL:4;                    /**< bit: 16..19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSC_OFFSET                      (0x50)                                        /**<  (PWM_OSC) PWM Output Selection Clear Register  Offset */
+
+#define PWM_OSC_OSCH0_Pos                   0                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 0 Position */
+#define PWM_OSC_OSCH0_Msk                   (_U_(0x1) << PWM_OSC_OSCH0_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 0 Mask */
+#define PWM_OSC_OSCH0                       PWM_OSC_OSCH0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH0_Msk instead */
+#define PWM_OSC_OSCH1_Pos                   1                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 1 Position */
+#define PWM_OSC_OSCH1_Msk                   (_U_(0x1) << PWM_OSC_OSCH1_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 1 Mask */
+#define PWM_OSC_OSCH1                       PWM_OSC_OSCH1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH1_Msk instead */
+#define PWM_OSC_OSCH2_Pos                   2                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 2 Position */
+#define PWM_OSC_OSCH2_Msk                   (_U_(0x1) << PWM_OSC_OSCH2_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 2 Mask */
+#define PWM_OSC_OSCH2                       PWM_OSC_OSCH2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH2_Msk instead */
+#define PWM_OSC_OSCH3_Pos                   3                                              /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 3 Position */
+#define PWM_OSC_OSCH3_Msk                   (_U_(0x1) << PWM_OSC_OSCH3_Pos)                /**< (PWM_OSC) Output Selection Clear for PWMH output of the channel 3 Mask */
+#define PWM_OSC_OSCH3                       PWM_OSC_OSCH3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCH3_Msk instead */
+#define PWM_OSC_OSCL0_Pos                   16                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 0 Position */
+#define PWM_OSC_OSCL0_Msk                   (_U_(0x1) << PWM_OSC_OSCL0_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 0 Mask */
+#define PWM_OSC_OSCL0                       PWM_OSC_OSCL0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL0_Msk instead */
+#define PWM_OSC_OSCL1_Pos                   17                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 1 Position */
+#define PWM_OSC_OSCL1_Msk                   (_U_(0x1) << PWM_OSC_OSCL1_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 1 Mask */
+#define PWM_OSC_OSCL1                       PWM_OSC_OSCL1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL1_Msk instead */
+#define PWM_OSC_OSCL2_Pos                   18                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 2 Position */
+#define PWM_OSC_OSCL2_Msk                   (_U_(0x1) << PWM_OSC_OSCL2_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 2 Mask */
+#define PWM_OSC_OSCL2                       PWM_OSC_OSCL2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL2_Msk instead */
+#define PWM_OSC_OSCL3_Pos                   19                                             /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 3 Position */
+#define PWM_OSC_OSCL3_Msk                   (_U_(0x1) << PWM_OSC_OSCL3_Pos)                /**< (PWM_OSC) Output Selection Clear for PWML output of the channel 3 Mask */
+#define PWM_OSC_OSCL3                       PWM_OSC_OSCL3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSC_OSCL3_Msk instead */
+#define PWM_OSC_MASK                        _U_(0xF000F)                                   /**< \deprecated (PWM_OSC) Register MASK  (Use PWM_OSC_Msk instead)  */
+#define PWM_OSC_Msk                         _U_(0xF000F)                                   /**< (PWM_OSC) Register Mask  */
+
+#define PWM_OSC_OSCH_Pos                    0                                              /**< (PWM_OSC Position) Output Selection Clear for PWMH output of the channel x */
+#define PWM_OSC_OSCH_Msk                    (_U_(0xF) << PWM_OSC_OSCH_Pos)                 /**< (PWM_OSC Mask) OSCH */
+#define PWM_OSC_OSCH(value)                 (PWM_OSC_OSCH_Msk & ((value) << PWM_OSC_OSCH_Pos))  
+#define PWM_OSC_OSCL_Pos                    16                                             /**< (PWM_OSC Position) Output Selection Clear for PWML output of the channel 3 */
+#define PWM_OSC_OSCL_Msk                    (_U_(0xF) << PWM_OSC_OSCL_Pos)                 /**< (PWM_OSC Mask) OSCL */
+#define PWM_OSC_OSCL(value)                 (PWM_OSC_OSCL_Msk & ((value) << PWM_OSC_OSCL_Pos))  
+
+/* -------- PWM_OSSUPD : (PWM Offset: 0x54) (/W 32) PWM Output Selection Set Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSSUPH0:1;                 /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
+    uint32_t OSSUPH1:1;                 /**< bit:      1  Output Selection Set for PWMH output of the channel 1 */
+    uint32_t OSSUPH2:1;                 /**< bit:      2  Output Selection Set for PWMH output of the channel 2 */
+    uint32_t OSSUPH3:1;                 /**< bit:      3  Output Selection Set for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSUPL0:1;                 /**< bit:     16  Output Selection Set for PWML output of the channel 0 */
+    uint32_t OSSUPL1:1;                 /**< bit:     17  Output Selection Set for PWML output of the channel 1 */
+    uint32_t OSSUPL2:1;                 /**< bit:     18  Output Selection Set for PWML output of the channel 2 */
+    uint32_t OSSUPL3:1;                 /**< bit:     19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSSUPH:4;                  /**< bit:   0..3  Output Selection Set for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSSUPL:4;                  /**< bit: 16..19  Output Selection Set for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSSUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSSUPD_OFFSET                   (0x54)                                        /**<  (PWM_OSSUPD) PWM Output Selection Set Update Register  Offset */
+
+#define PWM_OSSUPD_OSSUPH0_Pos              0                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 0 Position */
+#define PWM_OSSUPD_OSSUPH0_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH0_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 0 Mask */
+#define PWM_OSSUPD_OSSUPH0                  PWM_OSSUPD_OSSUPH0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH0_Msk instead */
+#define PWM_OSSUPD_OSSUPH1_Pos              1                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 1 Position */
+#define PWM_OSSUPD_OSSUPH1_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH1_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 1 Mask */
+#define PWM_OSSUPD_OSSUPH1                  PWM_OSSUPD_OSSUPH1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH1_Msk instead */
+#define PWM_OSSUPD_OSSUPH2_Pos              2                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 2 Position */
+#define PWM_OSSUPD_OSSUPH2_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH2_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 2 Mask */
+#define PWM_OSSUPD_OSSUPH2                  PWM_OSSUPD_OSSUPH2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH2_Msk instead */
+#define PWM_OSSUPD_OSSUPH3_Pos              3                                              /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 3 Position */
+#define PWM_OSSUPD_OSSUPH3_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPH3_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 3 Mask */
+#define PWM_OSSUPD_OSSUPH3                  PWM_OSSUPD_OSSUPH3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPH3_Msk instead */
+#define PWM_OSSUPD_OSSUPL0_Pos              16                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 0 Position */
+#define PWM_OSSUPD_OSSUPL0_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL0_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 0 Mask */
+#define PWM_OSSUPD_OSSUPL0                  PWM_OSSUPD_OSSUPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL0_Msk instead */
+#define PWM_OSSUPD_OSSUPL1_Pos              17                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 1 Position */
+#define PWM_OSSUPD_OSSUPL1_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL1_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 1 Mask */
+#define PWM_OSSUPD_OSSUPL1                  PWM_OSSUPD_OSSUPL1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL1_Msk instead */
+#define PWM_OSSUPD_OSSUPL2_Pos              18                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 2 Position */
+#define PWM_OSSUPD_OSSUPL2_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL2_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 2 Mask */
+#define PWM_OSSUPD_OSSUPL2                  PWM_OSSUPD_OSSUPL2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL2_Msk instead */
+#define PWM_OSSUPD_OSSUPL3_Pos              19                                             /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 3 Position */
+#define PWM_OSSUPD_OSSUPL3_Msk              (_U_(0x1) << PWM_OSSUPD_OSSUPL3_Pos)           /**< (PWM_OSSUPD) Output Selection Set for PWML output of the channel 3 Mask */
+#define PWM_OSSUPD_OSSUPL3                  PWM_OSSUPD_OSSUPL3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSSUPD_OSSUPL3_Msk instead */
+#define PWM_OSSUPD_MASK                     _U_(0xF000F)                                   /**< \deprecated (PWM_OSSUPD) Register MASK  (Use PWM_OSSUPD_Msk instead)  */
+#define PWM_OSSUPD_Msk                      _U_(0xF000F)                                   /**< (PWM_OSSUPD) Register Mask  */
+
+#define PWM_OSSUPD_OSSUPH_Pos               0                                              /**< (PWM_OSSUPD Position) Output Selection Set for PWMH output of the channel x */
+#define PWM_OSSUPD_OSSUPH_Msk               (_U_(0xF) << PWM_OSSUPD_OSSUPH_Pos)            /**< (PWM_OSSUPD Mask) OSSUPH */
+#define PWM_OSSUPD_OSSUPH(value)            (PWM_OSSUPD_OSSUPH_Msk & ((value) << PWM_OSSUPD_OSSUPH_Pos))  
+#define PWM_OSSUPD_OSSUPL_Pos               16                                             /**< (PWM_OSSUPD Position) Output Selection Set for PWML output of the channel 3 */
+#define PWM_OSSUPD_OSSUPL_Msk               (_U_(0xF) << PWM_OSSUPD_OSSUPL_Pos)            /**< (PWM_OSSUPD Mask) OSSUPL */
+#define PWM_OSSUPD_OSSUPL(value)            (PWM_OSSUPD_OSSUPL_Msk & ((value) << PWM_OSSUPD_OSSUPL_Pos))  
+
+/* -------- PWM_OSCUPD : (PWM Offset: 0x58) (/W 32) PWM Output Selection Clear Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OSCUPH0:1;                 /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
+    uint32_t OSCUPH1:1;                 /**< bit:      1  Output Selection Clear for PWMH output of the channel 1 */
+    uint32_t OSCUPH2:1;                 /**< bit:      2  Output Selection Clear for PWMH output of the channel 2 */
+    uint32_t OSCUPH3:1;                 /**< bit:      3  Output Selection Clear for PWMH output of the channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCUPL0:1;                 /**< bit:     16  Output Selection Clear for PWML output of the channel 0 */
+    uint32_t OSCUPL1:1;                 /**< bit:     17  Output Selection Clear for PWML output of the channel 1 */
+    uint32_t OSCUPL2:1;                 /**< bit:     18  Output Selection Clear for PWML output of the channel 2 */
+    uint32_t OSCUPL3:1;                 /**< bit:     19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t OSCUPH:4;                  /**< bit:   0..3  Output Selection Clear for PWMH output of the channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t OSCUPL:4;                  /**< bit: 16..19  Output Selection Clear for PWML output of the channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_OSCUPD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_OSCUPD_OFFSET                   (0x58)                                        /**<  (PWM_OSCUPD) PWM Output Selection Clear Update Register  Offset */
+
+#define PWM_OSCUPD_OSCUPH0_Pos              0                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 0 Position */
+#define PWM_OSCUPD_OSCUPH0_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH0_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 0 Mask */
+#define PWM_OSCUPD_OSCUPH0                  PWM_OSCUPD_OSCUPH0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH0_Msk instead */
+#define PWM_OSCUPD_OSCUPH1_Pos              1                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 1 Position */
+#define PWM_OSCUPD_OSCUPH1_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH1_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 1 Mask */
+#define PWM_OSCUPD_OSCUPH1                  PWM_OSCUPD_OSCUPH1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH1_Msk instead */
+#define PWM_OSCUPD_OSCUPH2_Pos              2                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 2 Position */
+#define PWM_OSCUPD_OSCUPH2_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH2_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 2 Mask */
+#define PWM_OSCUPD_OSCUPH2                  PWM_OSCUPD_OSCUPH2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH2_Msk instead */
+#define PWM_OSCUPD_OSCUPH3_Pos              3                                              /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 3 Position */
+#define PWM_OSCUPD_OSCUPH3_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPH3_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 3 Mask */
+#define PWM_OSCUPD_OSCUPH3                  PWM_OSCUPD_OSCUPH3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPH3_Msk instead */
+#define PWM_OSCUPD_OSCUPL0_Pos              16                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 0 Position */
+#define PWM_OSCUPD_OSCUPL0_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL0_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 0 Mask */
+#define PWM_OSCUPD_OSCUPL0                  PWM_OSCUPD_OSCUPL0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL0_Msk instead */
+#define PWM_OSCUPD_OSCUPL1_Pos              17                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 1 Position */
+#define PWM_OSCUPD_OSCUPL1_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL1_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 1 Mask */
+#define PWM_OSCUPD_OSCUPL1                  PWM_OSCUPD_OSCUPL1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL1_Msk instead */
+#define PWM_OSCUPD_OSCUPL2_Pos              18                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 2 Position */
+#define PWM_OSCUPD_OSCUPL2_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL2_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 2 Mask */
+#define PWM_OSCUPD_OSCUPL2                  PWM_OSCUPD_OSCUPL2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL2_Msk instead */
+#define PWM_OSCUPD_OSCUPL3_Pos              19                                             /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 3 Position */
+#define PWM_OSCUPD_OSCUPL3_Msk              (_U_(0x1) << PWM_OSCUPD_OSCUPL3_Pos)           /**< (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 3 Mask */
+#define PWM_OSCUPD_OSCUPL3                  PWM_OSCUPD_OSCUPL3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_OSCUPD_OSCUPL3_Msk instead */
+#define PWM_OSCUPD_MASK                     _U_(0xF000F)                                   /**< \deprecated (PWM_OSCUPD) Register MASK  (Use PWM_OSCUPD_Msk instead)  */
+#define PWM_OSCUPD_Msk                      _U_(0xF000F)                                   /**< (PWM_OSCUPD) Register Mask  */
+
+#define PWM_OSCUPD_OSCUPH_Pos               0                                              /**< (PWM_OSCUPD Position) Output Selection Clear for PWMH output of the channel x */
+#define PWM_OSCUPD_OSCUPH_Msk               (_U_(0xF) << PWM_OSCUPD_OSCUPH_Pos)            /**< (PWM_OSCUPD Mask) OSCUPH */
+#define PWM_OSCUPD_OSCUPH(value)            (PWM_OSCUPD_OSCUPH_Msk & ((value) << PWM_OSCUPD_OSCUPH_Pos))  
+#define PWM_OSCUPD_OSCUPL_Pos               16                                             /**< (PWM_OSCUPD Position) Output Selection Clear for PWML output of the channel 3 */
+#define PWM_OSCUPD_OSCUPL_Msk               (_U_(0xF) << PWM_OSCUPD_OSCUPL_Pos)            /**< (PWM_OSCUPD Mask) OSCUPL */
+#define PWM_OSCUPD_OSCUPL(value)            (PWM_OSCUPD_OSCUPL_Msk & ((value) << PWM_OSCUPD_OSCUPL_Pos))  
+
+/* -------- PWM_FMR : (PWM Offset: 0x5c) (R/W 32) PWM Fault Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPOL:8;                    /**< bit:   0..7  Fault Polarity                           */
+    uint32_t FMOD:8;                    /**< bit:  8..15  Fault Activation Mode                    */
+    uint32_t FFIL:8;                    /**< bit: 16..23  Fault Filtering                          */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FMR_OFFSET                      (0x5C)                                        /**<  (PWM_FMR) PWM Fault Mode Register  Offset */
+
+#define PWM_FMR_FPOL_Pos                    0                                              /**< (PWM_FMR) Fault Polarity Position */
+#define PWM_FMR_FPOL_Msk                    (_U_(0xFF) << PWM_FMR_FPOL_Pos)                /**< (PWM_FMR) Fault Polarity Mask */
+#define PWM_FMR_FPOL(value)                 (PWM_FMR_FPOL_Msk & ((value) << PWM_FMR_FPOL_Pos))
+#define PWM_FMR_FMOD_Pos                    8                                              /**< (PWM_FMR) Fault Activation Mode Position */
+#define PWM_FMR_FMOD_Msk                    (_U_(0xFF) << PWM_FMR_FMOD_Pos)                /**< (PWM_FMR) Fault Activation Mode Mask */
+#define PWM_FMR_FMOD(value)                 (PWM_FMR_FMOD_Msk & ((value) << PWM_FMR_FMOD_Pos))
+#define PWM_FMR_FFIL_Pos                    16                                             /**< (PWM_FMR) Fault Filtering Position */
+#define PWM_FMR_FFIL_Msk                    (_U_(0xFF) << PWM_FMR_FFIL_Pos)                /**< (PWM_FMR) Fault Filtering Mask */
+#define PWM_FMR_FFIL(value)                 (PWM_FMR_FFIL_Msk & ((value) << PWM_FMR_FFIL_Pos))
+#define PWM_FMR_MASK                        _U_(0xFFFFFF)                                  /**< \deprecated (PWM_FMR) Register MASK  (Use PWM_FMR_Msk instead)  */
+#define PWM_FMR_Msk                         _U_(0xFFFFFF)                                  /**< (PWM_FMR) Register Mask  */
+
+
+/* -------- PWM_FSR : (PWM Offset: 0x60) (R/ 32) PWM Fault Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FIV:8;                     /**< bit:   0..7  Fault Input Value                        */
+    uint32_t FS:8;                      /**< bit:  8..15  Fault Status                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FSR_OFFSET                      (0x60)                                        /**<  (PWM_FSR) PWM Fault Status Register  Offset */
+
+#define PWM_FSR_FIV_Pos                     0                                              /**< (PWM_FSR) Fault Input Value Position */
+#define PWM_FSR_FIV_Msk                     (_U_(0xFF) << PWM_FSR_FIV_Pos)                 /**< (PWM_FSR) Fault Input Value Mask */
+#define PWM_FSR_FIV(value)                  (PWM_FSR_FIV_Msk & ((value) << PWM_FSR_FIV_Pos))
+#define PWM_FSR_FS_Pos                      8                                              /**< (PWM_FSR) Fault Status Position */
+#define PWM_FSR_FS_Msk                      (_U_(0xFF) << PWM_FSR_FS_Pos)                  /**< (PWM_FSR) Fault Status Mask */
+#define PWM_FSR_FS(value)                   (PWM_FSR_FS_Msk & ((value) << PWM_FSR_FS_Pos))
+#define PWM_FSR_MASK                        _U_(0xFFFF)                                    /**< \deprecated (PWM_FSR) Register MASK  (Use PWM_FSR_Msk instead)  */
+#define PWM_FSR_Msk                         _U_(0xFFFF)                                    /**< (PWM_FSR) Register Mask  */
+
+
+/* -------- PWM_FCR : (PWM Offset: 0x64) (/W 32) PWM Fault Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FCLR:8;                    /**< bit:   0..7  Fault Clear                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FCR_OFFSET                      (0x64)                                        /**<  (PWM_FCR) PWM Fault Clear Register  Offset */
+
+#define PWM_FCR_FCLR_Pos                    0                                              /**< (PWM_FCR) Fault Clear Position */
+#define PWM_FCR_FCLR_Msk                    (_U_(0xFF) << PWM_FCR_FCLR_Pos)                /**< (PWM_FCR) Fault Clear Mask */
+#define PWM_FCR_FCLR(value)                 (PWM_FCR_FCLR_Msk & ((value) << PWM_FCR_FCLR_Pos))
+#define PWM_FCR_MASK                        _U_(0xFF)                                      /**< \deprecated (PWM_FCR) Register MASK  (Use PWM_FCR_Msk instead)  */
+#define PWM_FCR_Msk                         _U_(0xFF)                                      /**< (PWM_FCR) Register Mask  */
+
+
+/* -------- PWM_FPV1 : (PWM Offset: 0x68) (R/W 32) PWM Fault Protection Value Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPVH0:1;                   /**< bit:      0  Fault Protection Value for PWMH output on channel 0 */
+    uint32_t FPVH1:1;                   /**< bit:      1  Fault Protection Value for PWMH output on channel 1 */
+    uint32_t FPVH2:1;                   /**< bit:      2  Fault Protection Value for PWMH output on channel 2 */
+    uint32_t FPVH3:1;                   /**< bit:      3  Fault Protection Value for PWMH output on channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPVL0:1;                   /**< bit:     16  Fault Protection Value for PWML output on channel 0 */
+    uint32_t FPVL1:1;                   /**< bit:     17  Fault Protection Value for PWML output on channel 1 */
+    uint32_t FPVL2:1;                   /**< bit:     18  Fault Protection Value for PWML output on channel 2 */
+    uint32_t FPVL3:1;                   /**< bit:     19  Fault Protection Value for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FPVH:4;                    /**< bit:   0..3  Fault Protection Value for PWMH output on channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPVL:4;                    /**< bit: 16..19  Fault Protection Value for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPV1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPV1_OFFSET                     (0x68)                                        /**<  (PWM_FPV1) PWM Fault Protection Value Register 1  Offset */
+
+#define PWM_FPV1_FPVH0_Pos                  0                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 0 Position */
+#define PWM_FPV1_FPVH0_Msk                  (_U_(0x1) << PWM_FPV1_FPVH0_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 0 Mask */
+#define PWM_FPV1_FPVH0                      PWM_FPV1_FPVH0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH0_Msk instead */
+#define PWM_FPV1_FPVH1_Pos                  1                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 1 Position */
+#define PWM_FPV1_FPVH1_Msk                  (_U_(0x1) << PWM_FPV1_FPVH1_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 1 Mask */
+#define PWM_FPV1_FPVH1                      PWM_FPV1_FPVH1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH1_Msk instead */
+#define PWM_FPV1_FPVH2_Pos                  2                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 2 Position */
+#define PWM_FPV1_FPVH2_Msk                  (_U_(0x1) << PWM_FPV1_FPVH2_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 2 Mask */
+#define PWM_FPV1_FPVH2                      PWM_FPV1_FPVH2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH2_Msk instead */
+#define PWM_FPV1_FPVH3_Pos                  3                                              /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 3 Position */
+#define PWM_FPV1_FPVH3_Msk                  (_U_(0x1) << PWM_FPV1_FPVH3_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWMH output on channel 3 Mask */
+#define PWM_FPV1_FPVH3                      PWM_FPV1_FPVH3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVH3_Msk instead */
+#define PWM_FPV1_FPVL0_Pos                  16                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 0 Position */
+#define PWM_FPV1_FPVL0_Msk                  (_U_(0x1) << PWM_FPV1_FPVL0_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 0 Mask */
+#define PWM_FPV1_FPVL0                      PWM_FPV1_FPVL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL0_Msk instead */
+#define PWM_FPV1_FPVL1_Pos                  17                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 1 Position */
+#define PWM_FPV1_FPVL1_Msk                  (_U_(0x1) << PWM_FPV1_FPVL1_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 1 Mask */
+#define PWM_FPV1_FPVL1                      PWM_FPV1_FPVL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL1_Msk instead */
+#define PWM_FPV1_FPVL2_Pos                  18                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 2 Position */
+#define PWM_FPV1_FPVL2_Msk                  (_U_(0x1) << PWM_FPV1_FPVL2_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 2 Mask */
+#define PWM_FPV1_FPVL2                      PWM_FPV1_FPVL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL2_Msk instead */
+#define PWM_FPV1_FPVL3_Pos                  19                                             /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 3 Position */
+#define PWM_FPV1_FPVL3_Msk                  (_U_(0x1) << PWM_FPV1_FPVL3_Pos)               /**< (PWM_FPV1) Fault Protection Value for PWML output on channel 3 Mask */
+#define PWM_FPV1_FPVL3                      PWM_FPV1_FPVL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV1_FPVL3_Msk instead */
+#define PWM_FPV1_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_FPV1) Register MASK  (Use PWM_FPV1_Msk instead)  */
+#define PWM_FPV1_Msk                        _U_(0xF000F)                                   /**< (PWM_FPV1) Register Mask  */
+
+#define PWM_FPV1_FPVH_Pos                   0                                              /**< (PWM_FPV1 Position) Fault Protection Value for PWMH output on channel x */
+#define PWM_FPV1_FPVH_Msk                   (_U_(0xF) << PWM_FPV1_FPVH_Pos)                /**< (PWM_FPV1 Mask) FPVH */
+#define PWM_FPV1_FPVH(value)                (PWM_FPV1_FPVH_Msk & ((value) << PWM_FPV1_FPVH_Pos))  
+#define PWM_FPV1_FPVL_Pos                   16                                             /**< (PWM_FPV1 Position) Fault Protection Value for PWML output on channel 3 */
+#define PWM_FPV1_FPVL_Msk                   (_U_(0xF) << PWM_FPV1_FPVL_Pos)                /**< (PWM_FPV1 Mask) FPVL */
+#define PWM_FPV1_FPVL(value)                (PWM_FPV1_FPVL_Msk & ((value) << PWM_FPV1_FPVL_Pos))  
+
+/* -------- PWM_FPE : (PWM Offset: 0x6c) (R/W 32) PWM Fault Protection Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPE0:8;                    /**< bit:   0..7  Fault Protection Enable for channel 0    */
+    uint32_t FPE1:8;                    /**< bit:  8..15  Fault Protection Enable for channel 1    */
+    uint32_t FPE2:8;                    /**< bit: 16..23  Fault Protection Enable for channel 2    */
+    uint32_t FPE3:8;                    /**< bit: 24..31  Fault Protection Enable for channel 3    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPE_OFFSET                      (0x6C)                                        /**<  (PWM_FPE) PWM Fault Protection Enable Register  Offset */
+
+#define PWM_FPE_FPE0_Pos                    0                                              /**< (PWM_FPE) Fault Protection Enable for channel 0 Position */
+#define PWM_FPE_FPE0_Msk                    (_U_(0xFF) << PWM_FPE_FPE0_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 0 Mask */
+#define PWM_FPE_FPE0(value)                 (PWM_FPE_FPE0_Msk & ((value) << PWM_FPE_FPE0_Pos))
+#define PWM_FPE_FPE1_Pos                    8                                              /**< (PWM_FPE) Fault Protection Enable for channel 1 Position */
+#define PWM_FPE_FPE1_Msk                    (_U_(0xFF) << PWM_FPE_FPE1_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 1 Mask */
+#define PWM_FPE_FPE1(value)                 (PWM_FPE_FPE1_Msk & ((value) << PWM_FPE_FPE1_Pos))
+#define PWM_FPE_FPE2_Pos                    16                                             /**< (PWM_FPE) Fault Protection Enable for channel 2 Position */
+#define PWM_FPE_FPE2_Msk                    (_U_(0xFF) << PWM_FPE_FPE2_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 2 Mask */
+#define PWM_FPE_FPE2(value)                 (PWM_FPE_FPE2_Msk & ((value) << PWM_FPE_FPE2_Pos))
+#define PWM_FPE_FPE3_Pos                    24                                             /**< (PWM_FPE) Fault Protection Enable for channel 3 Position */
+#define PWM_FPE_FPE3_Msk                    (_U_(0xFF) << PWM_FPE_FPE3_Pos)                /**< (PWM_FPE) Fault Protection Enable for channel 3 Mask */
+#define PWM_FPE_FPE3(value)                 (PWM_FPE_FPE3_Msk & ((value) << PWM_FPE_FPE3_Pos))
+#define PWM_FPE_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_FPE) Register MASK  (Use PWM_FPE_Msk instead)  */
+#define PWM_FPE_Msk                         _U_(0xFFFFFFFF)                                /**< (PWM_FPE) Register Mask  */
+
+
+/* -------- PWM_ELMR : (PWM Offset: 0x7c) (R/W 32) PWM Event Line 0 Mode Register 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CSEL0:1;                   /**< bit:      0  Comparison 0 Selection                   */
+    uint32_t CSEL1:1;                   /**< bit:      1  Comparison 1 Selection                   */
+    uint32_t CSEL2:1;                   /**< bit:      2  Comparison 2 Selection                   */
+    uint32_t CSEL3:1;                   /**< bit:      3  Comparison 3 Selection                   */
+    uint32_t CSEL4:1;                   /**< bit:      4  Comparison 4 Selection                   */
+    uint32_t CSEL5:1;                   /**< bit:      5  Comparison 5 Selection                   */
+    uint32_t CSEL6:1;                   /**< bit:      6  Comparison 6 Selection                   */
+    uint32_t CSEL7:1;                   /**< bit:      7  Comparison 7 Selection                   */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t CSEL:8;                    /**< bit:   0..7  Comparison 7 Selection                   */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ELMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ELMR_OFFSET                     (0x7C)                                        /**<  (PWM_ELMR) PWM Event Line 0 Mode Register 0  Offset */
+
+#define PWM_ELMR_CSEL0_Pos                  0                                              /**< (PWM_ELMR) Comparison 0 Selection Position */
+#define PWM_ELMR_CSEL0_Msk                  (_U_(0x1) << PWM_ELMR_CSEL0_Pos)               /**< (PWM_ELMR) Comparison 0 Selection Mask */
+#define PWM_ELMR_CSEL0                      PWM_ELMR_CSEL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL0_Msk instead */
+#define PWM_ELMR_CSEL1_Pos                  1                                              /**< (PWM_ELMR) Comparison 1 Selection Position */
+#define PWM_ELMR_CSEL1_Msk                  (_U_(0x1) << PWM_ELMR_CSEL1_Pos)               /**< (PWM_ELMR) Comparison 1 Selection Mask */
+#define PWM_ELMR_CSEL1                      PWM_ELMR_CSEL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL1_Msk instead */
+#define PWM_ELMR_CSEL2_Pos                  2                                              /**< (PWM_ELMR) Comparison 2 Selection Position */
+#define PWM_ELMR_CSEL2_Msk                  (_U_(0x1) << PWM_ELMR_CSEL2_Pos)               /**< (PWM_ELMR) Comparison 2 Selection Mask */
+#define PWM_ELMR_CSEL2                      PWM_ELMR_CSEL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL2_Msk instead */
+#define PWM_ELMR_CSEL3_Pos                  3                                              /**< (PWM_ELMR) Comparison 3 Selection Position */
+#define PWM_ELMR_CSEL3_Msk                  (_U_(0x1) << PWM_ELMR_CSEL3_Pos)               /**< (PWM_ELMR) Comparison 3 Selection Mask */
+#define PWM_ELMR_CSEL3                      PWM_ELMR_CSEL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL3_Msk instead */
+#define PWM_ELMR_CSEL4_Pos                  4                                              /**< (PWM_ELMR) Comparison 4 Selection Position */
+#define PWM_ELMR_CSEL4_Msk                  (_U_(0x1) << PWM_ELMR_CSEL4_Pos)               /**< (PWM_ELMR) Comparison 4 Selection Mask */
+#define PWM_ELMR_CSEL4                      PWM_ELMR_CSEL4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL4_Msk instead */
+#define PWM_ELMR_CSEL5_Pos                  5                                              /**< (PWM_ELMR) Comparison 5 Selection Position */
+#define PWM_ELMR_CSEL5_Msk                  (_U_(0x1) << PWM_ELMR_CSEL5_Pos)               /**< (PWM_ELMR) Comparison 5 Selection Mask */
+#define PWM_ELMR_CSEL5                      PWM_ELMR_CSEL5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL5_Msk instead */
+#define PWM_ELMR_CSEL6_Pos                  6                                              /**< (PWM_ELMR) Comparison 6 Selection Position */
+#define PWM_ELMR_CSEL6_Msk                  (_U_(0x1) << PWM_ELMR_CSEL6_Pos)               /**< (PWM_ELMR) Comparison 6 Selection Mask */
+#define PWM_ELMR_CSEL6                      PWM_ELMR_CSEL6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL6_Msk instead */
+#define PWM_ELMR_CSEL7_Pos                  7                                              /**< (PWM_ELMR) Comparison 7 Selection Position */
+#define PWM_ELMR_CSEL7_Msk                  (_U_(0x1) << PWM_ELMR_CSEL7_Pos)               /**< (PWM_ELMR) Comparison 7 Selection Mask */
+#define PWM_ELMR_CSEL7                      PWM_ELMR_CSEL7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ELMR_CSEL7_Msk instead */
+#define PWM_ELMR_MASK                       _U_(0xFF)                                      /**< \deprecated (PWM_ELMR) Register MASK  (Use PWM_ELMR_Msk instead)  */
+#define PWM_ELMR_Msk                        _U_(0xFF)                                      /**< (PWM_ELMR) Register Mask  */
+
+#define PWM_ELMR_CSEL_Pos                   0                                              /**< (PWM_ELMR Position) Comparison 7 Selection */
+#define PWM_ELMR_CSEL_Msk                   (_U_(0xFF) << PWM_ELMR_CSEL_Pos)               /**< (PWM_ELMR Mask) CSEL */
+#define PWM_ELMR_CSEL(value)                (PWM_ELMR_CSEL_Msk & ((value) << PWM_ELMR_CSEL_Pos))  
+
+/* -------- PWM_SSPR : (PWM Offset: 0xa0) (R/W 32) PWM Spread Spectrum Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPRD:24;                   /**< bit:  0..23  Spread Spectrum Limit Value              */
+    uint32_t SPRDM:1;                   /**< bit:     24  Spread Spectrum Counter Mode             */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SSPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SSPR_OFFSET                     (0xA0)                                        /**<  (PWM_SSPR) PWM Spread Spectrum Register  Offset */
+
+#define PWM_SSPR_SPRD_Pos                   0                                              /**< (PWM_SSPR) Spread Spectrum Limit Value Position */
+#define PWM_SSPR_SPRD_Msk                   (_U_(0xFFFFFF) << PWM_SSPR_SPRD_Pos)           /**< (PWM_SSPR) Spread Spectrum Limit Value Mask */
+#define PWM_SSPR_SPRD(value)                (PWM_SSPR_SPRD_Msk & ((value) << PWM_SSPR_SPRD_Pos))
+#define PWM_SSPR_SPRDM_Pos                  24                                             /**< (PWM_SSPR) Spread Spectrum Counter Mode Position */
+#define PWM_SSPR_SPRDM_Msk                  (_U_(0x1) << PWM_SSPR_SPRDM_Pos)               /**< (PWM_SSPR) Spread Spectrum Counter Mode Mask */
+#define PWM_SSPR_SPRDM                      PWM_SSPR_SPRDM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SSPR_SPRDM_Msk instead */
+#define PWM_SSPR_MASK                       _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_SSPR) Register MASK  (Use PWM_SSPR_Msk instead)  */
+#define PWM_SSPR_Msk                        _U_(0x1FFFFFF)                                 /**< (PWM_SSPR) Register Mask  */
+
+
+/* -------- PWM_SSPUP : (PWM Offset: 0xa4) (/W 32) PWM Spread Spectrum Update Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPRDUP:24;                 /**< bit:  0..23  Spread Spectrum Limit Value Update       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SSPUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SSPUP_OFFSET                    (0xA4)                                        /**<  (PWM_SSPUP) PWM Spread Spectrum Update Register  Offset */
+
+#define PWM_SSPUP_SPRDUP_Pos                0                                              /**< (PWM_SSPUP) Spread Spectrum Limit Value Update Position */
+#define PWM_SSPUP_SPRDUP_Msk                (_U_(0xFFFFFF) << PWM_SSPUP_SPRDUP_Pos)        /**< (PWM_SSPUP) Spread Spectrum Limit Value Update Mask */
+#define PWM_SSPUP_SPRDUP(value)             (PWM_SSPUP_SPRDUP_Msk & ((value) << PWM_SSPUP_SPRDUP_Pos))
+#define PWM_SSPUP_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (PWM_SSPUP) Register MASK  (Use PWM_SSPUP_Msk instead)  */
+#define PWM_SSPUP_Msk                       _U_(0xFFFFFF)                                  /**< (PWM_SSPUP) Register Mask  */
+
+
+/* -------- PWM_SMMR : (PWM Offset: 0xb0) (R/W 32) PWM Stepper Motor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GCEN0:1;                   /**< bit:      0  Gray Count ENable                        */
+    uint32_t GCEN1:1;                   /**< bit:      1  Gray Count ENable                        */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t DOWN0:1;                   /**< bit:     16  DOWN Count                               */
+    uint32_t DOWN1:1;                   /**< bit:     17  DOWN Count                               */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t GCEN:2;                    /**< bit:   0..1  Gray Count ENable                        */
+    uint32_t :14;                       /**< bit:  2..15  Reserved */
+    uint32_t DOWN:2;                    /**< bit: 16..17  DOWN Count                               */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_SMMR_OFFSET                     (0xB0)                                        /**<  (PWM_SMMR) PWM Stepper Motor Mode Register  Offset */
+
+#define PWM_SMMR_GCEN0_Pos                  0                                              /**< (PWM_SMMR) Gray Count ENable Position */
+#define PWM_SMMR_GCEN0_Msk                  (_U_(0x1) << PWM_SMMR_GCEN0_Pos)               /**< (PWM_SMMR) Gray Count ENable Mask */
+#define PWM_SMMR_GCEN0                      PWM_SMMR_GCEN0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_GCEN0_Msk instead */
+#define PWM_SMMR_GCEN1_Pos                  1                                              /**< (PWM_SMMR) Gray Count ENable Position */
+#define PWM_SMMR_GCEN1_Msk                  (_U_(0x1) << PWM_SMMR_GCEN1_Pos)               /**< (PWM_SMMR) Gray Count ENable Mask */
+#define PWM_SMMR_GCEN1                      PWM_SMMR_GCEN1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_GCEN1_Msk instead */
+#define PWM_SMMR_DOWN0_Pos                  16                                             /**< (PWM_SMMR) DOWN Count Position */
+#define PWM_SMMR_DOWN0_Msk                  (_U_(0x1) << PWM_SMMR_DOWN0_Pos)               /**< (PWM_SMMR) DOWN Count Mask */
+#define PWM_SMMR_DOWN0                      PWM_SMMR_DOWN0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_DOWN0_Msk instead */
+#define PWM_SMMR_DOWN1_Pos                  17                                             /**< (PWM_SMMR) DOWN Count Position */
+#define PWM_SMMR_DOWN1_Msk                  (_U_(0x1) << PWM_SMMR_DOWN1_Pos)               /**< (PWM_SMMR) DOWN Count Mask */
+#define PWM_SMMR_DOWN1                      PWM_SMMR_DOWN1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_SMMR_DOWN1_Msk instead */
+#define PWM_SMMR_MASK                       _U_(0x30003)                                   /**< \deprecated (PWM_SMMR) Register MASK  (Use PWM_SMMR_Msk instead)  */
+#define PWM_SMMR_Msk                        _U_(0x30003)                                   /**< (PWM_SMMR) Register Mask  */
+
+#define PWM_SMMR_GCEN_Pos                   0                                              /**< (PWM_SMMR Position) Gray Count ENable */
+#define PWM_SMMR_GCEN_Msk                   (_U_(0x3) << PWM_SMMR_GCEN_Pos)                /**< (PWM_SMMR Mask) GCEN */
+#define PWM_SMMR_GCEN(value)                (PWM_SMMR_GCEN_Msk & ((value) << PWM_SMMR_GCEN_Pos))  
+#define PWM_SMMR_DOWN_Pos                   16                                             /**< (PWM_SMMR Position) DOWN Count */
+#define PWM_SMMR_DOWN_Msk                   (_U_(0x3) << PWM_SMMR_DOWN_Pos)                /**< (PWM_SMMR Mask) DOWN */
+#define PWM_SMMR_DOWN(value)                (PWM_SMMR_DOWN_Msk & ((value) << PWM_SMMR_DOWN_Pos))  
+
+/* -------- PWM_FPV2 : (PWM Offset: 0xc0) (R/W 32) PWM Fault Protection Value 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FPZH0:1;                   /**< bit:      0  Fault Protection to Hi-Z for PWMH output on channel 0 */
+    uint32_t FPZH1:1;                   /**< bit:      1  Fault Protection to Hi-Z for PWMH output on channel 1 */
+    uint32_t FPZH2:1;                   /**< bit:      2  Fault Protection to Hi-Z for PWMH output on channel 2 */
+    uint32_t FPZH3:1;                   /**< bit:      3  Fault Protection to Hi-Z for PWMH output on channel 3 */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPZL0:1;                   /**< bit:     16  Fault Protection to Hi-Z for PWML output on channel 0 */
+    uint32_t FPZL1:1;                   /**< bit:     17  Fault Protection to Hi-Z for PWML output on channel 1 */
+    uint32_t FPZL2:1;                   /**< bit:     18  Fault Protection to Hi-Z for PWML output on channel 2 */
+    uint32_t FPZL3:1;                   /**< bit:     19  Fault Protection to Hi-Z for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t FPZH:4;                    /**< bit:   0..3  Fault Protection to Hi-Z for PWMH output on channel x */
+    uint32_t :12;                       /**< bit:  4..15  Reserved */
+    uint32_t FPZL:4;                    /**< bit: 16..19  Fault Protection to Hi-Z for PWML output on channel 3 */
+    uint32_t :12;                       /**< bit: 20..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_FPV2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_FPV2_OFFSET                     (0xC0)                                        /**<  (PWM_FPV2) PWM Fault Protection Value 2 Register  Offset */
+
+#define PWM_FPV2_FPZH0_Pos                  0                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 0 Position */
+#define PWM_FPV2_FPZH0_Msk                  (_U_(0x1) << PWM_FPV2_FPZH0_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 0 Mask */
+#define PWM_FPV2_FPZH0                      PWM_FPV2_FPZH0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH0_Msk instead */
+#define PWM_FPV2_FPZH1_Pos                  1                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 1 Position */
+#define PWM_FPV2_FPZH1_Msk                  (_U_(0x1) << PWM_FPV2_FPZH1_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 1 Mask */
+#define PWM_FPV2_FPZH1                      PWM_FPV2_FPZH1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH1_Msk instead */
+#define PWM_FPV2_FPZH2_Pos                  2                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 2 Position */
+#define PWM_FPV2_FPZH2_Msk                  (_U_(0x1) << PWM_FPV2_FPZH2_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 2 Mask */
+#define PWM_FPV2_FPZH2                      PWM_FPV2_FPZH2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH2_Msk instead */
+#define PWM_FPV2_FPZH3_Pos                  3                                              /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 3 Position */
+#define PWM_FPV2_FPZH3_Msk                  (_U_(0x1) << PWM_FPV2_FPZH3_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 3 Mask */
+#define PWM_FPV2_FPZH3                      PWM_FPV2_FPZH3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZH3_Msk instead */
+#define PWM_FPV2_FPZL0_Pos                  16                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 0 Position */
+#define PWM_FPV2_FPZL0_Msk                  (_U_(0x1) << PWM_FPV2_FPZL0_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 0 Mask */
+#define PWM_FPV2_FPZL0                      PWM_FPV2_FPZL0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL0_Msk instead */
+#define PWM_FPV2_FPZL1_Pos                  17                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 1 Position */
+#define PWM_FPV2_FPZL1_Msk                  (_U_(0x1) << PWM_FPV2_FPZL1_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 1 Mask */
+#define PWM_FPV2_FPZL1                      PWM_FPV2_FPZL1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL1_Msk instead */
+#define PWM_FPV2_FPZL2_Pos                  18                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 2 Position */
+#define PWM_FPV2_FPZL2_Msk                  (_U_(0x1) << PWM_FPV2_FPZL2_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 2 Mask */
+#define PWM_FPV2_FPZL2                      PWM_FPV2_FPZL2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL2_Msk instead */
+#define PWM_FPV2_FPZL3_Pos                  19                                             /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 3 Position */
+#define PWM_FPV2_FPZL3_Msk                  (_U_(0x1) << PWM_FPV2_FPZL3_Pos)               /**< (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 3 Mask */
+#define PWM_FPV2_FPZL3                      PWM_FPV2_FPZL3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_FPV2_FPZL3_Msk instead */
+#define PWM_FPV2_MASK                       _U_(0xF000F)                                   /**< \deprecated (PWM_FPV2) Register MASK  (Use PWM_FPV2_Msk instead)  */
+#define PWM_FPV2_Msk                        _U_(0xF000F)                                   /**< (PWM_FPV2) Register Mask  */
+
+#define PWM_FPV2_FPZH_Pos                   0                                              /**< (PWM_FPV2 Position) Fault Protection to Hi-Z for PWMH output on channel x */
+#define PWM_FPV2_FPZH_Msk                   (_U_(0xF) << PWM_FPV2_FPZH_Pos)                /**< (PWM_FPV2 Mask) FPZH */
+#define PWM_FPV2_FPZH(value)                (PWM_FPV2_FPZH_Msk & ((value) << PWM_FPV2_FPZH_Pos))  
+#define PWM_FPV2_FPZL_Pos                   16                                             /**< (PWM_FPV2 Position) Fault Protection to Hi-Z for PWML output on channel 3 */
+#define PWM_FPV2_FPZL_Msk                   (_U_(0xF) << PWM_FPV2_FPZL_Pos)                /**< (PWM_FPV2 Mask) FPZL */
+#define PWM_FPV2_FPZL(value)                (PWM_FPV2_FPZL_Msk & ((value) << PWM_FPV2_FPZL_Pos))  
+
+/* -------- PWM_WPCR : (PWM Offset: 0xe4) (/W 32) PWM Write Protection Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPCMD:2;                   /**< bit:   0..1  Write Protection Command                 */
+    uint32_t WPRG0:1;                   /**< bit:      2  Write Protection Register Group 0        */
+    uint32_t WPRG1:1;                   /**< bit:      3  Write Protection Register Group 1        */
+    uint32_t WPRG2:1;                   /**< bit:      4  Write Protection Register Group 2        */
+    uint32_t WPRG3:1;                   /**< bit:      5  Write Protection Register Group 3        */
+    uint32_t WPRG4:1;                   /**< bit:      6  Write Protection Register Group 4        */
+    uint32_t WPRG5:1;                   /**< bit:      7  Write Protection Register Group 5        */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t WPRG:6;                    /**< bit:   2..7  Write Protection Register Group x        */
+    uint32_t :24;                       /**< bit:  8..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_WPCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_WPCR_OFFSET                     (0xE4)                                        /**<  (PWM_WPCR) PWM Write Protection Control Register  Offset */
+
+#define PWM_WPCR_WPCMD_Pos                  0                                              /**< (PWM_WPCR) Write Protection Command Position */
+#define PWM_WPCR_WPCMD_Msk                  (_U_(0x3) << PWM_WPCR_WPCMD_Pos)               /**< (PWM_WPCR) Write Protection Command Mask */
+#define PWM_WPCR_WPCMD(value)               (PWM_WPCR_WPCMD_Msk & ((value) << PWM_WPCR_WPCMD_Pos))
+#define   PWM_WPCR_WPCMD_DISABLE_SW_PROT_Val _U_(0x0)                                       /**< (PWM_WPCR) Disables the software write protection of the register groups of which the bit WPRGx is at '1'.  */
+#define   PWM_WPCR_WPCMD_ENABLE_SW_PROT_Val _U_(0x1)                                       /**< (PWM_WPCR) Enables the software write protection of the register groups of which the bit WPRGx is at '1'.  */
+#define   PWM_WPCR_WPCMD_ENABLE_HW_PROT_Val _U_(0x2)                                       /**< (PWM_WPCR) Enables the hardware write protection of the register groups of which the bit WPRGx is at '1'. Only a hardware reset of the PWM controller can disable the hardware write protection. Moreover, to meet security requirements, the PIO lines associated with the PWM can not be configured through the PIO interface.  */
+#define PWM_WPCR_WPCMD_DISABLE_SW_PROT      (PWM_WPCR_WPCMD_DISABLE_SW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Disables the software write protection of the register groups of which the bit WPRGx is at '1'. Position  */
+#define PWM_WPCR_WPCMD_ENABLE_SW_PROT       (PWM_WPCR_WPCMD_ENABLE_SW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Enables the software write protection of the register groups of which the bit WPRGx is at '1'. Position  */
+#define PWM_WPCR_WPCMD_ENABLE_HW_PROT       (PWM_WPCR_WPCMD_ENABLE_HW_PROT_Val << PWM_WPCR_WPCMD_Pos)  /**< (PWM_WPCR) Enables the hardware write protection of the register groups of which the bit WPRGx is at '1'. Only a hardware reset of the PWM controller can disable the hardware write protection. Moreover, to meet security requirements, the PIO lines associated with the PWM can not be configured through the PIO interface. Position  */
+#define PWM_WPCR_WPRG0_Pos                  2                                              /**< (PWM_WPCR) Write Protection Register Group 0 Position */
+#define PWM_WPCR_WPRG0_Msk                  (_U_(0x1) << PWM_WPCR_WPRG0_Pos)               /**< (PWM_WPCR) Write Protection Register Group 0 Mask */
+#define PWM_WPCR_WPRG0                      PWM_WPCR_WPRG0_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG0_Msk instead */
+#define PWM_WPCR_WPRG1_Pos                  3                                              /**< (PWM_WPCR) Write Protection Register Group 1 Position */
+#define PWM_WPCR_WPRG1_Msk                  (_U_(0x1) << PWM_WPCR_WPRG1_Pos)               /**< (PWM_WPCR) Write Protection Register Group 1 Mask */
+#define PWM_WPCR_WPRG1                      PWM_WPCR_WPRG1_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG1_Msk instead */
+#define PWM_WPCR_WPRG2_Pos                  4                                              /**< (PWM_WPCR) Write Protection Register Group 2 Position */
+#define PWM_WPCR_WPRG2_Msk                  (_U_(0x1) << PWM_WPCR_WPRG2_Pos)               /**< (PWM_WPCR) Write Protection Register Group 2 Mask */
+#define PWM_WPCR_WPRG2                      PWM_WPCR_WPRG2_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG2_Msk instead */
+#define PWM_WPCR_WPRG3_Pos                  5                                              /**< (PWM_WPCR) Write Protection Register Group 3 Position */
+#define PWM_WPCR_WPRG3_Msk                  (_U_(0x1) << PWM_WPCR_WPRG3_Pos)               /**< (PWM_WPCR) Write Protection Register Group 3 Mask */
+#define PWM_WPCR_WPRG3                      PWM_WPCR_WPRG3_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG3_Msk instead */
+#define PWM_WPCR_WPRG4_Pos                  6                                              /**< (PWM_WPCR) Write Protection Register Group 4 Position */
+#define PWM_WPCR_WPRG4_Msk                  (_U_(0x1) << PWM_WPCR_WPRG4_Pos)               /**< (PWM_WPCR) Write Protection Register Group 4 Mask */
+#define PWM_WPCR_WPRG4                      PWM_WPCR_WPRG4_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG4_Msk instead */
+#define PWM_WPCR_WPRG5_Pos                  7                                              /**< (PWM_WPCR) Write Protection Register Group 5 Position */
+#define PWM_WPCR_WPRG5_Msk                  (_U_(0x1) << PWM_WPCR_WPRG5_Pos)               /**< (PWM_WPCR) Write Protection Register Group 5 Mask */
+#define PWM_WPCR_WPRG5                      PWM_WPCR_WPRG5_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPCR_WPRG5_Msk instead */
+#define PWM_WPCR_WPKEY_Pos                  8                                              /**< (PWM_WPCR) Write Protection Key Position */
+#define PWM_WPCR_WPKEY_Msk                  (_U_(0xFFFFFF) << PWM_WPCR_WPKEY_Pos)          /**< (PWM_WPCR) Write Protection Key Mask */
+#define PWM_WPCR_WPKEY(value)               (PWM_WPCR_WPKEY_Msk & ((value) << PWM_WPCR_WPKEY_Pos))
+#define   PWM_WPCR_WPKEY_PASSWD_Val         _U_(0x50574D)                                  /**< (PWM_WPCR) Writing any other value in this field aborts the write operation of the WPCMD field.Always reads as 0  */
+#define PWM_WPCR_WPKEY_PASSWD               (PWM_WPCR_WPKEY_PASSWD_Val << PWM_WPCR_WPKEY_Pos)  /**< (PWM_WPCR) Writing any other value in this field aborts the write operation of the WPCMD field.Always reads as 0 Position  */
+#define PWM_WPCR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (PWM_WPCR) Register MASK  (Use PWM_WPCR_Msk instead)  */
+#define PWM_WPCR_Msk                        _U_(0xFFFFFFFF)                                /**< (PWM_WPCR) Register Mask  */
+
+#define PWM_WPCR_WPRG_Pos                   2                                              /**< (PWM_WPCR Position) Write Protection Register Group x */
+#define PWM_WPCR_WPRG_Msk                   (_U_(0x3F) << PWM_WPCR_WPRG_Pos)               /**< (PWM_WPCR Mask) WPRG */
+#define PWM_WPCR_WPRG(value)                (PWM_WPCR_WPRG_Msk & ((value) << PWM_WPCR_WPRG_Pos))  
+
+/* -------- PWM_WPSR : (PWM Offset: 0xe8) (R/ 32) PWM Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPSWS0:1;                  /**< bit:      0  Write Protect SW Status                  */
+    uint32_t WPSWS1:1;                  /**< bit:      1  Write Protect SW Status                  */
+    uint32_t WPSWS2:1;                  /**< bit:      2  Write Protect SW Status                  */
+    uint32_t WPSWS3:1;                  /**< bit:      3  Write Protect SW Status                  */
+    uint32_t WPSWS4:1;                  /**< bit:      4  Write Protect SW Status                  */
+    uint32_t WPSWS5:1;                  /**< bit:      5  Write Protect SW Status                  */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t WPVS:1;                    /**< bit:      7  Write Protect Violation Status           */
+    uint32_t WPHWS0:1;                  /**< bit:      8  Write Protect HW Status                  */
+    uint32_t WPHWS1:1;                  /**< bit:      9  Write Protect HW Status                  */
+    uint32_t WPHWS2:1;                  /**< bit:     10  Write Protect HW Status                  */
+    uint32_t WPHWS3:1;                  /**< bit:     11  Write Protect HW Status                  */
+    uint32_t WPHWS4:1;                  /**< bit:     12  Write Protect HW Status                  */
+    uint32_t WPHWS5:1;                  /**< bit:     13  Write Protect HW Status                  */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit: 16..31  Write Protect Violation Source           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WPSWS:6;                   /**< bit:   0..5  Write Protect SW Status                  */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t WPHWS:6;                   /**< bit:  8..13  Write Protect HW Status                  */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_WPSR_OFFSET                     (0xE8)                                        /**<  (PWM_WPSR) PWM Write Protection Status Register  Offset */
+
+#define PWM_WPSR_WPSWS0_Pos                 0                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS0_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS0_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS0                     PWM_WPSR_WPSWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS0_Msk instead */
+#define PWM_WPSR_WPSWS1_Pos                 1                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS1_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS1_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS1                     PWM_WPSR_WPSWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS1_Msk instead */
+#define PWM_WPSR_WPSWS2_Pos                 2                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS2_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS2_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS2                     PWM_WPSR_WPSWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS2_Msk instead */
+#define PWM_WPSR_WPSWS3_Pos                 3                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS3_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS3_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS3                     PWM_WPSR_WPSWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS3_Msk instead */
+#define PWM_WPSR_WPSWS4_Pos                 4                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS4_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS4_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS4                     PWM_WPSR_WPSWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS4_Msk instead */
+#define PWM_WPSR_WPSWS5_Pos                 5                                              /**< (PWM_WPSR) Write Protect SW Status Position */
+#define PWM_WPSR_WPSWS5_Msk                 (_U_(0x1) << PWM_WPSR_WPSWS5_Pos)              /**< (PWM_WPSR) Write Protect SW Status Mask */
+#define PWM_WPSR_WPSWS5                     PWM_WPSR_WPSWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPSWS5_Msk instead */
+#define PWM_WPSR_WPVS_Pos                   7                                              /**< (PWM_WPSR) Write Protect Violation Status Position */
+#define PWM_WPSR_WPVS_Msk                   (_U_(0x1) << PWM_WPSR_WPVS_Pos)                /**< (PWM_WPSR) Write Protect Violation Status Mask */
+#define PWM_WPSR_WPVS                       PWM_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPVS_Msk instead */
+#define PWM_WPSR_WPHWS0_Pos                 8                                              /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS0_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS0_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS0                     PWM_WPSR_WPHWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS0_Msk instead */
+#define PWM_WPSR_WPHWS1_Pos                 9                                              /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS1_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS1_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS1                     PWM_WPSR_WPHWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS1_Msk instead */
+#define PWM_WPSR_WPHWS2_Pos                 10                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS2_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS2_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS2                     PWM_WPSR_WPHWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS2_Msk instead */
+#define PWM_WPSR_WPHWS3_Pos                 11                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS3_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS3_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS3                     PWM_WPSR_WPHWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS3_Msk instead */
+#define PWM_WPSR_WPHWS4_Pos                 12                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS4_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS4_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS4                     PWM_WPSR_WPHWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS4_Msk instead */
+#define PWM_WPSR_WPHWS5_Pos                 13                                             /**< (PWM_WPSR) Write Protect HW Status Position */
+#define PWM_WPSR_WPHWS5_Msk                 (_U_(0x1) << PWM_WPSR_WPHWS5_Pos)              /**< (PWM_WPSR) Write Protect HW Status Mask */
+#define PWM_WPSR_WPHWS5                     PWM_WPSR_WPHWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_WPSR_WPHWS5_Msk instead */
+#define PWM_WPSR_WPVSRC_Pos                 16                                             /**< (PWM_WPSR) Write Protect Violation Source Position */
+#define PWM_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << PWM_WPSR_WPVSRC_Pos)           /**< (PWM_WPSR) Write Protect Violation Source Mask */
+#define PWM_WPSR_WPVSRC(value)              (PWM_WPSR_WPVSRC_Msk & ((value) << PWM_WPSR_WPVSRC_Pos))
+#define PWM_WPSR_MASK                       _U_(0xFFFF3FBF)                                /**< \deprecated (PWM_WPSR) Register MASK  (Use PWM_WPSR_Msk instead)  */
+#define PWM_WPSR_Msk                        _U_(0xFFFF3FBF)                                /**< (PWM_WPSR) Register Mask  */
+
+#define PWM_WPSR_WPSWS_Pos                  0                                              /**< (PWM_WPSR Position) Write Protect SW Status */
+#define PWM_WPSR_WPSWS_Msk                  (_U_(0x3F) << PWM_WPSR_WPSWS_Pos)              /**< (PWM_WPSR Mask) WPSWS */
+#define PWM_WPSR_WPSWS(value)               (PWM_WPSR_WPSWS_Msk & ((value) << PWM_WPSR_WPSWS_Pos))  
+#define PWM_WPSR_WPHWS_Pos                  8                                              /**< (PWM_WPSR Position) Write Protect HW Status */
+#define PWM_WPSR_WPHWS_Msk                  (_U_(0x3F) << PWM_WPSR_WPHWS_Pos)              /**< (PWM_WPSR Mask) WPHWS */
+#define PWM_WPSR_WPHWS(value)               (PWM_WPSR_WPHWS_Msk & ((value) << PWM_WPSR_WPHWS_Pos))  
+
+/* -------- PWM_CMUPD0 : (PWM Offset: 0x400) (/W 32) PWM Channel Mode Update Register (ch_num = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD0_OFFSET                   (0x400)                                       /**<  (PWM_CMUPD0) PWM Channel Mode Update Register (ch_num = 0)  Offset */
+
+#define PWM_CMUPD0_CPOLUP_Pos               9                                              /**< (PWM_CMUPD0) Channel Polarity Update Position */
+#define PWM_CMUPD0_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD0_CPOLUP_Pos)            /**< (PWM_CMUPD0) Channel Polarity Update Mask */
+#define PWM_CMUPD0_CPOLUP                   PWM_CMUPD0_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD0_CPOLUP_Msk instead */
+#define PWM_CMUPD0_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD0) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD0_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD0_CPOLINVUP_Pos)         /**< (PWM_CMUPD0) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD0_CPOLINVUP                PWM_CMUPD0_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD0_CPOLINVUP_Msk instead */
+#define PWM_CMUPD0_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD0) Register MASK  (Use PWM_CMUPD0_Msk instead)  */
+#define PWM_CMUPD0_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD0) Register Mask  */
+
+
+/* -------- PWM_CMUPD1 : (PWM Offset: 0x420) (/W 32) PWM Channel Mode Update Register (ch_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD1_OFFSET                   (0x420)                                       /**<  (PWM_CMUPD1) PWM Channel Mode Update Register (ch_num = 1)  Offset */
+
+#define PWM_CMUPD1_CPOLUP_Pos               9                                              /**< (PWM_CMUPD1) Channel Polarity Update Position */
+#define PWM_CMUPD1_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD1_CPOLUP_Pos)            /**< (PWM_CMUPD1) Channel Polarity Update Mask */
+#define PWM_CMUPD1_CPOLUP                   PWM_CMUPD1_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD1_CPOLUP_Msk instead */
+#define PWM_CMUPD1_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD1) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD1_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD1_CPOLINVUP_Pos)         /**< (PWM_CMUPD1) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD1_CPOLINVUP                PWM_CMUPD1_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD1_CPOLINVUP_Msk instead */
+#define PWM_CMUPD1_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD1) Register MASK  (Use PWM_CMUPD1_Msk instead)  */
+#define PWM_CMUPD1_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD1) Register Mask  */
+
+
+/* -------- PWM_ETRG1 : (PWM Offset: 0x42c) (R/W 32) PWM External Trigger Register (trg_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
+    uint32_t TRGMODE:2;                 /**< bit: 24..25  External Trigger Mode                    */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t TRGEDGE:1;                 /**< bit:     28  Edge Selection                           */
+    uint32_t TRGFILT:1;                 /**< bit:     29  Filtered input                           */
+    uint32_t TRGSRC:1;                  /**< bit:     30  Trigger Source                           */
+    uint32_t RFEN:1;                    /**< bit:     31  Recoverable Fault Enable                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ETRG1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ETRG1_OFFSET                    (0x42C)                                       /**<  (PWM_ETRG1) PWM External Trigger Register (trg_num = 1)  Offset */
+
+#define PWM_ETRG1_MAXCNT_Pos                0                                              /**< (PWM_ETRG1) Maximum Counter value Position */
+#define PWM_ETRG1_MAXCNT_Msk                (_U_(0xFFFFFF) << PWM_ETRG1_MAXCNT_Pos)        /**< (PWM_ETRG1) Maximum Counter value Mask */
+#define PWM_ETRG1_MAXCNT(value)             (PWM_ETRG1_MAXCNT_Msk & ((value) << PWM_ETRG1_MAXCNT_Pos))
+#define PWM_ETRG1_TRGMODE_Pos               24                                             /**< (PWM_ETRG1) External Trigger Mode Position */
+#define PWM_ETRG1_TRGMODE_Msk               (_U_(0x3) << PWM_ETRG1_TRGMODE_Pos)            /**< (PWM_ETRG1) External Trigger Mode Mask */
+#define PWM_ETRG1_TRGMODE(value)            (PWM_ETRG1_TRGMODE_Msk & ((value) << PWM_ETRG1_TRGMODE_Pos))
+#define   PWM_ETRG1_TRGMODE_OFF_Val         _U_(0x0)                                       /**< (PWM_ETRG1) External trigger is not enabled.  */
+#define   PWM_ETRG1_TRGMODE_MODE1_Val       _U_(0x1)                                       /**< (PWM_ETRG1) External PWM Reset Mode  */
+#define   PWM_ETRG1_TRGMODE_MODE2_Val       _U_(0x2)                                       /**< (PWM_ETRG1) External PWM Start Mode  */
+#define   PWM_ETRG1_TRGMODE_MODE3_Val       _U_(0x3)                                       /**< (PWM_ETRG1) Cycle-by-cycle Duty Mode  */
+#define PWM_ETRG1_TRGMODE_OFF               (PWM_ETRG1_TRGMODE_OFF_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External trigger is not enabled. Position  */
+#define PWM_ETRG1_TRGMODE_MODE1             (PWM_ETRG1_TRGMODE_MODE1_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External PWM Reset Mode Position  */
+#define PWM_ETRG1_TRGMODE_MODE2             (PWM_ETRG1_TRGMODE_MODE2_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) External PWM Start Mode Position  */
+#define PWM_ETRG1_TRGMODE_MODE3             (PWM_ETRG1_TRGMODE_MODE3_Val << PWM_ETRG1_TRGMODE_Pos)  /**< (PWM_ETRG1) Cycle-by-cycle Duty Mode Position  */
+#define PWM_ETRG1_TRGEDGE_Pos               28                                             /**< (PWM_ETRG1) Edge Selection Position */
+#define PWM_ETRG1_TRGEDGE_Msk               (_U_(0x1) << PWM_ETRG1_TRGEDGE_Pos)            /**< (PWM_ETRG1) Edge Selection Mask */
+#define PWM_ETRG1_TRGEDGE                   PWM_ETRG1_TRGEDGE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGEDGE_Msk instead */
+#define   PWM_ETRG1_TRGEDGE_FALLING_ZERO_Val _U_(0x0)                                       /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0  */
+#define   PWM_ETRG1_TRGEDGE_RISING_ONE_Val  _U_(0x1)                                       /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1  */
+#define PWM_ETRG1_TRGEDGE_FALLING_ZERO      (PWM_ETRG1_TRGEDGE_FALLING_ZERO_Val << PWM_ETRG1_TRGEDGE_Pos)  /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0 Position  */
+#define PWM_ETRG1_TRGEDGE_RISING_ONE        (PWM_ETRG1_TRGEDGE_RISING_ONE_Val << PWM_ETRG1_TRGEDGE_Pos)  /**< (PWM_ETRG1) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1 Position  */
+#define PWM_ETRG1_TRGFILT_Pos               29                                             /**< (PWM_ETRG1) Filtered input Position */
+#define PWM_ETRG1_TRGFILT_Msk               (_U_(0x1) << PWM_ETRG1_TRGFILT_Pos)            /**< (PWM_ETRG1) Filtered input Mask */
+#define PWM_ETRG1_TRGFILT                   PWM_ETRG1_TRGFILT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGFILT_Msk instead */
+#define PWM_ETRG1_TRGSRC_Pos                30                                             /**< (PWM_ETRG1) Trigger Source Position */
+#define PWM_ETRG1_TRGSRC_Msk                (_U_(0x1) << PWM_ETRG1_TRGSRC_Pos)             /**< (PWM_ETRG1) Trigger Source Mask */
+#define PWM_ETRG1_TRGSRC                    PWM_ETRG1_TRGSRC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_TRGSRC_Msk instead */
+#define PWM_ETRG1_RFEN_Pos                  31                                             /**< (PWM_ETRG1) Recoverable Fault Enable Position */
+#define PWM_ETRG1_RFEN_Msk                  (_U_(0x1) << PWM_ETRG1_RFEN_Pos)               /**< (PWM_ETRG1) Recoverable Fault Enable Mask */
+#define PWM_ETRG1_RFEN                      PWM_ETRG1_RFEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG1_RFEN_Msk instead */
+#define PWM_ETRG1_MASK                      _U_(0xF3FFFFFF)                                /**< \deprecated (PWM_ETRG1) Register MASK  (Use PWM_ETRG1_Msk instead)  */
+#define PWM_ETRG1_Msk                       _U_(0xF3FFFFFF)                                /**< (PWM_ETRG1) Register Mask  */
+
+
+/* -------- PWM_LEBR1 : (PWM Offset: 0x430) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 1) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t PWMLFEN:1;                 /**< bit:     16  PWML Falling Edge Enable                 */
+    uint32_t PWMLREN:1;                 /**< bit:     17  PWML Rising Edge Enable                  */
+    uint32_t PWMHFEN:1;                 /**< bit:     18  PWMH Falling Edge Enable                 */
+    uint32_t PWMHREN:1;                 /**< bit:     19  PWMH Rising Edge Enable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_LEBR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_LEBR1_OFFSET                    (0x430)                                       /**<  (PWM_LEBR1) PWM Leading-Edge Blanking Register (trg_num = 1)  Offset */
+
+#define PWM_LEBR1_LEBDELAY_Pos              0                                              /**< (PWM_LEBR1) Leading-Edge Blanking Delay for TRGINx Position */
+#define PWM_LEBR1_LEBDELAY_Msk              (_U_(0x7F) << PWM_LEBR1_LEBDELAY_Pos)          /**< (PWM_LEBR1) Leading-Edge Blanking Delay for TRGINx Mask */
+#define PWM_LEBR1_LEBDELAY(value)           (PWM_LEBR1_LEBDELAY_Msk & ((value) << PWM_LEBR1_LEBDELAY_Pos))
+#define PWM_LEBR1_PWMLFEN_Pos               16                                             /**< (PWM_LEBR1) PWML Falling Edge Enable Position */
+#define PWM_LEBR1_PWMLFEN_Msk               (_U_(0x1) << PWM_LEBR1_PWMLFEN_Pos)            /**< (PWM_LEBR1) PWML Falling Edge Enable Mask */
+#define PWM_LEBR1_PWMLFEN                   PWM_LEBR1_PWMLFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMLFEN_Msk instead */
+#define PWM_LEBR1_PWMLREN_Pos               17                                             /**< (PWM_LEBR1) PWML Rising Edge Enable Position */
+#define PWM_LEBR1_PWMLREN_Msk               (_U_(0x1) << PWM_LEBR1_PWMLREN_Pos)            /**< (PWM_LEBR1) PWML Rising Edge Enable Mask */
+#define PWM_LEBR1_PWMLREN                   PWM_LEBR1_PWMLREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMLREN_Msk instead */
+#define PWM_LEBR1_PWMHFEN_Pos               18                                             /**< (PWM_LEBR1) PWMH Falling Edge Enable Position */
+#define PWM_LEBR1_PWMHFEN_Msk               (_U_(0x1) << PWM_LEBR1_PWMHFEN_Pos)            /**< (PWM_LEBR1) PWMH Falling Edge Enable Mask */
+#define PWM_LEBR1_PWMHFEN                   PWM_LEBR1_PWMHFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMHFEN_Msk instead */
+#define PWM_LEBR1_PWMHREN_Pos               19                                             /**< (PWM_LEBR1) PWMH Rising Edge Enable Position */
+#define PWM_LEBR1_PWMHREN_Msk               (_U_(0x1) << PWM_LEBR1_PWMHREN_Pos)            /**< (PWM_LEBR1) PWMH Rising Edge Enable Mask */
+#define PWM_LEBR1_PWMHREN                   PWM_LEBR1_PWMHREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR1_PWMHREN_Msk instead */
+#define PWM_LEBR1_MASK                      _U_(0xF007F)                                   /**< \deprecated (PWM_LEBR1) Register MASK  (Use PWM_LEBR1_Msk instead)  */
+#define PWM_LEBR1_Msk                       _U_(0xF007F)                                   /**< (PWM_LEBR1) Register Mask  */
+
+
+/* -------- PWM_CMUPD2 : (PWM Offset: 0x440) (/W 32) PWM Channel Mode Update Register (ch_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD2_OFFSET                   (0x440)                                       /**<  (PWM_CMUPD2) PWM Channel Mode Update Register (ch_num = 2)  Offset */
+
+#define PWM_CMUPD2_CPOLUP_Pos               9                                              /**< (PWM_CMUPD2) Channel Polarity Update Position */
+#define PWM_CMUPD2_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD2_CPOLUP_Pos)            /**< (PWM_CMUPD2) Channel Polarity Update Mask */
+#define PWM_CMUPD2_CPOLUP                   PWM_CMUPD2_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD2_CPOLUP_Msk instead */
+#define PWM_CMUPD2_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD2) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD2_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD2_CPOLINVUP_Pos)         /**< (PWM_CMUPD2) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD2_CPOLINVUP                PWM_CMUPD2_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD2_CPOLINVUP_Msk instead */
+#define PWM_CMUPD2_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD2) Register MASK  (Use PWM_CMUPD2_Msk instead)  */
+#define PWM_CMUPD2_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD2) Register Mask  */
+
+
+/* -------- PWM_ETRG2 : (PWM Offset: 0x44c) (R/W 32) PWM External Trigger Register (trg_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
+    uint32_t TRGMODE:2;                 /**< bit: 24..25  External Trigger Mode                    */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t TRGEDGE:1;                 /**< bit:     28  Edge Selection                           */
+    uint32_t TRGFILT:1;                 /**< bit:     29  Filtered input                           */
+    uint32_t TRGSRC:1;                  /**< bit:     30  Trigger Source                           */
+    uint32_t RFEN:1;                    /**< bit:     31  Recoverable Fault Enable                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_ETRG2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_ETRG2_OFFSET                    (0x44C)                                       /**<  (PWM_ETRG2) PWM External Trigger Register (trg_num = 2)  Offset */
+
+#define PWM_ETRG2_MAXCNT_Pos                0                                              /**< (PWM_ETRG2) Maximum Counter value Position */
+#define PWM_ETRG2_MAXCNT_Msk                (_U_(0xFFFFFF) << PWM_ETRG2_MAXCNT_Pos)        /**< (PWM_ETRG2) Maximum Counter value Mask */
+#define PWM_ETRG2_MAXCNT(value)             (PWM_ETRG2_MAXCNT_Msk & ((value) << PWM_ETRG2_MAXCNT_Pos))
+#define PWM_ETRG2_TRGMODE_Pos               24                                             /**< (PWM_ETRG2) External Trigger Mode Position */
+#define PWM_ETRG2_TRGMODE_Msk               (_U_(0x3) << PWM_ETRG2_TRGMODE_Pos)            /**< (PWM_ETRG2) External Trigger Mode Mask */
+#define PWM_ETRG2_TRGMODE(value)            (PWM_ETRG2_TRGMODE_Msk & ((value) << PWM_ETRG2_TRGMODE_Pos))
+#define   PWM_ETRG2_TRGMODE_OFF_Val         _U_(0x0)                                       /**< (PWM_ETRG2) External trigger is not enabled.  */
+#define   PWM_ETRG2_TRGMODE_MODE1_Val       _U_(0x1)                                       /**< (PWM_ETRG2) External PWM Reset Mode  */
+#define   PWM_ETRG2_TRGMODE_MODE2_Val       _U_(0x2)                                       /**< (PWM_ETRG2) External PWM Start Mode  */
+#define   PWM_ETRG2_TRGMODE_MODE3_Val       _U_(0x3)                                       /**< (PWM_ETRG2) Cycle-by-cycle Duty Mode  */
+#define PWM_ETRG2_TRGMODE_OFF               (PWM_ETRG2_TRGMODE_OFF_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External trigger is not enabled. Position  */
+#define PWM_ETRG2_TRGMODE_MODE1             (PWM_ETRG2_TRGMODE_MODE1_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External PWM Reset Mode Position  */
+#define PWM_ETRG2_TRGMODE_MODE2             (PWM_ETRG2_TRGMODE_MODE2_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) External PWM Start Mode Position  */
+#define PWM_ETRG2_TRGMODE_MODE3             (PWM_ETRG2_TRGMODE_MODE3_Val << PWM_ETRG2_TRGMODE_Pos)  /**< (PWM_ETRG2) Cycle-by-cycle Duty Mode Position  */
+#define PWM_ETRG2_TRGEDGE_Pos               28                                             /**< (PWM_ETRG2) Edge Selection Position */
+#define PWM_ETRG2_TRGEDGE_Msk               (_U_(0x1) << PWM_ETRG2_TRGEDGE_Pos)            /**< (PWM_ETRG2) Edge Selection Mask */
+#define PWM_ETRG2_TRGEDGE                   PWM_ETRG2_TRGEDGE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGEDGE_Msk instead */
+#define   PWM_ETRG2_TRGEDGE_FALLING_ZERO_Val _U_(0x0)                                       /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0  */
+#define   PWM_ETRG2_TRGEDGE_RISING_ONE_Val  _U_(0x1)                                       /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1  */
+#define PWM_ETRG2_TRGEDGE_FALLING_ZERO      (PWM_ETRG2_TRGEDGE_FALLING_ZERO_Val << PWM_ETRG2_TRGEDGE_Pos)  /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on falling edge.TRGMODE = 2, 3: TRGINx active level is 0 Position  */
+#define PWM_ETRG2_TRGEDGE_RISING_ONE        (PWM_ETRG2_TRGEDGE_RISING_ONE_Val << PWM_ETRG2_TRGEDGE_Pos)  /**< (PWM_ETRG2) TRGMODE = 1: TRGINx event detection on rising edge.TRGMODE = 2, 3: TRGINx active level is 1 Position  */
+#define PWM_ETRG2_TRGFILT_Pos               29                                             /**< (PWM_ETRG2) Filtered input Position */
+#define PWM_ETRG2_TRGFILT_Msk               (_U_(0x1) << PWM_ETRG2_TRGFILT_Pos)            /**< (PWM_ETRG2) Filtered input Mask */
+#define PWM_ETRG2_TRGFILT                   PWM_ETRG2_TRGFILT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGFILT_Msk instead */
+#define PWM_ETRG2_TRGSRC_Pos                30                                             /**< (PWM_ETRG2) Trigger Source Position */
+#define PWM_ETRG2_TRGSRC_Msk                (_U_(0x1) << PWM_ETRG2_TRGSRC_Pos)             /**< (PWM_ETRG2) Trigger Source Mask */
+#define PWM_ETRG2_TRGSRC                    PWM_ETRG2_TRGSRC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_TRGSRC_Msk instead */
+#define PWM_ETRG2_RFEN_Pos                  31                                             /**< (PWM_ETRG2) Recoverable Fault Enable Position */
+#define PWM_ETRG2_RFEN_Msk                  (_U_(0x1) << PWM_ETRG2_RFEN_Pos)               /**< (PWM_ETRG2) Recoverable Fault Enable Mask */
+#define PWM_ETRG2_RFEN                      PWM_ETRG2_RFEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_ETRG2_RFEN_Msk instead */
+#define PWM_ETRG2_MASK                      _U_(0xF3FFFFFF)                                /**< \deprecated (PWM_ETRG2) Register MASK  (Use PWM_ETRG2_Msk instead)  */
+#define PWM_ETRG2_Msk                       _U_(0xF3FFFFFF)                                /**< (PWM_ETRG2) Register Mask  */
+
+
+/* -------- PWM_LEBR2 : (PWM Offset: 0x450) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 2) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t PWMLFEN:1;                 /**< bit:     16  PWML Falling Edge Enable                 */
+    uint32_t PWMLREN:1;                 /**< bit:     17  PWML Rising Edge Enable                  */
+    uint32_t PWMHFEN:1;                 /**< bit:     18  PWMH Falling Edge Enable                 */
+    uint32_t PWMHREN:1;                 /**< bit:     19  PWMH Rising Edge Enable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_LEBR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_LEBR2_OFFSET                    (0x450)                                       /**<  (PWM_LEBR2) PWM Leading-Edge Blanking Register (trg_num = 2)  Offset */
+
+#define PWM_LEBR2_LEBDELAY_Pos              0                                              /**< (PWM_LEBR2) Leading-Edge Blanking Delay for TRGINx Position */
+#define PWM_LEBR2_LEBDELAY_Msk              (_U_(0x7F) << PWM_LEBR2_LEBDELAY_Pos)          /**< (PWM_LEBR2) Leading-Edge Blanking Delay for TRGINx Mask */
+#define PWM_LEBR2_LEBDELAY(value)           (PWM_LEBR2_LEBDELAY_Msk & ((value) << PWM_LEBR2_LEBDELAY_Pos))
+#define PWM_LEBR2_PWMLFEN_Pos               16                                             /**< (PWM_LEBR2) PWML Falling Edge Enable Position */
+#define PWM_LEBR2_PWMLFEN_Msk               (_U_(0x1) << PWM_LEBR2_PWMLFEN_Pos)            /**< (PWM_LEBR2) PWML Falling Edge Enable Mask */
+#define PWM_LEBR2_PWMLFEN                   PWM_LEBR2_PWMLFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMLFEN_Msk instead */
+#define PWM_LEBR2_PWMLREN_Pos               17                                             /**< (PWM_LEBR2) PWML Rising Edge Enable Position */
+#define PWM_LEBR2_PWMLREN_Msk               (_U_(0x1) << PWM_LEBR2_PWMLREN_Pos)            /**< (PWM_LEBR2) PWML Rising Edge Enable Mask */
+#define PWM_LEBR2_PWMLREN                   PWM_LEBR2_PWMLREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMLREN_Msk instead */
+#define PWM_LEBR2_PWMHFEN_Pos               18                                             /**< (PWM_LEBR2) PWMH Falling Edge Enable Position */
+#define PWM_LEBR2_PWMHFEN_Msk               (_U_(0x1) << PWM_LEBR2_PWMHFEN_Pos)            /**< (PWM_LEBR2) PWMH Falling Edge Enable Mask */
+#define PWM_LEBR2_PWMHFEN                   PWM_LEBR2_PWMHFEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMHFEN_Msk instead */
+#define PWM_LEBR2_PWMHREN_Pos               19                                             /**< (PWM_LEBR2) PWMH Rising Edge Enable Position */
+#define PWM_LEBR2_PWMHREN_Msk               (_U_(0x1) << PWM_LEBR2_PWMHREN_Pos)            /**< (PWM_LEBR2) PWMH Rising Edge Enable Mask */
+#define PWM_LEBR2_PWMHREN                   PWM_LEBR2_PWMHREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_LEBR2_PWMHREN_Msk instead */
+#define PWM_LEBR2_MASK                      _U_(0xF007F)                                   /**< \deprecated (PWM_LEBR2) Register MASK  (Use PWM_LEBR2_Msk instead)  */
+#define PWM_LEBR2_Msk                       _U_(0xF007F)                                   /**< (PWM_LEBR2) Register Mask  */
+
+
+/* -------- PWM_CMUPD3 : (PWM Offset: 0x460) (/W 32) PWM Channel Mode Update Register (ch_num = 3) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t CPOLUP:1;                  /**< bit:      9  Channel Polarity Update                  */
+    uint32_t :3;                        /**< bit: 10..12  Reserved */
+    uint32_t CPOLINVUP:1;               /**< bit:     13  Channel Polarity Inversion Update        */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} PWM_CMUPD3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PWM_CMUPD3_OFFSET                   (0x460)                                       /**<  (PWM_CMUPD3) PWM Channel Mode Update Register (ch_num = 3)  Offset */
+
+#define PWM_CMUPD3_CPOLUP_Pos               9                                              /**< (PWM_CMUPD3) Channel Polarity Update Position */
+#define PWM_CMUPD3_CPOLUP_Msk               (_U_(0x1) << PWM_CMUPD3_CPOLUP_Pos)            /**< (PWM_CMUPD3) Channel Polarity Update Mask */
+#define PWM_CMUPD3_CPOLUP                   PWM_CMUPD3_CPOLUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD3_CPOLUP_Msk instead */
+#define PWM_CMUPD3_CPOLINVUP_Pos            13                                             /**< (PWM_CMUPD3) Channel Polarity Inversion Update Position */
+#define PWM_CMUPD3_CPOLINVUP_Msk            (_U_(0x1) << PWM_CMUPD3_CPOLINVUP_Pos)         /**< (PWM_CMUPD3) Channel Polarity Inversion Update Mask */
+#define PWM_CMUPD3_CPOLINVUP                PWM_CMUPD3_CPOLINVUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMUPD3_CPOLINVUP_Msk instead */
+#define PWM_CMUPD3_MASK                     _U_(0x2200)                                    /**< \deprecated (PWM_CMUPD3) Register MASK  (Use PWM_CMUPD3_Msk instead)  */
+#define PWM_CMUPD3_Msk                      _U_(0x2200)                                    /**< (PWM_CMUPD3) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief PWM_CH_NUM hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CMR;        /**< (PWM_CH_NUM Offset: 0x00) PWM Channel Mode Register */
+  __IO uint32_t PWM_CDTY;       /**< (PWM_CH_NUM Offset: 0x04) PWM Channel Duty Cycle Register */
+  __O  uint32_t PWM_CDTYUPD;    /**< (PWM_CH_NUM Offset: 0x08) PWM Channel Duty Cycle Update Register */
+  __IO uint32_t PWM_CPRD;       /**< (PWM_CH_NUM Offset: 0x0C) PWM Channel Period Register */
+  __O  uint32_t PWM_CPRDUPD;    /**< (PWM_CH_NUM Offset: 0x10) PWM Channel Period Update Register */
+  __I  uint32_t PWM_CCNT;       /**< (PWM_CH_NUM Offset: 0x14) PWM Channel Counter Register */
+  __IO uint32_t PWM_DT;         /**< (PWM_CH_NUM Offset: 0x18) PWM Channel Dead Time Register */
+  __O  uint32_t PWM_DTUPD;      /**< (PWM_CH_NUM Offset: 0x1C) PWM Channel Dead Time Update Register */
+} PwmChNum;
+
+/** \brief PWM_CMP hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CMPV;       /**< (PWM_CMP Offset: 0x00) PWM Comparison 0 Value Register */
+  __O  uint32_t PWM_CMPVUPD;    /**< (PWM_CMP Offset: 0x04) PWM Comparison 0 Value Update Register */
+  __IO uint32_t PWM_CMPM;       /**< (PWM_CMP Offset: 0x08) PWM Comparison 0 Mode Register */
+  __O  uint32_t PWM_CMPMUPD;    /**< (PWM_CMP Offset: 0x0C) PWM Comparison 0 Mode Update Register */
+} PwmCmp;
+
+#define PWMCMP_NUMBER 8
+#define PWMCHNUM_NUMBER 4
+/** \brief PWM hardware registers */
+typedef struct {  
+  __IO uint32_t PWM_CLK;        /**< (PWM Offset: 0x00) PWM Clock Register */
+  __O  uint32_t PWM_ENA;        /**< (PWM Offset: 0x04) PWM Enable Register */
+  __O  uint32_t PWM_DIS;        /**< (PWM Offset: 0x08) PWM Disable Register */
+  __I  uint32_t PWM_SR;         /**< (PWM Offset: 0x0C) PWM Status Register */
+  __O  uint32_t PWM_IER1;       /**< (PWM Offset: 0x10) PWM Interrupt Enable Register 1 */
+  __O  uint32_t PWM_IDR1;       /**< (PWM Offset: 0x14) PWM Interrupt Disable Register 1 */
+  __I  uint32_t PWM_IMR1;       /**< (PWM Offset: 0x18) PWM Interrupt Mask Register 1 */
+  __I  uint32_t PWM_ISR1;       /**< (PWM Offset: 0x1C) PWM Interrupt Status Register 1 */
+  __IO uint32_t PWM_SCM;        /**< (PWM Offset: 0x20) PWM Sync Channels Mode Register */
+  __O  uint32_t PWM_DMAR;       /**< (PWM Offset: 0x24) PWM DMA Register */
+  __IO uint32_t PWM_SCUC;       /**< (PWM Offset: 0x28) PWM Sync Channels Update Control Register */
+  __IO uint32_t PWM_SCUP;       /**< (PWM Offset: 0x2C) PWM Sync Channels Update Period Register */
+  __O  uint32_t PWM_SCUPUPD;    /**< (PWM Offset: 0x30) PWM Sync Channels Update Period Update Register */
+  __O  uint32_t PWM_IER2;       /**< (PWM Offset: 0x34) PWM Interrupt Enable Register 2 */
+  __O  uint32_t PWM_IDR2;       /**< (PWM Offset: 0x38) PWM Interrupt Disable Register 2 */
+  __I  uint32_t PWM_IMR2;       /**< (PWM Offset: 0x3C) PWM Interrupt Mask Register 2 */
+  __I  uint32_t PWM_ISR2;       /**< (PWM Offset: 0x40) PWM Interrupt Status Register 2 */
+  __IO uint32_t PWM_OOV;        /**< (PWM Offset: 0x44) PWM Output Override Value Register */
+  __IO uint32_t PWM_OS;         /**< (PWM Offset: 0x48) PWM Output Selection Register */
+  __O  uint32_t PWM_OSS;        /**< (PWM Offset: 0x4C) PWM Output Selection Set Register */
+  __O  uint32_t PWM_OSC;        /**< (PWM Offset: 0x50) PWM Output Selection Clear Register */
+  __O  uint32_t PWM_OSSUPD;     /**< (PWM Offset: 0x54) PWM Output Selection Set Update Register */
+  __O  uint32_t PWM_OSCUPD;     /**< (PWM Offset: 0x58) PWM Output Selection Clear Update Register */
+  __IO uint32_t PWM_FMR;        /**< (PWM Offset: 0x5C) PWM Fault Mode Register */
+  __I  uint32_t PWM_FSR;        /**< (PWM Offset: 0x60) PWM Fault Status Register */
+  __O  uint32_t PWM_FCR;        /**< (PWM Offset: 0x64) PWM Fault Clear Register */
+  __IO uint32_t PWM_FPV1;       /**< (PWM Offset: 0x68) PWM Fault Protection Value Register 1 */
+  __IO uint32_t PWM_FPE;        /**< (PWM Offset: 0x6C) PWM Fault Protection Enable Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO uint32_t PWM_ELMR[2];    /**< (PWM Offset: 0x7C) PWM Event Line 0 Mode Register 0 */
+  __I  uint8_t                        Reserved2[28];
+  __IO uint32_t PWM_SSPR;       /**< (PWM Offset: 0xA0) PWM Spread Spectrum Register */
+  __O  uint32_t PWM_SSPUP;      /**< (PWM Offset: 0xA4) PWM Spread Spectrum Update Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO uint32_t PWM_SMMR;       /**< (PWM Offset: 0xB0) PWM Stepper Motor Mode Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO uint32_t PWM_FPV2;       /**< (PWM Offset: 0xC0) PWM Fault Protection Value 2 Register */
+  __I  uint8_t                        Reserved5[32];
+  __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
+  __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register */
+  __I  uint8_t                        Reserved8[384];
+  __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
+  __I  uint8_t                        Reserved9[28];
+  __O  uint32_t PWM_CMUPD1;     /**< (PWM Offset: 0x420) PWM Channel Mode Update Register (ch_num = 1) */
+  __I  uint8_t                        Reserved10[8];
+  __IO uint32_t PWM_ETRG1;      /**< (PWM Offset: 0x42C) PWM External Trigger Register (trg_num = 1) */
+  __IO uint32_t PWM_LEBR1;      /**< (PWM Offset: 0x430) PWM Leading-Edge Blanking Register (trg_num = 1) */
+  __I  uint8_t                        Reserved11[12];
+  __O  uint32_t PWM_CMUPD2;     /**< (PWM Offset: 0x440) PWM Channel Mode Update Register (ch_num = 2) */
+  __I  uint8_t                        Reserved12[8];
+  __IO uint32_t PWM_ETRG2;      /**< (PWM Offset: 0x44C) PWM External Trigger Register (trg_num = 2) */
+  __IO uint32_t PWM_LEBR2;      /**< (PWM Offset: 0x450) PWM Leading-Edge Blanking Register (trg_num = 2) */
+  __I  uint8_t                        Reserved13[12];
+  __O  uint32_t PWM_CMUPD3;     /**< (PWM Offset: 0x460) PWM Channel Mode Update Register (ch_num = 3) */
+} Pwm;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief PWM_CH_NUM hardware registers */
+typedef struct {  
+  __IO PWM_CMR_Type                   PWM_CMR;        /**< Offset: 0x00 (R/W  32) PWM Channel Mode Register */
+  __IO PWM_CDTY_Type                  PWM_CDTY;       /**< Offset: 0x04 (R/W  32) PWM Channel Duty Cycle Register */
+  __O  PWM_CDTYUPD_Type               PWM_CDTYUPD;    /**< Offset: 0x08 ( /W  32) PWM Channel Duty Cycle Update Register */
+  __IO PWM_CPRD_Type                  PWM_CPRD;       /**< Offset: 0x0C (R/W  32) PWM Channel Period Register */
+  __O  PWM_CPRDUPD_Type               PWM_CPRDUPD;    /**< Offset: 0x10 ( /W  32) PWM Channel Period Update Register */
+  __I  PWM_CCNT_Type                  PWM_CCNT;       /**< Offset: 0x14 (R/   32) PWM Channel Counter Register */
+  __IO PWM_DT_Type                    PWM_DT;         /**< Offset: 0x18 (R/W  32) PWM Channel Dead Time Register */
+  __O  PWM_DTUPD_Type                 PWM_DTUPD;      /**< Offset: 0x1C ( /W  32) PWM Channel Dead Time Update Register */
+} PwmChNum;
+
+/** \brief PWM_CMP hardware registers */
+typedef struct {  
+  __IO PWM_CMPV_Type                  PWM_CMPV;       /**< Offset: 0x00 (R/W  32) PWM Comparison 0 Value Register */
+  __O  PWM_CMPVUPD_Type               PWM_CMPVUPD;    /**< Offset: 0x04 ( /W  32) PWM Comparison 0 Value Update Register */
+  __IO PWM_CMPM_Type                  PWM_CMPM;       /**< Offset: 0x08 (R/W  32) PWM Comparison 0 Mode Register */
+  __O  PWM_CMPMUPD_Type               PWM_CMPMUPD;    /**< Offset: 0x0C ( /W  32) PWM Comparison 0 Mode Update Register */
+} PwmCmp;
+
+/** \brief PWM hardware registers */
+typedef struct {  
+  __IO PWM_CLK_Type                   PWM_CLK;        /**< Offset: 0x00 (R/W  32) PWM Clock Register */
+  __O  PWM_ENA_Type                   PWM_ENA;        /**< Offset: 0x04 ( /W  32) PWM Enable Register */
+  __O  PWM_DIS_Type                   PWM_DIS;        /**< Offset: 0x08 ( /W  32) PWM Disable Register */
+  __I  PWM_SR_Type                    PWM_SR;         /**< Offset: 0x0C (R/   32) PWM Status Register */
+  __O  PWM_IER1_Type                  PWM_IER1;       /**< Offset: 0x10 ( /W  32) PWM Interrupt Enable Register 1 */
+  __O  PWM_IDR1_Type                  PWM_IDR1;       /**< Offset: 0x14 ( /W  32) PWM Interrupt Disable Register 1 */
+  __I  PWM_IMR1_Type                  PWM_IMR1;       /**< Offset: 0x18 (R/   32) PWM Interrupt Mask Register 1 */
+  __I  PWM_ISR1_Type                  PWM_ISR1;       /**< Offset: 0x1C (R/   32) PWM Interrupt Status Register 1 */
+  __IO PWM_SCM_Type                   PWM_SCM;        /**< Offset: 0x20 (R/W  32) PWM Sync Channels Mode Register */
+  __O  PWM_DMAR_Type                  PWM_DMAR;       /**< Offset: 0x24 ( /W  32) PWM DMA Register */
+  __IO PWM_SCUC_Type                  PWM_SCUC;       /**< Offset: 0x28 (R/W  32) PWM Sync Channels Update Control Register */
+  __IO PWM_SCUP_Type                  PWM_SCUP;       /**< Offset: 0x2C (R/W  32) PWM Sync Channels Update Period Register */
+  __O  PWM_SCUPUPD_Type               PWM_SCUPUPD;    /**< Offset: 0x30 ( /W  32) PWM Sync Channels Update Period Update Register */
+  __O  PWM_IER2_Type                  PWM_IER2;       /**< Offset: 0x34 ( /W  32) PWM Interrupt Enable Register 2 */
+  __O  PWM_IDR2_Type                  PWM_IDR2;       /**< Offset: 0x38 ( /W  32) PWM Interrupt Disable Register 2 */
+  __I  PWM_IMR2_Type                  PWM_IMR2;       /**< Offset: 0x3C (R/   32) PWM Interrupt Mask Register 2 */
+  __I  PWM_ISR2_Type                  PWM_ISR2;       /**< Offset: 0x40 (R/   32) PWM Interrupt Status Register 2 */
+  __IO PWM_OOV_Type                   PWM_OOV;        /**< Offset: 0x44 (R/W  32) PWM Output Override Value Register */
+  __IO PWM_OS_Type                    PWM_OS;         /**< Offset: 0x48 (R/W  32) PWM Output Selection Register */
+  __O  PWM_OSS_Type                   PWM_OSS;        /**< Offset: 0x4C ( /W  32) PWM Output Selection Set Register */
+  __O  PWM_OSC_Type                   PWM_OSC;        /**< Offset: 0x50 ( /W  32) PWM Output Selection Clear Register */
+  __O  PWM_OSSUPD_Type                PWM_OSSUPD;     /**< Offset: 0x54 ( /W  32) PWM Output Selection Set Update Register */
+  __O  PWM_OSCUPD_Type                PWM_OSCUPD;     /**< Offset: 0x58 ( /W  32) PWM Output Selection Clear Update Register */
+  __IO PWM_FMR_Type                   PWM_FMR;        /**< Offset: 0x5C (R/W  32) PWM Fault Mode Register */
+  __I  PWM_FSR_Type                   PWM_FSR;        /**< Offset: 0x60 (R/   32) PWM Fault Status Register */
+  __O  PWM_FCR_Type                   PWM_FCR;        /**< Offset: 0x64 ( /W  32) PWM Fault Clear Register */
+  __IO PWM_FPV1_Type                  PWM_FPV1;       /**< Offset: 0x68 (R/W  32) PWM Fault Protection Value Register 1 */
+  __IO PWM_FPE_Type                   PWM_FPE;        /**< Offset: 0x6C (R/W  32) PWM Fault Protection Enable Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO PWM_ELMR_Type                  PWM_ELMR[2];    /**< Offset: 0x7C (R/W  32) PWM Event Line 0 Mode Register 0 */
+  __I  uint8_t                        Reserved2[28];
+  __IO PWM_SSPR_Type                  PWM_SSPR;       /**< Offset: 0xA0 (R/W  32) PWM Spread Spectrum Register */
+  __O  PWM_SSPUP_Type                 PWM_SSPUP;      /**< Offset: 0xA4 ( /W  32) PWM Spread Spectrum Update Register */
+  __I  uint8_t                        Reserved3[8];
+  __IO PWM_SMMR_Type                  PWM_SMMR;       /**< Offset: 0xB0 (R/W  32) PWM Stepper Motor Mode Register */
+  __I  uint8_t                        Reserved4[12];
+  __IO PWM_FPV2_Type                  PWM_FPV2;       /**< Offset: 0xC0 (R/W  32) PWM Fault Protection Value 2 Register */
+  __I  uint8_t                        Reserved5[32];
+  __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
+  __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register */
+  __I  uint8_t                        Reserved8[384];
+  __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
+  __I  uint8_t                        Reserved9[28];
+  __O  PWM_CMUPD1_Type                PWM_CMUPD1;     /**< Offset: 0x420 ( /W  32) PWM Channel Mode Update Register (ch_num = 1) */
+  __I  uint8_t                        Reserved10[8];
+  __IO PWM_ETRG1_Type                 PWM_ETRG1;      /**< Offset: 0x42C (R/W  32) PWM External Trigger Register (trg_num = 1) */
+  __IO PWM_LEBR1_Type                 PWM_LEBR1;      /**< Offset: 0x430 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 1) */
+  __I  uint8_t                        Reserved11[12];
+  __O  PWM_CMUPD2_Type                PWM_CMUPD2;     /**< Offset: 0x440 ( /W  32) PWM Channel Mode Update Register (ch_num = 2) */
+  __I  uint8_t                        Reserved12[8];
+  __IO PWM_ETRG2_Type                 PWM_ETRG2;      /**< Offset: 0x44C (R/W  32) PWM External Trigger Register (trg_num = 2) */
+  __IO PWM_LEBR2_Type                 PWM_LEBR2;      /**< Offset: 0x450 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 2) */
+  __I  uint8_t                        Reserved13[12];
+  __O  PWM_CMUPD3_Type                PWM_CMUPD3;     /**< Offset: 0x460 ( /W  32) PWM Channel Mode Update Register (ch_num = 3) */
+} Pwm;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Pulse Width Modulation Controller */
+
+#endif /* _SAMV71_PWM_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/qspi.h
+++ b/asf/sam/include/samv71b/component/qspi.h
@@ -1,0 +1,735 @@
+/**
+ * \file
+ *
+ * \brief Component description for QSPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_QSPI_COMPONENT_H_
+#define _SAMV71_QSPI_COMPONENT_H_
+#define _SAMV71_QSPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Quad Serial Peripheral Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR QSPI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define QSPI_11171                      /**< (QSPI) Module ID */
+#define REV_QSPI J                      /**< (QSPI) Module revision */
+
+/* -------- QSPI_CR : (QSPI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t QSPIEN:1;                  /**< bit:      0  QSPI Enable                              */
+    uint32_t QSPIDIS:1;                 /**< bit:      1  QSPI Disable                             */
+    uint32_t :5;                        /**< bit:   2..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  QSPI Software Reset                      */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_CR_OFFSET                      (0x00)                                        /**<  (QSPI_CR) Control Register  Offset */
+
+#define QSPI_CR_QSPIEN_Pos                  0                                              /**< (QSPI_CR) QSPI Enable Position */
+#define QSPI_CR_QSPIEN_Msk                  (_U_(0x1) << QSPI_CR_QSPIEN_Pos)               /**< (QSPI_CR) QSPI Enable Mask */
+#define QSPI_CR_QSPIEN                      QSPI_CR_QSPIEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_QSPIEN_Msk instead */
+#define QSPI_CR_QSPIDIS_Pos                 1                                              /**< (QSPI_CR) QSPI Disable Position */
+#define QSPI_CR_QSPIDIS_Msk                 (_U_(0x1) << QSPI_CR_QSPIDIS_Pos)              /**< (QSPI_CR) QSPI Disable Mask */
+#define QSPI_CR_QSPIDIS                     QSPI_CR_QSPIDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_QSPIDIS_Msk instead */
+#define QSPI_CR_SWRST_Pos                   7                                              /**< (QSPI_CR) QSPI Software Reset Position */
+#define QSPI_CR_SWRST_Msk                   (_U_(0x1) << QSPI_CR_SWRST_Pos)                /**< (QSPI_CR) QSPI Software Reset Mask */
+#define QSPI_CR_SWRST                       QSPI_CR_SWRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_SWRST_Msk instead */
+#define QSPI_CR_LASTXFER_Pos                24                                             /**< (QSPI_CR) Last Transfer Position */
+#define QSPI_CR_LASTXFER_Msk                (_U_(0x1) << QSPI_CR_LASTXFER_Pos)             /**< (QSPI_CR) Last Transfer Mask */
+#define QSPI_CR_LASTXFER                    QSPI_CR_LASTXFER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_CR_LASTXFER_Msk instead */
+#define QSPI_CR_MASK                        _U_(0x1000083)                                 /**< \deprecated (QSPI_CR) Register MASK  (Use QSPI_CR_Msk instead)  */
+#define QSPI_CR_Msk                         _U_(0x1000083)                                 /**< (QSPI_CR) Register Mask  */
+
+
+/* -------- QSPI_MR : (QSPI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMM:1;                     /**< bit:      0  Serial Memory Mode                       */
+    uint32_t LLB:1;                     /**< bit:      1  Local Loopback Enable                    */
+    uint32_t WDRBT:1;                   /**< bit:      2  Wait Data Read Before Transfer           */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t CSMODE:2;                  /**< bit:   4..5  Chip Select Mode                         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NBBITS:4;                  /**< bit:  8..11  Number Of Bits Per Transfer              */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t DLYBCT:8;                  /**< bit: 16..23  Delay Between Consecutive Transfers      */
+    uint32_t DLYCS:8;                   /**< bit: 24..31  Minimum Inactive QCS Delay               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_MR_OFFSET                      (0x04)                                        /**<  (QSPI_MR) Mode Register  Offset */
+
+#define QSPI_MR_SMM_Pos                     0                                              /**< (QSPI_MR) Serial Memory Mode Position */
+#define QSPI_MR_SMM_Msk                     (_U_(0x1) << QSPI_MR_SMM_Pos)                  /**< (QSPI_MR) Serial Memory Mode Mask */
+#define QSPI_MR_SMM                         QSPI_MR_SMM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_SMM_Msk instead */
+#define   QSPI_MR_SMM_SPI_Val               _U_(0x0)                                       /**< (QSPI_MR) The QSPI is in SPI mode.  */
+#define   QSPI_MR_SMM_MEMORY_Val            _U_(0x1)                                       /**< (QSPI_MR) The QSPI is in Serial Memory mode.  */
+#define QSPI_MR_SMM_SPI                     (QSPI_MR_SMM_SPI_Val << QSPI_MR_SMM_Pos)       /**< (QSPI_MR) The QSPI is in SPI mode. Position  */
+#define QSPI_MR_SMM_MEMORY                  (QSPI_MR_SMM_MEMORY_Val << QSPI_MR_SMM_Pos)    /**< (QSPI_MR) The QSPI is in Serial Memory mode. Position  */
+#define QSPI_MR_LLB_Pos                     1                                              /**< (QSPI_MR) Local Loopback Enable Position */
+#define QSPI_MR_LLB_Msk                     (_U_(0x1) << QSPI_MR_LLB_Pos)                  /**< (QSPI_MR) Local Loopback Enable Mask */
+#define QSPI_MR_LLB                         QSPI_MR_LLB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_LLB_Msk instead */
+#define   QSPI_MR_LLB_DISABLED_Val          _U_(0x0)                                       /**< (QSPI_MR) Local loopback path disabled.  */
+#define   QSPI_MR_LLB_ENABLED_Val           _U_(0x1)                                       /**< (QSPI_MR) Local loopback path enabled.  */
+#define QSPI_MR_LLB_DISABLED                (QSPI_MR_LLB_DISABLED_Val << QSPI_MR_LLB_Pos)  /**< (QSPI_MR) Local loopback path disabled. Position  */
+#define QSPI_MR_LLB_ENABLED                 (QSPI_MR_LLB_ENABLED_Val << QSPI_MR_LLB_Pos)   /**< (QSPI_MR) Local loopback path enabled. Position  */
+#define QSPI_MR_WDRBT_Pos                   2                                              /**< (QSPI_MR) Wait Data Read Before Transfer Position */
+#define QSPI_MR_WDRBT_Msk                   (_U_(0x1) << QSPI_MR_WDRBT_Pos)                /**< (QSPI_MR) Wait Data Read Before Transfer Mask */
+#define QSPI_MR_WDRBT                       QSPI_MR_WDRBT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_MR_WDRBT_Msk instead */
+#define   QSPI_MR_WDRBT_DISABLED_Val        _U_(0x0)                                       /**< (QSPI_MR) No effect. In SPI mode, a transfer can be initiated whatever the state of the QSPI_RDR is.  */
+#define   QSPI_MR_WDRBT_ENABLED_Val         _U_(0x1)                                       /**< (QSPI_MR) In SPI mode, a transfer can start only if the QSPI_RDR is empty, i.e., does not contain any unread data. This mode prevents overrun error in reception.  */
+#define QSPI_MR_WDRBT_DISABLED              (QSPI_MR_WDRBT_DISABLED_Val << QSPI_MR_WDRBT_Pos)  /**< (QSPI_MR) No effect. In SPI mode, a transfer can be initiated whatever the state of the QSPI_RDR is. Position  */
+#define QSPI_MR_WDRBT_ENABLED               (QSPI_MR_WDRBT_ENABLED_Val << QSPI_MR_WDRBT_Pos)  /**< (QSPI_MR) In SPI mode, a transfer can start only if the QSPI_RDR is empty, i.e., does not contain any unread data. This mode prevents overrun error in reception. Position  */
+#define QSPI_MR_CSMODE_Pos                  4                                              /**< (QSPI_MR) Chip Select Mode Position */
+#define QSPI_MR_CSMODE_Msk                  (_U_(0x3) << QSPI_MR_CSMODE_Pos)               /**< (QSPI_MR) Chip Select Mode Mask */
+#define QSPI_MR_CSMODE(value)               (QSPI_MR_CSMODE_Msk & ((value) << QSPI_MR_CSMODE_Pos))
+#define   QSPI_MR_CSMODE_NOT_RELOADED_Val   _U_(0x0)                                       /**< (QSPI_MR) The chip select is deasserted if QSPI_TDR.TD has not been reloaded before the end of the current transfer.  */
+#define   QSPI_MR_CSMODE_LASTXFER_Val       _U_(0x1)                                       /**< (QSPI_MR) The chip select is deasserted when the bit LASTXFER is written at 1 and the character written in QSPI_TDR.TD has been transferred.  */
+#define   QSPI_MR_CSMODE_SYSTEMATICALLY_Val _U_(0x2)                                       /**< (QSPI_MR) The chip select is deasserted systematically after each transfer.  */
+#define QSPI_MR_CSMODE_NOT_RELOADED         (QSPI_MR_CSMODE_NOT_RELOADED_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted if QSPI_TDR.TD has not been reloaded before the end of the current transfer. Position  */
+#define QSPI_MR_CSMODE_LASTXFER             (QSPI_MR_CSMODE_LASTXFER_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted when the bit LASTXFER is written at 1 and the character written in QSPI_TDR.TD has been transferred. Position  */
+#define QSPI_MR_CSMODE_SYSTEMATICALLY       (QSPI_MR_CSMODE_SYSTEMATICALLY_Val << QSPI_MR_CSMODE_Pos)  /**< (QSPI_MR) The chip select is deasserted systematically after each transfer. Position  */
+#define QSPI_MR_NBBITS_Pos                  8                                              /**< (QSPI_MR) Number Of Bits Per Transfer Position */
+#define QSPI_MR_NBBITS_Msk                  (_U_(0xF) << QSPI_MR_NBBITS_Pos)               /**< (QSPI_MR) Number Of Bits Per Transfer Mask */
+#define QSPI_MR_NBBITS(value)               (QSPI_MR_NBBITS_Msk & ((value) << QSPI_MR_NBBITS_Pos))
+#define   QSPI_MR_NBBITS_8_BIT_Val          _U_(0x0)                                       /**< (QSPI_MR) 8 bits for transfer  */
+#define   QSPI_MR_NBBITS_16_BIT_Val         _U_(0x8)                                       /**< (QSPI_MR) 16 bits for transfer  */
+#define QSPI_MR_NBBITS_8_BIT                (QSPI_MR_NBBITS_8_BIT_Val << QSPI_MR_NBBITS_Pos)  /**< (QSPI_MR) 8 bits for transfer Position  */
+#define QSPI_MR_NBBITS_16_BIT               (QSPI_MR_NBBITS_16_BIT_Val << QSPI_MR_NBBITS_Pos)  /**< (QSPI_MR) 16 bits for transfer Position  */
+#define QSPI_MR_DLYBCT_Pos                  16                                             /**< (QSPI_MR) Delay Between Consecutive Transfers Position */
+#define QSPI_MR_DLYBCT_Msk                  (_U_(0xFF) << QSPI_MR_DLYBCT_Pos)              /**< (QSPI_MR) Delay Between Consecutive Transfers Mask */
+#define QSPI_MR_DLYBCT(value)               (QSPI_MR_DLYBCT_Msk & ((value) << QSPI_MR_DLYBCT_Pos))
+#define QSPI_MR_DLYCS_Pos                   24                                             /**< (QSPI_MR) Minimum Inactive QCS Delay Position */
+#define QSPI_MR_DLYCS_Msk                   (_U_(0xFF) << QSPI_MR_DLYCS_Pos)               /**< (QSPI_MR) Minimum Inactive QCS Delay Mask */
+#define QSPI_MR_DLYCS(value)                (QSPI_MR_DLYCS_Msk & ((value) << QSPI_MR_DLYCS_Pos))
+#define QSPI_MR_MASK                        _U_(0xFFFF0F37)                                /**< \deprecated (QSPI_MR) Register MASK  (Use QSPI_MR_Msk instead)  */
+#define QSPI_MR_Msk                         _U_(0xFFFF0F37)                                /**< (QSPI_MR) Register Mask  */
+
+
+/* -------- QSPI_RDR : (QSPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_RDR_OFFSET                     (0x08)                                        /**<  (QSPI_RDR) Receive Data Register  Offset */
+
+#define QSPI_RDR_RD_Pos                     0                                              /**< (QSPI_RDR) Receive Data Position */
+#define QSPI_RDR_RD_Msk                     (_U_(0xFFFF) << QSPI_RDR_RD_Pos)               /**< (QSPI_RDR) Receive Data Mask */
+#define QSPI_RDR_RD(value)                  (QSPI_RDR_RD_Msk & ((value) << QSPI_RDR_RD_Pos))
+#define QSPI_RDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (QSPI_RDR) Register MASK  (Use QSPI_RDR_Msk instead)  */
+#define QSPI_RDR_Msk                        _U_(0xFFFF)                                    /**< (QSPI_RDR) Register Mask  */
+
+
+/* -------- QSPI_TDR : (QSPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_TDR_OFFSET                     (0x0C)                                        /**<  (QSPI_TDR) Transmit Data Register  Offset */
+
+#define QSPI_TDR_TD_Pos                     0                                              /**< (QSPI_TDR) Transmit Data Position */
+#define QSPI_TDR_TD_Msk                     (_U_(0xFFFF) << QSPI_TDR_TD_Pos)               /**< (QSPI_TDR) Transmit Data Mask */
+#define QSPI_TDR_TD(value)                  (QSPI_TDR_TD_Msk & ((value) << QSPI_TDR_TD_Pos))
+#define QSPI_TDR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (QSPI_TDR) Register MASK  (Use QSPI_TDR_Msk instead)  */
+#define QSPI_TDR_Msk                        _U_(0xFFFF)                                    /**< (QSPI_TDR) Register Mask  */
+
+
+/* -------- QSPI_SR : (QSPI Offset: 0x10) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty (cleared by writing SPI_TDR) */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty (cleared by writing SPI_TDR) */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Status (cleared on read)   */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise (cleared on read)       */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status                       */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Status (cleared on read) */
+    uint32_t :13;                       /**< bit: 11..23  Reserved */
+    uint32_t QSPIENS:1;                 /**< bit:     24  QSPI Enable Status                       */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SR_OFFSET                      (0x10)                                        /**<  (QSPI_SR) Status Register  Offset */
+
+#define QSPI_SR_RDRF_Pos                    0                                              /**< (QSPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Position */
+#define QSPI_SR_RDRF_Msk                    (_U_(0x1) << QSPI_SR_RDRF_Pos)                 /**< (QSPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Mask */
+#define QSPI_SR_RDRF                        QSPI_SR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_RDRF_Msk instead */
+#define QSPI_SR_TDRE_Pos                    1                                              /**< (QSPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Position */
+#define QSPI_SR_TDRE_Msk                    (_U_(0x1) << QSPI_SR_TDRE_Pos)                 /**< (QSPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Mask */
+#define QSPI_SR_TDRE                        QSPI_SR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_TDRE_Msk instead */
+#define QSPI_SR_TXEMPTY_Pos                 2                                              /**< (QSPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Position */
+#define QSPI_SR_TXEMPTY_Msk                 (_U_(0x1) << QSPI_SR_TXEMPTY_Pos)              /**< (QSPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Mask */
+#define QSPI_SR_TXEMPTY                     QSPI_SR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_TXEMPTY_Msk instead */
+#define QSPI_SR_OVRES_Pos                   3                                              /**< (QSPI_SR) Overrun Error Status (cleared on read) Position */
+#define QSPI_SR_OVRES_Msk                   (_U_(0x1) << QSPI_SR_OVRES_Pos)                /**< (QSPI_SR) Overrun Error Status (cleared on read) Mask */
+#define QSPI_SR_OVRES                       QSPI_SR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_OVRES_Msk instead */
+#define QSPI_SR_CSR_Pos                     8                                              /**< (QSPI_SR) Chip Select Rise (cleared on read) Position */
+#define QSPI_SR_CSR_Msk                     (_U_(0x1) << QSPI_SR_CSR_Pos)                  /**< (QSPI_SR) Chip Select Rise (cleared on read) Mask */
+#define QSPI_SR_CSR                         QSPI_SR_CSR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_CSR_Msk instead */
+#define QSPI_SR_CSS_Pos                     9                                              /**< (QSPI_SR) Chip Select Status Position */
+#define QSPI_SR_CSS_Msk                     (_U_(0x1) << QSPI_SR_CSS_Pos)                  /**< (QSPI_SR) Chip Select Status Mask */
+#define QSPI_SR_CSS                         QSPI_SR_CSS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_CSS_Msk instead */
+#define QSPI_SR_INSTRE_Pos                  10                                             /**< (QSPI_SR) Instruction End Status (cleared on read) Position */
+#define QSPI_SR_INSTRE_Msk                  (_U_(0x1) << QSPI_SR_INSTRE_Pos)               /**< (QSPI_SR) Instruction End Status (cleared on read) Mask */
+#define QSPI_SR_INSTRE                      QSPI_SR_INSTRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_INSTRE_Msk instead */
+#define QSPI_SR_QSPIENS_Pos                 24                                             /**< (QSPI_SR) QSPI Enable Status Position */
+#define QSPI_SR_QSPIENS_Msk                 (_U_(0x1) << QSPI_SR_QSPIENS_Pos)              /**< (QSPI_SR) QSPI Enable Status Mask */
+#define QSPI_SR_QSPIENS                     QSPI_SR_QSPIENS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SR_QSPIENS_Msk instead */
+#define QSPI_SR_MASK                        _U_(0x100070F)                                 /**< \deprecated (QSPI_SR) Register MASK  (Use QSPI_SR_Msk instead)  */
+#define QSPI_SR_Msk                         _U_(0x100070F)                                 /**< (QSPI_SR) Register Mask  */
+
+
+/* -------- QSPI_IER : (QSPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Enable */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Enable      */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Enable           */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Enable        */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Enable      */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Enable         */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IER_OFFSET                     (0x14)                                        /**<  (QSPI_IER) Interrupt Enable Register  Offset */
+
+#define QSPI_IER_RDRF_Pos                   0                                              /**< (QSPI_IER) Receive Data Register Full Interrupt Enable Position */
+#define QSPI_IER_RDRF_Msk                   (_U_(0x1) << QSPI_IER_RDRF_Pos)                /**< (QSPI_IER) Receive Data Register Full Interrupt Enable Mask */
+#define QSPI_IER_RDRF                       QSPI_IER_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_RDRF_Msk instead */
+#define QSPI_IER_TDRE_Pos                   1                                              /**< (QSPI_IER) Transmit Data Register Empty Interrupt Enable Position */
+#define QSPI_IER_TDRE_Msk                   (_U_(0x1) << QSPI_IER_TDRE_Pos)                /**< (QSPI_IER) Transmit Data Register Empty Interrupt Enable Mask */
+#define QSPI_IER_TDRE                       QSPI_IER_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_TDRE_Msk instead */
+#define QSPI_IER_TXEMPTY_Pos                2                                              /**< (QSPI_IER) Transmission Registers Empty Enable Position */
+#define QSPI_IER_TXEMPTY_Msk                (_U_(0x1) << QSPI_IER_TXEMPTY_Pos)             /**< (QSPI_IER) Transmission Registers Empty Enable Mask */
+#define QSPI_IER_TXEMPTY                    QSPI_IER_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_TXEMPTY_Msk instead */
+#define QSPI_IER_OVRES_Pos                  3                                              /**< (QSPI_IER) Overrun Error Interrupt Enable Position */
+#define QSPI_IER_OVRES_Msk                  (_U_(0x1) << QSPI_IER_OVRES_Pos)               /**< (QSPI_IER) Overrun Error Interrupt Enable Mask */
+#define QSPI_IER_OVRES                      QSPI_IER_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_OVRES_Msk instead */
+#define QSPI_IER_CSR_Pos                    8                                              /**< (QSPI_IER) Chip Select Rise Interrupt Enable Position */
+#define QSPI_IER_CSR_Msk                    (_U_(0x1) << QSPI_IER_CSR_Pos)                 /**< (QSPI_IER) Chip Select Rise Interrupt Enable Mask */
+#define QSPI_IER_CSR                        QSPI_IER_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_CSR_Msk instead */
+#define QSPI_IER_CSS_Pos                    9                                              /**< (QSPI_IER) Chip Select Status Interrupt Enable Position */
+#define QSPI_IER_CSS_Msk                    (_U_(0x1) << QSPI_IER_CSS_Pos)                 /**< (QSPI_IER) Chip Select Status Interrupt Enable Mask */
+#define QSPI_IER_CSS                        QSPI_IER_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_CSS_Msk instead */
+#define QSPI_IER_INSTRE_Pos                 10                                             /**< (QSPI_IER) Instruction End Interrupt Enable Position */
+#define QSPI_IER_INSTRE_Msk                 (_U_(0x1) << QSPI_IER_INSTRE_Pos)              /**< (QSPI_IER) Instruction End Interrupt Enable Mask */
+#define QSPI_IER_INSTRE                     QSPI_IER_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IER_INSTRE_Msk instead */
+#define QSPI_IER_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IER) Register MASK  (Use QSPI_IER_Msk instead)  */
+#define QSPI_IER_Msk                        _U_(0x70F)                                     /**< (QSPI_IER) Register Mask  */
+
+
+/* -------- QSPI_IDR : (QSPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Disable */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Disable     */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Disable          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Disable       */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Disable     */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Disable        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IDR_OFFSET                     (0x18)                                        /**<  (QSPI_IDR) Interrupt Disable Register  Offset */
+
+#define QSPI_IDR_RDRF_Pos                   0                                              /**< (QSPI_IDR) Receive Data Register Full Interrupt Disable Position */
+#define QSPI_IDR_RDRF_Msk                   (_U_(0x1) << QSPI_IDR_RDRF_Pos)                /**< (QSPI_IDR) Receive Data Register Full Interrupt Disable Mask */
+#define QSPI_IDR_RDRF                       QSPI_IDR_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_RDRF_Msk instead */
+#define QSPI_IDR_TDRE_Pos                   1                                              /**< (QSPI_IDR) Transmit Data Register Empty Interrupt Disable Position */
+#define QSPI_IDR_TDRE_Msk                   (_U_(0x1) << QSPI_IDR_TDRE_Pos)                /**< (QSPI_IDR) Transmit Data Register Empty Interrupt Disable Mask */
+#define QSPI_IDR_TDRE                       QSPI_IDR_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_TDRE_Msk instead */
+#define QSPI_IDR_TXEMPTY_Pos                2                                              /**< (QSPI_IDR) Transmission Registers Empty Disable Position */
+#define QSPI_IDR_TXEMPTY_Msk                (_U_(0x1) << QSPI_IDR_TXEMPTY_Pos)             /**< (QSPI_IDR) Transmission Registers Empty Disable Mask */
+#define QSPI_IDR_TXEMPTY                    QSPI_IDR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_TXEMPTY_Msk instead */
+#define QSPI_IDR_OVRES_Pos                  3                                              /**< (QSPI_IDR) Overrun Error Interrupt Disable Position */
+#define QSPI_IDR_OVRES_Msk                  (_U_(0x1) << QSPI_IDR_OVRES_Pos)               /**< (QSPI_IDR) Overrun Error Interrupt Disable Mask */
+#define QSPI_IDR_OVRES                      QSPI_IDR_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_OVRES_Msk instead */
+#define QSPI_IDR_CSR_Pos                    8                                              /**< (QSPI_IDR) Chip Select Rise Interrupt Disable Position */
+#define QSPI_IDR_CSR_Msk                    (_U_(0x1) << QSPI_IDR_CSR_Pos)                 /**< (QSPI_IDR) Chip Select Rise Interrupt Disable Mask */
+#define QSPI_IDR_CSR                        QSPI_IDR_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_CSR_Msk instead */
+#define QSPI_IDR_CSS_Pos                    9                                              /**< (QSPI_IDR) Chip Select Status Interrupt Disable Position */
+#define QSPI_IDR_CSS_Msk                    (_U_(0x1) << QSPI_IDR_CSS_Pos)                 /**< (QSPI_IDR) Chip Select Status Interrupt Disable Mask */
+#define QSPI_IDR_CSS                        QSPI_IDR_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_CSS_Msk instead */
+#define QSPI_IDR_INSTRE_Pos                 10                                             /**< (QSPI_IDR) Instruction End Interrupt Disable Position */
+#define QSPI_IDR_INSTRE_Msk                 (_U_(0x1) << QSPI_IDR_INSTRE_Pos)              /**< (QSPI_IDR) Instruction End Interrupt Disable Mask */
+#define QSPI_IDR_INSTRE                     QSPI_IDR_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IDR_INSTRE_Msk instead */
+#define QSPI_IDR_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IDR) Register MASK  (Use QSPI_IDR_Msk instead)  */
+#define QSPI_IDR_Msk                        _U_(0x70F)                                     /**< (QSPI_IDR) Register Mask  */
+
+
+/* -------- QSPI_IMR : (QSPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty Interrupt Mask */
+    uint32_t TXEMPTY:1;                 /**< bit:      2  Transmission Registers Empty Mask        */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Mask             */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t CSR:1;                     /**< bit:      8  Chip Select Rise Interrupt Mask          */
+    uint32_t CSS:1;                     /**< bit:      9  Chip Select Status Interrupt Mask        */
+    uint32_t INSTRE:1;                  /**< bit:     10  Instruction End Interrupt Mask           */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IMR_OFFSET                     (0x1C)                                        /**<  (QSPI_IMR) Interrupt Mask Register  Offset */
+
+#define QSPI_IMR_RDRF_Pos                   0                                              /**< (QSPI_IMR) Receive Data Register Full Interrupt Mask Position */
+#define QSPI_IMR_RDRF_Msk                   (_U_(0x1) << QSPI_IMR_RDRF_Pos)                /**< (QSPI_IMR) Receive Data Register Full Interrupt Mask Mask */
+#define QSPI_IMR_RDRF                       QSPI_IMR_RDRF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_RDRF_Msk instead */
+#define QSPI_IMR_TDRE_Pos                   1                                              /**< (QSPI_IMR) Transmit Data Register Empty Interrupt Mask Position */
+#define QSPI_IMR_TDRE_Msk                   (_U_(0x1) << QSPI_IMR_TDRE_Pos)                /**< (QSPI_IMR) Transmit Data Register Empty Interrupt Mask Mask */
+#define QSPI_IMR_TDRE                       QSPI_IMR_TDRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_TDRE_Msk instead */
+#define QSPI_IMR_TXEMPTY_Pos                2                                              /**< (QSPI_IMR) Transmission Registers Empty Mask Position */
+#define QSPI_IMR_TXEMPTY_Msk                (_U_(0x1) << QSPI_IMR_TXEMPTY_Pos)             /**< (QSPI_IMR) Transmission Registers Empty Mask Mask */
+#define QSPI_IMR_TXEMPTY                    QSPI_IMR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_TXEMPTY_Msk instead */
+#define QSPI_IMR_OVRES_Pos                  3                                              /**< (QSPI_IMR) Overrun Error Interrupt Mask Position */
+#define QSPI_IMR_OVRES_Msk                  (_U_(0x1) << QSPI_IMR_OVRES_Pos)               /**< (QSPI_IMR) Overrun Error Interrupt Mask Mask */
+#define QSPI_IMR_OVRES                      QSPI_IMR_OVRES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_OVRES_Msk instead */
+#define QSPI_IMR_CSR_Pos                    8                                              /**< (QSPI_IMR) Chip Select Rise Interrupt Mask Position */
+#define QSPI_IMR_CSR_Msk                    (_U_(0x1) << QSPI_IMR_CSR_Pos)                 /**< (QSPI_IMR) Chip Select Rise Interrupt Mask Mask */
+#define QSPI_IMR_CSR                        QSPI_IMR_CSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_CSR_Msk instead */
+#define QSPI_IMR_CSS_Pos                    9                                              /**< (QSPI_IMR) Chip Select Status Interrupt Mask Position */
+#define QSPI_IMR_CSS_Msk                    (_U_(0x1) << QSPI_IMR_CSS_Pos)                 /**< (QSPI_IMR) Chip Select Status Interrupt Mask Mask */
+#define QSPI_IMR_CSS                        QSPI_IMR_CSS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_CSS_Msk instead */
+#define QSPI_IMR_INSTRE_Pos                 10                                             /**< (QSPI_IMR) Instruction End Interrupt Mask Position */
+#define QSPI_IMR_INSTRE_Msk                 (_U_(0x1) << QSPI_IMR_INSTRE_Pos)              /**< (QSPI_IMR) Instruction End Interrupt Mask Mask */
+#define QSPI_IMR_INSTRE                     QSPI_IMR_INSTRE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IMR_INSTRE_Msk instead */
+#define QSPI_IMR_MASK                       _U_(0x70F)                                     /**< \deprecated (QSPI_IMR) Register MASK  (Use QSPI_IMR_Msk instead)  */
+#define QSPI_IMR_Msk                        _U_(0x70F)                                     /**< (QSPI_IMR) Register Mask  */
+
+
+/* -------- QSPI_SCR : (QSPI Offset: 0x20) (R/W 32) Serial Clock Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
+    uint32_t CPHA:1;                    /**< bit:      1  Clock Phase                              */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t SCBR:8;                    /**< bit:  8..15  Serial Clock Baud Rate                   */
+    uint32_t DLYBS:8;                   /**< bit: 16..23  Delay Before QSCK                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SCR_OFFSET                     (0x20)                                        /**<  (QSPI_SCR) Serial Clock Register  Offset */
+
+#define QSPI_SCR_CPOL_Pos                   0                                              /**< (QSPI_SCR) Clock Polarity Position */
+#define QSPI_SCR_CPOL_Msk                   (_U_(0x1) << QSPI_SCR_CPOL_Pos)                /**< (QSPI_SCR) Clock Polarity Mask */
+#define QSPI_SCR_CPOL                       QSPI_SCR_CPOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SCR_CPOL_Msk instead */
+#define QSPI_SCR_CPHA_Pos                   1                                              /**< (QSPI_SCR) Clock Phase Position */
+#define QSPI_SCR_CPHA_Msk                   (_U_(0x1) << QSPI_SCR_CPHA_Pos)                /**< (QSPI_SCR) Clock Phase Mask */
+#define QSPI_SCR_CPHA                       QSPI_SCR_CPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SCR_CPHA_Msk instead */
+#define QSPI_SCR_SCBR_Pos                   8                                              /**< (QSPI_SCR) Serial Clock Baud Rate Position */
+#define QSPI_SCR_SCBR_Msk                   (_U_(0xFF) << QSPI_SCR_SCBR_Pos)               /**< (QSPI_SCR) Serial Clock Baud Rate Mask */
+#define QSPI_SCR_SCBR(value)                (QSPI_SCR_SCBR_Msk & ((value) << QSPI_SCR_SCBR_Pos))
+#define QSPI_SCR_DLYBS_Pos                  16                                             /**< (QSPI_SCR) Delay Before QSCK Position */
+#define QSPI_SCR_DLYBS_Msk                  (_U_(0xFF) << QSPI_SCR_DLYBS_Pos)              /**< (QSPI_SCR) Delay Before QSCK Mask */
+#define QSPI_SCR_DLYBS(value)               (QSPI_SCR_DLYBS_Msk & ((value) << QSPI_SCR_DLYBS_Pos))
+#define QSPI_SCR_MASK                       _U_(0xFFFF03)                                  /**< \deprecated (QSPI_SCR) Register MASK  (Use QSPI_SCR_Msk instead)  */
+#define QSPI_SCR_Msk                        _U_(0xFFFF03)                                  /**< (QSPI_SCR) Register Mask  */
+
+
+/* -------- QSPI_IAR : (QSPI Offset: 0x30) (R/W 32) Instruction Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ADDR:32;                   /**< bit:  0..31  Address                                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IAR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IAR_OFFSET                     (0x30)                                        /**<  (QSPI_IAR) Instruction Address Register  Offset */
+
+#define QSPI_IAR_ADDR_Pos                   0                                              /**< (QSPI_IAR) Address Position */
+#define QSPI_IAR_ADDR_Msk                   (_U_(0xFFFFFFFF) << QSPI_IAR_ADDR_Pos)         /**< (QSPI_IAR) Address Mask */
+#define QSPI_IAR_ADDR(value)                (QSPI_IAR_ADDR_Msk & ((value) << QSPI_IAR_ADDR_Pos))
+#define QSPI_IAR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (QSPI_IAR) Register MASK  (Use QSPI_IAR_Msk instead)  */
+#define QSPI_IAR_Msk                        _U_(0xFFFFFFFF)                                /**< (QSPI_IAR) Register Mask  */
+
+
+/* -------- QSPI_ICR : (QSPI Offset: 0x34) (R/W 32) Instruction Code Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INST:8;                    /**< bit:   0..7  Instruction Code                         */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t OPT:8;                     /**< bit: 16..23  Option Code                              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_ICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_ICR_OFFSET                     (0x34)                                        /**<  (QSPI_ICR) Instruction Code Register  Offset */
+
+#define QSPI_ICR_INST_Pos                   0                                              /**< (QSPI_ICR) Instruction Code Position */
+#define QSPI_ICR_INST_Msk                   (_U_(0xFF) << QSPI_ICR_INST_Pos)               /**< (QSPI_ICR) Instruction Code Mask */
+#define QSPI_ICR_INST(value)                (QSPI_ICR_INST_Msk & ((value) << QSPI_ICR_INST_Pos))
+#define QSPI_ICR_OPT_Pos                    16                                             /**< (QSPI_ICR) Option Code Position */
+#define QSPI_ICR_OPT_Msk                    (_U_(0xFF) << QSPI_ICR_OPT_Pos)                /**< (QSPI_ICR) Option Code Mask */
+#define QSPI_ICR_OPT(value)                 (QSPI_ICR_OPT_Msk & ((value) << QSPI_ICR_OPT_Pos))
+#define QSPI_ICR_MASK                       _U_(0xFF00FF)                                  /**< \deprecated (QSPI_ICR) Register MASK  (Use QSPI_ICR_Msk instead)  */
+#define QSPI_ICR_Msk                        _U_(0xFF00FF)                                  /**< (QSPI_ICR) Register Mask  */
+
+
+/* -------- QSPI_IFR : (QSPI Offset: 0x38) (R/W 32) Instruction Frame Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WIDTH:3;                   /**< bit:   0..2  Width of Instruction Code, Address, Option Code and Data */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t INSTEN:1;                  /**< bit:      4  Instruction Enable                       */
+    uint32_t ADDREN:1;                  /**< bit:      5  Address Enable                           */
+    uint32_t OPTEN:1;                   /**< bit:      6  Option Enable                            */
+    uint32_t DATAEN:1;                  /**< bit:      7  Data Enable                              */
+    uint32_t OPTL:2;                    /**< bit:   8..9  Option Code Length                       */
+    uint32_t ADDRL:1;                   /**< bit:     10  Address Length                           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t TFRTYP:2;                  /**< bit: 12..13  Data Transfer Type                       */
+    uint32_t CRM:1;                     /**< bit:     14  Continuous Read Mode                     */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t NBDUM:5;                   /**< bit: 16..20  Number Of Dummy Cycles                   */
+    uint32_t :11;                       /**< bit: 21..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_IFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_IFR_OFFSET                     (0x38)                                        /**<  (QSPI_IFR) Instruction Frame Register  Offset */
+
+#define QSPI_IFR_WIDTH_Pos                  0                                              /**< (QSPI_IFR) Width of Instruction Code, Address, Option Code and Data Position */
+#define QSPI_IFR_WIDTH_Msk                  (_U_(0x7) << QSPI_IFR_WIDTH_Pos)               /**< (QSPI_IFR) Width of Instruction Code, Address, Option Code and Data Mask */
+#define QSPI_IFR_WIDTH(value)               (QSPI_IFR_WIDTH_Msk & ((value) << QSPI_IFR_WIDTH_Pos))
+#define   QSPI_IFR_WIDTH_SINGLE_BIT_SPI_Val _U_(0x0)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Single-bit SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_OUTPUT_Val    _U_(0x1)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_OUTPUT_Val    _U_(0x2)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Quad SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_IO_Val        _U_(0x3)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Dual SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_IO_Val        _U_(0x4)                                       /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Quad SPI / Data: Quad SPI  */
+#define   QSPI_IFR_WIDTH_DUAL_CMD_Val       _U_(0x5)                                       /**< (QSPI_IFR) Instruction: Dual SPI / Address-Option: Dual SPI / Data: Dual SPI  */
+#define   QSPI_IFR_WIDTH_QUAD_CMD_Val       _U_(0x6)                                       /**< (QSPI_IFR) Instruction: Quad SPI / Address-Option: Quad SPI / Data: Quad SPI  */
+#define QSPI_IFR_WIDTH_SINGLE_BIT_SPI       (QSPI_IFR_WIDTH_SINGLE_BIT_SPI_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Single-bit SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_OUTPUT          (QSPI_IFR_WIDTH_DUAL_OUTPUT_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_OUTPUT          (QSPI_IFR_WIDTH_QUAD_OUTPUT_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Single-bit SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_IO              (QSPI_IFR_WIDTH_DUAL_IO_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Dual SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_IO              (QSPI_IFR_WIDTH_QUAD_IO_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Single-bit SPI / Address-Option: Quad SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_WIDTH_DUAL_CMD             (QSPI_IFR_WIDTH_DUAL_CMD_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Dual SPI / Address-Option: Dual SPI / Data: Dual SPI Position  */
+#define QSPI_IFR_WIDTH_QUAD_CMD             (QSPI_IFR_WIDTH_QUAD_CMD_Val << QSPI_IFR_WIDTH_Pos)  /**< (QSPI_IFR) Instruction: Quad SPI / Address-Option: Quad SPI / Data: Quad SPI Position  */
+#define QSPI_IFR_INSTEN_Pos                 4                                              /**< (QSPI_IFR) Instruction Enable Position */
+#define QSPI_IFR_INSTEN_Msk                 (_U_(0x1) << QSPI_IFR_INSTEN_Pos)              /**< (QSPI_IFR) Instruction Enable Mask */
+#define QSPI_IFR_INSTEN                     QSPI_IFR_INSTEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_INSTEN_Msk instead */
+#define QSPI_IFR_ADDREN_Pos                 5                                              /**< (QSPI_IFR) Address Enable Position */
+#define QSPI_IFR_ADDREN_Msk                 (_U_(0x1) << QSPI_IFR_ADDREN_Pos)              /**< (QSPI_IFR) Address Enable Mask */
+#define QSPI_IFR_ADDREN                     QSPI_IFR_ADDREN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_ADDREN_Msk instead */
+#define QSPI_IFR_OPTEN_Pos                  6                                              /**< (QSPI_IFR) Option Enable Position */
+#define QSPI_IFR_OPTEN_Msk                  (_U_(0x1) << QSPI_IFR_OPTEN_Pos)               /**< (QSPI_IFR) Option Enable Mask */
+#define QSPI_IFR_OPTEN                      QSPI_IFR_OPTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_OPTEN_Msk instead */
+#define QSPI_IFR_DATAEN_Pos                 7                                              /**< (QSPI_IFR) Data Enable Position */
+#define QSPI_IFR_DATAEN_Msk                 (_U_(0x1) << QSPI_IFR_DATAEN_Pos)              /**< (QSPI_IFR) Data Enable Mask */
+#define QSPI_IFR_DATAEN                     QSPI_IFR_DATAEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_DATAEN_Msk instead */
+#define QSPI_IFR_OPTL_Pos                   8                                              /**< (QSPI_IFR) Option Code Length Position */
+#define QSPI_IFR_OPTL_Msk                   (_U_(0x3) << QSPI_IFR_OPTL_Pos)                /**< (QSPI_IFR) Option Code Length Mask */
+#define QSPI_IFR_OPTL(value)                (QSPI_IFR_OPTL_Msk & ((value) << QSPI_IFR_OPTL_Pos))
+#define   QSPI_IFR_OPTL_OPTION_1BIT_Val     _U_(0x0)                                       /**< (QSPI_IFR) The option code is 1 bit long.  */
+#define   QSPI_IFR_OPTL_OPTION_2BIT_Val     _U_(0x1)                                       /**< (QSPI_IFR) The option code is 2 bits long.  */
+#define   QSPI_IFR_OPTL_OPTION_4BIT_Val     _U_(0x2)                                       /**< (QSPI_IFR) The option code is 4 bits long.  */
+#define   QSPI_IFR_OPTL_OPTION_8BIT_Val     _U_(0x3)                                       /**< (QSPI_IFR) The option code is 8 bits long.  */
+#define QSPI_IFR_OPTL_OPTION_1BIT           (QSPI_IFR_OPTL_OPTION_1BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 1 bit long. Position  */
+#define QSPI_IFR_OPTL_OPTION_2BIT           (QSPI_IFR_OPTL_OPTION_2BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 2 bits long. Position  */
+#define QSPI_IFR_OPTL_OPTION_4BIT           (QSPI_IFR_OPTL_OPTION_4BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 4 bits long. Position  */
+#define QSPI_IFR_OPTL_OPTION_8BIT           (QSPI_IFR_OPTL_OPTION_8BIT_Val << QSPI_IFR_OPTL_Pos)  /**< (QSPI_IFR) The option code is 8 bits long. Position  */
+#define QSPI_IFR_ADDRL_Pos                  10                                             /**< (QSPI_IFR) Address Length Position */
+#define QSPI_IFR_ADDRL_Msk                  (_U_(0x1) << QSPI_IFR_ADDRL_Pos)               /**< (QSPI_IFR) Address Length Mask */
+#define QSPI_IFR_ADDRL                      QSPI_IFR_ADDRL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_ADDRL_Msk instead */
+#define   QSPI_IFR_ADDRL_24_BIT_Val         _U_(0x0)                                       /**< (QSPI_IFR) The address is 24 bits long.  */
+#define   QSPI_IFR_ADDRL_32_BIT_Val         _U_(0x1)                                       /**< (QSPI_IFR) The address is 32 bits long.  */
+#define QSPI_IFR_ADDRL_24_BIT               (QSPI_IFR_ADDRL_24_BIT_Val << QSPI_IFR_ADDRL_Pos)  /**< (QSPI_IFR) The address is 24 bits long. Position  */
+#define QSPI_IFR_ADDRL_32_BIT               (QSPI_IFR_ADDRL_32_BIT_Val << QSPI_IFR_ADDRL_Pos)  /**< (QSPI_IFR) The address is 32 bits long. Position  */
+#define QSPI_IFR_TFRTYP_Pos                 12                                             /**< (QSPI_IFR) Data Transfer Type Position */
+#define QSPI_IFR_TFRTYP_Msk                 (_U_(0x3) << QSPI_IFR_TFRTYP_Pos)              /**< (QSPI_IFR) Data Transfer Type Mask */
+#define QSPI_IFR_TFRTYP(value)              (QSPI_IFR_TFRTYP_Msk & ((value) << QSPI_IFR_TFRTYP_Pos))
+#define   QSPI_IFR_TFRTYP_TRSFR_READ_Val    _U_(0x0)                                       /**< (QSPI_IFR) Read transfer from the serial memory.Scrambling is not performed.Read at random location (fetch) in the serial Flash memory is not possible.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY_Val _U_(0x1)                                       /**< (QSPI_IFR) Read data transfer from the serial memory.If enabled, scrambling is performed.Read at random location (fetch) in the serial Flash memory is possible.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_WRITE_Val   _U_(0x2)                                       /**< (QSPI_IFR) Write transfer into the serial memory.Scrambling is not performed.  */
+#define   QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY_Val _U_(0x3)                                       /**< (QSPI_IFR) Write data transfer into the serial memory.If enabled, scrambling is performed.  */
+#define QSPI_IFR_TFRTYP_TRSFR_READ          (QSPI_IFR_TFRTYP_TRSFR_READ_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Read transfer from the serial memory.Scrambling is not performed.Read at random location (fetch) in the serial Flash memory is not possible. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY   (QSPI_IFR_TFRTYP_TRSFR_READ_MEMORY_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Read data transfer from the serial memory.If enabled, scrambling is performed.Read at random location (fetch) in the serial Flash memory is possible. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_WRITE         (QSPI_IFR_TFRTYP_TRSFR_WRITE_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Write transfer into the serial memory.Scrambling is not performed. Position  */
+#define QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY  (QSPI_IFR_TFRTYP_TRSFR_WRITE_MEMORY_Val << QSPI_IFR_TFRTYP_Pos)  /**< (QSPI_IFR) Write data transfer into the serial memory.If enabled, scrambling is performed. Position  */
+#define QSPI_IFR_CRM_Pos                    14                                             /**< (QSPI_IFR) Continuous Read Mode Position */
+#define QSPI_IFR_CRM_Msk                    (_U_(0x1) << QSPI_IFR_CRM_Pos)                 /**< (QSPI_IFR) Continuous Read Mode Mask */
+#define QSPI_IFR_CRM                        QSPI_IFR_CRM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_IFR_CRM_Msk instead */
+#define   QSPI_IFR_CRM_DISABLED_Val         _U_(0x0)                                       /**< (QSPI_IFR) The Continuous Read mode is disabled.  */
+#define   QSPI_IFR_CRM_ENABLED_Val          _U_(0x1)                                       /**< (QSPI_IFR) The Continuous Read mode is enabled.  */
+#define QSPI_IFR_CRM_DISABLED               (QSPI_IFR_CRM_DISABLED_Val << QSPI_IFR_CRM_Pos)  /**< (QSPI_IFR) The Continuous Read mode is disabled. Position  */
+#define QSPI_IFR_CRM_ENABLED                (QSPI_IFR_CRM_ENABLED_Val << QSPI_IFR_CRM_Pos)  /**< (QSPI_IFR) The Continuous Read mode is enabled. Position  */
+#define QSPI_IFR_NBDUM_Pos                  16                                             /**< (QSPI_IFR) Number Of Dummy Cycles Position */
+#define QSPI_IFR_NBDUM_Msk                  (_U_(0x1F) << QSPI_IFR_NBDUM_Pos)              /**< (QSPI_IFR) Number Of Dummy Cycles Mask */
+#define QSPI_IFR_NBDUM(value)               (QSPI_IFR_NBDUM_Msk & ((value) << QSPI_IFR_NBDUM_Pos))
+#define QSPI_IFR_MASK                       _U_(0x1F77F7)                                  /**< \deprecated (QSPI_IFR) Register MASK  (Use QSPI_IFR_Msk instead)  */
+#define QSPI_IFR_Msk                        _U_(0x1F77F7)                                  /**< (QSPI_IFR) Register Mask  */
+
+
+/* -------- QSPI_SMR : (QSPI Offset: 0x40) (R/W 32) Scrambling Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SCREN:1;                   /**< bit:      0  Scrambling/Unscrambling Enable           */
+    uint32_t RVDIS:1;                   /**< bit:      1  Scrambling/Unscrambling Random Value Disable */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SMR_OFFSET                     (0x40)                                        /**<  (QSPI_SMR) Scrambling Mode Register  Offset */
+
+#define QSPI_SMR_SCREN_Pos                  0                                              /**< (QSPI_SMR) Scrambling/Unscrambling Enable Position */
+#define QSPI_SMR_SCREN_Msk                  (_U_(0x1) << QSPI_SMR_SCREN_Pos)               /**< (QSPI_SMR) Scrambling/Unscrambling Enable Mask */
+#define QSPI_SMR_SCREN                      QSPI_SMR_SCREN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SMR_SCREN_Msk instead */
+#define   QSPI_SMR_SCREN_DISABLED_Val       _U_(0x0)                                       /**< (QSPI_SMR) The scrambling/unscrambling is disabled.  */
+#define   QSPI_SMR_SCREN_ENABLED_Val        _U_(0x1)                                       /**< (QSPI_SMR) The scrambling/unscrambling is enabled.  */
+#define QSPI_SMR_SCREN_DISABLED             (QSPI_SMR_SCREN_DISABLED_Val << QSPI_SMR_SCREN_Pos)  /**< (QSPI_SMR) The scrambling/unscrambling is disabled. Position  */
+#define QSPI_SMR_SCREN_ENABLED              (QSPI_SMR_SCREN_ENABLED_Val << QSPI_SMR_SCREN_Pos)  /**< (QSPI_SMR) The scrambling/unscrambling is enabled. Position  */
+#define QSPI_SMR_RVDIS_Pos                  1                                              /**< (QSPI_SMR) Scrambling/Unscrambling Random Value Disable Position */
+#define QSPI_SMR_RVDIS_Msk                  (_U_(0x1) << QSPI_SMR_RVDIS_Pos)               /**< (QSPI_SMR) Scrambling/Unscrambling Random Value Disable Mask */
+#define QSPI_SMR_RVDIS                      QSPI_SMR_RVDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_SMR_RVDIS_Msk instead */
+#define QSPI_SMR_MASK                       _U_(0x03)                                      /**< \deprecated (QSPI_SMR) Register MASK  (Use QSPI_SMR_Msk instead)  */
+#define QSPI_SMR_Msk                        _U_(0x03)                                      /**< (QSPI_SMR) Register Mask  */
+
+
+/* -------- QSPI_SKR : (QSPI Offset: 0x44) (/W 32) Scrambling Key Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USRK:32;                   /**< bit:  0..31  User Scrambling Key                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_SKR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_SKR_OFFSET                     (0x44)                                        /**<  (QSPI_SKR) Scrambling Key Register  Offset */
+
+#define QSPI_SKR_USRK_Pos                   0                                              /**< (QSPI_SKR) User Scrambling Key Position */
+#define QSPI_SKR_USRK_Msk                   (_U_(0xFFFFFFFF) << QSPI_SKR_USRK_Pos)         /**< (QSPI_SKR) User Scrambling Key Mask */
+#define QSPI_SKR_USRK(value)                (QSPI_SKR_USRK_Msk & ((value) << QSPI_SKR_USRK_Pos))
+#define QSPI_SKR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (QSPI_SKR) Register MASK  (Use QSPI_SKR_Msk instead)  */
+#define QSPI_SKR_Msk                        _U_(0xFFFFFFFF)                                /**< (QSPI_SKR) Register Mask  */
+
+
+/* -------- QSPI_WPMR : (QSPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_WPMR_OFFSET                    (0xE4)                                        /**<  (QSPI_WPMR) Write Protection Mode Register  Offset */
+
+#define QSPI_WPMR_WPEN_Pos                  0                                              /**< (QSPI_WPMR) Write Protection Enable Position */
+#define QSPI_WPMR_WPEN_Msk                  (_U_(0x1) << QSPI_WPMR_WPEN_Pos)               /**< (QSPI_WPMR) Write Protection Enable Mask */
+#define QSPI_WPMR_WPEN                      QSPI_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_WPMR_WPEN_Msk instead */
+#define QSPI_WPMR_WPKEY_Pos                 8                                              /**< (QSPI_WPMR) Write Protection Key Position */
+#define QSPI_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << QSPI_WPMR_WPKEY_Pos)         /**< (QSPI_WPMR) Write Protection Key Mask */
+#define QSPI_WPMR_WPKEY(value)              (QSPI_WPMR_WPKEY_Msk & ((value) << QSPI_WPMR_WPKEY_Pos))
+#define   QSPI_WPMR_WPKEY_PASSWD_Val        _U_(0x515350)                                  /**< (QSPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define QSPI_WPMR_WPKEY_PASSWD              (QSPI_WPMR_WPKEY_PASSWD_Val << QSPI_WPMR_WPKEY_Pos)  /**< (QSPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define QSPI_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (QSPI_WPMR) Register MASK  (Use QSPI_WPMR_Msk instead)  */
+#define QSPI_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (QSPI_WPMR) Register Mask  */
+
+
+/* -------- QSPI_WPSR : (QSPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} QSPI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define QSPI_WPSR_OFFSET                    (0xE8)                                        /**<  (QSPI_WPSR) Write Protection Status Register  Offset */
+
+#define QSPI_WPSR_WPVS_Pos                  0                                              /**< (QSPI_WPSR) Write Protection Violation Status Position */
+#define QSPI_WPSR_WPVS_Msk                  (_U_(0x1) << QSPI_WPSR_WPVS_Pos)               /**< (QSPI_WPSR) Write Protection Violation Status Mask */
+#define QSPI_WPSR_WPVS                      QSPI_WPSR_WPVS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use QSPI_WPSR_WPVS_Msk instead */
+#define QSPI_WPSR_WPVSRC_Pos                8                                              /**< (QSPI_WPSR) Write Protection Violation Source Position */
+#define QSPI_WPSR_WPVSRC_Msk                (_U_(0xFF) << QSPI_WPSR_WPVSRC_Pos)            /**< (QSPI_WPSR) Write Protection Violation Source Mask */
+#define QSPI_WPSR_WPVSRC(value)             (QSPI_WPSR_WPVSRC_Msk & ((value) << QSPI_WPSR_WPVSRC_Pos))
+#define QSPI_WPSR_MASK                      _U_(0xFF01)                                    /**< \deprecated (QSPI_WPSR) Register MASK  (Use QSPI_WPSR_Msk instead)  */
+#define QSPI_WPSR_Msk                       _U_(0xFF01)                                    /**< (QSPI_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief QSPI hardware registers */
+typedef struct {  
+  __O  uint32_t QSPI_CR;        /**< (QSPI Offset: 0x00) Control Register */
+  __IO uint32_t QSPI_MR;        /**< (QSPI Offset: 0x04) Mode Register */
+  __I  uint32_t QSPI_RDR;       /**< (QSPI Offset: 0x08) Receive Data Register */
+  __O  uint32_t QSPI_TDR;       /**< (QSPI Offset: 0x0C) Transmit Data Register */
+  __I  uint32_t QSPI_SR;        /**< (QSPI Offset: 0x10) Status Register */
+  __O  uint32_t QSPI_IER;       /**< (QSPI Offset: 0x14) Interrupt Enable Register */
+  __O  uint32_t QSPI_IDR;       /**< (QSPI Offset: 0x18) Interrupt Disable Register */
+  __I  uint32_t QSPI_IMR;       /**< (QSPI Offset: 0x1C) Interrupt Mask Register */
+  __IO uint32_t QSPI_SCR;       /**< (QSPI Offset: 0x20) Serial Clock Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO uint32_t QSPI_IAR;       /**< (QSPI Offset: 0x30) Instruction Address Register */
+  __IO uint32_t QSPI_ICR;       /**< (QSPI Offset: 0x34) Instruction Code Register */
+  __IO uint32_t QSPI_IFR;       /**< (QSPI Offset: 0x38) Instruction Frame Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t QSPI_SMR;       /**< (QSPI Offset: 0x40) Scrambling Mode Register */
+  __O  uint32_t QSPI_SKR;       /**< (QSPI Offset: 0x44) Scrambling Key Register */
+  __I  uint8_t                        Reserved3[156];
+  __IO uint32_t QSPI_WPMR;      /**< (QSPI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t QSPI_WPSR;      /**< (QSPI Offset: 0xE8) Write Protection Status Register */
+} Qspi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief QSPI hardware registers */
+typedef struct {  
+  __O  QSPI_CR_Type                   QSPI_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO QSPI_MR_Type                   QSPI_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  QSPI_RDR_Type                  QSPI_RDR;       /**< Offset: 0x08 (R/   32) Receive Data Register */
+  __O  QSPI_TDR_Type                  QSPI_TDR;       /**< Offset: 0x0C ( /W  32) Transmit Data Register */
+  __I  QSPI_SR_Type                   QSPI_SR;        /**< Offset: 0x10 (R/   32) Status Register */
+  __O  QSPI_IER_Type                  QSPI_IER;       /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
+  __O  QSPI_IDR_Type                  QSPI_IDR;       /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
+  __I  QSPI_IMR_Type                  QSPI_IMR;       /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
+  __IO QSPI_SCR_Type                  QSPI_SCR;       /**< Offset: 0x20 (R/W  32) Serial Clock Register */
+  __I  uint8_t                        Reserved1[12];
+  __IO QSPI_IAR_Type                  QSPI_IAR;       /**< Offset: 0x30 (R/W  32) Instruction Address Register */
+  __IO QSPI_ICR_Type                  QSPI_ICR;       /**< Offset: 0x34 (R/W  32) Instruction Code Register */
+  __IO QSPI_IFR_Type                  QSPI_IFR;       /**< Offset: 0x38 (R/W  32) Instruction Frame Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO QSPI_SMR_Type                  QSPI_SMR;       /**< Offset: 0x40 (R/W  32) Scrambling Mode Register */
+  __O  QSPI_SKR_Type                  QSPI_SKR;       /**< Offset: 0x44 ( /W  32) Scrambling Key Register */
+  __I  uint8_t                        Reserved3[156];
+  __IO QSPI_WPMR_Type                 QSPI_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  QSPI_WPSR_Type                 QSPI_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Qspi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Quad Serial Peripheral Interface */
+
+#endif /* _SAMV71_QSPI_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/rstc.h
+++ b/asf/sam/include/samv71b/component/rstc.h
@@ -1,0 +1,189 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RSTC_COMPONENT_H_
+#define _SAMV71_RSTC_COMPONENT_H_
+#define _SAMV71_RSTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Reset Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSTC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RSTC_11009                      /**< (RSTC) Module ID */
+#define REV_RSTC N                      /**< (RSTC) Module revision */
+
+/* -------- RSTC_CR : (RSTC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PROCRST:1;                 /**< bit:      0  Processor Reset                          */
+    uint32_t :2;                        /**< bit:   1..2  Reserved */
+    uint32_t EXTRST:1;                  /**< bit:      3  External Reset                           */
+    uint32_t :20;                       /**< bit:  4..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  System Reset Key                         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_CR_OFFSET                      (0x00)                                        /**<  (RSTC_CR) Control Register  Offset */
+
+#define RSTC_CR_PROCRST_Pos                 0                                              /**< (RSTC_CR) Processor Reset Position */
+#define RSTC_CR_PROCRST_Msk                 (_U_(0x1) << RSTC_CR_PROCRST_Pos)              /**< (RSTC_CR) Processor Reset Mask */
+#define RSTC_CR_PROCRST                     RSTC_CR_PROCRST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_CR_PROCRST_Msk instead */
+#define RSTC_CR_EXTRST_Pos                  3                                              /**< (RSTC_CR) External Reset Position */
+#define RSTC_CR_EXTRST_Msk                  (_U_(0x1) << RSTC_CR_EXTRST_Pos)               /**< (RSTC_CR) External Reset Mask */
+#define RSTC_CR_EXTRST                      RSTC_CR_EXTRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_CR_EXTRST_Msk instead */
+#define RSTC_CR_KEY_Pos                     24                                             /**< (RSTC_CR) System Reset Key Position */
+#define RSTC_CR_KEY_Msk                     (_U_(0xFF) << RSTC_CR_KEY_Pos)                 /**< (RSTC_CR) System Reset Key Mask */
+#define RSTC_CR_KEY(value)                  (RSTC_CR_KEY_Msk & ((value) << RSTC_CR_KEY_Pos))
+#define   RSTC_CR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (RSTC_CR) Writing any other value in this field aborts the write operation.  */
+#define RSTC_CR_KEY_PASSWD                  (RSTC_CR_KEY_PASSWD_Val << RSTC_CR_KEY_Pos)    /**< (RSTC_CR) Writing any other value in this field aborts the write operation. Position  */
+#define RSTC_CR_MASK                        _U_(0xFF000009)                                /**< \deprecated (RSTC_CR) Register MASK  (Use RSTC_CR_Msk instead)  */
+#define RSTC_CR_Msk                         _U_(0xFF000009)                                /**< (RSTC_CR) Register Mask  */
+
+
+/* -------- RSTC_SR : (RSTC Offset: 0x04) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URSTS:1;                   /**< bit:      0  User Reset Status                        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t RSTTYP:3;                  /**< bit:  8..10  Reset Type                               */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t NRSTL:1;                   /**< bit:     16  NRST Pin Level                           */
+    uint32_t SRCMP:1;                   /**< bit:     17  Software Reset Command in Progress       */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_SR_OFFSET                      (0x04)                                        /**<  (RSTC_SR) Status Register  Offset */
+
+#define RSTC_SR_URSTS_Pos                   0                                              /**< (RSTC_SR) User Reset Status Position */
+#define RSTC_SR_URSTS_Msk                   (_U_(0x1) << RSTC_SR_URSTS_Pos)                /**< (RSTC_SR) User Reset Status Mask */
+#define RSTC_SR_URSTS                       RSTC_SR_URSTS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_URSTS_Msk instead */
+#define RSTC_SR_RSTTYP_Pos                  8                                              /**< (RSTC_SR) Reset Type Position */
+#define RSTC_SR_RSTTYP_Msk                  (_U_(0x7) << RSTC_SR_RSTTYP_Pos)               /**< (RSTC_SR) Reset Type Mask */
+#define RSTC_SR_RSTTYP(value)               (RSTC_SR_RSTTYP_Msk & ((value) << RSTC_SR_RSTTYP_Pos))
+#define   RSTC_SR_RSTTYP_GENERAL_RST_Val    _U_(0x0)                                       /**< (RSTC_SR) First power-up reset  */
+#define   RSTC_SR_RSTTYP_BACKUP_RST_Val     _U_(0x1)                                       /**< (RSTC_SR) Return from Backup Mode  */
+#define   RSTC_SR_RSTTYP_WDT_RST_Val        _U_(0x2)                                       /**< (RSTC_SR) Watchdog fault occurred  */
+#define   RSTC_SR_RSTTYP_SOFT_RST_Val       _U_(0x3)                                       /**< (RSTC_SR) Processor reset required by the software  */
+#define   RSTC_SR_RSTTYP_USER_RST_Val       _U_(0x4)                                       /**< (RSTC_SR) NRST pin detected low  */
+#define RSTC_SR_RSTTYP_GENERAL_RST          (RSTC_SR_RSTTYP_GENERAL_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) First power-up reset Position  */
+#define RSTC_SR_RSTTYP_BACKUP_RST           (RSTC_SR_RSTTYP_BACKUP_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Return from Backup Mode Position  */
+#define RSTC_SR_RSTTYP_WDT_RST              (RSTC_SR_RSTTYP_WDT_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Watchdog fault occurred Position  */
+#define RSTC_SR_RSTTYP_SOFT_RST             (RSTC_SR_RSTTYP_SOFT_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) Processor reset required by the software Position  */
+#define RSTC_SR_RSTTYP_USER_RST             (RSTC_SR_RSTTYP_USER_RST_Val << RSTC_SR_RSTTYP_Pos)  /**< (RSTC_SR) NRST pin detected low Position  */
+#define RSTC_SR_NRSTL_Pos                   16                                             /**< (RSTC_SR) NRST Pin Level Position */
+#define RSTC_SR_NRSTL_Msk                   (_U_(0x1) << RSTC_SR_NRSTL_Pos)                /**< (RSTC_SR) NRST Pin Level Mask */
+#define RSTC_SR_NRSTL                       RSTC_SR_NRSTL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_NRSTL_Msk instead */
+#define RSTC_SR_SRCMP_Pos                   17                                             /**< (RSTC_SR) Software Reset Command in Progress Position */
+#define RSTC_SR_SRCMP_Msk                   (_U_(0x1) << RSTC_SR_SRCMP_Pos)                /**< (RSTC_SR) Software Reset Command in Progress Mask */
+#define RSTC_SR_SRCMP                       RSTC_SR_SRCMP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_SR_SRCMP_Msk instead */
+#define RSTC_SR_MASK                        _U_(0x30701)                                   /**< \deprecated (RSTC_SR) Register MASK  (Use RSTC_SR_Msk instead)  */
+#define RSTC_SR_Msk                         _U_(0x30701)                                   /**< (RSTC_SR) Register Mask  */
+
+
+/* -------- RSTC_MR : (RSTC Offset: 0x08) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t URSTEN:1;                  /**< bit:      0  User Reset Enable                        */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t URSTIEN:1;                 /**< bit:      4  User Reset Interrupt Enable              */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t ERSTL:4;                   /**< bit:  8..11  External Reset Length                    */
+    uint32_t :12;                       /**< bit: 12..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Write Access Password                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSTC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_MR_OFFSET                      (0x08)                                        /**<  (RSTC_MR) Mode Register  Offset */
+
+#define RSTC_MR_URSTEN_Pos                  0                                              /**< (RSTC_MR) User Reset Enable Position */
+#define RSTC_MR_URSTEN_Msk                  (_U_(0x1) << RSTC_MR_URSTEN_Pos)               /**< (RSTC_MR) User Reset Enable Mask */
+#define RSTC_MR_URSTEN                      RSTC_MR_URSTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_MR_URSTEN_Msk instead */
+#define RSTC_MR_URSTIEN_Pos                 4                                              /**< (RSTC_MR) User Reset Interrupt Enable Position */
+#define RSTC_MR_URSTIEN_Msk                 (_U_(0x1) << RSTC_MR_URSTIEN_Pos)              /**< (RSTC_MR) User Reset Interrupt Enable Mask */
+#define RSTC_MR_URSTIEN                     RSTC_MR_URSTIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSTC_MR_URSTIEN_Msk instead */
+#define RSTC_MR_ERSTL_Pos                   8                                              /**< (RSTC_MR) External Reset Length Position */
+#define RSTC_MR_ERSTL_Msk                   (_U_(0xF) << RSTC_MR_ERSTL_Pos)                /**< (RSTC_MR) External Reset Length Mask */
+#define RSTC_MR_ERSTL(value)                (RSTC_MR_ERSTL_Msk & ((value) << RSTC_MR_ERSTL_Pos))
+#define RSTC_MR_KEY_Pos                     24                                             /**< (RSTC_MR) Write Access Password Position */
+#define RSTC_MR_KEY_Msk                     (_U_(0xFF) << RSTC_MR_KEY_Pos)                 /**< (RSTC_MR) Write Access Password Mask */
+#define RSTC_MR_KEY(value)                  (RSTC_MR_KEY_Msk & ((value) << RSTC_MR_KEY_Pos))
+#define   RSTC_MR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (RSTC_MR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define RSTC_MR_KEY_PASSWD                  (RSTC_MR_KEY_PASSWD_Val << RSTC_MR_KEY_Pos)    /**< (RSTC_MR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define RSTC_MR_MASK                        _U_(0xFF000F11)                                /**< \deprecated (RSTC_MR) Register MASK  (Use RSTC_MR_Msk instead)  */
+#define RSTC_MR_Msk                         _U_(0xFF000F11)                                /**< (RSTC_MR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RSTC hardware registers */
+typedef struct {  
+  __O  uint32_t RSTC_CR;        /**< (RSTC Offset: 0x00) Control Register */
+  __I  uint32_t RSTC_SR;        /**< (RSTC Offset: 0x04) Status Register */
+  __IO uint32_t RSTC_MR;        /**< (RSTC Offset: 0x08) Mode Register */
+} Rstc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RSTC hardware registers */
+typedef struct {  
+  __O  RSTC_CR_Type                   RSTC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __I  RSTC_SR_Type                   RSTC_SR;        /**< Offset: 0x04 (R/   32) Status Register */
+  __IO RSTC_MR_Type                   RSTC_MR;        /**< Offset: 0x08 (R/W  32) Mode Register */
+} Rstc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reset Controller */
+
+#endif /* _SAMV71_RSTC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/rswdt.h
+++ b/asf/sam/include/samv71b/component/rswdt.h
@@ -1,0 +1,169 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSWDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RSWDT_COMPONENT_H_
+#define _SAMV71_RSWDT_COMPONENT_H_
+#define _SAMV71_RSWDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Reinforced Safety Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSWDT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RSWDT_11110                      /**< (RSWDT) Module ID */
+#define REV_RSWDT G                      /**< (RSWDT) Module revision */
+
+/* -------- RSWDT_CR : (RSWDT Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
+    uint32_t :23;                       /**< bit:  1..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_CR_OFFSET                     (0x00)                                        /**<  (RSWDT_CR) Control Register  Offset */
+
+#define RSWDT_CR_WDRSTT_Pos                 0                                              /**< (RSWDT_CR) Watchdog Restart Position */
+#define RSWDT_CR_WDRSTT_Msk                 (_U_(0x1) << RSWDT_CR_WDRSTT_Pos)              /**< (RSWDT_CR) Watchdog Restart Mask */
+#define RSWDT_CR_WDRSTT                     RSWDT_CR_WDRSTT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_CR_WDRSTT_Msk instead */
+#define RSWDT_CR_KEY_Pos                    24                                             /**< (RSWDT_CR) Password Position */
+#define RSWDT_CR_KEY_Msk                    (_U_(0xFF) << RSWDT_CR_KEY_Pos)                /**< (RSWDT_CR) Password Mask */
+#define RSWDT_CR_KEY(value)                 (RSWDT_CR_KEY_Msk & ((value) << RSWDT_CR_KEY_Pos))
+#define   RSWDT_CR_KEY_PASSWD_Val           _U_(0xC4)                                      /**< (RSWDT_CR) Writing any other value in this field aborts the write operation.  */
+#define RSWDT_CR_KEY_PASSWD                 (RSWDT_CR_KEY_PASSWD_Val << RSWDT_CR_KEY_Pos)  /**< (RSWDT_CR) Writing any other value in this field aborts the write operation. Position  */
+#define RSWDT_CR_MASK                       _U_(0xFF000001)                                /**< \deprecated (RSWDT_CR) Register MASK  (Use RSWDT_CR_Msk instead)  */
+#define RSWDT_CR_Msk                        _U_(0xFF000001)                                /**< (RSWDT_CR) Register Mask  */
+
+
+/* -------- RSWDT_MR : (RSWDT Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
+    uint32_t WDFIEN:1;                  /**< bit:     12  Watchdog Fault Interrupt Enable          */
+    uint32_t WDRSTEN:1;                 /**< bit:     13  Watchdog Reset Enable                    */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t WDDIS:1;                   /**< bit:     15  Watchdog Disable                         */
+    uint32_t ALLONES:12;                /**< bit: 16..27  Must Always Be Written with 0xFFF        */
+    uint32_t WDDBGHLT:1;                /**< bit:     28  Watchdog Debug Halt                      */
+    uint32_t WDIDLEHLT:1;               /**< bit:     29  Watchdog Idle Halt                       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_MR_OFFSET                     (0x04)                                        /**<  (RSWDT_MR) Mode Register  Offset */
+
+#define RSWDT_MR_WDV_Pos                    0                                              /**< (RSWDT_MR) Watchdog Counter Value Position */
+#define RSWDT_MR_WDV_Msk                    (_U_(0xFFF) << RSWDT_MR_WDV_Pos)               /**< (RSWDT_MR) Watchdog Counter Value Mask */
+#define RSWDT_MR_WDV(value)                 (RSWDT_MR_WDV_Msk & ((value) << RSWDT_MR_WDV_Pos))
+#define RSWDT_MR_WDFIEN_Pos                 12                                             /**< (RSWDT_MR) Watchdog Fault Interrupt Enable Position */
+#define RSWDT_MR_WDFIEN_Msk                 (_U_(0x1) << RSWDT_MR_WDFIEN_Pos)              /**< (RSWDT_MR) Watchdog Fault Interrupt Enable Mask */
+#define RSWDT_MR_WDFIEN                     RSWDT_MR_WDFIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDFIEN_Msk instead */
+#define RSWDT_MR_WDRSTEN_Pos                13                                             /**< (RSWDT_MR) Watchdog Reset Enable Position */
+#define RSWDT_MR_WDRSTEN_Msk                (_U_(0x1) << RSWDT_MR_WDRSTEN_Pos)             /**< (RSWDT_MR) Watchdog Reset Enable Mask */
+#define RSWDT_MR_WDRSTEN                    RSWDT_MR_WDRSTEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDRSTEN_Msk instead */
+#define RSWDT_MR_WDDIS_Pos                  15                                             /**< (RSWDT_MR) Watchdog Disable Position */
+#define RSWDT_MR_WDDIS_Msk                  (_U_(0x1) << RSWDT_MR_WDDIS_Pos)               /**< (RSWDT_MR) Watchdog Disable Mask */
+#define RSWDT_MR_WDDIS                      RSWDT_MR_WDDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDDIS_Msk instead */
+#define RSWDT_MR_ALLONES_Pos                16                                             /**< (RSWDT_MR) Must Always Be Written with 0xFFF Position */
+#define RSWDT_MR_ALLONES_Msk                (_U_(0xFFF) << RSWDT_MR_ALLONES_Pos)           /**< (RSWDT_MR) Must Always Be Written with 0xFFF Mask */
+#define RSWDT_MR_ALLONES(value)             (RSWDT_MR_ALLONES_Msk & ((value) << RSWDT_MR_ALLONES_Pos))
+#define RSWDT_MR_WDDBGHLT_Pos               28                                             /**< (RSWDT_MR) Watchdog Debug Halt Position */
+#define RSWDT_MR_WDDBGHLT_Msk               (_U_(0x1) << RSWDT_MR_WDDBGHLT_Pos)            /**< (RSWDT_MR) Watchdog Debug Halt Mask */
+#define RSWDT_MR_WDDBGHLT                   RSWDT_MR_WDDBGHLT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDDBGHLT_Msk instead */
+#define RSWDT_MR_WDIDLEHLT_Pos              29                                             /**< (RSWDT_MR) Watchdog Idle Halt Position */
+#define RSWDT_MR_WDIDLEHLT_Msk              (_U_(0x1) << RSWDT_MR_WDIDLEHLT_Pos)           /**< (RSWDT_MR) Watchdog Idle Halt Mask */
+#define RSWDT_MR_WDIDLEHLT                  RSWDT_MR_WDIDLEHLT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_MR_WDIDLEHLT_Msk instead */
+#define RSWDT_MR_MASK                       _U_(0x3FFFBFFF)                                /**< \deprecated (RSWDT_MR) Register MASK  (Use RSWDT_MR_Msk instead)  */
+#define RSWDT_MR_Msk                        _U_(0x3FFFBFFF)                                /**< (RSWDT_MR) Register Mask  */
+
+
+/* -------- RSWDT_SR : (RSWDT Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow                       */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RSWDT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSWDT_SR_OFFSET                     (0x08)                                        /**<  (RSWDT_SR) Status Register  Offset */
+
+#define RSWDT_SR_WDUNF_Pos                  0                                              /**< (RSWDT_SR) Watchdog Underflow Position */
+#define RSWDT_SR_WDUNF_Msk                  (_U_(0x1) << RSWDT_SR_WDUNF_Pos)               /**< (RSWDT_SR) Watchdog Underflow Mask */
+#define RSWDT_SR_WDUNF                      RSWDT_SR_WDUNF_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RSWDT_SR_WDUNF_Msk instead */
+#define RSWDT_SR_MASK                       _U_(0x01)                                      /**< \deprecated (RSWDT_SR) Register MASK  (Use RSWDT_SR_Msk instead)  */
+#define RSWDT_SR_Msk                        _U_(0x01)                                      /**< (RSWDT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RSWDT hardware registers */
+typedef struct {  
+  __O  uint32_t RSWDT_CR;       /**< (RSWDT Offset: 0x00) Control Register */
+  __IO uint32_t RSWDT_MR;       /**< (RSWDT Offset: 0x04) Mode Register */
+  __I  uint32_t RSWDT_SR;       /**< (RSWDT Offset: 0x08) Status Register */
+} Rswdt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RSWDT hardware registers */
+typedef struct {  
+  __O  RSWDT_CR_Type                  RSWDT_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO RSWDT_MR_Type                  RSWDT_MR;       /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  RSWDT_SR_Type                  RSWDT_SR;       /**< Offset: 0x08 (R/   32) Status Register */
+} Rswdt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Reinforced Safety Watchdog Timer */
+
+#endif /* _SAMV71_RSWDT_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/rtc.h
+++ b/asf/sam/include/samv71b/component/rtc.h
@@ -1,0 +1,680 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RTC_COMPONENT_H_
+#define _SAMV71_RTC_COMPONENT_H_
+#define _SAMV71_RTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Real-time Clock
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RTC_6056                       /**< (RTC) Module ID */
+#define REV_RTC ZB                     /**< (RTC) Module revision */
+
+/* -------- RTC_CR : (RTC Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UPDTIM:1;                  /**< bit:      0  Update Request Time Register             */
+    uint32_t UPDCAL:1;                  /**< bit:      1  Update Request Calendar Register         */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t TIMEVSEL:2;                /**< bit:   8..9  Time Event Selection                     */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t CALEVSEL:2;                /**< bit: 16..17  Calendar Event Selection                 */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CR_OFFSET                       (0x00)                                        /**<  (RTC_CR) Control Register  Offset */
+
+#define RTC_CR_UPDTIM_Pos                   0                                              /**< (RTC_CR) Update Request Time Register Position */
+#define RTC_CR_UPDTIM_Msk                   (_U_(0x1) << RTC_CR_UPDTIM_Pos)                /**< (RTC_CR) Update Request Time Register Mask */
+#define RTC_CR_UPDTIM                       RTC_CR_UPDTIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CR_UPDTIM_Msk instead */
+#define RTC_CR_UPDCAL_Pos                   1                                              /**< (RTC_CR) Update Request Calendar Register Position */
+#define RTC_CR_UPDCAL_Msk                   (_U_(0x1) << RTC_CR_UPDCAL_Pos)                /**< (RTC_CR) Update Request Calendar Register Mask */
+#define RTC_CR_UPDCAL                       RTC_CR_UPDCAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CR_UPDCAL_Msk instead */
+#define RTC_CR_TIMEVSEL_Pos                 8                                              /**< (RTC_CR) Time Event Selection Position */
+#define RTC_CR_TIMEVSEL_Msk                 (_U_(0x3) << RTC_CR_TIMEVSEL_Pos)              /**< (RTC_CR) Time Event Selection Mask */
+#define RTC_CR_TIMEVSEL(value)              (RTC_CR_TIMEVSEL_Msk & ((value) << RTC_CR_TIMEVSEL_Pos))
+#define   RTC_CR_TIMEVSEL_MINUTE_Val        _U_(0x0)                                       /**< (RTC_CR) Minute change  */
+#define   RTC_CR_TIMEVSEL_HOUR_Val          _U_(0x1)                                       /**< (RTC_CR) Hour change  */
+#define   RTC_CR_TIMEVSEL_MIDNIGHT_Val      _U_(0x2)                                       /**< (RTC_CR) Every day at midnight  */
+#define   RTC_CR_TIMEVSEL_NOON_Val          _U_(0x3)                                       /**< (RTC_CR) Every day at noon  */
+#define RTC_CR_TIMEVSEL_MINUTE              (RTC_CR_TIMEVSEL_MINUTE_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Minute change Position  */
+#define RTC_CR_TIMEVSEL_HOUR                (RTC_CR_TIMEVSEL_HOUR_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Hour change Position  */
+#define RTC_CR_TIMEVSEL_MIDNIGHT            (RTC_CR_TIMEVSEL_MIDNIGHT_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Every day at midnight Position  */
+#define RTC_CR_TIMEVSEL_NOON                (RTC_CR_TIMEVSEL_NOON_Val << RTC_CR_TIMEVSEL_Pos)  /**< (RTC_CR) Every day at noon Position  */
+#define RTC_CR_CALEVSEL_Pos                 16                                             /**< (RTC_CR) Calendar Event Selection Position */
+#define RTC_CR_CALEVSEL_Msk                 (_U_(0x3) << RTC_CR_CALEVSEL_Pos)              /**< (RTC_CR) Calendar Event Selection Mask */
+#define RTC_CR_CALEVSEL(value)              (RTC_CR_CALEVSEL_Msk & ((value) << RTC_CR_CALEVSEL_Pos))
+#define   RTC_CR_CALEVSEL_WEEK_Val          _U_(0x0)                                       /**< (RTC_CR) Week change (every Monday at time 00:00:00)  */
+#define   RTC_CR_CALEVSEL_MONTH_Val         _U_(0x1)                                       /**< (RTC_CR) Month change (every 01 of each month at time 00:00:00)  */
+#define   RTC_CR_CALEVSEL_YEAR_Val          _U_(0x2)                                       /**< (RTC_CR) Year change (every January 1 at time 00:00:00)  */
+#define RTC_CR_CALEVSEL_WEEK                (RTC_CR_CALEVSEL_WEEK_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Week change (every Monday at time 00:00:00) Position  */
+#define RTC_CR_CALEVSEL_MONTH               (RTC_CR_CALEVSEL_MONTH_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Month change (every 01 of each month at time 00:00:00) Position  */
+#define RTC_CR_CALEVSEL_YEAR                (RTC_CR_CALEVSEL_YEAR_Val << RTC_CR_CALEVSEL_Pos)  /**< (RTC_CR) Year change (every January 1 at time 00:00:00) Position  */
+#define RTC_CR_MASK                         _U_(0x30303)                                   /**< \deprecated (RTC_CR) Register MASK  (Use RTC_CR_Msk instead)  */
+#define RTC_CR_Msk                          _U_(0x30303)                                   /**< (RTC_CR) Register Mask  */
+
+
+/* -------- RTC_MR : (RTC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HRMOD:1;                   /**< bit:      0  12-/24-hour Mode                         */
+    uint32_t PERSIAN:1;                 /**< bit:      1  PERSIAN Calendar                         */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t NEGPPM:1;                  /**< bit:      4  NEGative PPM Correction                  */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t CORRECTION:7;              /**< bit:  8..14  Slow Clock Correction                    */
+    uint32_t HIGHPPM:1;                 /**< bit:     15  HIGH PPM Correction                      */
+    uint32_t OUT0:3;                    /**< bit: 16..18  RTCOUT0 OutputSource Selection           */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t OUT1:3;                    /**< bit: 20..22  RTCOUT1 Output Source Selection          */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t THIGH:3;                   /**< bit: 24..26  High Duration of the Output Pulse        */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t TPERIOD:2;                 /**< bit: 28..29  Period of the Output Pulse               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MR_OFFSET                       (0x04)                                        /**<  (RTC_MR) Mode Register  Offset */
+
+#define RTC_MR_HRMOD_Pos                    0                                              /**< (RTC_MR) 12-/24-hour Mode Position */
+#define RTC_MR_HRMOD_Msk                    (_U_(0x1) << RTC_MR_HRMOD_Pos)                 /**< (RTC_MR) 12-/24-hour Mode Mask */
+#define RTC_MR_HRMOD                        RTC_MR_HRMOD_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_HRMOD_Msk instead */
+#define RTC_MR_PERSIAN_Pos                  1                                              /**< (RTC_MR) PERSIAN Calendar Position */
+#define RTC_MR_PERSIAN_Msk                  (_U_(0x1) << RTC_MR_PERSIAN_Pos)               /**< (RTC_MR) PERSIAN Calendar Mask */
+#define RTC_MR_PERSIAN                      RTC_MR_PERSIAN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_PERSIAN_Msk instead */
+#define RTC_MR_NEGPPM_Pos                   4                                              /**< (RTC_MR) NEGative PPM Correction Position */
+#define RTC_MR_NEGPPM_Msk                   (_U_(0x1) << RTC_MR_NEGPPM_Pos)                /**< (RTC_MR) NEGative PPM Correction Mask */
+#define RTC_MR_NEGPPM                       RTC_MR_NEGPPM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_NEGPPM_Msk instead */
+#define RTC_MR_CORRECTION_Pos               8                                              /**< (RTC_MR) Slow Clock Correction Position */
+#define RTC_MR_CORRECTION_Msk               (_U_(0x7F) << RTC_MR_CORRECTION_Pos)           /**< (RTC_MR) Slow Clock Correction Mask */
+#define RTC_MR_CORRECTION(value)            (RTC_MR_CORRECTION_Msk & ((value) << RTC_MR_CORRECTION_Pos))
+#define RTC_MR_HIGHPPM_Pos                  15                                             /**< (RTC_MR) HIGH PPM Correction Position */
+#define RTC_MR_HIGHPPM_Msk                  (_U_(0x1) << RTC_MR_HIGHPPM_Pos)               /**< (RTC_MR) HIGH PPM Correction Mask */
+#define RTC_MR_HIGHPPM                      RTC_MR_HIGHPPM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_MR_HIGHPPM_Msk instead */
+#define RTC_MR_OUT0_Pos                     16                                             /**< (RTC_MR) RTCOUT0 OutputSource Selection Position */
+#define RTC_MR_OUT0_Msk                     (_U_(0x7) << RTC_MR_OUT0_Pos)                  /**< (RTC_MR) RTCOUT0 OutputSource Selection Mask */
+#define RTC_MR_OUT0(value)                  (RTC_MR_OUT0_Msk & ((value) << RTC_MR_OUT0_Pos))
+#define   RTC_MR_OUT0_NO_WAVE_Val           _U_(0x0)                                       /**< (RTC_MR) No waveform, stuck at '0'  */
+#define   RTC_MR_OUT0_FREQ1HZ_Val           _U_(0x1)                                       /**< (RTC_MR) 1 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ32HZ_Val          _U_(0x2)                                       /**< (RTC_MR) 32 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ64HZ_Val          _U_(0x3)                                       /**< (RTC_MR) 64 Hz square wave  */
+#define   RTC_MR_OUT0_FREQ512HZ_Val         _U_(0x4)                                       /**< (RTC_MR) 512 Hz square wave  */
+#define   RTC_MR_OUT0_ALARM_TOGGLE_Val      _U_(0x5)                                       /**< (RTC_MR) Output toggles when alarm flag rises  */
+#define   RTC_MR_OUT0_ALARM_FLAG_Val        _U_(0x6)                                       /**< (RTC_MR) Output is a copy of the alarm flag  */
+#define   RTC_MR_OUT0_PROG_PULSE_Val        _U_(0x7)                                       /**< (RTC_MR) Duty cycle programmable pulse  */
+#define RTC_MR_OUT0_NO_WAVE                 (RTC_MR_OUT0_NO_WAVE_Val << RTC_MR_OUT0_Pos)   /**< (RTC_MR) No waveform, stuck at '0' Position  */
+#define RTC_MR_OUT0_FREQ1HZ                 (RTC_MR_OUT0_FREQ1HZ_Val << RTC_MR_OUT0_Pos)   /**< (RTC_MR) 1 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ32HZ                (RTC_MR_OUT0_FREQ32HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 32 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ64HZ                (RTC_MR_OUT0_FREQ64HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 64 Hz square wave Position  */
+#define RTC_MR_OUT0_FREQ512HZ               (RTC_MR_OUT0_FREQ512HZ_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) 512 Hz square wave Position  */
+#define RTC_MR_OUT0_ALARM_TOGGLE            (RTC_MR_OUT0_ALARM_TOGGLE_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Output toggles when alarm flag rises Position  */
+#define RTC_MR_OUT0_ALARM_FLAG              (RTC_MR_OUT0_ALARM_FLAG_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Output is a copy of the alarm flag Position  */
+#define RTC_MR_OUT0_PROG_PULSE              (RTC_MR_OUT0_PROG_PULSE_Val << RTC_MR_OUT0_Pos)  /**< (RTC_MR) Duty cycle programmable pulse Position  */
+#define RTC_MR_OUT1_Pos                     20                                             /**< (RTC_MR) RTCOUT1 Output Source Selection Position */
+#define RTC_MR_OUT1_Msk                     (_U_(0x7) << RTC_MR_OUT1_Pos)                  /**< (RTC_MR) RTCOUT1 Output Source Selection Mask */
+#define RTC_MR_OUT1(value)                  (RTC_MR_OUT1_Msk & ((value) << RTC_MR_OUT1_Pos))
+#define   RTC_MR_OUT1_NO_WAVE_Val           _U_(0x0)                                       /**< (RTC_MR) No waveform, stuck at '0'  */
+#define   RTC_MR_OUT1_FREQ1HZ_Val           _U_(0x1)                                       /**< (RTC_MR) 1 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ32HZ_Val          _U_(0x2)                                       /**< (RTC_MR) 32 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ64HZ_Val          _U_(0x3)                                       /**< (RTC_MR) 64 Hz square wave  */
+#define   RTC_MR_OUT1_FREQ512HZ_Val         _U_(0x4)                                       /**< (RTC_MR) 512 Hz square wave  */
+#define   RTC_MR_OUT1_ALARM_TOGGLE_Val      _U_(0x5)                                       /**< (RTC_MR) Output toggles when alarm flag rises  */
+#define   RTC_MR_OUT1_ALARM_FLAG_Val        _U_(0x6)                                       /**< (RTC_MR) Output is a copy of the alarm flag  */
+#define   RTC_MR_OUT1_PROG_PULSE_Val        _U_(0x7)                                       /**< (RTC_MR) Duty cycle programmable pulse  */
+#define RTC_MR_OUT1_NO_WAVE                 (RTC_MR_OUT1_NO_WAVE_Val << RTC_MR_OUT1_Pos)   /**< (RTC_MR) No waveform, stuck at '0' Position  */
+#define RTC_MR_OUT1_FREQ1HZ                 (RTC_MR_OUT1_FREQ1HZ_Val << RTC_MR_OUT1_Pos)   /**< (RTC_MR) 1 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ32HZ                (RTC_MR_OUT1_FREQ32HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 32 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ64HZ                (RTC_MR_OUT1_FREQ64HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 64 Hz square wave Position  */
+#define RTC_MR_OUT1_FREQ512HZ               (RTC_MR_OUT1_FREQ512HZ_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) 512 Hz square wave Position  */
+#define RTC_MR_OUT1_ALARM_TOGGLE            (RTC_MR_OUT1_ALARM_TOGGLE_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Output toggles when alarm flag rises Position  */
+#define RTC_MR_OUT1_ALARM_FLAG              (RTC_MR_OUT1_ALARM_FLAG_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Output is a copy of the alarm flag Position  */
+#define RTC_MR_OUT1_PROG_PULSE              (RTC_MR_OUT1_PROG_PULSE_Val << RTC_MR_OUT1_Pos)  /**< (RTC_MR) Duty cycle programmable pulse Position  */
+#define RTC_MR_THIGH_Pos                    24                                             /**< (RTC_MR) High Duration of the Output Pulse Position */
+#define RTC_MR_THIGH_Msk                    (_U_(0x7) << RTC_MR_THIGH_Pos)                 /**< (RTC_MR) High Duration of the Output Pulse Mask */
+#define RTC_MR_THIGH(value)                 (RTC_MR_THIGH_Msk & ((value) << RTC_MR_THIGH_Pos))
+#define   RTC_MR_THIGH_H_31MS_Val           _U_(0x0)                                       /**< (RTC_MR) 31.2 ms  */
+#define   RTC_MR_THIGH_H_16MS_Val           _U_(0x1)                                       /**< (RTC_MR) 15.6 ms  */
+#define   RTC_MR_THIGH_H_4MS_Val            _U_(0x2)                                       /**< (RTC_MR) 3.91 ms  */
+#define   RTC_MR_THIGH_H_976US_Val          _U_(0x3)                                       /**< (RTC_MR) 976 us  */
+#define   RTC_MR_THIGH_H_488US_Val          _U_(0x4)                                       /**< (RTC_MR) 488 us  */
+#define   RTC_MR_THIGH_H_122US_Val          _U_(0x5)                                       /**< (RTC_MR) 122 us  */
+#define   RTC_MR_THIGH_H_30US_Val           _U_(0x6)                                       /**< (RTC_MR) 30.5 us  */
+#define   RTC_MR_THIGH_H_15US_Val           _U_(0x7)                                       /**< (RTC_MR) 15.2 us  */
+#define RTC_MR_THIGH_H_31MS                 (RTC_MR_THIGH_H_31MS_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 31.2 ms Position  */
+#define RTC_MR_THIGH_H_16MS                 (RTC_MR_THIGH_H_16MS_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 15.6 ms Position  */
+#define RTC_MR_THIGH_H_4MS                  (RTC_MR_THIGH_H_4MS_Val << RTC_MR_THIGH_Pos)   /**< (RTC_MR) 3.91 ms Position  */
+#define RTC_MR_THIGH_H_976US                (RTC_MR_THIGH_H_976US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 976 us Position  */
+#define RTC_MR_THIGH_H_488US                (RTC_MR_THIGH_H_488US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 488 us Position  */
+#define RTC_MR_THIGH_H_122US                (RTC_MR_THIGH_H_122US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 122 us Position  */
+#define RTC_MR_THIGH_H_30US                 (RTC_MR_THIGH_H_30US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 30.5 us Position  */
+#define RTC_MR_THIGH_H_15US                 (RTC_MR_THIGH_H_15US_Val << RTC_MR_THIGH_Pos)  /**< (RTC_MR) 15.2 us Position  */
+#define RTC_MR_TPERIOD_Pos                  28                                             /**< (RTC_MR) Period of the Output Pulse Position */
+#define RTC_MR_TPERIOD_Msk                  (_U_(0x3) << RTC_MR_TPERIOD_Pos)               /**< (RTC_MR) Period of the Output Pulse Mask */
+#define RTC_MR_TPERIOD(value)               (RTC_MR_TPERIOD_Msk & ((value) << RTC_MR_TPERIOD_Pos))
+#define   RTC_MR_TPERIOD_P_1S_Val           _U_(0x0)                                       /**< (RTC_MR) 1 second  */
+#define   RTC_MR_TPERIOD_P_500MS_Val        _U_(0x1)                                       /**< (RTC_MR) 500 ms  */
+#define   RTC_MR_TPERIOD_P_250MS_Val        _U_(0x2)                                       /**< (RTC_MR) 250 ms  */
+#define   RTC_MR_TPERIOD_P_125MS_Val        _U_(0x3)                                       /**< (RTC_MR) 125 ms  */
+#define RTC_MR_TPERIOD_P_1S                 (RTC_MR_TPERIOD_P_1S_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 1 second Position  */
+#define RTC_MR_TPERIOD_P_500MS              (RTC_MR_TPERIOD_P_500MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 500 ms Position  */
+#define RTC_MR_TPERIOD_P_250MS              (RTC_MR_TPERIOD_P_250MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 250 ms Position  */
+#define RTC_MR_TPERIOD_P_125MS              (RTC_MR_TPERIOD_P_125MS_Val << RTC_MR_TPERIOD_Pos)  /**< (RTC_MR) 125 ms Position  */
+#define RTC_MR_MASK                         _U_(0x3777FF13)                                /**< \deprecated (RTC_MR) Register MASK  (Use RTC_MR_Msk instead)  */
+#define RTC_MR_Msk                          _U_(0x3777FF13)                                /**< (RTC_MR) Register Mask  */
+
+
+/* -------- RTC_TIMR : (RTC Offset: 0x08) (R/W 32) Time Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:7;                     /**< bit:   0..6  Current Second                           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MIN:7;                     /**< bit:  8..14  Current Minute                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HOUR:6;                    /**< bit: 16..21  Current Hour                             */
+    uint32_t AMPM:1;                    /**< bit:     22  Ante Meridiem Post Meridiem Indicator    */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TIMR_OFFSET                     (0x08)                                        /**<  (RTC_TIMR) Time Register  Offset */
+
+#define RTC_TIMR_SEC_Pos                    0                                              /**< (RTC_TIMR) Current Second Position */
+#define RTC_TIMR_SEC_Msk                    (_U_(0x7F) << RTC_TIMR_SEC_Pos)                /**< (RTC_TIMR) Current Second Mask */
+#define RTC_TIMR_SEC(value)                 (RTC_TIMR_SEC_Msk & ((value) << RTC_TIMR_SEC_Pos))
+#define RTC_TIMR_MIN_Pos                    8                                              /**< (RTC_TIMR) Current Minute Position */
+#define RTC_TIMR_MIN_Msk                    (_U_(0x7F) << RTC_TIMR_MIN_Pos)                /**< (RTC_TIMR) Current Minute Mask */
+#define RTC_TIMR_MIN(value)                 (RTC_TIMR_MIN_Msk & ((value) << RTC_TIMR_MIN_Pos))
+#define RTC_TIMR_HOUR_Pos                   16                                             /**< (RTC_TIMR) Current Hour Position */
+#define RTC_TIMR_HOUR_Msk                   (_U_(0x3F) << RTC_TIMR_HOUR_Pos)               /**< (RTC_TIMR) Current Hour Mask */
+#define RTC_TIMR_HOUR(value)                (RTC_TIMR_HOUR_Msk & ((value) << RTC_TIMR_HOUR_Pos))
+#define RTC_TIMR_AMPM_Pos                   22                                             /**< (RTC_TIMR) Ante Meridiem Post Meridiem Indicator Position */
+#define RTC_TIMR_AMPM_Msk                   (_U_(0x1) << RTC_TIMR_AMPM_Pos)                /**< (RTC_TIMR) Ante Meridiem Post Meridiem Indicator Mask */
+#define RTC_TIMR_AMPM                       RTC_TIMR_AMPM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMR_AMPM_Msk instead */
+#define RTC_TIMR_MASK                       _U_(0x7F7F7F)                                  /**< \deprecated (RTC_TIMR) Register MASK  (Use RTC_TIMR_Msk instead)  */
+#define RTC_TIMR_Msk                        _U_(0x7F7F7F)                                  /**< (RTC_TIMR) Register Mask  */
+
+
+/* -------- RTC_CALR : (RTC Offset: 0x0c) (R/W 32) Calendar Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CENT:7;                    /**< bit:   0..6  Current Century                          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t YEAR:8;                    /**< bit:  8..15  Current Year                             */
+    uint32_t MONTH:5;                   /**< bit: 16..20  Current Month                            */
+    uint32_t DAY:3;                     /**< bit: 21..23  Current Day in Current Week              */
+    uint32_t DATE:6;                    /**< bit: 24..29  Current Day in Current Month             */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CALR_OFFSET                     (0x0C)                                        /**<  (RTC_CALR) Calendar Register  Offset */
+
+#define RTC_CALR_CENT_Pos                   0                                              /**< (RTC_CALR) Current Century Position */
+#define RTC_CALR_CENT_Msk                   (_U_(0x7F) << RTC_CALR_CENT_Pos)               /**< (RTC_CALR) Current Century Mask */
+#define RTC_CALR_CENT(value)                (RTC_CALR_CENT_Msk & ((value) << RTC_CALR_CENT_Pos))
+#define RTC_CALR_YEAR_Pos                   8                                              /**< (RTC_CALR) Current Year Position */
+#define RTC_CALR_YEAR_Msk                   (_U_(0xFF) << RTC_CALR_YEAR_Pos)               /**< (RTC_CALR) Current Year Mask */
+#define RTC_CALR_YEAR(value)                (RTC_CALR_YEAR_Msk & ((value) << RTC_CALR_YEAR_Pos))
+#define RTC_CALR_MONTH_Pos                  16                                             /**< (RTC_CALR) Current Month Position */
+#define RTC_CALR_MONTH_Msk                  (_U_(0x1F) << RTC_CALR_MONTH_Pos)              /**< (RTC_CALR) Current Month Mask */
+#define RTC_CALR_MONTH(value)               (RTC_CALR_MONTH_Msk & ((value) << RTC_CALR_MONTH_Pos))
+#define RTC_CALR_DAY_Pos                    21                                             /**< (RTC_CALR) Current Day in Current Week Position */
+#define RTC_CALR_DAY_Msk                    (_U_(0x7) << RTC_CALR_DAY_Pos)                 /**< (RTC_CALR) Current Day in Current Week Mask */
+#define RTC_CALR_DAY(value)                 (RTC_CALR_DAY_Msk & ((value) << RTC_CALR_DAY_Pos))
+#define RTC_CALR_DATE_Pos                   24                                             /**< (RTC_CALR) Current Day in Current Month Position */
+#define RTC_CALR_DATE_Msk                   (_U_(0x3F) << RTC_CALR_DATE_Pos)               /**< (RTC_CALR) Current Day in Current Month Mask */
+#define RTC_CALR_DATE(value)                (RTC_CALR_DATE_Msk & ((value) << RTC_CALR_DATE_Pos))
+#define RTC_CALR_MASK                       _U_(0x3FFFFF7F)                                /**< \deprecated (RTC_CALR) Register MASK  (Use RTC_CALR_Msk instead)  */
+#define RTC_CALR_Msk                        _U_(0x3FFFFF7F)                                /**< (RTC_CALR) Register Mask  */
+
+
+/* -------- RTC_TIMALR : (RTC Offset: 0x10) (R/W 32) Time Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SEC:7;                     /**< bit:   0..6  Second Alarm                             */
+    uint32_t SECEN:1;                   /**< bit:      7  Second Alarm Enable                      */
+    uint32_t MIN:7;                     /**< bit:  8..14  Minute Alarm                             */
+    uint32_t MINEN:1;                   /**< bit:     15  Minute Alarm Enable                      */
+    uint32_t HOUR:6;                    /**< bit: 16..21  Hour Alarm                               */
+    uint32_t AMPM:1;                    /**< bit:     22  AM/PM Indicator                          */
+    uint32_t HOUREN:1;                  /**< bit:     23  Hour Alarm Enable                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_TIMALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_TIMALR_OFFSET                   (0x10)                                        /**<  (RTC_TIMALR) Time Alarm Register  Offset */
+
+#define RTC_TIMALR_SEC_Pos                  0                                              /**< (RTC_TIMALR) Second Alarm Position */
+#define RTC_TIMALR_SEC_Msk                  (_U_(0x7F) << RTC_TIMALR_SEC_Pos)              /**< (RTC_TIMALR) Second Alarm Mask */
+#define RTC_TIMALR_SEC(value)               (RTC_TIMALR_SEC_Msk & ((value) << RTC_TIMALR_SEC_Pos))
+#define RTC_TIMALR_SECEN_Pos                7                                              /**< (RTC_TIMALR) Second Alarm Enable Position */
+#define RTC_TIMALR_SECEN_Msk                (_U_(0x1) << RTC_TIMALR_SECEN_Pos)             /**< (RTC_TIMALR) Second Alarm Enable Mask */
+#define RTC_TIMALR_SECEN                    RTC_TIMALR_SECEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_SECEN_Msk instead */
+#define RTC_TIMALR_MIN_Pos                  8                                              /**< (RTC_TIMALR) Minute Alarm Position */
+#define RTC_TIMALR_MIN_Msk                  (_U_(0x7F) << RTC_TIMALR_MIN_Pos)              /**< (RTC_TIMALR) Minute Alarm Mask */
+#define RTC_TIMALR_MIN(value)               (RTC_TIMALR_MIN_Msk & ((value) << RTC_TIMALR_MIN_Pos))
+#define RTC_TIMALR_MINEN_Pos                15                                             /**< (RTC_TIMALR) Minute Alarm Enable Position */
+#define RTC_TIMALR_MINEN_Msk                (_U_(0x1) << RTC_TIMALR_MINEN_Pos)             /**< (RTC_TIMALR) Minute Alarm Enable Mask */
+#define RTC_TIMALR_MINEN                    RTC_TIMALR_MINEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_MINEN_Msk instead */
+#define RTC_TIMALR_HOUR_Pos                 16                                             /**< (RTC_TIMALR) Hour Alarm Position */
+#define RTC_TIMALR_HOUR_Msk                 (_U_(0x3F) << RTC_TIMALR_HOUR_Pos)             /**< (RTC_TIMALR) Hour Alarm Mask */
+#define RTC_TIMALR_HOUR(value)              (RTC_TIMALR_HOUR_Msk & ((value) << RTC_TIMALR_HOUR_Pos))
+#define RTC_TIMALR_AMPM_Pos                 22                                             /**< (RTC_TIMALR) AM/PM Indicator Position */
+#define RTC_TIMALR_AMPM_Msk                 (_U_(0x1) << RTC_TIMALR_AMPM_Pos)              /**< (RTC_TIMALR) AM/PM Indicator Mask */
+#define RTC_TIMALR_AMPM                     RTC_TIMALR_AMPM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_AMPM_Msk instead */
+#define RTC_TIMALR_HOUREN_Pos               23                                             /**< (RTC_TIMALR) Hour Alarm Enable Position */
+#define RTC_TIMALR_HOUREN_Msk               (_U_(0x1) << RTC_TIMALR_HOUREN_Pos)            /**< (RTC_TIMALR) Hour Alarm Enable Mask */
+#define RTC_TIMALR_HOUREN                   RTC_TIMALR_HOUREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_TIMALR_HOUREN_Msk instead */
+#define RTC_TIMALR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (RTC_TIMALR) Register MASK  (Use RTC_TIMALR_Msk instead)  */
+#define RTC_TIMALR_Msk                      _U_(0xFFFFFF)                                  /**< (RTC_TIMALR) Register Mask  */
+
+
+/* -------- RTC_CALALR : (RTC Offset: 0x14) (R/W 32) Calendar Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t MONTH:5;                   /**< bit: 16..20  Month Alarm                              */
+    uint32_t :2;                        /**< bit: 21..22  Reserved */
+    uint32_t MTHEN:1;                   /**< bit:     23  Month Alarm Enable                       */
+    uint32_t DATE:6;                    /**< bit: 24..29  Date Alarm                               */
+    uint32_t :1;                        /**< bit:     30  Reserved */
+    uint32_t DATEEN:1;                  /**< bit:     31  Date Alarm Enable                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_CALALR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_CALALR_OFFSET                   (0x14)                                        /**<  (RTC_CALALR) Calendar Alarm Register  Offset */
+
+#define RTC_CALALR_MONTH_Pos                16                                             /**< (RTC_CALALR) Month Alarm Position */
+#define RTC_CALALR_MONTH_Msk                (_U_(0x1F) << RTC_CALALR_MONTH_Pos)            /**< (RTC_CALALR) Month Alarm Mask */
+#define RTC_CALALR_MONTH(value)             (RTC_CALALR_MONTH_Msk & ((value) << RTC_CALALR_MONTH_Pos))
+#define RTC_CALALR_MTHEN_Pos                23                                             /**< (RTC_CALALR) Month Alarm Enable Position */
+#define RTC_CALALR_MTHEN_Msk                (_U_(0x1) << RTC_CALALR_MTHEN_Pos)             /**< (RTC_CALALR) Month Alarm Enable Mask */
+#define RTC_CALALR_MTHEN                    RTC_CALALR_MTHEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CALALR_MTHEN_Msk instead */
+#define RTC_CALALR_DATE_Pos                 24                                             /**< (RTC_CALALR) Date Alarm Position */
+#define RTC_CALALR_DATE_Msk                 (_U_(0x3F) << RTC_CALALR_DATE_Pos)             /**< (RTC_CALALR) Date Alarm Mask */
+#define RTC_CALALR_DATE(value)              (RTC_CALALR_DATE_Msk & ((value) << RTC_CALALR_DATE_Pos))
+#define RTC_CALALR_DATEEN_Pos               31                                             /**< (RTC_CALALR) Date Alarm Enable Position */
+#define RTC_CALALR_DATEEN_Msk               (_U_(0x1) << RTC_CALALR_DATEEN_Pos)            /**< (RTC_CALALR) Date Alarm Enable Mask */
+#define RTC_CALALR_DATEEN                   RTC_CALALR_DATEEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_CALALR_DATEEN_Msk instead */
+#define RTC_CALALR_MASK                     _U_(0xBF9F0000)                                /**< \deprecated (RTC_CALALR) Register MASK  (Use RTC_CALALR_Msk instead)  */
+#define RTC_CALALR_Msk                      _U_(0xBF9F0000)                                /**< (RTC_CALALR) Register Mask  */
+
+
+/* -------- RTC_SR : (RTC Offset: 0x18) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKUPD:1;                  /**< bit:      0  Acknowledge for Update                   */
+    uint32_t ALARM:1;                   /**< bit:      1  Alarm Flag                               */
+    uint32_t SEC:1;                     /**< bit:      2  Second Event                             */
+    uint32_t TIMEV:1;                   /**< bit:      3  Time Event                               */
+    uint32_t CALEV:1;                   /**< bit:      4  Calendar Event                           */
+    uint32_t TDERR:1;                   /**< bit:      5  Time and/or Date Free Running Error      */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_SR_OFFSET                       (0x18)                                        /**<  (RTC_SR) Status Register  Offset */
+
+#define RTC_SR_ACKUPD_Pos                   0                                              /**< (RTC_SR) Acknowledge for Update Position */
+#define RTC_SR_ACKUPD_Msk                   (_U_(0x1) << RTC_SR_ACKUPD_Pos)                /**< (RTC_SR) Acknowledge for Update Mask */
+#define RTC_SR_ACKUPD                       RTC_SR_ACKUPD_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_ACKUPD_Msk instead */
+#define   RTC_SR_ACKUPD_FREERUN_Val         _U_(0x0)                                       /**< (RTC_SR) Time and calendar registers cannot be updated.  */
+#define   RTC_SR_ACKUPD_UPDATE_Val          _U_(0x1)                                       /**< (RTC_SR) Time and calendar registers can be updated.  */
+#define RTC_SR_ACKUPD_FREERUN               (RTC_SR_ACKUPD_FREERUN_Val << RTC_SR_ACKUPD_Pos)  /**< (RTC_SR) Time and calendar registers cannot be updated. Position  */
+#define RTC_SR_ACKUPD_UPDATE                (RTC_SR_ACKUPD_UPDATE_Val << RTC_SR_ACKUPD_Pos)  /**< (RTC_SR) Time and calendar registers can be updated. Position  */
+#define RTC_SR_ALARM_Pos                    1                                              /**< (RTC_SR) Alarm Flag Position */
+#define RTC_SR_ALARM_Msk                    (_U_(0x1) << RTC_SR_ALARM_Pos)                 /**< (RTC_SR) Alarm Flag Mask */
+#define RTC_SR_ALARM                        RTC_SR_ALARM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_ALARM_Msk instead */
+#define   RTC_SR_ALARM_NO_ALARMEVENT_Val    _U_(0x0)                                       /**< (RTC_SR) No alarm matching condition occurred.  */
+#define   RTC_SR_ALARM_ALARMEVENT_Val       _U_(0x1)                                       /**< (RTC_SR) An alarm matching condition has occurred.  */
+#define RTC_SR_ALARM_NO_ALARMEVENT          (RTC_SR_ALARM_NO_ALARMEVENT_Val << RTC_SR_ALARM_Pos)  /**< (RTC_SR) No alarm matching condition occurred. Position  */
+#define RTC_SR_ALARM_ALARMEVENT             (RTC_SR_ALARM_ALARMEVENT_Val << RTC_SR_ALARM_Pos)  /**< (RTC_SR) An alarm matching condition has occurred. Position  */
+#define RTC_SR_SEC_Pos                      2                                              /**< (RTC_SR) Second Event Position */
+#define RTC_SR_SEC_Msk                      (_U_(0x1) << RTC_SR_SEC_Pos)                   /**< (RTC_SR) Second Event Mask */
+#define RTC_SR_SEC                          RTC_SR_SEC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_SEC_Msk instead */
+#define   RTC_SR_SEC_NO_SECEVENT_Val        _U_(0x0)                                       /**< (RTC_SR) No second event has occurred since the last clear.  */
+#define   RTC_SR_SEC_SECEVENT_Val           _U_(0x1)                                       /**< (RTC_SR) At least one second event has occurred since the last clear.  */
+#define RTC_SR_SEC_NO_SECEVENT              (RTC_SR_SEC_NO_SECEVENT_Val << RTC_SR_SEC_Pos)  /**< (RTC_SR) No second event has occurred since the last clear. Position  */
+#define RTC_SR_SEC_SECEVENT                 (RTC_SR_SEC_SECEVENT_Val << RTC_SR_SEC_Pos)    /**< (RTC_SR) At least one second event has occurred since the last clear. Position  */
+#define RTC_SR_TIMEV_Pos                    3                                              /**< (RTC_SR) Time Event Position */
+#define RTC_SR_TIMEV_Msk                    (_U_(0x1) << RTC_SR_TIMEV_Pos)                 /**< (RTC_SR) Time Event Mask */
+#define RTC_SR_TIMEV                        RTC_SR_TIMEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_TIMEV_Msk instead */
+#define   RTC_SR_TIMEV_NO_TIMEVENT_Val      _U_(0x0)                                       /**< (RTC_SR) No time event has occurred since the last clear.  */
+#define   RTC_SR_TIMEV_TIMEVENT_Val         _U_(0x1)                                       /**< (RTC_SR) At least one time event has occurred since the last clear.  */
+#define RTC_SR_TIMEV_NO_TIMEVENT            (RTC_SR_TIMEV_NO_TIMEVENT_Val << RTC_SR_TIMEV_Pos)  /**< (RTC_SR) No time event has occurred since the last clear. Position  */
+#define RTC_SR_TIMEV_TIMEVENT               (RTC_SR_TIMEV_TIMEVENT_Val << RTC_SR_TIMEV_Pos)  /**< (RTC_SR) At least one time event has occurred since the last clear. Position  */
+#define RTC_SR_CALEV_Pos                    4                                              /**< (RTC_SR) Calendar Event Position */
+#define RTC_SR_CALEV_Msk                    (_U_(0x1) << RTC_SR_CALEV_Pos)                 /**< (RTC_SR) Calendar Event Mask */
+#define RTC_SR_CALEV                        RTC_SR_CALEV_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_CALEV_Msk instead */
+#define   RTC_SR_CALEV_NO_CALEVENT_Val      _U_(0x0)                                       /**< (RTC_SR) No calendar event has occurred since the last clear.  */
+#define   RTC_SR_CALEV_CALEVENT_Val         _U_(0x1)                                       /**< (RTC_SR) At least one calendar event has occurred since the last clear.  */
+#define RTC_SR_CALEV_NO_CALEVENT            (RTC_SR_CALEV_NO_CALEVENT_Val << RTC_SR_CALEV_Pos)  /**< (RTC_SR) No calendar event has occurred since the last clear. Position  */
+#define RTC_SR_CALEV_CALEVENT               (RTC_SR_CALEV_CALEVENT_Val << RTC_SR_CALEV_Pos)  /**< (RTC_SR) At least one calendar event has occurred since the last clear. Position  */
+#define RTC_SR_TDERR_Pos                    5                                              /**< (RTC_SR) Time and/or Date Free Running Error Position */
+#define RTC_SR_TDERR_Msk                    (_U_(0x1) << RTC_SR_TDERR_Pos)                 /**< (RTC_SR) Time and/or Date Free Running Error Mask */
+#define RTC_SR_TDERR                        RTC_SR_TDERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SR_TDERR_Msk instead */
+#define   RTC_SR_TDERR_CORRECT_Val          _U_(0x0)                                       /**< (RTC_SR) The internal free running counters are carrying valid values since the last read of the Status Register (RTC_SR).  */
+#define   RTC_SR_TDERR_ERR_TIMEDATE_Val     _U_(0x1)                                       /**< (RTC_SR) The internal free running counters have been corrupted (invalid date or time, non-BCD values) since the last read and/or they are still invalid.  */
+#define RTC_SR_TDERR_CORRECT                (RTC_SR_TDERR_CORRECT_Val << RTC_SR_TDERR_Pos)  /**< (RTC_SR) The internal free running counters are carrying valid values since the last read of the Status Register (RTC_SR). Position  */
+#define RTC_SR_TDERR_ERR_TIMEDATE           (RTC_SR_TDERR_ERR_TIMEDATE_Val << RTC_SR_TDERR_Pos)  /**< (RTC_SR) The internal free running counters have been corrupted (invalid date or time, non-BCD values) since the last read and/or they are still invalid. Position  */
+#define RTC_SR_MASK                         _U_(0x3F)                                      /**< \deprecated (RTC_SR) Register MASK  (Use RTC_SR_Msk instead)  */
+#define RTC_SR_Msk                          _U_(0x3F)                                      /**< (RTC_SR) Register Mask  */
+
+
+/* -------- RTC_SCCR : (RTC Offset: 0x1c) (/W 32) Status Clear Command Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKCLR:1;                  /**< bit:      0  Acknowledge Clear                        */
+    uint32_t ALRCLR:1;                  /**< bit:      1  Alarm Clear                              */
+    uint32_t SECCLR:1;                  /**< bit:      2  Second Clear                             */
+    uint32_t TIMCLR:1;                  /**< bit:      3  Time Clear                               */
+    uint32_t CALCLR:1;                  /**< bit:      4  Calendar Clear                           */
+    uint32_t TDERRCLR:1;                /**< bit:      5  Time and/or Date Free Running Error Clear */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_SCCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_SCCR_OFFSET                     (0x1C)                                        /**<  (RTC_SCCR) Status Clear Command Register  Offset */
+
+#define RTC_SCCR_ACKCLR_Pos                 0                                              /**< (RTC_SCCR) Acknowledge Clear Position */
+#define RTC_SCCR_ACKCLR_Msk                 (_U_(0x1) << RTC_SCCR_ACKCLR_Pos)              /**< (RTC_SCCR) Acknowledge Clear Mask */
+#define RTC_SCCR_ACKCLR                     RTC_SCCR_ACKCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_ACKCLR_Msk instead */
+#define RTC_SCCR_ALRCLR_Pos                 1                                              /**< (RTC_SCCR) Alarm Clear Position */
+#define RTC_SCCR_ALRCLR_Msk                 (_U_(0x1) << RTC_SCCR_ALRCLR_Pos)              /**< (RTC_SCCR) Alarm Clear Mask */
+#define RTC_SCCR_ALRCLR                     RTC_SCCR_ALRCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_ALRCLR_Msk instead */
+#define RTC_SCCR_SECCLR_Pos                 2                                              /**< (RTC_SCCR) Second Clear Position */
+#define RTC_SCCR_SECCLR_Msk                 (_U_(0x1) << RTC_SCCR_SECCLR_Pos)              /**< (RTC_SCCR) Second Clear Mask */
+#define RTC_SCCR_SECCLR                     RTC_SCCR_SECCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_SECCLR_Msk instead */
+#define RTC_SCCR_TIMCLR_Pos                 3                                              /**< (RTC_SCCR) Time Clear Position */
+#define RTC_SCCR_TIMCLR_Msk                 (_U_(0x1) << RTC_SCCR_TIMCLR_Pos)              /**< (RTC_SCCR) Time Clear Mask */
+#define RTC_SCCR_TIMCLR                     RTC_SCCR_TIMCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_TIMCLR_Msk instead */
+#define RTC_SCCR_CALCLR_Pos                 4                                              /**< (RTC_SCCR) Calendar Clear Position */
+#define RTC_SCCR_CALCLR_Msk                 (_U_(0x1) << RTC_SCCR_CALCLR_Pos)              /**< (RTC_SCCR) Calendar Clear Mask */
+#define RTC_SCCR_CALCLR                     RTC_SCCR_CALCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_CALCLR_Msk instead */
+#define RTC_SCCR_TDERRCLR_Pos               5                                              /**< (RTC_SCCR) Time and/or Date Free Running Error Clear Position */
+#define RTC_SCCR_TDERRCLR_Msk               (_U_(0x1) << RTC_SCCR_TDERRCLR_Pos)            /**< (RTC_SCCR) Time and/or Date Free Running Error Clear Mask */
+#define RTC_SCCR_TDERRCLR                   RTC_SCCR_TDERRCLR_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_SCCR_TDERRCLR_Msk instead */
+#define RTC_SCCR_MASK                       _U_(0x3F)                                      /**< \deprecated (RTC_SCCR) Register MASK  (Use RTC_SCCR_Msk instead)  */
+#define RTC_SCCR_Msk                        _U_(0x3F)                                      /**< (RTC_SCCR) Register Mask  */
+
+
+/* -------- RTC_IER : (RTC Offset: 0x20) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKEN:1;                   /**< bit:      0  Acknowledge Update Interrupt Enable      */
+    uint32_t ALREN:1;                   /**< bit:      1  Alarm Interrupt Enable                   */
+    uint32_t SECEN:1;                   /**< bit:      2  Second Event Interrupt Enable            */
+    uint32_t TIMEN:1;                   /**< bit:      3  Time Event Interrupt Enable              */
+    uint32_t CALEN:1;                   /**< bit:      4  Calendar Event Interrupt Enable          */
+    uint32_t TDERREN:1;                 /**< bit:      5  Time and/or Date Error Interrupt Enable  */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IER_OFFSET                      (0x20)                                        /**<  (RTC_IER) Interrupt Enable Register  Offset */
+
+#define RTC_IER_ACKEN_Pos                   0                                              /**< (RTC_IER) Acknowledge Update Interrupt Enable Position */
+#define RTC_IER_ACKEN_Msk                   (_U_(0x1) << RTC_IER_ACKEN_Pos)                /**< (RTC_IER) Acknowledge Update Interrupt Enable Mask */
+#define RTC_IER_ACKEN                       RTC_IER_ACKEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_ACKEN_Msk instead */
+#define RTC_IER_ALREN_Pos                   1                                              /**< (RTC_IER) Alarm Interrupt Enable Position */
+#define RTC_IER_ALREN_Msk                   (_U_(0x1) << RTC_IER_ALREN_Pos)                /**< (RTC_IER) Alarm Interrupt Enable Mask */
+#define RTC_IER_ALREN                       RTC_IER_ALREN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_ALREN_Msk instead */
+#define RTC_IER_SECEN_Pos                   2                                              /**< (RTC_IER) Second Event Interrupt Enable Position */
+#define RTC_IER_SECEN_Msk                   (_U_(0x1) << RTC_IER_SECEN_Pos)                /**< (RTC_IER) Second Event Interrupt Enable Mask */
+#define RTC_IER_SECEN                       RTC_IER_SECEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_SECEN_Msk instead */
+#define RTC_IER_TIMEN_Pos                   3                                              /**< (RTC_IER) Time Event Interrupt Enable Position */
+#define RTC_IER_TIMEN_Msk                   (_U_(0x1) << RTC_IER_TIMEN_Pos)                /**< (RTC_IER) Time Event Interrupt Enable Mask */
+#define RTC_IER_TIMEN                       RTC_IER_TIMEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_TIMEN_Msk instead */
+#define RTC_IER_CALEN_Pos                   4                                              /**< (RTC_IER) Calendar Event Interrupt Enable Position */
+#define RTC_IER_CALEN_Msk                   (_U_(0x1) << RTC_IER_CALEN_Pos)                /**< (RTC_IER) Calendar Event Interrupt Enable Mask */
+#define RTC_IER_CALEN                       RTC_IER_CALEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_CALEN_Msk instead */
+#define RTC_IER_TDERREN_Pos                 5                                              /**< (RTC_IER) Time and/or Date Error Interrupt Enable Position */
+#define RTC_IER_TDERREN_Msk                 (_U_(0x1) << RTC_IER_TDERREN_Pos)              /**< (RTC_IER) Time and/or Date Error Interrupt Enable Mask */
+#define RTC_IER_TDERREN                     RTC_IER_TDERREN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IER_TDERREN_Msk instead */
+#define RTC_IER_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IER) Register MASK  (Use RTC_IER_Msk instead)  */
+#define RTC_IER_Msk                         _U_(0x3F)                                      /**< (RTC_IER) Register Mask  */
+
+
+/* -------- RTC_IDR : (RTC Offset: 0x24) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACKDIS:1;                  /**< bit:      0  Acknowledge Update Interrupt Disable     */
+    uint32_t ALRDIS:1;                  /**< bit:      1  Alarm Interrupt Disable                  */
+    uint32_t SECDIS:1;                  /**< bit:      2  Second Event Interrupt Disable           */
+    uint32_t TIMDIS:1;                  /**< bit:      3  Time Event Interrupt Disable             */
+    uint32_t CALDIS:1;                  /**< bit:      4  Calendar Event Interrupt Disable         */
+    uint32_t TDERRDIS:1;                /**< bit:      5  Time and/or Date Error Interrupt Disable */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IDR_OFFSET                      (0x24)                                        /**<  (RTC_IDR) Interrupt Disable Register  Offset */
+
+#define RTC_IDR_ACKDIS_Pos                  0                                              /**< (RTC_IDR) Acknowledge Update Interrupt Disable Position */
+#define RTC_IDR_ACKDIS_Msk                  (_U_(0x1) << RTC_IDR_ACKDIS_Pos)               /**< (RTC_IDR) Acknowledge Update Interrupt Disable Mask */
+#define RTC_IDR_ACKDIS                      RTC_IDR_ACKDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_ACKDIS_Msk instead */
+#define RTC_IDR_ALRDIS_Pos                  1                                              /**< (RTC_IDR) Alarm Interrupt Disable Position */
+#define RTC_IDR_ALRDIS_Msk                  (_U_(0x1) << RTC_IDR_ALRDIS_Pos)               /**< (RTC_IDR) Alarm Interrupt Disable Mask */
+#define RTC_IDR_ALRDIS                      RTC_IDR_ALRDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_ALRDIS_Msk instead */
+#define RTC_IDR_SECDIS_Pos                  2                                              /**< (RTC_IDR) Second Event Interrupt Disable Position */
+#define RTC_IDR_SECDIS_Msk                  (_U_(0x1) << RTC_IDR_SECDIS_Pos)               /**< (RTC_IDR) Second Event Interrupt Disable Mask */
+#define RTC_IDR_SECDIS                      RTC_IDR_SECDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_SECDIS_Msk instead */
+#define RTC_IDR_TIMDIS_Pos                  3                                              /**< (RTC_IDR) Time Event Interrupt Disable Position */
+#define RTC_IDR_TIMDIS_Msk                  (_U_(0x1) << RTC_IDR_TIMDIS_Pos)               /**< (RTC_IDR) Time Event Interrupt Disable Mask */
+#define RTC_IDR_TIMDIS                      RTC_IDR_TIMDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_TIMDIS_Msk instead */
+#define RTC_IDR_CALDIS_Pos                  4                                              /**< (RTC_IDR) Calendar Event Interrupt Disable Position */
+#define RTC_IDR_CALDIS_Msk                  (_U_(0x1) << RTC_IDR_CALDIS_Pos)               /**< (RTC_IDR) Calendar Event Interrupt Disable Mask */
+#define RTC_IDR_CALDIS                      RTC_IDR_CALDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_CALDIS_Msk instead */
+#define RTC_IDR_TDERRDIS_Pos                5                                              /**< (RTC_IDR) Time and/or Date Error Interrupt Disable Position */
+#define RTC_IDR_TDERRDIS_Msk                (_U_(0x1) << RTC_IDR_TDERRDIS_Pos)             /**< (RTC_IDR) Time and/or Date Error Interrupt Disable Mask */
+#define RTC_IDR_TDERRDIS                    RTC_IDR_TDERRDIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IDR_TDERRDIS_Msk instead */
+#define RTC_IDR_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IDR) Register MASK  (Use RTC_IDR_Msk instead)  */
+#define RTC_IDR_Msk                         _U_(0x3F)                                      /**< (RTC_IDR) Register Mask  */
+
+
+/* -------- RTC_IMR : (RTC Offset: 0x28) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ACK:1;                     /**< bit:      0  Acknowledge Update Interrupt Mask        */
+    uint32_t ALR:1;                     /**< bit:      1  Alarm Interrupt Mask                     */
+    uint32_t SEC:1;                     /**< bit:      2  Second Event Interrupt Mask              */
+    uint32_t TIM:1;                     /**< bit:      3  Time Event Interrupt Mask                */
+    uint32_t CAL:1;                     /**< bit:      4  Calendar Event Interrupt Mask            */
+    uint32_t TDERR:1;                   /**< bit:      5  Time and/or Date Error Mask              */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_IMR_OFFSET                      (0x28)                                        /**<  (RTC_IMR) Interrupt Mask Register  Offset */
+
+#define RTC_IMR_ACK_Pos                     0                                              /**< (RTC_IMR) Acknowledge Update Interrupt Mask Position */
+#define RTC_IMR_ACK_Msk                     (_U_(0x1) << RTC_IMR_ACK_Pos)                  /**< (RTC_IMR) Acknowledge Update Interrupt Mask Mask */
+#define RTC_IMR_ACK                         RTC_IMR_ACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_ACK_Msk instead */
+#define RTC_IMR_ALR_Pos                     1                                              /**< (RTC_IMR) Alarm Interrupt Mask Position */
+#define RTC_IMR_ALR_Msk                     (_U_(0x1) << RTC_IMR_ALR_Pos)                  /**< (RTC_IMR) Alarm Interrupt Mask Mask */
+#define RTC_IMR_ALR                         RTC_IMR_ALR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_ALR_Msk instead */
+#define RTC_IMR_SEC_Pos                     2                                              /**< (RTC_IMR) Second Event Interrupt Mask Position */
+#define RTC_IMR_SEC_Msk                     (_U_(0x1) << RTC_IMR_SEC_Pos)                  /**< (RTC_IMR) Second Event Interrupt Mask Mask */
+#define RTC_IMR_SEC                         RTC_IMR_SEC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_SEC_Msk instead */
+#define RTC_IMR_TIM_Pos                     3                                              /**< (RTC_IMR) Time Event Interrupt Mask Position */
+#define RTC_IMR_TIM_Msk                     (_U_(0x1) << RTC_IMR_TIM_Pos)                  /**< (RTC_IMR) Time Event Interrupt Mask Mask */
+#define RTC_IMR_TIM                         RTC_IMR_TIM_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_TIM_Msk instead */
+#define RTC_IMR_CAL_Pos                     4                                              /**< (RTC_IMR) Calendar Event Interrupt Mask Position */
+#define RTC_IMR_CAL_Msk                     (_U_(0x1) << RTC_IMR_CAL_Pos)                  /**< (RTC_IMR) Calendar Event Interrupt Mask Mask */
+#define RTC_IMR_CAL                         RTC_IMR_CAL_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_CAL_Msk instead */
+#define RTC_IMR_TDERR_Pos                   5                                              /**< (RTC_IMR) Time and/or Date Error Mask Position */
+#define RTC_IMR_TDERR_Msk                   (_U_(0x1) << RTC_IMR_TDERR_Pos)                /**< (RTC_IMR) Time and/or Date Error Mask Mask */
+#define RTC_IMR_TDERR                       RTC_IMR_TDERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_IMR_TDERR_Msk instead */
+#define RTC_IMR_MASK                        _U_(0x3F)                                      /**< \deprecated (RTC_IMR) Register MASK  (Use RTC_IMR_Msk instead)  */
+#define RTC_IMR_Msk                         _U_(0x3F)                                      /**< (RTC_IMR) Register Mask  */
+
+
+/* -------- RTC_VER : (RTC Offset: 0x2c) (R/ 32) Valid Entry Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NVTIM:1;                   /**< bit:      0  Non-valid Time                           */
+    uint32_t NVCAL:1;                   /**< bit:      1  Non-valid Calendar                       */
+    uint32_t NVTIMALR:1;                /**< bit:      2  Non-valid Time Alarm                     */
+    uint32_t NVCALALR:1;                /**< bit:      3  Non-valid Calendar Alarm                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTC_VER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_VER_OFFSET                      (0x2C)                                        /**<  (RTC_VER) Valid Entry Register  Offset */
+
+#define RTC_VER_NVTIM_Pos                   0                                              /**< (RTC_VER) Non-valid Time Position */
+#define RTC_VER_NVTIM_Msk                   (_U_(0x1) << RTC_VER_NVTIM_Pos)                /**< (RTC_VER) Non-valid Time Mask */
+#define RTC_VER_NVTIM                       RTC_VER_NVTIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVTIM_Msk instead */
+#define RTC_VER_NVCAL_Pos                   1                                              /**< (RTC_VER) Non-valid Calendar Position */
+#define RTC_VER_NVCAL_Msk                   (_U_(0x1) << RTC_VER_NVCAL_Pos)                /**< (RTC_VER) Non-valid Calendar Mask */
+#define RTC_VER_NVCAL                       RTC_VER_NVCAL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVCAL_Msk instead */
+#define RTC_VER_NVTIMALR_Pos                2                                              /**< (RTC_VER) Non-valid Time Alarm Position */
+#define RTC_VER_NVTIMALR_Msk                (_U_(0x1) << RTC_VER_NVTIMALR_Pos)             /**< (RTC_VER) Non-valid Time Alarm Mask */
+#define RTC_VER_NVTIMALR                    RTC_VER_NVTIMALR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVTIMALR_Msk instead */
+#define RTC_VER_NVCALALR_Pos                3                                              /**< (RTC_VER) Non-valid Calendar Alarm Position */
+#define RTC_VER_NVCALALR_Msk                (_U_(0x1) << RTC_VER_NVCALALR_Pos)             /**< (RTC_VER) Non-valid Calendar Alarm Mask */
+#define RTC_VER_NVCALALR                    RTC_VER_NVCALALR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_VER_NVCALALR_Msk instead */
+#define RTC_VER_MASK                        _U_(0x0F)                                      /**< \deprecated (RTC_VER) Register MASK  (Use RTC_VER_Msk instead)  */
+#define RTC_VER_Msk                         _U_(0x0F)                                      /**< (RTC_VER) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RTC hardware registers */
+typedef struct {  
+  __IO uint32_t RTC_CR;         /**< (RTC Offset: 0x00) Control Register */
+  __IO uint32_t RTC_MR;         /**< (RTC Offset: 0x04) Mode Register */
+  __IO uint32_t RTC_TIMR;       /**< (RTC Offset: 0x08) Time Register */
+  __IO uint32_t RTC_CALR;       /**< (RTC Offset: 0x0C) Calendar Register */
+  __IO uint32_t RTC_TIMALR;     /**< (RTC Offset: 0x10) Time Alarm Register */
+  __IO uint32_t RTC_CALALR;     /**< (RTC Offset: 0x14) Calendar Alarm Register */
+  __I  uint32_t RTC_SR;         /**< (RTC Offset: 0x18) Status Register */
+  __O  uint32_t RTC_SCCR;       /**< (RTC Offset: 0x1C) Status Clear Command Register */
+  __O  uint32_t RTC_IER;        /**< (RTC Offset: 0x20) Interrupt Enable Register */
+  __O  uint32_t RTC_IDR;        /**< (RTC Offset: 0x24) Interrupt Disable Register */
+  __I  uint32_t RTC_IMR;        /**< (RTC Offset: 0x28) Interrupt Mask Register */
+  __I  uint32_t RTC_VER;        /**< (RTC Offset: 0x2C) Valid Entry Register */
+} Rtc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RTC hardware registers */
+typedef struct {  
+  __IO RTC_CR_Type                    RTC_CR;         /**< Offset: 0x00 (R/W  32) Control Register */
+  __IO RTC_MR_Type                    RTC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __IO RTC_TIMR_Type                  RTC_TIMR;       /**< Offset: 0x08 (R/W  32) Time Register */
+  __IO RTC_CALR_Type                  RTC_CALR;       /**< Offset: 0x0C (R/W  32) Calendar Register */
+  __IO RTC_TIMALR_Type                RTC_TIMALR;     /**< Offset: 0x10 (R/W  32) Time Alarm Register */
+  __IO RTC_CALALR_Type                RTC_CALALR;     /**< Offset: 0x14 (R/W  32) Calendar Alarm Register */
+  __I  RTC_SR_Type                    RTC_SR;         /**< Offset: 0x18 (R/   32) Status Register */
+  __O  RTC_SCCR_Type                  RTC_SCCR;       /**< Offset: 0x1C ( /W  32) Status Clear Command Register */
+  __O  RTC_IER_Type                   RTC_IER;        /**< Offset: 0x20 ( /W  32) Interrupt Enable Register */
+  __O  RTC_IDR_Type                   RTC_IDR;        /**< Offset: 0x24 ( /W  32) Interrupt Disable Register */
+  __I  RTC_IMR_Type                   RTC_IMR;        /**< Offset: 0x28 (R/   32) Interrupt Mask Register */
+  __I  RTC_VER_Type                   RTC_VER;        /**< Offset: 0x2C (R/   32) Valid Entry Register */
+} Rtc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-time Clock */
+
+#endif /* _SAMV71_RTC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/rtt.h
+++ b/asf/sam/include/samv71b/component/rtt.h
@@ -1,0 +1,186 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RTT_COMPONENT_H_
+#define _SAMV71_RTT_COMPONENT_H_
+#define _SAMV71_RTT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Real-time Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define RTT_6081                       /**< (RTT) Module ID */
+#define REV_RTT M                      /**< (RTT) Module revision */
+
+/* -------- RTT_MR : (RTT Offset: 0x00) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RTPRES:16;                 /**< bit:  0..15  Real-time Timer Prescaler Value          */
+    uint32_t ALMIEN:1;                  /**< bit:     16  Alarm Interrupt Enable                   */
+    uint32_t RTTINCIEN:1;               /**< bit:     17  Real-time Timer Increment Interrupt Enable */
+    uint32_t RTTRST:1;                  /**< bit:     18  Real-time Timer Restart                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t RTTDIS:1;                  /**< bit:     20  Real-time Timer Disable                  */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t RTC1HZ:1;                  /**< bit:     24  Real-Time Clock 1Hz Clock Selection      */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_MR_OFFSET                       (0x00)                                        /**<  (RTT_MR) Mode Register  Offset */
+
+#define RTT_MR_RTPRES_Pos                   0                                              /**< (RTT_MR) Real-time Timer Prescaler Value Position */
+#define RTT_MR_RTPRES_Msk                   (_U_(0xFFFF) << RTT_MR_RTPRES_Pos)             /**< (RTT_MR) Real-time Timer Prescaler Value Mask */
+#define RTT_MR_RTPRES(value)                (RTT_MR_RTPRES_Msk & ((value) << RTT_MR_RTPRES_Pos))
+#define RTT_MR_ALMIEN_Pos                   16                                             /**< (RTT_MR) Alarm Interrupt Enable Position */
+#define RTT_MR_ALMIEN_Msk                   (_U_(0x1) << RTT_MR_ALMIEN_Pos)                /**< (RTT_MR) Alarm Interrupt Enable Mask */
+#define RTT_MR_ALMIEN                       RTT_MR_ALMIEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_ALMIEN_Msk instead */
+#define RTT_MR_RTTINCIEN_Pos                17                                             /**< (RTT_MR) Real-time Timer Increment Interrupt Enable Position */
+#define RTT_MR_RTTINCIEN_Msk                (_U_(0x1) << RTT_MR_RTTINCIEN_Pos)             /**< (RTT_MR) Real-time Timer Increment Interrupt Enable Mask */
+#define RTT_MR_RTTINCIEN                    RTT_MR_RTTINCIEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTINCIEN_Msk instead */
+#define RTT_MR_RTTRST_Pos                   18                                             /**< (RTT_MR) Real-time Timer Restart Position */
+#define RTT_MR_RTTRST_Msk                   (_U_(0x1) << RTT_MR_RTTRST_Pos)                /**< (RTT_MR) Real-time Timer Restart Mask */
+#define RTT_MR_RTTRST                       RTT_MR_RTTRST_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTRST_Msk instead */
+#define RTT_MR_RTTDIS_Pos                   20                                             /**< (RTT_MR) Real-time Timer Disable Position */
+#define RTT_MR_RTTDIS_Msk                   (_U_(0x1) << RTT_MR_RTTDIS_Pos)                /**< (RTT_MR) Real-time Timer Disable Mask */
+#define RTT_MR_RTTDIS                       RTT_MR_RTTDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTTDIS_Msk instead */
+#define RTT_MR_RTC1HZ_Pos                   24                                             /**< (RTT_MR) Real-Time Clock 1Hz Clock Selection Position */
+#define RTT_MR_RTC1HZ_Msk                   (_U_(0x1) << RTT_MR_RTC1HZ_Pos)                /**< (RTT_MR) Real-Time Clock 1Hz Clock Selection Mask */
+#define RTT_MR_RTC1HZ                       RTT_MR_RTC1HZ_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_MR_RTC1HZ_Msk instead */
+#define RTT_MR_MASK                         _U_(0x117FFFF)                                 /**< \deprecated (RTT_MR) Register MASK  (Use RTT_MR_Msk instead)  */
+#define RTT_MR_Msk                          _U_(0x117FFFF)                                 /**< (RTT_MR) Register Mask  */
+
+
+/* -------- RTT_AR : (RTT Offset: 0x04) (R/W 32) Alarm Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ALMV:32;                   /**< bit:  0..31  Alarm Value                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_AR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_AR_OFFSET                       (0x04)                                        /**<  (RTT_AR) Alarm Register  Offset */
+
+#define RTT_AR_ALMV_Pos                     0                                              /**< (RTT_AR) Alarm Value Position */
+#define RTT_AR_ALMV_Msk                     (_U_(0xFFFFFFFF) << RTT_AR_ALMV_Pos)           /**< (RTT_AR) Alarm Value Mask */
+#define RTT_AR_ALMV(value)                  (RTT_AR_ALMV_Msk & ((value) << RTT_AR_ALMV_Pos))
+#define RTT_AR_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTT_AR) Register MASK  (Use RTT_AR_Msk instead)  */
+#define RTT_AR_Msk                          _U_(0xFFFFFFFF)                                /**< (RTT_AR) Register Mask  */
+
+
+/* -------- RTT_VR : (RTT Offset: 0x08) (R/ 32) Value Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CRTV:32;                   /**< bit:  0..31  Current Real-time Value                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_VR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_VR_OFFSET                       (0x08)                                        /**<  (RTT_VR) Value Register  Offset */
+
+#define RTT_VR_CRTV_Pos                     0                                              /**< (RTT_VR) Current Real-time Value Position */
+#define RTT_VR_CRTV_Msk                     (_U_(0xFFFFFFFF) << RTT_VR_CRTV_Pos)           /**< (RTT_VR) Current Real-time Value Mask */
+#define RTT_VR_CRTV(value)                  (RTT_VR_CRTV_Msk & ((value) << RTT_VR_CRTV_Pos))
+#define RTT_VR_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (RTT_VR) Register MASK  (Use RTT_VR_Msk instead)  */
+#define RTT_VR_Msk                          _U_(0xFFFFFFFF)                                /**< (RTT_VR) Register Mask  */
+
+
+/* -------- RTT_SR : (RTT Offset: 0x0c) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ALMS:1;                    /**< bit:      0  Real-time Alarm Status (cleared on read) */
+    uint32_t RTTINC:1;                  /**< bit:      1  Prescaler Roll-over Status (cleared on read) */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} RTT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTT_SR_OFFSET                       (0x0C)                                        /**<  (RTT_SR) Status Register  Offset */
+
+#define RTT_SR_ALMS_Pos                     0                                              /**< (RTT_SR) Real-time Alarm Status (cleared on read) Position */
+#define RTT_SR_ALMS_Msk                     (_U_(0x1) << RTT_SR_ALMS_Pos)                  /**< (RTT_SR) Real-time Alarm Status (cleared on read) Mask */
+#define RTT_SR_ALMS                         RTT_SR_ALMS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_SR_ALMS_Msk instead */
+#define RTT_SR_RTTINC_Pos                   1                                              /**< (RTT_SR) Prescaler Roll-over Status (cleared on read) Position */
+#define RTT_SR_RTTINC_Msk                   (_U_(0x1) << RTT_SR_RTTINC_Pos)                /**< (RTT_SR) Prescaler Roll-over Status (cleared on read) Mask */
+#define RTT_SR_RTTINC                       RTT_SR_RTTINC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTT_SR_RTTINC_Msk instead */
+#define RTT_SR_MASK                         _U_(0x03)                                      /**< \deprecated (RTT_SR) Register MASK  (Use RTT_SR_Msk instead)  */
+#define RTT_SR_Msk                          _U_(0x03)                                      /**< (RTT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief RTT hardware registers */
+typedef struct {  
+  __IO uint32_t RTT_MR;         /**< (RTT Offset: 0x00) Mode Register */
+  __IO uint32_t RTT_AR;         /**< (RTT Offset: 0x04) Alarm Register */
+  __I  uint32_t RTT_VR;         /**< (RTT Offset: 0x08) Value Register */
+  __I  uint32_t RTT_SR;         /**< (RTT Offset: 0x0C) Status Register */
+} Rtt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief RTT hardware registers */
+typedef struct {  
+  __IO RTT_MR_Type                    RTT_MR;         /**< Offset: 0x00 (R/W  32) Mode Register */
+  __IO RTT_AR_Type                    RTT_AR;         /**< Offset: 0x04 (R/W  32) Alarm Register */
+  __I  RTT_VR_Type                    RTT_VR;         /**< Offset: 0x08 (R/   32) Value Register */
+  __I  RTT_SR_Type                    RTT_SR;         /**< Offset: 0x0C (R/   32) Status Register */
+} Rtt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Real-time Timer */
+
+#endif /* _SAMV71_RTT_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/sdramc.h
+++ b/asf/sam/include/samv71b/component/sdramc.h
@@ -1,0 +1,500 @@
+/**
+ * \file
+ *
+ * \brief Component description for SDRAMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SDRAMC_COMPONENT_H_
+#define _SAMV71_SDRAMC_COMPONENT_H_
+#define _SAMV71_SDRAMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 SDRAM Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SDRAMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SDRAMC_6100                       /**< (SDRAMC) Module ID */
+#define REV_SDRAMC U                      /**< (SDRAMC) Module revision */
+
+/* -------- SDRAMC_MR : (SDRAMC Offset: 0x00) (R/W 32) SDRAMC Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MODE:3;                    /**< bit:   0..2  SDRAMC Command Mode                      */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_MR_OFFSET                    (0x00)                                        /**<  (SDRAMC_MR) SDRAMC Mode Register  Offset */
+
+#define SDRAMC_MR_MODE_Pos                  0                                              /**< (SDRAMC_MR) SDRAMC Command Mode Position */
+#define SDRAMC_MR_MODE_Msk                  (_U_(0x7) << SDRAMC_MR_MODE_Pos)               /**< (SDRAMC_MR) SDRAMC Command Mode Mask */
+#define SDRAMC_MR_MODE(value)               (SDRAMC_MR_MODE_Msk & ((value) << SDRAMC_MR_MODE_Pos))
+#define   SDRAMC_MR_MODE_NORMAL_Val         _U_(0x0)                                       /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_NOP_Val            _U_(0x1)                                       /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val _U_(0x2)                                       /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_LOAD_MODEREG_Val   _U_(0x3)                                       /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_AUTO_REFRESH_Val   _U_(0x4)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val _U_(0x5)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1.  */
+#define   SDRAMC_MR_MODE_DEEP_POWERDOWN_Val _U_(0x6)                                       /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode.  */
+#define SDRAMC_MR_MODE_NORMAL               (SDRAMC_MR_MODE_NORMAL_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_NOP                  (SDRAMC_MR_MODE_NOP_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_ALLBANKS_PRECHARGE   (SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_LOAD_MODEREG         (SDRAMC_MR_MODE_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_AUTO_REFRESH         (SDRAMC_MR_MODE_AUTO_REFRESH_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_EXT_LOAD_MODEREG     (SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1. Position  */
+#define SDRAMC_MR_MODE_DEEP_POWERDOWN       (SDRAMC_MR_MODE_DEEP_POWERDOWN_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode. Position  */
+#define SDRAMC_MR_MASK                      _U_(0x07)                                      /**< \deprecated (SDRAMC_MR) Register MASK  (Use SDRAMC_MR_Msk instead)  */
+#define SDRAMC_MR_Msk                       _U_(0x07)                                      /**< (SDRAMC_MR) Register Mask  */
+
+
+/* -------- SDRAMC_TR : (SDRAMC Offset: 0x04) (R/W 32) SDRAMC Refresh Timer Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COUNT:12;                  /**< bit:  0..11  SDRAMC Refresh Timer Count               */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_TR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_TR_OFFSET                    (0x04)                                        /**<  (SDRAMC_TR) SDRAMC Refresh Timer Register  Offset */
+
+#define SDRAMC_TR_COUNT_Pos                 0                                              /**< (SDRAMC_TR) SDRAMC Refresh Timer Count Position */
+#define SDRAMC_TR_COUNT_Msk                 (_U_(0xFFF) << SDRAMC_TR_COUNT_Pos)            /**< (SDRAMC_TR) SDRAMC Refresh Timer Count Mask */
+#define SDRAMC_TR_COUNT(value)              (SDRAMC_TR_COUNT_Msk & ((value) << SDRAMC_TR_COUNT_Pos))
+#define SDRAMC_TR_MASK                      _U_(0xFFF)                                     /**< \deprecated (SDRAMC_TR) Register MASK  (Use SDRAMC_TR_Msk instead)  */
+#define SDRAMC_TR_Msk                       _U_(0xFFF)                                     /**< (SDRAMC_TR) Register Mask  */
+
+
+/* -------- SDRAMC_CR : (SDRAMC Offset: 0x08) (R/W 32) SDRAMC Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NC:2;                      /**< bit:   0..1  Number of Column Bits                    */
+    uint32_t NR:2;                      /**< bit:   2..3  Number of Row Bits                       */
+    uint32_t NB:1;                      /**< bit:      4  Number of Banks                          */
+    uint32_t CAS:2;                     /**< bit:   5..6  CAS Latency                              */
+    uint32_t DBW:1;                     /**< bit:      7  Data Bus Width                           */
+    uint32_t TWR:4;                     /**< bit:  8..11  Write Recovery Delay                     */
+    uint32_t TRC_TRFC:4;                /**< bit: 12..15  Row Cycle Delay and Row Refresh Cycle    */
+    uint32_t TRP:4;                     /**< bit: 16..19  Row Precharge Delay                      */
+    uint32_t TRCD:4;                    /**< bit: 20..23  Row to Column Delay                      */
+    uint32_t TRAS:4;                    /**< bit: 24..27  Active to Precharge Delay                */
+    uint32_t TXSR:4;                    /**< bit: 28..31  Exit Self-Refresh to Active Delay        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_CR_OFFSET                    (0x08)                                        /**<  (SDRAMC_CR) SDRAMC Configuration Register  Offset */
+
+#define SDRAMC_CR_NC_Pos                    0                                              /**< (SDRAMC_CR) Number of Column Bits Position */
+#define SDRAMC_CR_NC_Msk                    (_U_(0x3) << SDRAMC_CR_NC_Pos)                 /**< (SDRAMC_CR) Number of Column Bits Mask */
+#define SDRAMC_CR_NC(value)                 (SDRAMC_CR_NC_Msk & ((value) << SDRAMC_CR_NC_Pos))
+#define   SDRAMC_CR_NC_COL8_Val             _U_(0x0)                                       /**< (SDRAMC_CR) 8 column bits  */
+#define   SDRAMC_CR_NC_COL9_Val             _U_(0x1)                                       /**< (SDRAMC_CR) 9 column bits  */
+#define   SDRAMC_CR_NC_COL10_Val            _U_(0x2)                                       /**< (SDRAMC_CR) 10 column bits  */
+#define   SDRAMC_CR_NC_COL11_Val            _U_(0x3)                                       /**< (SDRAMC_CR) 11 column bits  */
+#define SDRAMC_CR_NC_COL8                   (SDRAMC_CR_NC_COL8_Val << SDRAMC_CR_NC_Pos)    /**< (SDRAMC_CR) 8 column bits Position  */
+#define SDRAMC_CR_NC_COL9                   (SDRAMC_CR_NC_COL9_Val << SDRAMC_CR_NC_Pos)    /**< (SDRAMC_CR) 9 column bits Position  */
+#define SDRAMC_CR_NC_COL10                  (SDRAMC_CR_NC_COL10_Val << SDRAMC_CR_NC_Pos)   /**< (SDRAMC_CR) 10 column bits Position  */
+#define SDRAMC_CR_NC_COL11                  (SDRAMC_CR_NC_COL11_Val << SDRAMC_CR_NC_Pos)   /**< (SDRAMC_CR) 11 column bits Position  */
+#define SDRAMC_CR_NR_Pos                    2                                              /**< (SDRAMC_CR) Number of Row Bits Position */
+#define SDRAMC_CR_NR_Msk                    (_U_(0x3) << SDRAMC_CR_NR_Pos)                 /**< (SDRAMC_CR) Number of Row Bits Mask */
+#define SDRAMC_CR_NR(value)                 (SDRAMC_CR_NR_Msk & ((value) << SDRAMC_CR_NR_Pos))
+#define   SDRAMC_CR_NR_ROW11_Val            _U_(0x0)                                       /**< (SDRAMC_CR) 11 row bits  */
+#define   SDRAMC_CR_NR_ROW12_Val            _U_(0x1)                                       /**< (SDRAMC_CR) 12 row bits  */
+#define   SDRAMC_CR_NR_ROW13_Val            _U_(0x2)                                       /**< (SDRAMC_CR) 13 row bits  */
+#define SDRAMC_CR_NR_ROW11                  (SDRAMC_CR_NR_ROW11_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 11 row bits Position  */
+#define SDRAMC_CR_NR_ROW12                  (SDRAMC_CR_NR_ROW12_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 12 row bits Position  */
+#define SDRAMC_CR_NR_ROW13                  (SDRAMC_CR_NR_ROW13_Val << SDRAMC_CR_NR_Pos)   /**< (SDRAMC_CR) 13 row bits Position  */
+#define SDRAMC_CR_NB_Pos                    4                                              /**< (SDRAMC_CR) Number of Banks Position */
+#define SDRAMC_CR_NB_Msk                    (_U_(0x1) << SDRAMC_CR_NB_Pos)                 /**< (SDRAMC_CR) Number of Banks Mask */
+#define SDRAMC_CR_NB                        SDRAMC_CR_NB_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CR_NB_Msk instead */
+#define   SDRAMC_CR_NB_BANK2_Val            _U_(0x0)                                       /**< (SDRAMC_CR) 2 banks  */
+#define   SDRAMC_CR_NB_BANK4_Val            _U_(0x1)                                       /**< (SDRAMC_CR) 4 banks  */
+#define SDRAMC_CR_NB_BANK2                  (SDRAMC_CR_NB_BANK2_Val << SDRAMC_CR_NB_Pos)   /**< (SDRAMC_CR) 2 banks Position  */
+#define SDRAMC_CR_NB_BANK4                  (SDRAMC_CR_NB_BANK4_Val << SDRAMC_CR_NB_Pos)   /**< (SDRAMC_CR) 4 banks Position  */
+#define SDRAMC_CR_CAS_Pos                   5                                              /**< (SDRAMC_CR) CAS Latency Position */
+#define SDRAMC_CR_CAS_Msk                   (_U_(0x3) << SDRAMC_CR_CAS_Pos)                /**< (SDRAMC_CR) CAS Latency Mask */
+#define SDRAMC_CR_CAS(value)                (SDRAMC_CR_CAS_Msk & ((value) << SDRAMC_CR_CAS_Pos))
+#define   SDRAMC_CR_CAS_LATENCY1_Val        _U_(0x1)                                       /**< (SDRAMC_CR) 1 cycle CAS latency  */
+#define   SDRAMC_CR_CAS_LATENCY2_Val        _U_(0x2)                                       /**< (SDRAMC_CR) 2 cycle CAS latency  */
+#define   SDRAMC_CR_CAS_LATENCY3_Val        _U_(0x3)                                       /**< (SDRAMC_CR) 3 cycle CAS latency  */
+#define SDRAMC_CR_CAS_LATENCY1              (SDRAMC_CR_CAS_LATENCY1_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 1 cycle CAS latency Position  */
+#define SDRAMC_CR_CAS_LATENCY2              (SDRAMC_CR_CAS_LATENCY2_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 2 cycle CAS latency Position  */
+#define SDRAMC_CR_CAS_LATENCY3              (SDRAMC_CR_CAS_LATENCY3_Val << SDRAMC_CR_CAS_Pos)  /**< (SDRAMC_CR) 3 cycle CAS latency Position  */
+#define SDRAMC_CR_DBW_Pos                   7                                              /**< (SDRAMC_CR) Data Bus Width Position */
+#define SDRAMC_CR_DBW_Msk                   (_U_(0x1) << SDRAMC_CR_DBW_Pos)                /**< (SDRAMC_CR) Data Bus Width Mask */
+#define SDRAMC_CR_DBW                       SDRAMC_CR_DBW_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CR_DBW_Msk instead */
+#define SDRAMC_CR_TWR_Pos                   8                                              /**< (SDRAMC_CR) Write Recovery Delay Position */
+#define SDRAMC_CR_TWR_Msk                   (_U_(0xF) << SDRAMC_CR_TWR_Pos)                /**< (SDRAMC_CR) Write Recovery Delay Mask */
+#define SDRAMC_CR_TWR(value)                (SDRAMC_CR_TWR_Msk & ((value) << SDRAMC_CR_TWR_Pos))
+#define SDRAMC_CR_TRC_TRFC_Pos              12                                             /**< (SDRAMC_CR) Row Cycle Delay and Row Refresh Cycle Position */
+#define SDRAMC_CR_TRC_TRFC_Msk              (_U_(0xF) << SDRAMC_CR_TRC_TRFC_Pos)           /**< (SDRAMC_CR) Row Cycle Delay and Row Refresh Cycle Mask */
+#define SDRAMC_CR_TRC_TRFC(value)           (SDRAMC_CR_TRC_TRFC_Msk & ((value) << SDRAMC_CR_TRC_TRFC_Pos))
+#define SDRAMC_CR_TRP_Pos                   16                                             /**< (SDRAMC_CR) Row Precharge Delay Position */
+#define SDRAMC_CR_TRP_Msk                   (_U_(0xF) << SDRAMC_CR_TRP_Pos)                /**< (SDRAMC_CR) Row Precharge Delay Mask */
+#define SDRAMC_CR_TRP(value)                (SDRAMC_CR_TRP_Msk & ((value) << SDRAMC_CR_TRP_Pos))
+#define SDRAMC_CR_TRCD_Pos                  20                                             /**< (SDRAMC_CR) Row to Column Delay Position */
+#define SDRAMC_CR_TRCD_Msk                  (_U_(0xF) << SDRAMC_CR_TRCD_Pos)               /**< (SDRAMC_CR) Row to Column Delay Mask */
+#define SDRAMC_CR_TRCD(value)               (SDRAMC_CR_TRCD_Msk & ((value) << SDRAMC_CR_TRCD_Pos))
+#define SDRAMC_CR_TRAS_Pos                  24                                             /**< (SDRAMC_CR) Active to Precharge Delay Position */
+#define SDRAMC_CR_TRAS_Msk                  (_U_(0xF) << SDRAMC_CR_TRAS_Pos)               /**< (SDRAMC_CR) Active to Precharge Delay Mask */
+#define SDRAMC_CR_TRAS(value)               (SDRAMC_CR_TRAS_Msk & ((value) << SDRAMC_CR_TRAS_Pos))
+#define SDRAMC_CR_TXSR_Pos                  28                                             /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Position */
+#define SDRAMC_CR_TXSR_Msk                  (_U_(0xF) << SDRAMC_CR_TXSR_Pos)               /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Mask */
+#define SDRAMC_CR_TXSR(value)               (SDRAMC_CR_TXSR_Msk & ((value) << SDRAMC_CR_TXSR_Pos))
+#define SDRAMC_CR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_CR) Register MASK  (Use SDRAMC_CR_Msk instead)  */
+#define SDRAMC_CR_Msk                       _U_(0xFFFFFFFF)                                /**< (SDRAMC_CR) Register Mask  */
+
+
+/* -------- SDRAMC_LPR : (SDRAMC Offset: 0x10) (R/W 32) SDRAMC Low Power Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LPCB:2;                    /**< bit:   0..1  Low-power Configuration Bits             */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t PASR:3;                    /**< bit:   4..6  Partial Array Self-refresh (only for low-power SDRAM) */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t TCSR:2;                    /**< bit:   8..9  Temperature Compensated Self-Refresh (only for low-power SDRAM) */
+    uint32_t DS:2;                      /**< bit: 10..11  Drive Strength (only for low-power SDRAM) */
+    uint32_t TIMEOUT:2;                 /**< bit: 12..13  Time to Define When Low-power Mode Is Enabled */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_LPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_LPR_OFFSET                   (0x10)                                        /**<  (SDRAMC_LPR) SDRAMC Low Power Register  Offset */
+
+#define SDRAMC_LPR_LPCB_Pos                 0                                              /**< (SDRAMC_LPR) Low-power Configuration Bits Position */
+#define SDRAMC_LPR_LPCB_Msk                 (_U_(0x3) << SDRAMC_LPR_LPCB_Pos)              /**< (SDRAMC_LPR) Low-power Configuration Bits Mask */
+#define SDRAMC_LPR_LPCB(value)              (SDRAMC_LPR_LPCB_Msk & ((value) << SDRAMC_LPR_LPCB_Pos))
+#define   SDRAMC_LPR_LPCB_DISABLED_Val      _U_(0x0)                                       /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device.  */
+#define   SDRAMC_LPR_LPCB_SELF_REFRESH_Val  _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_POWER_DOWN_Val    _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val _U_(0x3)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM.  */
+#define SDRAMC_LPR_LPCB_DISABLED            (SDRAMC_LPR_LPCB_DISABLED_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device. Position  */
+#define SDRAMC_LPR_LPCB_SELF_REFRESH        (SDRAMC_LPR_LPCB_SELF_REFRESH_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_POWER_DOWN          (SDRAMC_LPR_LPCB_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_DEEP_POWER_DOWN     (SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM. Position  */
+#define SDRAMC_LPR_PASR_Pos                 4                                              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_PASR_Msk                 (_U_(0x7) << SDRAMC_LPR_PASR_Pos)              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_PASR(value)              (SDRAMC_LPR_PASR_Msk & ((value) << SDRAMC_LPR_PASR_Pos))
+#define SDRAMC_LPR_TCSR_Pos                 8                                              /**< (SDRAMC_LPR) Temperature Compensated Self-Refresh (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_TCSR_Msk                 (_U_(0x3) << SDRAMC_LPR_TCSR_Pos)              /**< (SDRAMC_LPR) Temperature Compensated Self-Refresh (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_TCSR(value)              (SDRAMC_LPR_TCSR_Msk & ((value) << SDRAMC_LPR_TCSR_Pos))
+#define SDRAMC_LPR_DS_Pos                   10                                             /**< (SDRAMC_LPR) Drive Strength (only for low-power SDRAM) Position */
+#define SDRAMC_LPR_DS_Msk                   (_U_(0x3) << SDRAMC_LPR_DS_Pos)                /**< (SDRAMC_LPR) Drive Strength (only for low-power SDRAM) Mask */
+#define SDRAMC_LPR_DS(value)                (SDRAMC_LPR_DS_Msk & ((value) << SDRAMC_LPR_DS_Pos))
+#define SDRAMC_LPR_TIMEOUT_Pos              12                                             /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Position */
+#define SDRAMC_LPR_TIMEOUT_Msk              (_U_(0x3) << SDRAMC_LPR_TIMEOUT_Pos)           /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Mask */
+#define SDRAMC_LPR_TIMEOUT(value)           (SDRAMC_LPR_TIMEOUT_Msk & ((value) << SDRAMC_LPR_TIMEOUT_Pos))
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val _U_(0x0)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer.  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER     (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64  (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128 (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer. Position  */
+#define SDRAMC_LPR_MASK                     _U_(0x3F73)                                    /**< \deprecated (SDRAMC_LPR) Register MASK  (Use SDRAMC_LPR_Msk instead)  */
+#define SDRAMC_LPR_Msk                      _U_(0x3F73)                                    /**< (SDRAMC_LPR) Register Mask  */
+
+
+/* -------- SDRAMC_IER : (SDRAMC Offset: 0x14) (/W 32) SDRAMC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Enable           */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IER_OFFSET                   (0x14)                                        /**<  (SDRAMC_IER) SDRAMC Interrupt Enable Register  Offset */
+
+#define SDRAMC_IER_RES_Pos                  0                                              /**< (SDRAMC_IER) Refresh Error Interrupt Enable Position */
+#define SDRAMC_IER_RES_Msk                  (_U_(0x1) << SDRAMC_IER_RES_Pos)               /**< (SDRAMC_IER) Refresh Error Interrupt Enable Mask */
+#define SDRAMC_IER_RES                      SDRAMC_IER_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IER_RES_Msk instead */
+#define SDRAMC_IER_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IER) Register MASK  (Use SDRAMC_IER_Msk instead)  */
+#define SDRAMC_IER_Msk                      _U_(0x01)                                      /**< (SDRAMC_IER) Register Mask  */
+
+
+/* -------- SDRAMC_IDR : (SDRAMC Offset: 0x18) (/W 32) SDRAMC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Disable          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IDR_OFFSET                   (0x18)                                        /**<  (SDRAMC_IDR) SDRAMC Interrupt Disable Register  Offset */
+
+#define SDRAMC_IDR_RES_Pos                  0                                              /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Position */
+#define SDRAMC_IDR_RES_Msk                  (_U_(0x1) << SDRAMC_IDR_RES_Pos)               /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Mask */
+#define SDRAMC_IDR_RES                      SDRAMC_IDR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IDR_RES_Msk instead */
+#define SDRAMC_IDR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IDR) Register MASK  (Use SDRAMC_IDR_Msk instead)  */
+#define SDRAMC_IDR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IDR) Register Mask  */
+
+
+/* -------- SDRAMC_IMR : (SDRAMC Offset: 0x1c) (R/ 32) SDRAMC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Mask             */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_IMR_OFFSET                   (0x1C)                                        /**<  (SDRAMC_IMR) SDRAMC Interrupt Mask Register  Offset */
+
+#define SDRAMC_IMR_RES_Pos                  0                                              /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Position */
+#define SDRAMC_IMR_RES_Msk                  (_U_(0x1) << SDRAMC_IMR_RES_Pos)               /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Mask */
+#define SDRAMC_IMR_RES                      SDRAMC_IMR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IMR_RES_Msk instead */
+#define SDRAMC_IMR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IMR) Register MASK  (Use SDRAMC_IMR_Msk instead)  */
+#define SDRAMC_IMR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IMR) Register Mask  */
+
+
+/* -------- SDRAMC_ISR : (SDRAMC Offset: 0x20) (R/ 32) SDRAMC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Status (cleared on read)   */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_ISR_OFFSET                   (0x20)                                        /**<  (SDRAMC_ISR) SDRAMC Interrupt Status Register  Offset */
+
+#define SDRAMC_ISR_RES_Pos                  0                                              /**< (SDRAMC_ISR) Refresh Error Status (cleared on read) Position */
+#define SDRAMC_ISR_RES_Msk                  (_U_(0x1) << SDRAMC_ISR_RES_Pos)               /**< (SDRAMC_ISR) Refresh Error Status (cleared on read) Mask */
+#define SDRAMC_ISR_RES                      SDRAMC_ISR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_ISR_RES_Msk instead */
+#define SDRAMC_ISR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_ISR) Register MASK  (Use SDRAMC_ISR_Msk instead)  */
+#define SDRAMC_ISR_Msk                      _U_(0x01)                                      /**< (SDRAMC_ISR) Register Mask  */
+
+
+/* -------- SDRAMC_MDR : (SDRAMC Offset: 0x24) (R/W 32) SDRAMC Memory Device Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MD:2;                      /**< bit:   0..1  Memory Device Type                       */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_MDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_MDR_OFFSET                   (0x24)                                        /**<  (SDRAMC_MDR) SDRAMC Memory Device Register  Offset */
+
+#define SDRAMC_MDR_MD_Pos                   0                                              /**< (SDRAMC_MDR) Memory Device Type Position */
+#define SDRAMC_MDR_MD_Msk                   (_U_(0x3) << SDRAMC_MDR_MD_Pos)                /**< (SDRAMC_MDR) Memory Device Type Mask */
+#define SDRAMC_MDR_MD(value)                (SDRAMC_MDR_MD_Msk & ((value) << SDRAMC_MDR_MD_Pos))
+#define   SDRAMC_MDR_MD_SDRAM_Val           _U_(0x0)                                       /**< (SDRAMC_MDR) SDRAM  */
+#define   SDRAMC_MDR_MD_LPSDRAM_Val         _U_(0x1)                                       /**< (SDRAMC_MDR) Low-power SDRAM  */
+#define SDRAMC_MDR_MD_SDRAM                 (SDRAMC_MDR_MD_SDRAM_Val << SDRAMC_MDR_MD_Pos)  /**< (SDRAMC_MDR) SDRAM Position  */
+#define SDRAMC_MDR_MD_LPSDRAM               (SDRAMC_MDR_MD_LPSDRAM_Val << SDRAMC_MDR_MD_Pos)  /**< (SDRAMC_MDR) Low-power SDRAM Position  */
+#define SDRAMC_MDR_MASK                     _U_(0x03)                                      /**< \deprecated (SDRAMC_MDR) Register MASK  (Use SDRAMC_MDR_Msk instead)  */
+#define SDRAMC_MDR_Msk                      _U_(0x03)                                      /**< (SDRAMC_MDR) Register Mask  */
+
+
+/* -------- SDRAMC_CFR1 : (SDRAMC Offset: 0x28) (R/W 32) SDRAMC Configuration Register 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TMRD:4;                    /**< bit:   0..3  Load Mode Register Command to Active or Refresh Command */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t UNAL:1;                    /**< bit:      8  Support Unaligned Access                 */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_CFR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_CFR1_OFFSET                  (0x28)                                        /**<  (SDRAMC_CFR1) SDRAMC Configuration Register 1  Offset */
+
+#define SDRAMC_CFR1_TMRD_Pos                0                                              /**< (SDRAMC_CFR1) Load Mode Register Command to Active or Refresh Command Position */
+#define SDRAMC_CFR1_TMRD_Msk                (_U_(0xF) << SDRAMC_CFR1_TMRD_Pos)             /**< (SDRAMC_CFR1) Load Mode Register Command to Active or Refresh Command Mask */
+#define SDRAMC_CFR1_TMRD(value)             (SDRAMC_CFR1_TMRD_Msk & ((value) << SDRAMC_CFR1_TMRD_Pos))
+#define SDRAMC_CFR1_UNAL_Pos                8                                              /**< (SDRAMC_CFR1) Support Unaligned Access Position */
+#define SDRAMC_CFR1_UNAL_Msk                (_U_(0x1) << SDRAMC_CFR1_UNAL_Pos)             /**< (SDRAMC_CFR1) Support Unaligned Access Mask */
+#define SDRAMC_CFR1_UNAL                    SDRAMC_CFR1_UNAL_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_CFR1_UNAL_Msk instead */
+#define   SDRAMC_CFR1_UNAL_UNSUPPORTED_Val  _U_(0x0)                                       /**< (SDRAMC_CFR1) Unaligned access is not supported.  */
+#define   SDRAMC_CFR1_UNAL_SUPPORTED_Val    _U_(0x1)                                       /**< (SDRAMC_CFR1) Unaligned access is supported.  */
+#define SDRAMC_CFR1_UNAL_UNSUPPORTED        (SDRAMC_CFR1_UNAL_UNSUPPORTED_Val << SDRAMC_CFR1_UNAL_Pos)  /**< (SDRAMC_CFR1) Unaligned access is not supported. Position  */
+#define SDRAMC_CFR1_UNAL_SUPPORTED          (SDRAMC_CFR1_UNAL_SUPPORTED_Val << SDRAMC_CFR1_UNAL_Pos)  /**< (SDRAMC_CFR1) Unaligned access is supported. Position  */
+#define SDRAMC_CFR1_MASK                    _U_(0x10F)                                     /**< \deprecated (SDRAMC_CFR1) Register MASK  (Use SDRAMC_CFR1_Msk instead)  */
+#define SDRAMC_CFR1_Msk                     _U_(0x10F)                                     /**< (SDRAMC_CFR1) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS : (SDRAMC Offset: 0x2c) (R/W 32) SDRAMC OCMS Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDR_SE:1;                  /**< bit:      0  SDRAM Memory Controller Scrambling Enable */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_OFFSET                  (0x2C)                                        /**<  (SDRAMC_OCMS) SDRAMC OCMS Register  Offset */
+
+#define SDRAMC_OCMS_SDR_SE_Pos              0                                              /**< (SDRAMC_OCMS) SDRAM Memory Controller Scrambling Enable Position */
+#define SDRAMC_OCMS_SDR_SE_Msk              (_U_(0x1) << SDRAMC_OCMS_SDR_SE_Pos)           /**< (SDRAMC_OCMS) SDRAM Memory Controller Scrambling Enable Mask */
+#define SDRAMC_OCMS_SDR_SE                  SDRAMC_OCMS_SDR_SE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_OCMS_SDR_SE_Msk instead */
+#define SDRAMC_OCMS_MASK                    _U_(0x01)                                      /**< \deprecated (SDRAMC_OCMS) Register MASK  (Use SDRAMC_OCMS_Msk instead)  */
+#define SDRAMC_OCMS_Msk                     _U_(0x01)                                      /**< (SDRAMC_OCMS) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS_KEY1 : (SDRAMC Offset: 0x30) (/W 32) SDRAMC OCMS KEY1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY1:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 1 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_KEY1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_KEY1_OFFSET             (0x30)                                        /**<  (SDRAMC_OCMS_KEY1) SDRAMC OCMS KEY1 Register  Offset */
+
+#define SDRAMC_OCMS_KEY1_KEY1_Pos           0                                              /**< (SDRAMC_OCMS_KEY1) Off-chip Memory Scrambling (OCMS) Key Part 1 Position */
+#define SDRAMC_OCMS_KEY1_KEY1_Msk           (_U_(0xFFFFFFFF) << SDRAMC_OCMS_KEY1_KEY1_Pos)  /**< (SDRAMC_OCMS_KEY1) Off-chip Memory Scrambling (OCMS) Key Part 1 Mask */
+#define SDRAMC_OCMS_KEY1_KEY1(value)        (SDRAMC_OCMS_KEY1_KEY1_Msk & ((value) << SDRAMC_OCMS_KEY1_KEY1_Pos))
+#define SDRAMC_OCMS_KEY1_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_OCMS_KEY1) Register MASK  (Use SDRAMC_OCMS_KEY1_Msk instead)  */
+#define SDRAMC_OCMS_KEY1_Msk                _U_(0xFFFFFFFF)                                /**< (SDRAMC_OCMS_KEY1) Register Mask  */
+
+
+/* -------- SDRAMC_OCMS_KEY2 : (SDRAMC Offset: 0x34) (/W 32) SDRAMC OCMS KEY2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY2:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 2 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SDRAMC_OCMS_KEY2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SDRAMC_OCMS_KEY2_OFFSET             (0x34)                                        /**<  (SDRAMC_OCMS_KEY2) SDRAMC OCMS KEY2 Register  Offset */
+
+#define SDRAMC_OCMS_KEY2_KEY2_Pos           0                                              /**< (SDRAMC_OCMS_KEY2) Off-chip Memory Scrambling (OCMS) Key Part 2 Position */
+#define SDRAMC_OCMS_KEY2_KEY2_Msk           (_U_(0xFFFFFFFF) << SDRAMC_OCMS_KEY2_KEY2_Pos)  /**< (SDRAMC_OCMS_KEY2) Off-chip Memory Scrambling (OCMS) Key Part 2 Mask */
+#define SDRAMC_OCMS_KEY2_KEY2(value)        (SDRAMC_OCMS_KEY2_KEY2_Msk & ((value) << SDRAMC_OCMS_KEY2_KEY2_Pos))
+#define SDRAMC_OCMS_KEY2_MASK               _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_OCMS_KEY2) Register MASK  (Use SDRAMC_OCMS_KEY2_Msk instead)  */
+#define SDRAMC_OCMS_KEY2_Msk                _U_(0xFFFFFFFF)                                /**< (SDRAMC_OCMS_KEY2) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SDRAMC hardware registers */
+typedef struct {  
+  __IO uint32_t SDRAMC_MR;      /**< (SDRAMC Offset: 0x00) SDRAMC Mode Register */
+  __IO uint32_t SDRAMC_TR;      /**< (SDRAMC Offset: 0x04) SDRAMC Refresh Timer Register */
+  __IO uint32_t SDRAMC_CR;      /**< (SDRAMC Offset: 0x08) SDRAMC Configuration Register */
+  __I  uint8_t                        Reserved1[4];
+  __IO uint32_t SDRAMC_LPR;     /**< (SDRAMC Offset: 0x10) SDRAMC Low Power Register */
+  __O  uint32_t SDRAMC_IER;     /**< (SDRAMC Offset: 0x14) SDRAMC Interrupt Enable Register */
+  __O  uint32_t SDRAMC_IDR;     /**< (SDRAMC Offset: 0x18) SDRAMC Interrupt Disable Register */
+  __I  uint32_t SDRAMC_IMR;     /**< (SDRAMC Offset: 0x1C) SDRAMC Interrupt Mask Register */
+  __I  uint32_t SDRAMC_ISR;     /**< (SDRAMC Offset: 0x20) SDRAMC Interrupt Status Register */
+  __IO uint32_t SDRAMC_MDR;     /**< (SDRAMC Offset: 0x24) SDRAMC Memory Device Register */
+  __IO uint32_t SDRAMC_CFR1;    /**< (SDRAMC Offset: 0x28) SDRAMC Configuration Register 1 */
+  __IO uint32_t SDRAMC_OCMS;    /**< (SDRAMC Offset: 0x2C) SDRAMC OCMS Register */
+  __O  uint32_t SDRAMC_OCMS_KEY1; /**< (SDRAMC Offset: 0x30) SDRAMC OCMS KEY1 Register */
+  __O  uint32_t SDRAMC_OCMS_KEY2; /**< (SDRAMC Offset: 0x34) SDRAMC OCMS KEY2 Register */
+} Sdramc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SDRAMC hardware registers */
+typedef struct {  
+  __IO SDRAMC_MR_Type                 SDRAMC_MR;      /**< Offset: 0x00 (R/W  32) SDRAMC Mode Register */
+  __IO SDRAMC_TR_Type                 SDRAMC_TR;      /**< Offset: 0x04 (R/W  32) SDRAMC Refresh Timer Register */
+  __IO SDRAMC_CR_Type                 SDRAMC_CR;      /**< Offset: 0x08 (R/W  32) SDRAMC Configuration Register */
+  __I  uint8_t                        Reserved1[4];
+  __IO SDRAMC_LPR_Type                SDRAMC_LPR;     /**< Offset: 0x10 (R/W  32) SDRAMC Low Power Register */
+  __O  SDRAMC_IER_Type                SDRAMC_IER;     /**< Offset: 0x14 ( /W  32) SDRAMC Interrupt Enable Register */
+  __O  SDRAMC_IDR_Type                SDRAMC_IDR;     /**< Offset: 0x18 ( /W  32) SDRAMC Interrupt Disable Register */
+  __I  SDRAMC_IMR_Type                SDRAMC_IMR;     /**< Offset: 0x1C (R/   32) SDRAMC Interrupt Mask Register */
+  __I  SDRAMC_ISR_Type                SDRAMC_ISR;     /**< Offset: 0x20 (R/   32) SDRAMC Interrupt Status Register */
+  __IO SDRAMC_MDR_Type                SDRAMC_MDR;     /**< Offset: 0x24 (R/W  32) SDRAMC Memory Device Register */
+  __IO SDRAMC_CFR1_Type               SDRAMC_CFR1;    /**< Offset: 0x28 (R/W  32) SDRAMC Configuration Register 1 */
+  __IO SDRAMC_OCMS_Type               SDRAMC_OCMS;    /**< Offset: 0x2C (R/W  32) SDRAMC OCMS Register */
+  __O  SDRAMC_OCMS_KEY1_Type          SDRAMC_OCMS_KEY1; /**< Offset: 0x30 ( /W  32) SDRAMC OCMS KEY1 Register */
+  __O  SDRAMC_OCMS_KEY2_Type          SDRAMC_OCMS_KEY2; /**< Offset: 0x34 ( /W  32) SDRAMC OCMS KEY2 Register */
+} Sdramc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of SDRAM Controller */
+
+#endif /* _SAMV71_SDRAMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/smc.h
+++ b/asf/sam/include/samv71b/component/smc.h
@@ -1,0 +1,418 @@
+/**
+ * \file
+ *
+ * \brief Component description for SMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SMC_COMPONENT_H_
+#define _SAMV71_SMC_COMPONENT_H_
+#define _SAMV71_SMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Static Memory Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SMC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SMC_6498                       /**< (SMC) Module ID */
+#define REV_SMC J                      /**< (SMC) Module revision */
+
+/* -------- SMC_SETUP : (SMC Offset: 0x00) (R/W 32) SMC Setup Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_SETUP:6;               /**< bit:   0..5  NWE Setup Length                         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NCS_WR_SETUP:6;            /**< bit:  8..13  NCS Setup Length in WRITE Access         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t NRD_SETUP:6;               /**< bit: 16..21  NRD Setup Length                         */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t NCS_RD_SETUP:6;            /**< bit: 24..29  NCS Setup Length in READ Access          */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_SETUP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_SETUP_OFFSET                    (0x00)                                        /**<  (SMC_SETUP) SMC Setup Register  Offset */
+
+#define SMC_SETUP_NWE_SETUP_Pos             0                                              /**< (SMC_SETUP) NWE Setup Length Position */
+#define SMC_SETUP_NWE_SETUP_Msk             (_U_(0x3F) << SMC_SETUP_NWE_SETUP_Pos)         /**< (SMC_SETUP) NWE Setup Length Mask */
+#define SMC_SETUP_NWE_SETUP(value)          (SMC_SETUP_NWE_SETUP_Msk & ((value) << SMC_SETUP_NWE_SETUP_Pos))
+#define SMC_SETUP_NCS_WR_SETUP_Pos          8                                              /**< (SMC_SETUP) NCS Setup Length in WRITE Access Position */
+#define SMC_SETUP_NCS_WR_SETUP_Msk          (_U_(0x3F) << SMC_SETUP_NCS_WR_SETUP_Pos)      /**< (SMC_SETUP) NCS Setup Length in WRITE Access Mask */
+#define SMC_SETUP_NCS_WR_SETUP(value)       (SMC_SETUP_NCS_WR_SETUP_Msk & ((value) << SMC_SETUP_NCS_WR_SETUP_Pos))
+#define SMC_SETUP_NRD_SETUP_Pos             16                                             /**< (SMC_SETUP) NRD Setup Length Position */
+#define SMC_SETUP_NRD_SETUP_Msk             (_U_(0x3F) << SMC_SETUP_NRD_SETUP_Pos)         /**< (SMC_SETUP) NRD Setup Length Mask */
+#define SMC_SETUP_NRD_SETUP(value)          (SMC_SETUP_NRD_SETUP_Msk & ((value) << SMC_SETUP_NRD_SETUP_Pos))
+#define SMC_SETUP_NCS_RD_SETUP_Pos          24                                             /**< (SMC_SETUP) NCS Setup Length in READ Access Position */
+#define SMC_SETUP_NCS_RD_SETUP_Msk          (_U_(0x3F) << SMC_SETUP_NCS_RD_SETUP_Pos)      /**< (SMC_SETUP) NCS Setup Length in READ Access Mask */
+#define SMC_SETUP_NCS_RD_SETUP(value)       (SMC_SETUP_NCS_RD_SETUP_Msk & ((value) << SMC_SETUP_NCS_RD_SETUP_Pos))
+#define SMC_SETUP_MASK                      _U_(0x3F3F3F3F)                                /**< \deprecated (SMC_SETUP) Register MASK  (Use SMC_SETUP_Msk instead)  */
+#define SMC_SETUP_Msk                       _U_(0x3F3F3F3F)                                /**< (SMC_SETUP) Register Mask  */
+
+
+/* -------- SMC_PULSE : (SMC Offset: 0x04) (R/W 32) SMC Pulse Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_PULSE:7;               /**< bit:   0..6  NWE Pulse Length                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t NCS_WR_PULSE:7;            /**< bit:  8..14  NCS Pulse Length in WRITE Access         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t NRD_PULSE:7;               /**< bit: 16..22  NRD Pulse Length                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t NCS_RD_PULSE:7;            /**< bit: 24..30  NCS Pulse Length in READ Access          */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_PULSE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_PULSE_OFFSET                    (0x04)                                        /**<  (SMC_PULSE) SMC Pulse Register  Offset */
+
+#define SMC_PULSE_NWE_PULSE_Pos             0                                              /**< (SMC_PULSE) NWE Pulse Length Position */
+#define SMC_PULSE_NWE_PULSE_Msk             (_U_(0x7F) << SMC_PULSE_NWE_PULSE_Pos)         /**< (SMC_PULSE) NWE Pulse Length Mask */
+#define SMC_PULSE_NWE_PULSE(value)          (SMC_PULSE_NWE_PULSE_Msk & ((value) << SMC_PULSE_NWE_PULSE_Pos))
+#define SMC_PULSE_NCS_WR_PULSE_Pos          8                                              /**< (SMC_PULSE) NCS Pulse Length in WRITE Access Position */
+#define SMC_PULSE_NCS_WR_PULSE_Msk          (_U_(0x7F) << SMC_PULSE_NCS_WR_PULSE_Pos)      /**< (SMC_PULSE) NCS Pulse Length in WRITE Access Mask */
+#define SMC_PULSE_NCS_WR_PULSE(value)       (SMC_PULSE_NCS_WR_PULSE_Msk & ((value) << SMC_PULSE_NCS_WR_PULSE_Pos))
+#define SMC_PULSE_NRD_PULSE_Pos             16                                             /**< (SMC_PULSE) NRD Pulse Length Position */
+#define SMC_PULSE_NRD_PULSE_Msk             (_U_(0x7F) << SMC_PULSE_NRD_PULSE_Pos)         /**< (SMC_PULSE) NRD Pulse Length Mask */
+#define SMC_PULSE_NRD_PULSE(value)          (SMC_PULSE_NRD_PULSE_Msk & ((value) << SMC_PULSE_NRD_PULSE_Pos))
+#define SMC_PULSE_NCS_RD_PULSE_Pos          24                                             /**< (SMC_PULSE) NCS Pulse Length in READ Access Position */
+#define SMC_PULSE_NCS_RD_PULSE_Msk          (_U_(0x7F) << SMC_PULSE_NCS_RD_PULSE_Pos)      /**< (SMC_PULSE) NCS Pulse Length in READ Access Mask */
+#define SMC_PULSE_NCS_RD_PULSE(value)       (SMC_PULSE_NCS_RD_PULSE_Msk & ((value) << SMC_PULSE_NCS_RD_PULSE_Pos))
+#define SMC_PULSE_MASK                      _U_(0x7F7F7F7F)                                /**< \deprecated (SMC_PULSE) Register MASK  (Use SMC_PULSE_Msk instead)  */
+#define SMC_PULSE_Msk                       _U_(0x7F7F7F7F)                                /**< (SMC_PULSE) Register Mask  */
+
+
+/* -------- SMC_CYCLE : (SMC Offset: 0x08) (R/W 32) SMC Cycle Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NWE_CYCLE:9;               /**< bit:   0..8  Total Write Cycle Length                 */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t NRD_CYCLE:9;               /**< bit: 16..24  Total Read Cycle Length                  */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_CYCLE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_CYCLE_OFFSET                    (0x08)                                        /**<  (SMC_CYCLE) SMC Cycle Register  Offset */
+
+#define SMC_CYCLE_NWE_CYCLE_Pos             0                                              /**< (SMC_CYCLE) Total Write Cycle Length Position */
+#define SMC_CYCLE_NWE_CYCLE_Msk             (_U_(0x1FF) << SMC_CYCLE_NWE_CYCLE_Pos)        /**< (SMC_CYCLE) Total Write Cycle Length Mask */
+#define SMC_CYCLE_NWE_CYCLE(value)          (SMC_CYCLE_NWE_CYCLE_Msk & ((value) << SMC_CYCLE_NWE_CYCLE_Pos))
+#define SMC_CYCLE_NRD_CYCLE_Pos             16                                             /**< (SMC_CYCLE) Total Read Cycle Length Position */
+#define SMC_CYCLE_NRD_CYCLE_Msk             (_U_(0x1FF) << SMC_CYCLE_NRD_CYCLE_Pos)        /**< (SMC_CYCLE) Total Read Cycle Length Mask */
+#define SMC_CYCLE_NRD_CYCLE(value)          (SMC_CYCLE_NRD_CYCLE_Msk & ((value) << SMC_CYCLE_NRD_CYCLE_Pos))
+#define SMC_CYCLE_MASK                      _U_(0x1FF01FF)                                 /**< \deprecated (SMC_CYCLE) Register MASK  (Use SMC_CYCLE_Msk instead)  */
+#define SMC_CYCLE_Msk                       _U_(0x1FF01FF)                                 /**< (SMC_CYCLE) Register Mask  */
+
+
+/* -------- SMC_MODE : (SMC Offset: 0x0c) (R/W 32) SMC Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t READ_MODE:1;               /**< bit:      0  Read Mode                                */
+    uint32_t WRITE_MODE:1;              /**< bit:      1  Write Mode                               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t EXNW_MODE:2;               /**< bit:   4..5  NWAIT Mode                               */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t BAT:1;                     /**< bit:      8  Byte Access Type                         */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t DBW:1;                     /**< bit:     12  Data Bus Width                           */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t TDF_CYCLES:4;              /**< bit: 16..19  Data Float Time                          */
+    uint32_t TDF_MODE:1;                /**< bit:     20  TDF Optimization                         */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t PMEN:1;                    /**< bit:     24  Page Mode Enabled                        */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t PS:2;                      /**< bit: 28..29  Page Size                                */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_MODE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_MODE_OFFSET                     (0x0C)                                        /**<  (SMC_MODE) SMC Mode Register  Offset */
+
+#define SMC_MODE_READ_MODE_Pos              0                                              /**< (SMC_MODE) Read Mode Position */
+#define SMC_MODE_READ_MODE_Msk              (_U_(0x1) << SMC_MODE_READ_MODE_Pos)           /**< (SMC_MODE) Read Mode Mask */
+#define SMC_MODE_READ_MODE                  SMC_MODE_READ_MODE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_READ_MODE_Msk instead */
+#define SMC_MODE_WRITE_MODE_Pos             1                                              /**< (SMC_MODE) Write Mode Position */
+#define SMC_MODE_WRITE_MODE_Msk             (_U_(0x1) << SMC_MODE_WRITE_MODE_Pos)          /**< (SMC_MODE) Write Mode Mask */
+#define SMC_MODE_WRITE_MODE                 SMC_MODE_WRITE_MODE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_WRITE_MODE_Msk instead */
+#define SMC_MODE_EXNW_MODE_Pos              4                                              /**< (SMC_MODE) NWAIT Mode Position */
+#define SMC_MODE_EXNW_MODE_Msk              (_U_(0x3) << SMC_MODE_EXNW_MODE_Pos)           /**< (SMC_MODE) NWAIT Mode Mask */
+#define SMC_MODE_EXNW_MODE(value)           (SMC_MODE_EXNW_MODE_Msk & ((value) << SMC_MODE_EXNW_MODE_Pos))
+#define   SMC_MODE_EXNW_MODE_DISABLED_Val   _U_(0x0)                                       /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select.  */
+#define   SMC_MODE_EXNW_MODE_FROZEN_Val     _U_(0x2)                                       /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped.  */
+#define   SMC_MODE_EXNW_MODE_READY_Val      _U_(0x3)                                       /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high.  */
+#define SMC_MODE_EXNW_MODE_DISABLED         (SMC_MODE_EXNW_MODE_DISABLED_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select. Position  */
+#define SMC_MODE_EXNW_MODE_FROZEN           (SMC_MODE_EXNW_MODE_FROZEN_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped. Position  */
+#define SMC_MODE_EXNW_MODE_READY            (SMC_MODE_EXNW_MODE_READY_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high. Position  */
+#define SMC_MODE_BAT_Pos                    8                                              /**< (SMC_MODE) Byte Access Type Position */
+#define SMC_MODE_BAT_Msk                    (_U_(0x1) << SMC_MODE_BAT_Pos)                 /**< (SMC_MODE) Byte Access Type Mask */
+#define SMC_MODE_BAT                        SMC_MODE_BAT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_BAT_Msk instead */
+#define   SMC_MODE_BAT_BYTE_SELECT_Val      _U_(0x0)                                       /**< (SMC_MODE) Byte select access type:- Write operation is controlled using NCS, NWE, NBS0, NBS1.- Read operation is controlled using NCS, NRD, NBS0, NBS1.  */
+#define   SMC_MODE_BAT_BYTE_WRITE_Val       _U_(0x1)                                       /**< (SMC_MODE) Byte write access type:- Write operation is controlled using NCS, NWR0, NWR1.- Read operation is controlled using NCS and NRD.  */
+#define SMC_MODE_BAT_BYTE_SELECT            (SMC_MODE_BAT_BYTE_SELECT_Val << SMC_MODE_BAT_Pos)  /**< (SMC_MODE) Byte select access type:- Write operation is controlled using NCS, NWE, NBS0, NBS1.- Read operation is controlled using NCS, NRD, NBS0, NBS1. Position  */
+#define SMC_MODE_BAT_BYTE_WRITE             (SMC_MODE_BAT_BYTE_WRITE_Val << SMC_MODE_BAT_Pos)  /**< (SMC_MODE) Byte write access type:- Write operation is controlled using NCS, NWR0, NWR1.- Read operation is controlled using NCS and NRD. Position  */
+#define SMC_MODE_DBW_Pos                    12                                             /**< (SMC_MODE) Data Bus Width Position */
+#define SMC_MODE_DBW_Msk                    (_U_(0x1) << SMC_MODE_DBW_Pos)                 /**< (SMC_MODE) Data Bus Width Mask */
+#define SMC_MODE_DBW                        SMC_MODE_DBW_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_DBW_Msk instead */
+#define   SMC_MODE_DBW_8_BIT_Val            _U_(0x0)                                       /**< (SMC_MODE) 8-bit Data Bus  */
+#define   SMC_MODE_DBW_16_BIT_Val           _U_(0x1)                                       /**< (SMC_MODE) 16-bit Data Bus  */
+#define SMC_MODE_DBW_8_BIT                  (SMC_MODE_DBW_8_BIT_Val << SMC_MODE_DBW_Pos)   /**< (SMC_MODE) 8-bit Data Bus Position  */
+#define SMC_MODE_DBW_16_BIT                 (SMC_MODE_DBW_16_BIT_Val << SMC_MODE_DBW_Pos)  /**< (SMC_MODE) 16-bit Data Bus Position  */
+#define SMC_MODE_TDF_CYCLES_Pos             16                                             /**< (SMC_MODE) Data Float Time Position */
+#define SMC_MODE_TDF_CYCLES_Msk             (_U_(0xF) << SMC_MODE_TDF_CYCLES_Pos)          /**< (SMC_MODE) Data Float Time Mask */
+#define SMC_MODE_TDF_CYCLES(value)          (SMC_MODE_TDF_CYCLES_Msk & ((value) << SMC_MODE_TDF_CYCLES_Pos))
+#define SMC_MODE_TDF_MODE_Pos               20                                             /**< (SMC_MODE) TDF Optimization Position */
+#define SMC_MODE_TDF_MODE_Msk               (_U_(0x1) << SMC_MODE_TDF_MODE_Pos)            /**< (SMC_MODE) TDF Optimization Mask */
+#define SMC_MODE_TDF_MODE                   SMC_MODE_TDF_MODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_TDF_MODE_Msk instead */
+#define SMC_MODE_PMEN_Pos                   24                                             /**< (SMC_MODE) Page Mode Enabled Position */
+#define SMC_MODE_PMEN_Msk                   (_U_(0x1) << SMC_MODE_PMEN_Pos)                /**< (SMC_MODE) Page Mode Enabled Mask */
+#define SMC_MODE_PMEN                       SMC_MODE_PMEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_PMEN_Msk instead */
+#define SMC_MODE_PS_Pos                     28                                             /**< (SMC_MODE) Page Size Position */
+#define SMC_MODE_PS_Msk                     (_U_(0x3) << SMC_MODE_PS_Pos)                  /**< (SMC_MODE) Page Size Mask */
+#define SMC_MODE_PS(value)                  (SMC_MODE_PS_Msk & ((value) << SMC_MODE_PS_Pos))
+#define   SMC_MODE_PS_4_BYTE_Val            _U_(0x0)                                       /**< (SMC_MODE) 4-byte page  */
+#define   SMC_MODE_PS_8_BYTE_Val            _U_(0x1)                                       /**< (SMC_MODE) 8-byte page  */
+#define   SMC_MODE_PS_16_BYTE_Val           _U_(0x2)                                       /**< (SMC_MODE) 16-byte page  */
+#define   SMC_MODE_PS_32_BYTE_Val           _U_(0x3)                                       /**< (SMC_MODE) 32-byte page  */
+#define SMC_MODE_PS_4_BYTE                  (SMC_MODE_PS_4_BYTE_Val << SMC_MODE_PS_Pos)    /**< (SMC_MODE) 4-byte page Position  */
+#define SMC_MODE_PS_8_BYTE                  (SMC_MODE_PS_8_BYTE_Val << SMC_MODE_PS_Pos)    /**< (SMC_MODE) 8-byte page Position  */
+#define SMC_MODE_PS_16_BYTE                 (SMC_MODE_PS_16_BYTE_Val << SMC_MODE_PS_Pos)   /**< (SMC_MODE) 16-byte page Position  */
+#define SMC_MODE_PS_32_BYTE                 (SMC_MODE_PS_32_BYTE_Val << SMC_MODE_PS_Pos)   /**< (SMC_MODE) 32-byte page Position  */
+#define SMC_MODE_MASK                       _U_(0x311F1133)                                /**< \deprecated (SMC_MODE) Register MASK  (Use SMC_MODE_Msk instead)  */
+#define SMC_MODE_Msk                        _U_(0x311F1133)                                /**< (SMC_MODE) Register Mask  */
+
+
+/* -------- SMC_OCMS : (SMC Offset: 0x80) (R/W 32) SMC Off-Chip Memory Scrambling Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMSE:1;                    /**< bit:      0  Static Memory Controller Scrambling Enable */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t CS0SE:1;                   /**< bit:      8  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS1SE:1;                   /**< bit:      9  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS2SE:1;                   /**< bit:     10  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS3SE:1;                   /**< bit:     11  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_OCMS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_OCMS_OFFSET                     (0x80)                                        /**<  (SMC_OCMS) SMC Off-Chip Memory Scrambling Register  Offset */
+
+#define SMC_OCMS_SMSE_Pos                   0                                              /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Position */
+#define SMC_OCMS_SMSE_Msk                   (_U_(0x1) << SMC_OCMS_SMSE_Pos)                /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Mask */
+#define SMC_OCMS_SMSE                       SMC_OCMS_SMSE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_SMSE_Msk instead */
+#define SMC_OCMS_CS0SE_Pos                  8                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS0SE_Msk                  (_U_(0x1) << SMC_OCMS_CS0SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS0SE                      SMC_OCMS_CS0SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS0SE_Msk instead */
+#define SMC_OCMS_CS1SE_Pos                  9                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS1SE_Msk                  (_U_(0x1) << SMC_OCMS_CS1SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS1SE                      SMC_OCMS_CS1SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS1SE_Msk instead */
+#define SMC_OCMS_CS2SE_Pos                  10                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS2SE_Msk                  (_U_(0x1) << SMC_OCMS_CS2SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS2SE                      SMC_OCMS_CS2SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS2SE_Msk instead */
+#define SMC_OCMS_CS3SE_Pos                  11                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS3SE_Msk                  (_U_(0x1) << SMC_OCMS_CS3SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
+#define SMC_OCMS_CS3SE                      SMC_OCMS_CS3SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS3SE_Msk instead */
+#define SMC_OCMS_MASK                       _U_(0xF01)                                     /**< \deprecated (SMC_OCMS) Register MASK  (Use SMC_OCMS_Msk instead)  */
+#define SMC_OCMS_Msk                        _U_(0xF01)                                     /**< (SMC_OCMS) Register Mask  */
+
+
+/* -------- SMC_KEY1 : (SMC Offset: 0x84) (/W 32) SMC Off-Chip Memory Scrambling KEY1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY1:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 1 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_KEY1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_KEY1_OFFSET                     (0x84)                                        /**<  (SMC_KEY1) SMC Off-Chip Memory Scrambling KEY1 Register  Offset */
+
+#define SMC_KEY1_KEY1_Pos                   0                                              /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Position */
+#define SMC_KEY1_KEY1_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY1_KEY1_Pos)         /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Mask */
+#define SMC_KEY1_KEY1(value)                (SMC_KEY1_KEY1_Msk & ((value) << SMC_KEY1_KEY1_Pos))
+#define SMC_KEY1_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY1) Register MASK  (Use SMC_KEY1_Msk instead)  */
+#define SMC_KEY1_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY1) Register Mask  */
+
+
+/* -------- SMC_KEY2 : (SMC Offset: 0x88) (/W 32) SMC Off-Chip Memory Scrambling KEY2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t KEY2:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 2 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_KEY2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_KEY2_OFFSET                     (0x88)                                        /**<  (SMC_KEY2) SMC Off-Chip Memory Scrambling KEY2 Register  Offset */
+
+#define SMC_KEY2_KEY2_Pos                   0                                              /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Position */
+#define SMC_KEY2_KEY2_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY2_KEY2_Pos)         /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Mask */
+#define SMC_KEY2_KEY2(value)                (SMC_KEY2_KEY2_Msk & ((value) << SMC_KEY2_KEY2_Pos))
+#define SMC_KEY2_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY2) Register MASK  (Use SMC_KEY2_Msk instead)  */
+#define SMC_KEY2_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY2) Register Mask  */
+
+
+/* -------- SMC_WPMR : (SMC Offset: 0xe4) (R/W 32) SMC Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_WPMR_OFFSET                     (0xE4)                                        /**<  (SMC_WPMR) SMC Write Protection Mode Register  Offset */
+
+#define SMC_WPMR_WPEN_Pos                   0                                              /**< (SMC_WPMR) Write Protect Enable Position */
+#define SMC_WPMR_WPEN_Msk                   (_U_(0x1) << SMC_WPMR_WPEN_Pos)                /**< (SMC_WPMR) Write Protect Enable Mask */
+#define SMC_WPMR_WPEN                       SMC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_WPMR_WPEN_Msk instead */
+#define SMC_WPMR_WPKEY_Pos                  8                                              /**< (SMC_WPMR) Write Protection Key Position */
+#define SMC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SMC_WPMR_WPKEY_Pos)          /**< (SMC_WPMR) Write Protection Key Mask */
+#define SMC_WPMR_WPKEY(value)               (SMC_WPMR_WPKEY_Msk & ((value) << SMC_WPMR_WPKEY_Pos))
+#define   SMC_WPMR_WPKEY_PASSWD_Val         _U_(0x534D43)                                  /**< (SMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define SMC_WPMR_WPKEY_PASSWD               (SMC_WPMR_WPKEY_PASSWD_Val << SMC_WPMR_WPKEY_Pos)  /**< (SMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define SMC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SMC_WPMR) Register MASK  (Use SMC_WPMR_Msk instead)  */
+#define SMC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SMC_WPMR) Register Mask  */
+
+
+/* -------- SMC_WPSR : (SMC Offset: 0xe8) (R/ 32) SMC Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SMC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMC_WPSR_OFFSET                     (0xE8)                                        /**<  (SMC_WPSR) SMC Write Protection Status Register  Offset */
+
+#define SMC_WPSR_WPVS_Pos                   0                                              /**< (SMC_WPSR) Write Protection Violation Status Position */
+#define SMC_WPSR_WPVS_Msk                   (_U_(0x1) << SMC_WPSR_WPVS_Pos)                /**< (SMC_WPSR) Write Protection Violation Status Mask */
+#define SMC_WPSR_WPVS                       SMC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_WPSR_WPVS_Msk instead */
+#define SMC_WPSR_WPVSRC_Pos                 8                                              /**< (SMC_WPSR) Write Protection Violation Source Position */
+#define SMC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << SMC_WPSR_WPVSRC_Pos)           /**< (SMC_WPSR) Write Protection Violation Source Mask */
+#define SMC_WPSR_WPVSRC(value)              (SMC_WPSR_WPVSRC_Msk & ((value) << SMC_WPSR_WPVSRC_Pos))
+#define SMC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (SMC_WPSR) Register MASK  (Use SMC_WPSR_Msk instead)  */
+#define SMC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (SMC_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SMC_CS_NUMBER hardware registers */
+typedef struct {  
+  __IO uint32_t SMC_SETUP;      /**< (SMC_CS_NUMBER Offset: 0x00) SMC Setup Register */
+  __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register */
+  __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register */
+  __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register */
+} SmcCsNumber;
+
+#define SMCCSNUMBER_NUMBER 4
+/** \brief SMC hardware registers */
+typedef struct {  
+       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
+  __I  uint8_t                        Reserved1[64];
+  __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
+  __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  uint32_t SMC_KEY2;       /**< (SMC Offset: 0x88) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
+  __IO uint32_t SMC_WPMR;       /**< (SMC Offset: 0xE4) SMC Write Protection Mode Register */
+  __I  uint32_t SMC_WPSR;       /**< (SMC Offset: 0xE8) SMC Write Protection Status Register */
+} Smc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SMC_CS_NUMBER hardware registers */
+typedef struct {  
+  __IO SMC_SETUP_Type                 SMC_SETUP;      /**< Offset: 0x00 (R/W  32) SMC Setup Register */
+  __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register */
+  __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register */
+  __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register */
+} SmcCsNumber;
+
+/** \brief SMC hardware registers */
+typedef struct {  
+       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register */
+  __I  uint8_t                        Reserved1[64];
+  __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
+  __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  SMC_KEY2_Type                  SMC_KEY2;       /**< Offset: 0x88 ( /W  32) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
+  __IO SMC_WPMR_Type                  SMC_WPMR;       /**< Offset: 0xE4 (R/W  32) SMC Write Protection Mode Register */
+  __I  SMC_WPSR_Type                  SMC_WPSR;       /**< Offset: 0xE8 (R/   32) SMC Write Protection Status Register */
+} Smc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Static Memory Controller */
+
+#endif /* _SAMV71_SMC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/spi.h
+++ b/asf/sam/include/samv71b/component/spi.h
@@ -1,0 +1,586 @@
+/**
+ * \file
+ *
+ * \brief Component description for SPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SPI_COMPONENT_H_
+#define _SAMV71_SPI_COMPONENT_H_
+#define _SAMV71_SPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Serial Peripheral Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SPI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SPI_6088                       /**< (SPI) Module ID */
+#define REV_SPI ZM                     /**< (SPI) Module revision */
+
+/* -------- SPI_CR : (SPI Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SPIEN:1;                   /**< bit:      0  SPI Enable                               */
+    uint32_t SPIDIS:1;                  /**< bit:      1  SPI Disable                              */
+    uint32_t :5;                        /**< bit:   2..6  Reserved */
+    uint32_t SWRST:1;                   /**< bit:      7  SPI Software Reset                       */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t REQCLR:1;                  /**< bit:     12  Request to Clear the Comparison Trigger  */
+    uint32_t :11;                       /**< bit: 13..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CR_OFFSET                       (0x00)                                        /**<  (SPI_CR) Control Register  Offset */
+
+#define SPI_CR_SPIEN_Pos                    0                                              /**< (SPI_CR) SPI Enable Position */
+#define SPI_CR_SPIEN_Msk                    (_U_(0x1) << SPI_CR_SPIEN_Pos)                 /**< (SPI_CR) SPI Enable Mask */
+#define SPI_CR_SPIEN                        SPI_CR_SPIEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SPIEN_Msk instead */
+#define SPI_CR_SPIDIS_Pos                   1                                              /**< (SPI_CR) SPI Disable Position */
+#define SPI_CR_SPIDIS_Msk                   (_U_(0x1) << SPI_CR_SPIDIS_Pos)                /**< (SPI_CR) SPI Disable Mask */
+#define SPI_CR_SPIDIS                       SPI_CR_SPIDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SPIDIS_Msk instead */
+#define SPI_CR_SWRST_Pos                    7                                              /**< (SPI_CR) SPI Software Reset Position */
+#define SPI_CR_SWRST_Msk                    (_U_(0x1) << SPI_CR_SWRST_Pos)                 /**< (SPI_CR) SPI Software Reset Mask */
+#define SPI_CR_SWRST                        SPI_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_SWRST_Msk instead */
+#define SPI_CR_REQCLR_Pos                   12                                             /**< (SPI_CR) Request to Clear the Comparison Trigger Position */
+#define SPI_CR_REQCLR_Msk                   (_U_(0x1) << SPI_CR_REQCLR_Pos)                /**< (SPI_CR) Request to Clear the Comparison Trigger Mask */
+#define SPI_CR_REQCLR                       SPI_CR_REQCLR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_REQCLR_Msk instead */
+#define SPI_CR_LASTXFER_Pos                 24                                             /**< (SPI_CR) Last Transfer Position */
+#define SPI_CR_LASTXFER_Msk                 (_U_(0x1) << SPI_CR_LASTXFER_Pos)              /**< (SPI_CR) Last Transfer Mask */
+#define SPI_CR_LASTXFER                     SPI_CR_LASTXFER_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CR_LASTXFER_Msk instead */
+#define SPI_CR_MASK                         _U_(0x1001083)                                 /**< \deprecated (SPI_CR) Register MASK  (Use SPI_CR_Msk instead)  */
+#define SPI_CR_Msk                          _U_(0x1001083)                                 /**< (SPI_CR) Register Mask  */
+
+
+/* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MSTR:1;                    /**< bit:      0  Master/Slave Mode                        */
+    uint32_t PS:1;                      /**< bit:      1  Peripheral Select                        */
+    uint32_t PCSDEC:1;                  /**< bit:      2  Chip Select Decode                       */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t MODFDIS:1;                 /**< bit:      4  Mode Fault Detection                     */
+    uint32_t WDRBT:1;                   /**< bit:      5  Wait Data Read Before Transfer           */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t LLB:1;                     /**< bit:      7  Local Loopback Enable                    */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t DLYBCS:8;                  /**< bit: 24..31  Delay Between Chip Selects               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_MR_OFFSET                       (0x04)                                        /**<  (SPI_MR) Mode Register  Offset */
+
+#define SPI_MR_MSTR_Pos                     0                                              /**< (SPI_MR) Master/Slave Mode Position */
+#define SPI_MR_MSTR_Msk                     (_U_(0x1) << SPI_MR_MSTR_Pos)                  /**< (SPI_MR) Master/Slave Mode Mask */
+#define SPI_MR_MSTR                         SPI_MR_MSTR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_MSTR_Msk instead */
+#define   SPI_MR_MSTR_MASTER_Val            _U_(0x1)                                       /**< (SPI_MR) Master  */
+#define   SPI_MR_MSTR_SLAVE_Val             _U_(0x0)                                       /**< (SPI_MR) Slave  */
+#define SPI_MR_MSTR_MASTER                  (SPI_MR_MSTR_MASTER_Val << SPI_MR_MSTR_Pos)    /**< (SPI_MR) Master Position  */
+#define SPI_MR_MSTR_SLAVE                   (SPI_MR_MSTR_SLAVE_Val << SPI_MR_MSTR_Pos)     /**< (SPI_MR) Slave Position  */
+#define SPI_MR_PS_Pos                       1                                              /**< (SPI_MR) Peripheral Select Position */
+#define SPI_MR_PS_Msk                       (_U_(0x1) << SPI_MR_PS_Pos)                    /**< (SPI_MR) Peripheral Select Mask */
+#define SPI_MR_PS                           SPI_MR_PS_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_PS_Msk instead */
+#define SPI_MR_PCSDEC_Pos                   2                                              /**< (SPI_MR) Chip Select Decode Position */
+#define SPI_MR_PCSDEC_Msk                   (_U_(0x1) << SPI_MR_PCSDEC_Pos)                /**< (SPI_MR) Chip Select Decode Mask */
+#define SPI_MR_PCSDEC                       SPI_MR_PCSDEC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_PCSDEC_Msk instead */
+#define SPI_MR_MODFDIS_Pos                  4                                              /**< (SPI_MR) Mode Fault Detection Position */
+#define SPI_MR_MODFDIS_Msk                  (_U_(0x1) << SPI_MR_MODFDIS_Pos)               /**< (SPI_MR) Mode Fault Detection Mask */
+#define SPI_MR_MODFDIS                      SPI_MR_MODFDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_MODFDIS_Msk instead */
+#define SPI_MR_WDRBT_Pos                    5                                              /**< (SPI_MR) Wait Data Read Before Transfer Position */
+#define SPI_MR_WDRBT_Msk                    (_U_(0x1) << SPI_MR_WDRBT_Pos)                 /**< (SPI_MR) Wait Data Read Before Transfer Mask */
+#define SPI_MR_WDRBT                        SPI_MR_WDRBT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_WDRBT_Msk instead */
+#define SPI_MR_LLB_Pos                      7                                              /**< (SPI_MR) Local Loopback Enable Position */
+#define SPI_MR_LLB_Msk                      (_U_(0x1) << SPI_MR_LLB_Pos)                   /**< (SPI_MR) Local Loopback Enable Mask */
+#define SPI_MR_LLB                          SPI_MR_LLB_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_LLB_Msk instead */
+#define SPI_MR_PCS_Pos                      16                                             /**< (SPI_MR) Peripheral Chip Select Position */
+#define SPI_MR_PCS_Msk                      (_U_(0xF) << SPI_MR_PCS_Pos)                   /**< (SPI_MR) Peripheral Chip Select Mask */
+#define SPI_MR_PCS(value)                   (SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos))
+#define   SPI_MR_PCS_NPCS0_Val              _U_(0xE)                                       /**< (SPI_MR) NPCS0 as Chip Select  */
+#define   SPI_MR_PCS_NPCS1_Val              _U_(0xD)                                       /**< (SPI_MR) NPCS1 as Chip Select  */
+#define   SPI_MR_PCS_NPCS2_Val              _U_(0xB)                                       /**< (SPI_MR) NPCS2 as Chip Select  */
+#define   SPI_MR_PCS_NPCS3_Val              _U_(0x7)                                       /**< (SPI_MR) NPCS3 as Chip Select  */
+#define SPI_MR_PCS_NPCS0                    (SPI_MR_PCS_NPCS0_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS0 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS1                    (SPI_MR_PCS_NPCS1_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS1 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS2                    (SPI_MR_PCS_NPCS2_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS2 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS3                    (SPI_MR_PCS_NPCS3_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS3 as Chip Select Position  */
+#define SPI_MR_DLYBCS_Pos                   24                                             /**< (SPI_MR) Delay Between Chip Selects Position */
+#define SPI_MR_DLYBCS_Msk                   (_U_(0xFF) << SPI_MR_DLYBCS_Pos)               /**< (SPI_MR) Delay Between Chip Selects Mask */
+#define SPI_MR_DLYBCS(value)                (SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos))
+#define SPI_MR_MASK                         _U_(0xFF0F00B7)                                /**< \deprecated (SPI_MR) Register MASK  (Use SPI_MR_Msk instead)  */
+#define SPI_MR_Msk                          _U_(0xFF0F00B7)                                /**< (SPI_MR) Register Mask  */
+
+
+/* -------- SPI_RDR : (SPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_RDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_RDR_OFFSET                      (0x08)                                        /**<  (SPI_RDR) Receive Data Register  Offset */
+
+#define SPI_RDR_RD_Pos                      0                                              /**< (SPI_RDR) Receive Data Position */
+#define SPI_RDR_RD_Msk                      (_U_(0xFFFF) << SPI_RDR_RD_Pos)                /**< (SPI_RDR) Receive Data Mask */
+#define SPI_RDR_RD(value)                   (SPI_RDR_RD_Msk & ((value) << SPI_RDR_RD_Pos))
+#define SPI_RDR_PCS_Pos                     16                                             /**< (SPI_RDR) Peripheral Chip Select Position */
+#define SPI_RDR_PCS_Msk                     (_U_(0xF) << SPI_RDR_PCS_Pos)                  /**< (SPI_RDR) Peripheral Chip Select Mask */
+#define SPI_RDR_PCS(value)                  (SPI_RDR_PCS_Msk & ((value) << SPI_RDR_PCS_Pos))
+#define SPI_RDR_MASK                        _U_(0xFFFFF)                                   /**< \deprecated (SPI_RDR) Register MASK  (Use SPI_RDR_Msk instead)  */
+#define SPI_RDR_Msk                         _U_(0xFFFFF)                                   /**< (SPI_RDR) Register Mask  */
+
+
+/* -------- SPI_TDR : (SPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
+    uint32_t PCS:4;                     /**< bit: 16..19  Peripheral Chip Select                   */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t LASTXFER:1;                /**< bit:     24  Last Transfer                            */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_TDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_TDR_OFFSET                      (0x0C)                                        /**<  (SPI_TDR) Transmit Data Register  Offset */
+
+#define SPI_TDR_TD_Pos                      0                                              /**< (SPI_TDR) Transmit Data Position */
+#define SPI_TDR_TD_Msk                      (_U_(0xFFFF) << SPI_TDR_TD_Pos)                /**< (SPI_TDR) Transmit Data Mask */
+#define SPI_TDR_TD(value)                   (SPI_TDR_TD_Msk & ((value) << SPI_TDR_TD_Pos))
+#define SPI_TDR_PCS_Pos                     16                                             /**< (SPI_TDR) Peripheral Chip Select Position */
+#define SPI_TDR_PCS_Msk                     (_U_(0xF) << SPI_TDR_PCS_Pos)                  /**< (SPI_TDR) Peripheral Chip Select Mask */
+#define SPI_TDR_PCS(value)                  (SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos))
+#define   SPI_TDR_PCS_NPCS0_Val             _U_(0xE)                                       /**< (SPI_TDR) NPCS0 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS1_Val             _U_(0xD)                                       /**< (SPI_TDR) NPCS1 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS2_Val             _U_(0xB)                                       /**< (SPI_TDR) NPCS2 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS3_Val             _U_(0x7)                                       /**< (SPI_TDR) NPCS3 as Chip Select  */
+#define SPI_TDR_PCS_NPCS0                   (SPI_TDR_PCS_NPCS0_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS0 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS1                   (SPI_TDR_PCS_NPCS1_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS1 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS2                   (SPI_TDR_PCS_NPCS2_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS2 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS3                   (SPI_TDR_PCS_NPCS3_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS3 as Chip Select Position  */
+#define SPI_TDR_LASTXFER_Pos                24                                             /**< (SPI_TDR) Last Transfer Position */
+#define SPI_TDR_LASTXFER_Msk                (_U_(0x1) << SPI_TDR_LASTXFER_Pos)             /**< (SPI_TDR) Last Transfer Mask */
+#define SPI_TDR_LASTXFER                    SPI_TDR_LASTXFER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_TDR_LASTXFER_Msk instead */
+#define SPI_TDR_MASK                        _U_(0x10FFFFF)                                 /**< \deprecated (SPI_TDR) Register MASK  (Use SPI_TDR_Msk instead)  */
+#define SPI_TDR_Msk                         _U_(0x10FFFFF)                                 /**< (SPI_TDR) Register Mask  */
+
+
+/* -------- SPI_SR : (SPI Offset: 0x10) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
+    uint32_t TDRE:1;                    /**< bit:      1  Transmit Data Register Empty (cleared by writing SPI_TDR) */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error (cleared on read)       */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Status (cleared on read)   */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising (cleared on read)             */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty (cleared by writing SPI_TDR) */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Status (Slave mode only) (cleared on read) */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t SPIENS:1;                  /**< bit:     16  SPI Enable Status                        */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_SR_OFFSET                       (0x10)                                        /**<  (SPI_SR) Status Register  Offset */
+
+#define SPI_SR_RDRF_Pos                     0                                              /**< (SPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Position */
+#define SPI_SR_RDRF_Msk                     (_U_(0x1) << SPI_SR_RDRF_Pos)                  /**< (SPI_SR) Receive Data Register Full (cleared by reading SPI_RDR) Mask */
+#define SPI_SR_RDRF                         SPI_SR_RDRF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_RDRF_Msk instead */
+#define SPI_SR_TDRE_Pos                     1                                              /**< (SPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Position */
+#define SPI_SR_TDRE_Msk                     (_U_(0x1) << SPI_SR_TDRE_Pos)                  /**< (SPI_SR) Transmit Data Register Empty (cleared by writing SPI_TDR) Mask */
+#define SPI_SR_TDRE                         SPI_SR_TDRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_TDRE_Msk instead */
+#define SPI_SR_MODF_Pos                     2                                              /**< (SPI_SR) Mode Fault Error (cleared on read) Position */
+#define SPI_SR_MODF_Msk                     (_U_(0x1) << SPI_SR_MODF_Pos)                  /**< (SPI_SR) Mode Fault Error (cleared on read) Mask */
+#define SPI_SR_MODF                         SPI_SR_MODF_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_MODF_Msk instead */
+#define SPI_SR_OVRES_Pos                    3                                              /**< (SPI_SR) Overrun Error Status (cleared on read) Position */
+#define SPI_SR_OVRES_Msk                    (_U_(0x1) << SPI_SR_OVRES_Pos)                 /**< (SPI_SR) Overrun Error Status (cleared on read) Mask */
+#define SPI_SR_OVRES                        SPI_SR_OVRES_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_OVRES_Msk instead */
+#define SPI_SR_NSSR_Pos                     8                                              /**< (SPI_SR) NSS Rising (cleared on read) Position */
+#define SPI_SR_NSSR_Msk                     (_U_(0x1) << SPI_SR_NSSR_Pos)                  /**< (SPI_SR) NSS Rising (cleared on read) Mask */
+#define SPI_SR_NSSR                         SPI_SR_NSSR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_NSSR_Msk instead */
+#define SPI_SR_TXEMPTY_Pos                  9                                              /**< (SPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Position */
+#define SPI_SR_TXEMPTY_Msk                  (_U_(0x1) << SPI_SR_TXEMPTY_Pos)               /**< (SPI_SR) Transmission Registers Empty (cleared by writing SPI_TDR) Mask */
+#define SPI_SR_TXEMPTY                      SPI_SR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_TXEMPTY_Msk instead */
+#define SPI_SR_UNDES_Pos                    10                                             /**< (SPI_SR) Underrun Error Status (Slave mode only) (cleared on read) Position */
+#define SPI_SR_UNDES_Msk                    (_U_(0x1) << SPI_SR_UNDES_Pos)                 /**< (SPI_SR) Underrun Error Status (Slave mode only) (cleared on read) Mask */
+#define SPI_SR_UNDES                        SPI_SR_UNDES_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_UNDES_Msk instead */
+#define SPI_SR_SPIENS_Pos                   16                                             /**< (SPI_SR) SPI Enable Status Position */
+#define SPI_SR_SPIENS_Msk                   (_U_(0x1) << SPI_SR_SPIENS_Pos)                /**< (SPI_SR) SPI Enable Status Mask */
+#define SPI_SR_SPIENS                       SPI_SR_SPIENS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_SR_SPIENS_Msk instead */
+#define SPI_SR_MASK                         _U_(0x1070F)                                   /**< \deprecated (SPI_SR) Register MASK  (Use SPI_SR_Msk instead)  */
+#define SPI_SR_Msk                          _U_(0x1070F)                                   /**< (SPI_SR) Register Mask  */
+
+
+/* -------- SPI_IER : (SPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Enable */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Enable        */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Enable           */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Enable              */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Enable      */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Enable          */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IER_OFFSET                      (0x14)                                        /**<  (SPI_IER) Interrupt Enable Register  Offset */
+
+#define SPI_IER_RDRF_Pos                    0                                              /**< (SPI_IER) Receive Data Register Full Interrupt Enable Position */
+#define SPI_IER_RDRF_Msk                    (_U_(0x1) << SPI_IER_RDRF_Pos)                 /**< (SPI_IER) Receive Data Register Full Interrupt Enable Mask */
+#define SPI_IER_RDRF                        SPI_IER_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_RDRF_Msk instead */
+#define SPI_IER_TDRE_Pos                    1                                              /**< (SPI_IER) SPI Transmit Data Register Empty Interrupt Enable Position */
+#define SPI_IER_TDRE_Msk                    (_U_(0x1) << SPI_IER_TDRE_Pos)                 /**< (SPI_IER) SPI Transmit Data Register Empty Interrupt Enable Mask */
+#define SPI_IER_TDRE                        SPI_IER_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_TDRE_Msk instead */
+#define SPI_IER_MODF_Pos                    2                                              /**< (SPI_IER) Mode Fault Error Interrupt Enable Position */
+#define SPI_IER_MODF_Msk                    (_U_(0x1) << SPI_IER_MODF_Pos)                 /**< (SPI_IER) Mode Fault Error Interrupt Enable Mask */
+#define SPI_IER_MODF                        SPI_IER_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_MODF_Msk instead */
+#define SPI_IER_OVRES_Pos                   3                                              /**< (SPI_IER) Overrun Error Interrupt Enable Position */
+#define SPI_IER_OVRES_Msk                   (_U_(0x1) << SPI_IER_OVRES_Pos)                /**< (SPI_IER) Overrun Error Interrupt Enable Mask */
+#define SPI_IER_OVRES                       SPI_IER_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_OVRES_Msk instead */
+#define SPI_IER_NSSR_Pos                    8                                              /**< (SPI_IER) NSS Rising Interrupt Enable Position */
+#define SPI_IER_NSSR_Msk                    (_U_(0x1) << SPI_IER_NSSR_Pos)                 /**< (SPI_IER) NSS Rising Interrupt Enable Mask */
+#define SPI_IER_NSSR                        SPI_IER_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_NSSR_Msk instead */
+#define SPI_IER_TXEMPTY_Pos                 9                                              /**< (SPI_IER) Transmission Registers Empty Enable Position */
+#define SPI_IER_TXEMPTY_Msk                 (_U_(0x1) << SPI_IER_TXEMPTY_Pos)              /**< (SPI_IER) Transmission Registers Empty Enable Mask */
+#define SPI_IER_TXEMPTY                     SPI_IER_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_TXEMPTY_Msk instead */
+#define SPI_IER_UNDES_Pos                   10                                             /**< (SPI_IER) Underrun Error Interrupt Enable Position */
+#define SPI_IER_UNDES_Msk                   (_U_(0x1) << SPI_IER_UNDES_Pos)                /**< (SPI_IER) Underrun Error Interrupt Enable Mask */
+#define SPI_IER_UNDES                       SPI_IER_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IER_UNDES_Msk instead */
+#define SPI_IER_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IER) Register MASK  (Use SPI_IER_Msk instead)  */
+#define SPI_IER_Msk                         _U_(0x70F)                                     /**< (SPI_IER) Register Mask  */
+
+
+/* -------- SPI_IDR : (SPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Disable */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Disable       */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Disable          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Disable             */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Disable     */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Disable         */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IDR_OFFSET                      (0x18)                                        /**<  (SPI_IDR) Interrupt Disable Register  Offset */
+
+#define SPI_IDR_RDRF_Pos                    0                                              /**< (SPI_IDR) Receive Data Register Full Interrupt Disable Position */
+#define SPI_IDR_RDRF_Msk                    (_U_(0x1) << SPI_IDR_RDRF_Pos)                 /**< (SPI_IDR) Receive Data Register Full Interrupt Disable Mask */
+#define SPI_IDR_RDRF                        SPI_IDR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_RDRF_Msk instead */
+#define SPI_IDR_TDRE_Pos                    1                                              /**< (SPI_IDR) SPI Transmit Data Register Empty Interrupt Disable Position */
+#define SPI_IDR_TDRE_Msk                    (_U_(0x1) << SPI_IDR_TDRE_Pos)                 /**< (SPI_IDR) SPI Transmit Data Register Empty Interrupt Disable Mask */
+#define SPI_IDR_TDRE                        SPI_IDR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_TDRE_Msk instead */
+#define SPI_IDR_MODF_Pos                    2                                              /**< (SPI_IDR) Mode Fault Error Interrupt Disable Position */
+#define SPI_IDR_MODF_Msk                    (_U_(0x1) << SPI_IDR_MODF_Pos)                 /**< (SPI_IDR) Mode Fault Error Interrupt Disable Mask */
+#define SPI_IDR_MODF                        SPI_IDR_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_MODF_Msk instead */
+#define SPI_IDR_OVRES_Pos                   3                                              /**< (SPI_IDR) Overrun Error Interrupt Disable Position */
+#define SPI_IDR_OVRES_Msk                   (_U_(0x1) << SPI_IDR_OVRES_Pos)                /**< (SPI_IDR) Overrun Error Interrupt Disable Mask */
+#define SPI_IDR_OVRES                       SPI_IDR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_OVRES_Msk instead */
+#define SPI_IDR_NSSR_Pos                    8                                              /**< (SPI_IDR) NSS Rising Interrupt Disable Position */
+#define SPI_IDR_NSSR_Msk                    (_U_(0x1) << SPI_IDR_NSSR_Pos)                 /**< (SPI_IDR) NSS Rising Interrupt Disable Mask */
+#define SPI_IDR_NSSR                        SPI_IDR_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_NSSR_Msk instead */
+#define SPI_IDR_TXEMPTY_Pos                 9                                              /**< (SPI_IDR) Transmission Registers Empty Disable Position */
+#define SPI_IDR_TXEMPTY_Msk                 (_U_(0x1) << SPI_IDR_TXEMPTY_Pos)              /**< (SPI_IDR) Transmission Registers Empty Disable Mask */
+#define SPI_IDR_TXEMPTY                     SPI_IDR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_TXEMPTY_Msk instead */
+#define SPI_IDR_UNDES_Pos                   10                                             /**< (SPI_IDR) Underrun Error Interrupt Disable Position */
+#define SPI_IDR_UNDES_Msk                   (_U_(0x1) << SPI_IDR_UNDES_Pos)                /**< (SPI_IDR) Underrun Error Interrupt Disable Mask */
+#define SPI_IDR_UNDES                       SPI_IDR_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IDR_UNDES_Msk instead */
+#define SPI_IDR_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IDR) Register MASK  (Use SPI_IDR_Msk instead)  */
+#define SPI_IDR_Msk                         _U_(0x70F)                                     /**< (SPI_IDR) Register Mask  */
+
+
+/* -------- SPI_IMR : (SPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
+    uint32_t TDRE:1;                    /**< bit:      1  SPI Transmit Data Register Empty Interrupt Mask */
+    uint32_t MODF:1;                    /**< bit:      2  Mode Fault Error Interrupt Mask          */
+    uint32_t OVRES:1;                   /**< bit:      3  Overrun Error Interrupt Mask             */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t NSSR:1;                    /**< bit:      8  NSS Rising Interrupt Mask                */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmission Registers Empty Mask        */
+    uint32_t UNDES:1;                   /**< bit:     10  Underrun Error Interrupt Mask            */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IMR_OFFSET                      (0x1C)                                        /**<  (SPI_IMR) Interrupt Mask Register  Offset */
+
+#define SPI_IMR_RDRF_Pos                    0                                              /**< (SPI_IMR) Receive Data Register Full Interrupt Mask Position */
+#define SPI_IMR_RDRF_Msk                    (_U_(0x1) << SPI_IMR_RDRF_Pos)                 /**< (SPI_IMR) Receive Data Register Full Interrupt Mask Mask */
+#define SPI_IMR_RDRF                        SPI_IMR_RDRF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_RDRF_Msk instead */
+#define SPI_IMR_TDRE_Pos                    1                                              /**< (SPI_IMR) SPI Transmit Data Register Empty Interrupt Mask Position */
+#define SPI_IMR_TDRE_Msk                    (_U_(0x1) << SPI_IMR_TDRE_Pos)                 /**< (SPI_IMR) SPI Transmit Data Register Empty Interrupt Mask Mask */
+#define SPI_IMR_TDRE                        SPI_IMR_TDRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_TDRE_Msk instead */
+#define SPI_IMR_MODF_Pos                    2                                              /**< (SPI_IMR) Mode Fault Error Interrupt Mask Position */
+#define SPI_IMR_MODF_Msk                    (_U_(0x1) << SPI_IMR_MODF_Pos)                 /**< (SPI_IMR) Mode Fault Error Interrupt Mask Mask */
+#define SPI_IMR_MODF                        SPI_IMR_MODF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_MODF_Msk instead */
+#define SPI_IMR_OVRES_Pos                   3                                              /**< (SPI_IMR) Overrun Error Interrupt Mask Position */
+#define SPI_IMR_OVRES_Msk                   (_U_(0x1) << SPI_IMR_OVRES_Pos)                /**< (SPI_IMR) Overrun Error Interrupt Mask Mask */
+#define SPI_IMR_OVRES                       SPI_IMR_OVRES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_OVRES_Msk instead */
+#define SPI_IMR_NSSR_Pos                    8                                              /**< (SPI_IMR) NSS Rising Interrupt Mask Position */
+#define SPI_IMR_NSSR_Msk                    (_U_(0x1) << SPI_IMR_NSSR_Pos)                 /**< (SPI_IMR) NSS Rising Interrupt Mask Mask */
+#define SPI_IMR_NSSR                        SPI_IMR_NSSR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_NSSR_Msk instead */
+#define SPI_IMR_TXEMPTY_Pos                 9                                              /**< (SPI_IMR) Transmission Registers Empty Mask Position */
+#define SPI_IMR_TXEMPTY_Msk                 (_U_(0x1) << SPI_IMR_TXEMPTY_Pos)              /**< (SPI_IMR) Transmission Registers Empty Mask Mask */
+#define SPI_IMR_TXEMPTY                     SPI_IMR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_TXEMPTY_Msk instead */
+#define SPI_IMR_UNDES_Pos                   10                                             /**< (SPI_IMR) Underrun Error Interrupt Mask Position */
+#define SPI_IMR_UNDES_Msk                   (_U_(0x1) << SPI_IMR_UNDES_Pos)                /**< (SPI_IMR) Underrun Error Interrupt Mask Mask */
+#define SPI_IMR_UNDES                       SPI_IMR_UNDES_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_IMR_UNDES_Msk instead */
+#define SPI_IMR_MASK                        _U_(0x70F)                                     /**< \deprecated (SPI_IMR) Register MASK  (Use SPI_IMR_Msk instead)  */
+#define SPI_IMR_Msk                         _U_(0x70F)                                     /**< (SPI_IMR) Register Mask  */
+
+
+/* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
+    uint32_t NCPHA:1;                   /**< bit:      1  Clock Phase                              */
+    uint32_t CSNAAT:1;                  /**< bit:      2  Chip Select Not Active After Transfer (Ignored if CSAAT = 1) */
+    uint32_t CSAAT:1;                   /**< bit:      3  Chip Select Active After Transfer        */
+    uint32_t BITS:4;                    /**< bit:   4..7  Bits Per Transfer                        */
+    uint32_t SCBR:8;                    /**< bit:  8..15  Serial Clock Bit Rate                    */
+    uint32_t DLYBS:8;                   /**< bit: 16..23  Delay Before SPCK                        */
+    uint32_t DLYBCT:8;                  /**< bit: 24..31  Delay Between Consecutive Transfers      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_CSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CSR_OFFSET                      (0x30)                                        /**<  (SPI_CSR) Chip Select Register  Offset */
+
+#define SPI_CSR_CPOL_Pos                    0                                              /**< (SPI_CSR) Clock Polarity Position */
+#define SPI_CSR_CPOL_Msk                    (_U_(0x1) << SPI_CSR_CPOL_Pos)                 /**< (SPI_CSR) Clock Polarity Mask */
+#define SPI_CSR_CPOL                        SPI_CSR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CPOL_Msk instead */
+#define   SPI_CSR_CPOL_IDLE_LOW_Val         _U_(0x0)                                       /**< (SPI_CSR) Clock is low when inactive (CPOL=0)  */
+#define   SPI_CSR_CPOL_IDLE_HIGH_Val        _U_(0x1)                                       /**< (SPI_CSR) Clock is high when inactive (CPOL=1)  */
+#define SPI_CSR_CPOL_IDLE_LOW               (SPI_CSR_CPOL_IDLE_LOW_Val << SPI_CSR_CPOL_Pos)  /**< (SPI_CSR) Clock is low when inactive (CPOL=0) Position  */
+#define SPI_CSR_CPOL_IDLE_HIGH              (SPI_CSR_CPOL_IDLE_HIGH_Val << SPI_CSR_CPOL_Pos)  /**< (SPI_CSR) Clock is high when inactive (CPOL=1) Position  */
+#define SPI_CSR_NCPHA_Pos                   1                                              /**< (SPI_CSR) Clock Phase Position */
+#define SPI_CSR_NCPHA_Msk                   (_U_(0x1) << SPI_CSR_NCPHA_Pos)                /**< (SPI_CSR) Clock Phase Mask */
+#define SPI_CSR_NCPHA                       SPI_CSR_NCPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_NCPHA_Msk instead */
+#define   SPI_CSR_NCPHA_VALID_LEADING_EDGE_Val _U_(0x1)                                       /**< (SPI_CSR) Data is valid on clock leading edge (CPHA=0)  */
+#define   SPI_CSR_NCPHA_VALID_TRAILING_EDGE_Val _U_(0x0)                                       /**< (SPI_CSR) Data is valid on clock trailing edge (CPHA=1)  */
+#define SPI_CSR_NCPHA_VALID_LEADING_EDGE    (SPI_CSR_NCPHA_VALID_LEADING_EDGE_Val << SPI_CSR_NCPHA_Pos)  /**< (SPI_CSR) Data is valid on clock leading edge (CPHA=0) Position  */
+#define SPI_CSR_NCPHA_VALID_TRAILING_EDGE   (SPI_CSR_NCPHA_VALID_TRAILING_EDGE_Val << SPI_CSR_NCPHA_Pos)  /**< (SPI_CSR) Data is valid on clock trailing edge (CPHA=1) Position  */
+#define SPI_CSR_CSNAAT_Pos                  2                                              /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Position */
+#define SPI_CSR_CSNAAT_Msk                  (_U_(0x1) << SPI_CSR_CSNAAT_Pos)               /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Mask */
+#define SPI_CSR_CSNAAT                      SPI_CSR_CSNAAT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CSNAAT_Msk instead */
+#define SPI_CSR_CSAAT_Pos                   3                                              /**< (SPI_CSR) Chip Select Active After Transfer Position */
+#define SPI_CSR_CSAAT_Msk                   (_U_(0x1) << SPI_CSR_CSAAT_Pos)                /**< (SPI_CSR) Chip Select Active After Transfer Mask */
+#define SPI_CSR_CSAAT                       SPI_CSR_CSAAT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CSAAT_Msk instead */
+#define SPI_CSR_BITS_Pos                    4                                              /**< (SPI_CSR) Bits Per Transfer Position */
+#define SPI_CSR_BITS_Msk                    (_U_(0xF) << SPI_CSR_BITS_Pos)                 /**< (SPI_CSR) Bits Per Transfer Mask */
+#define SPI_CSR_BITS(value)                 (SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos))
+#define   SPI_CSR_BITS_8_BIT_Val            _U_(0x0)                                       /**< (SPI_CSR) 8 bits for transfer  */
+#define   SPI_CSR_BITS_9_BIT_Val            _U_(0x1)                                       /**< (SPI_CSR) 9 bits for transfer  */
+#define   SPI_CSR_BITS_10_BIT_Val           _U_(0x2)                                       /**< (SPI_CSR) 10 bits for transfer  */
+#define   SPI_CSR_BITS_11_BIT_Val           _U_(0x3)                                       /**< (SPI_CSR) 11 bits for transfer  */
+#define   SPI_CSR_BITS_12_BIT_Val           _U_(0x4)                                       /**< (SPI_CSR) 12 bits for transfer  */
+#define   SPI_CSR_BITS_13_BIT_Val           _U_(0x5)                                       /**< (SPI_CSR) 13 bits for transfer  */
+#define   SPI_CSR_BITS_14_BIT_Val           _U_(0x6)                                       /**< (SPI_CSR) 14 bits for transfer  */
+#define   SPI_CSR_BITS_15_BIT_Val           _U_(0x7)                                       /**< (SPI_CSR) 15 bits for transfer  */
+#define   SPI_CSR_BITS_16_BIT_Val           _U_(0x8)                                       /**< (SPI_CSR) 16 bits for transfer  */
+#define SPI_CSR_BITS_8_BIT                  (SPI_CSR_BITS_8_BIT_Val << SPI_CSR_BITS_Pos)   /**< (SPI_CSR) 8 bits for transfer Position  */
+#define SPI_CSR_BITS_9_BIT                  (SPI_CSR_BITS_9_BIT_Val << SPI_CSR_BITS_Pos)   /**< (SPI_CSR) 9 bits for transfer Position  */
+#define SPI_CSR_BITS_10_BIT                 (SPI_CSR_BITS_10_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 10 bits for transfer Position  */
+#define SPI_CSR_BITS_11_BIT                 (SPI_CSR_BITS_11_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 11 bits for transfer Position  */
+#define SPI_CSR_BITS_12_BIT                 (SPI_CSR_BITS_12_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 12 bits for transfer Position  */
+#define SPI_CSR_BITS_13_BIT                 (SPI_CSR_BITS_13_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 13 bits for transfer Position  */
+#define SPI_CSR_BITS_14_BIT                 (SPI_CSR_BITS_14_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 14 bits for transfer Position  */
+#define SPI_CSR_BITS_15_BIT                 (SPI_CSR_BITS_15_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 15 bits for transfer Position  */
+#define SPI_CSR_BITS_16_BIT                 (SPI_CSR_BITS_16_BIT_Val << SPI_CSR_BITS_Pos)  /**< (SPI_CSR) 16 bits for transfer Position  */
+#define SPI_CSR_SCBR_Pos                    8                                              /**< (SPI_CSR) Serial Clock Bit Rate Position */
+#define SPI_CSR_SCBR_Msk                    (_U_(0xFF) << SPI_CSR_SCBR_Pos)                /**< (SPI_CSR) Serial Clock Bit Rate Mask */
+#define SPI_CSR_SCBR(value)                 (SPI_CSR_SCBR_Msk & ((value) << SPI_CSR_SCBR_Pos))
+#define SPI_CSR_DLYBS_Pos                   16                                             /**< (SPI_CSR) Delay Before SPCK Position */
+#define SPI_CSR_DLYBS_Msk                   (_U_(0xFF) << SPI_CSR_DLYBS_Pos)               /**< (SPI_CSR) Delay Before SPCK Mask */
+#define SPI_CSR_DLYBS(value)                (SPI_CSR_DLYBS_Msk & ((value) << SPI_CSR_DLYBS_Pos))
+#define SPI_CSR_DLYBCT_Pos                  24                                             /**< (SPI_CSR) Delay Between Consecutive Transfers Position */
+#define SPI_CSR_DLYBCT_Msk                  (_U_(0xFF) << SPI_CSR_DLYBCT_Pos)              /**< (SPI_CSR) Delay Between Consecutive Transfers Mask */
+#define SPI_CSR_DLYBCT(value)               (SPI_CSR_DLYBCT_Msk & ((value) << SPI_CSR_DLYBCT_Pos))
+#define SPI_CSR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SPI_CSR) Register MASK  (Use SPI_CSR_Msk instead)  */
+#define SPI_CSR_Msk                         _U_(0xFFFFFFFF)                                /**< (SPI_CSR) Register Mask  */
+
+
+/* -------- SPI_WPMR : (SPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPMR_OFFSET                     (0xE4)                                        /**<  (SPI_WPMR) Write Protection Mode Register  Offset */
+
+#define SPI_WPMR_WPEN_Pos                   0                                              /**< (SPI_WPMR) Write Protection Enable Position */
+#define SPI_WPMR_WPEN_Msk                   (_U_(0x1) << SPI_WPMR_WPEN_Pos)                /**< (SPI_WPMR) Write Protection Enable Mask */
+#define SPI_WPMR_WPEN                       SPI_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_WPMR_WPEN_Msk instead */
+#define SPI_WPMR_WPKEY_Pos                  8                                              /**< (SPI_WPMR) Write Protection Key Position */
+#define SPI_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SPI_WPMR_WPKEY_Pos)          /**< (SPI_WPMR) Write Protection Key Mask */
+#define SPI_WPMR_WPKEY(value)               (SPI_WPMR_WPKEY_Msk & ((value) << SPI_WPMR_WPKEY_Pos))
+#define   SPI_WPMR_WPKEY_PASSWD_Val         _U_(0x535049)                                  /**< (SPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define SPI_WPMR_WPKEY_PASSWD               (SPI_WPMR_WPKEY_PASSWD_Val << SPI_WPMR_WPKEY_Pos)  /**< (SPI_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define SPI_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SPI_WPMR) Register MASK  (Use SPI_WPMR_Msk instead)  */
+#define SPI_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SPI_WPMR) Register Mask  */
+
+
+/* -------- SPI_WPSR : (SPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:8;                  /**< bit:  8..15  Write Protection Violation Source        */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SPI_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPSR_OFFSET                     (0xE8)                                        /**<  (SPI_WPSR) Write Protection Status Register  Offset */
+
+#define SPI_WPSR_WPVS_Pos                   0                                              /**< (SPI_WPSR) Write Protection Violation Status Position */
+#define SPI_WPSR_WPVS_Msk                   (_U_(0x1) << SPI_WPSR_WPVS_Pos)                /**< (SPI_WPSR) Write Protection Violation Status Mask */
+#define SPI_WPSR_WPVS                       SPI_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_WPSR_WPVS_Msk instead */
+#define SPI_WPSR_WPVSRC_Pos                 8                                              /**< (SPI_WPSR) Write Protection Violation Source Position */
+#define SPI_WPSR_WPVSRC_Msk                 (_U_(0xFF) << SPI_WPSR_WPVSRC_Pos)             /**< (SPI_WPSR) Write Protection Violation Source Mask */
+#define SPI_WPSR_WPVSRC(value)              (SPI_WPSR_WPVSRC_Msk & ((value) << SPI_WPSR_WPVSRC_Pos))
+#define SPI_WPSR_MASK                       _U_(0xFF01)                                    /**< \deprecated (SPI_WPSR) Register MASK  (Use SPI_WPSR_Msk instead)  */
+#define SPI_WPSR_Msk                        _U_(0xFF01)                                    /**< (SPI_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SPI hardware registers */
+typedef struct {  
+  __O  uint32_t SPI_CR;         /**< (SPI Offset: 0x00) Control Register */
+  __IO uint32_t SPI_MR;         /**< (SPI Offset: 0x04) Mode Register */
+  __I  uint32_t SPI_RDR;        /**< (SPI Offset: 0x08) Receive Data Register */
+  __O  uint32_t SPI_TDR;        /**< (SPI Offset: 0x0C) Transmit Data Register */
+  __I  uint32_t SPI_SR;         /**< (SPI Offset: 0x10) Status Register */
+  __O  uint32_t SPI_IER;        /**< (SPI Offset: 0x14) Interrupt Enable Register */
+  __O  uint32_t SPI_IDR;        /**< (SPI Offset: 0x18) Interrupt Disable Register */
+  __I  uint32_t SPI_IMR;        /**< (SPI Offset: 0x1C) Interrupt Mask Register */
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t SPI_CSR[4];     /**< (SPI Offset: 0x30) Chip Select Register */
+  __I  uint8_t                        Reserved2[164];
+  __IO uint32_t SPI_WPMR;       /**< (SPI Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t SPI_WPSR;       /**< (SPI Offset: 0xE8) Write Protection Status Register */
+} Spi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SPI hardware registers */
+typedef struct {  
+  __O  SPI_CR_Type                    SPI_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO SPI_MR_Type                    SPI_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  SPI_RDR_Type                   SPI_RDR;        /**< Offset: 0x08 (R/   32) Receive Data Register */
+  __O  SPI_TDR_Type                   SPI_TDR;        /**< Offset: 0x0C ( /W  32) Transmit Data Register */
+  __I  SPI_SR_Type                    SPI_SR;         /**< Offset: 0x10 (R/   32) Status Register */
+  __O  SPI_IER_Type                   SPI_IER;        /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
+  __O  SPI_IDR_Type                   SPI_IDR;        /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
+  __I  SPI_IMR_Type                   SPI_IMR;        /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
+  __I  uint8_t                        Reserved1[16];
+  __IO SPI_CSR_Type                   SPI_CSR[4];     /**< Offset: 0x30 (R/W  32) Chip Select Register */
+  __I  uint8_t                        Reserved2[164];
+  __IO SPI_WPMR_Type                  SPI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  SPI_WPSR_Type                  SPI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Spi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Serial Peripheral Interface */
+
+#endif /* _SAMV71_SPI_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/ssc.h
+++ b/asf/sam/include/samv71b/component/ssc.h
@@ -1,0 +1,911 @@
+/**
+ * \file
+ *
+ * \brief Component description for SSC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SSC_COMPONENT_H_
+#define _SAMV71_SSC_COMPONENT_H_
+#define _SAMV71_SSC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Synchronous Serial Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SSC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SSC_6078                       /**< (SSC) Module ID */
+#define REV_SSC Q                      /**< (SSC) Module revision */
+
+/* -------- SSC_CR : (SSC Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXEN:1;                    /**< bit:      0  Receive Enable                           */
+    uint32_t RXDIS:1;                   /**< bit:      1  Receive Disable                          */
+    uint32_t :6;                        /**< bit:   2..7  Reserved */
+    uint32_t TXEN:1;                    /**< bit:      8  Transmit Enable                          */
+    uint32_t TXDIS:1;                   /**< bit:      9  Transmit Disable                         */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t SWRST:1;                   /**< bit:     15  Software Reset                           */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_CR_OFFSET                       (0x00)                                        /**<  (SSC_CR) Control Register  Offset */
+
+#define SSC_CR_RXEN_Pos                     0                                              /**< (SSC_CR) Receive Enable Position */
+#define SSC_CR_RXEN_Msk                     (_U_(0x1) << SSC_CR_RXEN_Pos)                  /**< (SSC_CR) Receive Enable Mask */
+#define SSC_CR_RXEN                         SSC_CR_RXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_RXEN_Msk instead */
+#define SSC_CR_RXDIS_Pos                    1                                              /**< (SSC_CR) Receive Disable Position */
+#define SSC_CR_RXDIS_Msk                    (_U_(0x1) << SSC_CR_RXDIS_Pos)                 /**< (SSC_CR) Receive Disable Mask */
+#define SSC_CR_RXDIS                        SSC_CR_RXDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_RXDIS_Msk instead */
+#define SSC_CR_TXEN_Pos                     8                                              /**< (SSC_CR) Transmit Enable Position */
+#define SSC_CR_TXEN_Msk                     (_U_(0x1) << SSC_CR_TXEN_Pos)                  /**< (SSC_CR) Transmit Enable Mask */
+#define SSC_CR_TXEN                         SSC_CR_TXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_TXEN_Msk instead */
+#define SSC_CR_TXDIS_Pos                    9                                              /**< (SSC_CR) Transmit Disable Position */
+#define SSC_CR_TXDIS_Msk                    (_U_(0x1) << SSC_CR_TXDIS_Pos)                 /**< (SSC_CR) Transmit Disable Mask */
+#define SSC_CR_TXDIS                        SSC_CR_TXDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_TXDIS_Msk instead */
+#define SSC_CR_SWRST_Pos                    15                                             /**< (SSC_CR) Software Reset Position */
+#define SSC_CR_SWRST_Msk                    (_U_(0x1) << SSC_CR_SWRST_Pos)                 /**< (SSC_CR) Software Reset Mask */
+#define SSC_CR_SWRST                        SSC_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_CR_SWRST_Msk instead */
+#define SSC_CR_MASK                         _U_(0x8303)                                    /**< \deprecated (SSC_CR) Register MASK  (Use SSC_CR_Msk instead)  */
+#define SSC_CR_Msk                          _U_(0x8303)                                    /**< (SSC_CR) Register Mask  */
+
+
+/* -------- SSC_CMR : (SSC Offset: 0x04) (R/W 32) Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DIV:12;                    /**< bit:  0..11  Clock Divider                            */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_CMR_OFFSET                      (0x04)                                        /**<  (SSC_CMR) Clock Mode Register  Offset */
+
+#define SSC_CMR_DIV_Pos                     0                                              /**< (SSC_CMR) Clock Divider Position */
+#define SSC_CMR_DIV_Msk                     (_U_(0xFFF) << SSC_CMR_DIV_Pos)                /**< (SSC_CMR) Clock Divider Mask */
+#define SSC_CMR_DIV(value)                  (SSC_CMR_DIV_Msk & ((value) << SSC_CMR_DIV_Pos))
+#define SSC_CMR_MASK                        _U_(0xFFF)                                     /**< \deprecated (SSC_CMR) Register MASK  (Use SSC_CMR_Msk instead)  */
+#define SSC_CMR_Msk                         _U_(0xFFF)                                     /**< (SSC_CMR) Register Mask  */
+
+
+/* -------- SSC_RCMR : (SSC Offset: 0x10) (R/W 32) Receive Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CKS:2;                     /**< bit:   0..1  Receive Clock Selection                  */
+    uint32_t CKO:3;                     /**< bit:   2..4  Receive Clock Output Mode Selection      */
+    uint32_t CKI:1;                     /**< bit:      5  Receive Clock Inversion                  */
+    uint32_t CKG:2;                     /**< bit:   6..7  Receive Clock Gating Selection           */
+    uint32_t START:4;                   /**< bit:  8..11  Receive Start Selection                  */
+    uint32_t STOP:1;                    /**< bit:     12  Receive Stop Selection                   */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t STTDLY:8;                  /**< bit: 16..23  Receive Start Delay                      */
+    uint32_t PERIOD:8;                  /**< bit: 24..31  Receive Period Divider Selection         */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RCMR_OFFSET                     (0x10)                                        /**<  (SSC_RCMR) Receive Clock Mode Register  Offset */
+
+#define SSC_RCMR_CKS_Pos                    0                                              /**< (SSC_RCMR) Receive Clock Selection Position */
+#define SSC_RCMR_CKS_Msk                    (_U_(0x3) << SSC_RCMR_CKS_Pos)                 /**< (SSC_RCMR) Receive Clock Selection Mask */
+#define SSC_RCMR_CKS(value)                 (SSC_RCMR_CKS_Msk & ((value) << SSC_RCMR_CKS_Pos))
+#define   SSC_RCMR_CKS_MCK_Val              _U_(0x0)                                       /**< (SSC_RCMR) Divided Clock  */
+#define   SSC_RCMR_CKS_TK_Val               _U_(0x1)                                       /**< (SSC_RCMR) TK Clock signal  */
+#define   SSC_RCMR_CKS_RK_Val               _U_(0x2)                                       /**< (SSC_RCMR) RK pin  */
+#define SSC_RCMR_CKS_MCK                    (SSC_RCMR_CKS_MCK_Val << SSC_RCMR_CKS_Pos)     /**< (SSC_RCMR) Divided Clock Position  */
+#define SSC_RCMR_CKS_TK                     (SSC_RCMR_CKS_TK_Val << SSC_RCMR_CKS_Pos)      /**< (SSC_RCMR) TK Clock signal Position  */
+#define SSC_RCMR_CKS_RK                     (SSC_RCMR_CKS_RK_Val << SSC_RCMR_CKS_Pos)      /**< (SSC_RCMR) RK pin Position  */
+#define SSC_RCMR_CKO_Pos                    2                                              /**< (SSC_RCMR) Receive Clock Output Mode Selection Position */
+#define SSC_RCMR_CKO_Msk                    (_U_(0x7) << SSC_RCMR_CKO_Pos)                 /**< (SSC_RCMR) Receive Clock Output Mode Selection Mask */
+#define SSC_RCMR_CKO(value)                 (SSC_RCMR_CKO_Msk & ((value) << SSC_RCMR_CKO_Pos))
+#define   SSC_RCMR_CKO_NONE_Val             _U_(0x0)                                       /**< (SSC_RCMR) None, RK pin is an input  */
+#define   SSC_RCMR_CKO_CONTINUOUS_Val       _U_(0x1)                                       /**< (SSC_RCMR) Continuous Receive Clock, RK pin is an output  */
+#define   SSC_RCMR_CKO_TRANSFER_Val         _U_(0x2)                                       /**< (SSC_RCMR) Receive Clock only during data transfers, RK pin is an output  */
+#define SSC_RCMR_CKO_NONE                   (SSC_RCMR_CKO_NONE_Val << SSC_RCMR_CKO_Pos)    /**< (SSC_RCMR) None, RK pin is an input Position  */
+#define SSC_RCMR_CKO_CONTINUOUS             (SSC_RCMR_CKO_CONTINUOUS_Val << SSC_RCMR_CKO_Pos)  /**< (SSC_RCMR) Continuous Receive Clock, RK pin is an output Position  */
+#define SSC_RCMR_CKO_TRANSFER               (SSC_RCMR_CKO_TRANSFER_Val << SSC_RCMR_CKO_Pos)  /**< (SSC_RCMR) Receive Clock only during data transfers, RK pin is an output Position  */
+#define SSC_RCMR_CKI_Pos                    5                                              /**< (SSC_RCMR) Receive Clock Inversion Position */
+#define SSC_RCMR_CKI_Msk                    (_U_(0x1) << SSC_RCMR_CKI_Pos)                 /**< (SSC_RCMR) Receive Clock Inversion Mask */
+#define SSC_RCMR_CKI                        SSC_RCMR_CKI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RCMR_CKI_Msk instead */
+#define SSC_RCMR_CKG_Pos                    6                                              /**< (SSC_RCMR) Receive Clock Gating Selection Position */
+#define SSC_RCMR_CKG_Msk                    (_U_(0x3) << SSC_RCMR_CKG_Pos)                 /**< (SSC_RCMR) Receive Clock Gating Selection Mask */
+#define SSC_RCMR_CKG(value)                 (SSC_RCMR_CKG_Msk & ((value) << SSC_RCMR_CKG_Pos))
+#define   SSC_RCMR_CKG_CONTINUOUS_Val       _U_(0x0)                                       /**< (SSC_RCMR) None  */
+#define   SSC_RCMR_CKG_EN_RF_LOW_Val        _U_(0x1)                                       /**< (SSC_RCMR) Receive Clock enabled only if RF Low  */
+#define   SSC_RCMR_CKG_EN_RF_HIGH_Val       _U_(0x2)                                       /**< (SSC_RCMR) Receive Clock enabled only if RF High  */
+#define SSC_RCMR_CKG_CONTINUOUS             (SSC_RCMR_CKG_CONTINUOUS_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) None Position  */
+#define SSC_RCMR_CKG_EN_RF_LOW              (SSC_RCMR_CKG_EN_RF_LOW_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) Receive Clock enabled only if RF Low Position  */
+#define SSC_RCMR_CKG_EN_RF_HIGH             (SSC_RCMR_CKG_EN_RF_HIGH_Val << SSC_RCMR_CKG_Pos)  /**< (SSC_RCMR) Receive Clock enabled only if RF High Position  */
+#define SSC_RCMR_START_Pos                  8                                              /**< (SSC_RCMR) Receive Start Selection Position */
+#define SSC_RCMR_START_Msk                  (_U_(0xF) << SSC_RCMR_START_Pos)               /**< (SSC_RCMR) Receive Start Selection Mask */
+#define SSC_RCMR_START(value)               (SSC_RCMR_START_Msk & ((value) << SSC_RCMR_START_Pos))
+#define   SSC_RCMR_START_CONTINUOUS_Val     _U_(0x0)                                       /**< (SSC_RCMR) Continuous, as soon as the receiver is enabled, and immediately after the end of transfer of the previous data.  */
+#define   SSC_RCMR_START_TRANSMIT_Val       _U_(0x1)                                       /**< (SSC_RCMR) Transmit start  */
+#define   SSC_RCMR_START_RF_LOW_Val         _U_(0x2)                                       /**< (SSC_RCMR) Detection of a low level on RF signal  */
+#define   SSC_RCMR_START_RF_HIGH_Val        _U_(0x3)                                       /**< (SSC_RCMR) Detection of a high level on RF signal  */
+#define   SSC_RCMR_START_RF_FALLING_Val     _U_(0x4)                                       /**< (SSC_RCMR) Detection of a falling edge on RF signal  */
+#define   SSC_RCMR_START_RF_RISING_Val      _U_(0x5)                                       /**< (SSC_RCMR) Detection of a rising edge on RF signal  */
+#define   SSC_RCMR_START_RF_LEVEL_Val       _U_(0x6)                                       /**< (SSC_RCMR) Detection of any level change on RF signal  */
+#define   SSC_RCMR_START_RF_EDGE_Val        _U_(0x7)                                       /**< (SSC_RCMR) Detection of any edge on RF signal  */
+#define   SSC_RCMR_START_CMP_0_Val          _U_(0x8)                                       /**< (SSC_RCMR) Compare 0  */
+#define SSC_RCMR_START_CONTINUOUS           (SSC_RCMR_START_CONTINUOUS_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Continuous, as soon as the receiver is enabled, and immediately after the end of transfer of the previous data. Position  */
+#define SSC_RCMR_START_TRANSMIT             (SSC_RCMR_START_TRANSMIT_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Transmit start Position  */
+#define SSC_RCMR_START_RF_LOW               (SSC_RCMR_START_RF_LOW_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a low level on RF signal Position  */
+#define SSC_RCMR_START_RF_HIGH              (SSC_RCMR_START_RF_HIGH_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a high level on RF signal Position  */
+#define SSC_RCMR_START_RF_FALLING           (SSC_RCMR_START_RF_FALLING_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a falling edge on RF signal Position  */
+#define SSC_RCMR_START_RF_RISING            (SSC_RCMR_START_RF_RISING_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of a rising edge on RF signal Position  */
+#define SSC_RCMR_START_RF_LEVEL             (SSC_RCMR_START_RF_LEVEL_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of any level change on RF signal Position  */
+#define SSC_RCMR_START_RF_EDGE              (SSC_RCMR_START_RF_EDGE_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Detection of any edge on RF signal Position  */
+#define SSC_RCMR_START_CMP_0                (SSC_RCMR_START_CMP_0_Val << SSC_RCMR_START_Pos)  /**< (SSC_RCMR) Compare 0 Position  */
+#define SSC_RCMR_STOP_Pos                   12                                             /**< (SSC_RCMR) Receive Stop Selection Position */
+#define SSC_RCMR_STOP_Msk                   (_U_(0x1) << SSC_RCMR_STOP_Pos)                /**< (SSC_RCMR) Receive Stop Selection Mask */
+#define SSC_RCMR_STOP                       SSC_RCMR_STOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RCMR_STOP_Msk instead */
+#define SSC_RCMR_STTDLY_Pos                 16                                             /**< (SSC_RCMR) Receive Start Delay Position */
+#define SSC_RCMR_STTDLY_Msk                 (_U_(0xFF) << SSC_RCMR_STTDLY_Pos)             /**< (SSC_RCMR) Receive Start Delay Mask */
+#define SSC_RCMR_STTDLY(value)              (SSC_RCMR_STTDLY_Msk & ((value) << SSC_RCMR_STTDLY_Pos))
+#define SSC_RCMR_PERIOD_Pos                 24                                             /**< (SSC_RCMR) Receive Period Divider Selection Position */
+#define SSC_RCMR_PERIOD_Msk                 (_U_(0xFF) << SSC_RCMR_PERIOD_Pos)             /**< (SSC_RCMR) Receive Period Divider Selection Mask */
+#define SSC_RCMR_PERIOD(value)              (SSC_RCMR_PERIOD_Msk & ((value) << SSC_RCMR_PERIOD_Pos))
+#define SSC_RCMR_MASK                       _U_(0xFFFF1FFF)                                /**< \deprecated (SSC_RCMR) Register MASK  (Use SSC_RCMR_Msk instead)  */
+#define SSC_RCMR_Msk                        _U_(0xFFFF1FFF)                                /**< (SSC_RCMR) Register Mask  */
+
+
+/* -------- SSC_RFMR : (SSC Offset: 0x14) (R/W 32) Receive Frame Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
+    uint32_t LOOP:1;                    /**< bit:      5  Loop Mode                                */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MSBF:1;                    /**< bit:      7  Most Significant Bit First               */
+    uint32_t DATNB:4;                   /**< bit:  8..11  Data Number per Frame                    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t FSLEN:4;                   /**< bit: 16..19  Receive Frame Sync Length                */
+    uint32_t FSOS:3;                    /**< bit: 20..22  Receive Frame Sync Output Selection      */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t FSEDGE:1;                  /**< bit:     24  Frame Sync Edge Detection                */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t FSLEN_EXT:4;               /**< bit: 28..31  FSLEN Field Extension                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RFMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RFMR_OFFSET                     (0x14)                                        /**<  (SSC_RFMR) Receive Frame Mode Register  Offset */
+
+#define SSC_RFMR_DATLEN_Pos                 0                                              /**< (SSC_RFMR) Data Length Position */
+#define SSC_RFMR_DATLEN_Msk                 (_U_(0x1F) << SSC_RFMR_DATLEN_Pos)             /**< (SSC_RFMR) Data Length Mask */
+#define SSC_RFMR_DATLEN(value)              (SSC_RFMR_DATLEN_Msk & ((value) << SSC_RFMR_DATLEN_Pos))
+#define SSC_RFMR_LOOP_Pos                   5                                              /**< (SSC_RFMR) Loop Mode Position */
+#define SSC_RFMR_LOOP_Msk                   (_U_(0x1) << SSC_RFMR_LOOP_Pos)                /**< (SSC_RFMR) Loop Mode Mask */
+#define SSC_RFMR_LOOP                       SSC_RFMR_LOOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_LOOP_Msk instead */
+#define SSC_RFMR_MSBF_Pos                   7                                              /**< (SSC_RFMR) Most Significant Bit First Position */
+#define SSC_RFMR_MSBF_Msk                   (_U_(0x1) << SSC_RFMR_MSBF_Pos)                /**< (SSC_RFMR) Most Significant Bit First Mask */
+#define SSC_RFMR_MSBF                       SSC_RFMR_MSBF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_MSBF_Msk instead */
+#define SSC_RFMR_DATNB_Pos                  8                                              /**< (SSC_RFMR) Data Number per Frame Position */
+#define SSC_RFMR_DATNB_Msk                  (_U_(0xF) << SSC_RFMR_DATNB_Pos)               /**< (SSC_RFMR) Data Number per Frame Mask */
+#define SSC_RFMR_DATNB(value)               (SSC_RFMR_DATNB_Msk & ((value) << SSC_RFMR_DATNB_Pos))
+#define SSC_RFMR_FSLEN_Pos                  16                                             /**< (SSC_RFMR) Receive Frame Sync Length Position */
+#define SSC_RFMR_FSLEN_Msk                  (_U_(0xF) << SSC_RFMR_FSLEN_Pos)               /**< (SSC_RFMR) Receive Frame Sync Length Mask */
+#define SSC_RFMR_FSLEN(value)               (SSC_RFMR_FSLEN_Msk & ((value) << SSC_RFMR_FSLEN_Pos))
+#define SSC_RFMR_FSOS_Pos                   20                                             /**< (SSC_RFMR) Receive Frame Sync Output Selection Position */
+#define SSC_RFMR_FSOS_Msk                   (_U_(0x7) << SSC_RFMR_FSOS_Pos)                /**< (SSC_RFMR) Receive Frame Sync Output Selection Mask */
+#define SSC_RFMR_FSOS(value)                (SSC_RFMR_FSOS_Msk & ((value) << SSC_RFMR_FSOS_Pos))
+#define   SSC_RFMR_FSOS_NONE_Val            _U_(0x0)                                       /**< (SSC_RFMR) None, RF pin is an input  */
+#define   SSC_RFMR_FSOS_NEGATIVE_Val        _U_(0x1)                                       /**< (SSC_RFMR) Negative Pulse, RF pin is an output  */
+#define   SSC_RFMR_FSOS_POSITIVE_Val        _U_(0x2)                                       /**< (SSC_RFMR) Positive Pulse, RF pin is an output  */
+#define   SSC_RFMR_FSOS_LOW_Val             _U_(0x3)                                       /**< (SSC_RFMR) Driven Low during data transfer, RF pin is an output  */
+#define   SSC_RFMR_FSOS_HIGH_Val            _U_(0x4)                                       /**< (SSC_RFMR) Driven High during data transfer, RF pin is an output  */
+#define   SSC_RFMR_FSOS_TOGGLING_Val        _U_(0x5)                                       /**< (SSC_RFMR) Toggling at each start of data transfer, RF pin is an output  */
+#define SSC_RFMR_FSOS_NONE                  (SSC_RFMR_FSOS_NONE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) None, RF pin is an input Position  */
+#define SSC_RFMR_FSOS_NEGATIVE              (SSC_RFMR_FSOS_NEGATIVE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Negative Pulse, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_POSITIVE              (SSC_RFMR_FSOS_POSITIVE_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Positive Pulse, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_LOW                   (SSC_RFMR_FSOS_LOW_Val << SSC_RFMR_FSOS_Pos)   /**< (SSC_RFMR) Driven Low during data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_HIGH                  (SSC_RFMR_FSOS_HIGH_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Driven High during data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSOS_TOGGLING              (SSC_RFMR_FSOS_TOGGLING_Val << SSC_RFMR_FSOS_Pos)  /**< (SSC_RFMR) Toggling at each start of data transfer, RF pin is an output Position  */
+#define SSC_RFMR_FSEDGE_Pos                 24                                             /**< (SSC_RFMR) Frame Sync Edge Detection Position */
+#define SSC_RFMR_FSEDGE_Msk                 (_U_(0x1) << SSC_RFMR_FSEDGE_Pos)              /**< (SSC_RFMR) Frame Sync Edge Detection Mask */
+#define SSC_RFMR_FSEDGE                     SSC_RFMR_FSEDGE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_RFMR_FSEDGE_Msk instead */
+#define   SSC_RFMR_FSEDGE_POSITIVE_Val      _U_(0x0)                                       /**< (SSC_RFMR) Positive Edge Detection  */
+#define   SSC_RFMR_FSEDGE_NEGATIVE_Val      _U_(0x1)                                       /**< (SSC_RFMR) Negative Edge Detection  */
+#define SSC_RFMR_FSEDGE_POSITIVE            (SSC_RFMR_FSEDGE_POSITIVE_Val << SSC_RFMR_FSEDGE_Pos)  /**< (SSC_RFMR) Positive Edge Detection Position  */
+#define SSC_RFMR_FSEDGE_NEGATIVE            (SSC_RFMR_FSEDGE_NEGATIVE_Val << SSC_RFMR_FSEDGE_Pos)  /**< (SSC_RFMR) Negative Edge Detection Position  */
+#define SSC_RFMR_FSLEN_EXT_Pos              28                                             /**< (SSC_RFMR) FSLEN Field Extension Position */
+#define SSC_RFMR_FSLEN_EXT_Msk              (_U_(0xF) << SSC_RFMR_FSLEN_EXT_Pos)           /**< (SSC_RFMR) FSLEN Field Extension Mask */
+#define SSC_RFMR_FSLEN_EXT(value)           (SSC_RFMR_FSLEN_EXT_Msk & ((value) << SSC_RFMR_FSLEN_EXT_Pos))
+#define SSC_RFMR_MASK                       _U_(0xF17F0FBF)                                /**< \deprecated (SSC_RFMR) Register MASK  (Use SSC_RFMR_Msk instead)  */
+#define SSC_RFMR_Msk                        _U_(0xF17F0FBF)                                /**< (SSC_RFMR) Register Mask  */
+
+
+/* -------- SSC_TCMR : (SSC Offset: 0x18) (R/W 32) Transmit Clock Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CKS:2;                     /**< bit:   0..1  Transmit Clock Selection                 */
+    uint32_t CKO:3;                     /**< bit:   2..4  Transmit Clock Output Mode Selection     */
+    uint32_t CKI:1;                     /**< bit:      5  Transmit Clock Inversion                 */
+    uint32_t CKG:2;                     /**< bit:   6..7  Transmit Clock Gating Selection          */
+    uint32_t START:4;                   /**< bit:  8..11  Transmit Start Selection                 */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t STTDLY:8;                  /**< bit: 16..23  Transmit Start Delay                     */
+    uint32_t PERIOD:8;                  /**< bit: 24..31  Transmit Period Divider Selection        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TCMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TCMR_OFFSET                     (0x18)                                        /**<  (SSC_TCMR) Transmit Clock Mode Register  Offset */
+
+#define SSC_TCMR_CKS_Pos                    0                                              /**< (SSC_TCMR) Transmit Clock Selection Position */
+#define SSC_TCMR_CKS_Msk                    (_U_(0x3) << SSC_TCMR_CKS_Pos)                 /**< (SSC_TCMR) Transmit Clock Selection Mask */
+#define SSC_TCMR_CKS(value)                 (SSC_TCMR_CKS_Msk & ((value) << SSC_TCMR_CKS_Pos))
+#define   SSC_TCMR_CKS_MCK_Val              _U_(0x0)                                       /**< (SSC_TCMR) Divided Clock  */
+#define   SSC_TCMR_CKS_RK_Val               _U_(0x1)                                       /**< (SSC_TCMR) RK Clock signal  */
+#define   SSC_TCMR_CKS_TK_Val               _U_(0x2)                                       /**< (SSC_TCMR) TK pin  */
+#define SSC_TCMR_CKS_MCK                    (SSC_TCMR_CKS_MCK_Val << SSC_TCMR_CKS_Pos)     /**< (SSC_TCMR) Divided Clock Position  */
+#define SSC_TCMR_CKS_RK                     (SSC_TCMR_CKS_RK_Val << SSC_TCMR_CKS_Pos)      /**< (SSC_TCMR) RK Clock signal Position  */
+#define SSC_TCMR_CKS_TK                     (SSC_TCMR_CKS_TK_Val << SSC_TCMR_CKS_Pos)      /**< (SSC_TCMR) TK pin Position  */
+#define SSC_TCMR_CKO_Pos                    2                                              /**< (SSC_TCMR) Transmit Clock Output Mode Selection Position */
+#define SSC_TCMR_CKO_Msk                    (_U_(0x7) << SSC_TCMR_CKO_Pos)                 /**< (SSC_TCMR) Transmit Clock Output Mode Selection Mask */
+#define SSC_TCMR_CKO(value)                 (SSC_TCMR_CKO_Msk & ((value) << SSC_TCMR_CKO_Pos))
+#define   SSC_TCMR_CKO_NONE_Val             _U_(0x0)                                       /**< (SSC_TCMR) None, TK pin is an input  */
+#define   SSC_TCMR_CKO_CONTINUOUS_Val       _U_(0x1)                                       /**< (SSC_TCMR) Continuous Transmit Clock, TK pin is an output  */
+#define   SSC_TCMR_CKO_TRANSFER_Val         _U_(0x2)                                       /**< (SSC_TCMR) Transmit Clock only during data transfers, TK pin is an output  */
+#define SSC_TCMR_CKO_NONE                   (SSC_TCMR_CKO_NONE_Val << SSC_TCMR_CKO_Pos)    /**< (SSC_TCMR) None, TK pin is an input Position  */
+#define SSC_TCMR_CKO_CONTINUOUS             (SSC_TCMR_CKO_CONTINUOUS_Val << SSC_TCMR_CKO_Pos)  /**< (SSC_TCMR) Continuous Transmit Clock, TK pin is an output Position  */
+#define SSC_TCMR_CKO_TRANSFER               (SSC_TCMR_CKO_TRANSFER_Val << SSC_TCMR_CKO_Pos)  /**< (SSC_TCMR) Transmit Clock only during data transfers, TK pin is an output Position  */
+#define SSC_TCMR_CKI_Pos                    5                                              /**< (SSC_TCMR) Transmit Clock Inversion Position */
+#define SSC_TCMR_CKI_Msk                    (_U_(0x1) << SSC_TCMR_CKI_Pos)                 /**< (SSC_TCMR) Transmit Clock Inversion Mask */
+#define SSC_TCMR_CKI                        SSC_TCMR_CKI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TCMR_CKI_Msk instead */
+#define SSC_TCMR_CKG_Pos                    6                                              /**< (SSC_TCMR) Transmit Clock Gating Selection Position */
+#define SSC_TCMR_CKG_Msk                    (_U_(0x3) << SSC_TCMR_CKG_Pos)                 /**< (SSC_TCMR) Transmit Clock Gating Selection Mask */
+#define SSC_TCMR_CKG(value)                 (SSC_TCMR_CKG_Msk & ((value) << SSC_TCMR_CKG_Pos))
+#define   SSC_TCMR_CKG_CONTINUOUS_Val       _U_(0x0)                                       /**< (SSC_TCMR) None  */
+#define   SSC_TCMR_CKG_EN_TF_LOW_Val        _U_(0x1)                                       /**< (SSC_TCMR) Transmit Clock enabled only if TF Low  */
+#define   SSC_TCMR_CKG_EN_TF_HIGH_Val       _U_(0x2)                                       /**< (SSC_TCMR) Transmit Clock enabled only if TF High  */
+#define SSC_TCMR_CKG_CONTINUOUS             (SSC_TCMR_CKG_CONTINUOUS_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) None Position  */
+#define SSC_TCMR_CKG_EN_TF_LOW              (SSC_TCMR_CKG_EN_TF_LOW_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) Transmit Clock enabled only if TF Low Position  */
+#define SSC_TCMR_CKG_EN_TF_HIGH             (SSC_TCMR_CKG_EN_TF_HIGH_Val << SSC_TCMR_CKG_Pos)  /**< (SSC_TCMR) Transmit Clock enabled only if TF High Position  */
+#define SSC_TCMR_START_Pos                  8                                              /**< (SSC_TCMR) Transmit Start Selection Position */
+#define SSC_TCMR_START_Msk                  (_U_(0xF) << SSC_TCMR_START_Pos)               /**< (SSC_TCMR) Transmit Start Selection Mask */
+#define SSC_TCMR_START(value)               (SSC_TCMR_START_Msk & ((value) << SSC_TCMR_START_Pos))
+#define   SSC_TCMR_START_CONTINUOUS_Val     _U_(0x0)                                       /**< (SSC_TCMR) Continuous, as soon as a word is written in the SSC_THR (if Transmit is enabled), and immediately after the end of transfer of the previous data  */
+#define   SSC_TCMR_START_RECEIVE_Val        _U_(0x1)                                       /**< (SSC_TCMR) Receive start  */
+#define   SSC_TCMR_START_TF_LOW_Val         _U_(0x2)                                       /**< (SSC_TCMR) Detection of a low level on TF signal  */
+#define   SSC_TCMR_START_TF_HIGH_Val        _U_(0x3)                                       /**< (SSC_TCMR) Detection of a high level on TF signal  */
+#define   SSC_TCMR_START_TF_FALLING_Val     _U_(0x4)                                       /**< (SSC_TCMR) Detection of a falling edge on TF signal  */
+#define   SSC_TCMR_START_TF_RISING_Val      _U_(0x5)                                       /**< (SSC_TCMR) Detection of a rising edge on TF signal  */
+#define   SSC_TCMR_START_TF_LEVEL_Val       _U_(0x6)                                       /**< (SSC_TCMR) Detection of any level change on TF signal  */
+#define   SSC_TCMR_START_TF_EDGE_Val        _U_(0x7)                                       /**< (SSC_TCMR) Detection of any edge on TF signal  */
+#define SSC_TCMR_START_CONTINUOUS           (SSC_TCMR_START_CONTINUOUS_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Continuous, as soon as a word is written in the SSC_THR (if Transmit is enabled), and immediately after the end of transfer of the previous data Position  */
+#define SSC_TCMR_START_RECEIVE              (SSC_TCMR_START_RECEIVE_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Receive start Position  */
+#define SSC_TCMR_START_TF_LOW               (SSC_TCMR_START_TF_LOW_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a low level on TF signal Position  */
+#define SSC_TCMR_START_TF_HIGH              (SSC_TCMR_START_TF_HIGH_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a high level on TF signal Position  */
+#define SSC_TCMR_START_TF_FALLING           (SSC_TCMR_START_TF_FALLING_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a falling edge on TF signal Position  */
+#define SSC_TCMR_START_TF_RISING            (SSC_TCMR_START_TF_RISING_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of a rising edge on TF signal Position  */
+#define SSC_TCMR_START_TF_LEVEL             (SSC_TCMR_START_TF_LEVEL_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of any level change on TF signal Position  */
+#define SSC_TCMR_START_TF_EDGE              (SSC_TCMR_START_TF_EDGE_Val << SSC_TCMR_START_Pos)  /**< (SSC_TCMR) Detection of any edge on TF signal Position  */
+#define SSC_TCMR_STTDLY_Pos                 16                                             /**< (SSC_TCMR) Transmit Start Delay Position */
+#define SSC_TCMR_STTDLY_Msk                 (_U_(0xFF) << SSC_TCMR_STTDLY_Pos)             /**< (SSC_TCMR) Transmit Start Delay Mask */
+#define SSC_TCMR_STTDLY(value)              (SSC_TCMR_STTDLY_Msk & ((value) << SSC_TCMR_STTDLY_Pos))
+#define SSC_TCMR_PERIOD_Pos                 24                                             /**< (SSC_TCMR) Transmit Period Divider Selection Position */
+#define SSC_TCMR_PERIOD_Msk                 (_U_(0xFF) << SSC_TCMR_PERIOD_Pos)             /**< (SSC_TCMR) Transmit Period Divider Selection Mask */
+#define SSC_TCMR_PERIOD(value)              (SSC_TCMR_PERIOD_Msk & ((value) << SSC_TCMR_PERIOD_Pos))
+#define SSC_TCMR_MASK                       _U_(0xFFFF0FFF)                                /**< \deprecated (SSC_TCMR) Register MASK  (Use SSC_TCMR_Msk instead)  */
+#define SSC_TCMR_Msk                        _U_(0xFFFF0FFF)                                /**< (SSC_TCMR) Register Mask  */
+
+
+/* -------- SSC_TFMR : (SSC Offset: 0x1c) (R/W 32) Transmit Frame Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
+    uint32_t DATDEF:1;                  /**< bit:      5  Data Default Value                       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t MSBF:1;                    /**< bit:      7  Most Significant Bit First               */
+    uint32_t DATNB:4;                   /**< bit:  8..11  Data Number per Frame                    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t FSLEN:4;                   /**< bit: 16..19  Transmit Frame Sync Length               */
+    uint32_t FSOS:3;                    /**< bit: 20..22  Transmit Frame Sync Output Selection     */
+    uint32_t FSDEN:1;                   /**< bit:     23  Frame Sync Data Enable                   */
+    uint32_t FSEDGE:1;                  /**< bit:     24  Frame Sync Edge Detection                */
+    uint32_t :3;                        /**< bit: 25..27  Reserved */
+    uint32_t FSLEN_EXT:4;               /**< bit: 28..31  FSLEN Field Extension                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TFMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TFMR_OFFSET                     (0x1C)                                        /**<  (SSC_TFMR) Transmit Frame Mode Register  Offset */
+
+#define SSC_TFMR_DATLEN_Pos                 0                                              /**< (SSC_TFMR) Data Length Position */
+#define SSC_TFMR_DATLEN_Msk                 (_U_(0x1F) << SSC_TFMR_DATLEN_Pos)             /**< (SSC_TFMR) Data Length Mask */
+#define SSC_TFMR_DATLEN(value)              (SSC_TFMR_DATLEN_Msk & ((value) << SSC_TFMR_DATLEN_Pos))
+#define SSC_TFMR_DATDEF_Pos                 5                                              /**< (SSC_TFMR) Data Default Value Position */
+#define SSC_TFMR_DATDEF_Msk                 (_U_(0x1) << SSC_TFMR_DATDEF_Pos)              /**< (SSC_TFMR) Data Default Value Mask */
+#define SSC_TFMR_DATDEF                     SSC_TFMR_DATDEF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_DATDEF_Msk instead */
+#define SSC_TFMR_MSBF_Pos                   7                                              /**< (SSC_TFMR) Most Significant Bit First Position */
+#define SSC_TFMR_MSBF_Msk                   (_U_(0x1) << SSC_TFMR_MSBF_Pos)                /**< (SSC_TFMR) Most Significant Bit First Mask */
+#define SSC_TFMR_MSBF                       SSC_TFMR_MSBF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_MSBF_Msk instead */
+#define SSC_TFMR_DATNB_Pos                  8                                              /**< (SSC_TFMR) Data Number per Frame Position */
+#define SSC_TFMR_DATNB_Msk                  (_U_(0xF) << SSC_TFMR_DATNB_Pos)               /**< (SSC_TFMR) Data Number per Frame Mask */
+#define SSC_TFMR_DATNB(value)               (SSC_TFMR_DATNB_Msk & ((value) << SSC_TFMR_DATNB_Pos))
+#define SSC_TFMR_FSLEN_Pos                  16                                             /**< (SSC_TFMR) Transmit Frame Sync Length Position */
+#define SSC_TFMR_FSLEN_Msk                  (_U_(0xF) << SSC_TFMR_FSLEN_Pos)               /**< (SSC_TFMR) Transmit Frame Sync Length Mask */
+#define SSC_TFMR_FSLEN(value)               (SSC_TFMR_FSLEN_Msk & ((value) << SSC_TFMR_FSLEN_Pos))
+#define SSC_TFMR_FSOS_Pos                   20                                             /**< (SSC_TFMR) Transmit Frame Sync Output Selection Position */
+#define SSC_TFMR_FSOS_Msk                   (_U_(0x7) << SSC_TFMR_FSOS_Pos)                /**< (SSC_TFMR) Transmit Frame Sync Output Selection Mask */
+#define SSC_TFMR_FSOS(value)                (SSC_TFMR_FSOS_Msk & ((value) << SSC_TFMR_FSOS_Pos))
+#define   SSC_TFMR_FSOS_NONE_Val            _U_(0x0)                                       /**< (SSC_TFMR) None, TF pin is an input  */
+#define   SSC_TFMR_FSOS_NEGATIVE_Val        _U_(0x1)                                       /**< (SSC_TFMR) Negative Pulse, TF pin is an output  */
+#define   SSC_TFMR_FSOS_POSITIVE_Val        _U_(0x2)                                       /**< (SSC_TFMR) Positive Pulse, TF pin is an output  */
+#define   SSC_TFMR_FSOS_LOW_Val             _U_(0x3)                                       /**< (SSC_TFMR) Driven Low during data transfer  */
+#define   SSC_TFMR_FSOS_HIGH_Val            _U_(0x4)                                       /**< (SSC_TFMR) Driven High during data transfer  */
+#define   SSC_TFMR_FSOS_TOGGLING_Val        _U_(0x5)                                       /**< (SSC_TFMR) Toggling at each start of data transfer  */
+#define SSC_TFMR_FSOS_NONE                  (SSC_TFMR_FSOS_NONE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) None, TF pin is an input Position  */
+#define SSC_TFMR_FSOS_NEGATIVE              (SSC_TFMR_FSOS_NEGATIVE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Negative Pulse, TF pin is an output Position  */
+#define SSC_TFMR_FSOS_POSITIVE              (SSC_TFMR_FSOS_POSITIVE_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Positive Pulse, TF pin is an output Position  */
+#define SSC_TFMR_FSOS_LOW                   (SSC_TFMR_FSOS_LOW_Val << SSC_TFMR_FSOS_Pos)   /**< (SSC_TFMR) Driven Low during data transfer Position  */
+#define SSC_TFMR_FSOS_HIGH                  (SSC_TFMR_FSOS_HIGH_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Driven High during data transfer Position  */
+#define SSC_TFMR_FSOS_TOGGLING              (SSC_TFMR_FSOS_TOGGLING_Val << SSC_TFMR_FSOS_Pos)  /**< (SSC_TFMR) Toggling at each start of data transfer Position  */
+#define SSC_TFMR_FSDEN_Pos                  23                                             /**< (SSC_TFMR) Frame Sync Data Enable Position */
+#define SSC_TFMR_FSDEN_Msk                  (_U_(0x1) << SSC_TFMR_FSDEN_Pos)               /**< (SSC_TFMR) Frame Sync Data Enable Mask */
+#define SSC_TFMR_FSDEN                      SSC_TFMR_FSDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_FSDEN_Msk instead */
+#define SSC_TFMR_FSEDGE_Pos                 24                                             /**< (SSC_TFMR) Frame Sync Edge Detection Position */
+#define SSC_TFMR_FSEDGE_Msk                 (_U_(0x1) << SSC_TFMR_FSEDGE_Pos)              /**< (SSC_TFMR) Frame Sync Edge Detection Mask */
+#define SSC_TFMR_FSEDGE                     SSC_TFMR_FSEDGE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_TFMR_FSEDGE_Msk instead */
+#define   SSC_TFMR_FSEDGE_POSITIVE_Val      _U_(0x0)                                       /**< (SSC_TFMR) Positive Edge Detection  */
+#define   SSC_TFMR_FSEDGE_NEGATIVE_Val      _U_(0x1)                                       /**< (SSC_TFMR) Negative Edge Detection  */
+#define SSC_TFMR_FSEDGE_POSITIVE            (SSC_TFMR_FSEDGE_POSITIVE_Val << SSC_TFMR_FSEDGE_Pos)  /**< (SSC_TFMR) Positive Edge Detection Position  */
+#define SSC_TFMR_FSEDGE_NEGATIVE            (SSC_TFMR_FSEDGE_NEGATIVE_Val << SSC_TFMR_FSEDGE_Pos)  /**< (SSC_TFMR) Negative Edge Detection Position  */
+#define SSC_TFMR_FSLEN_EXT_Pos              28                                             /**< (SSC_TFMR) FSLEN Field Extension Position */
+#define SSC_TFMR_FSLEN_EXT_Msk              (_U_(0xF) << SSC_TFMR_FSLEN_EXT_Pos)           /**< (SSC_TFMR) FSLEN Field Extension Mask */
+#define SSC_TFMR_FSLEN_EXT(value)           (SSC_TFMR_FSLEN_EXT_Msk & ((value) << SSC_TFMR_FSLEN_EXT_Pos))
+#define SSC_TFMR_MASK                       _U_(0xF1FF0FBF)                                /**< \deprecated (SSC_TFMR) Register MASK  (Use SSC_TFMR_Msk instead)  */
+#define SSC_TFMR_Msk                        _U_(0xF1FF0FBF)                                /**< (SSC_TFMR) Register Mask  */
+
+
+/* -------- SSC_RHR : (SSC Offset: 0x20) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RDAT:32;                   /**< bit:  0..31  Receive Data                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RHR_OFFSET                      (0x20)                                        /**<  (SSC_RHR) Receive Holding Register  Offset */
+
+#define SSC_RHR_RDAT_Pos                    0                                              /**< (SSC_RHR) Receive Data Position */
+#define SSC_RHR_RDAT_Msk                    (_U_(0xFFFFFFFF) << SSC_RHR_RDAT_Pos)          /**< (SSC_RHR) Receive Data Mask */
+#define SSC_RHR_RDAT(value)                 (SSC_RHR_RDAT_Msk & ((value) << SSC_RHR_RDAT_Pos))
+#define SSC_RHR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SSC_RHR) Register MASK  (Use SSC_RHR_Msk instead)  */
+#define SSC_RHR_Msk                         _U_(0xFFFFFFFF)                                /**< (SSC_RHR) Register Mask  */
+
+
+/* -------- SSC_THR : (SSC Offset: 0x24) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TDAT:32;                   /**< bit:  0..31  Transmit Data                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_THR_OFFSET                      (0x24)                                        /**<  (SSC_THR) Transmit Holding Register  Offset */
+
+#define SSC_THR_TDAT_Pos                    0                                              /**< (SSC_THR) Transmit Data Position */
+#define SSC_THR_TDAT_Msk                    (_U_(0xFFFFFFFF) << SSC_THR_TDAT_Pos)          /**< (SSC_THR) Transmit Data Mask */
+#define SSC_THR_TDAT(value)                 (SSC_THR_TDAT_Msk & ((value) << SSC_THR_TDAT_Pos))
+#define SSC_THR_MASK                        _U_(0xFFFFFFFF)                                /**< \deprecated (SSC_THR) Register MASK  (Use SSC_THR_Msk instead)  */
+#define SSC_THR_Msk                         _U_(0xFFFFFFFF)                                /**< (SSC_THR) Register Mask  */
+
+
+/* -------- SSC_RSHR : (SSC Offset: 0x30) (R/ 32) Receive Sync. Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RSDAT:16;                  /**< bit:  0..15  Receive Synchronization Data             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RSHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RSHR_OFFSET                     (0x30)                                        /**<  (SSC_RSHR) Receive Sync. Holding Register  Offset */
+
+#define SSC_RSHR_RSDAT_Pos                  0                                              /**< (SSC_RSHR) Receive Synchronization Data Position */
+#define SSC_RSHR_RSDAT_Msk                  (_U_(0xFFFF) << SSC_RSHR_RSDAT_Pos)            /**< (SSC_RSHR) Receive Synchronization Data Mask */
+#define SSC_RSHR_RSDAT(value)               (SSC_RSHR_RSDAT_Msk & ((value) << SSC_RSHR_RSDAT_Pos))
+#define SSC_RSHR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RSHR) Register MASK  (Use SSC_RSHR_Msk instead)  */
+#define SSC_RSHR_Msk                        _U_(0xFFFF)                                    /**< (SSC_RSHR) Register Mask  */
+
+
+/* -------- SSC_TSHR : (SSC Offset: 0x34) (R/W 32) Transmit Sync. Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TSDAT:16;                  /**< bit:  0..15  Transmit Synchronization Data            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_TSHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_TSHR_OFFSET                     (0x34)                                        /**<  (SSC_TSHR) Transmit Sync. Holding Register  Offset */
+
+#define SSC_TSHR_TSDAT_Pos                  0                                              /**< (SSC_TSHR) Transmit Synchronization Data Position */
+#define SSC_TSHR_TSDAT_Msk                  (_U_(0xFFFF) << SSC_TSHR_TSDAT_Pos)            /**< (SSC_TSHR) Transmit Synchronization Data Mask */
+#define SSC_TSHR_TSDAT(value)               (SSC_TSHR_TSDAT_Msk & ((value) << SSC_TSHR_TSDAT_Pos))
+#define SSC_TSHR_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_TSHR) Register MASK  (Use SSC_TSHR_Msk instead)  */
+#define SSC_TSHR_Msk                        _U_(0xFFFF)                                    /**< (SSC_TSHR) Register Mask  */
+
+
+/* -------- SSC_RC0R : (SSC Offset: 0x38) (R/W 32) Receive Compare 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CP0:16;                    /**< bit:  0..15  Receive Compare Data 0                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RC0R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RC0R_OFFSET                     (0x38)                                        /**<  (SSC_RC0R) Receive Compare 0 Register  Offset */
+
+#define SSC_RC0R_CP0_Pos                    0                                              /**< (SSC_RC0R) Receive Compare Data 0 Position */
+#define SSC_RC0R_CP0_Msk                    (_U_(0xFFFF) << SSC_RC0R_CP0_Pos)              /**< (SSC_RC0R) Receive Compare Data 0 Mask */
+#define SSC_RC0R_CP0(value)                 (SSC_RC0R_CP0_Msk & ((value) << SSC_RC0R_CP0_Pos))
+#define SSC_RC0R_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RC0R) Register MASK  (Use SSC_RC0R_Msk instead)  */
+#define SSC_RC0R_Msk                        _U_(0xFFFF)                                    /**< (SSC_RC0R) Register Mask  */
+
+
+/* -------- SSC_RC1R : (SSC Offset: 0x3c) (R/W 32) Receive Compare 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CP1:16;                    /**< bit:  0..15  Receive Compare Data 1                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_RC1R_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_RC1R_OFFSET                     (0x3C)                                        /**<  (SSC_RC1R) Receive Compare 1 Register  Offset */
+
+#define SSC_RC1R_CP1_Pos                    0                                              /**< (SSC_RC1R) Receive Compare Data 1 Position */
+#define SSC_RC1R_CP1_Msk                    (_U_(0xFFFF) << SSC_RC1R_CP1_Pos)              /**< (SSC_RC1R) Receive Compare Data 1 Mask */
+#define SSC_RC1R_CP1(value)                 (SSC_RC1R_CP1_Msk & ((value) << SSC_RC1R_CP1_Pos))
+#define SSC_RC1R_MASK                       _U_(0xFFFF)                                    /**< \deprecated (SSC_RC1R) Register MASK  (Use SSC_RC1R_Msk instead)  */
+#define SSC_RC1R_Msk                        _U_(0xFFFF)                                    /**< (SSC_RC1R) Register Mask  */
+
+
+/* -------- SSC_SR : (SSC Offset: 0x40) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready                           */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty                           */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready                            */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun                          */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0                                */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1                                */
+    uint32_t TXSYN:1;                   /**< bit:     10  Transmit Sync                            */
+    uint32_t RXSYN:1;                   /**< bit:     11  Receive Sync                             */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t TXEN:1;                    /**< bit:     16  Transmit Enable                          */
+    uint32_t RXEN:1;                    /**< bit:     17  Receive Enable                           */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x                                */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_SR_OFFSET                       (0x40)                                        /**<  (SSC_SR) Status Register  Offset */
+
+#define SSC_SR_TXRDY_Pos                    0                                              /**< (SSC_SR) Transmit Ready Position */
+#define SSC_SR_TXRDY_Msk                    (_U_(0x1) << SSC_SR_TXRDY_Pos)                 /**< (SSC_SR) Transmit Ready Mask */
+#define SSC_SR_TXRDY                        SSC_SR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXRDY_Msk instead */
+#define SSC_SR_TXEMPTY_Pos                  1                                              /**< (SSC_SR) Transmit Empty Position */
+#define SSC_SR_TXEMPTY_Msk                  (_U_(0x1) << SSC_SR_TXEMPTY_Pos)               /**< (SSC_SR) Transmit Empty Mask */
+#define SSC_SR_TXEMPTY                      SSC_SR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXEMPTY_Msk instead */
+#define SSC_SR_RXRDY_Pos                    4                                              /**< (SSC_SR) Receive Ready Position */
+#define SSC_SR_RXRDY_Msk                    (_U_(0x1) << SSC_SR_RXRDY_Pos)                 /**< (SSC_SR) Receive Ready Mask */
+#define SSC_SR_RXRDY                        SSC_SR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXRDY_Msk instead */
+#define SSC_SR_OVRUN_Pos                    5                                              /**< (SSC_SR) Receive Overrun Position */
+#define SSC_SR_OVRUN_Msk                    (_U_(0x1) << SSC_SR_OVRUN_Pos)                 /**< (SSC_SR) Receive Overrun Mask */
+#define SSC_SR_OVRUN                        SSC_SR_OVRUN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_OVRUN_Msk instead */
+#define SSC_SR_CP0_Pos                      8                                              /**< (SSC_SR) Compare 0 Position */
+#define SSC_SR_CP0_Msk                      (_U_(0x1) << SSC_SR_CP0_Pos)                   /**< (SSC_SR) Compare 0 Mask */
+#define SSC_SR_CP0                          SSC_SR_CP0_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_CP0_Msk instead */
+#define SSC_SR_CP1_Pos                      9                                              /**< (SSC_SR) Compare 1 Position */
+#define SSC_SR_CP1_Msk                      (_U_(0x1) << SSC_SR_CP1_Pos)                   /**< (SSC_SR) Compare 1 Mask */
+#define SSC_SR_CP1                          SSC_SR_CP1_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_CP1_Msk instead */
+#define SSC_SR_TXSYN_Pos                    10                                             /**< (SSC_SR) Transmit Sync Position */
+#define SSC_SR_TXSYN_Msk                    (_U_(0x1) << SSC_SR_TXSYN_Pos)                 /**< (SSC_SR) Transmit Sync Mask */
+#define SSC_SR_TXSYN                        SSC_SR_TXSYN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXSYN_Msk instead */
+#define SSC_SR_RXSYN_Pos                    11                                             /**< (SSC_SR) Receive Sync Position */
+#define SSC_SR_RXSYN_Msk                    (_U_(0x1) << SSC_SR_RXSYN_Pos)                 /**< (SSC_SR) Receive Sync Mask */
+#define SSC_SR_RXSYN                        SSC_SR_RXSYN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXSYN_Msk instead */
+#define SSC_SR_TXEN_Pos                     16                                             /**< (SSC_SR) Transmit Enable Position */
+#define SSC_SR_TXEN_Msk                     (_U_(0x1) << SSC_SR_TXEN_Pos)                  /**< (SSC_SR) Transmit Enable Mask */
+#define SSC_SR_TXEN                         SSC_SR_TXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_TXEN_Msk instead */
+#define SSC_SR_RXEN_Pos                     17                                             /**< (SSC_SR) Receive Enable Position */
+#define SSC_SR_RXEN_Msk                     (_U_(0x1) << SSC_SR_RXEN_Pos)                  /**< (SSC_SR) Receive Enable Mask */
+#define SSC_SR_RXEN                         SSC_SR_RXEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_SR_RXEN_Msk instead */
+#define SSC_SR_MASK                         _U_(0x30F33)                                   /**< \deprecated (SSC_SR) Register MASK  (Use SSC_SR_Msk instead)  */
+#define SSC_SR_Msk                          _U_(0x30F33)                                   /**< (SSC_SR) Register Mask  */
+
+#define SSC_SR_CP_Pos                       8                                              /**< (SSC_SR Position) Compare x */
+#define SSC_SR_CP_Msk                       (_U_(0x3) << SSC_SR_CP_Pos)                    /**< (SSC_SR Mask) CP */
+#define SSC_SR_CP(value)                    (SSC_SR_CP_Msk & ((value) << SSC_SR_CP_Pos))   
+
+/* -------- SSC_IER : (SSC Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Enable          */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Enable          */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Enable           */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Enable         */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Enable               */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Enable               */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Enable                 */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Enable                 */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Enable               */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IER_OFFSET                      (0x44)                                        /**<  (SSC_IER) Interrupt Enable Register  Offset */
+
+#define SSC_IER_TXRDY_Pos                   0                                              /**< (SSC_IER) Transmit Ready Interrupt Enable Position */
+#define SSC_IER_TXRDY_Msk                   (_U_(0x1) << SSC_IER_TXRDY_Pos)                /**< (SSC_IER) Transmit Ready Interrupt Enable Mask */
+#define SSC_IER_TXRDY                       SSC_IER_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXRDY_Msk instead */
+#define SSC_IER_TXEMPTY_Pos                 1                                              /**< (SSC_IER) Transmit Empty Interrupt Enable Position */
+#define SSC_IER_TXEMPTY_Msk                 (_U_(0x1) << SSC_IER_TXEMPTY_Pos)              /**< (SSC_IER) Transmit Empty Interrupt Enable Mask */
+#define SSC_IER_TXEMPTY                     SSC_IER_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXEMPTY_Msk instead */
+#define SSC_IER_RXRDY_Pos                   4                                              /**< (SSC_IER) Receive Ready Interrupt Enable Position */
+#define SSC_IER_RXRDY_Msk                   (_U_(0x1) << SSC_IER_RXRDY_Pos)                /**< (SSC_IER) Receive Ready Interrupt Enable Mask */
+#define SSC_IER_RXRDY                       SSC_IER_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_RXRDY_Msk instead */
+#define SSC_IER_OVRUN_Pos                   5                                              /**< (SSC_IER) Receive Overrun Interrupt Enable Position */
+#define SSC_IER_OVRUN_Msk                   (_U_(0x1) << SSC_IER_OVRUN_Pos)                /**< (SSC_IER) Receive Overrun Interrupt Enable Mask */
+#define SSC_IER_OVRUN                       SSC_IER_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_OVRUN_Msk instead */
+#define SSC_IER_CP0_Pos                     8                                              /**< (SSC_IER) Compare 0 Interrupt Enable Position */
+#define SSC_IER_CP0_Msk                     (_U_(0x1) << SSC_IER_CP0_Pos)                  /**< (SSC_IER) Compare 0 Interrupt Enable Mask */
+#define SSC_IER_CP0                         SSC_IER_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_CP0_Msk instead */
+#define SSC_IER_CP1_Pos                     9                                              /**< (SSC_IER) Compare 1 Interrupt Enable Position */
+#define SSC_IER_CP1_Msk                     (_U_(0x1) << SSC_IER_CP1_Pos)                  /**< (SSC_IER) Compare 1 Interrupt Enable Mask */
+#define SSC_IER_CP1                         SSC_IER_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_CP1_Msk instead */
+#define SSC_IER_TXSYN_Pos                   10                                             /**< (SSC_IER) Tx Sync Interrupt Enable Position */
+#define SSC_IER_TXSYN_Msk                   (_U_(0x1) << SSC_IER_TXSYN_Pos)                /**< (SSC_IER) Tx Sync Interrupt Enable Mask */
+#define SSC_IER_TXSYN                       SSC_IER_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_TXSYN_Msk instead */
+#define SSC_IER_RXSYN_Pos                   11                                             /**< (SSC_IER) Rx Sync Interrupt Enable Position */
+#define SSC_IER_RXSYN_Msk                   (_U_(0x1) << SSC_IER_RXSYN_Pos)                /**< (SSC_IER) Rx Sync Interrupt Enable Mask */
+#define SSC_IER_RXSYN                       SSC_IER_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IER_RXSYN_Msk instead */
+#define SSC_IER_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IER) Register MASK  (Use SSC_IER_Msk instead)  */
+#define SSC_IER_Msk                         _U_(0xF33)                                     /**< (SSC_IER) Register Mask  */
+
+#define SSC_IER_CP_Pos                      8                                              /**< (SSC_IER Position) Compare x Interrupt Enable */
+#define SSC_IER_CP_Msk                      (_U_(0x3) << SSC_IER_CP_Pos)                   /**< (SSC_IER Mask) CP */
+#define SSC_IER_CP(value)                   (SSC_IER_CP_Msk & ((value) << SSC_IER_CP_Pos))  
+
+/* -------- SSC_IDR : (SSC Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Disable         */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Disable         */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Disable          */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Disable        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Disable              */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Disable              */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Enable                 */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Enable                 */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Disable              */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IDR_OFFSET                      (0x48)                                        /**<  (SSC_IDR) Interrupt Disable Register  Offset */
+
+#define SSC_IDR_TXRDY_Pos                   0                                              /**< (SSC_IDR) Transmit Ready Interrupt Disable Position */
+#define SSC_IDR_TXRDY_Msk                   (_U_(0x1) << SSC_IDR_TXRDY_Pos)                /**< (SSC_IDR) Transmit Ready Interrupt Disable Mask */
+#define SSC_IDR_TXRDY                       SSC_IDR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXRDY_Msk instead */
+#define SSC_IDR_TXEMPTY_Pos                 1                                              /**< (SSC_IDR) Transmit Empty Interrupt Disable Position */
+#define SSC_IDR_TXEMPTY_Msk                 (_U_(0x1) << SSC_IDR_TXEMPTY_Pos)              /**< (SSC_IDR) Transmit Empty Interrupt Disable Mask */
+#define SSC_IDR_TXEMPTY                     SSC_IDR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXEMPTY_Msk instead */
+#define SSC_IDR_RXRDY_Pos                   4                                              /**< (SSC_IDR) Receive Ready Interrupt Disable Position */
+#define SSC_IDR_RXRDY_Msk                   (_U_(0x1) << SSC_IDR_RXRDY_Pos)                /**< (SSC_IDR) Receive Ready Interrupt Disable Mask */
+#define SSC_IDR_RXRDY                       SSC_IDR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_RXRDY_Msk instead */
+#define SSC_IDR_OVRUN_Pos                   5                                              /**< (SSC_IDR) Receive Overrun Interrupt Disable Position */
+#define SSC_IDR_OVRUN_Msk                   (_U_(0x1) << SSC_IDR_OVRUN_Pos)                /**< (SSC_IDR) Receive Overrun Interrupt Disable Mask */
+#define SSC_IDR_OVRUN                       SSC_IDR_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_OVRUN_Msk instead */
+#define SSC_IDR_CP0_Pos                     8                                              /**< (SSC_IDR) Compare 0 Interrupt Disable Position */
+#define SSC_IDR_CP0_Msk                     (_U_(0x1) << SSC_IDR_CP0_Pos)                  /**< (SSC_IDR) Compare 0 Interrupt Disable Mask */
+#define SSC_IDR_CP0                         SSC_IDR_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_CP0_Msk instead */
+#define SSC_IDR_CP1_Pos                     9                                              /**< (SSC_IDR) Compare 1 Interrupt Disable Position */
+#define SSC_IDR_CP1_Msk                     (_U_(0x1) << SSC_IDR_CP1_Pos)                  /**< (SSC_IDR) Compare 1 Interrupt Disable Mask */
+#define SSC_IDR_CP1                         SSC_IDR_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_CP1_Msk instead */
+#define SSC_IDR_TXSYN_Pos                   10                                             /**< (SSC_IDR) Tx Sync Interrupt Enable Position */
+#define SSC_IDR_TXSYN_Msk                   (_U_(0x1) << SSC_IDR_TXSYN_Pos)                /**< (SSC_IDR) Tx Sync Interrupt Enable Mask */
+#define SSC_IDR_TXSYN                       SSC_IDR_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_TXSYN_Msk instead */
+#define SSC_IDR_RXSYN_Pos                   11                                             /**< (SSC_IDR) Rx Sync Interrupt Enable Position */
+#define SSC_IDR_RXSYN_Msk                   (_U_(0x1) << SSC_IDR_RXSYN_Pos)                /**< (SSC_IDR) Rx Sync Interrupt Enable Mask */
+#define SSC_IDR_RXSYN                       SSC_IDR_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IDR_RXSYN_Msk instead */
+#define SSC_IDR_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IDR) Register MASK  (Use SSC_IDR_Msk instead)  */
+#define SSC_IDR_Msk                         _U_(0xF33)                                     /**< (SSC_IDR) Register Mask  */
+
+#define SSC_IDR_CP_Pos                      8                                              /**< (SSC_IDR Position) Compare x Interrupt Disable */
+#define SSC_IDR_CP_Msk                      (_U_(0x3) << SSC_IDR_CP_Pos)                   /**< (SSC_IDR Mask) CP */
+#define SSC_IDR_CP(value)                   (SSC_IDR_CP_Msk & ((value) << SSC_IDR_CP_Pos))  
+
+/* -------- SSC_IMR : (SSC Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Mask            */
+    uint32_t TXEMPTY:1;                 /**< bit:      1  Transmit Empty Interrupt Mask            */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t RXRDY:1;                   /**< bit:      4  Receive Ready Interrupt Mask             */
+    uint32_t OVRUN:1;                   /**< bit:      5  Receive Overrun Interrupt Mask           */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t CP0:1;                     /**< bit:      8  Compare 0 Interrupt Mask                 */
+    uint32_t CP1:1;                     /**< bit:      9  Compare 1 Interrupt Mask                 */
+    uint32_t TXSYN:1;                   /**< bit:     10  Tx Sync Interrupt Mask                   */
+    uint32_t RXSYN:1;                   /**< bit:     11  Rx Sync Interrupt Mask                   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CP:2;                      /**< bit:   8..9  Compare x Interrupt Mask                 */
+    uint32_t :22;                       /**< bit: 10..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_IMR_OFFSET                      (0x4C)                                        /**<  (SSC_IMR) Interrupt Mask Register  Offset */
+
+#define SSC_IMR_TXRDY_Pos                   0                                              /**< (SSC_IMR) Transmit Ready Interrupt Mask Position */
+#define SSC_IMR_TXRDY_Msk                   (_U_(0x1) << SSC_IMR_TXRDY_Pos)                /**< (SSC_IMR) Transmit Ready Interrupt Mask Mask */
+#define SSC_IMR_TXRDY                       SSC_IMR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXRDY_Msk instead */
+#define SSC_IMR_TXEMPTY_Pos                 1                                              /**< (SSC_IMR) Transmit Empty Interrupt Mask Position */
+#define SSC_IMR_TXEMPTY_Msk                 (_U_(0x1) << SSC_IMR_TXEMPTY_Pos)              /**< (SSC_IMR) Transmit Empty Interrupt Mask Mask */
+#define SSC_IMR_TXEMPTY                     SSC_IMR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXEMPTY_Msk instead */
+#define SSC_IMR_RXRDY_Pos                   4                                              /**< (SSC_IMR) Receive Ready Interrupt Mask Position */
+#define SSC_IMR_RXRDY_Msk                   (_U_(0x1) << SSC_IMR_RXRDY_Pos)                /**< (SSC_IMR) Receive Ready Interrupt Mask Mask */
+#define SSC_IMR_RXRDY                       SSC_IMR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_RXRDY_Msk instead */
+#define SSC_IMR_OVRUN_Pos                   5                                              /**< (SSC_IMR) Receive Overrun Interrupt Mask Position */
+#define SSC_IMR_OVRUN_Msk                   (_U_(0x1) << SSC_IMR_OVRUN_Pos)                /**< (SSC_IMR) Receive Overrun Interrupt Mask Mask */
+#define SSC_IMR_OVRUN                       SSC_IMR_OVRUN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_OVRUN_Msk instead */
+#define SSC_IMR_CP0_Pos                     8                                              /**< (SSC_IMR) Compare 0 Interrupt Mask Position */
+#define SSC_IMR_CP0_Msk                     (_U_(0x1) << SSC_IMR_CP0_Pos)                  /**< (SSC_IMR) Compare 0 Interrupt Mask Mask */
+#define SSC_IMR_CP0                         SSC_IMR_CP0_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_CP0_Msk instead */
+#define SSC_IMR_CP1_Pos                     9                                              /**< (SSC_IMR) Compare 1 Interrupt Mask Position */
+#define SSC_IMR_CP1_Msk                     (_U_(0x1) << SSC_IMR_CP1_Pos)                  /**< (SSC_IMR) Compare 1 Interrupt Mask Mask */
+#define SSC_IMR_CP1                         SSC_IMR_CP1_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_CP1_Msk instead */
+#define SSC_IMR_TXSYN_Pos                   10                                             /**< (SSC_IMR) Tx Sync Interrupt Mask Position */
+#define SSC_IMR_TXSYN_Msk                   (_U_(0x1) << SSC_IMR_TXSYN_Pos)                /**< (SSC_IMR) Tx Sync Interrupt Mask Mask */
+#define SSC_IMR_TXSYN                       SSC_IMR_TXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_TXSYN_Msk instead */
+#define SSC_IMR_RXSYN_Pos                   11                                             /**< (SSC_IMR) Rx Sync Interrupt Mask Position */
+#define SSC_IMR_RXSYN_Msk                   (_U_(0x1) << SSC_IMR_RXSYN_Pos)                /**< (SSC_IMR) Rx Sync Interrupt Mask Mask */
+#define SSC_IMR_RXSYN                       SSC_IMR_RXSYN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_IMR_RXSYN_Msk instead */
+#define SSC_IMR_MASK                        _U_(0xF33)                                     /**< \deprecated (SSC_IMR) Register MASK  (Use SSC_IMR_Msk instead)  */
+#define SSC_IMR_Msk                         _U_(0xF33)                                     /**< (SSC_IMR) Register Mask  */
+
+#define SSC_IMR_CP_Pos                      8                                              /**< (SSC_IMR Position) Compare x Interrupt Mask */
+#define SSC_IMR_CP_Msk                      (_U_(0x3) << SSC_IMR_CP_Pos)                   /**< (SSC_IMR Mask) CP */
+#define SSC_IMR_CP(value)                   (SSC_IMR_CP_Msk & ((value) << SSC_IMR_CP_Pos))  
+
+/* -------- SSC_WPMR : (SSC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_WPMR_OFFSET                     (0xE4)                                        /**<  (SSC_WPMR) Write Protection Mode Register  Offset */
+
+#define SSC_WPMR_WPEN_Pos                   0                                              /**< (SSC_WPMR) Write Protection Enable Position */
+#define SSC_WPMR_WPEN_Msk                   (_U_(0x1) << SSC_WPMR_WPEN_Pos)                /**< (SSC_WPMR) Write Protection Enable Mask */
+#define SSC_WPMR_WPEN                       SSC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_WPMR_WPEN_Msk instead */
+#define SSC_WPMR_WPKEY_Pos                  8                                              /**< (SSC_WPMR) Write Protection Key Position */
+#define SSC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << SSC_WPMR_WPKEY_Pos)          /**< (SSC_WPMR) Write Protection Key Mask */
+#define SSC_WPMR_WPKEY(value)               (SSC_WPMR_WPKEY_Msk & ((value) << SSC_WPMR_WPKEY_Pos))
+#define   SSC_WPMR_WPKEY_PASSWD_Val         _U_(0x535343)                                  /**< (SSC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define SSC_WPMR_WPKEY_PASSWD               (SSC_WPMR_WPKEY_PASSWD_Val << SSC_WPMR_WPKEY_Pos)  /**< (SSC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define SSC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (SSC_WPMR) Register MASK  (Use SSC_WPMR_Msk instead)  */
+#define SSC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (SSC_WPMR) Register Mask  */
+
+
+/* -------- SSC_WPSR : (SSC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protect Violation Source           */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SSC_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SSC_WPSR_OFFSET                     (0xE8)                                        /**<  (SSC_WPSR) Write Protection Status Register  Offset */
+
+#define SSC_WPSR_WPVS_Pos                   0                                              /**< (SSC_WPSR) Write Protection Violation Status Position */
+#define SSC_WPSR_WPVS_Msk                   (_U_(0x1) << SSC_WPSR_WPVS_Pos)                /**< (SSC_WPSR) Write Protection Violation Status Mask */
+#define SSC_WPSR_WPVS                       SSC_WPSR_WPVS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SSC_WPSR_WPVS_Msk instead */
+#define SSC_WPSR_WPVSRC_Pos                 8                                              /**< (SSC_WPSR) Write Protect Violation Source Position */
+#define SSC_WPSR_WPVSRC_Msk                 (_U_(0xFFFF) << SSC_WPSR_WPVSRC_Pos)           /**< (SSC_WPSR) Write Protect Violation Source Mask */
+#define SSC_WPSR_WPVSRC(value)              (SSC_WPSR_WPVSRC_Msk & ((value) << SSC_WPSR_WPVSRC_Pos))
+#define SSC_WPSR_MASK                       _U_(0xFFFF01)                                  /**< \deprecated (SSC_WPSR) Register MASK  (Use SSC_WPSR_Msk instead)  */
+#define SSC_WPSR_Msk                        _U_(0xFFFF01)                                  /**< (SSC_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SSC hardware registers */
+typedef struct {  
+  __O  uint32_t SSC_CR;         /**< (SSC Offset: 0x00) Control Register */
+  __IO uint32_t SSC_CMR;        /**< (SSC Offset: 0x04) Clock Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t SSC_RCMR;       /**< (SSC Offset: 0x10) Receive Clock Mode Register */
+  __IO uint32_t SSC_RFMR;       /**< (SSC Offset: 0x14) Receive Frame Mode Register */
+  __IO uint32_t SSC_TCMR;       /**< (SSC Offset: 0x18) Transmit Clock Mode Register */
+  __IO uint32_t SSC_TFMR;       /**< (SSC Offset: 0x1C) Transmit Frame Mode Register */
+  __I  uint32_t SSC_RHR;        /**< (SSC Offset: 0x20) Receive Holding Register */
+  __O  uint32_t SSC_THR;        /**< (SSC Offset: 0x24) Transmit Holding Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  uint32_t SSC_RSHR;       /**< (SSC Offset: 0x30) Receive Sync. Holding Register */
+  __IO uint32_t SSC_TSHR;       /**< (SSC Offset: 0x34) Transmit Sync. Holding Register */
+  __IO uint32_t SSC_RC0R;       /**< (SSC Offset: 0x38) Receive Compare 0 Register */
+  __IO uint32_t SSC_RC1R;       /**< (SSC Offset: 0x3C) Receive Compare 1 Register */
+  __I  uint32_t SSC_SR;         /**< (SSC Offset: 0x40) Status Register */
+  __O  uint32_t SSC_IER;        /**< (SSC Offset: 0x44) Interrupt Enable Register */
+  __O  uint32_t SSC_IDR;        /**< (SSC Offset: 0x48) Interrupt Disable Register */
+  __I  uint32_t SSC_IMR;        /**< (SSC Offset: 0x4C) Interrupt Mask Register */
+  __I  uint8_t                        Reserved3[148];
+  __IO uint32_t SSC_WPMR;       /**< (SSC Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t SSC_WPSR;       /**< (SSC Offset: 0xE8) Write Protection Status Register */
+} Ssc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SSC hardware registers */
+typedef struct {  
+  __O  SSC_CR_Type                    SSC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO SSC_CMR_Type                   SSC_CMR;        /**< Offset: 0x04 (R/W  32) Clock Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO SSC_RCMR_Type                  SSC_RCMR;       /**< Offset: 0x10 (R/W  32) Receive Clock Mode Register */
+  __IO SSC_RFMR_Type                  SSC_RFMR;       /**< Offset: 0x14 (R/W  32) Receive Frame Mode Register */
+  __IO SSC_TCMR_Type                  SSC_TCMR;       /**< Offset: 0x18 (R/W  32) Transmit Clock Mode Register */
+  __IO SSC_TFMR_Type                  SSC_TFMR;       /**< Offset: 0x1C (R/W  32) Transmit Frame Mode Register */
+  __I  SSC_RHR_Type                   SSC_RHR;        /**< Offset: 0x20 (R/   32) Receive Holding Register */
+  __O  SSC_THR_Type                   SSC_THR;        /**< Offset: 0x24 ( /W  32) Transmit Holding Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  SSC_RSHR_Type                  SSC_RSHR;       /**< Offset: 0x30 (R/   32) Receive Sync. Holding Register */
+  __IO SSC_TSHR_Type                  SSC_TSHR;       /**< Offset: 0x34 (R/W  32) Transmit Sync. Holding Register */
+  __IO SSC_RC0R_Type                  SSC_RC0R;       /**< Offset: 0x38 (R/W  32) Receive Compare 0 Register */
+  __IO SSC_RC1R_Type                  SSC_RC1R;       /**< Offset: 0x3C (R/W  32) Receive Compare 1 Register */
+  __I  SSC_SR_Type                    SSC_SR;         /**< Offset: 0x40 (R/   32) Status Register */
+  __O  SSC_IER_Type                   SSC_IER;        /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
+  __O  SSC_IDR_Type                   SSC_IDR;        /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
+  __I  SSC_IMR_Type                   SSC_IMR;        /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
+  __I  uint8_t                        Reserved3[148];
+  __IO SSC_WPMR_Type                  SSC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  SSC_WPSR_Type                  SSC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Ssc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Synchronous Serial Controller */
+
+#endif /* _SAMV71_SSC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/supc.h
+++ b/asf/sam/include/samv71b/component/supc.h
@@ -1,0 +1,823 @@
+/**
+ * \file
+ *
+ * \brief Component description for SUPC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SUPC_COMPONENT_H_
+#define _SAMV71_SUPC_COMPONENT_H_
+#define _SAMV71_SUPC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Supply Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SUPC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define SUPC_6452                       /**< (SUPC) Module ID */
+#define REV_SUPC ZE                     /**< (SUPC) Module revision */
+
+/* -------- SUPC_CR : (SUPC Offset: 0x00) (/W 32) Supply Controller Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t VROFF:1;                   /**< bit:      2  Voltage Regulator Off                    */
+    uint32_t XTALSEL:1;                 /**< bit:      3  Crystal Oscillator Select                */
+    uint32_t :20;                       /**< bit:  4..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_CR_OFFSET                      (0x00)                                        /**<  (SUPC_CR) Supply Controller Control Register  Offset */
+
+#define SUPC_CR_VROFF_Pos                   2                                              /**< (SUPC_CR) Voltage Regulator Off Position */
+#define SUPC_CR_VROFF_Msk                   (_U_(0x1) << SUPC_CR_VROFF_Pos)                /**< (SUPC_CR) Voltage Regulator Off Mask */
+#define SUPC_CR_VROFF                       SUPC_CR_VROFF_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_CR_VROFF_Msk instead */
+#define   SUPC_CR_VROFF_NO_EFFECT_Val       _U_(0x0)                                       /**< (SUPC_CR) No effect.  */
+#define   SUPC_CR_VROFF_STOP_VREG_Val       _U_(0x1)                                       /**< (SUPC_CR) If KEY is correct, VROFF asserts the vddcore_nreset and stops the voltage regulator.  */
+#define SUPC_CR_VROFF_NO_EFFECT             (SUPC_CR_VROFF_NO_EFFECT_Val << SUPC_CR_VROFF_Pos)  /**< (SUPC_CR) No effect. Position  */
+#define SUPC_CR_VROFF_STOP_VREG             (SUPC_CR_VROFF_STOP_VREG_Val << SUPC_CR_VROFF_Pos)  /**< (SUPC_CR) If KEY is correct, VROFF asserts the vddcore_nreset and stops the voltage regulator. Position  */
+#define SUPC_CR_XTALSEL_Pos                 3                                              /**< (SUPC_CR) Crystal Oscillator Select Position */
+#define SUPC_CR_XTALSEL_Msk                 (_U_(0x1) << SUPC_CR_XTALSEL_Pos)              /**< (SUPC_CR) Crystal Oscillator Select Mask */
+#define SUPC_CR_XTALSEL                     SUPC_CR_XTALSEL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_CR_XTALSEL_Msk instead */
+#define   SUPC_CR_XTALSEL_NO_EFFECT_Val     _U_(0x0)                                       /**< (SUPC_CR) No effect.  */
+#define   SUPC_CR_XTALSEL_CRYSTAL_SEL_Val   _U_(0x1)                                       /**< (SUPC_CR) If KEY is correct, XTALSEL switches the slow clock on the crystal oscillator output.  */
+#define SUPC_CR_XTALSEL_NO_EFFECT           (SUPC_CR_XTALSEL_NO_EFFECT_Val << SUPC_CR_XTALSEL_Pos)  /**< (SUPC_CR) No effect. Position  */
+#define SUPC_CR_XTALSEL_CRYSTAL_SEL         (SUPC_CR_XTALSEL_CRYSTAL_SEL_Val << SUPC_CR_XTALSEL_Pos)  /**< (SUPC_CR) If KEY is correct, XTALSEL switches the slow clock on the crystal oscillator output. Position  */
+#define SUPC_CR_KEY_Pos                     24                                             /**< (SUPC_CR) Password Position */
+#define SUPC_CR_KEY_Msk                     (_U_(0xFF) << SUPC_CR_KEY_Pos)                 /**< (SUPC_CR) Password Mask */
+#define SUPC_CR_KEY(value)                  (SUPC_CR_KEY_Msk & ((value) << SUPC_CR_KEY_Pos))
+#define   SUPC_CR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (SUPC_CR) Writing any other value in this field aborts the write operation.  */
+#define SUPC_CR_KEY_PASSWD                  (SUPC_CR_KEY_PASSWD_Val << SUPC_CR_KEY_Pos)    /**< (SUPC_CR) Writing any other value in this field aborts the write operation. Position  */
+#define SUPC_CR_MASK                        _U_(0xFF00000C)                                /**< \deprecated (SUPC_CR) Register MASK  (Use SUPC_CR_Msk instead)  */
+#define SUPC_CR_Msk                         _U_(0xFF00000C)                                /**< (SUPC_CR) Register Mask  */
+
+
+/* -------- SUPC_SMMR : (SUPC Offset: 0x04) (R/W 32) Supply Controller Supply Monitor Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SMTH:4;                    /**< bit:   0..3  Supply Monitor Threshold                 */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t SMSMPL:3;                  /**< bit:  8..10  Supply Monitor Sampling Period           */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t SMRSTEN:1;                 /**< bit:     12  Supply Monitor Reset Enable              */
+    uint32_t SMIEN:1;                   /**< bit:     13  Supply Monitor Interrupt Enable          */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_SMMR_OFFSET                    (0x04)                                        /**<  (SUPC_SMMR) Supply Controller Supply Monitor Mode Register  Offset */
+
+#define SUPC_SMMR_SMTH_Pos                  0                                              /**< (SUPC_SMMR) Supply Monitor Threshold Position */
+#define SUPC_SMMR_SMTH_Msk                  (_U_(0xF) << SUPC_SMMR_SMTH_Pos)               /**< (SUPC_SMMR) Supply Monitor Threshold Mask */
+#define SUPC_SMMR_SMTH(value)               (SUPC_SMMR_SMTH_Msk & ((value) << SUPC_SMMR_SMTH_Pos))
+#define SUPC_SMMR_SMSMPL_Pos                8                                              /**< (SUPC_SMMR) Supply Monitor Sampling Period Position */
+#define SUPC_SMMR_SMSMPL_Msk                (_U_(0x7) << SUPC_SMMR_SMSMPL_Pos)             /**< (SUPC_SMMR) Supply Monitor Sampling Period Mask */
+#define SUPC_SMMR_SMSMPL(value)             (SUPC_SMMR_SMSMPL_Msk & ((value) << SUPC_SMMR_SMSMPL_Pos))
+#define   SUPC_SMMR_SMSMPL_SMD_Val          _U_(0x0)                                       /**< (SUPC_SMMR) Supply Monitor disabled  */
+#define   SUPC_SMMR_SMSMPL_CSM_Val          _U_(0x1)                                       /**< (SUPC_SMMR) Continuous Supply Monitor  */
+#define   SUPC_SMMR_SMSMPL_32SLCK_Val       _U_(0x2)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 32 SLCK periods  */
+#define   SUPC_SMMR_SMSMPL_256SLCK_Val      _U_(0x3)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 256 SLCK periods  */
+#define   SUPC_SMMR_SMSMPL_2048SLCK_Val     _U_(0x4)                                       /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 2,048 SLCK periods  */
+#define SUPC_SMMR_SMSMPL_SMD                (SUPC_SMMR_SMSMPL_SMD_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor disabled Position  */
+#define SUPC_SMMR_SMSMPL_CSM                (SUPC_SMMR_SMSMPL_CSM_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Continuous Supply Monitor Position  */
+#define SUPC_SMMR_SMSMPL_32SLCK             (SUPC_SMMR_SMSMPL_32SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 32 SLCK periods Position  */
+#define SUPC_SMMR_SMSMPL_256SLCK            (SUPC_SMMR_SMSMPL_256SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 256 SLCK periods Position  */
+#define SUPC_SMMR_SMSMPL_2048SLCK           (SUPC_SMMR_SMSMPL_2048SLCK_Val << SUPC_SMMR_SMSMPL_Pos)  /**< (SUPC_SMMR) Supply Monitor enabled one SLCK period every 2,048 SLCK periods Position  */
+#define SUPC_SMMR_SMRSTEN_Pos               12                                             /**< (SUPC_SMMR) Supply Monitor Reset Enable Position */
+#define SUPC_SMMR_SMRSTEN_Msk               (_U_(0x1) << SUPC_SMMR_SMRSTEN_Pos)            /**< (SUPC_SMMR) Supply Monitor Reset Enable Mask */
+#define SUPC_SMMR_SMRSTEN                   SUPC_SMMR_SMRSTEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SMMR_SMRSTEN_Msk instead */
+#define   SUPC_SMMR_SMRSTEN_NOT_ENABLE_Val  _U_(0x0)                                       /**< (SUPC_SMMR) The core reset signal vddcore_nreset is not affected when a supply monitor detection occurs.  */
+#define   SUPC_SMMR_SMRSTEN_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_SMMR) The core reset signal, vddcore_nreset is asserted when a supply monitor detection occurs.  */
+#define SUPC_SMMR_SMRSTEN_NOT_ENABLE        (SUPC_SMMR_SMRSTEN_NOT_ENABLE_Val << SUPC_SMMR_SMRSTEN_Pos)  /**< (SUPC_SMMR) The core reset signal vddcore_nreset is not affected when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMRSTEN_ENABLE            (SUPC_SMMR_SMRSTEN_ENABLE_Val << SUPC_SMMR_SMRSTEN_Pos)  /**< (SUPC_SMMR) The core reset signal, vddcore_nreset is asserted when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMIEN_Pos                 13                                             /**< (SUPC_SMMR) Supply Monitor Interrupt Enable Position */
+#define SUPC_SMMR_SMIEN_Msk                 (_U_(0x1) << SUPC_SMMR_SMIEN_Pos)              /**< (SUPC_SMMR) Supply Monitor Interrupt Enable Mask */
+#define SUPC_SMMR_SMIEN                     SUPC_SMMR_SMIEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SMMR_SMIEN_Msk instead */
+#define   SUPC_SMMR_SMIEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_SMMR) The SUPC interrupt signal is not affected when a supply monitor detection occurs.  */
+#define   SUPC_SMMR_SMIEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_SMMR) The SUPC interrupt signal is asserted when a supply monitor detection occurs.  */
+#define SUPC_SMMR_SMIEN_NOT_ENABLE          (SUPC_SMMR_SMIEN_NOT_ENABLE_Val << SUPC_SMMR_SMIEN_Pos)  /**< (SUPC_SMMR) The SUPC interrupt signal is not affected when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_SMIEN_ENABLE              (SUPC_SMMR_SMIEN_ENABLE_Val << SUPC_SMMR_SMIEN_Pos)  /**< (SUPC_SMMR) The SUPC interrupt signal is asserted when a supply monitor detection occurs. Position  */
+#define SUPC_SMMR_MASK                      _U_(0x370F)                                    /**< \deprecated (SUPC_SMMR) Register MASK  (Use SUPC_SMMR_Msk instead)  */
+#define SUPC_SMMR_Msk                       _U_(0x370F)                                    /**< (SUPC_SMMR) Register Mask  */
+
+
+/* -------- SUPC_MR : (SUPC Offset: 0x08) (R/W 32) Supply Controller Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t BODRSTEN:1;                /**< bit:     12  Brownout Detector Reset Enable           */
+    uint32_t BODDIS:1;                  /**< bit:     13  Brownout Detector Disable                */
+    uint32_t ONREG:1;                   /**< bit:     14  Voltage Regulator Enable                 */
+    uint32_t :2;                        /**< bit: 15..16  Reserved */
+    uint32_t BKUPRETON:1;               /**< bit:     17  SRAM On In Backup Mode                   */
+    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t OSCBYPASS:1;               /**< bit:     20  Oscillator Bypass                        */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password Key                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_MR_OFFSET                      (0x08)                                        /**<  (SUPC_MR) Supply Controller Mode Register  Offset */
+
+#define SUPC_MR_BODRSTEN_Pos                12                                             /**< (SUPC_MR) Brownout Detector Reset Enable Position */
+#define SUPC_MR_BODRSTEN_Msk                (_U_(0x1) << SUPC_MR_BODRSTEN_Pos)             /**< (SUPC_MR) Brownout Detector Reset Enable Mask */
+#define SUPC_MR_BODRSTEN                    SUPC_MR_BODRSTEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BODRSTEN_Msk instead */
+#define   SUPC_MR_BODRSTEN_NOT_ENABLE_Val   _U_(0x0)                                       /**< (SUPC_MR) The core reset signal vddcore_nreset is not affected when a brownout detection occurs.  */
+#define   SUPC_MR_BODRSTEN_ENABLE_Val       _U_(0x1)                                       /**< (SUPC_MR) The core reset signal, vddcore_nreset is asserted when a brownout detection occurs.  */
+#define SUPC_MR_BODRSTEN_NOT_ENABLE         (SUPC_MR_BODRSTEN_NOT_ENABLE_Val << SUPC_MR_BODRSTEN_Pos)  /**< (SUPC_MR) The core reset signal vddcore_nreset is not affected when a brownout detection occurs. Position  */
+#define SUPC_MR_BODRSTEN_ENABLE             (SUPC_MR_BODRSTEN_ENABLE_Val << SUPC_MR_BODRSTEN_Pos)  /**< (SUPC_MR) The core reset signal, vddcore_nreset is asserted when a brownout detection occurs. Position  */
+#define SUPC_MR_BODDIS_Pos                  13                                             /**< (SUPC_MR) Brownout Detector Disable Position */
+#define SUPC_MR_BODDIS_Msk                  (_U_(0x1) << SUPC_MR_BODDIS_Pos)               /**< (SUPC_MR) Brownout Detector Disable Mask */
+#define SUPC_MR_BODDIS                      SUPC_MR_BODDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BODDIS_Msk instead */
+#define   SUPC_MR_BODDIS_ENABLE_Val         _U_(0x0)                                       /**< (SUPC_MR) The core brownout detector is enabled.  */
+#define   SUPC_MR_BODDIS_DISABLE_Val        _U_(0x1)                                       /**< (SUPC_MR) The core brownout detector is disabled.  */
+#define SUPC_MR_BODDIS_ENABLE               (SUPC_MR_BODDIS_ENABLE_Val << SUPC_MR_BODDIS_Pos)  /**< (SUPC_MR) The core brownout detector is enabled. Position  */
+#define SUPC_MR_BODDIS_DISABLE              (SUPC_MR_BODDIS_DISABLE_Val << SUPC_MR_BODDIS_Pos)  /**< (SUPC_MR) The core brownout detector is disabled. Position  */
+#define SUPC_MR_ONREG_Pos                   14                                             /**< (SUPC_MR) Voltage Regulator Enable Position */
+#define SUPC_MR_ONREG_Msk                   (_U_(0x1) << SUPC_MR_ONREG_Pos)                /**< (SUPC_MR) Voltage Regulator Enable Mask */
+#define SUPC_MR_ONREG                       SUPC_MR_ONREG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_ONREG_Msk instead */
+#define   SUPC_MR_ONREG_ONREG_UNUSED_Val    _U_(0x0)                                       /**< (SUPC_MR) Internal voltage regulator is not used (external power supply is used).  */
+#define   SUPC_MR_ONREG_ONREG_USED_Val      _U_(0x1)                                       /**< (SUPC_MR) Internal voltage regulator is used.  */
+#define SUPC_MR_ONREG_ONREG_UNUSED          (SUPC_MR_ONREG_ONREG_UNUSED_Val << SUPC_MR_ONREG_Pos)  /**< (SUPC_MR) Internal voltage regulator is not used (external power supply is used). Position  */
+#define SUPC_MR_ONREG_ONREG_USED            (SUPC_MR_ONREG_ONREG_USED_Val << SUPC_MR_ONREG_Pos)  /**< (SUPC_MR) Internal voltage regulator is used. Position  */
+#define SUPC_MR_BKUPRETON_Pos               17                                             /**< (SUPC_MR) SRAM On In Backup Mode Position */
+#define SUPC_MR_BKUPRETON_Msk               (_U_(0x1) << SUPC_MR_BKUPRETON_Pos)            /**< (SUPC_MR) SRAM On In Backup Mode Mask */
+#define SUPC_MR_BKUPRETON                   SUPC_MR_BKUPRETON_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_BKUPRETON_Msk instead */
+#define SUPC_MR_OSCBYPASS_Pos               20                                             /**< (SUPC_MR) Oscillator Bypass Position */
+#define SUPC_MR_OSCBYPASS_Msk               (_U_(0x1) << SUPC_MR_OSCBYPASS_Pos)            /**< (SUPC_MR) Oscillator Bypass Mask */
+#define SUPC_MR_OSCBYPASS                   SUPC_MR_OSCBYPASS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_MR_OSCBYPASS_Msk instead */
+#define   SUPC_MR_OSCBYPASS_NO_EFFECT_Val   _U_(0x0)                                       /**< (SUPC_MR) No effect. Clock selection depends on the value of XTALSEL (SUPC_CR).  */
+#define   SUPC_MR_OSCBYPASS_BYPASS_Val      _U_(0x1)                                       /**< (SUPC_MR) The 32 kHz crystal oscillator is bypassed if XTALSEL (SUPC_CR) is set. OSCBYPASS must be set prior to setting XTALSEL.  */
+#define SUPC_MR_OSCBYPASS_NO_EFFECT         (SUPC_MR_OSCBYPASS_NO_EFFECT_Val << SUPC_MR_OSCBYPASS_Pos)  /**< (SUPC_MR) No effect. Clock selection depends on the value of XTALSEL (SUPC_CR). Position  */
+#define SUPC_MR_OSCBYPASS_BYPASS            (SUPC_MR_OSCBYPASS_BYPASS_Val << SUPC_MR_OSCBYPASS_Pos)  /**< (SUPC_MR) The 32 kHz crystal oscillator is bypassed if XTALSEL (SUPC_CR) is set. OSCBYPASS must be set prior to setting XTALSEL. Position  */
+#define SUPC_MR_KEY_Pos                     24                                             /**< (SUPC_MR) Password Key Position */
+#define SUPC_MR_KEY_Msk                     (_U_(0xFF) << SUPC_MR_KEY_Pos)                 /**< (SUPC_MR) Password Key Mask */
+#define SUPC_MR_KEY(value)                  (SUPC_MR_KEY_Msk & ((value) << SUPC_MR_KEY_Pos))
+#define   SUPC_MR_KEY_PASSWD_Val            _U_(0xA5)                                      /**< (SUPC_MR) Writing any other value in this field aborts the write operation.  */
+#define SUPC_MR_KEY_PASSWD                  (SUPC_MR_KEY_PASSWD_Val << SUPC_MR_KEY_Pos)    /**< (SUPC_MR) Writing any other value in this field aborts the write operation. Position  */
+#define SUPC_MR_MASK                        _U_(0xFF127000)                                /**< \deprecated (SUPC_MR) Register MASK  (Use SUPC_MR_Msk instead)  */
+#define SUPC_MR_Msk                         _U_(0xFF127000)                                /**< (SUPC_MR) Register Mask  */
+
+
+/* -------- SUPC_WUMR : (SUPC Offset: 0x0c) (R/W 32) Supply Controller Wake-up Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t SMEN:1;                    /**< bit:      1  Supply Monitor Wake-up Enable            */
+    uint32_t RTTEN:1;                   /**< bit:      2  Real-time Timer Wake-up Enable           */
+    uint32_t RTCEN:1;                   /**< bit:      3  Real-time Clock Wake-up Enable           */
+    uint32_t :1;                        /**< bit:      4  Reserved */
+    uint32_t LPDBCEN0:1;                /**< bit:      5  Low-power Debouncer Enable WKUP0         */
+    uint32_t LPDBCEN1:1;                /**< bit:      6  Low-power Debouncer Enable WKUP1         */
+    uint32_t LPDBCCLR:1;                /**< bit:      7  Low-power Debouncer Clear                */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t WKUPDBC:3;                 /**< bit: 12..14  Wake-up Inputs Debouncer Period          */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t LPDBC:3;                   /**< bit: 16..18  Low-power Debouncer Period               */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :5;                        /**< bit:   0..4  Reserved */
+    uint32_t LPDBCEN:2;                 /**< bit:   5..6  Low-power Debouncer Enable WKUPx         */
+    uint32_t :25;                       /**< bit:  7..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_WUMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_WUMR_OFFSET                    (0x0C)                                        /**<  (SUPC_WUMR) Supply Controller Wake-up Mode Register  Offset */
+
+#define SUPC_WUMR_SMEN_Pos                  1                                              /**< (SUPC_WUMR) Supply Monitor Wake-up Enable Position */
+#define SUPC_WUMR_SMEN_Msk                  (_U_(0x1) << SUPC_WUMR_SMEN_Pos)               /**< (SUPC_WUMR) Supply Monitor Wake-up Enable Mask */
+#define SUPC_WUMR_SMEN                      SUPC_WUMR_SMEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_SMEN_Msk instead */
+#define   SUPC_WUMR_SMEN_NOT_ENABLE_Val     _U_(0x0)                                       /**< (SUPC_WUMR) The supply monitor detection has no wake-up effect.  */
+#define   SUPC_WUMR_SMEN_ENABLE_Val         _U_(0x1)                                       /**< (SUPC_WUMR) The supply monitor detection forces the wake-up of the core power supply.  */
+#define SUPC_WUMR_SMEN_NOT_ENABLE           (SUPC_WUMR_SMEN_NOT_ENABLE_Val << SUPC_WUMR_SMEN_Pos)  /**< (SUPC_WUMR) The supply monitor detection has no wake-up effect. Position  */
+#define SUPC_WUMR_SMEN_ENABLE               (SUPC_WUMR_SMEN_ENABLE_Val << SUPC_WUMR_SMEN_Pos)  /**< (SUPC_WUMR) The supply monitor detection forces the wake-up of the core power supply. Position  */
+#define SUPC_WUMR_RTTEN_Pos                 2                                              /**< (SUPC_WUMR) Real-time Timer Wake-up Enable Position */
+#define SUPC_WUMR_RTTEN_Msk                 (_U_(0x1) << SUPC_WUMR_RTTEN_Pos)              /**< (SUPC_WUMR) Real-time Timer Wake-up Enable Mask */
+#define SUPC_WUMR_RTTEN                     SUPC_WUMR_RTTEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_RTTEN_Msk instead */
+#define   SUPC_WUMR_RTTEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_WUMR) The RTT alarm signal has no wake-up effect.  */
+#define   SUPC_WUMR_RTTEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_WUMR) The RTT alarm signal forces the wake-up of the core power supply.  */
+#define SUPC_WUMR_RTTEN_NOT_ENABLE          (SUPC_WUMR_RTTEN_NOT_ENABLE_Val << SUPC_WUMR_RTTEN_Pos)  /**< (SUPC_WUMR) The RTT alarm signal has no wake-up effect. Position  */
+#define SUPC_WUMR_RTTEN_ENABLE              (SUPC_WUMR_RTTEN_ENABLE_Val << SUPC_WUMR_RTTEN_Pos)  /**< (SUPC_WUMR) The RTT alarm signal forces the wake-up of the core power supply. Position  */
+#define SUPC_WUMR_RTCEN_Pos                 3                                              /**< (SUPC_WUMR) Real-time Clock Wake-up Enable Position */
+#define SUPC_WUMR_RTCEN_Msk                 (_U_(0x1) << SUPC_WUMR_RTCEN_Pos)              /**< (SUPC_WUMR) Real-time Clock Wake-up Enable Mask */
+#define SUPC_WUMR_RTCEN                     SUPC_WUMR_RTCEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_RTCEN_Msk instead */
+#define   SUPC_WUMR_RTCEN_NOT_ENABLE_Val    _U_(0x0)                                       /**< (SUPC_WUMR) The RTC alarm signal has no wake-up effect.  */
+#define   SUPC_WUMR_RTCEN_ENABLE_Val        _U_(0x1)                                       /**< (SUPC_WUMR) The RTC alarm signal forces the wake-up of the core power supply.  */
+#define SUPC_WUMR_RTCEN_NOT_ENABLE          (SUPC_WUMR_RTCEN_NOT_ENABLE_Val << SUPC_WUMR_RTCEN_Pos)  /**< (SUPC_WUMR) The RTC alarm signal has no wake-up effect. Position  */
+#define SUPC_WUMR_RTCEN_ENABLE              (SUPC_WUMR_RTCEN_ENABLE_Val << SUPC_WUMR_RTCEN_Pos)  /**< (SUPC_WUMR) The RTC alarm signal forces the wake-up of the core power supply. Position  */
+#define SUPC_WUMR_LPDBCEN0_Pos              5                                              /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP0 Position */
+#define SUPC_WUMR_LPDBCEN0_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCEN0_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP0 Mask */
+#define SUPC_WUMR_LPDBCEN0                  SUPC_WUMR_LPDBCEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCEN0_Msk instead */
+#define   SUPC_WUMR_LPDBCEN0_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) The WKUP0 input pin is not connected to the low-power debouncer.  */
+#define   SUPC_WUMR_LPDBCEN0_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) The WKUP0 input pin is connected to the low-power debouncer and forces a system wake-up.  */
+#define SUPC_WUMR_LPDBCEN0_NOT_ENABLE       (SUPC_WUMR_LPDBCEN0_NOT_ENABLE_Val << SUPC_WUMR_LPDBCEN0_Pos)  /**< (SUPC_WUMR) The WKUP0 input pin is not connected to the low-power debouncer. Position  */
+#define SUPC_WUMR_LPDBCEN0_ENABLE           (SUPC_WUMR_LPDBCEN0_ENABLE_Val << SUPC_WUMR_LPDBCEN0_Pos)  /**< (SUPC_WUMR) The WKUP0 input pin is connected to the low-power debouncer and forces a system wake-up. Position  */
+#define SUPC_WUMR_LPDBCEN1_Pos              6                                              /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP1 Position */
+#define SUPC_WUMR_LPDBCEN1_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCEN1_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Enable WKUP1 Mask */
+#define SUPC_WUMR_LPDBCEN1                  SUPC_WUMR_LPDBCEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCEN1_Msk instead */
+#define   SUPC_WUMR_LPDBCEN1_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) The WKUP1 input pin is not connected to the low-power debouncer.  */
+#define   SUPC_WUMR_LPDBCEN1_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) The WKUP1 input pin is connected to the low-power debouncer and forces a system wake-up.  */
+#define SUPC_WUMR_LPDBCEN1_NOT_ENABLE       (SUPC_WUMR_LPDBCEN1_NOT_ENABLE_Val << SUPC_WUMR_LPDBCEN1_Pos)  /**< (SUPC_WUMR) The WKUP1 input pin is not connected to the low-power debouncer. Position  */
+#define SUPC_WUMR_LPDBCEN1_ENABLE           (SUPC_WUMR_LPDBCEN1_ENABLE_Val << SUPC_WUMR_LPDBCEN1_Pos)  /**< (SUPC_WUMR) The WKUP1 input pin is connected to the low-power debouncer and forces a system wake-up. Position  */
+#define SUPC_WUMR_LPDBCCLR_Pos              7                                              /**< (SUPC_WUMR) Low-power Debouncer Clear Position */
+#define SUPC_WUMR_LPDBCCLR_Msk              (_U_(0x1) << SUPC_WUMR_LPDBCCLR_Pos)           /**< (SUPC_WUMR) Low-power Debouncer Clear Mask */
+#define SUPC_WUMR_LPDBCCLR                  SUPC_WUMR_LPDBCCLR_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUMR_LPDBCCLR_Msk instead */
+#define   SUPC_WUMR_LPDBCCLR_NOT_ENABLE_Val _U_(0x0)                                       /**< (SUPC_WUMR) A low-power debounce event does not create an immediate clear on the first half of GPBR registers.  */
+#define   SUPC_WUMR_LPDBCCLR_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUMR) A low-power debounce event on WKUP0 or WKUP1 generates an immediate clear on the first half of GPBR registers.  */
+#define SUPC_WUMR_LPDBCCLR_NOT_ENABLE       (SUPC_WUMR_LPDBCCLR_NOT_ENABLE_Val << SUPC_WUMR_LPDBCCLR_Pos)  /**< (SUPC_WUMR) A low-power debounce event does not create an immediate clear on the first half of GPBR registers. Position  */
+#define SUPC_WUMR_LPDBCCLR_ENABLE           (SUPC_WUMR_LPDBCCLR_ENABLE_Val << SUPC_WUMR_LPDBCCLR_Pos)  /**< (SUPC_WUMR) A low-power debounce event on WKUP0 or WKUP1 generates an immediate clear on the first half of GPBR registers. Position  */
+#define SUPC_WUMR_WKUPDBC_Pos               12                                             /**< (SUPC_WUMR) Wake-up Inputs Debouncer Period Position */
+#define SUPC_WUMR_WKUPDBC_Msk               (_U_(0x7) << SUPC_WUMR_WKUPDBC_Pos)            /**< (SUPC_WUMR) Wake-up Inputs Debouncer Period Mask */
+#define SUPC_WUMR_WKUPDBC(value)            (SUPC_WUMR_WKUPDBC_Msk & ((value) << SUPC_WUMR_WKUPDBC_Pos))
+#define   SUPC_WUMR_WKUPDBC_IMMEDIATE_Val   _U_(0x0)                                       /**< (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge.  */
+#define   SUPC_WUMR_WKUPDBC_3_SLCK_Val      _U_(0x1)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 3 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_32_SLCK_Val     _U_(0x2)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_512_SLCK_Val    _U_(0x3)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 512 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_4096_SLCK_Val   _U_(0x4)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 4,096 SLCK periods  */
+#define   SUPC_WUMR_WKUPDBC_32768_SLCK_Val  _U_(0x5)                                       /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32,768 SLCK periods  */
+#define SUPC_WUMR_WKUPDBC_IMMEDIATE         (SUPC_WUMR_WKUPDBC_IMMEDIATE_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge. Position  */
+#define SUPC_WUMR_WKUPDBC_3_SLCK            (SUPC_WUMR_WKUPDBC_3_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 3 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_32_SLCK           (SUPC_WUMR_WKUPDBC_32_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_512_SLCK          (SUPC_WUMR_WKUPDBC_512_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 512 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_4096_SLCK         (SUPC_WUMR_WKUPDBC_4096_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 4,096 SLCK periods Position  */
+#define SUPC_WUMR_WKUPDBC_32768_SLCK        (SUPC_WUMR_WKUPDBC_32768_SLCK_Val << SUPC_WUMR_WKUPDBC_Pos)  /**< (SUPC_WUMR) WKUPx shall be in its active state for at least 32,768 SLCK periods Position  */
+#define SUPC_WUMR_LPDBC_Pos                 16                                             /**< (SUPC_WUMR) Low-power Debouncer Period Position */
+#define SUPC_WUMR_LPDBC_Msk                 (_U_(0x7) << SUPC_WUMR_LPDBC_Pos)              /**< (SUPC_WUMR) Low-power Debouncer Period Mask */
+#define SUPC_WUMR_LPDBC(value)              (SUPC_WUMR_LPDBC_Msk & ((value) << SUPC_WUMR_LPDBC_Pos))
+#define   SUPC_WUMR_LPDBC_DISABLE_Val       _U_(0x0)                                       /**< (SUPC_WUMR) Disable the low-power debouncers.  */
+#define   SUPC_WUMR_LPDBC_2_RTCOUT_Val      _U_(0x1)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 2 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_3_RTCOUT_Val      _U_(0x2)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 3 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_4_RTCOUT_Val      _U_(0x3)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 4 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_5_RTCOUT_Val      _U_(0x4)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 5 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_6_RTCOUT_Val      _U_(0x5)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 6 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_7_RTCOUT_Val      _U_(0x6)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 7 RTCOUTx clock periods  */
+#define   SUPC_WUMR_LPDBC_8_RTCOUT_Val      _U_(0x7)                                       /**< (SUPC_WUMR) WKUP0/1 in active state for at least 8 RTCOUTx clock periods  */
+#define SUPC_WUMR_LPDBC_DISABLE             (SUPC_WUMR_LPDBC_DISABLE_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) Disable the low-power debouncers. Position  */
+#define SUPC_WUMR_LPDBC_2_RTCOUT            (SUPC_WUMR_LPDBC_2_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 2 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_3_RTCOUT            (SUPC_WUMR_LPDBC_3_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 3 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_4_RTCOUT            (SUPC_WUMR_LPDBC_4_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 4 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_5_RTCOUT            (SUPC_WUMR_LPDBC_5_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 5 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_6_RTCOUT            (SUPC_WUMR_LPDBC_6_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 6 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_7_RTCOUT            (SUPC_WUMR_LPDBC_7_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 7 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_LPDBC_8_RTCOUT            (SUPC_WUMR_LPDBC_8_RTCOUT_Val << SUPC_WUMR_LPDBC_Pos)  /**< (SUPC_WUMR) WKUP0/1 in active state for at least 8 RTCOUTx clock periods Position  */
+#define SUPC_WUMR_MASK                      _U_(0x770EE)                                   /**< \deprecated (SUPC_WUMR) Register MASK  (Use SUPC_WUMR_Msk instead)  */
+#define SUPC_WUMR_Msk                       _U_(0x770EE)                                   /**< (SUPC_WUMR) Register Mask  */
+
+#define SUPC_WUMR_LPDBCEN_Pos               5                                              /**< (SUPC_WUMR Position) Low-power Debouncer Enable WKUPx */
+#define SUPC_WUMR_LPDBCEN_Msk               (_U_(0x3) << SUPC_WUMR_LPDBCEN_Pos)            /**< (SUPC_WUMR Mask) LPDBCEN */
+#define SUPC_WUMR_LPDBCEN(value)            (SUPC_WUMR_LPDBCEN_Msk & ((value) << SUPC_WUMR_LPDBCEN_Pos))  
+
+/* -------- SUPC_WUIR : (SUPC Offset: 0x10) (R/W 32) Supply Controller Wake-up Inputs Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WKUPEN0:1;                 /**< bit:      0  Wake-up Input Enable 0 to 0              */
+    uint32_t WKUPEN1:1;                 /**< bit:      1  Wake-up Input Enable 0 to 1              */
+    uint32_t WKUPEN2:1;                 /**< bit:      2  Wake-up Input Enable 0 to 2              */
+    uint32_t WKUPEN3:1;                 /**< bit:      3  Wake-up Input Enable 0 to 3              */
+    uint32_t WKUPEN4:1;                 /**< bit:      4  Wake-up Input Enable 0 to 4              */
+    uint32_t WKUPEN5:1;                 /**< bit:      5  Wake-up Input Enable 0 to 5              */
+    uint32_t WKUPEN6:1;                 /**< bit:      6  Wake-up Input Enable 0 to 6              */
+    uint32_t WKUPEN7:1;                 /**< bit:      7  Wake-up Input Enable 0 to 7              */
+    uint32_t WKUPEN8:1;                 /**< bit:      8  Wake-up Input Enable 0 to 8              */
+    uint32_t WKUPEN9:1;                 /**< bit:      9  Wake-up Input Enable 0 to 9              */
+    uint32_t WKUPEN10:1;                /**< bit:     10  Wake-up Input Enable 0 to 10             */
+    uint32_t WKUPEN11:1;                /**< bit:     11  Wake-up Input Enable 0 to 11             */
+    uint32_t WKUPEN12:1;                /**< bit:     12  Wake-up Input Enable 0 to 12             */
+    uint32_t WKUPEN13:1;                /**< bit:     13  Wake-up Input Enable 0 to 13             */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WKUPT0:1;                  /**< bit:     16  Wake-up Input Type 0 to 0                */
+    uint32_t WKUPT1:1;                  /**< bit:     17  Wake-up Input Type 0 to 1                */
+    uint32_t WKUPT2:1;                  /**< bit:     18  Wake-up Input Type 0 to 2                */
+    uint32_t WKUPT3:1;                  /**< bit:     19  Wake-up Input Type 0 to 3                */
+    uint32_t WKUPT4:1;                  /**< bit:     20  Wake-up Input Type 0 to 4                */
+    uint32_t WKUPT5:1;                  /**< bit:     21  Wake-up Input Type 0 to 5                */
+    uint32_t WKUPT6:1;                  /**< bit:     22  Wake-up Input Type 0 to 6                */
+    uint32_t WKUPT7:1;                  /**< bit:     23  Wake-up Input Type 0 to 7                */
+    uint32_t WKUPT8:1;                  /**< bit:     24  Wake-up Input Type 0 to 8                */
+    uint32_t WKUPT9:1;                  /**< bit:     25  Wake-up Input Type 0 to 9                */
+    uint32_t WKUPT10:1;                 /**< bit:     26  Wake-up Input Type 0 to 10               */
+    uint32_t WKUPT11:1;                 /**< bit:     27  Wake-up Input Type 0 to 11               */
+    uint32_t WKUPT12:1;                 /**< bit:     28  Wake-up Input Type 0 to 12               */
+    uint32_t WKUPT13:1;                 /**< bit:     29  Wake-up Input Type 0 to 13               */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WKUPEN:14;                 /**< bit:  0..13  Wake-up Input Enable x to x              */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t WKUPT:14;                  /**< bit: 16..29  Wake-up Input Type x to x3               */
+    uint32_t :2;                        /**< bit: 30..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_WUIR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_WUIR_OFFSET                    (0x10)                                        /**<  (SUPC_WUIR) Supply Controller Wake-up Inputs Register  Offset */
+
+#define SUPC_WUIR_WKUPEN0_Pos               0                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 0 Position */
+#define SUPC_WUIR_WKUPEN0_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN0_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 0 Mask */
+#define SUPC_WUIR_WKUPEN0                   SUPC_WUIR_WKUPEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN0_Msk instead */
+#define   SUPC_WUIR_WKUPEN0_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN0_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN0_DISABLE           (SUPC_WUIR_WKUPEN0_DISABLE_Val << SUPC_WUIR_WKUPEN0_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN0_ENABLE            (SUPC_WUIR_WKUPEN0_ENABLE_Val << SUPC_WUIR_WKUPEN0_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN1_Pos               1                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 1 Position */
+#define SUPC_WUIR_WKUPEN1_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN1_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 1 Mask */
+#define SUPC_WUIR_WKUPEN1                   SUPC_WUIR_WKUPEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN1_Msk instead */
+#define   SUPC_WUIR_WKUPEN1_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN1_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN1_DISABLE           (SUPC_WUIR_WKUPEN1_DISABLE_Val << SUPC_WUIR_WKUPEN1_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN1_ENABLE            (SUPC_WUIR_WKUPEN1_ENABLE_Val << SUPC_WUIR_WKUPEN1_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN2_Pos               2                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 2 Position */
+#define SUPC_WUIR_WKUPEN2_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN2_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 2 Mask */
+#define SUPC_WUIR_WKUPEN2                   SUPC_WUIR_WKUPEN2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN2_Msk instead */
+#define   SUPC_WUIR_WKUPEN2_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN2_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN2_DISABLE           (SUPC_WUIR_WKUPEN2_DISABLE_Val << SUPC_WUIR_WKUPEN2_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN2_ENABLE            (SUPC_WUIR_WKUPEN2_ENABLE_Val << SUPC_WUIR_WKUPEN2_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN3_Pos               3                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 3 Position */
+#define SUPC_WUIR_WKUPEN3_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN3_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 3 Mask */
+#define SUPC_WUIR_WKUPEN3                   SUPC_WUIR_WKUPEN3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN3_Msk instead */
+#define   SUPC_WUIR_WKUPEN3_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN3_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN3_DISABLE           (SUPC_WUIR_WKUPEN3_DISABLE_Val << SUPC_WUIR_WKUPEN3_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN3_ENABLE            (SUPC_WUIR_WKUPEN3_ENABLE_Val << SUPC_WUIR_WKUPEN3_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN4_Pos               4                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 4 Position */
+#define SUPC_WUIR_WKUPEN4_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN4_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 4 Mask */
+#define SUPC_WUIR_WKUPEN4                   SUPC_WUIR_WKUPEN4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN4_Msk instead */
+#define   SUPC_WUIR_WKUPEN4_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN4_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN4_DISABLE           (SUPC_WUIR_WKUPEN4_DISABLE_Val << SUPC_WUIR_WKUPEN4_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN4_ENABLE            (SUPC_WUIR_WKUPEN4_ENABLE_Val << SUPC_WUIR_WKUPEN4_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN5_Pos               5                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 5 Position */
+#define SUPC_WUIR_WKUPEN5_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN5_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 5 Mask */
+#define SUPC_WUIR_WKUPEN5                   SUPC_WUIR_WKUPEN5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN5_Msk instead */
+#define   SUPC_WUIR_WKUPEN5_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN5_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN5_DISABLE           (SUPC_WUIR_WKUPEN5_DISABLE_Val << SUPC_WUIR_WKUPEN5_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN5_ENABLE            (SUPC_WUIR_WKUPEN5_ENABLE_Val << SUPC_WUIR_WKUPEN5_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN6_Pos               6                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 6 Position */
+#define SUPC_WUIR_WKUPEN6_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN6_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 6 Mask */
+#define SUPC_WUIR_WKUPEN6                   SUPC_WUIR_WKUPEN6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN6_Msk instead */
+#define   SUPC_WUIR_WKUPEN6_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN6_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN6_DISABLE           (SUPC_WUIR_WKUPEN6_DISABLE_Val << SUPC_WUIR_WKUPEN6_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN6_ENABLE            (SUPC_WUIR_WKUPEN6_ENABLE_Val << SUPC_WUIR_WKUPEN6_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN7_Pos               7                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 7 Position */
+#define SUPC_WUIR_WKUPEN7_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN7_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 7 Mask */
+#define SUPC_WUIR_WKUPEN7                   SUPC_WUIR_WKUPEN7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN7_Msk instead */
+#define   SUPC_WUIR_WKUPEN7_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN7_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN7_DISABLE           (SUPC_WUIR_WKUPEN7_DISABLE_Val << SUPC_WUIR_WKUPEN7_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN7_ENABLE            (SUPC_WUIR_WKUPEN7_ENABLE_Val << SUPC_WUIR_WKUPEN7_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN8_Pos               8                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 8 Position */
+#define SUPC_WUIR_WKUPEN8_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN8_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 8 Mask */
+#define SUPC_WUIR_WKUPEN8                   SUPC_WUIR_WKUPEN8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN8_Msk instead */
+#define   SUPC_WUIR_WKUPEN8_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN8_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN8_DISABLE           (SUPC_WUIR_WKUPEN8_DISABLE_Val << SUPC_WUIR_WKUPEN8_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN8_ENABLE            (SUPC_WUIR_WKUPEN8_ENABLE_Val << SUPC_WUIR_WKUPEN8_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN9_Pos               9                                              /**< (SUPC_WUIR) Wake-up Input Enable 0 to 9 Position */
+#define SUPC_WUIR_WKUPEN9_Msk               (_U_(0x1) << SUPC_WUIR_WKUPEN9_Pos)            /**< (SUPC_WUIR) Wake-up Input Enable 0 to 9 Mask */
+#define SUPC_WUIR_WKUPEN9                   SUPC_WUIR_WKUPEN9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN9_Msk instead */
+#define   SUPC_WUIR_WKUPEN9_DISABLE_Val     _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN9_ENABLE_Val      _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN9_DISABLE           (SUPC_WUIR_WKUPEN9_DISABLE_Val << SUPC_WUIR_WKUPEN9_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN9_ENABLE            (SUPC_WUIR_WKUPEN9_ENABLE_Val << SUPC_WUIR_WKUPEN9_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN10_Pos              10                                             /**< (SUPC_WUIR) Wake-up Input Enable 0 to 10 Position */
+#define SUPC_WUIR_WKUPEN10_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN10_Pos)           /**< (SUPC_WUIR) Wake-up Input Enable 0 to 10 Mask */
+#define SUPC_WUIR_WKUPEN10                  SUPC_WUIR_WKUPEN10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN10_Msk instead */
+#define   SUPC_WUIR_WKUPEN10_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN10_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN10_DISABLE          (SUPC_WUIR_WKUPEN10_DISABLE_Val << SUPC_WUIR_WKUPEN10_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN10_ENABLE           (SUPC_WUIR_WKUPEN10_ENABLE_Val << SUPC_WUIR_WKUPEN10_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN11_Pos              11                                             /**< (SUPC_WUIR) Wake-up Input Enable 0 to 11 Position */
+#define SUPC_WUIR_WKUPEN11_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN11_Pos)           /**< (SUPC_WUIR) Wake-up Input Enable 0 to 11 Mask */
+#define SUPC_WUIR_WKUPEN11                  SUPC_WUIR_WKUPEN11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN11_Msk instead */
+#define   SUPC_WUIR_WKUPEN11_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN11_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN11_DISABLE          (SUPC_WUIR_WKUPEN11_DISABLE_Val << SUPC_WUIR_WKUPEN11_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN11_ENABLE           (SUPC_WUIR_WKUPEN11_ENABLE_Val << SUPC_WUIR_WKUPEN11_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN12_Pos              12                                             /**< (SUPC_WUIR) Wake-up Input Enable 0 to 12 Position */
+#define SUPC_WUIR_WKUPEN12_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN12_Pos)           /**< (SUPC_WUIR) Wake-up Input Enable 0 to 12 Mask */
+#define SUPC_WUIR_WKUPEN12                  SUPC_WUIR_WKUPEN12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN12_Msk instead */
+#define   SUPC_WUIR_WKUPEN12_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN12_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN12_DISABLE          (SUPC_WUIR_WKUPEN12_DISABLE_Val << SUPC_WUIR_WKUPEN12_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN12_ENABLE           (SUPC_WUIR_WKUPEN12_ENABLE_Val << SUPC_WUIR_WKUPEN12_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPEN13_Pos              13                                             /**< (SUPC_WUIR) Wake-up Input Enable 0 to 13 Position */
+#define SUPC_WUIR_WKUPEN13_Msk              (_U_(0x1) << SUPC_WUIR_WKUPEN13_Pos)           /**< (SUPC_WUIR) Wake-up Input Enable 0 to 13 Mask */
+#define SUPC_WUIR_WKUPEN13                  SUPC_WUIR_WKUPEN13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPEN13_Msk instead */
+#define   SUPC_WUIR_WKUPEN13_DISABLE_Val    _U_(0x0)                                       /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect.  */
+#define   SUPC_WUIR_WKUPEN13_ENABLE_Val     _U_(0x1)                                       /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPEN13_DISABLE          (SUPC_WUIR_WKUPEN13_DISABLE_Val << SUPC_WUIR_WKUPEN13_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input has no wake-up effect. Position  */
+#define SUPC_WUIR_WKUPEN13_ENABLE           (SUPC_WUIR_WKUPEN13_ENABLE_Val << SUPC_WUIR_WKUPEN13_Pos)  /**< (SUPC_WUIR) The corresponding wake-up input is enabled for a wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT0_Pos                16                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 0 Position */
+#define SUPC_WUIR_WKUPT0_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT0_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 0 Mask */
+#define SUPC_WUIR_WKUPT0                    SUPC_WUIR_WKUPT0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT0_Msk instead */
+#define   SUPC_WUIR_WKUPT0_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT0_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT0_LOW                (SUPC_WUIR_WKUPT0_LOW_Val << SUPC_WUIR_WKUPT0_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT0_HIGH               (SUPC_WUIR_WKUPT0_HIGH_Val << SUPC_WUIR_WKUPT0_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT1_Pos                17                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 1 Position */
+#define SUPC_WUIR_WKUPT1_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT1_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 1 Mask */
+#define SUPC_WUIR_WKUPT1                    SUPC_WUIR_WKUPT1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT1_Msk instead */
+#define   SUPC_WUIR_WKUPT1_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT1_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT1_LOW                (SUPC_WUIR_WKUPT1_LOW_Val << SUPC_WUIR_WKUPT1_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT1_HIGH               (SUPC_WUIR_WKUPT1_HIGH_Val << SUPC_WUIR_WKUPT1_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT2_Pos                18                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 2 Position */
+#define SUPC_WUIR_WKUPT2_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT2_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 2 Mask */
+#define SUPC_WUIR_WKUPT2                    SUPC_WUIR_WKUPT2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT2_Msk instead */
+#define   SUPC_WUIR_WKUPT2_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT2_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT2_LOW                (SUPC_WUIR_WKUPT2_LOW_Val << SUPC_WUIR_WKUPT2_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT2_HIGH               (SUPC_WUIR_WKUPT2_HIGH_Val << SUPC_WUIR_WKUPT2_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT3_Pos                19                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 3 Position */
+#define SUPC_WUIR_WKUPT3_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT3_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 3 Mask */
+#define SUPC_WUIR_WKUPT3                    SUPC_WUIR_WKUPT3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT3_Msk instead */
+#define   SUPC_WUIR_WKUPT3_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT3_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT3_LOW                (SUPC_WUIR_WKUPT3_LOW_Val << SUPC_WUIR_WKUPT3_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT3_HIGH               (SUPC_WUIR_WKUPT3_HIGH_Val << SUPC_WUIR_WKUPT3_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT4_Pos                20                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 4 Position */
+#define SUPC_WUIR_WKUPT4_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT4_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 4 Mask */
+#define SUPC_WUIR_WKUPT4                    SUPC_WUIR_WKUPT4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT4_Msk instead */
+#define   SUPC_WUIR_WKUPT4_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT4_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT4_LOW                (SUPC_WUIR_WKUPT4_LOW_Val << SUPC_WUIR_WKUPT4_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT4_HIGH               (SUPC_WUIR_WKUPT4_HIGH_Val << SUPC_WUIR_WKUPT4_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT5_Pos                21                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 5 Position */
+#define SUPC_WUIR_WKUPT5_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT5_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 5 Mask */
+#define SUPC_WUIR_WKUPT5                    SUPC_WUIR_WKUPT5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT5_Msk instead */
+#define   SUPC_WUIR_WKUPT5_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT5_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT5_LOW                (SUPC_WUIR_WKUPT5_LOW_Val << SUPC_WUIR_WKUPT5_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT5_HIGH               (SUPC_WUIR_WKUPT5_HIGH_Val << SUPC_WUIR_WKUPT5_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT6_Pos                22                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 6 Position */
+#define SUPC_WUIR_WKUPT6_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT6_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 6 Mask */
+#define SUPC_WUIR_WKUPT6                    SUPC_WUIR_WKUPT6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT6_Msk instead */
+#define   SUPC_WUIR_WKUPT6_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT6_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT6_LOW                (SUPC_WUIR_WKUPT6_LOW_Val << SUPC_WUIR_WKUPT6_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT6_HIGH               (SUPC_WUIR_WKUPT6_HIGH_Val << SUPC_WUIR_WKUPT6_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT7_Pos                23                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 7 Position */
+#define SUPC_WUIR_WKUPT7_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT7_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 7 Mask */
+#define SUPC_WUIR_WKUPT7                    SUPC_WUIR_WKUPT7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT7_Msk instead */
+#define   SUPC_WUIR_WKUPT7_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT7_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT7_LOW                (SUPC_WUIR_WKUPT7_LOW_Val << SUPC_WUIR_WKUPT7_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT7_HIGH               (SUPC_WUIR_WKUPT7_HIGH_Val << SUPC_WUIR_WKUPT7_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT8_Pos                24                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 8 Position */
+#define SUPC_WUIR_WKUPT8_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT8_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 8 Mask */
+#define SUPC_WUIR_WKUPT8                    SUPC_WUIR_WKUPT8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT8_Msk instead */
+#define   SUPC_WUIR_WKUPT8_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT8_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT8_LOW                (SUPC_WUIR_WKUPT8_LOW_Val << SUPC_WUIR_WKUPT8_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT8_HIGH               (SUPC_WUIR_WKUPT8_HIGH_Val << SUPC_WUIR_WKUPT8_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT9_Pos                25                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 9 Position */
+#define SUPC_WUIR_WKUPT9_Msk                (_U_(0x1) << SUPC_WUIR_WKUPT9_Pos)             /**< (SUPC_WUIR) Wake-up Input Type 0 to 9 Mask */
+#define SUPC_WUIR_WKUPT9                    SUPC_WUIR_WKUPT9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT9_Msk instead */
+#define   SUPC_WUIR_WKUPT9_LOW_Val          _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT9_HIGH_Val         _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT9_LOW                (SUPC_WUIR_WKUPT9_LOW_Val << SUPC_WUIR_WKUPT9_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT9_HIGH               (SUPC_WUIR_WKUPT9_HIGH_Val << SUPC_WUIR_WKUPT9_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT10_Pos               26                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 10 Position */
+#define SUPC_WUIR_WKUPT10_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT10_Pos)            /**< (SUPC_WUIR) Wake-up Input Type 0 to 10 Mask */
+#define SUPC_WUIR_WKUPT10                   SUPC_WUIR_WKUPT10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT10_Msk instead */
+#define   SUPC_WUIR_WKUPT10_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT10_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT10_LOW               (SUPC_WUIR_WKUPT10_LOW_Val << SUPC_WUIR_WKUPT10_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT10_HIGH              (SUPC_WUIR_WKUPT10_HIGH_Val << SUPC_WUIR_WKUPT10_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT11_Pos               27                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 11 Position */
+#define SUPC_WUIR_WKUPT11_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT11_Pos)            /**< (SUPC_WUIR) Wake-up Input Type 0 to 11 Mask */
+#define SUPC_WUIR_WKUPT11                   SUPC_WUIR_WKUPT11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT11_Msk instead */
+#define   SUPC_WUIR_WKUPT11_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT11_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT11_LOW               (SUPC_WUIR_WKUPT11_LOW_Val << SUPC_WUIR_WKUPT11_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT11_HIGH              (SUPC_WUIR_WKUPT11_HIGH_Val << SUPC_WUIR_WKUPT11_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT12_Pos               28                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 12 Position */
+#define SUPC_WUIR_WKUPT12_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT12_Pos)            /**< (SUPC_WUIR) Wake-up Input Type 0 to 12 Mask */
+#define SUPC_WUIR_WKUPT12                   SUPC_WUIR_WKUPT12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT12_Msk instead */
+#define   SUPC_WUIR_WKUPT12_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT12_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT12_LOW               (SUPC_WUIR_WKUPT12_LOW_Val << SUPC_WUIR_WKUPT12_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT12_HIGH              (SUPC_WUIR_WKUPT12_HIGH_Val << SUPC_WUIR_WKUPT12_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT13_Pos               29                                             /**< (SUPC_WUIR) Wake-up Input Type 0 to 13 Position */
+#define SUPC_WUIR_WKUPT13_Msk               (_U_(0x1) << SUPC_WUIR_WKUPT13_Pos)            /**< (SUPC_WUIR) Wake-up Input Type 0 to 13 Mask */
+#define SUPC_WUIR_WKUPT13                   SUPC_WUIR_WKUPT13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_WUIR_WKUPT13_Msk instead */
+#define   SUPC_WUIR_WKUPT13_LOW_Val         _U_(0x0)                                       /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply.  */
+#define   SUPC_WUIR_WKUPT13_HIGH_Val        _U_(0x1)                                       /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply.  */
+#define SUPC_WUIR_WKUPT13_LOW               (SUPC_WUIR_WKUPT13_LOW_Val << SUPC_WUIR_WKUPT13_Pos)  /**< (SUPC_WUIR) A falling edge followed by a low level for a period defined by WKUPDBC on the corre-sponding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_WKUPT13_HIGH              (SUPC_WUIR_WKUPT13_HIGH_Val << SUPC_WUIR_WKUPT13_Pos)  /**< (SUPC_WUIR) A rising edge followed by a high level for a period defined by WKUPDBC on the cor-responding wake-up input forces the wake-up of the core power supply. Position  */
+#define SUPC_WUIR_MASK                      _U_(0x3FFF3FFF)                                /**< \deprecated (SUPC_WUIR) Register MASK  (Use SUPC_WUIR_Msk instead)  */
+#define SUPC_WUIR_Msk                       _U_(0x3FFF3FFF)                                /**< (SUPC_WUIR) Register Mask  */
+
+#define SUPC_WUIR_WKUPEN_Pos                0                                              /**< (SUPC_WUIR Position) Wake-up Input Enable x to x */
+#define SUPC_WUIR_WKUPEN_Msk                (_U_(0x3FFF) << SUPC_WUIR_WKUPEN_Pos)          /**< (SUPC_WUIR Mask) WKUPEN */
+#define SUPC_WUIR_WKUPEN(value)             (SUPC_WUIR_WKUPEN_Msk & ((value) << SUPC_WUIR_WKUPEN_Pos))  
+#define SUPC_WUIR_WKUPT_Pos                 16                                             /**< (SUPC_WUIR Position) Wake-up Input Type x to x3 */
+#define SUPC_WUIR_WKUPT_Msk                 (_U_(0x3FFF) << SUPC_WUIR_WKUPT_Pos)           /**< (SUPC_WUIR Mask) WKUPT */
+#define SUPC_WUIR_WKUPT(value)              (SUPC_WUIR_WKUPT_Msk & ((value) << SUPC_WUIR_WKUPT_Pos))  
+
+/* -------- SUPC_SR : (SUPC Offset: 0x14) (R/ 32) Supply Controller Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t WKUPS:1;                   /**< bit:      1  WKUP Wake-up Status (cleared on read)    */
+    uint32_t SMWS:1;                    /**< bit:      2  Supply Monitor Detection Wake-up Status (cleared on read) */
+    uint32_t BODRSTS:1;                 /**< bit:      3  Brownout Detector Reset Status (cleared on read) */
+    uint32_t SMRSTS:1;                  /**< bit:      4  Supply Monitor Reset Status (cleared on read) */
+    uint32_t SMS:1;                     /**< bit:      5  Supply Monitor Status (cleared on read)  */
+    uint32_t SMOS:1;                    /**< bit:      6  Supply Monitor Output Status             */
+    uint32_t OSCSEL:1;                  /**< bit:      7  32-kHz Oscillator Selection Status       */
+    uint32_t :5;                        /**< bit:  8..12  Reserved */
+    uint32_t LPDBCS0:1;                 /**< bit:     13  Low-power Debouncer Wake-up Status on WKUP0 (cleared on read) */
+    uint32_t LPDBCS1:1;                 /**< bit:     14  Low-power Debouncer Wake-up Status on WKUP1 (cleared on read) */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t WKUPIS0:1;                 /**< bit:     16  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS1:1;                 /**< bit:     17  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS2:1;                 /**< bit:     18  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS3:1;                 /**< bit:     19  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS4:1;                 /**< bit:     20  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS5:1;                 /**< bit:     21  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS6:1;                 /**< bit:     22  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS7:1;                 /**< bit:     23  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS8:1;                 /**< bit:     24  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS9:1;                 /**< bit:     25  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS10:1;                /**< bit:     26  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS11:1;                /**< bit:     27  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS12:1;                /**< bit:     28  WKUPx Input Status (cleared on read)     */
+    uint32_t WKUPIS13:1;                /**< bit:     29  WKUPx Input Status (cleared on read)     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LPDBCS:2;                  /**< bit: 13..14  Low-power Debouncer Wake-up Status on WKUPx (cleared on read) */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t WKUPIS:14;                 /**< bit: 16..29  WKUPx Input Status (cleared on read)     */
+    uint32_t :2;                        /**< bit: 30..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} SUPC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_SR_OFFSET                      (0x14)                                        /**<  (SUPC_SR) Supply Controller Status Register  Offset */
+
+#define SUPC_SR_WKUPS_Pos                   1                                              /**< (SUPC_SR) WKUP Wake-up Status (cleared on read) Position */
+#define SUPC_SR_WKUPS_Msk                   (_U_(0x1) << SUPC_SR_WKUPS_Pos)                /**< (SUPC_SR) WKUP Wake-up Status (cleared on read) Mask */
+#define SUPC_SR_WKUPS                       SUPC_SR_WKUPS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPS_Msk instead */
+#define   SUPC_SR_WKUPS_NO_Val              _U_(0x0)                                       /**< (SUPC_SR) No wake-up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_WKUPS_PRESENT_Val         _U_(0x1)                                       /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPS_NO                    (SUPC_SR_WKUPS_NO_Val << SUPC_SR_WKUPS_Pos)    /**< (SUPC_SR) No wake-up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPS_PRESENT               (SUPC_SR_WKUPS_PRESENT_Val << SUPC_SR_WKUPS_Pos)  /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMWS_Pos                    2                                              /**< (SUPC_SR) Supply Monitor Detection Wake-up Status (cleared on read) Position */
+#define SUPC_SR_SMWS_Msk                    (_U_(0x1) << SUPC_SR_SMWS_Pos)                 /**< (SUPC_SR) Supply Monitor Detection Wake-up Status (cleared on read) Mask */
+#define SUPC_SR_SMWS                        SUPC_SR_SMWS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMWS_Msk instead */
+#define   SUPC_SR_SMWS_NO_Val               _U_(0x0)                                       /**< (SUPC_SR) No wake-up due to a supply monitor detection has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_SMWS_PRESENT_Val          _U_(0x1)                                       /**< (SUPC_SR) At least one wake-up due to a supply monitor detection has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_SMWS_NO                     (SUPC_SR_SMWS_NO_Val << SUPC_SR_SMWS_Pos)      /**< (SUPC_SR) No wake-up due to a supply monitor detection has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMWS_PRESENT                (SUPC_SR_SMWS_PRESENT_Val << SUPC_SR_SMWS_Pos)  /**< (SUPC_SR) At least one wake-up due to a supply monitor detection has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_BODRSTS_Pos                 3                                              /**< (SUPC_SR) Brownout Detector Reset Status (cleared on read) Position */
+#define SUPC_SR_BODRSTS_Msk                 (_U_(0x1) << SUPC_SR_BODRSTS_Pos)              /**< (SUPC_SR) Brownout Detector Reset Status (cleared on read) Mask */
+#define SUPC_SR_BODRSTS                     SUPC_SR_BODRSTS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_BODRSTS_Msk instead */
+#define   SUPC_SR_BODRSTS_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No core brownout rising edge event has been detected since the last read of the SUPC_SR.  */
+#define   SUPC_SR_BODRSTS_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one brownout output rising edge event has been detected since the last read of the SUPC_SR.  */
+#define SUPC_SR_BODRSTS_NO                  (SUPC_SR_BODRSTS_NO_Val << SUPC_SR_BODRSTS_Pos)  /**< (SUPC_SR) No core brownout rising edge event has been detected since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_BODRSTS_PRESENT             (SUPC_SR_BODRSTS_PRESENT_Val << SUPC_SR_BODRSTS_Pos)  /**< (SUPC_SR) At least one brownout output rising edge event has been detected since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMRSTS_Pos                  4                                              /**< (SUPC_SR) Supply Monitor Reset Status (cleared on read) Position */
+#define SUPC_SR_SMRSTS_Msk                  (_U_(0x1) << SUPC_SR_SMRSTS_Pos)               /**< (SUPC_SR) Supply Monitor Reset Status (cleared on read) Mask */
+#define SUPC_SR_SMRSTS                      SUPC_SR_SMRSTS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMRSTS_Msk instead */
+#define   SUPC_SR_SMRSTS_NO_Val             _U_(0x0)                                       /**< (SUPC_SR) No supply monitor detection has generated a core reset since the last read of the SUPC_SR.  */
+#define   SUPC_SR_SMRSTS_PRESENT_Val        _U_(0x1)                                       /**< (SUPC_SR) At least one supply monitor detection has generated a core reset since the last read of the SUPC_SR.  */
+#define SUPC_SR_SMRSTS_NO                   (SUPC_SR_SMRSTS_NO_Val << SUPC_SR_SMRSTS_Pos)  /**< (SUPC_SR) No supply monitor detection has generated a core reset since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMRSTS_PRESENT              (SUPC_SR_SMRSTS_PRESENT_Val << SUPC_SR_SMRSTS_Pos)  /**< (SUPC_SR) At least one supply monitor detection has generated a core reset since the last read of the SUPC_SR. Position  */
+#define SUPC_SR_SMS_Pos                     5                                              /**< (SUPC_SR) Supply Monitor Status (cleared on read) Position */
+#define SUPC_SR_SMS_Msk                     (_U_(0x1) << SUPC_SR_SMS_Pos)                  /**< (SUPC_SR) Supply Monitor Status (cleared on read) Mask */
+#define SUPC_SR_SMS                         SUPC_SR_SMS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMS_Msk instead */
+#define   SUPC_SR_SMS_NO_Val                _U_(0x0)                                       /**< (SUPC_SR) No supply monitor detection since the last read of SUPC_SR.  */
+#define   SUPC_SR_SMS_PRESENT_Val           _U_(0x1)                                       /**< (SUPC_SR) At least one supply monitor detection since the last read of SUPC_SR.  */
+#define SUPC_SR_SMS_NO                      (SUPC_SR_SMS_NO_Val << SUPC_SR_SMS_Pos)        /**< (SUPC_SR) No supply monitor detection since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMS_PRESENT                 (SUPC_SR_SMS_PRESENT_Val << SUPC_SR_SMS_Pos)   /**< (SUPC_SR) At least one supply monitor detection since the last read of SUPC_SR. Position  */
+#define SUPC_SR_SMOS_Pos                    6                                              /**< (SUPC_SR) Supply Monitor Output Status Position */
+#define SUPC_SR_SMOS_Msk                    (_U_(0x1) << SUPC_SR_SMOS_Pos)                 /**< (SUPC_SR) Supply Monitor Output Status Mask */
+#define SUPC_SR_SMOS                        SUPC_SR_SMOS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_SMOS_Msk instead */
+#define   SUPC_SR_SMOS_HIGH_Val             _U_(0x0)                                       /**< (SUPC_SR) The supply monitor detected VDDIO higher than its threshold at its last measurement.  */
+#define   SUPC_SR_SMOS_LOW_Val              _U_(0x1)                                       /**< (SUPC_SR) The supply monitor detected VDDIO lower than its threshold at its last measurement.  */
+#define SUPC_SR_SMOS_HIGH                   (SUPC_SR_SMOS_HIGH_Val << SUPC_SR_SMOS_Pos)    /**< (SUPC_SR) The supply monitor detected VDDIO higher than its threshold at its last measurement. Position  */
+#define SUPC_SR_SMOS_LOW                    (SUPC_SR_SMOS_LOW_Val << SUPC_SR_SMOS_Pos)     /**< (SUPC_SR) The supply monitor detected VDDIO lower than its threshold at its last measurement. Position  */
+#define SUPC_SR_OSCSEL_Pos                  7                                              /**< (SUPC_SR) 32-kHz Oscillator Selection Status Position */
+#define SUPC_SR_OSCSEL_Msk                  (_U_(0x1) << SUPC_SR_OSCSEL_Pos)               /**< (SUPC_SR) 32-kHz Oscillator Selection Status Mask */
+#define SUPC_SR_OSCSEL                      SUPC_SR_OSCSEL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_OSCSEL_Msk instead */
+#define   SUPC_SR_OSCSEL_RC_Val             _U_(0x0)                                       /**< (SUPC_SR) The slow clock, SLCK, is generated by the embedded 32 kHz RC oscillator.  */
+#define   SUPC_SR_OSCSEL_CRYST_Val          _U_(0x1)                                       /**< (SUPC_SR) The slow clock, SLCK, is generated by the 32 kHz crystal oscillator.  */
+#define SUPC_SR_OSCSEL_RC                   (SUPC_SR_OSCSEL_RC_Val << SUPC_SR_OSCSEL_Pos)  /**< (SUPC_SR) The slow clock, SLCK, is generated by the embedded 32 kHz RC oscillator. Position  */
+#define SUPC_SR_OSCSEL_CRYST                (SUPC_SR_OSCSEL_CRYST_Val << SUPC_SR_OSCSEL_Pos)  /**< (SUPC_SR) The slow clock, SLCK, is generated by the 32 kHz crystal oscillator. Position  */
+#define SUPC_SR_LPDBCS0_Pos                 13                                             /**< (SUPC_SR) Low-power Debouncer Wake-up Status on WKUP0 (cleared on read) Position */
+#define SUPC_SR_LPDBCS0_Msk                 (_U_(0x1) << SUPC_SR_LPDBCS0_Pos)              /**< (SUPC_SR) Low-power Debouncer Wake-up Status on WKUP0 (cleared on read) Mask */
+#define SUPC_SR_LPDBCS0                     SUPC_SR_LPDBCS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_LPDBCS0_Msk instead */
+#define   SUPC_SR_LPDBCS0_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No wake-up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_LPDBCS0_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_LPDBCS0_NO                  (SUPC_SR_LPDBCS0_NO_Val << SUPC_SR_LPDBCS0_Pos)  /**< (SUPC_SR) No wake-up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS0_PRESENT             (SUPC_SR_LPDBCS0_PRESENT_Val << SUPC_SR_LPDBCS0_Pos)  /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS1_Pos                 14                                             /**< (SUPC_SR) Low-power Debouncer Wake-up Status on WKUP1 (cleared on read) Position */
+#define SUPC_SR_LPDBCS1_Msk                 (_U_(0x1) << SUPC_SR_LPDBCS1_Pos)              /**< (SUPC_SR) Low-power Debouncer Wake-up Status on WKUP1 (cleared on read) Mask */
+#define SUPC_SR_LPDBCS1                     SUPC_SR_LPDBCS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_LPDBCS1_Msk instead */
+#define   SUPC_SR_LPDBCS1_NO_Val            _U_(0x0)                                       /**< (SUPC_SR) No wake-up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR.  */
+#define   SUPC_SR_LPDBCS1_PRESENT_Val       _U_(0x1)                                       /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR.  */
+#define SUPC_SR_LPDBCS1_NO                  (SUPC_SR_LPDBCS1_NO_Val << SUPC_SR_LPDBCS1_Pos)  /**< (SUPC_SR) No wake-up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_LPDBCS1_PRESENT             (SUPC_SR_LPDBCS1_PRESENT_Val << SUPC_SR_LPDBCS1_Pos)  /**< (SUPC_SR) At least one wake-up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS0_Pos                 16                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS0_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS0_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS0                     SUPC_SR_WKUPIS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS0_Msk instead */
+#define   SUPC_SR_WKUPIS0_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS0_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS0_DIS                 (SUPC_SR_WKUPIS0_DIS_Val << SUPC_SR_WKUPIS0_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS0_EN                  (SUPC_SR_WKUPIS0_EN_Val << SUPC_SR_WKUPIS0_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS1_Pos                 17                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS1_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS1_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS1                     SUPC_SR_WKUPIS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS1_Msk instead */
+#define   SUPC_SR_WKUPIS1_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS1_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS1_DIS                 (SUPC_SR_WKUPIS1_DIS_Val << SUPC_SR_WKUPIS1_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS1_EN                  (SUPC_SR_WKUPIS1_EN_Val << SUPC_SR_WKUPIS1_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS2_Pos                 18                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS2_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS2_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS2                     SUPC_SR_WKUPIS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS2_Msk instead */
+#define   SUPC_SR_WKUPIS2_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS2_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS2_DIS                 (SUPC_SR_WKUPIS2_DIS_Val << SUPC_SR_WKUPIS2_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS2_EN                  (SUPC_SR_WKUPIS2_EN_Val << SUPC_SR_WKUPIS2_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS3_Pos                 19                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS3_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS3_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS3                     SUPC_SR_WKUPIS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS3_Msk instead */
+#define   SUPC_SR_WKUPIS3_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS3_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS3_DIS                 (SUPC_SR_WKUPIS3_DIS_Val << SUPC_SR_WKUPIS3_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS3_EN                  (SUPC_SR_WKUPIS3_EN_Val << SUPC_SR_WKUPIS3_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS4_Pos                 20                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS4_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS4_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS4                     SUPC_SR_WKUPIS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS4_Msk instead */
+#define   SUPC_SR_WKUPIS4_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS4_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS4_DIS                 (SUPC_SR_WKUPIS4_DIS_Val << SUPC_SR_WKUPIS4_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS4_EN                  (SUPC_SR_WKUPIS4_EN_Val << SUPC_SR_WKUPIS4_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS5_Pos                 21                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS5_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS5_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS5                     SUPC_SR_WKUPIS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS5_Msk instead */
+#define   SUPC_SR_WKUPIS5_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS5_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS5_DIS                 (SUPC_SR_WKUPIS5_DIS_Val << SUPC_SR_WKUPIS5_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS5_EN                  (SUPC_SR_WKUPIS5_EN_Val << SUPC_SR_WKUPIS5_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS6_Pos                 22                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS6_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS6_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS6                     SUPC_SR_WKUPIS6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS6_Msk instead */
+#define   SUPC_SR_WKUPIS6_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS6_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS6_DIS                 (SUPC_SR_WKUPIS6_DIS_Val << SUPC_SR_WKUPIS6_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS6_EN                  (SUPC_SR_WKUPIS6_EN_Val << SUPC_SR_WKUPIS6_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS7_Pos                 23                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS7_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS7_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS7                     SUPC_SR_WKUPIS7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS7_Msk instead */
+#define   SUPC_SR_WKUPIS7_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS7_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS7_DIS                 (SUPC_SR_WKUPIS7_DIS_Val << SUPC_SR_WKUPIS7_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS7_EN                  (SUPC_SR_WKUPIS7_EN_Val << SUPC_SR_WKUPIS7_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS8_Pos                 24                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS8_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS8_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS8                     SUPC_SR_WKUPIS8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS8_Msk instead */
+#define   SUPC_SR_WKUPIS8_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS8_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS8_DIS                 (SUPC_SR_WKUPIS8_DIS_Val << SUPC_SR_WKUPIS8_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS8_EN                  (SUPC_SR_WKUPIS8_EN_Val << SUPC_SR_WKUPIS8_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS9_Pos                 25                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS9_Msk                 (_U_(0x1) << SUPC_SR_WKUPIS9_Pos)              /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS9                     SUPC_SR_WKUPIS9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS9_Msk instead */
+#define   SUPC_SR_WKUPIS9_DIS_Val           _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS9_EN_Val            _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS9_DIS                 (SUPC_SR_WKUPIS9_DIS_Val << SUPC_SR_WKUPIS9_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS9_EN                  (SUPC_SR_WKUPIS9_EN_Val << SUPC_SR_WKUPIS9_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS10_Pos                26                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS10_Msk                (_U_(0x1) << SUPC_SR_WKUPIS10_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS10                    SUPC_SR_WKUPIS10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS10_Msk instead */
+#define   SUPC_SR_WKUPIS10_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS10_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS10_DIS                (SUPC_SR_WKUPIS10_DIS_Val << SUPC_SR_WKUPIS10_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS10_EN                 (SUPC_SR_WKUPIS10_EN_Val << SUPC_SR_WKUPIS10_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS11_Pos                27                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS11_Msk                (_U_(0x1) << SUPC_SR_WKUPIS11_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS11                    SUPC_SR_WKUPIS11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS11_Msk instead */
+#define   SUPC_SR_WKUPIS11_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS11_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS11_DIS                (SUPC_SR_WKUPIS11_DIS_Val << SUPC_SR_WKUPIS11_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS11_EN                 (SUPC_SR_WKUPIS11_EN_Val << SUPC_SR_WKUPIS11_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS12_Pos                28                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS12_Msk                (_U_(0x1) << SUPC_SR_WKUPIS12_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS12                    SUPC_SR_WKUPIS12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS12_Msk instead */
+#define   SUPC_SR_WKUPIS12_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS12_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS12_DIS                (SUPC_SR_WKUPIS12_DIS_Val << SUPC_SR_WKUPIS12_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS12_EN                 (SUPC_SR_WKUPIS12_EN_Val << SUPC_SR_WKUPIS12_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_WKUPIS13_Pos                29                                             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Position */
+#define SUPC_SR_WKUPIS13_Msk                (_U_(0x1) << SUPC_SR_WKUPIS13_Pos)             /**< (SUPC_SR) WKUPx Input Status (cleared on read) Mask */
+#define SUPC_SR_WKUPIS13                    SUPC_SR_WKUPIS13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SUPC_SR_WKUPIS13_Msk instead */
+#define   SUPC_SR_WKUPIS13_DIS_Val          _U_(0x0)                                       /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event.  */
+#define   SUPC_SR_WKUPIS13_EN_Val           _U_(0x1)                                       /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR.  */
+#define SUPC_SR_WKUPIS13_DIS                (SUPC_SR_WKUPIS13_DIS_Val << SUPC_SR_WKUPIS13_Pos)  /**< (SUPC_SR) The corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake-up event. Position  */
+#define SUPC_SR_WKUPIS13_EN                 (SUPC_SR_WKUPIS13_EN_Val << SUPC_SR_WKUPIS13_Pos)  /**< (SUPC_SR) The corresponding wake-up input was active at the time the debouncer triggered a wake-up event since the last read of SUPC_SR. Position  */
+#define SUPC_SR_MASK                        _U_(0x3FFF60FE)                                /**< \deprecated (SUPC_SR) Register MASK  (Use SUPC_SR_Msk instead)  */
+#define SUPC_SR_Msk                         _U_(0x3FFF60FE)                                /**< (SUPC_SR) Register Mask  */
+
+#define SUPC_SR_LPDBCS_Pos                  13                                             /**< (SUPC_SR Position) Low-power Debouncer Wake-up Status on WKUPx (cleared on read) */
+#define SUPC_SR_LPDBCS_Msk                  (_U_(0x3) << SUPC_SR_LPDBCS_Pos)               /**< (SUPC_SR Mask) LPDBCS */
+#define SUPC_SR_LPDBCS(value)               (SUPC_SR_LPDBCS_Msk & ((value) << SUPC_SR_LPDBCS_Pos))  
+#define SUPC_SR_WKUPIS_Pos                  16                                             /**< (SUPC_SR Position) WKUPx Input Status (cleared on read) */
+#define SUPC_SR_WKUPIS_Msk                  (_U_(0x3FFF) << SUPC_SR_WKUPIS_Pos)            /**< (SUPC_SR Mask) WKUPIS */
+#define SUPC_SR_WKUPIS(value)               (SUPC_SR_WKUPIS_Msk & ((value) << SUPC_SR_WKUPIS_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief SUPC hardware registers */
+typedef struct {  
+  __O  uint32_t SUPC_CR;        /**< (SUPC Offset: 0x00) Supply Controller Control Register */
+  __IO uint32_t SUPC_SMMR;      /**< (SUPC Offset: 0x04) Supply Controller Supply Monitor Mode Register */
+  __IO uint32_t SUPC_MR;        /**< (SUPC Offset: 0x08) Supply Controller Mode Register */
+  __IO uint32_t SUPC_WUMR;      /**< (SUPC Offset: 0x0C) Supply Controller Wake-up Mode Register */
+  __IO uint32_t SUPC_WUIR;      /**< (SUPC Offset: 0x10) Supply Controller Wake-up Inputs Register */
+  __I  uint32_t SUPC_SR;        /**< (SUPC Offset: 0x14) Supply Controller Status Register */
+} Supc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief SUPC hardware registers */
+typedef struct {  
+  __O  SUPC_CR_Type                   SUPC_CR;        /**< Offset: 0x00 ( /W  32) Supply Controller Control Register */
+  __IO SUPC_SMMR_Type                 SUPC_SMMR;      /**< Offset: 0x04 (R/W  32) Supply Controller Supply Monitor Mode Register */
+  __IO SUPC_MR_Type                   SUPC_MR;        /**< Offset: 0x08 (R/W  32) Supply Controller Mode Register */
+  __IO SUPC_WUMR_Type                 SUPC_WUMR;      /**< Offset: 0x0C (R/W  32) Supply Controller Wake-up Mode Register */
+  __IO SUPC_WUIR_Type                 SUPC_WUIR;      /**< Offset: 0x10 (R/W  32) Supply Controller Wake-up Inputs Register */
+  __I  SUPC_SR_Type                   SUPC_SR;        /**< Offset: 0x14 (R/   32) Supply Controller Status Register */
+} Supc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Supply Controller */
+
+#endif /* _SAMV71_SUPC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/tc.h
+++ b/asf/sam/include/samv71b/component/tc.h
@@ -1,0 +1,1150 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TC_COMPONENT_H_
+#define _SAMV71_TC_COMPONENT_H_
+#define _SAMV71_TC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Timer Counter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TC_6082                       /**< (TC) Module ID */
+#define REV_TC ZL                     /**< (TC) Module revision */
+
+/* -------- TC_CCR : (TC Offset: 0x00) (/W 32) Channel Control Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLKEN:1;                   /**< bit:      0  Counter Clock Enable Command             */
+    uint32_t CLKDIS:1;                  /**< bit:      1  Counter Clock Disable Command            */
+    uint32_t SWTRG:1;                   /**< bit:      2  Software Trigger Command                 */
+    uint32_t :29;                       /**< bit:  3..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CCR_OFFSET                       (0x00)                                        /**<  (TC_CCR) Channel Control Register (channel = 0)  Offset */
+
+#define TC_CCR_CLKEN_Pos                    0                                              /**< (TC_CCR) Counter Clock Enable Command Position */
+#define TC_CCR_CLKEN_Msk                    (_U_(0x1) << TC_CCR_CLKEN_Pos)                 /**< (TC_CCR) Counter Clock Enable Command Mask */
+#define TC_CCR_CLKEN                        TC_CCR_CLKEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_CLKEN_Msk instead */
+#define TC_CCR_CLKDIS_Pos                   1                                              /**< (TC_CCR) Counter Clock Disable Command Position */
+#define TC_CCR_CLKDIS_Msk                   (_U_(0x1) << TC_CCR_CLKDIS_Pos)                /**< (TC_CCR) Counter Clock Disable Command Mask */
+#define TC_CCR_CLKDIS                       TC_CCR_CLKDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_CLKDIS_Msk instead */
+#define TC_CCR_SWTRG_Pos                    2                                              /**< (TC_CCR) Software Trigger Command Position */
+#define TC_CCR_SWTRG_Msk                    (_U_(0x1) << TC_CCR_SWTRG_Pos)                 /**< (TC_CCR) Software Trigger Command Mask */
+#define TC_CCR_SWTRG                        TC_CCR_SWTRG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CCR_SWTRG_Msk instead */
+#define TC_CCR_MASK                         _U_(0x07)                                      /**< \deprecated (TC_CCR) Register MASK  (Use TC_CCR_Msk instead)  */
+#define TC_CCR_Msk                          _U_(0x07)                                      /**< (TC_CCR) Register Mask  */
+
+
+/* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) Channel Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TCCLKS:3;                  /**< bit:   0..2  Clock Selection                          */
+    uint32_t CLKI:1;                    /**< bit:      3  Clock Invert                             */
+    uint32_t BURST:2;                   /**< bit:   4..5  Burst Signal Selection                   */
+    uint32_t :9;                        /**< bit:  6..14  Reserved */
+    uint32_t WAVE:1;                    /**< bit:     15  Waveform Mode                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CAPTURE mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LDBSTOP:1;                 /**< bit:      6  Counter Clock Stopped with RB Loading    */
+    uint32_t LDBDIS:1;                  /**< bit:      7  Counter Clock Disable with RB Loading    */
+    uint32_t ETRGEDG:2;                 /**< bit:   8..9  External Trigger Edge Selection          */
+    uint32_t ABETRG:1;                  /**< bit:     10  TIOAx or TIOBx External Trigger Selection */
+    uint32_t :3;                        /**< bit: 11..13  Reserved */
+    uint32_t CPCTRG:1;                  /**< bit:     14  RC Compare Trigger Enable                */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t LDRA:2;                    /**< bit: 16..17  RA Loading Edge Selection                */
+    uint32_t LDRB:2;                    /**< bit: 18..19  RB Loading Edge Selection                */
+    uint32_t SBSMPLR:3;                 /**< bit: 20..22  Loading Edge Subsampling Ratio           */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } CAPTURE;                                /**< Structure used for CAPTURE mode access */
+  struct { // WAVEFORM mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t CPCSTOP:1;                 /**< bit:      6  Counter Clock Stopped with RC Compare    */
+    uint32_t CPCDIS:1;                  /**< bit:      7  Counter Clock Disable with RC Loading    */
+    uint32_t EEVTEDG:2;                 /**< bit:   8..9  External Event Edge Selection            */
+    uint32_t EEVT:2;                    /**< bit: 10..11  External Event Selection                 */
+    uint32_t ENETRG:1;                  /**< bit:     12  External Event Trigger Enable            */
+    uint32_t WAVSEL:2;                  /**< bit: 13..14  Waveform Selection                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t ACPA:2;                    /**< bit: 16..17  RA Compare Effect on TIOAx               */
+    uint32_t ACPC:2;                    /**< bit: 18..19  RC Compare Effect on TIOAx               */
+    uint32_t AEEVT:2;                   /**< bit: 20..21  External Event Effect on TIOAx           */
+    uint32_t ASWTRG:2;                  /**< bit: 22..23  Software Trigger Effect on TIOAx         */
+    uint32_t BCPB:2;                    /**< bit: 24..25  RB Compare Effect on TIOBx               */
+    uint32_t BCPC:2;                    /**< bit: 26..27  RC Compare Effect on TIOBx               */
+    uint32_t BEEVT:2;                   /**< bit: 28..29  External Event Effect on TIOBx           */
+    uint32_t BSWTRG:2;                  /**< bit: 30..31  Software Trigger Effect on TIOBx         */
+  } WAVEFORM;                                /**< Structure used for WAVEFORM mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CMR_OFFSET                       (0x04)                                        /**<  (TC_CMR) Channel Mode Register (channel = 0)  Offset */
+
+#define TC_CMR_TCCLKS_Pos                   0                                              /**< (TC_CMR) Clock Selection Position */
+#define TC_CMR_TCCLKS_Msk                   (_U_(0x7) << TC_CMR_TCCLKS_Pos)                /**< (TC_CMR) Clock Selection Mask */
+#define TC_CMR_TCCLKS(value)                (TC_CMR_TCCLKS_Msk & ((value) << TC_CMR_TCCLKS_Pos))
+#define   TC_CMR_TCCLKS_TIMER_CLOCK1_Val    _U_(0x0)                                       /**< (TC_CMR) Clock selected: internal PCK6 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK2_Val    _U_(0x1)                                       /**< (TC_CMR) Clock selected: internal MCK/8 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK3_Val    _U_(0x2)                                       /**< (TC_CMR) Clock selected: internal MCK/32 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK4_Val    _U_(0x3)                                       /**< (TC_CMR) Clock selected: internal MCK/128 clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK5_Val    _U_(0x4)                                       /**< (TC_CMR) Clock selected: internal SLCK clock signal (from PMC)  */
+#define   TC_CMR_TCCLKS_XC0_Val             _U_(0x5)                                       /**< (TC_CMR) Clock selected: XC0  */
+#define   TC_CMR_TCCLKS_XC1_Val             _U_(0x6)                                       /**< (TC_CMR) Clock selected: XC1  */
+#define   TC_CMR_TCCLKS_XC2_Val             _U_(0x7)                                       /**< (TC_CMR) Clock selected: XC2  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK1          (TC_CMR_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal PCK6 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK2          (TC_CMR_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/8 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK3          (TC_CMR_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/32 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK4          (TC_CMR_TCCLKS_TIMER_CLOCK4_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal MCK/128 clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_TIMER_CLOCK5          (TC_CMR_TCCLKS_TIMER_CLOCK5_Val << TC_CMR_TCCLKS_Pos)  /**< (TC_CMR) Clock selected: internal SLCK clock signal (from PMC) Position  */
+#define TC_CMR_TCCLKS_XC0                   (TC_CMR_TCCLKS_XC0_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC0 Position  */
+#define TC_CMR_TCCLKS_XC1                   (TC_CMR_TCCLKS_XC1_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC1 Position  */
+#define TC_CMR_TCCLKS_XC2                   (TC_CMR_TCCLKS_XC2_Val << TC_CMR_TCCLKS_Pos)   /**< (TC_CMR) Clock selected: XC2 Position  */
+#define TC_CMR_CLKI_Pos                     3                                              /**< (TC_CMR) Clock Invert Position */
+#define TC_CMR_CLKI_Msk                     (_U_(0x1) << TC_CMR_CLKI_Pos)                  /**< (TC_CMR) Clock Invert Mask */
+#define TC_CMR_CLKI                         TC_CMR_CLKI_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CLKI_Msk instead */
+#define TC_CMR_BURST_Pos                    4                                              /**< (TC_CMR) Burst Signal Selection Position */
+#define TC_CMR_BURST_Msk                    (_U_(0x3) << TC_CMR_BURST_Pos)                 /**< (TC_CMR) Burst Signal Selection Mask */
+#define TC_CMR_BURST(value)                 (TC_CMR_BURST_Msk & ((value) << TC_CMR_BURST_Pos))
+#define   TC_CMR_BURST_NONE_Val             _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
+#define   TC_CMR_BURST_XC0_Val              _U_(0x1)                                       /**< (TC_CMR) XC0 is ANDed with the selected clock.  */
+#define   TC_CMR_BURST_XC1_Val              _U_(0x2)                                       /**< (TC_CMR) XC1 is ANDed with the selected clock.  */
+#define   TC_CMR_BURST_XC2_Val              _U_(0x3)                                       /**< (TC_CMR) XC2 is ANDed with the selected clock.  */
+#define TC_CMR_BURST_NONE                   (TC_CMR_BURST_NONE_Val << TC_CMR_BURST_Pos)    /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_BURST_XC0                    (TC_CMR_BURST_XC0_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC0 is ANDed with the selected clock. Position  */
+#define TC_CMR_BURST_XC1                    (TC_CMR_BURST_XC1_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC1 is ANDed with the selected clock. Position  */
+#define TC_CMR_BURST_XC2                    (TC_CMR_BURST_XC2_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC2 is ANDed with the selected clock. Position  */
+#define TC_CMR_WAVE_Pos                     15                                             /**< (TC_CMR) Waveform Mode Position */
+#define TC_CMR_WAVE_Msk                     (_U_(0x1) << TC_CMR_WAVE_Pos)                  /**< (TC_CMR) Waveform Mode Mask */
+#define TC_CMR_WAVE                         TC_CMR_WAVE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVE_Msk instead */
+#define TC_CMR_MASK                         _U_(0x803F)                                    /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
+#define TC_CMR_Msk                          _U_(0x803F)                                    /**< (TC_CMR) Register Mask  */
+
+/* CAPTURE mode */
+#define TC_CMR_CAPTURE_LDBSTOP_Pos          6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_CAPTURE_LDBSTOP_Msk          (_U_(0x1) << TC_CMR_CAPTURE_LDBSTOP_Pos)       /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_CAPTURE_LDBSTOP              TC_CMR_CAPTURE_LDBSTOP_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_LDBSTOP_Msk instead */
+#define TC_CMR_CAPTURE_LDBDIS_Pos           7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_CAPTURE_LDBDIS_Msk           (_U_(0x1) << TC_CMR_CAPTURE_LDBDIS_Pos)        /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_CAPTURE_LDBDIS               TC_CMR_CAPTURE_LDBDIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_LDBDIS_Msk instead */
+#define TC_CMR_CAPTURE_ETRGEDG_Pos          8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_CAPTURE_ETRGEDG_Msk          (_U_(0x3) << TC_CMR_CAPTURE_ETRGEDG_Pos)       /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_CAPTURE_ETRGEDG(value)       (TC_CMR_CAPTURE_ETRGEDG_Msk & ((value) << TC_CMR_CAPTURE_ETRGEDG_Pos))
+#define   TC_CMR_CAPTURE_ETRGEDG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) CAPTURE The clock is not gated by an external signal.  */
+#define   TC_CMR_CAPTURE_ETRGEDG_RISING_Val _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge  */
+#define   TC_CMR_CAPTURE_ETRGEDG_FALLING_Val _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge  */
+#define   TC_CMR_CAPTURE_ETRGEDG_EDGE_Val   _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge  */
+#define TC_CMR_CAPTURE_ETRGEDG_NONE         (TC_CMR_CAPTURE_ETRGEDG_NONE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_RISING       (TC_CMR_CAPTURE_ETRGEDG_RISING_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_FALLING      (TC_CMR_CAPTURE_ETRGEDG_FALLING_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_EDGE         (TC_CMR_CAPTURE_ETRGEDG_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
+#define TC_CMR_CAPTURE_ABETRG_Pos           10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_CAPTURE_ABETRG_Msk           (_U_(0x1) << TC_CMR_CAPTURE_ABETRG_Pos)        /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_CAPTURE_ABETRG               TC_CMR_CAPTURE_ABETRG_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_ABETRG_Msk instead */
+#define TC_CMR_CAPTURE_CPCTRG_Pos           14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CAPTURE_CPCTRG_Msk           (_U_(0x1) << TC_CMR_CAPTURE_CPCTRG_Pos)        /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CAPTURE_CPCTRG               TC_CMR_CAPTURE_CPCTRG_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_CPCTRG_Msk instead */
+#define TC_CMR_CAPTURE_LDRA_Pos             16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_CAPTURE_LDRA_Msk             (_U_(0x3) << TC_CMR_CAPTURE_LDRA_Pos)          /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_CAPTURE_LDRA(value)          (TC_CMR_CAPTURE_LDRA_Msk & ((value) << TC_CMR_CAPTURE_LDRA_Pos))
+#define   TC_CMR_CAPTURE_LDRA_NONE_Val      _U_(0x0)                                       /**< (TC_CMR) CAPTURE None  */
+#define   TC_CMR_CAPTURE_LDRA_RISING_Val    _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRA_FALLING_Val   _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRA_EDGE_Val      _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge of TIOAx  */
+#define TC_CMR_CAPTURE_LDRA_NONE            (TC_CMR_CAPTURE_LDRA_NONE_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_CAPTURE_LDRA_RISING          (TC_CMR_CAPTURE_LDRA_RISING_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRA_FALLING         (TC_CMR_CAPTURE_LDRA_FALLING_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRA_EDGE            (TC_CMR_CAPTURE_LDRA_EDGE_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_Pos             18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_CAPTURE_LDRB_Msk             (_U_(0x3) << TC_CMR_CAPTURE_LDRB_Pos)          /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_CAPTURE_LDRB(value)          (TC_CMR_CAPTURE_LDRB_Msk & ((value) << TC_CMR_CAPTURE_LDRB_Pos))
+#define   TC_CMR_CAPTURE_LDRB_NONE_Val      _U_(0x0)                                       /**< (TC_CMR) CAPTURE None  */
+#define   TC_CMR_CAPTURE_LDRB_RISING_Val    _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRB_FALLING_Val   _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRB_EDGE_Val      _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge of TIOAx  */
+#define TC_CMR_CAPTURE_LDRB_NONE            (TC_CMR_CAPTURE_LDRB_NONE_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_CAPTURE_LDRB_RISING          (TC_CMR_CAPTURE_LDRB_RISING_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_FALLING         (TC_CMR_CAPTURE_LDRB_FALLING_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_EDGE            (TC_CMR_CAPTURE_LDRB_EDGE_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_Pos          20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_CAPTURE_SBSMPLR_Msk          (_U_(0x7) << TC_CMR_CAPTURE_SBSMPLR_Pos)       /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_CAPTURE_SBSMPLR(value)       (TC_CMR_CAPTURE_SBSMPLR_Msk & ((value) << TC_CMR_CAPTURE_SBSMPLR_Pos))
+#define   TC_CMR_CAPTURE_SBSMPLR_ONE_Val    _U_(0x0)                                       /**< (TC_CMR) CAPTURE Load a Capture Register each selected edge  */
+#define   TC_CMR_CAPTURE_SBSMPLR_HALF_Val   _U_(0x1)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 2 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_FOURTH_Val _U_(0x2)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 4 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_EIGHTH_Val _U_(0x3)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 8 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH_Val _U_(0x4)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 16 selected edges  */
+#define TC_CMR_CAPTURE_SBSMPLR_ONE          (TC_CMR_CAPTURE_SBSMPLR_ONE_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_HALF         (TC_CMR_CAPTURE_SBSMPLR_HALF_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_FOURTH       (TC_CMR_CAPTURE_SBSMPLR_FOURTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_EIGHTH       (TC_CMR_CAPTURE_SBSMPLR_EIGHTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH    (TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
+#define TC_CMR_CAPTURE_MASK                 _U_(0x7F47C0)                                  /**< \deprecated (TC_CMR_CAPTURE) Register MASK  (Use TC_CMR_CAPTURE_Msk instead)  */
+#define TC_CMR_CAPTURE_Msk                  _U_(0x7F47C0)                                  /**< (TC_CMR_CAPTURE) Register Mask  */
+
+/* WAVEFORM mode */
+#define TC_CMR_WAVEFORM_CPCSTOP_Pos         6                                              /**< (TC_CMR) Counter Clock Stopped with RC Compare Position */
+#define TC_CMR_WAVEFORM_CPCSTOP_Msk         (_U_(0x1) << TC_CMR_WAVEFORM_CPCSTOP_Pos)      /**< (TC_CMR) Counter Clock Stopped with RC Compare Mask */
+#define TC_CMR_WAVEFORM_CPCSTOP             TC_CMR_WAVEFORM_CPCSTOP_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_CPCSTOP_Msk instead */
+#define TC_CMR_WAVEFORM_CPCDIS_Pos          7                                              /**< (TC_CMR) Counter Clock Disable with RC Loading Position */
+#define TC_CMR_WAVEFORM_CPCDIS_Msk          (_U_(0x1) << TC_CMR_WAVEFORM_CPCDIS_Pos)       /**< (TC_CMR) Counter Clock Disable with RC Loading Mask */
+#define TC_CMR_WAVEFORM_CPCDIS              TC_CMR_WAVEFORM_CPCDIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_CPCDIS_Msk instead */
+#define TC_CMR_WAVEFORM_EEVTEDG_Pos         8                                              /**< (TC_CMR) External Event Edge Selection Position */
+#define TC_CMR_WAVEFORM_EEVTEDG_Msk         (_U_(0x3) << TC_CMR_WAVEFORM_EEVTEDG_Pos)      /**< (TC_CMR) External Event Edge Selection Mask */
+#define TC_CMR_WAVEFORM_EEVTEDG(value)      (TC_CMR_WAVEFORM_EEVTEDG_Msk & ((value) << TC_CMR_WAVEFORM_EEVTEDG_Pos))
+#define   TC_CMR_WAVEFORM_EEVTEDG_NONE_Val  _U_(0x0)                                       /**< (TC_CMR) WAVEFORM None  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_RISING_Val _U_(0x1)                                       /**< (TC_CMR) WAVEFORM Rising edge  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_FALLING_Val _U_(0x2)                                       /**< (TC_CMR) WAVEFORM Falling edge  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_EDGE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM Each edges  */
+#define TC_CMR_WAVEFORM_EEVTEDG_NONE        (TC_CMR_WAVEFORM_EEVTEDG_NONE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_RISING      (TC_CMR_WAVEFORM_EEVTEDG_RISING_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_FALLING     (TC_CMR_WAVEFORM_EEVTEDG_FALLING_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_EDGE        (TC_CMR_WAVEFORM_EEVTEDG_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Each edges Position  */
+#define TC_CMR_WAVEFORM_EEVT_Pos            10                                             /**< (TC_CMR) External Event Selection Position */
+#define TC_CMR_WAVEFORM_EEVT_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_EEVT_Pos)         /**< (TC_CMR) External Event Selection Mask */
+#define TC_CMR_WAVEFORM_EEVT(value)         (TC_CMR_WAVEFORM_EEVT_Msk & ((value) << TC_CMR_WAVEFORM_EEVT_Pos))
+#define   TC_CMR_WAVEFORM_EEVT_TIOB_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM TIOB  */
+#define   TC_CMR_WAVEFORM_EEVT_XC0_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM XC0  */
+#define   TC_CMR_WAVEFORM_EEVT_XC1_Val      _U_(0x2)                                       /**< (TC_CMR) WAVEFORM XC1  */
+#define   TC_CMR_WAVEFORM_EEVT_XC2_Val      _U_(0x3)                                       /**< (TC_CMR) WAVEFORM XC2  */
+#define TC_CMR_WAVEFORM_EEVT_TIOB           (TC_CMR_WAVEFORM_EEVT_TIOB_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) TIOB Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC0            (TC_CMR_WAVEFORM_EEVT_XC0_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC0 Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC1            (TC_CMR_WAVEFORM_EEVT_XC1_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC1 Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC2            (TC_CMR_WAVEFORM_EEVT_XC2_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC2 Position  */
+#define TC_CMR_WAVEFORM_ENETRG_Pos          12                                             /**< (TC_CMR) External Event Trigger Enable Position */
+#define TC_CMR_WAVEFORM_ENETRG_Msk          (_U_(0x1) << TC_CMR_WAVEFORM_ENETRG_Pos)       /**< (TC_CMR) External Event Trigger Enable Mask */
+#define TC_CMR_WAVEFORM_ENETRG              TC_CMR_WAVEFORM_ENETRG_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_ENETRG_Msk instead */
+#define TC_CMR_WAVEFORM_WAVSEL_Pos          13                                             /**< (TC_CMR) Waveform Selection Position */
+#define TC_CMR_WAVEFORM_WAVSEL_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_WAVSEL_Pos)       /**< (TC_CMR) Waveform Selection Mask */
+#define TC_CMR_WAVEFORM_WAVSEL(value)       (TC_CMR_WAVEFORM_WAVSEL_Msk & ((value) << TC_CMR_WAVEFORM_WAVSEL_Pos))
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM UP mode without automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_Val _U_(0x1)                                       /**< (TC_CMR) WAVEFORM UPDOWN mode without automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_RC_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM UP mode with automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM UPDOWN mode with automatic trigger on RC Compare  */
+#define TC_CMR_WAVEFORM_WAVSEL_UP           (TC_CMR_WAVEFORM_WAVSEL_UP_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UP mode without automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN       (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UPDOWN mode without automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UP_RC        (TC_CMR_WAVEFORM_WAVSEL_UP_RC_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UP mode with automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC    (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UPDOWN mode with automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_ACPA_Pos            16                                             /**< (TC_CMR) RA Compare Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ACPA_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_ACPA_Pos)         /**< (TC_CMR) RA Compare Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ACPA(value)         (TC_CMR_WAVEFORM_ACPA_Msk & ((value) << TC_CMR_WAVEFORM_ACPA_Pos))
+#define   TC_CMR_WAVEFORM_ACPA_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ACPA_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ACPA_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ACPA_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ACPA_NONE           (TC_CMR_WAVEFORM_ACPA_NONE_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ACPA_SET            (TC_CMR_WAVEFORM_ACPA_SET_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ACPA_CLEAR          (TC_CMR_WAVEFORM_ACPA_CLEAR_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ACPA_TOGGLE         (TC_CMR_WAVEFORM_ACPA_TOGGLE_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_ACPC_Pos            18                                             /**< (TC_CMR) RC Compare Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ACPC_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_ACPC_Pos)         /**< (TC_CMR) RC Compare Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ACPC(value)         (TC_CMR_WAVEFORM_ACPC_Msk & ((value) << TC_CMR_WAVEFORM_ACPC_Pos))
+#define   TC_CMR_WAVEFORM_ACPC_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ACPC_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ACPC_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ACPC_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ACPC_NONE           (TC_CMR_WAVEFORM_ACPC_NONE_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ACPC_SET            (TC_CMR_WAVEFORM_ACPC_SET_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ACPC_CLEAR          (TC_CMR_WAVEFORM_ACPC_CLEAR_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ACPC_TOGGLE         (TC_CMR_WAVEFORM_ACPC_TOGGLE_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_AEEVT_Pos           20                                             /**< (TC_CMR) External Event Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_AEEVT_Msk           (_U_(0x3) << TC_CMR_WAVEFORM_AEEVT_Pos)        /**< (TC_CMR) External Event Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_AEEVT(value)        (TC_CMR_WAVEFORM_AEEVT_Msk & ((value) << TC_CMR_WAVEFORM_AEEVT_Pos))
+#define   TC_CMR_WAVEFORM_AEEVT_NONE_Val    _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_AEEVT_SET_Val     _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_AEEVT_CLEAR_Val   _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_AEEVT_NONE          (TC_CMR_WAVEFORM_AEEVT_NONE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_AEEVT_SET           (TC_CMR_WAVEFORM_AEEVT_SET_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_AEEVT_CLEAR         (TC_CMR_WAVEFORM_AEEVT_CLEAR_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_AEEVT_TOGGLE        (TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_Pos          22                                             /**< (TC_CMR) Software Trigger Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ASWTRG_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_ASWTRG_Pos)       /**< (TC_CMR) Software Trigger Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ASWTRG(value)       (TC_CMR_WAVEFORM_ASWTRG_Msk & ((value) << TC_CMR_WAVEFORM_ASWTRG_Pos))
+#define   TC_CMR_WAVEFORM_ASWTRG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ASWTRG_SET_Val    _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ASWTRG_NONE         (TC_CMR_WAVEFORM_ASWTRG_NONE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_SET          (TC_CMR_WAVEFORM_ASWTRG_SET_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_CLEAR        (TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_TOGGLE       (TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BCPB_Pos            24                                             /**< (TC_CMR) RB Compare Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BCPB_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_BCPB_Pos)         /**< (TC_CMR) RB Compare Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BCPB(value)         (TC_CMR_WAVEFORM_BCPB_Msk & ((value) << TC_CMR_WAVEFORM_BCPB_Pos))
+#define   TC_CMR_WAVEFORM_BCPB_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BCPB_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BCPB_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BCPB_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BCPB_NONE           (TC_CMR_WAVEFORM_BCPB_NONE_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BCPB_SET            (TC_CMR_WAVEFORM_BCPB_SET_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BCPB_CLEAR          (TC_CMR_WAVEFORM_BCPB_CLEAR_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BCPB_TOGGLE         (TC_CMR_WAVEFORM_BCPB_TOGGLE_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BCPC_Pos            26                                             /**< (TC_CMR) RC Compare Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BCPC_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_BCPC_Pos)         /**< (TC_CMR) RC Compare Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BCPC(value)         (TC_CMR_WAVEFORM_BCPC_Msk & ((value) << TC_CMR_WAVEFORM_BCPC_Pos))
+#define   TC_CMR_WAVEFORM_BCPC_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BCPC_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BCPC_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BCPC_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BCPC_NONE           (TC_CMR_WAVEFORM_BCPC_NONE_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BCPC_SET            (TC_CMR_WAVEFORM_BCPC_SET_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BCPC_CLEAR          (TC_CMR_WAVEFORM_BCPC_CLEAR_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BCPC_TOGGLE         (TC_CMR_WAVEFORM_BCPC_TOGGLE_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BEEVT_Pos           28                                             /**< (TC_CMR) External Event Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BEEVT_Msk           (_U_(0x3) << TC_CMR_WAVEFORM_BEEVT_Pos)        /**< (TC_CMR) External Event Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BEEVT(value)        (TC_CMR_WAVEFORM_BEEVT_Msk & ((value) << TC_CMR_WAVEFORM_BEEVT_Pos))
+#define   TC_CMR_WAVEFORM_BEEVT_NONE_Val    _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BEEVT_SET_Val     _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BEEVT_CLEAR_Val   _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BEEVT_NONE          (TC_CMR_WAVEFORM_BEEVT_NONE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BEEVT_SET           (TC_CMR_WAVEFORM_BEEVT_SET_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BEEVT_CLEAR         (TC_CMR_WAVEFORM_BEEVT_CLEAR_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BEEVT_TOGGLE        (TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_Pos          30                                             /**< (TC_CMR) Software Trigger Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BSWTRG_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_BSWTRG_Pos)       /**< (TC_CMR) Software Trigger Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BSWTRG(value)       (TC_CMR_WAVEFORM_BSWTRG_Msk & ((value) << TC_CMR_WAVEFORM_BSWTRG_Pos))
+#define   TC_CMR_WAVEFORM_BSWTRG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BSWTRG_SET_Val    _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BSWTRG_NONE         (TC_CMR_WAVEFORM_BSWTRG_NONE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_SET          (TC_CMR_WAVEFORM_BSWTRG_SET_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_CLEAR        (TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_TOGGLE       (TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_MASK                _U_(0xFFFF7FC0)                                /**< \deprecated (TC_CMR_WAVEFORM) Register MASK  (Use TC_CMR_WAVEFORM_Msk instead)  */
+#define TC_CMR_WAVEFORM_Msk                 _U_(0xFFFF7FC0)                                /**< (TC_CMR_WAVEFORM) Register Mask  */
+
+
+/* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) Stepper Motor Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t GCEN:1;                    /**< bit:      0  Gray Count Enable                        */
+    uint32_t DOWN:1;                    /**< bit:      1  Down Count                               */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SMMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SMMR_OFFSET                      (0x08)                                        /**<  (TC_SMMR) Stepper Motor Mode Register (channel = 0)  Offset */
+
+#define TC_SMMR_GCEN_Pos                    0                                              /**< (TC_SMMR) Gray Count Enable Position */
+#define TC_SMMR_GCEN_Msk                    (_U_(0x1) << TC_SMMR_GCEN_Pos)                 /**< (TC_SMMR) Gray Count Enable Mask */
+#define TC_SMMR_GCEN                        TC_SMMR_GCEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SMMR_GCEN_Msk instead */
+#define TC_SMMR_DOWN_Pos                    1                                              /**< (TC_SMMR) Down Count Position */
+#define TC_SMMR_DOWN_Msk                    (_U_(0x1) << TC_SMMR_DOWN_Pos)                 /**< (TC_SMMR) Down Count Mask */
+#define TC_SMMR_DOWN                        TC_SMMR_DOWN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SMMR_DOWN_Msk instead */
+#define TC_SMMR_MASK                        _U_(0x03)                                      /**< \deprecated (TC_SMMR) Register MASK  (Use TC_SMMR_Msk instead)  */
+#define TC_SMMR_Msk                         _U_(0x03)                                      /**< (TC_SMMR) Register Mask  */
+
+
+/* -------- TC_RAB : (TC Offset: 0x0c) (R/ 32) Register AB (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RAB:32;                    /**< bit:  0..31  Register A or Register B                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RAB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RAB_OFFSET                       (0x0C)                                        /**<  (TC_RAB) Register AB (channel = 0)  Offset */
+
+#define TC_RAB_RAB_Pos                      0                                              /**< (TC_RAB) Register A or Register B Position */
+#define TC_RAB_RAB_Msk                      (_U_(0xFFFFFFFF) << TC_RAB_RAB_Pos)            /**< (TC_RAB) Register A or Register B Mask */
+#define TC_RAB_RAB(value)                   (TC_RAB_RAB_Msk & ((value) << TC_RAB_RAB_Pos))
+#define TC_RAB_MASK                         _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RAB) Register MASK  (Use TC_RAB_Msk instead)  */
+#define TC_RAB_Msk                          _U_(0xFFFFFFFF)                                /**< (TC_RAB) Register Mask  */
+
+
+/* -------- TC_CV : (TC Offset: 0x10) (R/ 32) Counter Value (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CV:32;                     /**< bit:  0..31  Counter Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_CV_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CV_OFFSET                        (0x10)                                        /**<  (TC_CV) Counter Value (channel = 0)  Offset */
+
+#define TC_CV_CV_Pos                        0                                              /**< (TC_CV) Counter Value Position */
+#define TC_CV_CV_Msk                        (_U_(0xFFFFFFFF) << TC_CV_CV_Pos)              /**< (TC_CV) Counter Value Mask */
+#define TC_CV_CV(value)                     (TC_CV_CV_Msk & ((value) << TC_CV_CV_Pos))   
+#define TC_CV_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_CV) Register MASK  (Use TC_CV_Msk instead)  */
+#define TC_CV_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_CV) Register Mask  */
+
+
+/* -------- TC_RA : (TC Offset: 0x14) (R/W 32) Register A (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RA:32;                     /**< bit:  0..31  Register A                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RA_OFFSET                        (0x14)                                        /**<  (TC_RA) Register A (channel = 0)  Offset */
+
+#define TC_RA_RA_Pos                        0                                              /**< (TC_RA) Register A Position */
+#define TC_RA_RA_Msk                        (_U_(0xFFFFFFFF) << TC_RA_RA_Pos)              /**< (TC_RA) Register A Mask */
+#define TC_RA_RA(value)                     (TC_RA_RA_Msk & ((value) << TC_RA_RA_Pos))   
+#define TC_RA_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RA) Register MASK  (Use TC_RA_Msk instead)  */
+#define TC_RA_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RA) Register Mask  */
+
+
+/* -------- TC_RB : (TC Offset: 0x18) (R/W 32) Register B (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RB:32;                     /**< bit:  0..31  Register B                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RB_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RB_OFFSET                        (0x18)                                        /**<  (TC_RB) Register B (channel = 0)  Offset */
+
+#define TC_RB_RB_Pos                        0                                              /**< (TC_RB) Register B Position */
+#define TC_RB_RB_Msk                        (_U_(0xFFFFFFFF) << TC_RB_RB_Pos)              /**< (TC_RB) Register B Mask */
+#define TC_RB_RB(value)                     (TC_RB_RB_Msk & ((value) << TC_RB_RB_Pos))   
+#define TC_RB_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RB) Register MASK  (Use TC_RB_Msk instead)  */
+#define TC_RB_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RB) Register Mask  */
+
+
+/* -------- TC_RC : (TC Offset: 0x1c) (R/W 32) Register C (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RC:32;                     /**< bit:  0..31  Register C                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_RC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RC_OFFSET                        (0x1C)                                        /**<  (TC_RC) Register C (channel = 0)  Offset */
+
+#define TC_RC_RC_Pos                        0                                              /**< (TC_RC) Register C Position */
+#define TC_RC_RC_Msk                        (_U_(0xFFFFFFFF) << TC_RC_RC_Pos)              /**< (TC_RC) Register C Mask */
+#define TC_RC_RC(value)                     (TC_RC_RC_Msk & ((value) << TC_RC_RC_Pos))   
+#define TC_RC_MASK                          _U_(0xFFFFFFFF)                                /**< \deprecated (TC_RC) Register MASK  (Use TC_RC_Msk instead)  */
+#define TC_RC_Msk                           _U_(0xFFFFFFFF)                                /**< (TC_RC) Register Mask  */
+
+
+/* -------- TC_SR : (TC Offset: 0x20) (R/ 32) Status Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow Status (cleared on read) */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun Status (cleared on read)    */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare Status (cleared on read)      */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare Status (cleared on read)      */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare Status (cleared on read)      */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading Status (cleared on read)      */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading Status (cleared on read)      */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger Status (cleared on read) */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t CLKSTA:1;                  /**< bit:     16  Clock Enabling Status                    */
+    uint32_t MTIOA:1;                   /**< bit:     17  TIOAx Mirror                             */
+    uint32_t MTIOB:1;                   /**< bit:     18  TIOBx Mirror                             */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SR_OFFSET                        (0x20)                                        /**<  (TC_SR) Status Register (channel = 0)  Offset */
+
+#define TC_SR_COVFS_Pos                     0                                              /**< (TC_SR) Counter Overflow Status (cleared on read) Position */
+#define TC_SR_COVFS_Msk                     (_U_(0x1) << TC_SR_COVFS_Pos)                  /**< (TC_SR) Counter Overflow Status (cleared on read) Mask */
+#define TC_SR_COVFS                         TC_SR_COVFS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_COVFS_Msk instead */
+#define TC_SR_LOVRS_Pos                     1                                              /**< (TC_SR) Load Overrun Status (cleared on read) Position */
+#define TC_SR_LOVRS_Msk                     (_U_(0x1) << TC_SR_LOVRS_Pos)                  /**< (TC_SR) Load Overrun Status (cleared on read) Mask */
+#define TC_SR_LOVRS                         TC_SR_LOVRS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LOVRS_Msk instead */
+#define TC_SR_CPAS_Pos                      2                                              /**< (TC_SR) RA Compare Status (cleared on read) Position */
+#define TC_SR_CPAS_Msk                      (_U_(0x1) << TC_SR_CPAS_Pos)                   /**< (TC_SR) RA Compare Status (cleared on read) Mask */
+#define TC_SR_CPAS                          TC_SR_CPAS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPAS_Msk instead */
+#define TC_SR_CPBS_Pos                      3                                              /**< (TC_SR) RB Compare Status (cleared on read) Position */
+#define TC_SR_CPBS_Msk                      (_U_(0x1) << TC_SR_CPBS_Pos)                   /**< (TC_SR) RB Compare Status (cleared on read) Mask */
+#define TC_SR_CPBS                          TC_SR_CPBS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPBS_Msk instead */
+#define TC_SR_CPCS_Pos                      4                                              /**< (TC_SR) RC Compare Status (cleared on read) Position */
+#define TC_SR_CPCS_Msk                      (_U_(0x1) << TC_SR_CPCS_Pos)                   /**< (TC_SR) RC Compare Status (cleared on read) Mask */
+#define TC_SR_CPCS                          TC_SR_CPCS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CPCS_Msk instead */
+#define TC_SR_LDRAS_Pos                     5                                              /**< (TC_SR) RA Loading Status (cleared on read) Position */
+#define TC_SR_LDRAS_Msk                     (_U_(0x1) << TC_SR_LDRAS_Pos)                  /**< (TC_SR) RA Loading Status (cleared on read) Mask */
+#define TC_SR_LDRAS                         TC_SR_LDRAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LDRAS_Msk instead */
+#define TC_SR_LDRBS_Pos                     6                                              /**< (TC_SR) RB Loading Status (cleared on read) Position */
+#define TC_SR_LDRBS_Msk                     (_U_(0x1) << TC_SR_LDRBS_Pos)                  /**< (TC_SR) RB Loading Status (cleared on read) Mask */
+#define TC_SR_LDRBS                         TC_SR_LDRBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_LDRBS_Msk instead */
+#define TC_SR_ETRGS_Pos                     7                                              /**< (TC_SR) External Trigger Status (cleared on read) Position */
+#define TC_SR_ETRGS_Msk                     (_U_(0x1) << TC_SR_ETRGS_Pos)                  /**< (TC_SR) External Trigger Status (cleared on read) Mask */
+#define TC_SR_ETRGS                         TC_SR_ETRGS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_ETRGS_Msk instead */
+#define TC_SR_CLKSTA_Pos                    16                                             /**< (TC_SR) Clock Enabling Status Position */
+#define TC_SR_CLKSTA_Msk                    (_U_(0x1) << TC_SR_CLKSTA_Pos)                 /**< (TC_SR) Clock Enabling Status Mask */
+#define TC_SR_CLKSTA                        TC_SR_CLKSTA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_CLKSTA_Msk instead */
+#define TC_SR_MTIOA_Pos                     17                                             /**< (TC_SR) TIOAx Mirror Position */
+#define TC_SR_MTIOA_Msk                     (_U_(0x1) << TC_SR_MTIOA_Pos)                  /**< (TC_SR) TIOAx Mirror Mask */
+#define TC_SR_MTIOA                         TC_SR_MTIOA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_MTIOA_Msk instead */
+#define TC_SR_MTIOB_Pos                     18                                             /**< (TC_SR) TIOBx Mirror Position */
+#define TC_SR_MTIOB_Msk                     (_U_(0x1) << TC_SR_MTIOB_Pos)                  /**< (TC_SR) TIOBx Mirror Mask */
+#define TC_SR_MTIOB                         TC_SR_MTIOB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_SR_MTIOB_Msk instead */
+#define TC_SR_MASK                          _U_(0x700FF)                                   /**< \deprecated (TC_SR) Register MASK  (Use TC_SR_Msk instead)  */
+#define TC_SR_Msk                           _U_(0x700FF)                                   /**< (TC_SR) Register Mask  */
+
+
+/* -------- TC_IER : (TC Offset: 0x24) (/W 32) Interrupt Enable Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IER_OFFSET                       (0x24)                                        /**<  (TC_IER) Interrupt Enable Register (channel = 0)  Offset */
+
+#define TC_IER_COVFS_Pos                    0                                              /**< (TC_IER) Counter Overflow Position */
+#define TC_IER_COVFS_Msk                    (_U_(0x1) << TC_IER_COVFS_Pos)                 /**< (TC_IER) Counter Overflow Mask */
+#define TC_IER_COVFS                        TC_IER_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_COVFS_Msk instead */
+#define TC_IER_LOVRS_Pos                    1                                              /**< (TC_IER) Load Overrun Position */
+#define TC_IER_LOVRS_Msk                    (_U_(0x1) << TC_IER_LOVRS_Pos)                 /**< (TC_IER) Load Overrun Mask */
+#define TC_IER_LOVRS                        TC_IER_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LOVRS_Msk instead */
+#define TC_IER_CPAS_Pos                     2                                              /**< (TC_IER) RA Compare Position */
+#define TC_IER_CPAS_Msk                     (_U_(0x1) << TC_IER_CPAS_Pos)                  /**< (TC_IER) RA Compare Mask */
+#define TC_IER_CPAS                         TC_IER_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPAS_Msk instead */
+#define TC_IER_CPBS_Pos                     3                                              /**< (TC_IER) RB Compare Position */
+#define TC_IER_CPBS_Msk                     (_U_(0x1) << TC_IER_CPBS_Pos)                  /**< (TC_IER) RB Compare Mask */
+#define TC_IER_CPBS                         TC_IER_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPBS_Msk instead */
+#define TC_IER_CPCS_Pos                     4                                              /**< (TC_IER) RC Compare Position */
+#define TC_IER_CPCS_Msk                     (_U_(0x1) << TC_IER_CPCS_Pos)                  /**< (TC_IER) RC Compare Mask */
+#define TC_IER_CPCS                         TC_IER_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_CPCS_Msk instead */
+#define TC_IER_LDRAS_Pos                    5                                              /**< (TC_IER) RA Loading Position */
+#define TC_IER_LDRAS_Msk                    (_U_(0x1) << TC_IER_LDRAS_Pos)                 /**< (TC_IER) RA Loading Mask */
+#define TC_IER_LDRAS                        TC_IER_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LDRAS_Msk instead */
+#define TC_IER_LDRBS_Pos                    6                                              /**< (TC_IER) RB Loading Position */
+#define TC_IER_LDRBS_Msk                    (_U_(0x1) << TC_IER_LDRBS_Pos)                 /**< (TC_IER) RB Loading Mask */
+#define TC_IER_LDRBS                        TC_IER_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_LDRBS_Msk instead */
+#define TC_IER_ETRGS_Pos                    7                                              /**< (TC_IER) External Trigger Position */
+#define TC_IER_ETRGS_Msk                    (_U_(0x1) << TC_IER_ETRGS_Pos)                 /**< (TC_IER) External Trigger Mask */
+#define TC_IER_ETRGS                        TC_IER_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IER_ETRGS_Msk instead */
+#define TC_IER_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IER) Register MASK  (Use TC_IER_Msk instead)  */
+#define TC_IER_Msk                          _U_(0xFF)                                      /**< (TC_IER) Register Mask  */
+
+
+/* -------- TC_IDR : (TC Offset: 0x28) (/W 32) Interrupt Disable Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IDR_OFFSET                       (0x28)                                        /**<  (TC_IDR) Interrupt Disable Register (channel = 0)  Offset */
+
+#define TC_IDR_COVFS_Pos                    0                                              /**< (TC_IDR) Counter Overflow Position */
+#define TC_IDR_COVFS_Msk                    (_U_(0x1) << TC_IDR_COVFS_Pos)                 /**< (TC_IDR) Counter Overflow Mask */
+#define TC_IDR_COVFS                        TC_IDR_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_COVFS_Msk instead */
+#define TC_IDR_LOVRS_Pos                    1                                              /**< (TC_IDR) Load Overrun Position */
+#define TC_IDR_LOVRS_Msk                    (_U_(0x1) << TC_IDR_LOVRS_Pos)                 /**< (TC_IDR) Load Overrun Mask */
+#define TC_IDR_LOVRS                        TC_IDR_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LOVRS_Msk instead */
+#define TC_IDR_CPAS_Pos                     2                                              /**< (TC_IDR) RA Compare Position */
+#define TC_IDR_CPAS_Msk                     (_U_(0x1) << TC_IDR_CPAS_Pos)                  /**< (TC_IDR) RA Compare Mask */
+#define TC_IDR_CPAS                         TC_IDR_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPAS_Msk instead */
+#define TC_IDR_CPBS_Pos                     3                                              /**< (TC_IDR) RB Compare Position */
+#define TC_IDR_CPBS_Msk                     (_U_(0x1) << TC_IDR_CPBS_Pos)                  /**< (TC_IDR) RB Compare Mask */
+#define TC_IDR_CPBS                         TC_IDR_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPBS_Msk instead */
+#define TC_IDR_CPCS_Pos                     4                                              /**< (TC_IDR) RC Compare Position */
+#define TC_IDR_CPCS_Msk                     (_U_(0x1) << TC_IDR_CPCS_Pos)                  /**< (TC_IDR) RC Compare Mask */
+#define TC_IDR_CPCS                         TC_IDR_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_CPCS_Msk instead */
+#define TC_IDR_LDRAS_Pos                    5                                              /**< (TC_IDR) RA Loading Position */
+#define TC_IDR_LDRAS_Msk                    (_U_(0x1) << TC_IDR_LDRAS_Pos)                 /**< (TC_IDR) RA Loading Mask */
+#define TC_IDR_LDRAS                        TC_IDR_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LDRAS_Msk instead */
+#define TC_IDR_LDRBS_Pos                    6                                              /**< (TC_IDR) RB Loading Position */
+#define TC_IDR_LDRBS_Msk                    (_U_(0x1) << TC_IDR_LDRBS_Pos)                 /**< (TC_IDR) RB Loading Mask */
+#define TC_IDR_LDRBS                        TC_IDR_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_LDRBS_Msk instead */
+#define TC_IDR_ETRGS_Pos                    7                                              /**< (TC_IDR) External Trigger Position */
+#define TC_IDR_ETRGS_Msk                    (_U_(0x1) << TC_IDR_ETRGS_Pos)                 /**< (TC_IDR) External Trigger Mask */
+#define TC_IDR_ETRGS                        TC_IDR_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IDR_ETRGS_Msk instead */
+#define TC_IDR_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IDR) Register MASK  (Use TC_IDR_Msk instead)  */
+#define TC_IDR_Msk                          _U_(0xFF)                                      /**< (TC_IDR) Register Mask  */
+
+
+/* -------- TC_IMR : (TC Offset: 0x2c) (R/ 32) Interrupt Mask Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
+    uint32_t LOVRS:1;                   /**< bit:      1  Load Overrun                             */
+    uint32_t CPAS:1;                    /**< bit:      2  RA Compare                               */
+    uint32_t CPBS:1;                    /**< bit:      3  RB Compare                               */
+    uint32_t CPCS:1;                    /**< bit:      4  RC Compare                               */
+    uint32_t LDRAS:1;                   /**< bit:      5  RA Loading                               */
+    uint32_t LDRBS:1;                   /**< bit:      6  RB Loading                               */
+    uint32_t ETRGS:1;                   /**< bit:      7  External Trigger                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IMR_OFFSET                       (0x2C)                                        /**<  (TC_IMR) Interrupt Mask Register (channel = 0)  Offset */
+
+#define TC_IMR_COVFS_Pos                    0                                              /**< (TC_IMR) Counter Overflow Position */
+#define TC_IMR_COVFS_Msk                    (_U_(0x1) << TC_IMR_COVFS_Pos)                 /**< (TC_IMR) Counter Overflow Mask */
+#define TC_IMR_COVFS                        TC_IMR_COVFS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_COVFS_Msk instead */
+#define TC_IMR_LOVRS_Pos                    1                                              /**< (TC_IMR) Load Overrun Position */
+#define TC_IMR_LOVRS_Msk                    (_U_(0x1) << TC_IMR_LOVRS_Pos)                 /**< (TC_IMR) Load Overrun Mask */
+#define TC_IMR_LOVRS                        TC_IMR_LOVRS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LOVRS_Msk instead */
+#define TC_IMR_CPAS_Pos                     2                                              /**< (TC_IMR) RA Compare Position */
+#define TC_IMR_CPAS_Msk                     (_U_(0x1) << TC_IMR_CPAS_Pos)                  /**< (TC_IMR) RA Compare Mask */
+#define TC_IMR_CPAS                         TC_IMR_CPAS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPAS_Msk instead */
+#define TC_IMR_CPBS_Pos                     3                                              /**< (TC_IMR) RB Compare Position */
+#define TC_IMR_CPBS_Msk                     (_U_(0x1) << TC_IMR_CPBS_Pos)                  /**< (TC_IMR) RB Compare Mask */
+#define TC_IMR_CPBS                         TC_IMR_CPBS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPBS_Msk instead */
+#define TC_IMR_CPCS_Pos                     4                                              /**< (TC_IMR) RC Compare Position */
+#define TC_IMR_CPCS_Msk                     (_U_(0x1) << TC_IMR_CPCS_Pos)                  /**< (TC_IMR) RC Compare Mask */
+#define TC_IMR_CPCS                         TC_IMR_CPCS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_CPCS_Msk instead */
+#define TC_IMR_LDRAS_Pos                    5                                              /**< (TC_IMR) RA Loading Position */
+#define TC_IMR_LDRAS_Msk                    (_U_(0x1) << TC_IMR_LDRAS_Pos)                 /**< (TC_IMR) RA Loading Mask */
+#define TC_IMR_LDRAS                        TC_IMR_LDRAS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LDRAS_Msk instead */
+#define TC_IMR_LDRBS_Pos                    6                                              /**< (TC_IMR) RB Loading Position */
+#define TC_IMR_LDRBS_Msk                    (_U_(0x1) << TC_IMR_LDRBS_Pos)                 /**< (TC_IMR) RB Loading Mask */
+#define TC_IMR_LDRBS                        TC_IMR_LDRBS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_LDRBS_Msk instead */
+#define TC_IMR_ETRGS_Pos                    7                                              /**< (TC_IMR) External Trigger Position */
+#define TC_IMR_ETRGS_Msk                    (_U_(0x1) << TC_IMR_ETRGS_Pos)                 /**< (TC_IMR) External Trigger Mask */
+#define TC_IMR_ETRGS                        TC_IMR_ETRGS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_IMR_ETRGS_Msk instead */
+#define TC_IMR_MASK                         _U_(0xFF)                                      /**< \deprecated (TC_IMR) Register MASK  (Use TC_IMR_Msk instead)  */
+#define TC_IMR_Msk                          _U_(0xFF)                                      /**< (TC_IMR) Register Mask  */
+
+
+/* -------- TC_EMR : (TC Offset: 0x30) (R/W 32) Extended Mode Register (channel = 0) -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TRIGSRCA:2;                /**< bit:   0..1  Trigger Source for Input A               */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t TRIGSRCB:2;                /**< bit:   4..5  Trigger Source for Input B               */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t NODIVCLK:1;                /**< bit:      8  No Divided Clock                         */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_EMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EMR_OFFSET                       (0x30)                                        /**<  (TC_EMR) Extended Mode Register (channel = 0)  Offset */
+
+#define TC_EMR_TRIGSRCA_Pos                 0                                              /**< (TC_EMR) Trigger Source for Input A Position */
+#define TC_EMR_TRIGSRCA_Msk                 (_U_(0x3) << TC_EMR_TRIGSRCA_Pos)              /**< (TC_EMR) Trigger Source for Input A Mask */
+#define TC_EMR_TRIGSRCA(value)              (TC_EMR_TRIGSRCA_Msk & ((value) << TC_EMR_TRIGSRCA_Pos))
+#define   TC_EMR_TRIGSRCA_EXTERNAL_TIOAx_Val _U_(0x0)                                       /**< (TC_EMR) The trigger/capture input A is driven by external pin TIOAx  */
+#define   TC_EMR_TRIGSRCA_PWMx_Val          _U_(0x1)                                       /**< (TC_EMR) The trigger/capture input A is driven internally by PWMx  */
+#define TC_EMR_TRIGSRCA_EXTERNAL_TIOAx      (TC_EMR_TRIGSRCA_EXTERNAL_TIOAx_Val << TC_EMR_TRIGSRCA_Pos)  /**< (TC_EMR) The trigger/capture input A is driven by external pin TIOAx Position  */
+#define TC_EMR_TRIGSRCA_PWMx                (TC_EMR_TRIGSRCA_PWMx_Val << TC_EMR_TRIGSRCA_Pos)  /**< (TC_EMR) The trigger/capture input A is driven internally by PWMx Position  */
+#define TC_EMR_TRIGSRCB_Pos                 4                                              /**< (TC_EMR) Trigger Source for Input B Position */
+#define TC_EMR_TRIGSRCB_Msk                 (_U_(0x3) << TC_EMR_TRIGSRCB_Pos)              /**< (TC_EMR) Trigger Source for Input B Mask */
+#define TC_EMR_TRIGSRCB(value)              (TC_EMR_TRIGSRCB_Msk & ((value) << TC_EMR_TRIGSRCB_Pos))
+#define   TC_EMR_TRIGSRCB_EXTERNAL_TIOBx_Val _U_(0x0)                                       /**< (TC_EMR) The trigger/capture input B is driven by external pin TIOBx  */
+#define   TC_EMR_TRIGSRCB_PWMx_Val          _U_(0x1)                                       /**< (TC_EMR) For TC0 to TC10: The trigger/capture input B is driven internally by the comparator output (see Figure 7-16) of the PWMx.For TC11: The trigger/capture input B is driven internally by the GTSUCOMP signal of the Ethernet MAC (GMAC).  */
+#define TC_EMR_TRIGSRCB_EXTERNAL_TIOBx      (TC_EMR_TRIGSRCB_EXTERNAL_TIOBx_Val << TC_EMR_TRIGSRCB_Pos)  /**< (TC_EMR) The trigger/capture input B is driven by external pin TIOBx Position  */
+#define TC_EMR_TRIGSRCB_PWMx                (TC_EMR_TRIGSRCB_PWMx_Val << TC_EMR_TRIGSRCB_Pos)  /**< (TC_EMR) For TC0 to TC10: The trigger/capture input B is driven internally by the comparator output (see Figure 7-16) of the PWMx.For TC11: The trigger/capture input B is driven internally by the GTSUCOMP signal of the Ethernet MAC (GMAC). Position  */
+#define TC_EMR_NODIVCLK_Pos                 8                                              /**< (TC_EMR) No Divided Clock Position */
+#define TC_EMR_NODIVCLK_Msk                 (_U_(0x1) << TC_EMR_NODIVCLK_Pos)              /**< (TC_EMR) No Divided Clock Mask */
+#define TC_EMR_NODIVCLK                     TC_EMR_NODIVCLK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_EMR_NODIVCLK_Msk instead */
+#define TC_EMR_MASK                         _U_(0x133)                                     /**< \deprecated (TC_EMR) Register MASK  (Use TC_EMR_Msk instead)  */
+#define TC_EMR_Msk                          _U_(0x133)                                     /**< (TC_EMR) Register Mask  */
+
+
+/* -------- TC_BCR : (TC Offset: 0xc0) (/W 32) Block Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SYNC:1;                    /**< bit:      0  Synchro Command                          */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_BCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BCR_OFFSET                       (0xC0)                                        /**<  (TC_BCR) Block Control Register  Offset */
+
+#define TC_BCR_SYNC_Pos                     0                                              /**< (TC_BCR) Synchro Command Position */
+#define TC_BCR_SYNC_Msk                     (_U_(0x1) << TC_BCR_SYNC_Pos)                  /**< (TC_BCR) Synchro Command Mask */
+#define TC_BCR_SYNC                         TC_BCR_SYNC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BCR_SYNC_Msk instead */
+#define TC_BCR_MASK                         _U_(0x01)                                      /**< \deprecated (TC_BCR) Register MASK  (Use TC_BCR_Msk instead)  */
+#define TC_BCR_Msk                          _U_(0x01)                                      /**< (TC_BCR) Register Mask  */
+
+
+/* -------- TC_BMR : (TC Offset: 0xc4) (R/W 32) Block Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TC0XC0S:2;                 /**< bit:   0..1  External Clock Signal 0 Selection        */
+    uint32_t TC1XC1S:2;                 /**< bit:   2..3  External Clock Signal 1 Selection        */
+    uint32_t TC2XC2S:2;                 /**< bit:   4..5  External Clock Signal 2 Selection        */
+    uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t QDEN:1;                    /**< bit:      8  Quadrature Decoder Enabled               */
+    uint32_t POSEN:1;                   /**< bit:      9  Position Enabled                         */
+    uint32_t SPEEDEN:1;                 /**< bit:     10  Speed Enabled                            */
+    uint32_t QDTRANS:1;                 /**< bit:     11  Quadrature Decoding Transparent          */
+    uint32_t EDGPHA:1;                  /**< bit:     12  Edge on PHA Count Mode                   */
+    uint32_t INVA:1;                    /**< bit:     13  Inverted PHA                             */
+    uint32_t INVB:1;                    /**< bit:     14  Inverted PHB                             */
+    uint32_t INVIDX:1;                  /**< bit:     15  Inverted Index                           */
+    uint32_t SWAP:1;                    /**< bit:     16  Swap PHA and PHB                         */
+    uint32_t IDXPHB:1;                  /**< bit:     17  Index Pin is PHB Pin                     */
+    uint32_t AUTOC:1;                   /**< bit:     18  AutoCorrection of missing pulses         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t MAXFILT:6;                 /**< bit: 20..25  Maximum Filter                           */
+    uint32_t MAXCMP:4;                  /**< bit: 26..29  Maximum Consecutive Missing Pulses       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_BMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BMR_OFFSET                       (0xC4)                                        /**<  (TC_BMR) Block Mode Register  Offset */
+
+#define TC_BMR_TC0XC0S_Pos                  0                                              /**< (TC_BMR) External Clock Signal 0 Selection Position */
+#define TC_BMR_TC0XC0S_Msk                  (_U_(0x3) << TC_BMR_TC0XC0S_Pos)               /**< (TC_BMR) External Clock Signal 0 Selection Mask */
+#define TC_BMR_TC0XC0S(value)               (TC_BMR_TC0XC0S_Msk & ((value) << TC_BMR_TC0XC0S_Pos))
+#define   TC_BMR_TC0XC0S_TCLK0_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC0: TCLK0  */
+#define   TC_BMR_TC0XC0S_TIOA1_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC0: TIOA1  */
+#define   TC_BMR_TC0XC0S_TIOA2_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC0: TIOA2  */
+#define TC_BMR_TC0XC0S_TCLK0                (TC_BMR_TC0XC0S_TCLK0_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TCLK0 Position  */
+#define TC_BMR_TC0XC0S_TIOA1                (TC_BMR_TC0XC0S_TIOA1_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TIOA1 Position  */
+#define TC_BMR_TC0XC0S_TIOA2                (TC_BMR_TC0XC0S_TIOA2_Val << TC_BMR_TC0XC0S_Pos)  /**< (TC_BMR) Signal connected to XC0: TIOA2 Position  */
+#define TC_BMR_TC1XC1S_Pos                  2                                              /**< (TC_BMR) External Clock Signal 1 Selection Position */
+#define TC_BMR_TC1XC1S_Msk                  (_U_(0x3) << TC_BMR_TC1XC1S_Pos)               /**< (TC_BMR) External Clock Signal 1 Selection Mask */
+#define TC_BMR_TC1XC1S(value)               (TC_BMR_TC1XC1S_Msk & ((value) << TC_BMR_TC1XC1S_Pos))
+#define   TC_BMR_TC1XC1S_TCLK1_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC1: TCLK1  */
+#define   TC_BMR_TC1XC1S_TIOA0_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC1: TIOA0  */
+#define   TC_BMR_TC1XC1S_TIOA2_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC1: TIOA2  */
+#define TC_BMR_TC1XC1S_TCLK1                (TC_BMR_TC1XC1S_TCLK1_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TCLK1 Position  */
+#define TC_BMR_TC1XC1S_TIOA0                (TC_BMR_TC1XC1S_TIOA0_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TIOA0 Position  */
+#define TC_BMR_TC1XC1S_TIOA2                (TC_BMR_TC1XC1S_TIOA2_Val << TC_BMR_TC1XC1S_Pos)  /**< (TC_BMR) Signal connected to XC1: TIOA2 Position  */
+#define TC_BMR_TC2XC2S_Pos                  4                                              /**< (TC_BMR) External Clock Signal 2 Selection Position */
+#define TC_BMR_TC2XC2S_Msk                  (_U_(0x3) << TC_BMR_TC2XC2S_Pos)               /**< (TC_BMR) External Clock Signal 2 Selection Mask */
+#define TC_BMR_TC2XC2S(value)               (TC_BMR_TC2XC2S_Msk & ((value) << TC_BMR_TC2XC2S_Pos))
+#define   TC_BMR_TC2XC2S_TCLK2_Val          _U_(0x0)                                       /**< (TC_BMR) Signal connected to XC2: TCLK2  */
+#define   TC_BMR_TC2XC2S_TIOA0_Val          _U_(0x2)                                       /**< (TC_BMR) Signal connected to XC2: TIOA0  */
+#define   TC_BMR_TC2XC2S_TIOA1_Val          _U_(0x3)                                       /**< (TC_BMR) Signal connected to XC2: TIOA1  */
+#define TC_BMR_TC2XC2S_TCLK2                (TC_BMR_TC2XC2S_TCLK2_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TCLK2 Position  */
+#define TC_BMR_TC2XC2S_TIOA0                (TC_BMR_TC2XC2S_TIOA0_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TIOA0 Position  */
+#define TC_BMR_TC2XC2S_TIOA1                (TC_BMR_TC2XC2S_TIOA1_Val << TC_BMR_TC2XC2S_Pos)  /**< (TC_BMR) Signal connected to XC2: TIOA1 Position  */
+#define TC_BMR_QDEN_Pos                     8                                              /**< (TC_BMR) Quadrature Decoder Enabled Position */
+#define TC_BMR_QDEN_Msk                     (_U_(0x1) << TC_BMR_QDEN_Pos)                  /**< (TC_BMR) Quadrature Decoder Enabled Mask */
+#define TC_BMR_QDEN                         TC_BMR_QDEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_QDEN_Msk instead */
+#define TC_BMR_POSEN_Pos                    9                                              /**< (TC_BMR) Position Enabled Position */
+#define TC_BMR_POSEN_Msk                    (_U_(0x1) << TC_BMR_POSEN_Pos)                 /**< (TC_BMR) Position Enabled Mask */
+#define TC_BMR_POSEN                        TC_BMR_POSEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_POSEN_Msk instead */
+#define TC_BMR_SPEEDEN_Pos                  10                                             /**< (TC_BMR) Speed Enabled Position */
+#define TC_BMR_SPEEDEN_Msk                  (_U_(0x1) << TC_BMR_SPEEDEN_Pos)               /**< (TC_BMR) Speed Enabled Mask */
+#define TC_BMR_SPEEDEN                      TC_BMR_SPEEDEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_SPEEDEN_Msk instead */
+#define TC_BMR_QDTRANS_Pos                  11                                             /**< (TC_BMR) Quadrature Decoding Transparent Position */
+#define TC_BMR_QDTRANS_Msk                  (_U_(0x1) << TC_BMR_QDTRANS_Pos)               /**< (TC_BMR) Quadrature Decoding Transparent Mask */
+#define TC_BMR_QDTRANS                      TC_BMR_QDTRANS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_QDTRANS_Msk instead */
+#define TC_BMR_EDGPHA_Pos                   12                                             /**< (TC_BMR) Edge on PHA Count Mode Position */
+#define TC_BMR_EDGPHA_Msk                   (_U_(0x1) << TC_BMR_EDGPHA_Pos)                /**< (TC_BMR) Edge on PHA Count Mode Mask */
+#define TC_BMR_EDGPHA                       TC_BMR_EDGPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_EDGPHA_Msk instead */
+#define TC_BMR_INVA_Pos                     13                                             /**< (TC_BMR) Inverted PHA Position */
+#define TC_BMR_INVA_Msk                     (_U_(0x1) << TC_BMR_INVA_Pos)                  /**< (TC_BMR) Inverted PHA Mask */
+#define TC_BMR_INVA                         TC_BMR_INVA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVA_Msk instead */
+#define TC_BMR_INVB_Pos                     14                                             /**< (TC_BMR) Inverted PHB Position */
+#define TC_BMR_INVB_Msk                     (_U_(0x1) << TC_BMR_INVB_Pos)                  /**< (TC_BMR) Inverted PHB Mask */
+#define TC_BMR_INVB                         TC_BMR_INVB_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVB_Msk instead */
+#define TC_BMR_INVIDX_Pos                   15                                             /**< (TC_BMR) Inverted Index Position */
+#define TC_BMR_INVIDX_Msk                   (_U_(0x1) << TC_BMR_INVIDX_Pos)                /**< (TC_BMR) Inverted Index Mask */
+#define TC_BMR_INVIDX                       TC_BMR_INVIDX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_INVIDX_Msk instead */
+#define TC_BMR_SWAP_Pos                     16                                             /**< (TC_BMR) Swap PHA and PHB Position */
+#define TC_BMR_SWAP_Msk                     (_U_(0x1) << TC_BMR_SWAP_Pos)                  /**< (TC_BMR) Swap PHA and PHB Mask */
+#define TC_BMR_SWAP                         TC_BMR_SWAP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_SWAP_Msk instead */
+#define TC_BMR_IDXPHB_Pos                   17                                             /**< (TC_BMR) Index Pin is PHB Pin Position */
+#define TC_BMR_IDXPHB_Msk                   (_U_(0x1) << TC_BMR_IDXPHB_Pos)                /**< (TC_BMR) Index Pin is PHB Pin Mask */
+#define TC_BMR_IDXPHB                       TC_BMR_IDXPHB_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_IDXPHB_Msk instead */
+#define TC_BMR_AUTOC_Pos                    18                                             /**< (TC_BMR) AutoCorrection of missing pulses Position */
+#define TC_BMR_AUTOC_Msk                    (_U_(0x1) << TC_BMR_AUTOC_Pos)                 /**< (TC_BMR) AutoCorrection of missing pulses Mask */
+#define TC_BMR_AUTOC                        TC_BMR_AUTOC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_AUTOC_Msk instead */
+#define TC_BMR_MAXFILT_Pos                  20                                             /**< (TC_BMR) Maximum Filter Position */
+#define TC_BMR_MAXFILT_Msk                  (_U_(0x3F) << TC_BMR_MAXFILT_Pos)              /**< (TC_BMR) Maximum Filter Mask */
+#define TC_BMR_MAXFILT(value)               (TC_BMR_MAXFILT_Msk & ((value) << TC_BMR_MAXFILT_Pos))
+#define TC_BMR_MAXCMP_Pos                   26                                             /**< (TC_BMR) Maximum Consecutive Missing Pulses Position */
+#define TC_BMR_MAXCMP_Msk                   (_U_(0xF) << TC_BMR_MAXCMP_Pos)                /**< (TC_BMR) Maximum Consecutive Missing Pulses Mask */
+#define TC_BMR_MAXCMP(value)                (TC_BMR_MAXCMP_Msk & ((value) << TC_BMR_MAXCMP_Pos))
+#define TC_BMR_MASK                         _U_(0x3FF7FF3F)                                /**< \deprecated (TC_BMR) Register MASK  (Use TC_BMR_Msk instead)  */
+#define TC_BMR_Msk                          _U_(0x3FF7FF3F)                                /**< (TC_BMR) Register Mask  */
+
+
+/* -------- TC_QIER : (TC Offset: 0xc8) (/W 32) QDEC Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIER_OFFSET                      (0xC8)                                        /**<  (TC_QIER) QDEC Interrupt Enable Register  Offset */
+
+#define TC_QIER_IDX_Pos                     0                                              /**< (TC_QIER) Index Position */
+#define TC_QIER_IDX_Msk                     (_U_(0x1) << TC_QIER_IDX_Pos)                  /**< (TC_QIER) Index Mask */
+#define TC_QIER_IDX                         TC_QIER_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_IDX_Msk instead */
+#define TC_QIER_DIRCHG_Pos                  1                                              /**< (TC_QIER) Direction Change Position */
+#define TC_QIER_DIRCHG_Msk                  (_U_(0x1) << TC_QIER_DIRCHG_Pos)               /**< (TC_QIER) Direction Change Mask */
+#define TC_QIER_DIRCHG                      TC_QIER_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_DIRCHG_Msk instead */
+#define TC_QIER_QERR_Pos                    2                                              /**< (TC_QIER) Quadrature Error Position */
+#define TC_QIER_QERR_Msk                    (_U_(0x1) << TC_QIER_QERR_Pos)                 /**< (TC_QIER) Quadrature Error Mask */
+#define TC_QIER_QERR                        TC_QIER_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_QERR_Msk instead */
+#define TC_QIER_MPE_Pos                     3                                              /**< (TC_QIER) Consecutive Missing Pulse Error Position */
+#define TC_QIER_MPE_Msk                     (_U_(0x1) << TC_QIER_MPE_Pos)                  /**< (TC_QIER) Consecutive Missing Pulse Error Mask */
+#define TC_QIER_MPE                         TC_QIER_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_MPE_Msk instead */
+#define TC_QIER_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIER) Register MASK  (Use TC_QIER_Msk instead)  */
+#define TC_QIER_Msk                         _U_(0x0F)                                      /**< (TC_QIER) Register Mask  */
+
+
+/* -------- TC_QIDR : (TC Offset: 0xcc) (/W 32) QDEC Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIDR_OFFSET                      (0xCC)                                        /**<  (TC_QIDR) QDEC Interrupt Disable Register  Offset */
+
+#define TC_QIDR_IDX_Pos                     0                                              /**< (TC_QIDR) Index Position */
+#define TC_QIDR_IDX_Msk                     (_U_(0x1) << TC_QIDR_IDX_Pos)                  /**< (TC_QIDR) Index Mask */
+#define TC_QIDR_IDX                         TC_QIDR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_IDX_Msk instead */
+#define TC_QIDR_DIRCHG_Pos                  1                                              /**< (TC_QIDR) Direction Change Position */
+#define TC_QIDR_DIRCHG_Msk                  (_U_(0x1) << TC_QIDR_DIRCHG_Pos)               /**< (TC_QIDR) Direction Change Mask */
+#define TC_QIDR_DIRCHG                      TC_QIDR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_DIRCHG_Msk instead */
+#define TC_QIDR_QERR_Pos                    2                                              /**< (TC_QIDR) Quadrature Error Position */
+#define TC_QIDR_QERR_Msk                    (_U_(0x1) << TC_QIDR_QERR_Pos)                 /**< (TC_QIDR) Quadrature Error Mask */
+#define TC_QIDR_QERR                        TC_QIDR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_QERR_Msk instead */
+#define TC_QIDR_MPE_Pos                     3                                              /**< (TC_QIDR) Consecutive Missing Pulse Error Position */
+#define TC_QIDR_MPE_Msk                     (_U_(0x1) << TC_QIDR_MPE_Pos)                  /**< (TC_QIDR) Consecutive Missing Pulse Error Mask */
+#define TC_QIDR_MPE                         TC_QIDR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_MPE_Msk instead */
+#define TC_QIDR_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIDR) Register MASK  (Use TC_QIDR_Msk instead)  */
+#define TC_QIDR_Msk                         _U_(0x0F)                                      /**< (TC_QIDR) Register Mask  */
+
+
+/* -------- TC_QIMR : (TC Offset: 0xd0) (R/ 32) QDEC Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QIMR_OFFSET                      (0xD0)                                        /**<  (TC_QIMR) QDEC Interrupt Mask Register  Offset */
+
+#define TC_QIMR_IDX_Pos                     0                                              /**< (TC_QIMR) Index Position */
+#define TC_QIMR_IDX_Msk                     (_U_(0x1) << TC_QIMR_IDX_Pos)                  /**< (TC_QIMR) Index Mask */
+#define TC_QIMR_IDX                         TC_QIMR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_IDX_Msk instead */
+#define TC_QIMR_DIRCHG_Pos                  1                                              /**< (TC_QIMR) Direction Change Position */
+#define TC_QIMR_DIRCHG_Msk                  (_U_(0x1) << TC_QIMR_DIRCHG_Pos)               /**< (TC_QIMR) Direction Change Mask */
+#define TC_QIMR_DIRCHG                      TC_QIMR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_DIRCHG_Msk instead */
+#define TC_QIMR_QERR_Pos                    2                                              /**< (TC_QIMR) Quadrature Error Position */
+#define TC_QIMR_QERR_Msk                    (_U_(0x1) << TC_QIMR_QERR_Pos)                 /**< (TC_QIMR) Quadrature Error Mask */
+#define TC_QIMR_QERR                        TC_QIMR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_QERR_Msk instead */
+#define TC_QIMR_MPE_Pos                     3                                              /**< (TC_QIMR) Consecutive Missing Pulse Error Position */
+#define TC_QIMR_MPE_Msk                     (_U_(0x1) << TC_QIMR_MPE_Pos)                  /**< (TC_QIMR) Consecutive Missing Pulse Error Mask */
+#define TC_QIMR_MPE                         TC_QIMR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_MPE_Msk instead */
+#define TC_QIMR_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIMR) Register MASK  (Use TC_QIMR_Msk instead)  */
+#define TC_QIMR_Msk                         _U_(0x0F)                                      /**< (TC_QIMR) Register Mask  */
+
+
+/* -------- TC_QISR : (TC Offset: 0xd4) (R/ 32) QDEC Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDX:1;                     /**< bit:      0  Index                                    */
+    uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
+    uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t DIR:1;                     /**< bit:      8  Direction                                */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_QISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_QISR_OFFSET                      (0xD4)                                        /**<  (TC_QISR) QDEC Interrupt Status Register  Offset */
+
+#define TC_QISR_IDX_Pos                     0                                              /**< (TC_QISR) Index Position */
+#define TC_QISR_IDX_Msk                     (_U_(0x1) << TC_QISR_IDX_Pos)                  /**< (TC_QISR) Index Mask */
+#define TC_QISR_IDX                         TC_QISR_IDX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_IDX_Msk instead */
+#define TC_QISR_DIRCHG_Pos                  1                                              /**< (TC_QISR) Direction Change Position */
+#define TC_QISR_DIRCHG_Msk                  (_U_(0x1) << TC_QISR_DIRCHG_Pos)               /**< (TC_QISR) Direction Change Mask */
+#define TC_QISR_DIRCHG                      TC_QISR_DIRCHG_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_DIRCHG_Msk instead */
+#define TC_QISR_QERR_Pos                    2                                              /**< (TC_QISR) Quadrature Error Position */
+#define TC_QISR_QERR_Msk                    (_U_(0x1) << TC_QISR_QERR_Pos)                 /**< (TC_QISR) Quadrature Error Mask */
+#define TC_QISR_QERR                        TC_QISR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_QERR_Msk instead */
+#define TC_QISR_MPE_Pos                     3                                              /**< (TC_QISR) Consecutive Missing Pulse Error Position */
+#define TC_QISR_MPE_Msk                     (_U_(0x1) << TC_QISR_MPE_Pos)                  /**< (TC_QISR) Consecutive Missing Pulse Error Mask */
+#define TC_QISR_MPE                         TC_QISR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_MPE_Msk instead */
+#define TC_QISR_DIR_Pos                     8                                              /**< (TC_QISR) Direction Position */
+#define TC_QISR_DIR_Msk                     (_U_(0x1) << TC_QISR_DIR_Pos)                  /**< (TC_QISR) Direction Mask */
+#define TC_QISR_DIR                         TC_QISR_DIR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_DIR_Msk instead */
+#define TC_QISR_MASK                        _U_(0x10F)                                     /**< \deprecated (TC_QISR) Register MASK  (Use TC_QISR_Msk instead)  */
+#define TC_QISR_Msk                         _U_(0x10F)                                     /**< (TC_QISR) Register Mask  */
+
+
+/* -------- TC_FMR : (TC Offset: 0xd8) (R/W 32) Fault Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENCF0:1;                   /**< bit:      0  Enable Compare Fault Channel 0           */
+    uint32_t ENCF1:1;                   /**< bit:      1  Enable Compare Fault Channel 1           */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ENCF:2;                    /**< bit:   0..1  Enable Compare Fault Channel x           */
+    uint32_t :30;                       /**< bit:  2..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_FMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_FMR_OFFSET                       (0xD8)                                        /**<  (TC_FMR) Fault Mode Register  Offset */
+
+#define TC_FMR_ENCF0_Pos                    0                                              /**< (TC_FMR) Enable Compare Fault Channel 0 Position */
+#define TC_FMR_ENCF0_Msk                    (_U_(0x1) << TC_FMR_ENCF0_Pos)                 /**< (TC_FMR) Enable Compare Fault Channel 0 Mask */
+#define TC_FMR_ENCF0                        TC_FMR_ENCF0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_FMR_ENCF0_Msk instead */
+#define TC_FMR_ENCF1_Pos                    1                                              /**< (TC_FMR) Enable Compare Fault Channel 1 Position */
+#define TC_FMR_ENCF1_Msk                    (_U_(0x1) << TC_FMR_ENCF1_Pos)                 /**< (TC_FMR) Enable Compare Fault Channel 1 Mask */
+#define TC_FMR_ENCF1                        TC_FMR_ENCF1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_FMR_ENCF1_Msk instead */
+#define TC_FMR_MASK                         _U_(0x03)                                      /**< \deprecated (TC_FMR) Register MASK  (Use TC_FMR_Msk instead)  */
+#define TC_FMR_Msk                          _U_(0x03)                                      /**< (TC_FMR) Register Mask  */
+
+#define TC_FMR_ENCF_Pos                     0                                              /**< (TC_FMR Position) Enable Compare Fault Channel x */
+#define TC_FMR_ENCF_Msk                     (_U_(0x3) << TC_FMR_ENCF_Pos)                  /**< (TC_FMR Mask) ENCF */
+#define TC_FMR_ENCF(value)                  (TC_FMR_ENCF_Msk & ((value) << TC_FMR_ENCF_Pos))  
+
+/* -------- TC_WPMR : (TC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TC_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WPMR_OFFSET                      (0xE4)                                        /**<  (TC_WPMR) Write Protection Mode Register  Offset */
+
+#define TC_WPMR_WPEN_Pos                    0                                              /**< (TC_WPMR) Write Protection Enable Position */
+#define TC_WPMR_WPEN_Msk                    (_U_(0x1) << TC_WPMR_WPEN_Pos)                 /**< (TC_WPMR) Write Protection Enable Mask */
+#define TC_WPMR_WPEN                        TC_WPMR_WPEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_WPMR_WPEN_Msk instead */
+#define TC_WPMR_WPKEY_Pos                   8                                              /**< (TC_WPMR) Write Protection Key Position */
+#define TC_WPMR_WPKEY_Msk                   (_U_(0xFFFFFF) << TC_WPMR_WPKEY_Pos)           /**< (TC_WPMR) Write Protection Key Mask */
+#define TC_WPMR_WPKEY(value)                (TC_WPMR_WPKEY_Msk & ((value) << TC_WPMR_WPKEY_Pos))
+#define   TC_WPMR_WPKEY_PASSWD_Val          _U_(0x54494D)                                  /**< (TC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define TC_WPMR_WPKEY_PASSWD                (TC_WPMR_WPKEY_PASSWD_Val << TC_WPMR_WPKEY_Pos)  /**< (TC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
+#define TC_WPMR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (TC_WPMR) Register MASK  (Use TC_WPMR_Msk instead)  */
+#define TC_WPMR_Msk                         _U_(0xFFFFFF01)                                /**< (TC_WPMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TC_CHANNEL hardware registers */
+typedef struct {  
+  __O  uint32_t TC_CCR;         /**< (TC_CHANNEL Offset: 0x00) Channel Control Register (channel = 0) */
+  __IO uint32_t TC_CMR;         /**< (TC_CHANNEL Offset: 0x04) Channel Mode Register (channel = 0) */
+  __IO uint32_t TC_SMMR;        /**< (TC_CHANNEL Offset: 0x08) Stepper Motor Mode Register (channel = 0) */
+  __I  uint32_t TC_RAB;         /**< (TC_CHANNEL Offset: 0x0C) Register AB (channel = 0) */
+  __I  uint32_t TC_CV;          /**< (TC_CHANNEL Offset: 0x10) Counter Value (channel = 0) */
+  __IO uint32_t TC_RA;          /**< (TC_CHANNEL Offset: 0x14) Register A (channel = 0) */
+  __IO uint32_t TC_RB;          /**< (TC_CHANNEL Offset: 0x18) Register B (channel = 0) */
+  __IO uint32_t TC_RC;          /**< (TC_CHANNEL Offset: 0x1C) Register C (channel = 0) */
+  __I  uint32_t TC_SR;          /**< (TC_CHANNEL Offset: 0x20) Status Register (channel = 0) */
+  __O  uint32_t TC_IER;         /**< (TC_CHANNEL Offset: 0x24) Interrupt Enable Register (channel = 0) */
+  __O  uint32_t TC_IDR;         /**< (TC_CHANNEL Offset: 0x28) Interrupt Disable Register (channel = 0) */
+  __I  uint32_t TC_IMR;         /**< (TC_CHANNEL Offset: 0x2C) Interrupt Mask Register (channel = 0) */
+  __IO uint32_t TC_EMR;         /**< (TC_CHANNEL Offset: 0x30) Extended Mode Register (channel = 0) */
+  __I  uint8_t                        Reserved1[12];
+} TcChannel;
+
+#define TCCHANNEL_NUMBER 3
+/** \brief TC hardware registers */
+typedef struct {  
+       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+  __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
+  __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
+  __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
+  __O  uint32_t TC_QIDR;        /**< (TC Offset: 0xCC) QDEC Interrupt Disable Register */
+  __I  uint32_t TC_QIMR;        /**< (TC Offset: 0xD0) QDEC Interrupt Mask Register */
+  __I  uint32_t TC_QISR;        /**< (TC Offset: 0xD4) QDEC Interrupt Status Register */
+  __IO uint32_t TC_FMR;         /**< (TC Offset: 0xD8) Fault Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO uint32_t TC_WPMR;        /**< (TC Offset: 0xE4) Write Protection Mode Register */
+} Tc;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TC_CHANNEL hardware registers */
+typedef struct {  
+  __O  TC_CCR_Type                    TC_CCR;         /**< Offset: 0x00 ( /W  32) Channel Control Register (channel = 0) */
+  __IO TC_CMR_Type                    TC_CMR;         /**< Offset: 0x04 (R/W  32) Channel Mode Register (channel = 0) */
+  __IO TC_SMMR_Type                   TC_SMMR;        /**< Offset: 0x08 (R/W  32) Stepper Motor Mode Register (channel = 0) */
+  __I  TC_RAB_Type                    TC_RAB;         /**< Offset: 0x0C (R/   32) Register AB (channel = 0) */
+  __I  TC_CV_Type                     TC_CV;          /**< Offset: 0x10 (R/   32) Counter Value (channel = 0) */
+  __IO TC_RA_Type                     TC_RA;          /**< Offset: 0x14 (R/W  32) Register A (channel = 0) */
+  __IO TC_RB_Type                     TC_RB;          /**< Offset: 0x18 (R/W  32) Register B (channel = 0) */
+  __IO TC_RC_Type                     TC_RC;          /**< Offset: 0x1C (R/W  32) Register C (channel = 0) */
+  __I  TC_SR_Type                     TC_SR;          /**< Offset: 0x20 (R/   32) Status Register (channel = 0) */
+  __O  TC_IER_Type                    TC_IER;         /**< Offset: 0x24 ( /W  32) Interrupt Enable Register (channel = 0) */
+  __O  TC_IDR_Type                    TC_IDR;         /**< Offset: 0x28 ( /W  32) Interrupt Disable Register (channel = 0) */
+  __I  TC_IMR_Type                    TC_IMR;         /**< Offset: 0x2C (R/   32) Interrupt Mask Register (channel = 0) */
+  __IO TC_EMR_Type                    TC_EMR;         /**< Offset: 0x30 (R/W  32) Extended Mode Register (channel = 0) */
+  __I  uint8_t                        Reserved1[12];
+} TcChannel;
+
+/** \brief TC hardware registers */
+typedef struct {  
+       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
+  __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
+  __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
+  __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */
+  __O  TC_QIDR_Type                   TC_QIDR;        /**< Offset: 0xCC ( /W  32) QDEC Interrupt Disable Register */
+  __I  TC_QIMR_Type                   TC_QIMR;        /**< Offset: 0xD0 (R/   32) QDEC Interrupt Mask Register */
+  __I  TC_QISR_Type                   TC_QISR;        /**< Offset: 0xD4 (R/   32) QDEC Interrupt Status Register */
+  __IO TC_FMR_Type                    TC_FMR;         /**< Offset: 0xD8 (R/W  32) Fault Mode Register */
+  __I  uint8_t                        Reserved1[8];
+  __IO TC_WPMR_Type                   TC_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+} Tc;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Timer Counter */
+
+#endif /* _SAMV71_TC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/trng.h
+++ b/asf/sam/include/samv71b/component/trng.h
@@ -1,0 +1,219 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TRNG_COMPONENT_H_
+#define _SAMV71_TRNG_COMPONENT_H_
+#define _SAMV71_TRNG_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 True Random Number Generator
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TRNG_6334                       /**< (TRNG) Module ID */
+#define REV_TRNG G                      /**< (TRNG) Module revision */
+
+/* -------- TRNG_CR : (TRNG Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ENABLE:1;                  /**< bit:      0  Enables the TRNG to Provide Random Values */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t KEY:24;                    /**< bit:  8..31  Security Key                             */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CR_OFFSET                      (0x00)                                        /**<  (TRNG_CR) Control Register  Offset */
+
+#define TRNG_CR_ENABLE_Pos                  0                                              /**< (TRNG_CR) Enables the TRNG to Provide Random Values Position */
+#define TRNG_CR_ENABLE_Msk                  (_U_(0x1) << TRNG_CR_ENABLE_Pos)               /**< (TRNG_CR) Enables the TRNG to Provide Random Values Mask */
+#define TRNG_CR_ENABLE                      TRNG_CR_ENABLE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_CR_ENABLE_Msk instead */
+#define TRNG_CR_KEY_Pos                     8                                              /**< (TRNG_CR) Security Key Position */
+#define TRNG_CR_KEY_Msk                     (_U_(0xFFFFFF) << TRNG_CR_KEY_Pos)             /**< (TRNG_CR) Security Key Mask */
+#define TRNG_CR_KEY(value)                  (TRNG_CR_KEY_Msk & ((value) << TRNG_CR_KEY_Pos))
+#define   TRNG_CR_KEY_PASSWD_Val            _U_(0x524E47)                                  /**< (TRNG_CR) Writing any other value in this field aborts the write operation.  */
+#define TRNG_CR_KEY_PASSWD                  (TRNG_CR_KEY_PASSWD_Val << TRNG_CR_KEY_Pos)    /**< (TRNG_CR) Writing any other value in this field aborts the write operation. Position  */
+#define TRNG_CR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (TRNG_CR) Register MASK  (Use TRNG_CR_Msk instead)  */
+#define TRNG_CR_Msk                         _U_(0xFFFFFF01)                                /**< (TRNG_CR) Register Mask  */
+
+
+/* -------- TRNG_IER : (TRNG Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IER_OFFSET                     (0x10)                                        /**<  (TRNG_IER) Interrupt Enable Register  Offset */
+
+#define TRNG_IER_DATRDY_Pos                 0                                              /**< (TRNG_IER) Data Ready Interrupt Enable Position */
+#define TRNG_IER_DATRDY_Msk                 (_U_(0x1) << TRNG_IER_DATRDY_Pos)              /**< (TRNG_IER) Data Ready Interrupt Enable Mask */
+#define TRNG_IER_DATRDY                     TRNG_IER_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IER_DATRDY_Msk instead */
+#define TRNG_IER_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IER) Register MASK  (Use TRNG_IER_Msk instead)  */
+#define TRNG_IER_Msk                        _U_(0x01)                                      /**< (TRNG_IER) Register Mask  */
+
+
+/* -------- TRNG_IDR : (TRNG Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IDR_OFFSET                     (0x14)                                        /**<  (TRNG_IDR) Interrupt Disable Register  Offset */
+
+#define TRNG_IDR_DATRDY_Pos                 0                                              /**< (TRNG_IDR) Data Ready Interrupt Disable Position */
+#define TRNG_IDR_DATRDY_Msk                 (_U_(0x1) << TRNG_IDR_DATRDY_Pos)              /**< (TRNG_IDR) Data Ready Interrupt Disable Mask */
+#define TRNG_IDR_DATRDY                     TRNG_IDR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IDR_DATRDY_Msk instead */
+#define TRNG_IDR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IDR) Register MASK  (Use TRNG_IDR_Msk instead)  */
+#define TRNG_IDR_Msk                        _U_(0x01)                                      /**< (TRNG_IDR) Register Mask  */
+
+
+/* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IMR_OFFSET                     (0x18)                                        /**<  (TRNG_IMR) Interrupt Mask Register  Offset */
+
+#define TRNG_IMR_DATRDY_Pos                 0                                              /**< (TRNG_IMR) Data Ready Interrupt Mask Position */
+#define TRNG_IMR_DATRDY_Msk                 (_U_(0x1) << TRNG_IMR_DATRDY_Pos)              /**< (TRNG_IMR) Data Ready Interrupt Mask Mask */
+#define TRNG_IMR_DATRDY                     TRNG_IMR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_IMR_DATRDY_Msk instead */
+#define TRNG_IMR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_IMR) Register MASK  (Use TRNG_IMR_Msk instead)  */
+#define TRNG_IMR_Msk                        _U_(0x01)                                      /**< (TRNG_IMR) Register Mask  */
+
+
+/* -------- TRNG_ISR : (TRNG Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATRDY:1;                  /**< bit:      0  Data Ready                               */
+    uint32_t :31;                       /**< bit:  1..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_ISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ISR_OFFSET                     (0x1C)                                        /**<  (TRNG_ISR) Interrupt Status Register  Offset */
+
+#define TRNG_ISR_DATRDY_Pos                 0                                              /**< (TRNG_ISR) Data Ready Position */
+#define TRNG_ISR_DATRDY_Msk                 (_U_(0x1) << TRNG_ISR_DATRDY_Pos)              /**< (TRNG_ISR) Data Ready Mask */
+#define TRNG_ISR_DATRDY                     TRNG_ISR_DATRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TRNG_ISR_DATRDY_Msk instead */
+#define TRNG_ISR_MASK                       _U_(0x01)                                      /**< \deprecated (TRNG_ISR) Register MASK  (Use TRNG_ISR_Msk instead)  */
+#define TRNG_ISR_Msk                        _U_(0x01)                                      /**< (TRNG_ISR) Register Mask  */
+
+
+/* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/ 32) Output Data Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TRNG_ODATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ODATA_OFFSET                   (0x50)                                        /**<  (TRNG_ODATA) Output Data Register  Offset */
+
+#define TRNG_ODATA_ODATA_Pos                0                                              /**< (TRNG_ODATA) Output Data Position */
+#define TRNG_ODATA_ODATA_Msk                (_U_(0xFFFFFFFF) << TRNG_ODATA_ODATA_Pos)      /**< (TRNG_ODATA) Output Data Mask */
+#define TRNG_ODATA_ODATA(value)             (TRNG_ODATA_ODATA_Msk & ((value) << TRNG_ODATA_ODATA_Pos))
+#define TRNG_ODATA_MASK                     _U_(0xFFFFFFFF)                                /**< \deprecated (TRNG_ODATA) Register MASK  (Use TRNG_ODATA_Msk instead)  */
+#define TRNG_ODATA_Msk                      _U_(0xFFFFFFFF)                                /**< (TRNG_ODATA) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TRNG hardware registers */
+typedef struct {  
+  __O  uint32_t TRNG_CR;        /**< (TRNG Offset: 0x00) Control Register */
+  __I  uint8_t                        Reserved1[12];
+  __O  uint32_t TRNG_IER;       /**< (TRNG Offset: 0x10) Interrupt Enable Register */
+  __O  uint32_t TRNG_IDR;       /**< (TRNG Offset: 0x14) Interrupt Disable Register */
+  __I  uint32_t TRNG_IMR;       /**< (TRNG Offset: 0x18) Interrupt Mask Register */
+  __I  uint32_t TRNG_ISR;       /**< (TRNG Offset: 0x1C) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[48];
+  __I  uint32_t TRNG_ODATA;     /**< (TRNG Offset: 0x50) Output Data Register */
+} Trng;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TRNG hardware registers */
+typedef struct {  
+  __O  TRNG_CR_Type                   TRNG_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __I  uint8_t                        Reserved1[12];
+  __O  TRNG_IER_Type                  TRNG_IER;       /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
+  __O  TRNG_IDR_Type                  TRNG_IDR;       /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
+  __I  TRNG_IMR_Type                  TRNG_IMR;       /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
+  __I  TRNG_ISR_Type                  TRNG_ISR;       /**< Offset: 0x1C (R/   32) Interrupt Status Register */
+  __I  uint8_t                        Reserved2[48];
+  __I  TRNG_ODATA_Type                TRNG_ODATA;     /**< Offset: 0x50 (R/   32) Output Data Register */
+} Trng;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of True Random Number Generator */
+
+#endif /* _SAMV71_TRNG_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/twihs.h
+++ b/asf/sam/include/samv71b/component/twihs.h
@@ -1,0 +1,929 @@
+/**
+ * \file
+ *
+ * \brief Component description for TWIHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TWIHS_COMPONENT_H_
+#define _SAMV71_TWIHS_COMPONENT_H_
+#define _SAMV71_TWIHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Two-wire Interface High Speed
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TWIHS */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define TWIHS_11210                      /**< (TWIHS) Module ID */
+#define REV_TWIHS Z                      /**< (TWIHS) Module revision */
+
+/* -------- TWIHS_CR : (TWIHS Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t START:1;                   /**< bit:      0  Send a START Condition                   */
+    uint32_t STOP:1;                    /**< bit:      1  Send a STOP Condition                    */
+    uint32_t MSEN:1;                    /**< bit:      2  TWIHS Master Mode Enabled                */
+    uint32_t MSDIS:1;                   /**< bit:      3  TWIHS Master Mode Disabled               */
+    uint32_t SVEN:1;                    /**< bit:      4  TWIHS Slave Mode Enabled                 */
+    uint32_t SVDIS:1;                   /**< bit:      5  TWIHS Slave Mode Disabled                */
+    uint32_t QUICK:1;                   /**< bit:      6  SMBus Quick Command                      */
+    uint32_t SWRST:1;                   /**< bit:      7  Software Reset                           */
+    uint32_t HSEN:1;                    /**< bit:      8  TWIHS High-Speed Mode Enabled            */
+    uint32_t HSDIS:1;                   /**< bit:      9  TWIHS High-Speed Mode Disabled           */
+    uint32_t SMBEN:1;                   /**< bit:     10  SMBus Mode Enabled                       */
+    uint32_t SMBDIS:1;                  /**< bit:     11  SMBus Mode Disabled                      */
+    uint32_t PECEN:1;                   /**< bit:     12  Packet Error Checking Enable             */
+    uint32_t PECDIS:1;                  /**< bit:     13  Packet Error Checking Disable            */
+    uint32_t PECRQ:1;                   /**< bit:     14  PEC Request                              */
+    uint32_t CLEAR:1;                   /**< bit:     15  Bus CLEAR Command                        */
+    uint32_t ACMEN:1;                   /**< bit:     16  Alternative Command Mode Enable          */
+    uint32_t ACMDIS:1;                  /**< bit:     17  Alternative Command Mode Disable         */
+    uint32_t :6;                        /**< bit: 18..23  Reserved */
+    uint32_t THRCLR:1;                  /**< bit:     24  Transmit Holding Register Clear          */
+    uint32_t :1;                        /**< bit:     25  Reserved */
+    uint32_t LOCKCLR:1;                 /**< bit:     26  Lock Clear                               */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t FIFOEN:1;                  /**< bit:     28  FIFO Enable                              */
+    uint32_t FIFODIS:1;                 /**< bit:     29  FIFO Disable                             */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_CR_OFFSET                     (0x00)                                        /**<  (TWIHS_CR) Control Register  Offset */
+
+#define TWIHS_CR_START_Pos                  0                                              /**< (TWIHS_CR) Send a START Condition Position */
+#define TWIHS_CR_START_Msk                  (_U_(0x1) << TWIHS_CR_START_Pos)               /**< (TWIHS_CR) Send a START Condition Mask */
+#define TWIHS_CR_START                      TWIHS_CR_START_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_START_Msk instead */
+#define TWIHS_CR_STOP_Pos                   1                                              /**< (TWIHS_CR) Send a STOP Condition Position */
+#define TWIHS_CR_STOP_Msk                   (_U_(0x1) << TWIHS_CR_STOP_Pos)                /**< (TWIHS_CR) Send a STOP Condition Mask */
+#define TWIHS_CR_STOP                       TWIHS_CR_STOP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_STOP_Msk instead */
+#define TWIHS_CR_MSEN_Pos                   2                                              /**< (TWIHS_CR) TWIHS Master Mode Enabled Position */
+#define TWIHS_CR_MSEN_Msk                   (_U_(0x1) << TWIHS_CR_MSEN_Pos)                /**< (TWIHS_CR) TWIHS Master Mode Enabled Mask */
+#define TWIHS_CR_MSEN                       TWIHS_CR_MSEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_MSEN_Msk instead */
+#define TWIHS_CR_MSDIS_Pos                  3                                              /**< (TWIHS_CR) TWIHS Master Mode Disabled Position */
+#define TWIHS_CR_MSDIS_Msk                  (_U_(0x1) << TWIHS_CR_MSDIS_Pos)               /**< (TWIHS_CR) TWIHS Master Mode Disabled Mask */
+#define TWIHS_CR_MSDIS                      TWIHS_CR_MSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_MSDIS_Msk instead */
+#define TWIHS_CR_SVEN_Pos                   4                                              /**< (TWIHS_CR) TWIHS Slave Mode Enabled Position */
+#define TWIHS_CR_SVEN_Msk                   (_U_(0x1) << TWIHS_CR_SVEN_Pos)                /**< (TWIHS_CR) TWIHS Slave Mode Enabled Mask */
+#define TWIHS_CR_SVEN                       TWIHS_CR_SVEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SVEN_Msk instead */
+#define TWIHS_CR_SVDIS_Pos                  5                                              /**< (TWIHS_CR) TWIHS Slave Mode Disabled Position */
+#define TWIHS_CR_SVDIS_Msk                  (_U_(0x1) << TWIHS_CR_SVDIS_Pos)               /**< (TWIHS_CR) TWIHS Slave Mode Disabled Mask */
+#define TWIHS_CR_SVDIS                      TWIHS_CR_SVDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SVDIS_Msk instead */
+#define TWIHS_CR_QUICK_Pos                  6                                              /**< (TWIHS_CR) SMBus Quick Command Position */
+#define TWIHS_CR_QUICK_Msk                  (_U_(0x1) << TWIHS_CR_QUICK_Pos)               /**< (TWIHS_CR) SMBus Quick Command Mask */
+#define TWIHS_CR_QUICK                      TWIHS_CR_QUICK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_QUICK_Msk instead */
+#define TWIHS_CR_SWRST_Pos                  7                                              /**< (TWIHS_CR) Software Reset Position */
+#define TWIHS_CR_SWRST_Msk                  (_U_(0x1) << TWIHS_CR_SWRST_Pos)               /**< (TWIHS_CR) Software Reset Mask */
+#define TWIHS_CR_SWRST                      TWIHS_CR_SWRST_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SWRST_Msk instead */
+#define TWIHS_CR_HSEN_Pos                   8                                              /**< (TWIHS_CR) TWIHS High-Speed Mode Enabled Position */
+#define TWIHS_CR_HSEN_Msk                   (_U_(0x1) << TWIHS_CR_HSEN_Pos)                /**< (TWIHS_CR) TWIHS High-Speed Mode Enabled Mask */
+#define TWIHS_CR_HSEN                       TWIHS_CR_HSEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_HSEN_Msk instead */
+#define TWIHS_CR_HSDIS_Pos                  9                                              /**< (TWIHS_CR) TWIHS High-Speed Mode Disabled Position */
+#define TWIHS_CR_HSDIS_Msk                  (_U_(0x1) << TWIHS_CR_HSDIS_Pos)               /**< (TWIHS_CR) TWIHS High-Speed Mode Disabled Mask */
+#define TWIHS_CR_HSDIS                      TWIHS_CR_HSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_HSDIS_Msk instead */
+#define TWIHS_CR_SMBEN_Pos                  10                                             /**< (TWIHS_CR) SMBus Mode Enabled Position */
+#define TWIHS_CR_SMBEN_Msk                  (_U_(0x1) << TWIHS_CR_SMBEN_Pos)               /**< (TWIHS_CR) SMBus Mode Enabled Mask */
+#define TWIHS_CR_SMBEN                      TWIHS_CR_SMBEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SMBEN_Msk instead */
+#define TWIHS_CR_SMBDIS_Pos                 11                                             /**< (TWIHS_CR) SMBus Mode Disabled Position */
+#define TWIHS_CR_SMBDIS_Msk                 (_U_(0x1) << TWIHS_CR_SMBDIS_Pos)              /**< (TWIHS_CR) SMBus Mode Disabled Mask */
+#define TWIHS_CR_SMBDIS                     TWIHS_CR_SMBDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_SMBDIS_Msk instead */
+#define TWIHS_CR_PECEN_Pos                  12                                             /**< (TWIHS_CR) Packet Error Checking Enable Position */
+#define TWIHS_CR_PECEN_Msk                  (_U_(0x1) << TWIHS_CR_PECEN_Pos)               /**< (TWIHS_CR) Packet Error Checking Enable Mask */
+#define TWIHS_CR_PECEN                      TWIHS_CR_PECEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECEN_Msk instead */
+#define TWIHS_CR_PECDIS_Pos                 13                                             /**< (TWIHS_CR) Packet Error Checking Disable Position */
+#define TWIHS_CR_PECDIS_Msk                 (_U_(0x1) << TWIHS_CR_PECDIS_Pos)              /**< (TWIHS_CR) Packet Error Checking Disable Mask */
+#define TWIHS_CR_PECDIS                     TWIHS_CR_PECDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECDIS_Msk instead */
+#define TWIHS_CR_PECRQ_Pos                  14                                             /**< (TWIHS_CR) PEC Request Position */
+#define TWIHS_CR_PECRQ_Msk                  (_U_(0x1) << TWIHS_CR_PECRQ_Pos)               /**< (TWIHS_CR) PEC Request Mask */
+#define TWIHS_CR_PECRQ                      TWIHS_CR_PECRQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_PECRQ_Msk instead */
+#define TWIHS_CR_CLEAR_Pos                  15                                             /**< (TWIHS_CR) Bus CLEAR Command Position */
+#define TWIHS_CR_CLEAR_Msk                  (_U_(0x1) << TWIHS_CR_CLEAR_Pos)               /**< (TWIHS_CR) Bus CLEAR Command Mask */
+#define TWIHS_CR_CLEAR                      TWIHS_CR_CLEAR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_CLEAR_Msk instead */
+#define TWIHS_CR_ACMEN_Pos                  16                                             /**< (TWIHS_CR) Alternative Command Mode Enable Position */
+#define TWIHS_CR_ACMEN_Msk                  (_U_(0x1) << TWIHS_CR_ACMEN_Pos)               /**< (TWIHS_CR) Alternative Command Mode Enable Mask */
+#define TWIHS_CR_ACMEN                      TWIHS_CR_ACMEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_ACMEN_Msk instead */
+#define TWIHS_CR_ACMDIS_Pos                 17                                             /**< (TWIHS_CR) Alternative Command Mode Disable Position */
+#define TWIHS_CR_ACMDIS_Msk                 (_U_(0x1) << TWIHS_CR_ACMDIS_Pos)              /**< (TWIHS_CR) Alternative Command Mode Disable Mask */
+#define TWIHS_CR_ACMDIS                     TWIHS_CR_ACMDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_ACMDIS_Msk instead */
+#define TWIHS_CR_THRCLR_Pos                 24                                             /**< (TWIHS_CR) Transmit Holding Register Clear Position */
+#define TWIHS_CR_THRCLR_Msk                 (_U_(0x1) << TWIHS_CR_THRCLR_Pos)              /**< (TWIHS_CR) Transmit Holding Register Clear Mask */
+#define TWIHS_CR_THRCLR                     TWIHS_CR_THRCLR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_THRCLR_Msk instead */
+#define TWIHS_CR_LOCKCLR_Pos                26                                             /**< (TWIHS_CR) Lock Clear Position */
+#define TWIHS_CR_LOCKCLR_Msk                (_U_(0x1) << TWIHS_CR_LOCKCLR_Pos)             /**< (TWIHS_CR) Lock Clear Mask */
+#define TWIHS_CR_LOCKCLR                    TWIHS_CR_LOCKCLR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_LOCKCLR_Msk instead */
+#define TWIHS_CR_FIFOEN_Pos                 28                                             /**< (TWIHS_CR) FIFO Enable Position */
+#define TWIHS_CR_FIFOEN_Msk                 (_U_(0x1) << TWIHS_CR_FIFOEN_Pos)              /**< (TWIHS_CR) FIFO Enable Mask */
+#define TWIHS_CR_FIFOEN                     TWIHS_CR_FIFOEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_FIFOEN_Msk instead */
+#define TWIHS_CR_FIFODIS_Pos                29                                             /**< (TWIHS_CR) FIFO Disable Position */
+#define TWIHS_CR_FIFODIS_Msk                (_U_(0x1) << TWIHS_CR_FIFODIS_Pos)             /**< (TWIHS_CR) FIFO Disable Mask */
+#define TWIHS_CR_FIFODIS                    TWIHS_CR_FIFODIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_CR_FIFODIS_Msk instead */
+#define TWIHS_CR_MASK                       _U_(0x3503FFFF)                                /**< \deprecated (TWIHS_CR) Register MASK  (Use TWIHS_CR_Msk instead)  */
+#define TWIHS_CR_Msk                        _U_(0x3503FFFF)                                /**< (TWIHS_CR) Register Mask  */
+
+
+/* -------- TWIHS_MMR : (TWIHS Offset: 0x04) (R/W 32) Master Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t IADRSZ:2;                  /**< bit:   8..9  Internal Device Address Size             */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t MREAD:1;                   /**< bit:     12  Master Read Direction                    */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t DADR:7;                    /**< bit: 16..22  Device Address                           */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_MMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_MMR_OFFSET                    (0x04)                                        /**<  (TWIHS_MMR) Master Mode Register  Offset */
+
+#define TWIHS_MMR_IADRSZ_Pos                8                                              /**< (TWIHS_MMR) Internal Device Address Size Position */
+#define TWIHS_MMR_IADRSZ_Msk                (_U_(0x3) << TWIHS_MMR_IADRSZ_Pos)             /**< (TWIHS_MMR) Internal Device Address Size Mask */
+#define TWIHS_MMR_IADRSZ(value)             (TWIHS_MMR_IADRSZ_Msk & ((value) << TWIHS_MMR_IADRSZ_Pos))
+#define   TWIHS_MMR_IADRSZ_NONE_Val         _U_(0x0)                                       /**< (TWIHS_MMR) No internal device address  */
+#define   TWIHS_MMR_IADRSZ_1_BYTE_Val       _U_(0x1)                                       /**< (TWIHS_MMR) One-byte internal device address  */
+#define   TWIHS_MMR_IADRSZ_2_BYTE_Val       _U_(0x2)                                       /**< (TWIHS_MMR) Two-byte internal device address  */
+#define   TWIHS_MMR_IADRSZ_3_BYTE_Val       _U_(0x3)                                       /**< (TWIHS_MMR) Three-byte internal device address  */
+#define TWIHS_MMR_IADRSZ_NONE               (TWIHS_MMR_IADRSZ_NONE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) No internal device address Position  */
+#define TWIHS_MMR_IADRSZ_1_BYTE             (TWIHS_MMR_IADRSZ_1_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) One-byte internal device address Position  */
+#define TWIHS_MMR_IADRSZ_2_BYTE             (TWIHS_MMR_IADRSZ_2_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) Two-byte internal device address Position  */
+#define TWIHS_MMR_IADRSZ_3_BYTE             (TWIHS_MMR_IADRSZ_3_BYTE_Val << TWIHS_MMR_IADRSZ_Pos)  /**< (TWIHS_MMR) Three-byte internal device address Position  */
+#define TWIHS_MMR_MREAD_Pos                 12                                             /**< (TWIHS_MMR) Master Read Direction Position */
+#define TWIHS_MMR_MREAD_Msk                 (_U_(0x1) << TWIHS_MMR_MREAD_Pos)              /**< (TWIHS_MMR) Master Read Direction Mask */
+#define TWIHS_MMR_MREAD                     TWIHS_MMR_MREAD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_MMR_MREAD_Msk instead */
+#define TWIHS_MMR_DADR_Pos                  16                                             /**< (TWIHS_MMR) Device Address Position */
+#define TWIHS_MMR_DADR_Msk                  (_U_(0x7F) << TWIHS_MMR_DADR_Pos)              /**< (TWIHS_MMR) Device Address Mask */
+#define TWIHS_MMR_DADR(value)               (TWIHS_MMR_DADR_Msk & ((value) << TWIHS_MMR_DADR_Pos))
+#define TWIHS_MMR_MASK                      _U_(0x7F1300)                                  /**< \deprecated (TWIHS_MMR) Register MASK  (Use TWIHS_MMR_Msk instead)  */
+#define TWIHS_MMR_Msk                       _U_(0x7F1300)                                  /**< (TWIHS_MMR) Register Mask  */
+
+
+/* -------- TWIHS_SMR : (TWIHS Offset: 0x08) (R/W 32) Slave Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NACKEN:1;                  /**< bit:      0  Slave Receiver Data Phase NACK enable    */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t SMDA:1;                    /**< bit:      2  SMBus Default Address                    */
+    uint32_t SMHH:1;                    /**< bit:      3  SMBus Host Header                        */
+    uint32_t :2;                        /**< bit:   4..5  Reserved */
+    uint32_t SCLWSDIS:1;                /**< bit:      6  Clock Wait State Disable                 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MASK:7;                    /**< bit:  8..14  Slave Address Mask                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SADR:7;                    /**< bit: 16..22  Slave Address                            */
+    uint32_t :5;                        /**< bit: 23..27  Reserved */
+    uint32_t SADR1EN:1;                 /**< bit:     28  Slave Address 1 Enable                   */
+    uint32_t SADR2EN:1;                 /**< bit:     29  Slave Address 2 Enable                   */
+    uint32_t SADR3EN:1;                 /**< bit:     30  Slave Address 3 Enable                   */
+    uint32_t DATAMEN:1;                 /**< bit:     31  Data Matching Enable                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SMR_OFFSET                    (0x08)                                        /**<  (TWIHS_SMR) Slave Mode Register  Offset */
+
+#define TWIHS_SMR_NACKEN_Pos                0                                              /**< (TWIHS_SMR) Slave Receiver Data Phase NACK enable Position */
+#define TWIHS_SMR_NACKEN_Msk                (_U_(0x1) << TWIHS_SMR_NACKEN_Pos)             /**< (TWIHS_SMR) Slave Receiver Data Phase NACK enable Mask */
+#define TWIHS_SMR_NACKEN                    TWIHS_SMR_NACKEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_NACKEN_Msk instead */
+#define TWIHS_SMR_SMDA_Pos                  2                                              /**< (TWIHS_SMR) SMBus Default Address Position */
+#define TWIHS_SMR_SMDA_Msk                  (_U_(0x1) << TWIHS_SMR_SMDA_Pos)               /**< (TWIHS_SMR) SMBus Default Address Mask */
+#define TWIHS_SMR_SMDA                      TWIHS_SMR_SMDA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SMDA_Msk instead */
+#define TWIHS_SMR_SMHH_Pos                  3                                              /**< (TWIHS_SMR) SMBus Host Header Position */
+#define TWIHS_SMR_SMHH_Msk                  (_U_(0x1) << TWIHS_SMR_SMHH_Pos)               /**< (TWIHS_SMR) SMBus Host Header Mask */
+#define TWIHS_SMR_SMHH                      TWIHS_SMR_SMHH_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SMHH_Msk instead */
+#define TWIHS_SMR_SCLWSDIS_Pos              6                                              /**< (TWIHS_SMR) Clock Wait State Disable Position */
+#define TWIHS_SMR_SCLWSDIS_Msk              (_U_(0x1) << TWIHS_SMR_SCLWSDIS_Pos)           /**< (TWIHS_SMR) Clock Wait State Disable Mask */
+#define TWIHS_SMR_SCLWSDIS                  TWIHS_SMR_SCLWSDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SCLWSDIS_Msk instead */
+#define TWIHS_SMR_MASK_Pos                  8                                              /**< (TWIHS_SMR) Slave Address Mask Position */
+#define TWIHS_SMR_MASK_Msk                  (_U_(0x7F) << TWIHS_SMR_MASK_Pos)              /**< (TWIHS_SMR) Slave Address Mask Mask */
+#define TWIHS_SMR_MASK(value)               (TWIHS_SMR_MASK_Msk & ((value) << TWIHS_SMR_MASK_Pos))
+#define TWIHS_SMR_SADR_Pos                  16                                             /**< (TWIHS_SMR) Slave Address Position */
+#define TWIHS_SMR_SADR_Msk                  (_U_(0x7F) << TWIHS_SMR_SADR_Pos)              /**< (TWIHS_SMR) Slave Address Mask */
+#define TWIHS_SMR_SADR(value)               (TWIHS_SMR_SADR_Msk & ((value) << TWIHS_SMR_SADR_Pos))
+#define TWIHS_SMR_SADR1EN_Pos               28                                             /**< (TWIHS_SMR) Slave Address 1 Enable Position */
+#define TWIHS_SMR_SADR1EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR1EN_Pos)            /**< (TWIHS_SMR) Slave Address 1 Enable Mask */
+#define TWIHS_SMR_SADR1EN                   TWIHS_SMR_SADR1EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR1EN_Msk instead */
+#define TWIHS_SMR_SADR2EN_Pos               29                                             /**< (TWIHS_SMR) Slave Address 2 Enable Position */
+#define TWIHS_SMR_SADR2EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR2EN_Pos)            /**< (TWIHS_SMR) Slave Address 2 Enable Mask */
+#define TWIHS_SMR_SADR2EN                   TWIHS_SMR_SADR2EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR2EN_Msk instead */
+#define TWIHS_SMR_SADR3EN_Pos               30                                             /**< (TWIHS_SMR) Slave Address 3 Enable Position */
+#define TWIHS_SMR_SADR3EN_Msk               (_U_(0x1) << TWIHS_SMR_SADR3EN_Pos)            /**< (TWIHS_SMR) Slave Address 3 Enable Mask */
+#define TWIHS_SMR_SADR3EN                   TWIHS_SMR_SADR3EN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_SADR3EN_Msk instead */
+#define TWIHS_SMR_DATAMEN_Pos               31                                             /**< (TWIHS_SMR) Data Matching Enable Position */
+#define TWIHS_SMR_DATAMEN_Msk               (_U_(0x1) << TWIHS_SMR_DATAMEN_Pos)            /**< (TWIHS_SMR) Data Matching Enable Mask */
+#define TWIHS_SMR_DATAMEN                   TWIHS_SMR_DATAMEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SMR_DATAMEN_Msk instead */
+#define TWIHS_SMR_Msk                       _U_(0xF07F7F4D)                                /**< (TWIHS_SMR) Register Mask  */
+
+
+/* -------- TWIHS_IADR : (TWIHS Offset: 0x0c) (R/W 32) Internal Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IADR:24;                   /**< bit:  0..23  Internal Address                         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IADR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IADR_OFFSET                   (0x0C)                                        /**<  (TWIHS_IADR) Internal Address Register  Offset */
+
+#define TWIHS_IADR_IADR_Pos                 0                                              /**< (TWIHS_IADR) Internal Address Position */
+#define TWIHS_IADR_IADR_Msk                 (_U_(0xFFFFFF) << TWIHS_IADR_IADR_Pos)         /**< (TWIHS_IADR) Internal Address Mask */
+#define TWIHS_IADR_IADR(value)              (TWIHS_IADR_IADR_Msk & ((value) << TWIHS_IADR_IADR_Pos))
+#define TWIHS_IADR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (TWIHS_IADR) Register MASK  (Use TWIHS_IADR_Msk instead)  */
+#define TWIHS_IADR_Msk                      _U_(0xFFFFFF)                                  /**< (TWIHS_IADR) Register Mask  */
+
+
+/* -------- TWIHS_CWGR : (TWIHS Offset: 0x10) (R/W 32) Clock Waveform Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CLDIV:8;                   /**< bit:   0..7  Clock Low Divider                        */
+    uint32_t CHDIV:8;                   /**< bit:  8..15  Clock High Divider                       */
+    uint32_t CKDIV:3;                   /**< bit: 16..18  Clock Divider                            */
+    uint32_t :5;                        /**< bit: 19..23  Reserved */
+    uint32_t HOLD:6;                    /**< bit: 24..29  TWD Hold Time Versus TWCK Falling        */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_CWGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_CWGR_OFFSET                   (0x10)                                        /**<  (TWIHS_CWGR) Clock Waveform Generator Register  Offset */
+
+#define TWIHS_CWGR_CLDIV_Pos                0                                              /**< (TWIHS_CWGR) Clock Low Divider Position */
+#define TWIHS_CWGR_CLDIV_Msk                (_U_(0xFF) << TWIHS_CWGR_CLDIV_Pos)            /**< (TWIHS_CWGR) Clock Low Divider Mask */
+#define TWIHS_CWGR_CLDIV(value)             (TWIHS_CWGR_CLDIV_Msk & ((value) << TWIHS_CWGR_CLDIV_Pos))
+#define TWIHS_CWGR_CHDIV_Pos                8                                              /**< (TWIHS_CWGR) Clock High Divider Position */
+#define TWIHS_CWGR_CHDIV_Msk                (_U_(0xFF) << TWIHS_CWGR_CHDIV_Pos)            /**< (TWIHS_CWGR) Clock High Divider Mask */
+#define TWIHS_CWGR_CHDIV(value)             (TWIHS_CWGR_CHDIV_Msk & ((value) << TWIHS_CWGR_CHDIV_Pos))
+#define TWIHS_CWGR_CKDIV_Pos                16                                             /**< (TWIHS_CWGR) Clock Divider Position */
+#define TWIHS_CWGR_CKDIV_Msk                (_U_(0x7) << TWIHS_CWGR_CKDIV_Pos)             /**< (TWIHS_CWGR) Clock Divider Mask */
+#define TWIHS_CWGR_CKDIV(value)             (TWIHS_CWGR_CKDIV_Msk & ((value) << TWIHS_CWGR_CKDIV_Pos))
+#define TWIHS_CWGR_HOLD_Pos                 24                                             /**< (TWIHS_CWGR) TWD Hold Time Versus TWCK Falling Position */
+#define TWIHS_CWGR_HOLD_Msk                 (_U_(0x3F) << TWIHS_CWGR_HOLD_Pos)             /**< (TWIHS_CWGR) TWD Hold Time Versus TWCK Falling Mask */
+#define TWIHS_CWGR_HOLD(value)              (TWIHS_CWGR_HOLD_Msk & ((value) << TWIHS_CWGR_HOLD_Pos))
+#define TWIHS_CWGR_MASK                     _U_(0x3F07FFFF)                                /**< \deprecated (TWIHS_CWGR) Register MASK  (Use TWIHS_CWGR_Msk instead)  */
+#define TWIHS_CWGR_Msk                      _U_(0x3F07FFFF)                                /**< (TWIHS_CWGR) Register Mask  */
+
+
+/* -------- TWIHS_SR : (TWIHS Offset: 0x20) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed (cleared by writing TWIHS_THR) */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready (cleared by reading TWIHS_RHR) */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready (cleared by writing TWIHS_THR) */
+    uint32_t SVREAD:1;                  /**< bit:      3  Slave Read                               */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access                             */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access (cleared on read)    */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error (cleared on read)          */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error (cleared on read)         */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledged (cleared on read)       */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost (cleared on read)       */
+    uint32_t SCLWS:1;                   /**< bit:     10  Clock Wait State                         */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access (cleared on read)    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge (cleared on read) */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error (cleared on read)          */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error (cleared on read)              */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match (cleared on read) */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match (cleared on read) */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t SCL:1;                     /**< bit:     24  SCL Line Value                           */
+    uint32_t SDA:1;                     /**< bit:     25  SDA Line Value                           */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SR_OFFSET                     (0x20)                                        /**<  (TWIHS_SR) Status Register  Offset */
+
+#define TWIHS_SR_TXCOMP_Pos                 0                                              /**< (TWIHS_SR) Transmission Completed (cleared by writing TWIHS_THR) Position */
+#define TWIHS_SR_TXCOMP_Msk                 (_U_(0x1) << TWIHS_SR_TXCOMP_Pos)              /**< (TWIHS_SR) Transmission Completed (cleared by writing TWIHS_THR) Mask */
+#define TWIHS_SR_TXCOMP                     TWIHS_SR_TXCOMP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TXCOMP_Msk instead */
+#define TWIHS_SR_RXRDY_Pos                  1                                              /**< (TWIHS_SR) Receive Holding Register Ready (cleared by reading TWIHS_RHR) Position */
+#define TWIHS_SR_RXRDY_Msk                  (_U_(0x1) << TWIHS_SR_RXRDY_Pos)               /**< (TWIHS_SR) Receive Holding Register Ready (cleared by reading TWIHS_RHR) Mask */
+#define TWIHS_SR_RXRDY                      TWIHS_SR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_RXRDY_Msk instead */
+#define TWIHS_SR_TXRDY_Pos                  2                                              /**< (TWIHS_SR) Transmit Holding Register Ready (cleared by writing TWIHS_THR) Position */
+#define TWIHS_SR_TXRDY_Msk                  (_U_(0x1) << TWIHS_SR_TXRDY_Pos)               /**< (TWIHS_SR) Transmit Holding Register Ready (cleared by writing TWIHS_THR) Mask */
+#define TWIHS_SR_TXRDY                      TWIHS_SR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TXRDY_Msk instead */
+#define TWIHS_SR_SVREAD_Pos                 3                                              /**< (TWIHS_SR) Slave Read Position */
+#define TWIHS_SR_SVREAD_Msk                 (_U_(0x1) << TWIHS_SR_SVREAD_Pos)              /**< (TWIHS_SR) Slave Read Mask */
+#define TWIHS_SR_SVREAD                     TWIHS_SR_SVREAD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SVREAD_Msk instead */
+#define TWIHS_SR_SVACC_Pos                  4                                              /**< (TWIHS_SR) Slave Access Position */
+#define TWIHS_SR_SVACC_Msk                  (_U_(0x1) << TWIHS_SR_SVACC_Pos)               /**< (TWIHS_SR) Slave Access Mask */
+#define TWIHS_SR_SVACC                      TWIHS_SR_SVACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SVACC_Msk instead */
+#define TWIHS_SR_GACC_Pos                   5                                              /**< (TWIHS_SR) General Call Access (cleared on read) Position */
+#define TWIHS_SR_GACC_Msk                   (_U_(0x1) << TWIHS_SR_GACC_Pos)                /**< (TWIHS_SR) General Call Access (cleared on read) Mask */
+#define TWIHS_SR_GACC                       TWIHS_SR_GACC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_GACC_Msk instead */
+#define TWIHS_SR_OVRE_Pos                   6                                              /**< (TWIHS_SR) Overrun Error (cleared on read) Position */
+#define TWIHS_SR_OVRE_Msk                   (_U_(0x1) << TWIHS_SR_OVRE_Pos)                /**< (TWIHS_SR) Overrun Error (cleared on read) Mask */
+#define TWIHS_SR_OVRE                       TWIHS_SR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_OVRE_Msk instead */
+#define TWIHS_SR_UNRE_Pos                   7                                              /**< (TWIHS_SR) Underrun Error (cleared on read) Position */
+#define TWIHS_SR_UNRE_Msk                   (_U_(0x1) << TWIHS_SR_UNRE_Pos)                /**< (TWIHS_SR) Underrun Error (cleared on read) Mask */
+#define TWIHS_SR_UNRE                       TWIHS_SR_UNRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_UNRE_Msk instead */
+#define TWIHS_SR_NACK_Pos                   8                                              /**< (TWIHS_SR) Not Acknowledged (cleared on read) Position */
+#define TWIHS_SR_NACK_Msk                   (_U_(0x1) << TWIHS_SR_NACK_Pos)                /**< (TWIHS_SR) Not Acknowledged (cleared on read) Mask */
+#define TWIHS_SR_NACK                       TWIHS_SR_NACK_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_NACK_Msk instead */
+#define TWIHS_SR_ARBLST_Pos                 9                                              /**< (TWIHS_SR) Arbitration Lost (cleared on read) Position */
+#define TWIHS_SR_ARBLST_Msk                 (_U_(0x1) << TWIHS_SR_ARBLST_Pos)              /**< (TWIHS_SR) Arbitration Lost (cleared on read) Mask */
+#define TWIHS_SR_ARBLST                     TWIHS_SR_ARBLST_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_ARBLST_Msk instead */
+#define TWIHS_SR_SCLWS_Pos                  10                                             /**< (TWIHS_SR) Clock Wait State Position */
+#define TWIHS_SR_SCLWS_Msk                  (_U_(0x1) << TWIHS_SR_SCLWS_Pos)               /**< (TWIHS_SR) Clock Wait State Mask */
+#define TWIHS_SR_SCLWS                      TWIHS_SR_SCLWS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SCLWS_Msk instead */
+#define TWIHS_SR_EOSACC_Pos                 11                                             /**< (TWIHS_SR) End Of Slave Access (cleared on read) Position */
+#define TWIHS_SR_EOSACC_Msk                 (_U_(0x1) << TWIHS_SR_EOSACC_Pos)              /**< (TWIHS_SR) End Of Slave Access (cleared on read) Mask */
+#define TWIHS_SR_EOSACC                     TWIHS_SR_EOSACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_EOSACC_Msk instead */
+#define TWIHS_SR_MCACK_Pos                  16                                             /**< (TWIHS_SR) Master Code Acknowledge (cleared on read) Position */
+#define TWIHS_SR_MCACK_Msk                  (_U_(0x1) << TWIHS_SR_MCACK_Pos)               /**< (TWIHS_SR) Master Code Acknowledge (cleared on read) Mask */
+#define TWIHS_SR_MCACK                      TWIHS_SR_MCACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_MCACK_Msk instead */
+#define TWIHS_SR_TOUT_Pos                   18                                             /**< (TWIHS_SR) Timeout Error (cleared on read) Position */
+#define TWIHS_SR_TOUT_Msk                   (_U_(0x1) << TWIHS_SR_TOUT_Pos)                /**< (TWIHS_SR) Timeout Error (cleared on read) Mask */
+#define TWIHS_SR_TOUT                       TWIHS_SR_TOUT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_TOUT_Msk instead */
+#define TWIHS_SR_PECERR_Pos                 19                                             /**< (TWIHS_SR) PEC Error (cleared on read) Position */
+#define TWIHS_SR_PECERR_Msk                 (_U_(0x1) << TWIHS_SR_PECERR_Pos)              /**< (TWIHS_SR) PEC Error (cleared on read) Mask */
+#define TWIHS_SR_PECERR                     TWIHS_SR_PECERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_PECERR_Msk instead */
+#define TWIHS_SR_SMBDAM_Pos                 20                                             /**< (TWIHS_SR) SMBus Default Address Match (cleared on read) Position */
+#define TWIHS_SR_SMBDAM_Msk                 (_U_(0x1) << TWIHS_SR_SMBDAM_Pos)              /**< (TWIHS_SR) SMBus Default Address Match (cleared on read) Mask */
+#define TWIHS_SR_SMBDAM                     TWIHS_SR_SMBDAM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SMBDAM_Msk instead */
+#define TWIHS_SR_SMBHHM_Pos                 21                                             /**< (TWIHS_SR) SMBus Host Header Address Match (cleared on read) Position */
+#define TWIHS_SR_SMBHHM_Msk                 (_U_(0x1) << TWIHS_SR_SMBHHM_Pos)              /**< (TWIHS_SR) SMBus Host Header Address Match (cleared on read) Mask */
+#define TWIHS_SR_SMBHHM                     TWIHS_SR_SMBHHM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SMBHHM_Msk instead */
+#define TWIHS_SR_SCL_Pos                    24                                             /**< (TWIHS_SR) SCL Line Value Position */
+#define TWIHS_SR_SCL_Msk                    (_U_(0x1) << TWIHS_SR_SCL_Pos)                 /**< (TWIHS_SR) SCL Line Value Mask */
+#define TWIHS_SR_SCL                        TWIHS_SR_SCL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SCL_Msk instead */
+#define TWIHS_SR_SDA_Pos                    25                                             /**< (TWIHS_SR) SDA Line Value Position */
+#define TWIHS_SR_SDA_Msk                    (_U_(0x1) << TWIHS_SR_SDA_Pos)                 /**< (TWIHS_SR) SDA Line Value Mask */
+#define TWIHS_SR_SDA                        TWIHS_SR_SDA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_SR_SDA_Msk instead */
+#define TWIHS_SR_MASK                       _U_(0x33D0FFF)                                 /**< \deprecated (TWIHS_SR) Register MASK  (Use TWIHS_SR_Msk instead)  */
+#define TWIHS_SR_Msk                        _U_(0x33D0FFF)                                 /**< (TWIHS_SR) Register Mask  */
+
+
+/* -------- TWIHS_IER : (TWIHS Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Enable  */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Enable */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Enable */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Enable            */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Enable     */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Enable           */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Enable          */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Enable         */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Enable        */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Enable        */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Enable     */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Enable */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Enable           */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Enable               */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Enable */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Enable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IER_OFFSET                    (0x24)                                        /**<  (TWIHS_IER) Interrupt Enable Register  Offset */
+
+#define TWIHS_IER_TXCOMP_Pos                0                                              /**< (TWIHS_IER) Transmission Completed Interrupt Enable Position */
+#define TWIHS_IER_TXCOMP_Msk                (_U_(0x1) << TWIHS_IER_TXCOMP_Pos)             /**< (TWIHS_IER) Transmission Completed Interrupt Enable Mask */
+#define TWIHS_IER_TXCOMP                    TWIHS_IER_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TXCOMP_Msk instead */
+#define TWIHS_IER_RXRDY_Pos                 1                                              /**< (TWIHS_IER) Receive Holding Register Ready Interrupt Enable Position */
+#define TWIHS_IER_RXRDY_Msk                 (_U_(0x1) << TWIHS_IER_RXRDY_Pos)              /**< (TWIHS_IER) Receive Holding Register Ready Interrupt Enable Mask */
+#define TWIHS_IER_RXRDY                     TWIHS_IER_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_RXRDY_Msk instead */
+#define TWIHS_IER_TXRDY_Pos                 2                                              /**< (TWIHS_IER) Transmit Holding Register Ready Interrupt Enable Position */
+#define TWIHS_IER_TXRDY_Msk                 (_U_(0x1) << TWIHS_IER_TXRDY_Pos)              /**< (TWIHS_IER) Transmit Holding Register Ready Interrupt Enable Mask */
+#define TWIHS_IER_TXRDY                     TWIHS_IER_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TXRDY_Msk instead */
+#define TWIHS_IER_SVACC_Pos                 4                                              /**< (TWIHS_IER) Slave Access Interrupt Enable Position */
+#define TWIHS_IER_SVACC_Msk                 (_U_(0x1) << TWIHS_IER_SVACC_Pos)              /**< (TWIHS_IER) Slave Access Interrupt Enable Mask */
+#define TWIHS_IER_SVACC                     TWIHS_IER_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SVACC_Msk instead */
+#define TWIHS_IER_GACC_Pos                  5                                              /**< (TWIHS_IER) General Call Access Interrupt Enable Position */
+#define TWIHS_IER_GACC_Msk                  (_U_(0x1) << TWIHS_IER_GACC_Pos)               /**< (TWIHS_IER) General Call Access Interrupt Enable Mask */
+#define TWIHS_IER_GACC                      TWIHS_IER_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_GACC_Msk instead */
+#define TWIHS_IER_OVRE_Pos                  6                                              /**< (TWIHS_IER) Overrun Error Interrupt Enable Position */
+#define TWIHS_IER_OVRE_Msk                  (_U_(0x1) << TWIHS_IER_OVRE_Pos)               /**< (TWIHS_IER) Overrun Error Interrupt Enable Mask */
+#define TWIHS_IER_OVRE                      TWIHS_IER_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_OVRE_Msk instead */
+#define TWIHS_IER_UNRE_Pos                  7                                              /**< (TWIHS_IER) Underrun Error Interrupt Enable Position */
+#define TWIHS_IER_UNRE_Msk                  (_U_(0x1) << TWIHS_IER_UNRE_Pos)               /**< (TWIHS_IER) Underrun Error Interrupt Enable Mask */
+#define TWIHS_IER_UNRE                      TWIHS_IER_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_UNRE_Msk instead */
+#define TWIHS_IER_NACK_Pos                  8                                              /**< (TWIHS_IER) Not Acknowledge Interrupt Enable Position */
+#define TWIHS_IER_NACK_Msk                  (_U_(0x1) << TWIHS_IER_NACK_Pos)               /**< (TWIHS_IER) Not Acknowledge Interrupt Enable Mask */
+#define TWIHS_IER_NACK                      TWIHS_IER_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_NACK_Msk instead */
+#define TWIHS_IER_ARBLST_Pos                9                                              /**< (TWIHS_IER) Arbitration Lost Interrupt Enable Position */
+#define TWIHS_IER_ARBLST_Msk                (_U_(0x1) << TWIHS_IER_ARBLST_Pos)             /**< (TWIHS_IER) Arbitration Lost Interrupt Enable Mask */
+#define TWIHS_IER_ARBLST                    TWIHS_IER_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_ARBLST_Msk instead */
+#define TWIHS_IER_SCL_WS_Pos                10                                             /**< (TWIHS_IER) Clock Wait State Interrupt Enable Position */
+#define TWIHS_IER_SCL_WS_Msk                (_U_(0x1) << TWIHS_IER_SCL_WS_Pos)             /**< (TWIHS_IER) Clock Wait State Interrupt Enable Mask */
+#define TWIHS_IER_SCL_WS                    TWIHS_IER_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SCL_WS_Msk instead */
+#define TWIHS_IER_EOSACC_Pos                11                                             /**< (TWIHS_IER) End Of Slave Access Interrupt Enable Position */
+#define TWIHS_IER_EOSACC_Msk                (_U_(0x1) << TWIHS_IER_EOSACC_Pos)             /**< (TWIHS_IER) End Of Slave Access Interrupt Enable Mask */
+#define TWIHS_IER_EOSACC                    TWIHS_IER_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_EOSACC_Msk instead */
+#define TWIHS_IER_MCACK_Pos                 16                                             /**< (TWIHS_IER) Master Code Acknowledge Interrupt Enable Position */
+#define TWIHS_IER_MCACK_Msk                 (_U_(0x1) << TWIHS_IER_MCACK_Pos)              /**< (TWIHS_IER) Master Code Acknowledge Interrupt Enable Mask */
+#define TWIHS_IER_MCACK                     TWIHS_IER_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_MCACK_Msk instead */
+#define TWIHS_IER_TOUT_Pos                  18                                             /**< (TWIHS_IER) Timeout Error Interrupt Enable Position */
+#define TWIHS_IER_TOUT_Msk                  (_U_(0x1) << TWIHS_IER_TOUT_Pos)               /**< (TWIHS_IER) Timeout Error Interrupt Enable Mask */
+#define TWIHS_IER_TOUT                      TWIHS_IER_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_TOUT_Msk instead */
+#define TWIHS_IER_PECERR_Pos                19                                             /**< (TWIHS_IER) PEC Error Interrupt Enable Position */
+#define TWIHS_IER_PECERR_Msk                (_U_(0x1) << TWIHS_IER_PECERR_Pos)             /**< (TWIHS_IER) PEC Error Interrupt Enable Mask */
+#define TWIHS_IER_PECERR                    TWIHS_IER_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_PECERR_Msk instead */
+#define TWIHS_IER_SMBDAM_Pos                20                                             /**< (TWIHS_IER) SMBus Default Address Match Interrupt Enable Position */
+#define TWIHS_IER_SMBDAM_Msk                (_U_(0x1) << TWIHS_IER_SMBDAM_Pos)             /**< (TWIHS_IER) SMBus Default Address Match Interrupt Enable Mask */
+#define TWIHS_IER_SMBDAM                    TWIHS_IER_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SMBDAM_Msk instead */
+#define TWIHS_IER_SMBHHM_Pos                21                                             /**< (TWIHS_IER) SMBus Host Header Address Match Interrupt Enable Position */
+#define TWIHS_IER_SMBHHM_Msk                (_U_(0x1) << TWIHS_IER_SMBHHM_Pos)             /**< (TWIHS_IER) SMBus Host Header Address Match Interrupt Enable Mask */
+#define TWIHS_IER_SMBHHM                    TWIHS_IER_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IER_SMBHHM_Msk instead */
+#define TWIHS_IER_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IER) Register MASK  (Use TWIHS_IER_Msk instead)  */
+#define TWIHS_IER_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IER) Register Mask  */
+
+
+/* -------- TWIHS_IDR : (TWIHS Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Disable */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Disable */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Disable */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Disable           */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Disable    */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Disable          */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Disable         */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Disable        */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Disable       */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Disable       */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Disable    */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Disable */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Disable          */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Disable              */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Disable */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Disable */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IDR_OFFSET                    (0x28)                                        /**<  (TWIHS_IDR) Interrupt Disable Register  Offset */
+
+#define TWIHS_IDR_TXCOMP_Pos                0                                              /**< (TWIHS_IDR) Transmission Completed Interrupt Disable Position */
+#define TWIHS_IDR_TXCOMP_Msk                (_U_(0x1) << TWIHS_IDR_TXCOMP_Pos)             /**< (TWIHS_IDR) Transmission Completed Interrupt Disable Mask */
+#define TWIHS_IDR_TXCOMP                    TWIHS_IDR_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TXCOMP_Msk instead */
+#define TWIHS_IDR_RXRDY_Pos                 1                                              /**< (TWIHS_IDR) Receive Holding Register Ready Interrupt Disable Position */
+#define TWIHS_IDR_RXRDY_Msk                 (_U_(0x1) << TWIHS_IDR_RXRDY_Pos)              /**< (TWIHS_IDR) Receive Holding Register Ready Interrupt Disable Mask */
+#define TWIHS_IDR_RXRDY                     TWIHS_IDR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_RXRDY_Msk instead */
+#define TWIHS_IDR_TXRDY_Pos                 2                                              /**< (TWIHS_IDR) Transmit Holding Register Ready Interrupt Disable Position */
+#define TWIHS_IDR_TXRDY_Msk                 (_U_(0x1) << TWIHS_IDR_TXRDY_Pos)              /**< (TWIHS_IDR) Transmit Holding Register Ready Interrupt Disable Mask */
+#define TWIHS_IDR_TXRDY                     TWIHS_IDR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TXRDY_Msk instead */
+#define TWIHS_IDR_SVACC_Pos                 4                                              /**< (TWIHS_IDR) Slave Access Interrupt Disable Position */
+#define TWIHS_IDR_SVACC_Msk                 (_U_(0x1) << TWIHS_IDR_SVACC_Pos)              /**< (TWIHS_IDR) Slave Access Interrupt Disable Mask */
+#define TWIHS_IDR_SVACC                     TWIHS_IDR_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SVACC_Msk instead */
+#define TWIHS_IDR_GACC_Pos                  5                                              /**< (TWIHS_IDR) General Call Access Interrupt Disable Position */
+#define TWIHS_IDR_GACC_Msk                  (_U_(0x1) << TWIHS_IDR_GACC_Pos)               /**< (TWIHS_IDR) General Call Access Interrupt Disable Mask */
+#define TWIHS_IDR_GACC                      TWIHS_IDR_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_GACC_Msk instead */
+#define TWIHS_IDR_OVRE_Pos                  6                                              /**< (TWIHS_IDR) Overrun Error Interrupt Disable Position */
+#define TWIHS_IDR_OVRE_Msk                  (_U_(0x1) << TWIHS_IDR_OVRE_Pos)               /**< (TWIHS_IDR) Overrun Error Interrupt Disable Mask */
+#define TWIHS_IDR_OVRE                      TWIHS_IDR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_OVRE_Msk instead */
+#define TWIHS_IDR_UNRE_Pos                  7                                              /**< (TWIHS_IDR) Underrun Error Interrupt Disable Position */
+#define TWIHS_IDR_UNRE_Msk                  (_U_(0x1) << TWIHS_IDR_UNRE_Pos)               /**< (TWIHS_IDR) Underrun Error Interrupt Disable Mask */
+#define TWIHS_IDR_UNRE                      TWIHS_IDR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_UNRE_Msk instead */
+#define TWIHS_IDR_NACK_Pos                  8                                              /**< (TWIHS_IDR) Not Acknowledge Interrupt Disable Position */
+#define TWIHS_IDR_NACK_Msk                  (_U_(0x1) << TWIHS_IDR_NACK_Pos)               /**< (TWIHS_IDR) Not Acknowledge Interrupt Disable Mask */
+#define TWIHS_IDR_NACK                      TWIHS_IDR_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_NACK_Msk instead */
+#define TWIHS_IDR_ARBLST_Pos                9                                              /**< (TWIHS_IDR) Arbitration Lost Interrupt Disable Position */
+#define TWIHS_IDR_ARBLST_Msk                (_U_(0x1) << TWIHS_IDR_ARBLST_Pos)             /**< (TWIHS_IDR) Arbitration Lost Interrupt Disable Mask */
+#define TWIHS_IDR_ARBLST                    TWIHS_IDR_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_ARBLST_Msk instead */
+#define TWIHS_IDR_SCL_WS_Pos                10                                             /**< (TWIHS_IDR) Clock Wait State Interrupt Disable Position */
+#define TWIHS_IDR_SCL_WS_Msk                (_U_(0x1) << TWIHS_IDR_SCL_WS_Pos)             /**< (TWIHS_IDR) Clock Wait State Interrupt Disable Mask */
+#define TWIHS_IDR_SCL_WS                    TWIHS_IDR_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SCL_WS_Msk instead */
+#define TWIHS_IDR_EOSACC_Pos                11                                             /**< (TWIHS_IDR) End Of Slave Access Interrupt Disable Position */
+#define TWIHS_IDR_EOSACC_Msk                (_U_(0x1) << TWIHS_IDR_EOSACC_Pos)             /**< (TWIHS_IDR) End Of Slave Access Interrupt Disable Mask */
+#define TWIHS_IDR_EOSACC                    TWIHS_IDR_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_EOSACC_Msk instead */
+#define TWIHS_IDR_MCACK_Pos                 16                                             /**< (TWIHS_IDR) Master Code Acknowledge Interrupt Disable Position */
+#define TWIHS_IDR_MCACK_Msk                 (_U_(0x1) << TWIHS_IDR_MCACK_Pos)              /**< (TWIHS_IDR) Master Code Acknowledge Interrupt Disable Mask */
+#define TWIHS_IDR_MCACK                     TWIHS_IDR_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_MCACK_Msk instead */
+#define TWIHS_IDR_TOUT_Pos                  18                                             /**< (TWIHS_IDR) Timeout Error Interrupt Disable Position */
+#define TWIHS_IDR_TOUT_Msk                  (_U_(0x1) << TWIHS_IDR_TOUT_Pos)               /**< (TWIHS_IDR) Timeout Error Interrupt Disable Mask */
+#define TWIHS_IDR_TOUT                      TWIHS_IDR_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_TOUT_Msk instead */
+#define TWIHS_IDR_PECERR_Pos                19                                             /**< (TWIHS_IDR) PEC Error Interrupt Disable Position */
+#define TWIHS_IDR_PECERR_Msk                (_U_(0x1) << TWIHS_IDR_PECERR_Pos)             /**< (TWIHS_IDR) PEC Error Interrupt Disable Mask */
+#define TWIHS_IDR_PECERR                    TWIHS_IDR_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_PECERR_Msk instead */
+#define TWIHS_IDR_SMBDAM_Pos                20                                             /**< (TWIHS_IDR) SMBus Default Address Match Interrupt Disable Position */
+#define TWIHS_IDR_SMBDAM_Msk                (_U_(0x1) << TWIHS_IDR_SMBDAM_Pos)             /**< (TWIHS_IDR) SMBus Default Address Match Interrupt Disable Mask */
+#define TWIHS_IDR_SMBDAM                    TWIHS_IDR_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SMBDAM_Msk instead */
+#define TWIHS_IDR_SMBHHM_Pos                21                                             /**< (TWIHS_IDR) SMBus Host Header Address Match Interrupt Disable Position */
+#define TWIHS_IDR_SMBHHM_Msk                (_U_(0x1) << TWIHS_IDR_SMBHHM_Pos)             /**< (TWIHS_IDR) SMBus Host Header Address Match Interrupt Disable Mask */
+#define TWIHS_IDR_SMBHHM                    TWIHS_IDR_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IDR_SMBHHM_Msk instead */
+#define TWIHS_IDR_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IDR) Register MASK  (Use TWIHS_IDR_Msk instead)  */
+#define TWIHS_IDR_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IDR) Register Mask  */
+
+
+/* -------- TWIHS_IMR : (TWIHS Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Mask    */
+    uint32_t RXRDY:1;                   /**< bit:      1  Receive Holding Register Ready Interrupt Mask */
+    uint32_t TXRDY:1;                   /**< bit:      2  Transmit Holding Register Ready Interrupt Mask */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t SVACC:1;                   /**< bit:      4  Slave Access Interrupt Mask              */
+    uint32_t GACC:1;                    /**< bit:      5  General Call Access Interrupt Mask       */
+    uint32_t OVRE:1;                    /**< bit:      6  Overrun Error Interrupt Mask             */
+    uint32_t UNRE:1;                    /**< bit:      7  Underrun Error Interrupt Mask            */
+    uint32_t NACK:1;                    /**< bit:      8  Not Acknowledge Interrupt Mask           */
+    uint32_t ARBLST:1;                  /**< bit:      9  Arbitration Lost Interrupt Mask          */
+    uint32_t SCL_WS:1;                  /**< bit:     10  Clock Wait State Interrupt Mask          */
+    uint32_t EOSACC:1;                  /**< bit:     11  End Of Slave Access Interrupt Mask       */
+    uint32_t :4;                        /**< bit: 12..15  Reserved */
+    uint32_t MCACK:1;                   /**< bit:     16  Master Code Acknowledge Interrupt Mask   */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t TOUT:1;                    /**< bit:     18  Timeout Error Interrupt Mask             */
+    uint32_t PECERR:1;                  /**< bit:     19  PEC Error Interrupt Mask                 */
+    uint32_t SMBDAM:1;                  /**< bit:     20  SMBus Default Address Match Interrupt Mask */
+    uint32_t SMBHHM:1;                  /**< bit:     21  SMBus Host Header Address Match Interrupt Mask */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_IMR_OFFSET                    (0x2C)                                        /**<  (TWIHS_IMR) Interrupt Mask Register  Offset */
+
+#define TWIHS_IMR_TXCOMP_Pos                0                                              /**< (TWIHS_IMR) Transmission Completed Interrupt Mask Position */
+#define TWIHS_IMR_TXCOMP_Msk                (_U_(0x1) << TWIHS_IMR_TXCOMP_Pos)             /**< (TWIHS_IMR) Transmission Completed Interrupt Mask Mask */
+#define TWIHS_IMR_TXCOMP                    TWIHS_IMR_TXCOMP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TXCOMP_Msk instead */
+#define TWIHS_IMR_RXRDY_Pos                 1                                              /**< (TWIHS_IMR) Receive Holding Register Ready Interrupt Mask Position */
+#define TWIHS_IMR_RXRDY_Msk                 (_U_(0x1) << TWIHS_IMR_RXRDY_Pos)              /**< (TWIHS_IMR) Receive Holding Register Ready Interrupt Mask Mask */
+#define TWIHS_IMR_RXRDY                     TWIHS_IMR_RXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_RXRDY_Msk instead */
+#define TWIHS_IMR_TXRDY_Pos                 2                                              /**< (TWIHS_IMR) Transmit Holding Register Ready Interrupt Mask Position */
+#define TWIHS_IMR_TXRDY_Msk                 (_U_(0x1) << TWIHS_IMR_TXRDY_Pos)              /**< (TWIHS_IMR) Transmit Holding Register Ready Interrupt Mask Mask */
+#define TWIHS_IMR_TXRDY                     TWIHS_IMR_TXRDY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TXRDY_Msk instead */
+#define TWIHS_IMR_SVACC_Pos                 4                                              /**< (TWIHS_IMR) Slave Access Interrupt Mask Position */
+#define TWIHS_IMR_SVACC_Msk                 (_U_(0x1) << TWIHS_IMR_SVACC_Pos)              /**< (TWIHS_IMR) Slave Access Interrupt Mask Mask */
+#define TWIHS_IMR_SVACC                     TWIHS_IMR_SVACC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SVACC_Msk instead */
+#define TWIHS_IMR_GACC_Pos                  5                                              /**< (TWIHS_IMR) General Call Access Interrupt Mask Position */
+#define TWIHS_IMR_GACC_Msk                  (_U_(0x1) << TWIHS_IMR_GACC_Pos)               /**< (TWIHS_IMR) General Call Access Interrupt Mask Mask */
+#define TWIHS_IMR_GACC                      TWIHS_IMR_GACC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_GACC_Msk instead */
+#define TWIHS_IMR_OVRE_Pos                  6                                              /**< (TWIHS_IMR) Overrun Error Interrupt Mask Position */
+#define TWIHS_IMR_OVRE_Msk                  (_U_(0x1) << TWIHS_IMR_OVRE_Pos)               /**< (TWIHS_IMR) Overrun Error Interrupt Mask Mask */
+#define TWIHS_IMR_OVRE                      TWIHS_IMR_OVRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_OVRE_Msk instead */
+#define TWIHS_IMR_UNRE_Pos                  7                                              /**< (TWIHS_IMR) Underrun Error Interrupt Mask Position */
+#define TWIHS_IMR_UNRE_Msk                  (_U_(0x1) << TWIHS_IMR_UNRE_Pos)               /**< (TWIHS_IMR) Underrun Error Interrupt Mask Mask */
+#define TWIHS_IMR_UNRE                      TWIHS_IMR_UNRE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_UNRE_Msk instead */
+#define TWIHS_IMR_NACK_Pos                  8                                              /**< (TWIHS_IMR) Not Acknowledge Interrupt Mask Position */
+#define TWIHS_IMR_NACK_Msk                  (_U_(0x1) << TWIHS_IMR_NACK_Pos)               /**< (TWIHS_IMR) Not Acknowledge Interrupt Mask Mask */
+#define TWIHS_IMR_NACK                      TWIHS_IMR_NACK_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_NACK_Msk instead */
+#define TWIHS_IMR_ARBLST_Pos                9                                              /**< (TWIHS_IMR) Arbitration Lost Interrupt Mask Position */
+#define TWIHS_IMR_ARBLST_Msk                (_U_(0x1) << TWIHS_IMR_ARBLST_Pos)             /**< (TWIHS_IMR) Arbitration Lost Interrupt Mask Mask */
+#define TWIHS_IMR_ARBLST                    TWIHS_IMR_ARBLST_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_ARBLST_Msk instead */
+#define TWIHS_IMR_SCL_WS_Pos                10                                             /**< (TWIHS_IMR) Clock Wait State Interrupt Mask Position */
+#define TWIHS_IMR_SCL_WS_Msk                (_U_(0x1) << TWIHS_IMR_SCL_WS_Pos)             /**< (TWIHS_IMR) Clock Wait State Interrupt Mask Mask */
+#define TWIHS_IMR_SCL_WS                    TWIHS_IMR_SCL_WS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SCL_WS_Msk instead */
+#define TWIHS_IMR_EOSACC_Pos                11                                             /**< (TWIHS_IMR) End Of Slave Access Interrupt Mask Position */
+#define TWIHS_IMR_EOSACC_Msk                (_U_(0x1) << TWIHS_IMR_EOSACC_Pos)             /**< (TWIHS_IMR) End Of Slave Access Interrupt Mask Mask */
+#define TWIHS_IMR_EOSACC                    TWIHS_IMR_EOSACC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_EOSACC_Msk instead */
+#define TWIHS_IMR_MCACK_Pos                 16                                             /**< (TWIHS_IMR) Master Code Acknowledge Interrupt Mask Position */
+#define TWIHS_IMR_MCACK_Msk                 (_U_(0x1) << TWIHS_IMR_MCACK_Pos)              /**< (TWIHS_IMR) Master Code Acknowledge Interrupt Mask Mask */
+#define TWIHS_IMR_MCACK                     TWIHS_IMR_MCACK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_MCACK_Msk instead */
+#define TWIHS_IMR_TOUT_Pos                  18                                             /**< (TWIHS_IMR) Timeout Error Interrupt Mask Position */
+#define TWIHS_IMR_TOUT_Msk                  (_U_(0x1) << TWIHS_IMR_TOUT_Pos)               /**< (TWIHS_IMR) Timeout Error Interrupt Mask Mask */
+#define TWIHS_IMR_TOUT                      TWIHS_IMR_TOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_TOUT_Msk instead */
+#define TWIHS_IMR_PECERR_Pos                19                                             /**< (TWIHS_IMR) PEC Error Interrupt Mask Position */
+#define TWIHS_IMR_PECERR_Msk                (_U_(0x1) << TWIHS_IMR_PECERR_Pos)             /**< (TWIHS_IMR) PEC Error Interrupt Mask Mask */
+#define TWIHS_IMR_PECERR                    TWIHS_IMR_PECERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_PECERR_Msk instead */
+#define TWIHS_IMR_SMBDAM_Pos                20                                             /**< (TWIHS_IMR) SMBus Default Address Match Interrupt Mask Position */
+#define TWIHS_IMR_SMBDAM_Msk                (_U_(0x1) << TWIHS_IMR_SMBDAM_Pos)             /**< (TWIHS_IMR) SMBus Default Address Match Interrupt Mask Mask */
+#define TWIHS_IMR_SMBDAM                    TWIHS_IMR_SMBDAM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SMBDAM_Msk instead */
+#define TWIHS_IMR_SMBHHM_Pos                21                                             /**< (TWIHS_IMR) SMBus Host Header Address Match Interrupt Mask Position */
+#define TWIHS_IMR_SMBHHM_Msk                (_U_(0x1) << TWIHS_IMR_SMBHHM_Pos)             /**< (TWIHS_IMR) SMBus Host Header Address Match Interrupt Mask Mask */
+#define TWIHS_IMR_SMBHHM                    TWIHS_IMR_SMBHHM_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_IMR_SMBHHM_Msk instead */
+#define TWIHS_IMR_MASK                      _U_(0x3D0FF7)                                  /**< \deprecated (TWIHS_IMR) Register MASK  (Use TWIHS_IMR_Msk instead)  */
+#define TWIHS_IMR_Msk                       _U_(0x3D0FF7)                                  /**< (TWIHS_IMR) Register Mask  */
+
+
+/* -------- TWIHS_RHR : (TWIHS Offset: 0x30) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXDATA:8;                  /**< bit:   0..7  Master or Slave Receive Holding Data     */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_RHR_OFFSET                    (0x30)                                        /**<  (TWIHS_RHR) Receive Holding Register  Offset */
+
+#define TWIHS_RHR_RXDATA_Pos                0                                              /**< (TWIHS_RHR) Master or Slave Receive Holding Data Position */
+#define TWIHS_RHR_RXDATA_Msk                (_U_(0xFF) << TWIHS_RHR_RXDATA_Pos)            /**< (TWIHS_RHR) Master or Slave Receive Holding Data Mask */
+#define TWIHS_RHR_RXDATA(value)             (TWIHS_RHR_RXDATA_Msk & ((value) << TWIHS_RHR_RXDATA_Pos))
+#define TWIHS_RHR_MASK                      _U_(0xFF)                                      /**< \deprecated (TWIHS_RHR) Register MASK  (Use TWIHS_RHR_Msk instead)  */
+#define TWIHS_RHR_Msk                       _U_(0xFF)                                      /**< (TWIHS_RHR) Register Mask  */
+
+
+/* -------- TWIHS_THR : (TWIHS Offset: 0x34) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXDATA:8;                  /**< bit:   0..7  Master or Slave Transmit Holding Data    */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_THR_OFFSET                    (0x34)                                        /**<  (TWIHS_THR) Transmit Holding Register  Offset */
+
+#define TWIHS_THR_TXDATA_Pos                0                                              /**< (TWIHS_THR) Master or Slave Transmit Holding Data Position */
+#define TWIHS_THR_TXDATA_Msk                (_U_(0xFF) << TWIHS_THR_TXDATA_Pos)            /**< (TWIHS_THR) Master or Slave Transmit Holding Data Mask */
+#define TWIHS_THR_TXDATA(value)             (TWIHS_THR_TXDATA_Msk & ((value) << TWIHS_THR_TXDATA_Pos))
+#define TWIHS_THR_MASK                      _U_(0xFF)                                      /**< \deprecated (TWIHS_THR) Register MASK  (Use TWIHS_THR_Msk instead)  */
+#define TWIHS_THR_Msk                       _U_(0xFF)                                      /**< (TWIHS_THR) Register Mask  */
+
+
+/* -------- TWIHS_SMBTR : (TWIHS Offset: 0x38) (R/W 32) SMBus Timing Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PRESC:4;                   /**< bit:   0..3  SMBus Clock Prescaler                    */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t TLOWS:8;                   /**< bit:  8..15  Slave Clock Stretch Maximum Cycles       */
+    uint32_t TLOWM:8;                   /**< bit: 16..23  Master Clock Stretch Maximum Cycles      */
+    uint32_t THMAX:8;                   /**< bit: 24..31  Clock High Maximum Cycles                */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SMBTR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SMBTR_OFFSET                  (0x38)                                        /**<  (TWIHS_SMBTR) SMBus Timing Register  Offset */
+
+#define TWIHS_SMBTR_PRESC_Pos               0                                              /**< (TWIHS_SMBTR) SMBus Clock Prescaler Position */
+#define TWIHS_SMBTR_PRESC_Msk               (_U_(0xF) << TWIHS_SMBTR_PRESC_Pos)            /**< (TWIHS_SMBTR) SMBus Clock Prescaler Mask */
+#define TWIHS_SMBTR_PRESC(value)            (TWIHS_SMBTR_PRESC_Msk & ((value) << TWIHS_SMBTR_PRESC_Pos))
+#define TWIHS_SMBTR_TLOWS_Pos               8                                              /**< (TWIHS_SMBTR) Slave Clock Stretch Maximum Cycles Position */
+#define TWIHS_SMBTR_TLOWS_Msk               (_U_(0xFF) << TWIHS_SMBTR_TLOWS_Pos)           /**< (TWIHS_SMBTR) Slave Clock Stretch Maximum Cycles Mask */
+#define TWIHS_SMBTR_TLOWS(value)            (TWIHS_SMBTR_TLOWS_Msk & ((value) << TWIHS_SMBTR_TLOWS_Pos))
+#define TWIHS_SMBTR_TLOWM_Pos               16                                             /**< (TWIHS_SMBTR) Master Clock Stretch Maximum Cycles Position */
+#define TWIHS_SMBTR_TLOWM_Msk               (_U_(0xFF) << TWIHS_SMBTR_TLOWM_Pos)           /**< (TWIHS_SMBTR) Master Clock Stretch Maximum Cycles Mask */
+#define TWIHS_SMBTR_TLOWM(value)            (TWIHS_SMBTR_TLOWM_Msk & ((value) << TWIHS_SMBTR_TLOWM_Pos))
+#define TWIHS_SMBTR_THMAX_Pos               24                                             /**< (TWIHS_SMBTR) Clock High Maximum Cycles Position */
+#define TWIHS_SMBTR_THMAX_Msk               (_U_(0xFF) << TWIHS_SMBTR_THMAX_Pos)           /**< (TWIHS_SMBTR) Clock High Maximum Cycles Mask */
+#define TWIHS_SMBTR_THMAX(value)            (TWIHS_SMBTR_THMAX_Msk & ((value) << TWIHS_SMBTR_THMAX_Pos))
+#define TWIHS_SMBTR_MASK                    _U_(0xFFFFFF0F)                                /**< \deprecated (TWIHS_SMBTR) Register MASK  (Use TWIHS_SMBTR_Msk instead)  */
+#define TWIHS_SMBTR_Msk                     _U_(0xFFFFFF0F)                                /**< (TWIHS_SMBTR) Register Mask  */
+
+
+/* -------- TWIHS_FILTR : (TWIHS Offset: 0x44) (R/W 32) Filter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FILT:1;                    /**< bit:      0  RX Digital Filter                        */
+    uint32_t PADFEN:1;                  /**< bit:      1  PAD Filter Enable                        */
+    uint32_t PADFCFG:1;                 /**< bit:      2  PAD Filter Config                        */
+    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t THRES:3;                   /**< bit:  8..10  Digital Filter Threshold                 */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_FILTR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_FILTR_OFFSET                  (0x44)                                        /**<  (TWIHS_FILTR) Filter Register  Offset */
+
+#define TWIHS_FILTR_FILT_Pos                0                                              /**< (TWIHS_FILTR) RX Digital Filter Position */
+#define TWIHS_FILTR_FILT_Msk                (_U_(0x1) << TWIHS_FILTR_FILT_Pos)             /**< (TWIHS_FILTR) RX Digital Filter Mask */
+#define TWIHS_FILTR_FILT                    TWIHS_FILTR_FILT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_FILT_Msk instead */
+#define TWIHS_FILTR_PADFEN_Pos              1                                              /**< (TWIHS_FILTR) PAD Filter Enable Position */
+#define TWIHS_FILTR_PADFEN_Msk              (_U_(0x1) << TWIHS_FILTR_PADFEN_Pos)           /**< (TWIHS_FILTR) PAD Filter Enable Mask */
+#define TWIHS_FILTR_PADFEN                  TWIHS_FILTR_PADFEN_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_PADFEN_Msk instead */
+#define TWIHS_FILTR_PADFCFG_Pos             2                                              /**< (TWIHS_FILTR) PAD Filter Config Position */
+#define TWIHS_FILTR_PADFCFG_Msk             (_U_(0x1) << TWIHS_FILTR_PADFCFG_Pos)          /**< (TWIHS_FILTR) PAD Filter Config Mask */
+#define TWIHS_FILTR_PADFCFG                 TWIHS_FILTR_PADFCFG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_FILTR_PADFCFG_Msk instead */
+#define TWIHS_FILTR_THRES_Pos               8                                              /**< (TWIHS_FILTR) Digital Filter Threshold Position */
+#define TWIHS_FILTR_THRES_Msk               (_U_(0x7) << TWIHS_FILTR_THRES_Pos)            /**< (TWIHS_FILTR) Digital Filter Threshold Mask */
+#define TWIHS_FILTR_THRES(value)            (TWIHS_FILTR_THRES_Msk & ((value) << TWIHS_FILTR_THRES_Pos))
+#define TWIHS_FILTR_MASK                    _U_(0x707)                                     /**< \deprecated (TWIHS_FILTR) Register MASK  (Use TWIHS_FILTR_Msk instead)  */
+#define TWIHS_FILTR_Msk                     _U_(0x707)                                     /**< (TWIHS_FILTR) Register Mask  */
+
+
+/* -------- TWIHS_SWMR : (TWIHS Offset: 0x4c) (R/W 32) SleepWalking Matching Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SADR1:7;                   /**< bit:   0..6  Slave Address 1                          */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t SADR2:7;                   /**< bit:  8..14  Slave Address 2                          */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SADR3:7;                   /**< bit: 16..22  Slave Address 3                          */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t DATAM:8;                   /**< bit: 24..31  Data Match                               */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_SWMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_SWMR_OFFSET                   (0x4C)                                        /**<  (TWIHS_SWMR) SleepWalking Matching Register  Offset */
+
+#define TWIHS_SWMR_SADR1_Pos                0                                              /**< (TWIHS_SWMR) Slave Address 1 Position */
+#define TWIHS_SWMR_SADR1_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR1_Pos)            /**< (TWIHS_SWMR) Slave Address 1 Mask */
+#define TWIHS_SWMR_SADR1(value)             (TWIHS_SWMR_SADR1_Msk & ((value) << TWIHS_SWMR_SADR1_Pos))
+#define TWIHS_SWMR_SADR2_Pos                8                                              /**< (TWIHS_SWMR) Slave Address 2 Position */
+#define TWIHS_SWMR_SADR2_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR2_Pos)            /**< (TWIHS_SWMR) Slave Address 2 Mask */
+#define TWIHS_SWMR_SADR2(value)             (TWIHS_SWMR_SADR2_Msk & ((value) << TWIHS_SWMR_SADR2_Pos))
+#define TWIHS_SWMR_SADR3_Pos                16                                             /**< (TWIHS_SWMR) Slave Address 3 Position */
+#define TWIHS_SWMR_SADR3_Msk                (_U_(0x7F) << TWIHS_SWMR_SADR3_Pos)            /**< (TWIHS_SWMR) Slave Address 3 Mask */
+#define TWIHS_SWMR_SADR3(value)             (TWIHS_SWMR_SADR3_Msk & ((value) << TWIHS_SWMR_SADR3_Pos))
+#define TWIHS_SWMR_DATAM_Pos                24                                             /**< (TWIHS_SWMR) Data Match Position */
+#define TWIHS_SWMR_DATAM_Msk                (_U_(0xFF) << TWIHS_SWMR_DATAM_Pos)            /**< (TWIHS_SWMR) Data Match Mask */
+#define TWIHS_SWMR_DATAM(value)             (TWIHS_SWMR_DATAM_Msk & ((value) << TWIHS_SWMR_DATAM_Pos))
+#define TWIHS_SWMR_MASK                     _U_(0xFF7F7F7F)                                /**< \deprecated (TWIHS_SWMR) Register MASK  (Use TWIHS_SWMR_Msk instead)  */
+#define TWIHS_SWMR_Msk                      _U_(0xFF7F7F7F)                                /**< (TWIHS_SWMR) Register Mask  */
+
+
+/* -------- TWIHS_WPMR : (TWIHS Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_WPMR_OFFSET                   (0xE4)                                        /**<  (TWIHS_WPMR) Write Protection Mode Register  Offset */
+
+#define TWIHS_WPMR_WPEN_Pos                 0                                              /**< (TWIHS_WPMR) Write Protection Enable Position */
+#define TWIHS_WPMR_WPEN_Msk                 (_U_(0x1) << TWIHS_WPMR_WPEN_Pos)              /**< (TWIHS_WPMR) Write Protection Enable Mask */
+#define TWIHS_WPMR_WPEN                     TWIHS_WPMR_WPEN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_WPMR_WPEN_Msk instead */
+#define TWIHS_WPMR_WPKEY_Pos                8                                              /**< (TWIHS_WPMR) Write Protection Key Position */
+#define TWIHS_WPMR_WPKEY_Msk                (_U_(0xFFFFFF) << TWIHS_WPMR_WPKEY_Pos)        /**< (TWIHS_WPMR) Write Protection Key Mask */
+#define TWIHS_WPMR_WPKEY(value)             (TWIHS_WPMR_WPKEY_Msk & ((value) << TWIHS_WPMR_WPKEY_Pos))
+#define   TWIHS_WPMR_WPKEY_PASSWD_Val       _U_(0x545749)                                  /**< (TWIHS_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0  */
+#define TWIHS_WPMR_WPKEY_PASSWD             (TWIHS_WPMR_WPKEY_PASSWD_Val << TWIHS_WPMR_WPKEY_Pos)  /**< (TWIHS_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0 Position  */
+#define TWIHS_WPMR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (TWIHS_WPMR) Register MASK  (Use TWIHS_WPMR_Msk instead)  */
+#define TWIHS_WPMR_Msk                      _U_(0xFFFFFF01)                                /**< (TWIHS_WPMR) Register Mask  */
+
+
+/* -------- TWIHS_WPSR : (TWIHS Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:24;                 /**< bit:  8..31  Write Protection Violation Source        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} TWIHS_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIHS_WPSR_OFFSET                   (0xE8)                                        /**<  (TWIHS_WPSR) Write Protection Status Register  Offset */
+
+#define TWIHS_WPSR_WPVS_Pos                 0                                              /**< (TWIHS_WPSR) Write Protection Violation Status Position */
+#define TWIHS_WPSR_WPVS_Msk                 (_U_(0x1) << TWIHS_WPSR_WPVS_Pos)              /**< (TWIHS_WPSR) Write Protection Violation Status Mask */
+#define TWIHS_WPSR_WPVS                     TWIHS_WPSR_WPVS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use TWIHS_WPSR_WPVS_Msk instead */
+#define TWIHS_WPSR_WPVSRC_Pos               8                                              /**< (TWIHS_WPSR) Write Protection Violation Source Position */
+#define TWIHS_WPSR_WPVSRC_Msk               (_U_(0xFFFFFF) << TWIHS_WPSR_WPVSRC_Pos)       /**< (TWIHS_WPSR) Write Protection Violation Source Mask */
+#define TWIHS_WPSR_WPVSRC(value)            (TWIHS_WPSR_WPVSRC_Msk & ((value) << TWIHS_WPSR_WPVSRC_Pos))
+#define TWIHS_WPSR_MASK                     _U_(0xFFFFFF01)                                /**< \deprecated (TWIHS_WPSR) Register MASK  (Use TWIHS_WPSR_Msk instead)  */
+#define TWIHS_WPSR_Msk                      _U_(0xFFFFFF01)                                /**< (TWIHS_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief TWIHS hardware registers */
+typedef struct {  
+  __O  uint32_t TWIHS_CR;       /**< (TWIHS Offset: 0x00) Control Register */
+  __IO uint32_t TWIHS_MMR;      /**< (TWIHS Offset: 0x04) Master Mode Register */
+  __IO uint32_t TWIHS_SMR;      /**< (TWIHS Offset: 0x08) Slave Mode Register */
+  __IO uint32_t TWIHS_IADR;     /**< (TWIHS Offset: 0x0C) Internal Address Register */
+  __IO uint32_t TWIHS_CWGR;     /**< (TWIHS Offset: 0x10) Clock Waveform Generator Register */
+  __I  uint8_t                        Reserved1[12];
+  __I  uint32_t TWIHS_SR;       /**< (TWIHS Offset: 0x20) Status Register */
+  __O  uint32_t TWIHS_IER;      /**< (TWIHS Offset: 0x24) Interrupt Enable Register */
+  __O  uint32_t TWIHS_IDR;      /**< (TWIHS Offset: 0x28) Interrupt Disable Register */
+  __I  uint32_t TWIHS_IMR;      /**< (TWIHS Offset: 0x2C) Interrupt Mask Register */
+  __I  uint32_t TWIHS_RHR;      /**< (TWIHS Offset: 0x30) Receive Holding Register */
+  __O  uint32_t TWIHS_THR;      /**< (TWIHS Offset: 0x34) Transmit Holding Register */
+  __IO uint32_t TWIHS_SMBTR;    /**< (TWIHS Offset: 0x38) SMBus Timing Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO uint32_t TWIHS_FILTR;    /**< (TWIHS Offset: 0x44) Filter Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO uint32_t TWIHS_SWMR;     /**< (TWIHS Offset: 0x4C) SleepWalking Matching Register */
+  __I  uint8_t                        Reserved4[148];
+  __IO uint32_t TWIHS_WPMR;     /**< (TWIHS Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t TWIHS_WPSR;     /**< (TWIHS Offset: 0xE8) Write Protection Status Register */
+} Twihs;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief TWIHS hardware registers */
+typedef struct {  
+  __O  TWIHS_CR_Type                  TWIHS_CR;       /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO TWIHS_MMR_Type                 TWIHS_MMR;      /**< Offset: 0x04 (R/W  32) Master Mode Register */
+  __IO TWIHS_SMR_Type                 TWIHS_SMR;      /**< Offset: 0x08 (R/W  32) Slave Mode Register */
+  __IO TWIHS_IADR_Type                TWIHS_IADR;     /**< Offset: 0x0C (R/W  32) Internal Address Register */
+  __IO TWIHS_CWGR_Type                TWIHS_CWGR;     /**< Offset: 0x10 (R/W  32) Clock Waveform Generator Register */
+  __I  uint8_t                        Reserved1[12];
+  __I  TWIHS_SR_Type                  TWIHS_SR;       /**< Offset: 0x20 (R/   32) Status Register */
+  __O  TWIHS_IER_Type                 TWIHS_IER;      /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
+  __O  TWIHS_IDR_Type                 TWIHS_IDR;      /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
+  __I  TWIHS_IMR_Type                 TWIHS_IMR;      /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
+  __I  TWIHS_RHR_Type                 TWIHS_RHR;      /**< Offset: 0x30 (R/   32) Receive Holding Register */
+  __O  TWIHS_THR_Type                 TWIHS_THR;      /**< Offset: 0x34 ( /W  32) Transmit Holding Register */
+  __IO TWIHS_SMBTR_Type               TWIHS_SMBTR;    /**< Offset: 0x38 (R/W  32) SMBus Timing Register */
+  __I  uint8_t                        Reserved2[8];
+  __IO TWIHS_FILTR_Type               TWIHS_FILTR;    /**< Offset: 0x44 (R/W  32) Filter Register */
+  __I  uint8_t                        Reserved3[4];
+  __IO TWIHS_SWMR_Type                TWIHS_SWMR;     /**< Offset: 0x4C (R/W  32) SleepWalking Matching Register */
+  __I  uint8_t                        Reserved4[148];
+  __IO TWIHS_WPMR_Type                TWIHS_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  TWIHS_WPSR_Type                TWIHS_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Twihs;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Two-wire Interface High Speed */
+
+#endif /* _SAMV71_TWIHS_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/uart.h
+++ b/asf/sam/include/samv71b/component/uart.h
@@ -1,0 +1,536 @@
+/**
+ * \file
+ *
+ * \brief Component description for UART
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART_COMPONENT_H_
+#define _SAMV71_UART_COMPONENT_H_
+#define _SAMV71_UART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Universal Asynchronous Receiver Transmitter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR UART */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define UART_6418                       /**< (UART) Module ID */
+#define REV_UART R                      /**< (UART) Module revision */
+
+/* -------- UART_CR : (UART Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RSTRX:1;                   /**< bit:      2  Reset Receiver                           */
+    uint32_t RSTTX:1;                   /**< bit:      3  Reset Transmitter                        */
+    uint32_t RXEN:1;                    /**< bit:      4  Receiver Enable                          */
+    uint32_t RXDIS:1;                   /**< bit:      5  Receiver Disable                         */
+    uint32_t TXEN:1;                    /**< bit:      6  Transmitter Enable                       */
+    uint32_t TXDIS:1;                   /**< bit:      7  Transmitter Disable                      */
+    uint32_t RSTSTA:1;                  /**< bit:      8  Reset Status                             */
+    uint32_t :3;                        /**< bit:  9..11  Reserved */
+    uint32_t REQCLR:1;                  /**< bit:     12  Request Clear                            */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_CR_OFFSET                      (0x00)                                        /**<  (UART_CR) Control Register  Offset */
+
+#define UART_CR_RSTRX_Pos                   2                                              /**< (UART_CR) Reset Receiver Position */
+#define UART_CR_RSTRX_Msk                   (_U_(0x1) << UART_CR_RSTRX_Pos)                /**< (UART_CR) Reset Receiver Mask */
+#define UART_CR_RSTRX                       UART_CR_RSTRX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTRX_Msk instead */
+#define UART_CR_RSTTX_Pos                   3                                              /**< (UART_CR) Reset Transmitter Position */
+#define UART_CR_RSTTX_Msk                   (_U_(0x1) << UART_CR_RSTTX_Pos)                /**< (UART_CR) Reset Transmitter Mask */
+#define UART_CR_RSTTX                       UART_CR_RSTTX_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTTX_Msk instead */
+#define UART_CR_RXEN_Pos                    4                                              /**< (UART_CR) Receiver Enable Position */
+#define UART_CR_RXEN_Msk                    (_U_(0x1) << UART_CR_RXEN_Pos)                 /**< (UART_CR) Receiver Enable Mask */
+#define UART_CR_RXEN                        UART_CR_RXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RXEN_Msk instead */
+#define UART_CR_RXDIS_Pos                   5                                              /**< (UART_CR) Receiver Disable Position */
+#define UART_CR_RXDIS_Msk                   (_U_(0x1) << UART_CR_RXDIS_Pos)                /**< (UART_CR) Receiver Disable Mask */
+#define UART_CR_RXDIS                       UART_CR_RXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RXDIS_Msk instead */
+#define UART_CR_TXEN_Pos                    6                                              /**< (UART_CR) Transmitter Enable Position */
+#define UART_CR_TXEN_Msk                    (_U_(0x1) << UART_CR_TXEN_Pos)                 /**< (UART_CR) Transmitter Enable Mask */
+#define UART_CR_TXEN                        UART_CR_TXEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_TXEN_Msk instead */
+#define UART_CR_TXDIS_Pos                   7                                              /**< (UART_CR) Transmitter Disable Position */
+#define UART_CR_TXDIS_Msk                   (_U_(0x1) << UART_CR_TXDIS_Pos)                /**< (UART_CR) Transmitter Disable Mask */
+#define UART_CR_TXDIS                       UART_CR_TXDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_TXDIS_Msk instead */
+#define UART_CR_RSTSTA_Pos                  8                                              /**< (UART_CR) Reset Status Position */
+#define UART_CR_RSTSTA_Msk                  (_U_(0x1) << UART_CR_RSTSTA_Pos)               /**< (UART_CR) Reset Status Mask */
+#define UART_CR_RSTSTA                      UART_CR_RSTSTA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_RSTSTA_Msk instead */
+#define UART_CR_REQCLR_Pos                  12                                             /**< (UART_CR) Request Clear Position */
+#define UART_CR_REQCLR_Msk                  (_U_(0x1) << UART_CR_REQCLR_Pos)               /**< (UART_CR) Request Clear Mask */
+#define UART_CR_REQCLR                      UART_CR_REQCLR_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CR_REQCLR_Msk instead */
+#define UART_CR_MASK                        _U_(0x11FC)                                    /**< \deprecated (UART_CR) Register MASK  (Use UART_CR_Msk instead)  */
+#define UART_CR_Msk                         _U_(0x11FC)                                    /**< (UART_CR) Register Mask  */
+
+
+/* -------- UART_MR : (UART Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t FILTER:1;                  /**< bit:      4  Receiver Digital Filter                  */
+    uint32_t :4;                        /**< bit:   5..8  Reserved */
+    uint32_t PAR:3;                     /**< bit:  9..11  Parity Type                              */
+    uint32_t BRSRCCK:1;                 /**< bit:     12  Baud Rate Source Clock                   */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CHMODE:2;                  /**< bit: 14..15  Channel Mode                             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_MR_OFFSET                      (0x04)                                        /**<  (UART_MR) Mode Register  Offset */
+
+#define UART_MR_FILTER_Pos                  4                                              /**< (UART_MR) Receiver Digital Filter Position */
+#define UART_MR_FILTER_Msk                  (_U_(0x1) << UART_MR_FILTER_Pos)               /**< (UART_MR) Receiver Digital Filter Mask */
+#define UART_MR_FILTER                      UART_MR_FILTER_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_MR_FILTER_Msk instead */
+#define   UART_MR_FILTER_DISABLED_Val       _U_(0x0)                                       /**< (UART_MR) UART does not filter the receive line.  */
+#define   UART_MR_FILTER_ENABLED_Val        _U_(0x1)                                       /**< (UART_MR) UART filters the receive line using a three-sample filter (16x-bit clock) (2 over 3 majority).  */
+#define UART_MR_FILTER_DISABLED             (UART_MR_FILTER_DISABLED_Val << UART_MR_FILTER_Pos)  /**< (UART_MR) UART does not filter the receive line. Position  */
+#define UART_MR_FILTER_ENABLED              (UART_MR_FILTER_ENABLED_Val << UART_MR_FILTER_Pos)  /**< (UART_MR) UART filters the receive line using a three-sample filter (16x-bit clock) (2 over 3 majority). Position  */
+#define UART_MR_PAR_Pos                     9                                              /**< (UART_MR) Parity Type Position */
+#define UART_MR_PAR_Msk                     (_U_(0x7) << UART_MR_PAR_Pos)                  /**< (UART_MR) Parity Type Mask */
+#define UART_MR_PAR(value)                  (UART_MR_PAR_Msk & ((value) << UART_MR_PAR_Pos))
+#define   UART_MR_PAR_EVEN_Val              _U_(0x0)                                       /**< (UART_MR) Even Parity  */
+#define   UART_MR_PAR_ODD_Val               _U_(0x1)                                       /**< (UART_MR) Odd Parity  */
+#define   UART_MR_PAR_SPACE_Val             _U_(0x2)                                       /**< (UART_MR) Space: parity forced to 0  */
+#define   UART_MR_PAR_MARK_Val              _U_(0x3)                                       /**< (UART_MR) Mark: parity forced to 1  */
+#define   UART_MR_PAR_NO_Val                _U_(0x4)                                       /**< (UART_MR) No parity  */
+#define UART_MR_PAR_EVEN                    (UART_MR_PAR_EVEN_Val << UART_MR_PAR_Pos)      /**< (UART_MR) Even Parity Position  */
+#define UART_MR_PAR_ODD                     (UART_MR_PAR_ODD_Val << UART_MR_PAR_Pos)       /**< (UART_MR) Odd Parity Position  */
+#define UART_MR_PAR_SPACE                   (UART_MR_PAR_SPACE_Val << UART_MR_PAR_Pos)     /**< (UART_MR) Space: parity forced to 0 Position  */
+#define UART_MR_PAR_MARK                    (UART_MR_PAR_MARK_Val << UART_MR_PAR_Pos)      /**< (UART_MR) Mark: parity forced to 1 Position  */
+#define UART_MR_PAR_NO                      (UART_MR_PAR_NO_Val << UART_MR_PAR_Pos)        /**< (UART_MR) No parity Position  */
+#define UART_MR_BRSRCCK_Pos                 12                                             /**< (UART_MR) Baud Rate Source Clock Position */
+#define UART_MR_BRSRCCK_Msk                 (_U_(0x1) << UART_MR_BRSRCCK_Pos)              /**< (UART_MR) Baud Rate Source Clock Mask */
+#define UART_MR_BRSRCCK                     UART_MR_BRSRCCK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_MR_BRSRCCK_Msk instead */
+#define   UART_MR_BRSRCCK_PERIPH_CLK_Val    _U_(0x0)                                       /**< (UART_MR) The baud rate is driven by the peripheral clock  */
+#define   UART_MR_BRSRCCK_PMC_PCK_Val       _U_(0x1)                                       /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)).  */
+#define UART_MR_BRSRCCK_PERIPH_CLK          (UART_MR_BRSRCCK_PERIPH_CLK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by the peripheral clock Position  */
+#define UART_MR_BRSRCCK_PMC_PCK             (UART_MR_BRSRCCK_PMC_PCK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)). Position  */
+#define UART_MR_CHMODE_Pos                  14                                             /**< (UART_MR) Channel Mode Position */
+#define UART_MR_CHMODE_Msk                  (_U_(0x3) << UART_MR_CHMODE_Pos)               /**< (UART_MR) Channel Mode Mask */
+#define UART_MR_CHMODE(value)               (UART_MR_CHMODE_Msk & ((value) << UART_MR_CHMODE_Pos))
+#define   UART_MR_CHMODE_NORMAL_Val         _U_(0x0)                                       /**< (UART_MR) Normal mode  */
+#define   UART_MR_CHMODE_AUTOMATIC_Val      _U_(0x1)                                       /**< (UART_MR) Automatic echo  */
+#define   UART_MR_CHMODE_LOCAL_LOOPBACK_Val _U_(0x2)                                       /**< (UART_MR) Local loopback  */
+#define   UART_MR_CHMODE_REMOTE_LOOPBACK_Val _U_(0x3)                                       /**< (UART_MR) Remote loopback  */
+#define UART_MR_CHMODE_NORMAL               (UART_MR_CHMODE_NORMAL_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Normal mode Position  */
+#define UART_MR_CHMODE_AUTOMATIC            (UART_MR_CHMODE_AUTOMATIC_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Automatic echo Position  */
+#define UART_MR_CHMODE_LOCAL_LOOPBACK       (UART_MR_CHMODE_LOCAL_LOOPBACK_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Local loopback Position  */
+#define UART_MR_CHMODE_REMOTE_LOOPBACK      (UART_MR_CHMODE_REMOTE_LOOPBACK_Val << UART_MR_CHMODE_Pos)  /**< (UART_MR) Remote loopback Position  */
+#define UART_MR_MASK                        _U_(0xDE10)                                    /**< \deprecated (UART_MR) Register MASK  (Use UART_MR_Msk instead)  */
+#define UART_MR_Msk                         _U_(0xDE10)                                    /**< (UART_MR) Register Mask  */
+
+
+/* -------- UART_IER : (UART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Enable RXRDY Interrupt                   */
+    uint32_t TXRDY:1;                   /**< bit:      1  Enable TXRDY Interrupt                   */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Enable Overrun Error Interrupt           */
+    uint32_t FRAME:1;                   /**< bit:      6  Enable Framing Error Interrupt           */
+    uint32_t PARE:1;                    /**< bit:      7  Enable Parity Error Interrupt            */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Enable TXEMPTY Interrupt                 */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Enable Comparison Interrupt              */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IER_OFFSET                     (0x08)                                        /**<  (UART_IER) Interrupt Enable Register  Offset */
+
+#define UART_IER_RXRDY_Pos                  0                                              /**< (UART_IER) Enable RXRDY Interrupt Position */
+#define UART_IER_RXRDY_Msk                  (_U_(0x1) << UART_IER_RXRDY_Pos)               /**< (UART_IER) Enable RXRDY Interrupt Mask */
+#define UART_IER_RXRDY                      UART_IER_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_RXRDY_Msk instead */
+#define UART_IER_TXRDY_Pos                  1                                              /**< (UART_IER) Enable TXRDY Interrupt Position */
+#define UART_IER_TXRDY_Msk                  (_U_(0x1) << UART_IER_TXRDY_Pos)               /**< (UART_IER) Enable TXRDY Interrupt Mask */
+#define UART_IER_TXRDY                      UART_IER_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_TXRDY_Msk instead */
+#define UART_IER_OVRE_Pos                   5                                              /**< (UART_IER) Enable Overrun Error Interrupt Position */
+#define UART_IER_OVRE_Msk                   (_U_(0x1) << UART_IER_OVRE_Pos)                /**< (UART_IER) Enable Overrun Error Interrupt Mask */
+#define UART_IER_OVRE                       UART_IER_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_OVRE_Msk instead */
+#define UART_IER_FRAME_Pos                  6                                              /**< (UART_IER) Enable Framing Error Interrupt Position */
+#define UART_IER_FRAME_Msk                  (_U_(0x1) << UART_IER_FRAME_Pos)               /**< (UART_IER) Enable Framing Error Interrupt Mask */
+#define UART_IER_FRAME                      UART_IER_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_FRAME_Msk instead */
+#define UART_IER_PARE_Pos                   7                                              /**< (UART_IER) Enable Parity Error Interrupt Position */
+#define UART_IER_PARE_Msk                   (_U_(0x1) << UART_IER_PARE_Pos)                /**< (UART_IER) Enable Parity Error Interrupt Mask */
+#define UART_IER_PARE                       UART_IER_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_PARE_Msk instead */
+#define UART_IER_TXEMPTY_Pos                9                                              /**< (UART_IER) Enable TXEMPTY Interrupt Position */
+#define UART_IER_TXEMPTY_Msk                (_U_(0x1) << UART_IER_TXEMPTY_Pos)             /**< (UART_IER) Enable TXEMPTY Interrupt Mask */
+#define UART_IER_TXEMPTY                    UART_IER_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_TXEMPTY_Msk instead */
+#define UART_IER_CMP_Pos                    15                                             /**< (UART_IER) Enable Comparison Interrupt Position */
+#define UART_IER_CMP_Msk                    (_U_(0x1) << UART_IER_CMP_Pos)                 /**< (UART_IER) Enable Comparison Interrupt Mask */
+#define UART_IER_CMP                        UART_IER_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IER_CMP_Msk instead */
+#define UART_IER_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IER) Register MASK  (Use UART_IER_Msk instead)  */
+#define UART_IER_Msk                        _U_(0x82E3)                                    /**< (UART_IER) Register Mask  */
+
+
+/* -------- UART_IDR : (UART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Disable RXRDY Interrupt                  */
+    uint32_t TXRDY:1;                   /**< bit:      1  Disable TXRDY Interrupt                  */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Disable Overrun Error Interrupt          */
+    uint32_t FRAME:1;                   /**< bit:      6  Disable Framing Error Interrupt          */
+    uint32_t PARE:1;                    /**< bit:      7  Disable Parity Error Interrupt           */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Disable TXEMPTY Interrupt                */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Disable Comparison Interrupt             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IDR_OFFSET                     (0x0C)                                        /**<  (UART_IDR) Interrupt Disable Register  Offset */
+
+#define UART_IDR_RXRDY_Pos                  0                                              /**< (UART_IDR) Disable RXRDY Interrupt Position */
+#define UART_IDR_RXRDY_Msk                  (_U_(0x1) << UART_IDR_RXRDY_Pos)               /**< (UART_IDR) Disable RXRDY Interrupt Mask */
+#define UART_IDR_RXRDY                      UART_IDR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_RXRDY_Msk instead */
+#define UART_IDR_TXRDY_Pos                  1                                              /**< (UART_IDR) Disable TXRDY Interrupt Position */
+#define UART_IDR_TXRDY_Msk                  (_U_(0x1) << UART_IDR_TXRDY_Pos)               /**< (UART_IDR) Disable TXRDY Interrupt Mask */
+#define UART_IDR_TXRDY                      UART_IDR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_TXRDY_Msk instead */
+#define UART_IDR_OVRE_Pos                   5                                              /**< (UART_IDR) Disable Overrun Error Interrupt Position */
+#define UART_IDR_OVRE_Msk                   (_U_(0x1) << UART_IDR_OVRE_Pos)                /**< (UART_IDR) Disable Overrun Error Interrupt Mask */
+#define UART_IDR_OVRE                       UART_IDR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_OVRE_Msk instead */
+#define UART_IDR_FRAME_Pos                  6                                              /**< (UART_IDR) Disable Framing Error Interrupt Position */
+#define UART_IDR_FRAME_Msk                  (_U_(0x1) << UART_IDR_FRAME_Pos)               /**< (UART_IDR) Disable Framing Error Interrupt Mask */
+#define UART_IDR_FRAME                      UART_IDR_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_FRAME_Msk instead */
+#define UART_IDR_PARE_Pos                   7                                              /**< (UART_IDR) Disable Parity Error Interrupt Position */
+#define UART_IDR_PARE_Msk                   (_U_(0x1) << UART_IDR_PARE_Pos)                /**< (UART_IDR) Disable Parity Error Interrupt Mask */
+#define UART_IDR_PARE                       UART_IDR_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_PARE_Msk instead */
+#define UART_IDR_TXEMPTY_Pos                9                                              /**< (UART_IDR) Disable TXEMPTY Interrupt Position */
+#define UART_IDR_TXEMPTY_Msk                (_U_(0x1) << UART_IDR_TXEMPTY_Pos)             /**< (UART_IDR) Disable TXEMPTY Interrupt Mask */
+#define UART_IDR_TXEMPTY                    UART_IDR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_TXEMPTY_Msk instead */
+#define UART_IDR_CMP_Pos                    15                                             /**< (UART_IDR) Disable Comparison Interrupt Position */
+#define UART_IDR_CMP_Msk                    (_U_(0x1) << UART_IDR_CMP_Pos)                 /**< (UART_IDR) Disable Comparison Interrupt Mask */
+#define UART_IDR_CMP                        UART_IDR_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IDR_CMP_Msk instead */
+#define UART_IDR_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IDR) Register MASK  (Use UART_IDR_Msk instead)  */
+#define UART_IDR_Msk                        _U_(0x82E3)                                    /**< (UART_IDR) Register Mask  */
+
+
+/* -------- UART_IMR : (UART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Mask RXRDY Interrupt                     */
+    uint32_t TXRDY:1;                   /**< bit:      1  Disable TXRDY Interrupt                  */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Mask Overrun Error Interrupt             */
+    uint32_t FRAME:1;                   /**< bit:      6  Mask Framing Error Interrupt             */
+    uint32_t PARE:1;                    /**< bit:      7  Mask Parity Error Interrupt              */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Mask TXEMPTY Interrupt                   */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Mask Comparison Interrupt                */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_IMR_OFFSET                     (0x10)                                        /**<  (UART_IMR) Interrupt Mask Register  Offset */
+
+#define UART_IMR_RXRDY_Pos                  0                                              /**< (UART_IMR) Mask RXRDY Interrupt Position */
+#define UART_IMR_RXRDY_Msk                  (_U_(0x1) << UART_IMR_RXRDY_Pos)               /**< (UART_IMR) Mask RXRDY Interrupt Mask */
+#define UART_IMR_RXRDY                      UART_IMR_RXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_RXRDY_Msk instead */
+#define UART_IMR_TXRDY_Pos                  1                                              /**< (UART_IMR) Disable TXRDY Interrupt Position */
+#define UART_IMR_TXRDY_Msk                  (_U_(0x1) << UART_IMR_TXRDY_Pos)               /**< (UART_IMR) Disable TXRDY Interrupt Mask */
+#define UART_IMR_TXRDY                      UART_IMR_TXRDY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_TXRDY_Msk instead */
+#define UART_IMR_OVRE_Pos                   5                                              /**< (UART_IMR) Mask Overrun Error Interrupt Position */
+#define UART_IMR_OVRE_Msk                   (_U_(0x1) << UART_IMR_OVRE_Pos)                /**< (UART_IMR) Mask Overrun Error Interrupt Mask */
+#define UART_IMR_OVRE                       UART_IMR_OVRE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_OVRE_Msk instead */
+#define UART_IMR_FRAME_Pos                  6                                              /**< (UART_IMR) Mask Framing Error Interrupt Position */
+#define UART_IMR_FRAME_Msk                  (_U_(0x1) << UART_IMR_FRAME_Pos)               /**< (UART_IMR) Mask Framing Error Interrupt Mask */
+#define UART_IMR_FRAME                      UART_IMR_FRAME_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_FRAME_Msk instead */
+#define UART_IMR_PARE_Pos                   7                                              /**< (UART_IMR) Mask Parity Error Interrupt Position */
+#define UART_IMR_PARE_Msk                   (_U_(0x1) << UART_IMR_PARE_Pos)                /**< (UART_IMR) Mask Parity Error Interrupt Mask */
+#define UART_IMR_PARE                       UART_IMR_PARE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_PARE_Msk instead */
+#define UART_IMR_TXEMPTY_Pos                9                                              /**< (UART_IMR) Mask TXEMPTY Interrupt Position */
+#define UART_IMR_TXEMPTY_Msk                (_U_(0x1) << UART_IMR_TXEMPTY_Pos)             /**< (UART_IMR) Mask TXEMPTY Interrupt Mask */
+#define UART_IMR_TXEMPTY                    UART_IMR_TXEMPTY_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_TXEMPTY_Msk instead */
+#define UART_IMR_CMP_Pos                    15                                             /**< (UART_IMR) Mask Comparison Interrupt Position */
+#define UART_IMR_CMP_Msk                    (_U_(0x1) << UART_IMR_CMP_Pos)                 /**< (UART_IMR) Mask Comparison Interrupt Mask */
+#define UART_IMR_CMP                        UART_IMR_CMP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_IMR_CMP_Msk instead */
+#define UART_IMR_MASK                       _U_(0x82E3)                                    /**< \deprecated (UART_IMR) Register MASK  (Use UART_IMR_Msk instead)  */
+#define UART_IMR_Msk                        _U_(0x82E3)                                    /**< (UART_IMR) Register Mask  */
+
+
+/* -------- UART_SR : (UART Offset: 0x14) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready                           */
+    uint32_t TXRDY:1;                   /**< bit:      1  Transmitter Ready                        */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error                            */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error                            */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error                             */
+    uint32_t :1;                        /**< bit:      8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmitter Empty                        */
+    uint32_t :5;                        /**< bit: 10..14  Reserved */
+    uint32_t CMP:1;                     /**< bit:     15  Comparison Match                         */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_SR_OFFSET                      (0x14)                                        /**<  (UART_SR) Status Register  Offset */
+
+#define UART_SR_RXRDY_Pos                   0                                              /**< (UART_SR) Receiver Ready Position */
+#define UART_SR_RXRDY_Msk                   (_U_(0x1) << UART_SR_RXRDY_Pos)                /**< (UART_SR) Receiver Ready Mask */
+#define UART_SR_RXRDY                       UART_SR_RXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_RXRDY_Msk instead */
+#define UART_SR_TXRDY_Pos                   1                                              /**< (UART_SR) Transmitter Ready Position */
+#define UART_SR_TXRDY_Msk                   (_U_(0x1) << UART_SR_TXRDY_Pos)                /**< (UART_SR) Transmitter Ready Mask */
+#define UART_SR_TXRDY                       UART_SR_TXRDY_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_TXRDY_Msk instead */
+#define UART_SR_OVRE_Pos                    5                                              /**< (UART_SR) Overrun Error Position */
+#define UART_SR_OVRE_Msk                    (_U_(0x1) << UART_SR_OVRE_Pos)                 /**< (UART_SR) Overrun Error Mask */
+#define UART_SR_OVRE                        UART_SR_OVRE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_OVRE_Msk instead */
+#define UART_SR_FRAME_Pos                   6                                              /**< (UART_SR) Framing Error Position */
+#define UART_SR_FRAME_Msk                   (_U_(0x1) << UART_SR_FRAME_Pos)                /**< (UART_SR) Framing Error Mask */
+#define UART_SR_FRAME                       UART_SR_FRAME_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_FRAME_Msk instead */
+#define UART_SR_PARE_Pos                    7                                              /**< (UART_SR) Parity Error Position */
+#define UART_SR_PARE_Msk                    (_U_(0x1) << UART_SR_PARE_Pos)                 /**< (UART_SR) Parity Error Mask */
+#define UART_SR_PARE                        UART_SR_PARE_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_PARE_Msk instead */
+#define UART_SR_TXEMPTY_Pos                 9                                              /**< (UART_SR) Transmitter Empty Position */
+#define UART_SR_TXEMPTY_Msk                 (_U_(0x1) << UART_SR_TXEMPTY_Pos)              /**< (UART_SR) Transmitter Empty Mask */
+#define UART_SR_TXEMPTY                     UART_SR_TXEMPTY_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_TXEMPTY_Msk instead */
+#define UART_SR_CMP_Pos                     15                                             /**< (UART_SR) Comparison Match Position */
+#define UART_SR_CMP_Msk                     (_U_(0x1) << UART_SR_CMP_Pos)                  /**< (UART_SR) Comparison Match Mask */
+#define UART_SR_CMP                         UART_SR_CMP_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_SR_CMP_Msk instead */
+#define UART_SR_MASK                        _U_(0x82E3)                                    /**< \deprecated (UART_SR) Register MASK  (Use UART_SR_Msk instead)  */
+#define UART_SR_Msk                         _U_(0x82E3)                                    /**< (UART_SR) Register Mask  */
+
+
+/* -------- UART_RHR : (UART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXCHR:8;                   /**< bit:   0..7  Received Character                       */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_RHR_OFFSET                     (0x18)                                        /**<  (UART_RHR) Receive Holding Register  Offset */
+
+#define UART_RHR_RXCHR_Pos                  0                                              /**< (UART_RHR) Received Character Position */
+#define UART_RHR_RXCHR_Msk                  (_U_(0xFF) << UART_RHR_RXCHR_Pos)              /**< (UART_RHR) Received Character Mask */
+#define UART_RHR_RXCHR(value)               (UART_RHR_RXCHR_Msk & ((value) << UART_RHR_RXCHR_Pos))
+#define UART_RHR_MASK                       _U_(0xFF)                                      /**< \deprecated (UART_RHR) Register MASK  (Use UART_RHR_Msk instead)  */
+#define UART_RHR_Msk                        _U_(0xFF)                                      /**< (UART_RHR) Register Mask  */
+
+
+/* -------- UART_THR : (UART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCHR:8;                   /**< bit:   0..7  Character to be Transmitted              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_THR_OFFSET                     (0x1C)                                        /**<  (UART_THR) Transmit Holding Register  Offset */
+
+#define UART_THR_TXCHR_Pos                  0                                              /**< (UART_THR) Character to be Transmitted Position */
+#define UART_THR_TXCHR_Msk                  (_U_(0xFF) << UART_THR_TXCHR_Pos)              /**< (UART_THR) Character to be Transmitted Mask */
+#define UART_THR_TXCHR(value)               (UART_THR_TXCHR_Msk & ((value) << UART_THR_TXCHR_Pos))
+#define UART_THR_MASK                       _U_(0xFF)                                      /**< \deprecated (UART_THR) Register MASK  (Use UART_THR_Msk instead)  */
+#define UART_THR_Msk                        _U_(0xFF)                                      /**< (UART_THR) Register Mask  */
+
+
+/* -------- UART_BRGR : (UART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CD:16;                     /**< bit:  0..15  Clock Divisor                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_BRGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_BRGR_OFFSET                    (0x20)                                        /**<  (UART_BRGR) Baud Rate Generator Register  Offset */
+
+#define UART_BRGR_CD_Pos                    0                                              /**< (UART_BRGR) Clock Divisor Position */
+#define UART_BRGR_CD_Msk                    (_U_(0xFFFF) << UART_BRGR_CD_Pos)              /**< (UART_BRGR) Clock Divisor Mask */
+#define UART_BRGR_CD(value)                 (UART_BRGR_CD_Msk & ((value) << UART_BRGR_CD_Pos))
+#define UART_BRGR_MASK                      _U_(0xFFFF)                                    /**< \deprecated (UART_BRGR) Register MASK  (Use UART_BRGR_Msk instead)  */
+#define UART_BRGR_Msk                       _U_(0xFFFF)                                    /**< (UART_BRGR) Register Mask  */
+
+
+/* -------- UART_CMPR : (UART Offset: 0x24) (R/W 32) Comparison Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t VAL1:8;                    /**< bit:   0..7  First Comparison Value for Received Character */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t CMPMODE:1;                 /**< bit:     12  Comparison Mode                          */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t CMPPAR:1;                  /**< bit:     14  Compare Parity                           */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t VAL2:8;                    /**< bit: 16..23  Second Comparison Value for Received Character */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_CMPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_CMPR_OFFSET                    (0x24)                                        /**<  (UART_CMPR) Comparison Register  Offset */
+
+#define UART_CMPR_VAL1_Pos                  0                                              /**< (UART_CMPR) First Comparison Value for Received Character Position */
+#define UART_CMPR_VAL1_Msk                  (_U_(0xFF) << UART_CMPR_VAL1_Pos)              /**< (UART_CMPR) First Comparison Value for Received Character Mask */
+#define UART_CMPR_VAL1(value)               (UART_CMPR_VAL1_Msk & ((value) << UART_CMPR_VAL1_Pos))
+#define UART_CMPR_CMPMODE_Pos               12                                             /**< (UART_CMPR) Comparison Mode Position */
+#define UART_CMPR_CMPMODE_Msk               (_U_(0x1) << UART_CMPR_CMPMODE_Pos)            /**< (UART_CMPR) Comparison Mode Mask */
+#define UART_CMPR_CMPMODE                   UART_CMPR_CMPMODE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CMPR_CMPMODE_Msk instead */
+#define   UART_CMPR_CMPMODE_FLAG_ONLY_Val   _U_(0x0)                                       /**< (UART_CMPR) Any character is received and comparison function drives CMP flag.  */
+#define   UART_CMPR_CMPMODE_START_CONDITION_Val _U_(0x1)                                       /**< (UART_CMPR) Comparison condition must be met to start reception.  */
+#define UART_CMPR_CMPMODE_FLAG_ONLY         (UART_CMPR_CMPMODE_FLAG_ONLY_Val << UART_CMPR_CMPMODE_Pos)  /**< (UART_CMPR) Any character is received and comparison function drives CMP flag. Position  */
+#define UART_CMPR_CMPMODE_START_CONDITION   (UART_CMPR_CMPMODE_START_CONDITION_Val << UART_CMPR_CMPMODE_Pos)  /**< (UART_CMPR) Comparison condition must be met to start reception. Position  */
+#define UART_CMPR_CMPPAR_Pos                14                                             /**< (UART_CMPR) Compare Parity Position */
+#define UART_CMPR_CMPPAR_Msk                (_U_(0x1) << UART_CMPR_CMPPAR_Pos)             /**< (UART_CMPR) Compare Parity Mask */
+#define UART_CMPR_CMPPAR                    UART_CMPR_CMPPAR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_CMPR_CMPPAR_Msk instead */
+#define UART_CMPR_VAL2_Pos                  16                                             /**< (UART_CMPR) Second Comparison Value for Received Character Position */
+#define UART_CMPR_VAL2_Msk                  (_U_(0xFF) << UART_CMPR_VAL2_Pos)              /**< (UART_CMPR) Second Comparison Value for Received Character Mask */
+#define UART_CMPR_VAL2(value)               (UART_CMPR_VAL2_Msk & ((value) << UART_CMPR_VAL2_Pos))
+#define UART_CMPR_MASK                      _U_(0xFF50FF)                                  /**< \deprecated (UART_CMPR) Register MASK  (Use UART_CMPR_Msk instead)  */
+#define UART_CMPR_Msk                       _U_(0xFF50FF)                                  /**< (UART_CMPR) Register Mask  */
+
+
+/* -------- UART_WPMR : (UART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UART_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UART_WPMR_OFFSET                    (0xE4)                                        /**<  (UART_WPMR) Write Protection Mode Register  Offset */
+
+#define UART_WPMR_WPEN_Pos                  0                                              /**< (UART_WPMR) Write Protection Enable Position */
+#define UART_WPMR_WPEN_Msk                  (_U_(0x1) << UART_WPMR_WPEN_Pos)               /**< (UART_WPMR) Write Protection Enable Mask */
+#define UART_WPMR_WPEN                      UART_WPMR_WPEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_WPMR_WPEN_Msk instead */
+#define UART_WPMR_WPKEY_Pos                 8                                              /**< (UART_WPMR) Write Protection Key Position */
+#define UART_WPMR_WPKEY_Msk                 (_U_(0xFFFFFF) << UART_WPMR_WPKEY_Pos)         /**< (UART_WPMR) Write Protection Key Mask */
+#define UART_WPMR_WPKEY(value)              (UART_WPMR_WPKEY_Msk & ((value) << UART_WPMR_WPKEY_Pos))
+#define   UART_WPMR_WPKEY_PASSWD_Val        _U_(0x554152)                                  /**< (UART_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0.  */
+#define UART_WPMR_WPKEY_PASSWD              (UART_WPMR_WPKEY_PASSWD_Val << UART_WPMR_WPKEY_Pos)  /**< (UART_WPMR) Writing any other value in this field aborts the write operation.Always reads as 0. Position  */
+#define UART_WPMR_MASK                      _U_(0xFFFFFF01)                                /**< \deprecated (UART_WPMR) Register MASK  (Use UART_WPMR_Msk instead)  */
+#define UART_WPMR_Msk                       _U_(0xFFFFFF01)                                /**< (UART_WPMR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief UART hardware registers */
+typedef struct {  
+  __O  uint32_t UART_CR;        /**< (UART Offset: 0x00) Control Register */
+  __IO uint32_t UART_MR;        /**< (UART Offset: 0x04) Mode Register */
+  __O  uint32_t UART_IER;       /**< (UART Offset: 0x08) Interrupt Enable Register */
+  __O  uint32_t UART_IDR;       /**< (UART Offset: 0x0C) Interrupt Disable Register */
+  __I  uint32_t UART_IMR;       /**< (UART Offset: 0x10) Interrupt Mask Register */
+  __I  uint32_t UART_SR;        /**< (UART Offset: 0x14) Status Register */
+  __I  uint32_t UART_RHR;       /**< (UART Offset: 0x18) Receive Holding Register */
+  __O  uint32_t UART_THR;       /**< (UART Offset: 0x1C) Transmit Holding Register */
+  __IO uint32_t UART_BRGR;      /**< (UART Offset: 0x20) Baud Rate Generator Register */
+  __IO uint32_t UART_CMPR;      /**< (UART Offset: 0x24) Comparison Register */
+  __I  uint8_t                        Reserved1[188];
+  __IO uint32_t UART_WPMR;      /**< (UART Offset: 0xE4) Write Protection Mode Register */
+} Uart;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief UART hardware registers */
+typedef struct {  
+  __O  UART_CR_Type                   UART_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO UART_MR_Type                   UART_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
+  __O  UART_IER_Type                  UART_IER;       /**< Offset: 0x08 ( /W  32) Interrupt Enable Register */
+  __O  UART_IDR_Type                  UART_IDR;       /**< Offset: 0x0C ( /W  32) Interrupt Disable Register */
+  __I  UART_IMR_Type                  UART_IMR;       /**< Offset: 0x10 (R/   32) Interrupt Mask Register */
+  __I  UART_SR_Type                   UART_SR;        /**< Offset: 0x14 (R/   32) Status Register */
+  __I  UART_RHR_Type                  UART_RHR;       /**< Offset: 0x18 (R/   32) Receive Holding Register */
+  __O  UART_THR_Type                  UART_THR;       /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
+  __IO UART_BRGR_Type                 UART_BRGR;      /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
+  __IO UART_CMPR_Type                 UART_CMPR;      /**< Offset: 0x24 (R/W  32) Comparison Register */
+  __I  uint8_t                        Reserved1[188];
+  __IO UART_WPMR_Type                 UART_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+} Uart;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Universal Asynchronous Receiver Transmitter */
+
+#endif /* _SAMV71_UART_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/usart.h
+++ b/asf/sam/include/samv71b/component/usart.h
@@ -176,6 +176,7 @@ typedef union {
 #define US_CR_LIN_Msk                       _U_(0x300000)                                  /**< (US_CR_LIN) Register Mask  */
 
 
+
 /* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
@@ -274,9 +275,83 @@ typedef union {
 #define US_MR_CHRL_6_BIT                    (US_MR_CHRL_6_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 6 bits Position  */
 #define US_MR_CHRL_7_BIT                    (US_MR_CHRL_7_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 7 bits Position  */
 #define US_MR_CHRL_8_BIT                    (US_MR_CHRL_8_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 8 bits Position  */
+#define US_MR_SYNC_Pos                      8                                              /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_SYNC_Msk                      (_U_(0x1) << US_MR_SYNC_Pos)                   /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_SYNC                          US_MR_SYNC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SYNC_Msk instead */
+#define US_MR_PAR_Pos                       9                                              /**< (US_MR) Parity Type Position */
+#define US_MR_PAR_Msk                       (_U_(0x7) << US_MR_PAR_Pos)                    /**< (US_MR) Parity Type Mask */
+#define US_MR_PAR(value)                    (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos))
+#define   US_MR_PAR_EVEN_Val                _U_(0x0)                                       /**< (US_MR) Even parity  */
+#define   US_MR_PAR_ODD_Val                 _U_(0x1)                                       /**< (US_MR) Odd parity  */
+#define   US_MR_PAR_SPACE_Val               _U_(0x2)                                       /**< (US_MR) Parity forced to 0 (Space)  */
+#define   US_MR_PAR_MARK_Val                _U_(0x3)                                       /**< (US_MR) Parity forced to 1 (Mark)  */
+#define   US_MR_PAR_NO_Val                  _U_(0x4)                                       /**< (US_MR) No parity  */
+#define   US_MR_PAR_MULTIDROP_Val           _U_(0x6)                                       /**< (US_MR) Multidrop mode  */
+#define US_MR_PAR_EVEN                      (US_MR_PAR_EVEN_Val << US_MR_PAR_Pos)          /**< (US_MR) Even parity Position  */
+#define US_MR_PAR_ODD                       (US_MR_PAR_ODD_Val << US_MR_PAR_Pos)           /**< (US_MR) Odd parity Position  */
+#define US_MR_PAR_SPACE                     (US_MR_PAR_SPACE_Val << US_MR_PAR_Pos)         /**< (US_MR) Parity forced to 0 (Space) Position  */
+#define US_MR_PAR_MARK                      (US_MR_PAR_MARK_Val << US_MR_PAR_Pos)          /**< (US_MR) Parity forced to 1 (Mark) Position  */
+#define US_MR_PAR_NO                        (US_MR_PAR_NO_Val << US_MR_PAR_Pos)            /**< (US_MR) No parity Position  */
+#define US_MR_PAR_MULTIDROP                 (US_MR_PAR_MULTIDROP_Val << US_MR_PAR_Pos)     /**< (US_MR) Multidrop mode Position  */
+#define US_MR_NBSTOP_Pos                    12                                             /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_NBSTOP_Msk                    (_U_(0x3) << US_MR_NBSTOP_Pos)                 /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_NBSTOP(value)                 (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
+#define   US_MR_NBSTOP_1_BIT_Val            _U_(0x0)                                       /**< (US_MR) 1 stop bit  */
+#define   US_MR_NBSTOP_1_5_BIT_Val          _U_(0x1)                                       /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
+#define   US_MR_NBSTOP_2_BIT_Val            _U_(0x2)                                       /**< (US_MR) 2 stop bits  */
+#define US_MR_NBSTOP_1_BIT                  (US_MR_NBSTOP_1_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 1 stop bit Position  */
+#define US_MR_NBSTOP_1_5_BIT                (US_MR_NBSTOP_1_5_BIT_Val << US_MR_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
+#define US_MR_NBSTOP_2_BIT                  (US_MR_NBSTOP_2_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 2 stop bits Position  */
+#define US_MR_CHMODE_Pos                    14                                             /**< (US_MR) Channel Mode Position */
+#define US_MR_CHMODE_Msk                    (_U_(0x3) << US_MR_CHMODE_Pos)                 /**< (US_MR) Channel Mode Mask */
+#define US_MR_CHMODE(value)                 (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
+#define   US_MR_CHMODE_NORMAL_Val           _U_(0x0)                                       /**< (US_MR) Normal mode  */
+#define   US_MR_CHMODE_AUTOMATIC_Val        _U_(0x1)                                       /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin.  */
+#define   US_MR_CHMODE_LOCAL_LOOPBACK_Val   _U_(0x2)                                       /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input.  */
+#define   US_MR_CHMODE_REMOTE_LOOPBACK_Val  _U_(0x3)                                       /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin.  */
+#define US_MR_CHMODE_NORMAL                 (US_MR_CHMODE_NORMAL_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_CHMODE_AUTOMATIC              (US_MR_CHMODE_AUTOMATIC_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
+#define US_MR_CHMODE_LOCAL_LOOPBACK         (US_MR_CHMODE_LOCAL_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
+#define US_MR_CHMODE_REMOTE_LOOPBACK        (US_MR_CHMODE_REMOTE_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
+#define US_MR_MSBF_Pos                      16                                             /**< (US_MR) Bit Order Position */
+#define US_MR_MSBF_Msk                      (_U_(0x1) << US_MR_MSBF_Pos)                   /**< (US_MR) Bit Order Mask */
+#define US_MR_MSBF                          US_MR_MSBF_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MSBF_Msk instead */
+#define US_MR_MODE9_Pos                     17                                             /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_MODE9_Msk                     (_U_(0x1) << US_MR_MODE9_Pos)                  /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_MODE9                         US_MR_MODE9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODE9_Msk instead */
 #define US_MR_CLKO_Pos                      18                                             /**< (US_MR) Clock Output Select Position */
 #define US_MR_CLKO_Msk                      (_U_(0x1) << US_MR_CLKO_Pos)                   /**< (US_MR) Clock Output Select Mask */
 #define US_MR_CLKO                          US_MR_CLKO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_CLKO_Msk instead */
+#define US_MR_OVER_Pos                      19                                             /**< (US_MR) Oversampling Mode Position */
+#define US_MR_OVER_Msk                      (_U_(0x1) << US_MR_OVER_Pos)                   /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_OVER                          US_MR_OVER_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_OVER_Msk instead */
+#define US_MR_INACK_Pos                     20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_INACK_Msk                     (_U_(0x1) << US_MR_INACK_Pos)                  /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_INACK                         US_MR_INACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INACK_Msk instead */
+#define US_MR_DSNACK_Pos                    21                                             /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_DSNACK_Msk                    (_U_(0x1) << US_MR_DSNACK_Pos)                 /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_DSNACK                        US_MR_DSNACK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_DSNACK_Msk instead */
+#define US_MR_VAR_SYNC_Pos                  22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_VAR_SYNC_Msk                  (_U_(0x1) << US_MR_VAR_SYNC_Pos)               /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_VAR_SYNC                      US_MR_VAR_SYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_VAR_SYNC_Msk instead */
+#define US_MR_INVDATA_Pos                   23                                             /**< (US_MR) Inverted Data Position */
+#define US_MR_INVDATA_Msk                   (_U_(0x1) << US_MR_INVDATA_Pos)                /**< (US_MR) Inverted Data Mask */
+#define US_MR_INVDATA                       US_MR_INVDATA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INVDATA_Msk instead */
+#define US_MR_MAX_ITERATION_Pos             24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_MAX_ITERATION_Msk             (_U_(0x7) << US_MR_MAX_ITERATION_Pos)          /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_MAX_ITERATION(value)          (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
+#define US_MR_FILTER_Pos                    28                                             /**< (US_MR) Receive Line Filter Position */
+#define US_MR_FILTER_Msk                    (_U_(0x1) << US_MR_FILTER_Pos)                 /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_FILTER                        US_MR_FILTER_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_FILTER_Msk instead */
+#define US_MR_MAN_Pos                       29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_MAN_Msk                       (_U_(0x1) << US_MR_MAN_Pos)                    /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_MAN                           US_MR_MAN_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MAN_Msk instead */
+#define US_MR_MODSYNC_Pos                   30                                             /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_MODSYNC_Msk                   (_U_(0x1) << US_MR_MODSYNC_Pos)                /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_MODSYNC                       US_MR_MODSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODSYNC_Msk instead */
+#define US_MR_ONEBIT_Pos                    31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_ONEBIT_Msk                    (_U_(0x1) << US_MR_ONEBIT_Pos)                 /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_ONEBIT                        US_MR_ONEBIT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_ONEBIT_Msk instead */
 #define US_MR_MASK                          _U_(0x400FF)                                   /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
 #define US_MR_Msk                           _U_(0x400FF)                                   /**< (US_MR) Register Mask  */
 
@@ -457,12 +532,45 @@ typedef union {
 #define US_IER_TXRDY_Pos                    1                                              /**< (US_IER) TXRDY Interrupt Enable Position */
 #define US_IER_TXRDY_Msk                    (_U_(0x1) << US_IER_TXRDY_Pos)                 /**< (US_IER) TXRDY Interrupt Enable Mask */
 #define US_IER_TXRDY                        US_IER_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXRDY_Msk instead */
+#define US_IER_RXBRK_Pos                    2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_RXBRK_Msk                    (_U_(0x1) << US_IER_RXBRK_Pos)                 /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_RXBRK                        US_IER_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXBRK_Msk instead */
 #define US_IER_OVRE_Pos                     5                                              /**< (US_IER) Overrun Error Interrupt Enable Position */
 #define US_IER_OVRE_Msk                     (_U_(0x1) << US_IER_OVRE_Pos)                  /**< (US_IER) Overrun Error Interrupt Enable Mask */
 #define US_IER_OVRE                         US_IER_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_OVRE_Msk instead */
+#define US_IER_FRAME_Pos                    6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_FRAME_Msk                    (_U_(0x1) << US_IER_FRAME_Pos)                 /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_FRAME                        US_IER_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_FRAME_Msk instead */
+#define US_IER_PARE_Pos                     7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_PARE_Msk                     (_U_(0x1) << US_IER_PARE_Pos)                  /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_PARE                         US_IER_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_PARE_Msk instead */
+#define US_IER_TIMEOUT_Pos                  8                                              /**< (US_IER) Timeout Interrupt Enable Position */
+#define US_IER_TIMEOUT_Msk                  (_U_(0x1) << US_IER_TIMEOUT_Pos)               /**< (US_IER) Timeout Interrupt Enable Mask */
+#define US_IER_TIMEOUT                      US_IER_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TIMEOUT_Msk instead */
 #define US_IER_TXEMPTY_Pos                  9                                              /**< (US_IER) TXEMPTY Interrupt Enable Position */
 #define US_IER_TXEMPTY_Msk                  (_U_(0x1) << US_IER_TXEMPTY_Pos)               /**< (US_IER) TXEMPTY Interrupt Enable Mask */
 #define US_IER_TXEMPTY                      US_IER_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXEMPTY_Msk instead */
+#define US_IER_ITER_Pos                     10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_ITER_Msk                     (_U_(0x1) << US_IER_ITER_Pos)                  /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_ITER                         US_IER_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_ITER_Msk instead */
+#define US_IER_NACK_Pos                     13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_NACK_Msk                     (_U_(0x1) << US_IER_NACK_Pos)                  /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_NACK                         US_IER_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_NACK_Msk instead */
+#define US_IER_RIIC_Pos                     16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_RIIC_Msk                     (_U_(0x1) << US_IER_RIIC_Pos)                  /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_RIIC                         US_IER_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RIIC_Msk instead */
+#define US_IER_DSRIC_Pos                    17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_DSRIC_Msk                    (_U_(0x1) << US_IER_DSRIC_Pos)                 /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_DSRIC                        US_IER_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DSRIC_Msk instead */
+#define US_IER_DCDIC_Pos                    18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_DCDIC_Msk                    (_U_(0x1) << US_IER_DCDIC_Pos)                 /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_DCDIC                        US_IER_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DCDIC_Msk instead */
+#define US_IER_CTSIC_Pos                    19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_CTSIC_Msk                    (_U_(0x1) << US_IER_CTSIC_Pos)                 /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_CTSIC                        US_IER_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_CTSIC_Msk instead */
+#define US_IER_MANE_Pos                     24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_MANE_Msk                     (_U_(0x1) << US_IER_MANE_Pos)                  /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_MANE                         US_IER_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_MANE_Msk instead */
 #define US_IER_MASK                         _U_(0x223)                                     /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
 #define US_IER_Msk                          _U_(0x223)                                     /**< (US_IER) Register Mask  */
 
@@ -667,12 +775,30 @@ typedef union {
 #define US_IDR_TXRDY_Pos                    1                                              /**< (US_IDR) TXRDY Interrupt Disable Position */
 #define US_IDR_TXRDY_Msk                    (_U_(0x1) << US_IDR_TXRDY_Pos)                 /**< (US_IDR) TXRDY Interrupt Disable Mask */
 #define US_IDR_TXRDY                        US_IDR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXRDY_Msk instead */
+#define US_IDR_RXBRK_Pos                    2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_RXBRK_Msk                    (_U_(0x1) << US_IDR_RXBRK_Pos)                 /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_RXBRK                        US_IDR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXBRK_Msk instead */
 #define US_IDR_OVRE_Pos                     5                                              /**< (US_IDR) Overrun Error Interrupt Enable Position */
 #define US_IDR_OVRE_Msk                     (_U_(0x1) << US_IDR_OVRE_Pos)                  /**< (US_IDR) Overrun Error Interrupt Enable Mask */
 #define US_IDR_OVRE                         US_IDR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_OVRE_Msk instead */
+#define US_IDR_FRAME_Pos                    6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_FRAME_Msk                    (_U_(0x1) << US_IDR_FRAME_Pos)                 /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_FRAME                        US_IDR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_FRAME_Msk instead */
+#define US_IDR_PARE_Pos                     7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_PARE_Msk                     (_U_(0x1) << US_IDR_PARE_Pos)                  /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_PARE                         US_IDR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_PARE_Msk instead */
+#define US_IDR_TIMEOUT_Pos                  8                                              /**< (US_IDR) Timeout Interrupt Disable Position */
+#define US_IDR_TIMEOUT_Msk                  (_U_(0x1) << US_IDR_TIMEOUT_Pos)               /**< (US_IDR) Timeout Interrupt Disable Mask */
+#define US_IDR_TIMEOUT                      US_IDR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TIMEOUT_Msk instead */
 #define US_IDR_TXEMPTY_Pos                  9                                              /**< (US_IDR) TXEMPTY Interrupt Disable Position */
 #define US_IDR_TXEMPTY_Msk                  (_U_(0x1) << US_IDR_TXEMPTY_Pos)               /**< (US_IDR) TXEMPTY Interrupt Disable Mask */
 #define US_IDR_TXEMPTY                      US_IDR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXEMPTY_Msk instead */
+#define US_IDR_ITER_Pos                     10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_ITER_Msk                     (_U_(0x1) << US_IDR_ITER_Pos)                  /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_ITER                         US_IDR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_ITER_Msk instead */
+#define US_IDR_NACK_Pos                     13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_NACK_Msk                     (_U_(0x1) << US_IDR_NACK_Pos)                  /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_NACK                         US_IDR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_NACK_Msk instead */
 #define US_IDR_RIIC_Pos                     16                                             /**< (US_IDR) Ring Indicator Input Change Disable Position */
 #define US_IDR_RIIC_Msk                     (_U_(0x1) << US_IDR_RIIC_Pos)                  /**< (US_IDR) Ring Indicator Input Change Disable Mask */
 #define US_IDR_RIIC                         US_IDR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RIIC_Msk instead */
@@ -682,6 +808,12 @@ typedef union {
 #define US_IDR_DCDIC_Pos                    18                                             /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Position */
 #define US_IDR_DCDIC_Msk                    (_U_(0x1) << US_IDR_DCDIC_Pos)                 /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Mask */
 #define US_IDR_DCDIC                        US_IDR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DCDIC_Msk instead */
+#define US_IDR_CTSIC_Pos                    19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_CTSIC_Msk                    (_U_(0x1) << US_IDR_CTSIC_Pos)                 /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_CTSIC                        US_IDR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_CTSIC_Msk instead */
+#define US_IDR_MANE_Pos                     24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_MANE_Msk                     (_U_(0x1) << US_IDR_MANE_Pos)                  /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_MANE                         US_IDR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_MANE_Msk instead */
 #define US_IDR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
 #define US_IDR_Msk                          _U_(0x70223)                                   /**< (US_IDR) Register Mask  */
 
@@ -1094,12 +1226,30 @@ typedef union {
 #define US_CSR_TXRDY_Pos                    1                                              /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Position */
 #define US_CSR_TXRDY_Msk                    (_U_(0x1) << US_CSR_TXRDY_Pos)                 /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Mask */
 #define US_CSR_TXRDY                        US_CSR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXRDY_Msk instead */
+#define US_CSR_RXBRK_Pos                    2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_RXBRK_Msk                    (_U_(0x1) << US_CSR_RXBRK_Pos)                 /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_RXBRK                        US_CSR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXBRK_Msk instead */
 #define US_CSR_OVRE_Pos                     5                                              /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
 #define US_CSR_OVRE_Msk                     (_U_(0x1) << US_CSR_OVRE_Pos)                  /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
 #define US_CSR_OVRE                         US_CSR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_OVRE_Msk instead */
+#define US_CSR_FRAME_Pos                    6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_FRAME_Msk                    (_U_(0x1) << US_CSR_FRAME_Pos)                 /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_FRAME                        US_CSR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_FRAME_Msk instead */
+#define US_CSR_PARE_Pos                     7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_PARE_Msk                     (_U_(0x1) << US_CSR_PARE_Pos)                  /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_PARE                         US_CSR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_PARE_Msk instead */
+#define US_CSR_TIMEOUT_Pos                  8                                              /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_TIMEOUT_Msk                  (_U_(0x1) << US_CSR_TIMEOUT_Pos)               /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_TIMEOUT                      US_CSR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TIMEOUT_Msk instead */
 #define US_CSR_TXEMPTY_Pos                  9                                              /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Position */
 #define US_CSR_TXEMPTY_Msk                  (_U_(0x1) << US_CSR_TXEMPTY_Pos)               /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Mask */
 #define US_CSR_TXEMPTY                      US_CSR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXEMPTY_Msk instead */
+#define US_CSR_ITER_Pos                     10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_ITER_Msk                     (_U_(0x1) << US_CSR_ITER_Pos)                  /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_ITER                         US_CSR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_ITER_Msk instead */
+#define US_CSR_NACK_Pos                     13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_NACK_Msk                     (_U_(0x1) << US_CSR_NACK_Pos)                  /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_NACK                         US_CSR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_NACK_Msk instead */
 #define US_CSR_RIIC_Pos                     16                                             /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Position */
 #define US_CSR_RIIC_Msk                     (_U_(0x1) << US_CSR_RIIC_Pos)                  /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Mask */
 #define US_CSR_RIIC                         US_CSR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RIIC_Msk instead */
@@ -1109,6 +1259,24 @@ typedef union {
 #define US_CSR_DCDIC_Pos                    18                                             /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Position */
 #define US_CSR_DCDIC_Msk                    (_U_(0x1) << US_CSR_DCDIC_Pos)                 /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Mask */
 #define US_CSR_DCDIC                        US_CSR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCDIC_Msk instead */
+#define US_CSR_CTSIC_Pos                    19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_CTSIC_Msk                    (_U_(0x1) << US_CSR_CTSIC_Pos)                 /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_CTSIC                        US_CSR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTSIC_Msk instead */
+#define US_CSR_RI_Pos                       20                                             /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_RI_Msk                       (_U_(0x1) << US_CSR_RI_Pos)                    /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_RI                           US_CSR_RI_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RI_Msk instead */
+#define US_CSR_DSR_Pos                      21                                             /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_DSR_Msk                      (_U_(0x1) << US_CSR_DSR_Pos)                   /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_DSR                          US_CSR_DSR_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSR_Msk instead */
+#define US_CSR_DCD_Pos                      22                                             /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_DCD_Msk                      (_U_(0x1) << US_CSR_DCD_Pos)                   /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_DCD                          US_CSR_DCD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCD_Msk instead */
+#define US_CSR_CTS_Pos                      23                                             /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_CTS_Msk                      (_U_(0x1) << US_CSR_CTS_Pos)                   /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_CTS                          US_CSR_CTS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTS_Msk instead */
+#define US_CSR_MANERR_Pos                   24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_MANERR_Msk                   (_U_(0x1) << US_CSR_MANERR_Pos)                /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_MANERR                       US_CSR_MANERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_MANERR_Msk instead */
 #define US_CSR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
 #define US_CSR_Msk                          _U_(0x70223)                                   /**< (US_CSR) Register Mask  */
 

--- a/asf/sam/include/samv71b/component/usart.h
+++ b/asf/sam/include/samv71b/component/usart.h
@@ -1,0 +1,2066 @@
+/**
+ * \file
+ *
+ * \brief Component description for USART
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USART_COMPONENT_H_
+#define _SAMV71_USART_COMPONENT_H_
+#define _SAMV71_USART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Universal Synchronous Asynchronous Receiver Transmitter
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USART */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define USART_6089                       /**< (USART) Module ID */
+#define REV_USART ZW                     /**< (USART) Module revision */
+
+/* -------- US_CR : (USART Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RSTRX:1;                   /**< bit:      2  Reset Receiver                           */
+    uint32_t RSTTX:1;                   /**< bit:      3  Reset Transmitter                        */
+    uint32_t RXEN:1;                    /**< bit:      4  Receiver Enable                          */
+    uint32_t RXDIS:1;                   /**< bit:      5  Receiver Disable                         */
+    uint32_t TXEN:1;                    /**< bit:      6  Transmitter Enable                       */
+    uint32_t TXDIS:1;                   /**< bit:      7  Transmitter Disable                      */
+    uint32_t RSTSTA:1;                  /**< bit:      8  Reset Status Bits                        */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
+    uint32_t STTBRK:1;                  /**< bit:      9  Start Break                              */
+    uint32_t STPBRK:1;                  /**< bit:     10  Stop Break                               */
+    uint32_t STTTO:1;                   /**< bit:     11  Clear TIMEOUT Flag and Start Timeout After Next Character Received */
+    uint32_t SENDA:1;                   /**< bit:     12  Send Address                             */
+    uint32_t RSTIT:1;                   /**< bit:     13  Reset Iterations                         */
+    uint32_t RSTNACK:1;                 /**< bit:     14  Reset Non Acknowledge                    */
+    uint32_t RETTO:1;                   /**< bit:     15  Start Timeout Immediately                */
+    uint32_t DTREN:1;                   /**< bit:     16  Data Terminal Ready Enable               */
+    uint32_t DTRDIS:1;                  /**< bit:     17  Data Terminal Ready Disable              */
+    uint32_t RTSEN:1;                   /**< bit:     18  Request to Send Enable                   */
+    uint32_t RTSDIS:1;                  /**< bit:     19  Request to Send Disable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // SPI mode
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t FCS:1;                     /**< bit:     18  Force SPI Chip Select                    */
+    uint32_t RCS:1;                     /**< bit:     19  Release SPI Chip Select                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :20;                       /**< bit:  0..19  Reserved */
+    uint32_t LINABT:1;                  /**< bit:     20  Abort LIN Transmission                   */
+    uint32_t LINWKUP:1;                 /**< bit:     21  Send LIN Wakeup Signal                   */
+    uint32_t :10;                       /**< bit: 22..31  Reserved */
+  } LIN;                                /**< Structure used for LIN mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CR_OFFSET                        (0x00)                                        /**<  (US_CR) Control Register  Offset */
+
+#define US_CR_RSTRX_Pos                     2                                              /**< (US_CR) Reset Receiver Position */
+#define US_CR_RSTRX_Msk                     (_U_(0x1) << US_CR_RSTRX_Pos)                  /**< (US_CR) Reset Receiver Mask */
+#define US_CR_RSTRX                         US_CR_RSTRX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTRX_Msk instead */
+#define US_CR_RSTTX_Pos                     3                                              /**< (US_CR) Reset Transmitter Position */
+#define US_CR_RSTTX_Msk                     (_U_(0x1) << US_CR_RSTTX_Pos)                  /**< (US_CR) Reset Transmitter Mask */
+#define US_CR_RSTTX                         US_CR_RSTTX_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTTX_Msk instead */
+#define US_CR_RXEN_Pos                      4                                              /**< (US_CR) Receiver Enable Position */
+#define US_CR_RXEN_Msk                      (_U_(0x1) << US_CR_RXEN_Pos)                   /**< (US_CR) Receiver Enable Mask */
+#define US_CR_RXEN                          US_CR_RXEN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RXEN_Msk instead */
+#define US_CR_RXDIS_Pos                     5                                              /**< (US_CR) Receiver Disable Position */
+#define US_CR_RXDIS_Msk                     (_U_(0x1) << US_CR_RXDIS_Pos)                  /**< (US_CR) Receiver Disable Mask */
+#define US_CR_RXDIS                         US_CR_RXDIS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RXDIS_Msk instead */
+#define US_CR_TXEN_Pos                      6                                              /**< (US_CR) Transmitter Enable Position */
+#define US_CR_TXEN_Msk                      (_U_(0x1) << US_CR_TXEN_Pos)                   /**< (US_CR) Transmitter Enable Mask */
+#define US_CR_TXEN                          US_CR_TXEN_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_TXEN_Msk instead */
+#define US_CR_TXDIS_Pos                     7                                              /**< (US_CR) Transmitter Disable Position */
+#define US_CR_TXDIS_Msk                     (_U_(0x1) << US_CR_TXDIS_Pos)                  /**< (US_CR) Transmitter Disable Mask */
+#define US_CR_TXDIS                         US_CR_TXDIS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_TXDIS_Msk instead */
+#define US_CR_RSTSTA_Pos                    8                                              /**< (US_CR) Reset Status Bits Position */
+#define US_CR_RSTSTA_Msk                    (_U_(0x1) << US_CR_RSTSTA_Pos)                 /**< (US_CR) Reset Status Bits Mask */
+#define US_CR_RSTSTA                        US_CR_RSTSTA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTSTA_Msk instead */
+#define US_CR_MASK                          _U_(0x1FC)                                     /**< \deprecated (US_CR) Register MASK  (Use US_CR_Msk instead)  */
+#define US_CR_Msk                           _U_(0x1FC)                                     /**< (US_CR) Register Mask  */
+
+/* USART mode */
+#define US_CR_USART_STTBRK_Pos              9                                              /**< (US_CR) Start Break Position */
+#define US_CR_USART_STTBRK_Msk              (_U_(0x1) << US_CR_USART_STTBRK_Pos)           /**< (US_CR) Start Break Mask */
+#define US_CR_USART_STTBRK                  US_CR_USART_STTBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STTBRK_Msk instead */
+#define US_CR_USART_STPBRK_Pos              10                                             /**< (US_CR) Stop Break Position */
+#define US_CR_USART_STPBRK_Msk              (_U_(0x1) << US_CR_USART_STPBRK_Pos)           /**< (US_CR) Stop Break Mask */
+#define US_CR_USART_STPBRK                  US_CR_USART_STPBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STPBRK_Msk instead */
+#define US_CR_USART_STTTO_Pos               11                                             /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Position */
+#define US_CR_USART_STTTO_Msk               (_U_(0x1) << US_CR_USART_STTTO_Pos)            /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Mask */
+#define US_CR_USART_STTTO                   US_CR_USART_STTTO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STTTO_Msk instead */
+#define US_CR_USART_SENDA_Pos               12                                             /**< (US_CR) Send Address Position */
+#define US_CR_USART_SENDA_Msk               (_U_(0x1) << US_CR_USART_SENDA_Pos)            /**< (US_CR) Send Address Mask */
+#define US_CR_USART_SENDA                   US_CR_USART_SENDA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_SENDA_Msk instead */
+#define US_CR_USART_RSTIT_Pos               13                                             /**< (US_CR) Reset Iterations Position */
+#define US_CR_USART_RSTIT_Msk               (_U_(0x1) << US_CR_USART_RSTIT_Pos)            /**< (US_CR) Reset Iterations Mask */
+#define US_CR_USART_RSTIT                   US_CR_USART_RSTIT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RSTIT_Msk instead */
+#define US_CR_USART_RSTNACK_Pos             14                                             /**< (US_CR) Reset Non Acknowledge Position */
+#define US_CR_USART_RSTNACK_Msk             (_U_(0x1) << US_CR_USART_RSTNACK_Pos)          /**< (US_CR) Reset Non Acknowledge Mask */
+#define US_CR_USART_RSTNACK                 US_CR_USART_RSTNACK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RSTNACK_Msk instead */
+#define US_CR_USART_RETTO_Pos               15                                             /**< (US_CR) Start Timeout Immediately Position */
+#define US_CR_USART_RETTO_Msk               (_U_(0x1) << US_CR_USART_RETTO_Pos)            /**< (US_CR) Start Timeout Immediately Mask */
+#define US_CR_USART_RETTO                   US_CR_USART_RETTO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RETTO_Msk instead */
+#define US_CR_USART_DTREN_Pos               16                                             /**< (US_CR) Data Terminal Ready Enable Position */
+#define US_CR_USART_DTREN_Msk               (_U_(0x1) << US_CR_USART_DTREN_Pos)            /**< (US_CR) Data Terminal Ready Enable Mask */
+#define US_CR_USART_DTREN                   US_CR_USART_DTREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_DTREN_Msk instead */
+#define US_CR_USART_DTRDIS_Pos              17                                             /**< (US_CR) Data Terminal Ready Disable Position */
+#define US_CR_USART_DTRDIS_Msk              (_U_(0x1) << US_CR_USART_DTRDIS_Pos)           /**< (US_CR) Data Terminal Ready Disable Mask */
+#define US_CR_USART_DTRDIS                  US_CR_USART_DTRDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_DTRDIS_Msk instead */
+#define US_CR_USART_RTSEN_Pos               18                                             /**< (US_CR) Request to Send Enable Position */
+#define US_CR_USART_RTSEN_Msk               (_U_(0x1) << US_CR_USART_RTSEN_Pos)            /**< (US_CR) Request to Send Enable Mask */
+#define US_CR_USART_RTSEN                   US_CR_USART_RTSEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RTSEN_Msk instead */
+#define US_CR_USART_RTSDIS_Pos              19                                             /**< (US_CR) Request to Send Disable Position */
+#define US_CR_USART_RTSDIS_Msk              (_U_(0x1) << US_CR_USART_RTSDIS_Pos)           /**< (US_CR) Request to Send Disable Mask */
+#define US_CR_USART_RTSDIS                  US_CR_USART_RTSDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RTSDIS_Msk instead */
+#define US_CR_USART_MASK                    _U_(0xFFE00)                                   /**< \deprecated (US_CR_USART) Register MASK  (Use US_CR_USART_Msk instead)  */
+#define US_CR_USART_Msk                     _U_(0xFFE00)                                   /**< (US_CR_USART) Register Mask  */
+
+/* SPI mode */
+#define US_CR_SPI_FCS_Pos                   18                                             /**< (US_CR) Force SPI Chip Select Position */
+#define US_CR_SPI_FCS_Msk                   (_U_(0x1) << US_CR_SPI_FCS_Pos)                /**< (US_CR) Force SPI Chip Select Mask */
+#define US_CR_SPI_FCS                       US_CR_SPI_FCS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SPI_FCS_Msk instead */
+#define US_CR_SPI_RCS_Pos                   19                                             /**< (US_CR) Release SPI Chip Select Position */
+#define US_CR_SPI_RCS_Msk                   (_U_(0x1) << US_CR_SPI_RCS_Pos)                /**< (US_CR) Release SPI Chip Select Mask */
+#define US_CR_SPI_RCS                       US_CR_SPI_RCS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SPI_RCS_Msk instead */
+#define US_CR_SPI_MASK                      _U_(0xC0000)                                   /**< \deprecated (US_CR_SPI) Register MASK  (Use US_CR_SPI_Msk instead)  */
+#define US_CR_SPI_Msk                       _U_(0xC0000)                                   /**< (US_CR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_CR_LIN_LINABT_Pos                20                                             /**< (US_CR) Abort LIN Transmission Position */
+#define US_CR_LIN_LINABT_Msk                (_U_(0x1) << US_CR_LIN_LINABT_Pos)             /**< (US_CR) Abort LIN Transmission Mask */
+#define US_CR_LIN_LINABT                    US_CR_LIN_LINABT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LIN_LINABT_Msk instead */
+#define US_CR_LIN_LINWKUP_Pos               21                                             /**< (US_CR) Send LIN Wakeup Signal Position */
+#define US_CR_LIN_LINWKUP_Msk               (_U_(0x1) << US_CR_LIN_LINWKUP_Pos)            /**< (US_CR) Send LIN Wakeup Signal Mask */
+#define US_CR_LIN_LINWKUP                   US_CR_LIN_LINWKUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LIN_LINWKUP_Msk instead */
+#define US_CR_LIN_MASK                      _U_(0x300000)                                  /**< \deprecated (US_CR_LIN) Register MASK  (Use US_CR_LIN_Msk instead)  */
+#define US_CR_LIN_Msk                       _U_(0x300000)                                  /**< (US_CR_LIN) Register Mask  */
+
+
+/* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t USART_MODE:4;              /**< bit:   0..3  USART Mode of Operation                  */
+    uint32_t USCLKS:2;                  /**< bit:   4..5  Clock Selection                          */
+    uint32_t CHRL:2;                    /**< bit:   6..7  Character Length                         */
+    uint32_t :10;                       /**< bit:  8..17  Reserved */
+    uint32_t CLKO:1;                    /**< bit:     18  Clock Output Select                      */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SYNC:1;                    /**< bit:      8  Synchronous Mode Select                  */
+    uint32_t PAR:3;                     /**< bit:  9..11  Parity Type                              */
+    uint32_t NBSTOP:2;                  /**< bit: 12..13  Number of Stop Bits                      */
+    uint32_t CHMODE:2;                  /**< bit: 14..15  Channel Mode                             */
+    uint32_t MSBF:1;                    /**< bit:     16  Bit Order                                */
+    uint32_t MODE9:1;                   /**< bit:     17  9-bit Character Length                   */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t OVER:1;                    /**< bit:     19  Oversampling Mode                        */
+    uint32_t INACK:1;                   /**< bit:     20  Inhibit Non Acknowledge                  */
+    uint32_t DSNACK:1;                  /**< bit:     21  Disable Successive NACK                  */
+    uint32_t VAR_SYNC:1;                /**< bit:     22  Variable Synchronization of Command/Data Sync Start Frame Delimiter */
+    uint32_t INVDATA:1;                 /**< bit:     23  Inverted Data                            */
+    uint32_t MAX_ITERATION:3;           /**< bit: 24..26  Maximum Number of Automatic Iteration    */
+    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t FILTER:1;                  /**< bit:     28  Receive Line Filter                      */
+    uint32_t MAN:1;                     /**< bit:     29  Manchester Encoder/Decoder Enable        */
+    uint32_t MODSYNC:1;                 /**< bit:     30  Manchester Synchronization Mode          */
+    uint32_t ONEBIT:1;                  /**< bit:     31  Start Frame Delimiter Selector           */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // SPI mode
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CPHA:1;                    /**< bit:      8  SPI Clock Phase                          */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t CPOL:1;                    /**< bit:     16  SPI Clock Polarity                       */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t WRDBT:1;                   /**< bit:     20  Wait Read Data Before Transfer           */
+    uint32_t :11;                       /**< bit: 21..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MR_OFFSET                        (0x04)                                        /**<  (US_MR) Mode Register  Offset */
+
+#define US_MR_USART_MODE_Pos                0                                              /**< (US_MR) USART Mode of Operation Position */
+#define US_MR_USART_MODE_Msk                (_U_(0xF) << US_MR_USART_MODE_Pos)             /**< (US_MR) USART Mode of Operation Mask */
+#define US_MR_USART_MODE(value)             (US_MR_USART_MODE_Msk & ((value) << US_MR_USART_MODE_Pos))
+#define   US_MR_USART_MODE_NORMAL_Val       _U_(0x0)                                       /**< (US_MR) Normal mode  */
+#define   US_MR_USART_MODE_RS485_Val        _U_(0x1)                                       /**< (US_MR) RS485  */
+#define   US_MR_USART_MODE_HW_HANDSHAKING_Val _U_(0x2)                                       /**< (US_MR) Hardware handshaking  */
+#define   US_MR_USART_MODE_MODEM_Val        _U_(0x3)                                       /**< (US_MR) Modem  */
+#define   US_MR_USART_MODE_IS07816_T_0_Val  _U_(0x4)                                       /**< (US_MR) IS07816 Protocol: T = 0  */
+#define   US_MR_USART_MODE_IS07816_T_1_Val  _U_(0x6)                                       /**< (US_MR) IS07816 Protocol: T = 1  */
+#define   US_MR_USART_MODE_IRDA_Val         _U_(0x8)                                       /**< (US_MR) IrDA  */
+#define   US_MR_USART_MODE_LON_Val          _U_(0x9)                                       /**< (US_MR) LON  */
+#define   US_MR_USART_MODE_LIN_MASTER_Val   _U_(0xA)                                       /**< (US_MR) LIN Master mode  */
+#define   US_MR_USART_MODE_LIN_SLAVE_Val    _U_(0xB)                                       /**< (US_MR) LIN Slave mode  */
+#define   US_MR_USART_MODE_SPI_MASTER_Val   _U_(0xE)                                       /**< (US_MR) SPI Master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2)  */
+#define   US_MR_USART_MODE_SPI_SLAVE_Val    _U_(0xF)                                       /**< (US_MR) SPI Slave mode  */
+#define US_MR_USART_MODE_NORMAL             (US_MR_USART_MODE_NORMAL_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_USART_MODE_RS485              (US_MR_USART_MODE_RS485_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) RS485 Position  */
+#define US_MR_USART_MODE_HW_HANDSHAKING     (US_MR_USART_MODE_HW_HANDSHAKING_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Hardware handshaking Position  */
+#define US_MR_USART_MODE_MODEM              (US_MR_USART_MODE_MODEM_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Modem Position  */
+#define US_MR_USART_MODE_IS07816_T_0        (US_MR_USART_MODE_IS07816_T_0_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 0 Position  */
+#define US_MR_USART_MODE_IS07816_T_1        (US_MR_USART_MODE_IS07816_T_1_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 1 Position  */
+#define US_MR_USART_MODE_IRDA               (US_MR_USART_MODE_IRDA_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IrDA Position  */
+#define US_MR_USART_MODE_LON                (US_MR_USART_MODE_LON_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LON Position  */
+#define US_MR_USART_MODE_LIN_MASTER         (US_MR_USART_MODE_LIN_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN Master mode Position  */
+#define US_MR_USART_MODE_LIN_SLAVE          (US_MR_USART_MODE_LIN_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN Slave mode Position  */
+#define US_MR_USART_MODE_SPI_MASTER         (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2) Position  */
+#define US_MR_USART_MODE_SPI_SLAVE          (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Slave mode Position  */
+#define US_MR_USCLKS_Pos                    4                                              /**< (US_MR) Clock Selection Position */
+#define US_MR_USCLKS_Msk                    (_U_(0x3) << US_MR_USCLKS_Pos)                 /**< (US_MR) Clock Selection Mask */
+#define US_MR_USCLKS(value)                 (US_MR_USCLKS_Msk & ((value) << US_MR_USCLKS_Pos))
+#define   US_MR_USCLKS_MCK_Val              _U_(0x0)                                       /**< (US_MR) Peripheral clock is selected  */
+#define   US_MR_USCLKS_DIV_Val              _U_(0x1)                                       /**< (US_MR) Peripheral clock divided (DIV = 8) is selected  */
+#define   US_MR_USCLKS_PCK_Val              _U_(0x2)                                       /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1.  */
+#define   US_MR_USCLKS_SCK_Val              _U_(0x3)                                       /**< (US_MR) Serial clock (SCK) is selected  */
+#define US_MR_USCLKS_MCK                    (US_MR_USCLKS_MCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock is selected Position  */
+#define US_MR_USCLKS_DIV                    (US_MR_USCLKS_DIV_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock divided (DIV = 8) is selected Position  */
+#define US_MR_USCLKS_PCK                    (US_MR_USCLKS_PCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1. Position  */
+#define US_MR_USCLKS_SCK                    (US_MR_USCLKS_SCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Serial clock (SCK) is selected Position  */
+#define US_MR_CHRL_Pos                      6                                              /**< (US_MR) Character Length Position */
+#define US_MR_CHRL_Msk                      (_U_(0x3) << US_MR_CHRL_Pos)                   /**< (US_MR) Character Length Mask */
+#define US_MR_CHRL(value)                   (US_MR_CHRL_Msk & ((value) << US_MR_CHRL_Pos))
+#define   US_MR_CHRL_5_BIT_Val              _U_(0x0)                                       /**< (US_MR) Character length is 5 bits  */
+#define   US_MR_CHRL_6_BIT_Val              _U_(0x1)                                       /**< (US_MR) Character length is 6 bits  */
+#define   US_MR_CHRL_7_BIT_Val              _U_(0x2)                                       /**< (US_MR) Character length is 7 bits  */
+#define   US_MR_CHRL_8_BIT_Val              _U_(0x3)                                       /**< (US_MR) Character length is 8 bits  */
+#define US_MR_CHRL_5_BIT                    (US_MR_CHRL_5_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 5 bits Position  */
+#define US_MR_CHRL_6_BIT                    (US_MR_CHRL_6_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 6 bits Position  */
+#define US_MR_CHRL_7_BIT                    (US_MR_CHRL_7_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 7 bits Position  */
+#define US_MR_CHRL_8_BIT                    (US_MR_CHRL_8_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 8 bits Position  */
+#define US_MR_CLKO_Pos                      18                                             /**< (US_MR) Clock Output Select Position */
+#define US_MR_CLKO_Msk                      (_U_(0x1) << US_MR_CLKO_Pos)                   /**< (US_MR) Clock Output Select Mask */
+#define US_MR_CLKO                          US_MR_CLKO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_CLKO_Msk instead */
+#define US_MR_MASK                          _U_(0x400FF)                                   /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
+#define US_MR_Msk                           _U_(0x400FF)                                   /**< (US_MR) Register Mask  */
+
+/* USART mode */
+#define US_MR_USART_SYNC_Pos                8                                              /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_USART_SYNC_Msk                (_U_(0x1) << US_MR_USART_SYNC_Pos)             /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_USART_SYNC                    US_MR_USART_SYNC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_SYNC_Msk instead */
+#define US_MR_USART_PAR_Pos                 9                                              /**< (US_MR) Parity Type Position */
+#define US_MR_USART_PAR_Msk                 (_U_(0x7) << US_MR_USART_PAR_Pos)              /**< (US_MR) Parity Type Mask */
+#define US_MR_USART_PAR(value)              (US_MR_USART_PAR_Msk & ((value) << US_MR_USART_PAR_Pos))
+#define   US_MR_USART_PAR_EVEN_Val          _U_(0x0)                                       /**< (US_MR) USART Even parity  */
+#define   US_MR_USART_PAR_ODD_Val           _U_(0x1)                                       /**< (US_MR) USART Odd parity  */
+#define   US_MR_USART_PAR_SPACE_Val         _U_(0x2)                                       /**< (US_MR) USART Parity forced to 0 (Space)  */
+#define   US_MR_USART_PAR_MARK_Val          _U_(0x3)                                       /**< (US_MR) USART Parity forced to 1 (Mark)  */
+#define   US_MR_USART_PAR_NO_Val            _U_(0x4)                                       /**< (US_MR) USART No parity  */
+#define   US_MR_USART_PAR_MULTIDROP_Val     _U_(0x6)                                       /**< (US_MR) USART Multidrop mode  */
+#define US_MR_USART_PAR_EVEN                (US_MR_USART_PAR_EVEN_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Even parity Position  */
+#define US_MR_USART_PAR_ODD                 (US_MR_USART_PAR_ODD_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Odd parity Position  */
+#define US_MR_USART_PAR_SPACE               (US_MR_USART_PAR_SPACE_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Parity forced to 0 (Space) Position  */
+#define US_MR_USART_PAR_MARK                (US_MR_USART_PAR_MARK_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Parity forced to 1 (Mark) Position  */
+#define US_MR_USART_PAR_NO                  (US_MR_USART_PAR_NO_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) No parity Position  */
+#define US_MR_USART_PAR_MULTIDROP           (US_MR_USART_PAR_MULTIDROP_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Multidrop mode Position  */
+#define US_MR_USART_NBSTOP_Pos              12                                             /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_USART_NBSTOP_Msk              (_U_(0x3) << US_MR_USART_NBSTOP_Pos)           /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_USART_NBSTOP(value)           (US_MR_USART_NBSTOP_Msk & ((value) << US_MR_USART_NBSTOP_Pos))
+#define   US_MR_USART_NBSTOP_1_BIT_Val      _U_(0x0)                                       /**< (US_MR) USART 1 stop bit  */
+#define   US_MR_USART_NBSTOP_1_5_BIT_Val    _U_(0x1)                                       /**< (US_MR) USART 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
+#define   US_MR_USART_NBSTOP_2_BIT_Val      _U_(0x2)                                       /**< (US_MR) USART 2 stop bits  */
+#define US_MR_USART_NBSTOP_1_BIT            (US_MR_USART_NBSTOP_1_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 1 stop bit Position  */
+#define US_MR_USART_NBSTOP_1_5_BIT          (US_MR_USART_NBSTOP_1_5_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
+#define US_MR_USART_NBSTOP_2_BIT            (US_MR_USART_NBSTOP_2_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 2 stop bits Position  */
+#define US_MR_USART_CHMODE_Pos              14                                             /**< (US_MR) Channel Mode Position */
+#define US_MR_USART_CHMODE_Msk              (_U_(0x3) << US_MR_USART_CHMODE_Pos)           /**< (US_MR) Channel Mode Mask */
+#define US_MR_USART_CHMODE(value)           (US_MR_USART_CHMODE_Msk & ((value) << US_MR_USART_CHMODE_Pos))
+#define   US_MR_USART_CHMODE_NORMAL_Val     _U_(0x0)                                       /**< (US_MR) USART Normal mode  */
+#define   US_MR_USART_CHMODE_AUTOMATIC_Val  _U_(0x1)                                       /**< (US_MR) USART Automatic Echo. Receiver input is connected to the TXD pin.  */
+#define   US_MR_USART_CHMODE_LOCAL_LOOPBACK_Val _U_(0x2)                                       /**< (US_MR) USART Local Loopback. Transmitter output is connected to the Receiver Input.  */
+#define   US_MR_USART_CHMODE_REMOTE_LOOPBACK_Val _U_(0x3)                                       /**< (US_MR) USART Remote Loopback. RXD pin is internally connected to the TXD pin.  */
+#define US_MR_USART_CHMODE_NORMAL           (US_MR_USART_CHMODE_NORMAL_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_USART_CHMODE_AUTOMATIC        (US_MR_USART_CHMODE_AUTOMATIC_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
+#define US_MR_USART_CHMODE_LOCAL_LOOPBACK   (US_MR_USART_CHMODE_LOCAL_LOOPBACK_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
+#define US_MR_USART_CHMODE_REMOTE_LOOPBACK  (US_MR_USART_CHMODE_REMOTE_LOOPBACK_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
+#define US_MR_USART_MSBF_Pos                16                                             /**< (US_MR) Bit Order Position */
+#define US_MR_USART_MSBF_Msk                (_U_(0x1) << US_MR_USART_MSBF_Pos)             /**< (US_MR) Bit Order Mask */
+#define US_MR_USART_MSBF                    US_MR_USART_MSBF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MSBF_Msk instead */
+#define US_MR_USART_MODE9_Pos               17                                             /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_USART_MODE9_Msk               (_U_(0x1) << US_MR_USART_MODE9_Pos)            /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_USART_MODE9                   US_MR_USART_MODE9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MODE9_Msk instead */
+#define US_MR_USART_OVER_Pos                19                                             /**< (US_MR) Oversampling Mode Position */
+#define US_MR_USART_OVER_Msk                (_U_(0x1) << US_MR_USART_OVER_Pos)             /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_USART_OVER                    US_MR_USART_OVER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_OVER_Msk instead */
+#define US_MR_USART_INACK_Pos               20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_USART_INACK_Msk               (_U_(0x1) << US_MR_USART_INACK_Pos)            /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_USART_INACK                   US_MR_USART_INACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_INACK_Msk instead */
+#define US_MR_USART_DSNACK_Pos              21                                             /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_USART_DSNACK_Msk              (_U_(0x1) << US_MR_USART_DSNACK_Pos)           /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_USART_DSNACK                  US_MR_USART_DSNACK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_DSNACK_Msk instead */
+#define US_MR_USART_VAR_SYNC_Pos            22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_USART_VAR_SYNC_Msk            (_U_(0x1) << US_MR_USART_VAR_SYNC_Pos)         /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_USART_VAR_SYNC                US_MR_USART_VAR_SYNC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_VAR_SYNC_Msk instead */
+#define US_MR_USART_INVDATA_Pos             23                                             /**< (US_MR) Inverted Data Position */
+#define US_MR_USART_INVDATA_Msk             (_U_(0x1) << US_MR_USART_INVDATA_Pos)          /**< (US_MR) Inverted Data Mask */
+#define US_MR_USART_INVDATA                 US_MR_USART_INVDATA_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_INVDATA_Msk instead */
+#define US_MR_USART_MAX_ITERATION_Pos       24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_USART_MAX_ITERATION_Msk       (_U_(0x7) << US_MR_USART_MAX_ITERATION_Pos)    /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_USART_MAX_ITERATION(value)    (US_MR_USART_MAX_ITERATION_Msk & ((value) << US_MR_USART_MAX_ITERATION_Pos))
+#define US_MR_USART_FILTER_Pos              28                                             /**< (US_MR) Receive Line Filter Position */
+#define US_MR_USART_FILTER_Msk              (_U_(0x1) << US_MR_USART_FILTER_Pos)           /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_USART_FILTER                  US_MR_USART_FILTER_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_FILTER_Msk instead */
+#define US_MR_USART_MAN_Pos                 29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_USART_MAN_Msk                 (_U_(0x1) << US_MR_USART_MAN_Pos)              /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_USART_MAN                     US_MR_USART_MAN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MAN_Msk instead */
+#define US_MR_USART_MODSYNC_Pos             30                                             /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_USART_MODSYNC_Msk             (_U_(0x1) << US_MR_USART_MODSYNC_Pos)          /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_USART_MODSYNC                 US_MR_USART_MODSYNC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MODSYNC_Msk instead */
+#define US_MR_USART_ONEBIT_Pos              31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_USART_ONEBIT_Msk              (_U_(0x1) << US_MR_USART_ONEBIT_Pos)           /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_USART_ONEBIT                  US_MR_USART_ONEBIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_ONEBIT_Msk instead */
+#define US_MR_USART_MASK                    _U_(0xF7FBFF00)                                /**< \deprecated (US_MR_USART) Register MASK  (Use US_MR_USART_Msk instead)  */
+#define US_MR_USART_Msk                     _U_(0xF7FBFF00)                                /**< (US_MR_USART) Register Mask  */
+
+/* SPI mode */
+#define US_MR_SPI_CPHA_Pos                  8                                              /**< (US_MR) SPI Clock Phase Position */
+#define US_MR_SPI_CPHA_Msk                  (_U_(0x1) << US_MR_SPI_CPHA_Pos)               /**< (US_MR) SPI Clock Phase Mask */
+#define US_MR_SPI_CPHA                      US_MR_SPI_CPHA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_CPHA_Msk instead */
+#define US_MR_SPI_CPOL_Pos                  16                                             /**< (US_MR) SPI Clock Polarity Position */
+#define US_MR_SPI_CPOL_Msk                  (_U_(0x1) << US_MR_SPI_CPOL_Pos)               /**< (US_MR) SPI Clock Polarity Mask */
+#define US_MR_SPI_CPOL                      US_MR_SPI_CPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_CPOL_Msk instead */
+#define US_MR_SPI_WRDBT_Pos                 20                                             /**< (US_MR) Wait Read Data Before Transfer Position */
+#define US_MR_SPI_WRDBT_Msk                 (_U_(0x1) << US_MR_SPI_WRDBT_Pos)              /**< (US_MR) Wait Read Data Before Transfer Mask */
+#define US_MR_SPI_WRDBT                     US_MR_SPI_WRDBT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_WRDBT_Msk instead */
+#define US_MR_SPI_MASK                      _U_(0x110100)                                  /**< \deprecated (US_MR_SPI) Register MASK  (Use US_MR_SPI_Msk instead)  */
+#define US_MR_SPI_Msk                       _U_(0x110100)                                  /**< (US_MR_SPI) Register Mask  */
+
+
+/* -------- US_IER : (USART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Enable                   */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Enable                   */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Enable                 */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Enable          */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max number of Repetitions Reached Interrupt Enable */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Enable         */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Enable       */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Enable       */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Enable */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Enable */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Enable        */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Enable           */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Enable            */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Enable                 */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Enable */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Enable  */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Enable           */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Enable */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Enable   */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Enable      */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Enable */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Enable */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Enable */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Enable   */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Enable           */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Enable   */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Enable           */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Enable */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Enable      */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Enable */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  Underrun Error Interrupt Enable          */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IER_OFFSET                       (0x08)                                        /**<  (US_IER) Interrupt Enable Register  Offset */
+
+#define US_IER_RXRDY_Pos                    0                                              /**< (US_IER) RXRDY Interrupt Enable Position */
+#define US_IER_RXRDY_Msk                    (_U_(0x1) << US_IER_RXRDY_Pos)                 /**< (US_IER) RXRDY Interrupt Enable Mask */
+#define US_IER_RXRDY                        US_IER_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXRDY_Msk instead */
+#define US_IER_TXRDY_Pos                    1                                              /**< (US_IER) TXRDY Interrupt Enable Position */
+#define US_IER_TXRDY_Msk                    (_U_(0x1) << US_IER_TXRDY_Pos)                 /**< (US_IER) TXRDY Interrupt Enable Mask */
+#define US_IER_TXRDY                        US_IER_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXRDY_Msk instead */
+#define US_IER_OVRE_Pos                     5                                              /**< (US_IER) Overrun Error Interrupt Enable Position */
+#define US_IER_OVRE_Msk                     (_U_(0x1) << US_IER_OVRE_Pos)                  /**< (US_IER) Overrun Error Interrupt Enable Mask */
+#define US_IER_OVRE                         US_IER_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_OVRE_Msk instead */
+#define US_IER_TXEMPTY_Pos                  9                                              /**< (US_IER) TXEMPTY Interrupt Enable Position */
+#define US_IER_TXEMPTY_Msk                  (_U_(0x1) << US_IER_TXEMPTY_Pos)               /**< (US_IER) TXEMPTY Interrupt Enable Mask */
+#define US_IER_TXEMPTY                      US_IER_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXEMPTY_Msk instead */
+#define US_IER_MASK                         _U_(0x223)                                     /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
+#define US_IER_Msk                          _U_(0x223)                                     /**< (US_IER) Register Mask  */
+
+/* USART mode */
+#define US_IER_USART_RXBRK_Pos              2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_USART_RXBRK_Msk              (_U_(0x1) << US_IER_USART_RXBRK_Pos)           /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_USART_RXBRK                  US_IER_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_RXBRK_Msk instead */
+#define US_IER_USART_ITER_Pos               10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_USART_ITER_Msk               (_U_(0x1) << US_IER_USART_ITER_Pos)            /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_USART_ITER                   US_IER_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_ITER_Msk instead */
+#define US_IER_USART_NACK_Pos               13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_USART_NACK_Msk               (_U_(0x1) << US_IER_USART_NACK_Pos)            /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_USART_NACK                   US_IER_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_NACK_Msk instead */
+#define US_IER_USART_RIIC_Pos               16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_USART_RIIC_Msk               (_U_(0x1) << US_IER_USART_RIIC_Pos)            /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_USART_RIIC                   US_IER_USART_RIIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_RIIC_Msk instead */
+#define US_IER_USART_DSRIC_Pos              17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_USART_DSRIC_Msk              (_U_(0x1) << US_IER_USART_DSRIC_Pos)           /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_USART_DSRIC                  US_IER_USART_DSRIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_DSRIC_Msk instead */
+#define US_IER_USART_DCDIC_Pos              18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_USART_DCDIC_Msk              (_U_(0x1) << US_IER_USART_DCDIC_Pos)           /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_USART_DCDIC                  US_IER_USART_DCDIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_DCDIC_Msk instead */
+#define US_IER_USART_CTSIC_Pos              19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_USART_CTSIC_Msk              (_U_(0x1) << US_IER_USART_CTSIC_Pos)           /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_USART_CTSIC                  US_IER_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_CTSIC_Msk instead */
+#define US_IER_USART_MANE_Pos               24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_USART_MANE_Msk               (_U_(0x1) << US_IER_USART_MANE_Pos)            /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_USART_MANE                   US_IER_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_MANE_Msk instead */
+#define US_IER_USART_MASK                   _U_(0x10F2404)                                 /**< \deprecated (US_IER_USART) Register MASK  (Use US_IER_USART_Msk instead)  */
+#define US_IER_USART_Msk                    _U_(0x10F2404)                                 /**< (US_IER_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IER_USART_LIN_FRAME_Pos          6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IER_USART_LIN_FRAME_Pos)       /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_USART_LIN_FRAME              US_IER_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_FRAME_Msk instead */
+#define US_IER_USART_LIN_PARE_Pos           7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_USART_LIN_PARE_Msk           (_U_(0x1) << US_IER_USART_LIN_PARE_Pos)        /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_USART_LIN_PARE               US_IER_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_PARE_Msk instead */
+#define US_IER_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IER) Timeout Interrupt Enable Position */
+#define US_IER_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IER_USART_LIN_TIMEOUT_Pos)     /**< (US_IER) Timeout Interrupt Enable Mask */
+#define US_IER_USART_LIN_TIMEOUT            US_IER_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_TIMEOUT_Msk instead */
+#define US_IER_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IER_USART_LIN) Register MASK  (Use US_IER_USART_LIN_Msk instead)  */
+#define US_IER_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IER_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IER_SPI_NSSE_Pos                 19                                             /**< (US_IER) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IER_SPI_NSSE_Msk                 (_U_(0x1) << US_IER_SPI_NSSE_Pos)              /**< (US_IER) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IER_SPI_NSSE                     US_IER_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_SPI_NSSE_Msk instead */
+#define US_IER_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IER_SPI) Register MASK  (Use US_IER_SPI_Msk instead)  */
+#define US_IER_SPI_Msk                      _U_(0x80000)                                   /**< (US_IER_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IER_LIN_LINBK_Pos                13                                             /**< (US_IER) LIN Break Sent or LIN Break Received Interrupt Enable Position */
+#define US_IER_LIN_LINBK_Msk                (_U_(0x1) << US_IER_LIN_LINBK_Pos)             /**< (US_IER) LIN Break Sent or LIN Break Received Interrupt Enable Mask */
+#define US_IER_LIN_LINBK                    US_IER_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINBK_Msk instead */
+#define US_IER_LIN_LINID_Pos                14                                             /**< (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable Position */
+#define US_IER_LIN_LINID_Msk                (_U_(0x1) << US_IER_LIN_LINID_Pos)             /**< (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable Mask */
+#define US_IER_LIN_LINID                    US_IER_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINID_Msk instead */
+#define US_IER_LIN_LINTC_Pos                15                                             /**< (US_IER) LIN Transfer Completed Interrupt Enable Position */
+#define US_IER_LIN_LINTC_Msk                (_U_(0x1) << US_IER_LIN_LINTC_Pos)             /**< (US_IER) LIN Transfer Completed Interrupt Enable Mask */
+#define US_IER_LIN_LINTC                    US_IER_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINTC_Msk instead */
+#define US_IER_LIN_LINBE_Pos                25                                             /**< (US_IER) LIN Bus Error Interrupt Enable Position */
+#define US_IER_LIN_LINBE_Msk                (_U_(0x1) << US_IER_LIN_LINBE_Pos)             /**< (US_IER) LIN Bus Error Interrupt Enable Mask */
+#define US_IER_LIN_LINBE                    US_IER_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINBE_Msk instead */
+#define US_IER_LIN_LINISFE_Pos              26                                             /**< (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable Position */
+#define US_IER_LIN_LINISFE_Msk              (_U_(0x1) << US_IER_LIN_LINISFE_Pos)           /**< (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable Mask */
+#define US_IER_LIN_LINISFE                  US_IER_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINISFE_Msk instead */
+#define US_IER_LIN_LINIPE_Pos               27                                             /**< (US_IER) LIN Identifier Parity Interrupt Enable Position */
+#define US_IER_LIN_LINIPE_Msk               (_U_(0x1) << US_IER_LIN_LINIPE_Pos)            /**< (US_IER) LIN Identifier Parity Interrupt Enable Mask */
+#define US_IER_LIN_LINIPE                   US_IER_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINIPE_Msk instead */
+#define US_IER_LIN_LINCE_Pos                28                                             /**< (US_IER) LIN Checksum Error Interrupt Enable Position */
+#define US_IER_LIN_LINCE_Msk                (_U_(0x1) << US_IER_LIN_LINCE_Pos)             /**< (US_IER) LIN Checksum Error Interrupt Enable Mask */
+#define US_IER_LIN_LINCE                    US_IER_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINCE_Msk instead */
+#define US_IER_LIN_LINSNRE_Pos              29                                             /**< (US_IER) LIN Slave Not Responding Error Interrupt Enable Position */
+#define US_IER_LIN_LINSNRE_Msk              (_U_(0x1) << US_IER_LIN_LINSNRE_Pos)           /**< (US_IER) LIN Slave Not Responding Error Interrupt Enable Mask */
+#define US_IER_LIN_LINSNRE                  US_IER_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINSNRE_Msk instead */
+#define US_IER_LIN_LINSTE_Pos               30                                             /**< (US_IER) LIN Synch Tolerance Error Interrupt Enable Position */
+#define US_IER_LIN_LINSTE_Msk               (_U_(0x1) << US_IER_LIN_LINSTE_Pos)            /**< (US_IER) LIN Synch Tolerance Error Interrupt Enable Mask */
+#define US_IER_LIN_LINSTE                   US_IER_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINSTE_Msk instead */
+#define US_IER_LIN_LINHTE_Pos               31                                             /**< (US_IER) LIN Header Timeout Error Interrupt Enable Position */
+#define US_IER_LIN_LINHTE_Msk               (_U_(0x1) << US_IER_LIN_LINHTE_Pos)            /**< (US_IER) LIN Header Timeout Error Interrupt Enable Mask */
+#define US_IER_LIN_LINHTE                   US_IER_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINHTE_Msk instead */
+#define US_IER_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IER_LIN) Register MASK  (Use US_IER_LIN_Msk instead)  */
+#define US_IER_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IER_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IER_LON_LSFE_Pos                 6                                              /**< (US_IER) LON Short Frame Error Interrupt Enable Position */
+#define US_IER_LON_LSFE_Msk                 (_U_(0x1) << US_IER_LON_LSFE_Pos)              /**< (US_IER) LON Short Frame Error Interrupt Enable Mask */
+#define US_IER_LON_LSFE                     US_IER_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LSFE_Msk instead */
+#define US_IER_LON_LCRCE_Pos                7                                              /**< (US_IER) LON CRC Error Interrupt Enable Position */
+#define US_IER_LON_LCRCE_Msk                (_U_(0x1) << US_IER_LON_LCRCE_Pos)             /**< (US_IER) LON CRC Error Interrupt Enable Mask */
+#define US_IER_LON_LCRCE                    US_IER_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LCRCE_Msk instead */
+#define US_IER_LON_LTXD_Pos                 24                                             /**< (US_IER) LON Transmission Done Interrupt Enable Position */
+#define US_IER_LON_LTXD_Msk                 (_U_(0x1) << US_IER_LON_LTXD_Pos)              /**< (US_IER) LON Transmission Done Interrupt Enable Mask */
+#define US_IER_LON_LTXD                     US_IER_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LTXD_Msk instead */
+#define US_IER_LON_LCOL_Pos                 25                                             /**< (US_IER) LON Collision Interrupt Enable Position */
+#define US_IER_LON_LCOL_Msk                 (_U_(0x1) << US_IER_LON_LCOL_Pos)              /**< (US_IER) LON Collision Interrupt Enable Mask */
+#define US_IER_LON_LCOL                     US_IER_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LCOL_Msk instead */
+#define US_IER_LON_LFET_Pos                 26                                             /**< (US_IER) LON Frame Early Termination Interrupt Enable Position */
+#define US_IER_LON_LFET_Msk                 (_U_(0x1) << US_IER_LON_LFET_Pos)              /**< (US_IER) LON Frame Early Termination Interrupt Enable Mask */
+#define US_IER_LON_LFET                     US_IER_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LFET_Msk instead */
+#define US_IER_LON_LRXD_Pos                 27                                             /**< (US_IER) LON Reception Done Interrupt Enable Position */
+#define US_IER_LON_LRXD_Msk                 (_U_(0x1) << US_IER_LON_LRXD_Pos)              /**< (US_IER) LON Reception Done Interrupt Enable Mask */
+#define US_IER_LON_LRXD                     US_IER_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LRXD_Msk instead */
+#define US_IER_LON_LBLOVFE_Pos              28                                             /**< (US_IER) LON Backlog Overflow Error Interrupt Enable Position */
+#define US_IER_LON_LBLOVFE_Msk              (_U_(0x1) << US_IER_LON_LBLOVFE_Pos)           /**< (US_IER) LON Backlog Overflow Error Interrupt Enable Mask */
+#define US_IER_LON_LBLOVFE                  US_IER_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LBLOVFE_Msk instead */
+#define US_IER_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IER_LON) Register MASK  (Use US_IER_LON_Msk instead)  */
+#define US_IER_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IER_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IER_LON_SPI_UNRE_Pos             10                                             /**< (US_IER) Underrun Error Interrupt Enable Position */
+#define US_IER_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IER_LON_SPI_UNRE_Pos)          /**< (US_IER) Underrun Error Interrupt Enable Mask */
+#define US_IER_LON_SPI_UNRE                 US_IER_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_SPI_UNRE_Msk instead */
+#define US_IER_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IER_LON_SPI) Register MASK  (Use US_IER_LON_SPI_Msk instead)  */
+#define US_IER_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IER_LON_SPI) Register Mask  */
+
+
+/* -------- US_IDR : (USART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Disable                  */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Disable                  */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Disable                */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Disable      */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Disable      */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Disable         */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Disable */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Disable        */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Disable */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Disable       */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Disable          */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Disable           */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Disable                */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Disable */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Disable */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Disable          */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Disable */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Disable  */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Disable     */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Disable */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Disable */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Disable */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Disable  */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Disable          */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Disable  */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Disable          */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Disable */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Disable     */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Disable */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error Interrupt Disable     */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDR_OFFSET                       (0x0C)                                        /**<  (US_IDR) Interrupt Disable Register  Offset */
+
+#define US_IDR_RXRDY_Pos                    0                                              /**< (US_IDR) RXRDY Interrupt Disable Position */
+#define US_IDR_RXRDY_Msk                    (_U_(0x1) << US_IDR_RXRDY_Pos)                 /**< (US_IDR) RXRDY Interrupt Disable Mask */
+#define US_IDR_RXRDY                        US_IDR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXRDY_Msk instead */
+#define US_IDR_TXRDY_Pos                    1                                              /**< (US_IDR) TXRDY Interrupt Disable Position */
+#define US_IDR_TXRDY_Msk                    (_U_(0x1) << US_IDR_TXRDY_Pos)                 /**< (US_IDR) TXRDY Interrupt Disable Mask */
+#define US_IDR_TXRDY                        US_IDR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXRDY_Msk instead */
+#define US_IDR_OVRE_Pos                     5                                              /**< (US_IDR) Overrun Error Interrupt Enable Position */
+#define US_IDR_OVRE_Msk                     (_U_(0x1) << US_IDR_OVRE_Pos)                  /**< (US_IDR) Overrun Error Interrupt Enable Mask */
+#define US_IDR_OVRE                         US_IDR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_OVRE_Msk instead */
+#define US_IDR_TXEMPTY_Pos                  9                                              /**< (US_IDR) TXEMPTY Interrupt Disable Position */
+#define US_IDR_TXEMPTY_Msk                  (_U_(0x1) << US_IDR_TXEMPTY_Pos)               /**< (US_IDR) TXEMPTY Interrupt Disable Mask */
+#define US_IDR_TXEMPTY                      US_IDR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXEMPTY_Msk instead */
+#define US_IDR_RIIC_Pos                     16                                             /**< (US_IDR) Ring Indicator Input Change Disable Position */
+#define US_IDR_RIIC_Msk                     (_U_(0x1) << US_IDR_RIIC_Pos)                  /**< (US_IDR) Ring Indicator Input Change Disable Mask */
+#define US_IDR_RIIC                         US_IDR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RIIC_Msk instead */
+#define US_IDR_DSRIC_Pos                    17                                             /**< (US_IDR) Data Set Ready Input Change Disable Position */
+#define US_IDR_DSRIC_Msk                    (_U_(0x1) << US_IDR_DSRIC_Pos)                 /**< (US_IDR) Data Set Ready Input Change Disable Mask */
+#define US_IDR_DSRIC                        US_IDR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DSRIC_Msk instead */
+#define US_IDR_DCDIC_Pos                    18                                             /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Position */
+#define US_IDR_DCDIC_Msk                    (_U_(0x1) << US_IDR_DCDIC_Pos)                 /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Mask */
+#define US_IDR_DCDIC                        US_IDR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DCDIC_Msk instead */
+#define US_IDR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
+#define US_IDR_Msk                          _U_(0x70223)                                   /**< (US_IDR) Register Mask  */
+
+/* USART mode */
+#define US_IDR_USART_RXBRK_Pos              2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_USART_RXBRK_Msk              (_U_(0x1) << US_IDR_USART_RXBRK_Pos)           /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_USART_RXBRK                  US_IDR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_RXBRK_Msk instead */
+#define US_IDR_USART_ITER_Pos               10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_USART_ITER_Msk               (_U_(0x1) << US_IDR_USART_ITER_Pos)            /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_USART_ITER                   US_IDR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_ITER_Msk instead */
+#define US_IDR_USART_NACK_Pos               13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_USART_NACK_Msk               (_U_(0x1) << US_IDR_USART_NACK_Pos)            /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_USART_NACK                   US_IDR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_NACK_Msk instead */
+#define US_IDR_USART_CTSIC_Pos              19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_USART_CTSIC_Msk              (_U_(0x1) << US_IDR_USART_CTSIC_Pos)           /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_USART_CTSIC                  US_IDR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_CTSIC_Msk instead */
+#define US_IDR_USART_MANE_Pos               24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_USART_MANE_Msk               (_U_(0x1) << US_IDR_USART_MANE_Pos)            /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_USART_MANE                   US_IDR_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_MANE_Msk instead */
+#define US_IDR_USART_MASK                   _U_(0x1082404)                                 /**< \deprecated (US_IDR_USART) Register MASK  (Use US_IDR_USART_Msk instead)  */
+#define US_IDR_USART_Msk                    _U_(0x1082404)                                 /**< (US_IDR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IDR_USART_LIN_FRAME_Pos          6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IDR_USART_LIN_FRAME_Pos)       /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_USART_LIN_FRAME              US_IDR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_FRAME_Msk instead */
+#define US_IDR_USART_LIN_PARE_Pos           7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_USART_LIN_PARE_Msk           (_U_(0x1) << US_IDR_USART_LIN_PARE_Pos)        /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_USART_LIN_PARE               US_IDR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_PARE_Msk instead */
+#define US_IDR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IDR) Timeout Interrupt Disable Position */
+#define US_IDR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IDR_USART_LIN_TIMEOUT_Pos)     /**< (US_IDR) Timeout Interrupt Disable Mask */
+#define US_IDR_USART_LIN_TIMEOUT            US_IDR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_TIMEOUT_Msk instead */
+#define US_IDR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IDR_USART_LIN) Register MASK  (Use US_IDR_USART_LIN_Msk instead)  */
+#define US_IDR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IDR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IDR_SPI_NSSE_Pos                 19                                             /**< (US_IDR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IDR_SPI_NSSE_Msk                 (_U_(0x1) << US_IDR_SPI_NSSE_Pos)              /**< (US_IDR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IDR_SPI_NSSE                     US_IDR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_SPI_NSSE_Msk instead */
+#define US_IDR_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IDR_SPI) Register MASK  (Use US_IDR_SPI_Msk instead)  */
+#define US_IDR_SPI_Msk                      _U_(0x80000)                                   /**< (US_IDR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IDR_LIN_LINBK_Pos                13                                             /**< (US_IDR) LIN Break Sent or LIN Break Received Interrupt Disable Position */
+#define US_IDR_LIN_LINBK_Msk                (_U_(0x1) << US_IDR_LIN_LINBK_Pos)             /**< (US_IDR) LIN Break Sent or LIN Break Received Interrupt Disable Mask */
+#define US_IDR_LIN_LINBK                    US_IDR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINBK_Msk instead */
+#define US_IDR_LIN_LINID_Pos                14                                             /**< (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable Position */
+#define US_IDR_LIN_LINID_Msk                (_U_(0x1) << US_IDR_LIN_LINID_Pos)             /**< (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable Mask */
+#define US_IDR_LIN_LINID                    US_IDR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINID_Msk instead */
+#define US_IDR_LIN_LINTC_Pos                15                                             /**< (US_IDR) LIN Transfer Completed Interrupt Disable Position */
+#define US_IDR_LIN_LINTC_Msk                (_U_(0x1) << US_IDR_LIN_LINTC_Pos)             /**< (US_IDR) LIN Transfer Completed Interrupt Disable Mask */
+#define US_IDR_LIN_LINTC                    US_IDR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINTC_Msk instead */
+#define US_IDR_LIN_LINBE_Pos                25                                             /**< (US_IDR) LIN Bus Error Interrupt Disable Position */
+#define US_IDR_LIN_LINBE_Msk                (_U_(0x1) << US_IDR_LIN_LINBE_Pos)             /**< (US_IDR) LIN Bus Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINBE                    US_IDR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINBE_Msk instead */
+#define US_IDR_LIN_LINISFE_Pos              26                                             /**< (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable Position */
+#define US_IDR_LIN_LINISFE_Msk              (_U_(0x1) << US_IDR_LIN_LINISFE_Pos)           /**< (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINISFE                  US_IDR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINISFE_Msk instead */
+#define US_IDR_LIN_LINIPE_Pos               27                                             /**< (US_IDR) LIN Identifier Parity Interrupt Disable Position */
+#define US_IDR_LIN_LINIPE_Msk               (_U_(0x1) << US_IDR_LIN_LINIPE_Pos)            /**< (US_IDR) LIN Identifier Parity Interrupt Disable Mask */
+#define US_IDR_LIN_LINIPE                   US_IDR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINIPE_Msk instead */
+#define US_IDR_LIN_LINCE_Pos                28                                             /**< (US_IDR) LIN Checksum Error Interrupt Disable Position */
+#define US_IDR_LIN_LINCE_Msk                (_U_(0x1) << US_IDR_LIN_LINCE_Pos)             /**< (US_IDR) LIN Checksum Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINCE                    US_IDR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINCE_Msk instead */
+#define US_IDR_LIN_LINSNRE_Pos              29                                             /**< (US_IDR) LIN Slave Not Responding Error Interrupt Disable Position */
+#define US_IDR_LIN_LINSNRE_Msk              (_U_(0x1) << US_IDR_LIN_LINSNRE_Pos)           /**< (US_IDR) LIN Slave Not Responding Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINSNRE                  US_IDR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINSNRE_Msk instead */
+#define US_IDR_LIN_LINSTE_Pos               30                                             /**< (US_IDR) LIN Synch Tolerance Error Interrupt Disable Position */
+#define US_IDR_LIN_LINSTE_Msk               (_U_(0x1) << US_IDR_LIN_LINSTE_Pos)            /**< (US_IDR) LIN Synch Tolerance Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINSTE                   US_IDR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINSTE_Msk instead */
+#define US_IDR_LIN_LINHTE_Pos               31                                             /**< (US_IDR) LIN Header Timeout Error Interrupt Disable Position */
+#define US_IDR_LIN_LINHTE_Msk               (_U_(0x1) << US_IDR_LIN_LINHTE_Pos)            /**< (US_IDR) LIN Header Timeout Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINHTE                   US_IDR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINHTE_Msk instead */
+#define US_IDR_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IDR_LIN) Register MASK  (Use US_IDR_LIN_Msk instead)  */
+#define US_IDR_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IDR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IDR_LON_LSFE_Pos                 6                                              /**< (US_IDR) LON Short Frame Error Interrupt Disable Position */
+#define US_IDR_LON_LSFE_Msk                 (_U_(0x1) << US_IDR_LON_LSFE_Pos)              /**< (US_IDR) LON Short Frame Error Interrupt Disable Mask */
+#define US_IDR_LON_LSFE                     US_IDR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LSFE_Msk instead */
+#define US_IDR_LON_LCRCE_Pos                7                                              /**< (US_IDR) LON CRC Error Interrupt Disable Position */
+#define US_IDR_LON_LCRCE_Msk                (_U_(0x1) << US_IDR_LON_LCRCE_Pos)             /**< (US_IDR) LON CRC Error Interrupt Disable Mask */
+#define US_IDR_LON_LCRCE                    US_IDR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LCRCE_Msk instead */
+#define US_IDR_LON_LTXD_Pos                 24                                             /**< (US_IDR) LON Transmission Done Interrupt Disable Position */
+#define US_IDR_LON_LTXD_Msk                 (_U_(0x1) << US_IDR_LON_LTXD_Pos)              /**< (US_IDR) LON Transmission Done Interrupt Disable Mask */
+#define US_IDR_LON_LTXD                     US_IDR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LTXD_Msk instead */
+#define US_IDR_LON_LCOL_Pos                 25                                             /**< (US_IDR) LON Collision Interrupt Disable Position */
+#define US_IDR_LON_LCOL_Msk                 (_U_(0x1) << US_IDR_LON_LCOL_Pos)              /**< (US_IDR) LON Collision Interrupt Disable Mask */
+#define US_IDR_LON_LCOL                     US_IDR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LCOL_Msk instead */
+#define US_IDR_LON_LFET_Pos                 26                                             /**< (US_IDR) LON Frame Early Termination Interrupt Disable Position */
+#define US_IDR_LON_LFET_Msk                 (_U_(0x1) << US_IDR_LON_LFET_Pos)              /**< (US_IDR) LON Frame Early Termination Interrupt Disable Mask */
+#define US_IDR_LON_LFET                     US_IDR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LFET_Msk instead */
+#define US_IDR_LON_LRXD_Pos                 27                                             /**< (US_IDR) LON Reception Done Interrupt Disable Position */
+#define US_IDR_LON_LRXD_Msk                 (_U_(0x1) << US_IDR_LON_LRXD_Pos)              /**< (US_IDR) LON Reception Done Interrupt Disable Mask */
+#define US_IDR_LON_LRXD                     US_IDR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LRXD_Msk instead */
+#define US_IDR_LON_LBLOVFE_Pos              28                                             /**< (US_IDR) LON Backlog Overflow Error Interrupt Disable Position */
+#define US_IDR_LON_LBLOVFE_Msk              (_U_(0x1) << US_IDR_LON_LBLOVFE_Pos)           /**< (US_IDR) LON Backlog Overflow Error Interrupt Disable Mask */
+#define US_IDR_LON_LBLOVFE                  US_IDR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LBLOVFE_Msk instead */
+#define US_IDR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IDR_LON) Register MASK  (Use US_IDR_LON_Msk instead)  */
+#define US_IDR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IDR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IDR_LON_SPI_UNRE_Pos             10                                             /**< (US_IDR) SPI Underrun Error Interrupt Disable Position */
+#define US_IDR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IDR_LON_SPI_UNRE_Pos)          /**< (US_IDR) SPI Underrun Error Interrupt Disable Mask */
+#define US_IDR_LON_SPI_UNRE                 US_IDR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_SPI_UNRE_Msk instead */
+#define US_IDR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IDR_LON_SPI) Register MASK  (Use US_IDR_LON_SPI_Msk instead)  */
+#define US_IDR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IDR_LON_SPI) Register Mask  */
+
+
+/* -------- US_IMR : (USART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Mask                     */
+    uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Mask                     */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Mask             */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Mask                   */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Mask         */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Mask         */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Mask            */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Mask */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Mask           */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Mask */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Mask          */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Mask             */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Mask              */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Mask                   */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Mask */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Mask */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Mask    */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Mask             */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Mask */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Mask     */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Mask        */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Mask */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Mask */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Mask  */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Mask     */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Mask             */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Mask     */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Mask             */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Mask */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Mask        */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Mask */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error Interrupt Mask        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IMR_OFFSET                       (0x10)                                        /**<  (US_IMR) Interrupt Mask Register  Offset */
+
+#define US_IMR_RXRDY_Pos                    0                                              /**< (US_IMR) RXRDY Interrupt Mask Position */
+#define US_IMR_RXRDY_Msk                    (_U_(0x1) << US_IMR_RXRDY_Pos)                 /**< (US_IMR) RXRDY Interrupt Mask Mask */
+#define US_IMR_RXRDY                        US_IMR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RXRDY_Msk instead */
+#define US_IMR_TXRDY_Pos                    1                                              /**< (US_IMR) TXRDY Interrupt Mask Position */
+#define US_IMR_TXRDY_Msk                    (_U_(0x1) << US_IMR_TXRDY_Pos)                 /**< (US_IMR) TXRDY Interrupt Mask Mask */
+#define US_IMR_TXRDY                        US_IMR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXRDY_Msk instead */
+#define US_IMR_OVRE_Pos                     5                                              /**< (US_IMR) Overrun Error Interrupt Mask Position */
+#define US_IMR_OVRE_Msk                     (_U_(0x1) << US_IMR_OVRE_Pos)                  /**< (US_IMR) Overrun Error Interrupt Mask Mask */
+#define US_IMR_OVRE                         US_IMR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_OVRE_Msk instead */
+#define US_IMR_TXEMPTY_Pos                  9                                              /**< (US_IMR) TXEMPTY Interrupt Mask Position */
+#define US_IMR_TXEMPTY_Msk                  (_U_(0x1) << US_IMR_TXEMPTY_Pos)               /**< (US_IMR) TXEMPTY Interrupt Mask Mask */
+#define US_IMR_TXEMPTY                      US_IMR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXEMPTY_Msk instead */
+#define US_IMR_RIIC_Pos                     16                                             /**< (US_IMR) Ring Indicator Input Change Mask Position */
+#define US_IMR_RIIC_Msk                     (_U_(0x1) << US_IMR_RIIC_Pos)                  /**< (US_IMR) Ring Indicator Input Change Mask Mask */
+#define US_IMR_RIIC                         US_IMR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RIIC_Msk instead */
+#define US_IMR_DSRIC_Pos                    17                                             /**< (US_IMR) Data Set Ready Input Change Mask Position */
+#define US_IMR_DSRIC_Msk                    (_U_(0x1) << US_IMR_DSRIC_Pos)                 /**< (US_IMR) Data Set Ready Input Change Mask Mask */
+#define US_IMR_DSRIC                        US_IMR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_DSRIC_Msk instead */
+#define US_IMR_DCDIC_Pos                    18                                             /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Position */
+#define US_IMR_DCDIC_Msk                    (_U_(0x1) << US_IMR_DCDIC_Pos)                 /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Mask */
+#define US_IMR_DCDIC                        US_IMR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_DCDIC_Msk instead */
+#define US_IMR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IMR) Register MASK  (Use US_IMR_Msk instead)  */
+#define US_IMR_Msk                          _U_(0x70223)                                   /**< (US_IMR) Register Mask  */
+
+/* USART mode */
+#define US_IMR_USART_RXBRK_Pos              2                                              /**< (US_IMR) Receiver Break Interrupt Mask Position */
+#define US_IMR_USART_RXBRK_Msk              (_U_(0x1) << US_IMR_USART_RXBRK_Pos)           /**< (US_IMR) Receiver Break Interrupt Mask Mask */
+#define US_IMR_USART_RXBRK                  US_IMR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_RXBRK_Msk instead */
+#define US_IMR_USART_ITER_Pos               10                                             /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Position */
+#define US_IMR_USART_ITER_Msk               (_U_(0x1) << US_IMR_USART_ITER_Pos)            /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Mask */
+#define US_IMR_USART_ITER                   US_IMR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_ITER_Msk instead */
+#define US_IMR_USART_NACK_Pos               13                                             /**< (US_IMR) Non Acknowledge Interrupt Mask Position */
+#define US_IMR_USART_NACK_Msk               (_U_(0x1) << US_IMR_USART_NACK_Pos)            /**< (US_IMR) Non Acknowledge Interrupt Mask Mask */
+#define US_IMR_USART_NACK                   US_IMR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_NACK_Msk instead */
+#define US_IMR_USART_CTSIC_Pos              19                                             /**< (US_IMR) Clear to Send Input Change Interrupt Mask Position */
+#define US_IMR_USART_CTSIC_Msk              (_U_(0x1) << US_IMR_USART_CTSIC_Pos)           /**< (US_IMR) Clear to Send Input Change Interrupt Mask Mask */
+#define US_IMR_USART_CTSIC                  US_IMR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_CTSIC_Msk instead */
+#define US_IMR_USART_MANE_Pos               24                                             /**< (US_IMR) Manchester Error Interrupt Mask Position */
+#define US_IMR_USART_MANE_Msk               (_U_(0x1) << US_IMR_USART_MANE_Pos)            /**< (US_IMR) Manchester Error Interrupt Mask Mask */
+#define US_IMR_USART_MANE                   US_IMR_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_MANE_Msk instead */
+#define US_IMR_USART_MASK                   _U_(0x1082404)                                 /**< \deprecated (US_IMR_USART) Register MASK  (Use US_IMR_USART_Msk instead)  */
+#define US_IMR_USART_Msk                    _U_(0x1082404)                                 /**< (US_IMR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IMR_USART_LIN_FRAME_Pos          6                                              /**< (US_IMR) Framing Error Interrupt Mask Position */
+#define US_IMR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IMR_USART_LIN_FRAME_Pos)       /**< (US_IMR) Framing Error Interrupt Mask Mask */
+#define US_IMR_USART_LIN_FRAME              US_IMR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_FRAME_Msk instead */
+#define US_IMR_USART_LIN_PARE_Pos           7                                              /**< (US_IMR) Parity Error Interrupt Mask Position */
+#define US_IMR_USART_LIN_PARE_Msk           (_U_(0x1) << US_IMR_USART_LIN_PARE_Pos)        /**< (US_IMR) Parity Error Interrupt Mask Mask */
+#define US_IMR_USART_LIN_PARE               US_IMR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_PARE_Msk instead */
+#define US_IMR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IMR) Timeout Interrupt Mask Position */
+#define US_IMR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IMR_USART_LIN_TIMEOUT_Pos)     /**< (US_IMR) Timeout Interrupt Mask Mask */
+#define US_IMR_USART_LIN_TIMEOUT            US_IMR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_TIMEOUT_Msk instead */
+#define US_IMR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IMR_USART_LIN) Register MASK  (Use US_IMR_USART_LIN_Msk instead)  */
+#define US_IMR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IMR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IMR_SPI_NSSE_Pos                 19                                             /**< (US_IMR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IMR_SPI_NSSE_Msk                 (_U_(0x1) << US_IMR_SPI_NSSE_Pos)              /**< (US_IMR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IMR_SPI_NSSE                     US_IMR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_SPI_NSSE_Msk instead */
+#define US_IMR_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IMR_SPI) Register MASK  (Use US_IMR_SPI_Msk instead)  */
+#define US_IMR_SPI_Msk                      _U_(0x80000)                                   /**< (US_IMR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IMR_LIN_LINBK_Pos                13                                             /**< (US_IMR) LIN Break Sent or LIN Break Received Interrupt Mask Position */
+#define US_IMR_LIN_LINBK_Msk                (_U_(0x1) << US_IMR_LIN_LINBK_Pos)             /**< (US_IMR) LIN Break Sent or LIN Break Received Interrupt Mask Mask */
+#define US_IMR_LIN_LINBK                    US_IMR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINBK_Msk instead */
+#define US_IMR_LIN_LINID_Pos                14                                             /**< (US_IMR) LIN Identifier Sent or LIN Identifier Received Interrupt Mask Position */
+#define US_IMR_LIN_LINID_Msk                (_U_(0x1) << US_IMR_LIN_LINID_Pos)             /**< (US_IMR) LIN Identifier Sent or LIN Identifier Received Interrupt Mask Mask */
+#define US_IMR_LIN_LINID                    US_IMR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINID_Msk instead */
+#define US_IMR_LIN_LINTC_Pos                15                                             /**< (US_IMR) LIN Transfer Completed Interrupt Mask Position */
+#define US_IMR_LIN_LINTC_Msk                (_U_(0x1) << US_IMR_LIN_LINTC_Pos)             /**< (US_IMR) LIN Transfer Completed Interrupt Mask Mask */
+#define US_IMR_LIN_LINTC                    US_IMR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINTC_Msk instead */
+#define US_IMR_LIN_LINBE_Pos                25                                             /**< (US_IMR) LIN Bus Error Interrupt Mask Position */
+#define US_IMR_LIN_LINBE_Msk                (_U_(0x1) << US_IMR_LIN_LINBE_Pos)             /**< (US_IMR) LIN Bus Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINBE                    US_IMR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINBE_Msk instead */
+#define US_IMR_LIN_LINISFE_Pos              26                                             /**< (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask Position */
+#define US_IMR_LIN_LINISFE_Msk              (_U_(0x1) << US_IMR_LIN_LINISFE_Pos)           /**< (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINISFE                  US_IMR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINISFE_Msk instead */
+#define US_IMR_LIN_LINIPE_Pos               27                                             /**< (US_IMR) LIN Identifier Parity Interrupt Mask Position */
+#define US_IMR_LIN_LINIPE_Msk               (_U_(0x1) << US_IMR_LIN_LINIPE_Pos)            /**< (US_IMR) LIN Identifier Parity Interrupt Mask Mask */
+#define US_IMR_LIN_LINIPE                   US_IMR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINIPE_Msk instead */
+#define US_IMR_LIN_LINCE_Pos                28                                             /**< (US_IMR) LIN Checksum Error Interrupt Mask Position */
+#define US_IMR_LIN_LINCE_Msk                (_U_(0x1) << US_IMR_LIN_LINCE_Pos)             /**< (US_IMR) LIN Checksum Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINCE                    US_IMR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINCE_Msk instead */
+#define US_IMR_LIN_LINSNRE_Pos              29                                             /**< (US_IMR) LIN Slave Not Responding Error Interrupt Mask Position */
+#define US_IMR_LIN_LINSNRE_Msk              (_U_(0x1) << US_IMR_LIN_LINSNRE_Pos)           /**< (US_IMR) LIN Slave Not Responding Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINSNRE                  US_IMR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINSNRE_Msk instead */
+#define US_IMR_LIN_LINSTE_Pos               30                                             /**< (US_IMR) LIN Synch Tolerance Error Interrupt Mask Position */
+#define US_IMR_LIN_LINSTE_Msk               (_U_(0x1) << US_IMR_LIN_LINSTE_Pos)            /**< (US_IMR) LIN Synch Tolerance Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINSTE                   US_IMR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINSTE_Msk instead */
+#define US_IMR_LIN_LINHTE_Pos               31                                             /**< (US_IMR) LIN Header Timeout Error Interrupt Mask Position */
+#define US_IMR_LIN_LINHTE_Msk               (_U_(0x1) << US_IMR_LIN_LINHTE_Pos)            /**< (US_IMR) LIN Header Timeout Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINHTE                   US_IMR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINHTE_Msk instead */
+#define US_IMR_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IMR_LIN) Register MASK  (Use US_IMR_LIN_Msk instead)  */
+#define US_IMR_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IMR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IMR_LON_LSFE_Pos                 6                                              /**< (US_IMR) LON Short Frame Error Interrupt Mask Position */
+#define US_IMR_LON_LSFE_Msk                 (_U_(0x1) << US_IMR_LON_LSFE_Pos)              /**< (US_IMR) LON Short Frame Error Interrupt Mask Mask */
+#define US_IMR_LON_LSFE                     US_IMR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LSFE_Msk instead */
+#define US_IMR_LON_LCRCE_Pos                7                                              /**< (US_IMR) LON CRC Error Interrupt Mask Position */
+#define US_IMR_LON_LCRCE_Msk                (_U_(0x1) << US_IMR_LON_LCRCE_Pos)             /**< (US_IMR) LON CRC Error Interrupt Mask Mask */
+#define US_IMR_LON_LCRCE                    US_IMR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LCRCE_Msk instead */
+#define US_IMR_LON_LTXD_Pos                 24                                             /**< (US_IMR) LON Transmission Done Interrupt Mask Position */
+#define US_IMR_LON_LTXD_Msk                 (_U_(0x1) << US_IMR_LON_LTXD_Pos)              /**< (US_IMR) LON Transmission Done Interrupt Mask Mask */
+#define US_IMR_LON_LTXD                     US_IMR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LTXD_Msk instead */
+#define US_IMR_LON_LCOL_Pos                 25                                             /**< (US_IMR) LON Collision Interrupt Mask Position */
+#define US_IMR_LON_LCOL_Msk                 (_U_(0x1) << US_IMR_LON_LCOL_Pos)              /**< (US_IMR) LON Collision Interrupt Mask Mask */
+#define US_IMR_LON_LCOL                     US_IMR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LCOL_Msk instead */
+#define US_IMR_LON_LFET_Pos                 26                                             /**< (US_IMR) LON Frame Early Termination Interrupt Mask Position */
+#define US_IMR_LON_LFET_Msk                 (_U_(0x1) << US_IMR_LON_LFET_Pos)              /**< (US_IMR) LON Frame Early Termination Interrupt Mask Mask */
+#define US_IMR_LON_LFET                     US_IMR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LFET_Msk instead */
+#define US_IMR_LON_LRXD_Pos                 27                                             /**< (US_IMR) LON Reception Done Interrupt Mask Position */
+#define US_IMR_LON_LRXD_Msk                 (_U_(0x1) << US_IMR_LON_LRXD_Pos)              /**< (US_IMR) LON Reception Done Interrupt Mask Mask */
+#define US_IMR_LON_LRXD                     US_IMR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LRXD_Msk instead */
+#define US_IMR_LON_LBLOVFE_Pos              28                                             /**< (US_IMR) LON Backlog Overflow Error Interrupt Mask Position */
+#define US_IMR_LON_LBLOVFE_Msk              (_U_(0x1) << US_IMR_LON_LBLOVFE_Pos)           /**< (US_IMR) LON Backlog Overflow Error Interrupt Mask Mask */
+#define US_IMR_LON_LBLOVFE                  US_IMR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LBLOVFE_Msk instead */
+#define US_IMR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IMR_LON) Register MASK  (Use US_IMR_LON_Msk instead)  */
+#define US_IMR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IMR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IMR_LON_SPI_UNRE_Pos             10                                             /**< (US_IMR) SPI Underrun Error Interrupt Mask Position */
+#define US_IMR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IMR_LON_SPI_UNRE_Pos)          /**< (US_IMR) SPI Underrun Error Interrupt Mask Mask */
+#define US_IMR_LON_SPI_UNRE                 US_IMR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_SPI_UNRE_Msk instead */
+#define US_IMR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IMR_LON_SPI) Register MASK  (Use US_IMR_LON_SPI_Msk instead)  */
+#define US_IMR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IMR_LON_SPI) Register Mask  */
+
+
+/* -------- US_CSR : (USART Offset: 0x14) (R/ 32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready (cleared by reading US_RHR) */
+    uint32_t TXRDY:1;                   /**< bit:      1  Transmitter Ready (cleared by writing US_THR) */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVRE:1;                    /**< bit:      5  Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
+    uint32_t TXEMPTY:1;                 /**< bit:      9  Transmitter Empty (cleared by writing US_THR) */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Flag (cleared on read) */
+    uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Flag (cleared on read) */
+    uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Flag (cleared on read) */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
+    uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Flag (cleared on read) */
+    uint32_t RI:1;                      /**< bit:     20  Image of RI Input                        */
+    uint32_t DSR:1;                     /**< bit:     21  Image of DSR Input                       */
+    uint32_t DCD:1;                     /**< bit:     22  Image of DCD Input                       */
+    uint32_t CTS:1;                     /**< bit:     23  Image of CTS Input                       */
+    uint32_t MANERR:1;                  /**< bit:     24  Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :3;                        /**< bit: 20..22  Reserved */
+    uint32_t NSS:1;                     /**< bit:     23  Image of NSS Line                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received     */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed                   */
+    uint32_t :7;                        /**< bit: 16..22  Reserved */
+    uint32_t LINBLS:1;                  /**< bit:     23  LIN Bus Line Status                      */
+    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error                            */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error       */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Error              */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error                       */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Mask */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error                */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error                 */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error                    */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error                            */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission End Flag                */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Detected Flag              */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination              */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception End Flag                   */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error                       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_CSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CSR_OFFSET                       (0x14)                                        /**<  (US_CSR) Channel Status Register  Offset */
+
+#define US_CSR_RXRDY_Pos                    0                                              /**< (US_CSR) Receiver Ready (cleared by reading US_RHR) Position */
+#define US_CSR_RXRDY_Msk                    (_U_(0x1) << US_CSR_RXRDY_Pos)                 /**< (US_CSR) Receiver Ready (cleared by reading US_RHR) Mask */
+#define US_CSR_RXRDY                        US_CSR_RXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXRDY_Msk instead */
+#define US_CSR_TXRDY_Pos                    1                                              /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Position */
+#define US_CSR_TXRDY_Msk                    (_U_(0x1) << US_CSR_TXRDY_Pos)                 /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Mask */
+#define US_CSR_TXRDY                        US_CSR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXRDY_Msk instead */
+#define US_CSR_OVRE_Pos                     5                                              /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_OVRE_Msk                     (_U_(0x1) << US_CSR_OVRE_Pos)                  /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_OVRE                         US_CSR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_OVRE_Msk instead */
+#define US_CSR_TXEMPTY_Pos                  9                                              /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Position */
+#define US_CSR_TXEMPTY_Msk                  (_U_(0x1) << US_CSR_TXEMPTY_Pos)               /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Mask */
+#define US_CSR_TXEMPTY                      US_CSR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXEMPTY_Msk instead */
+#define US_CSR_RIIC_Pos                     16                                             /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Position */
+#define US_CSR_RIIC_Msk                     (_U_(0x1) << US_CSR_RIIC_Pos)                  /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Mask */
+#define US_CSR_RIIC                         US_CSR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RIIC_Msk instead */
+#define US_CSR_DSRIC_Pos                    17                                             /**< (US_CSR) Data Set Ready Input Change Flag (cleared on read) Position */
+#define US_CSR_DSRIC_Msk                    (_U_(0x1) << US_CSR_DSRIC_Pos)                 /**< (US_CSR) Data Set Ready Input Change Flag (cleared on read) Mask */
+#define US_CSR_DSRIC                        US_CSR_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSRIC_Msk instead */
+#define US_CSR_DCDIC_Pos                    18                                             /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Position */
+#define US_CSR_DCDIC_Msk                    (_U_(0x1) << US_CSR_DCDIC_Pos)                 /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Mask */
+#define US_CSR_DCDIC                        US_CSR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCDIC_Msk instead */
+#define US_CSR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
+#define US_CSR_Msk                          _U_(0x70223)                                   /**< (US_CSR) Register Mask  */
+
+/* USART mode */
+#define US_CSR_USART_RXBRK_Pos              2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_RXBRK_Msk              (_U_(0x1) << US_CSR_USART_RXBRK_Pos)           /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_RXBRK                  US_CSR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_RXBRK_Msk instead */
+#define US_CSR_USART_ITER_Pos               10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_USART_ITER_Msk               (_U_(0x1) << US_CSR_USART_ITER_Pos)            /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_USART_ITER                   US_CSR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_ITER_Msk instead */
+#define US_CSR_USART_NACK_Pos               13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_USART_NACK_Msk               (_U_(0x1) << US_CSR_USART_NACK_Pos)            /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_USART_NACK                   US_CSR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_NACK_Msk instead */
+#define US_CSR_USART_CTSIC_Pos              19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_USART_CTSIC_Msk              (_U_(0x1) << US_CSR_USART_CTSIC_Pos)           /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_USART_CTSIC                  US_CSR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_CTSIC_Msk instead */
+#define US_CSR_USART_RI_Pos                 20                                             /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_USART_RI_Msk                 (_U_(0x1) << US_CSR_USART_RI_Pos)              /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_USART_RI                     US_CSR_USART_RI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_RI_Msk instead */
+#define US_CSR_USART_DSR_Pos                21                                             /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_USART_DSR_Msk                (_U_(0x1) << US_CSR_USART_DSR_Pos)             /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_USART_DSR                    US_CSR_USART_DSR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_DSR_Msk instead */
+#define US_CSR_USART_DCD_Pos                22                                             /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_USART_DCD_Msk                (_U_(0x1) << US_CSR_USART_DCD_Pos)             /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_USART_DCD                    US_CSR_USART_DCD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_DCD_Msk instead */
+#define US_CSR_USART_CTS_Pos                23                                             /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_USART_CTS_Msk                (_U_(0x1) << US_CSR_USART_CTS_Pos)             /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_USART_CTS                    US_CSR_USART_CTS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_CTS_Msk instead */
+#define US_CSR_USART_MANERR_Pos             24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_MANERR_Msk             (_U_(0x1) << US_CSR_USART_MANERR_Pos)          /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_MANERR                 US_CSR_USART_MANERR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_MANERR_Msk instead */
+#define US_CSR_USART_MASK                   _U_(0x1F82404)                                 /**< \deprecated (US_CSR_USART) Register MASK  (Use US_CSR_USART_Msk instead)  */
+#define US_CSR_USART_Msk                    _U_(0x1F82404)                                 /**< (US_CSR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_CSR_USART_LIN_FRAME_Pos          6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_CSR_USART_LIN_FRAME_Pos)       /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_LIN_FRAME              US_CSR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_FRAME_Msk instead */
+#define US_CSR_USART_LIN_PARE_Pos           7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_LIN_PARE_Msk           (_U_(0x1) << US_CSR_USART_LIN_PARE_Pos)        /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_LIN_PARE               US_CSR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_PARE_Msk instead */
+#define US_CSR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_CSR_USART_LIN_TIMEOUT_Pos)     /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_USART_LIN_TIMEOUT            US_CSR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_TIMEOUT_Msk instead */
+#define US_CSR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_CSR_USART_LIN) Register MASK  (Use US_CSR_USART_LIN_Msk instead)  */
+#define US_CSR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_CSR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_CSR_SPI_NSSE_Pos                 19                                             /**< (US_CSR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_CSR_SPI_NSSE_Msk                 (_U_(0x1) << US_CSR_SPI_NSSE_Pos)              /**< (US_CSR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_CSR_SPI_NSSE                     US_CSR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_SPI_NSSE_Msk instead */
+#define US_CSR_SPI_NSS_Pos                  23                                             /**< (US_CSR) Image of NSS Line Position */
+#define US_CSR_SPI_NSS_Msk                  (_U_(0x1) << US_CSR_SPI_NSS_Pos)               /**< (US_CSR) Image of NSS Line Mask */
+#define US_CSR_SPI_NSS                      US_CSR_SPI_NSS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_SPI_NSS_Msk instead */
+#define US_CSR_SPI_MASK                     _U_(0x880000)                                  /**< \deprecated (US_CSR_SPI) Register MASK  (Use US_CSR_SPI_Msk instead)  */
+#define US_CSR_SPI_Msk                      _U_(0x880000)                                  /**< (US_CSR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_CSR_LIN_LINBK_Pos                13                                             /**< (US_CSR) LIN Break Sent or LIN Break Received Position */
+#define US_CSR_LIN_LINBK_Msk                (_U_(0x1) << US_CSR_LIN_LINBK_Pos)             /**< (US_CSR) LIN Break Sent or LIN Break Received Mask */
+#define US_CSR_LIN_LINBK                    US_CSR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBK_Msk instead */
+#define US_CSR_LIN_LINID_Pos                14                                             /**< (US_CSR) LIN Identifier Sent or LIN Identifier Received Position */
+#define US_CSR_LIN_LINID_Msk                (_U_(0x1) << US_CSR_LIN_LINID_Pos)             /**< (US_CSR) LIN Identifier Sent or LIN Identifier Received Mask */
+#define US_CSR_LIN_LINID                    US_CSR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINID_Msk instead */
+#define US_CSR_LIN_LINTC_Pos                15                                             /**< (US_CSR) LIN Transfer Completed Position */
+#define US_CSR_LIN_LINTC_Msk                (_U_(0x1) << US_CSR_LIN_LINTC_Pos)             /**< (US_CSR) LIN Transfer Completed Mask */
+#define US_CSR_LIN_LINTC                    US_CSR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINTC_Msk instead */
+#define US_CSR_LIN_LINBLS_Pos               23                                             /**< (US_CSR) LIN Bus Line Status Position */
+#define US_CSR_LIN_LINBLS_Msk               (_U_(0x1) << US_CSR_LIN_LINBLS_Pos)            /**< (US_CSR) LIN Bus Line Status Mask */
+#define US_CSR_LIN_LINBLS                   US_CSR_LIN_LINBLS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBLS_Msk instead */
+#define US_CSR_LIN_LINBE_Pos                25                                             /**< (US_CSR) LIN Bus Error Position */
+#define US_CSR_LIN_LINBE_Msk                (_U_(0x1) << US_CSR_LIN_LINBE_Pos)             /**< (US_CSR) LIN Bus Error Mask */
+#define US_CSR_LIN_LINBE                    US_CSR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBE_Msk instead */
+#define US_CSR_LIN_LINISFE_Pos              26                                             /**< (US_CSR) LIN Inconsistent Synch Field Error Position */
+#define US_CSR_LIN_LINISFE_Msk              (_U_(0x1) << US_CSR_LIN_LINISFE_Pos)           /**< (US_CSR) LIN Inconsistent Synch Field Error Mask */
+#define US_CSR_LIN_LINISFE                  US_CSR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINISFE_Msk instead */
+#define US_CSR_LIN_LINIPE_Pos               27                                             /**< (US_CSR) LIN Identifier Parity Error Position */
+#define US_CSR_LIN_LINIPE_Msk               (_U_(0x1) << US_CSR_LIN_LINIPE_Pos)            /**< (US_CSR) LIN Identifier Parity Error Mask */
+#define US_CSR_LIN_LINIPE                   US_CSR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINIPE_Msk instead */
+#define US_CSR_LIN_LINCE_Pos                28                                             /**< (US_CSR) LIN Checksum Error Position */
+#define US_CSR_LIN_LINCE_Msk                (_U_(0x1) << US_CSR_LIN_LINCE_Pos)             /**< (US_CSR) LIN Checksum Error Mask */
+#define US_CSR_LIN_LINCE                    US_CSR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINCE_Msk instead */
+#define US_CSR_LIN_LINSNRE_Pos              29                                             /**< (US_CSR) LIN Slave Not Responding Error Interrupt Mask Position */
+#define US_CSR_LIN_LINSNRE_Msk              (_U_(0x1) << US_CSR_LIN_LINSNRE_Pos)           /**< (US_CSR) LIN Slave Not Responding Error Interrupt Mask Mask */
+#define US_CSR_LIN_LINSNRE                  US_CSR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINSNRE_Msk instead */
+#define US_CSR_LIN_LINSTE_Pos               30                                             /**< (US_CSR) LIN Synch Tolerance Error Position */
+#define US_CSR_LIN_LINSTE_Msk               (_U_(0x1) << US_CSR_LIN_LINSTE_Pos)            /**< (US_CSR) LIN Synch Tolerance Error Mask */
+#define US_CSR_LIN_LINSTE                   US_CSR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINSTE_Msk instead */
+#define US_CSR_LIN_LINHTE_Pos               31                                             /**< (US_CSR) LIN Header Timeout Error Position */
+#define US_CSR_LIN_LINHTE_Msk               (_U_(0x1) << US_CSR_LIN_LINHTE_Pos)            /**< (US_CSR) LIN Header Timeout Error Mask */
+#define US_CSR_LIN_LINHTE                   US_CSR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINHTE_Msk instead */
+#define US_CSR_LIN_MASK                     _U_(0xFE80E000)                                /**< \deprecated (US_CSR_LIN) Register MASK  (Use US_CSR_LIN_Msk instead)  */
+#define US_CSR_LIN_Msk                      _U_(0xFE80E000)                                /**< (US_CSR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_CSR_LON_LSFE_Pos                 6                                              /**< (US_CSR) LON Short Frame Error Position */
+#define US_CSR_LON_LSFE_Msk                 (_U_(0x1) << US_CSR_LON_LSFE_Pos)              /**< (US_CSR) LON Short Frame Error Mask */
+#define US_CSR_LON_LSFE                     US_CSR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LSFE_Msk instead */
+#define US_CSR_LON_LCRCE_Pos                7                                              /**< (US_CSR) LON CRC Error Position */
+#define US_CSR_LON_LCRCE_Msk                (_U_(0x1) << US_CSR_LON_LCRCE_Pos)             /**< (US_CSR) LON CRC Error Mask */
+#define US_CSR_LON_LCRCE                    US_CSR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LCRCE_Msk instead */
+#define US_CSR_LON_LTXD_Pos                 24                                             /**< (US_CSR) LON Transmission End Flag Position */
+#define US_CSR_LON_LTXD_Msk                 (_U_(0x1) << US_CSR_LON_LTXD_Pos)              /**< (US_CSR) LON Transmission End Flag Mask */
+#define US_CSR_LON_LTXD                     US_CSR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LTXD_Msk instead */
+#define US_CSR_LON_LCOL_Pos                 25                                             /**< (US_CSR) LON Collision Detected Flag Position */
+#define US_CSR_LON_LCOL_Msk                 (_U_(0x1) << US_CSR_LON_LCOL_Pos)              /**< (US_CSR) LON Collision Detected Flag Mask */
+#define US_CSR_LON_LCOL                     US_CSR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LCOL_Msk instead */
+#define US_CSR_LON_LFET_Pos                 26                                             /**< (US_CSR) LON Frame Early Termination Position */
+#define US_CSR_LON_LFET_Msk                 (_U_(0x1) << US_CSR_LON_LFET_Pos)              /**< (US_CSR) LON Frame Early Termination Mask */
+#define US_CSR_LON_LFET                     US_CSR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LFET_Msk instead */
+#define US_CSR_LON_LRXD_Pos                 27                                             /**< (US_CSR) LON Reception End Flag Position */
+#define US_CSR_LON_LRXD_Msk                 (_U_(0x1) << US_CSR_LON_LRXD_Pos)              /**< (US_CSR) LON Reception End Flag Mask */
+#define US_CSR_LON_LRXD                     US_CSR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LRXD_Msk instead */
+#define US_CSR_LON_LBLOVFE_Pos              28                                             /**< (US_CSR) LON Backlog Overflow Error Position */
+#define US_CSR_LON_LBLOVFE_Msk              (_U_(0x1) << US_CSR_LON_LBLOVFE_Pos)           /**< (US_CSR) LON Backlog Overflow Error Mask */
+#define US_CSR_LON_LBLOVFE                  US_CSR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LBLOVFE_Msk instead */
+#define US_CSR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_CSR_LON) Register MASK  (Use US_CSR_LON_Msk instead)  */
+#define US_CSR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_CSR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_CSR_LON_SPI_UNRE_Pos             10                                             /**< (US_CSR) SPI Underrun Error Position */
+#define US_CSR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_CSR_LON_SPI_UNRE_Pos)          /**< (US_CSR) SPI Underrun Error Mask */
+#define US_CSR_LON_SPI_UNRE                 US_CSR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_SPI_UNRE_Msk instead */
+#define US_CSR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_CSR_LON_SPI) Register MASK  (Use US_CSR_LON_SPI_Msk instead)  */
+#define US_CSR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_CSR_LON_SPI) Register Mask  */
+
+
+/* -------- US_RHR : (USART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXCHR:9;                   /**< bit:   0..8  Received Character                       */
+    uint32_t :6;                        /**< bit:  9..14  Reserved */
+    uint32_t RXSYNH:1;                  /**< bit:     15  Received Sync                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_RHR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RHR_OFFSET                       (0x18)                                        /**<  (US_RHR) Receive Holding Register  Offset */
+
+#define US_RHR_RXCHR_Pos                    0                                              /**< (US_RHR) Received Character Position */
+#define US_RHR_RXCHR_Msk                    (_U_(0x1FF) << US_RHR_RXCHR_Pos)               /**< (US_RHR) Received Character Mask */
+#define US_RHR_RXCHR(value)                 (US_RHR_RXCHR_Msk & ((value) << US_RHR_RXCHR_Pos))
+#define US_RHR_RXSYNH_Pos                   15                                             /**< (US_RHR) Received Sync Position */
+#define US_RHR_RXSYNH_Msk                   (_U_(0x1) << US_RHR_RXSYNH_Pos)                /**< (US_RHR) Received Sync Mask */
+#define US_RHR_RXSYNH                       US_RHR_RXSYNH_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_RHR_RXSYNH_Msk instead */
+#define US_RHR_MASK                         _U_(0x81FF)                                    /**< \deprecated (US_RHR) Register MASK  (Use US_RHR_Msk instead)  */
+#define US_RHR_Msk                          _U_(0x81FF)                                    /**< (US_RHR) Register Mask  */
+
+
+/* -------- US_THR : (USART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXCHR:9;                   /**< bit:   0..8  Character to be Transmitted              */
+    uint32_t :6;                        /**< bit:  9..14  Reserved */
+    uint32_t TXSYNH:1;                  /**< bit:     15  Sync Field to be Transmitted             */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_THR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_THR_OFFSET                       (0x1C)                                        /**<  (US_THR) Transmit Holding Register  Offset */
+
+#define US_THR_TXCHR_Pos                    0                                              /**< (US_THR) Character to be Transmitted Position */
+#define US_THR_TXCHR_Msk                    (_U_(0x1FF) << US_THR_TXCHR_Pos)               /**< (US_THR) Character to be Transmitted Mask */
+#define US_THR_TXCHR(value)                 (US_THR_TXCHR_Msk & ((value) << US_THR_TXCHR_Pos))
+#define US_THR_TXSYNH_Pos                   15                                             /**< (US_THR) Sync Field to be Transmitted Position */
+#define US_THR_TXSYNH_Msk                   (_U_(0x1) << US_THR_TXSYNH_Pos)                /**< (US_THR) Sync Field to be Transmitted Mask */
+#define US_THR_TXSYNH                       US_THR_TXSYNH_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_THR_TXSYNH_Msk instead */
+#define US_THR_MASK                         _U_(0x81FF)                                    /**< \deprecated (US_THR) Register MASK  (Use US_THR_Msk instead)  */
+#define US_THR_Msk                          _U_(0x81FF)                                    /**< (US_THR) Register Mask  */
+
+
+/* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CD:16;                     /**< bit:  0..15  Clock Divider                            */
+    uint32_t FP:3;                      /**< bit: 16..18  Fractional Part                          */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_BRGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_BRGR_OFFSET                      (0x20)                                        /**<  (US_BRGR) Baud Rate Generator Register  Offset */
+
+#define US_BRGR_CD_Pos                      0                                              /**< (US_BRGR) Clock Divider Position */
+#define US_BRGR_CD_Msk                      (_U_(0xFFFF) << US_BRGR_CD_Pos)                /**< (US_BRGR) Clock Divider Mask */
+#define US_BRGR_CD(value)                   (US_BRGR_CD_Msk & ((value) << US_BRGR_CD_Pos))
+#define US_BRGR_FP_Pos                      16                                             /**< (US_BRGR) Fractional Part Position */
+#define US_BRGR_FP_Msk                      (_U_(0x7) << US_BRGR_FP_Pos)                   /**< (US_BRGR) Fractional Part Mask */
+#define US_BRGR_FP(value)                   (US_BRGR_FP_Msk & ((value) << US_BRGR_FP_Pos))
+#define US_BRGR_MASK                        _U_(0x7FFFF)                                   /**< \deprecated (US_BRGR) Register MASK  (Use US_BRGR_Msk instead)  */
+#define US_BRGR_Msk                         _U_(0x7FFFF)                                   /**< (US_BRGR) Register Mask  */
+
+
+/* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Timeout Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TO:17;                     /**< bit:  0..16  Timeout Value                            */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_RTOR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RTOR_OFFSET                      (0x24)                                        /**<  (US_RTOR) Receiver Timeout Register  Offset */
+
+#define US_RTOR_TO_Pos                      0                                              /**< (US_RTOR) Timeout Value Position */
+#define US_RTOR_TO_Msk                      (_U_(0x1FFFF) << US_RTOR_TO_Pos)               /**< (US_RTOR) Timeout Value Mask */
+#define US_RTOR_TO(value)                   (US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos))
+#define US_RTOR_MASK                        _U_(0x1FFFF)                                   /**< \deprecated (US_RTOR) Register MASK  (Use US_RTOR_Msk instead)  */
+#define US_RTOR_Msk                         _U_(0x1FFFF)                                   /**< (US_RTOR) Register Mask  */
+
+
+/* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct { // USART mode
+    uint32_t TG:8;                      /**< bit:   0..7  Timeguard Value                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // LON mode
+    uint32_t PCYCLE:24;                 /**< bit:  0..23  LON PCYCLE Length                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_TTGR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_TTGR_OFFSET                      (0x28)                                        /**<  (US_TTGR) Transmitter Timeguard Register  Offset */
+
+#define US_TTGR_MASK                        _U_(0x00)                                      /**< \deprecated (US_TTGR) Register MASK  (Use US_TTGR_Msk instead)  */
+#define US_TTGR_Msk                         _U_(0x00)                                      /**< (US_TTGR) Register Mask  */
+
+/* USART mode */
+#define US_TTGR_USART_TG_Pos                0                                              /**< (US_TTGR) Timeguard Value Position */
+#define US_TTGR_USART_TG_Msk                (_U_(0xFF) << US_TTGR_USART_TG_Pos)            /**< (US_TTGR) Timeguard Value Mask */
+#define US_TTGR_USART_TG(value)             (US_TTGR_USART_TG_Msk & ((value) << US_TTGR_USART_TG_Pos))
+#define US_TTGR_USART_MASK                  _U_(0xFF)                                      /**< \deprecated (US_TTGR_USART) Register MASK  (Use US_TTGR_USART_Msk instead)  */
+#define US_TTGR_USART_Msk                   _U_(0xFF)                                      /**< (US_TTGR_USART) Register Mask  */
+
+/* LON mode */
+#define US_TTGR_LON_PCYCLE_Pos              0                                              /**< (US_TTGR) LON PCYCLE Length Position */
+#define US_TTGR_LON_PCYCLE_Msk              (_U_(0xFFFFFF) << US_TTGR_LON_PCYCLE_Pos)      /**< (US_TTGR) LON PCYCLE Length Mask */
+#define US_TTGR_LON_PCYCLE(value)           (US_TTGR_LON_PCYCLE_Msk & ((value) << US_TTGR_LON_PCYCLE_Pos))
+#define US_TTGR_LON_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (US_TTGR_LON) Register MASK  (Use US_TTGR_LON_Msk instead)  */
+#define US_TTGR_LON_Msk                     _U_(0xFFFFFF)                                  /**< (US_TTGR_LON) Register Mask  */
+
+
+/* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct { // USART mode
+    uint32_t FI_DI_RATIO:16;            /**< bit:  0..15  FI Over DI Ratio Value                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // LON mode
+    uint32_t BETA2:24;                  /**< bit:  0..23  LON BETA2 Length                         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_FIDI_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_FIDI_OFFSET                      (0x40)                                        /**<  (US_FIDI) FI DI Ratio Register  Offset */
+
+#define US_FIDI_MASK                        _U_(0x00)                                      /**< \deprecated (US_FIDI) Register MASK  (Use US_FIDI_Msk instead)  */
+#define US_FIDI_Msk                         _U_(0x00)                                      /**< (US_FIDI) Register Mask  */
+
+/* USART mode */
+#define US_FIDI_USART_FI_DI_RATIO_Pos       0                                              /**< (US_FIDI) FI Over DI Ratio Value Position */
+#define US_FIDI_USART_FI_DI_RATIO_Msk       (_U_(0xFFFF) << US_FIDI_USART_FI_DI_RATIO_Pos)  /**< (US_FIDI) FI Over DI Ratio Value Mask */
+#define US_FIDI_USART_FI_DI_RATIO(value)    (US_FIDI_USART_FI_DI_RATIO_Msk & ((value) << US_FIDI_USART_FI_DI_RATIO_Pos))
+#define US_FIDI_USART_MASK                  _U_(0xFFFF)                                    /**< \deprecated (US_FIDI_USART) Register MASK  (Use US_FIDI_USART_Msk instead)  */
+#define US_FIDI_USART_Msk                   _U_(0xFFFF)                                    /**< (US_FIDI_USART) Register Mask  */
+
+/* LON mode */
+#define US_FIDI_LON_BETA2_Pos               0                                              /**< (US_FIDI) LON BETA2 Length Position */
+#define US_FIDI_LON_BETA2_Msk               (_U_(0xFFFFFF) << US_FIDI_LON_BETA2_Pos)       /**< (US_FIDI) LON BETA2 Length Mask */
+#define US_FIDI_LON_BETA2(value)            (US_FIDI_LON_BETA2_Msk & ((value) << US_FIDI_LON_BETA2_Pos))
+#define US_FIDI_LON_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (US_FIDI_LON) Register MASK  (Use US_FIDI_LON_Msk instead)  */
+#define US_FIDI_LON_Msk                     _U_(0xFFFFFF)                                  /**< (US_FIDI_LON) Register Mask  */
+
+
+/* -------- US_NER : (USART Offset: 0x44) (R/ 32) Number of Errors Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NB_ERRORS:8;               /**< bit:   0..7  Number of Errors                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_NER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_NER_OFFSET                       (0x44)                                        /**<  (US_NER) Number of Errors Register  Offset */
+
+#define US_NER_NB_ERRORS_Pos                0                                              /**< (US_NER) Number of Errors Position */
+#define US_NER_NB_ERRORS_Msk                (_U_(0xFF) << US_NER_NB_ERRORS_Pos)            /**< (US_NER) Number of Errors Mask */
+#define US_NER_NB_ERRORS(value)             (US_NER_NB_ERRORS_Msk & ((value) << US_NER_NB_ERRORS_Pos))
+#define US_NER_MASK                         _U_(0xFF)                                      /**< \deprecated (US_NER) Register MASK  (Use US_NER_Msk instead)  */
+#define US_NER_Msk                          _U_(0xFF)                                      /**< (US_NER) Register Mask  */
+
+
+/* -------- US_IF : (USART Offset: 0x4c) (R/W 32) IrDA Filter Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IRDA_FILTER:8;             /**< bit:   0..7  IrDA Filter                              */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IF_OFFSET                        (0x4C)                                        /**<  (US_IF) IrDA Filter Register  Offset */
+
+#define US_IF_IRDA_FILTER_Pos               0                                              /**< (US_IF) IrDA Filter Position */
+#define US_IF_IRDA_FILTER_Msk               (_U_(0xFF) << US_IF_IRDA_FILTER_Pos)           /**< (US_IF) IrDA Filter Mask */
+#define US_IF_IRDA_FILTER(value)            (US_IF_IRDA_FILTER_Msk & ((value) << US_IF_IRDA_FILTER_Pos))
+#define US_IF_MASK                          _U_(0xFF)                                      /**< \deprecated (US_IF) Register MASK  (Use US_IF_Msk instead)  */
+#define US_IF_Msk                           _U_(0xFF)                                      /**< (US_IF) Register Mask  */
+
+
+/* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TX_PL:4;                   /**< bit:   0..3  Transmitter Preamble Length              */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t TX_PP:2;                   /**< bit:   8..9  Transmitter Preamble Pattern             */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t TX_MPOL:1;                 /**< bit:     12  Transmitter Manchester Polarity          */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t RX_PL:4;                   /**< bit: 16..19  Receiver Preamble Length                 */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t RX_PP:2;                   /**< bit: 24..25  Receiver Preamble Pattern detected       */
+    uint32_t :2;                        /**< bit: 26..27  Reserved */
+    uint32_t RX_MPOL:1;                 /**< bit:     28  Receiver Manchester Polarity             */
+    uint32_t ONE:1;                     /**< bit:     29  Must Be Set to 1                         */
+    uint32_t DRIFT:1;                   /**< bit:     30  Drift Compensation                       */
+    uint32_t RXIDLEV:1;                 /**< bit:     31  Receiver Idle Value                      */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_MAN_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MAN_OFFSET                       (0x50)                                        /**<  (US_MAN) Manchester Configuration Register  Offset */
+
+#define US_MAN_TX_PL_Pos                    0                                              /**< (US_MAN) Transmitter Preamble Length Position */
+#define US_MAN_TX_PL_Msk                    (_U_(0xF) << US_MAN_TX_PL_Pos)                 /**< (US_MAN) Transmitter Preamble Length Mask */
+#define US_MAN_TX_PL(value)                 (US_MAN_TX_PL_Msk & ((value) << US_MAN_TX_PL_Pos))
+#define US_MAN_TX_PP_Pos                    8                                              /**< (US_MAN) Transmitter Preamble Pattern Position */
+#define US_MAN_TX_PP_Msk                    (_U_(0x3) << US_MAN_TX_PP_Pos)                 /**< (US_MAN) Transmitter Preamble Pattern Mask */
+#define US_MAN_TX_PP(value)                 (US_MAN_TX_PP_Msk & ((value) << US_MAN_TX_PP_Pos))
+#define   US_MAN_TX_PP_ALL_ONE_Val          _U_(0x0)                                       /**< (US_MAN) The preamble is composed of '1's  */
+#define   US_MAN_TX_PP_ALL_ZERO_Val         _U_(0x1)                                       /**< (US_MAN) The preamble is composed of '0's  */
+#define   US_MAN_TX_PP_ZERO_ONE_Val         _U_(0x2)                                       /**< (US_MAN) The preamble is composed of '01's  */
+#define   US_MAN_TX_PP_ONE_ZERO_Val         _U_(0x3)                                       /**< (US_MAN) The preamble is composed of '10's  */
+#define US_MAN_TX_PP_ALL_ONE                (US_MAN_TX_PP_ALL_ONE_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '1's Position  */
+#define US_MAN_TX_PP_ALL_ZERO               (US_MAN_TX_PP_ALL_ZERO_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '0's Position  */
+#define US_MAN_TX_PP_ZERO_ONE               (US_MAN_TX_PP_ZERO_ONE_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '01's Position  */
+#define US_MAN_TX_PP_ONE_ZERO               (US_MAN_TX_PP_ONE_ZERO_Val << US_MAN_TX_PP_Pos)  /**< (US_MAN) The preamble is composed of '10's Position  */
+#define US_MAN_TX_MPOL_Pos                  12                                             /**< (US_MAN) Transmitter Manchester Polarity Position */
+#define US_MAN_TX_MPOL_Msk                  (_U_(0x1) << US_MAN_TX_MPOL_Pos)               /**< (US_MAN) Transmitter Manchester Polarity Mask */
+#define US_MAN_TX_MPOL                      US_MAN_TX_MPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_TX_MPOL_Msk instead */
+#define US_MAN_RX_PL_Pos                    16                                             /**< (US_MAN) Receiver Preamble Length Position */
+#define US_MAN_RX_PL_Msk                    (_U_(0xF) << US_MAN_RX_PL_Pos)                 /**< (US_MAN) Receiver Preamble Length Mask */
+#define US_MAN_RX_PL(value)                 (US_MAN_RX_PL_Msk & ((value) << US_MAN_RX_PL_Pos))
+#define US_MAN_RX_PP_Pos                    24                                             /**< (US_MAN) Receiver Preamble Pattern detected Position */
+#define US_MAN_RX_PP_Msk                    (_U_(0x3) << US_MAN_RX_PP_Pos)                 /**< (US_MAN) Receiver Preamble Pattern detected Mask */
+#define US_MAN_RX_PP(value)                 (US_MAN_RX_PP_Msk & ((value) << US_MAN_RX_PP_Pos))
+#define   US_MAN_RX_PP_ALL_ONE_Val          _U_(0x0)                                       /**< (US_MAN) The preamble is composed of '1's  */
+#define   US_MAN_RX_PP_ALL_ZERO_Val         _U_(0x1)                                       /**< (US_MAN) The preamble is composed of '0's  */
+#define   US_MAN_RX_PP_ZERO_ONE_Val         _U_(0x2)                                       /**< (US_MAN) The preamble is composed of '01's  */
+#define   US_MAN_RX_PP_ONE_ZERO_Val         _U_(0x3)                                       /**< (US_MAN) The preamble is composed of '10's  */
+#define US_MAN_RX_PP_ALL_ONE                (US_MAN_RX_PP_ALL_ONE_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '1's Position  */
+#define US_MAN_RX_PP_ALL_ZERO               (US_MAN_RX_PP_ALL_ZERO_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '0's Position  */
+#define US_MAN_RX_PP_ZERO_ONE               (US_MAN_RX_PP_ZERO_ONE_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '01's Position  */
+#define US_MAN_RX_PP_ONE_ZERO               (US_MAN_RX_PP_ONE_ZERO_Val << US_MAN_RX_PP_Pos)  /**< (US_MAN) The preamble is composed of '10's Position  */
+#define US_MAN_RX_MPOL_Pos                  28                                             /**< (US_MAN) Receiver Manchester Polarity Position */
+#define US_MAN_RX_MPOL_Msk                  (_U_(0x1) << US_MAN_RX_MPOL_Pos)               /**< (US_MAN) Receiver Manchester Polarity Mask */
+#define US_MAN_RX_MPOL                      US_MAN_RX_MPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_RX_MPOL_Msk instead */
+#define US_MAN_ONE_Pos                      29                                             /**< (US_MAN) Must Be Set to 1 Position */
+#define US_MAN_ONE_Msk                      (_U_(0x1) << US_MAN_ONE_Pos)                   /**< (US_MAN) Must Be Set to 1 Mask */
+#define US_MAN_ONE                          US_MAN_ONE_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_ONE_Msk instead */
+#define US_MAN_DRIFT_Pos                    30                                             /**< (US_MAN) Drift Compensation Position */
+#define US_MAN_DRIFT_Msk                    (_U_(0x1) << US_MAN_DRIFT_Pos)                 /**< (US_MAN) Drift Compensation Mask */
+#define US_MAN_DRIFT                        US_MAN_DRIFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_DRIFT_Msk instead */
+#define US_MAN_RXIDLEV_Pos                  31                                             /**< (US_MAN) Receiver Idle Value Position */
+#define US_MAN_RXIDLEV_Msk                  (_U_(0x1) << US_MAN_RXIDLEV_Pos)               /**< (US_MAN) Receiver Idle Value Mask */
+#define US_MAN_RXIDLEV                      US_MAN_RXIDLEV_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_RXIDLEV_Msk instead */
+#define US_MAN_MASK                         _U_(0xF30F130F)                                /**< \deprecated (US_MAN) Register MASK  (Use US_MAN_Msk instead)  */
+#define US_MAN_Msk                          _U_(0xF30F130F)                                /**< (US_MAN) Register Mask  */
+
+
+/* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NACT:2;                    /**< bit:   0..1  LIN Node Action                          */
+    uint32_t PARDIS:1;                  /**< bit:      2  Parity Disable                           */
+    uint32_t CHKDIS:1;                  /**< bit:      3  Checksum Disable                         */
+    uint32_t CHKTYP:1;                  /**< bit:      4  Checksum Type                            */
+    uint32_t DLM:1;                     /**< bit:      5  Data Length Mode                         */
+    uint32_t FSDIS:1;                   /**< bit:      6  Frame Slot Mode Disable                  */
+    uint32_t WKUPTYP:1;                 /**< bit:      7  Wakeup Signal Type                       */
+    uint32_t DLC:8;                     /**< bit:  8..15  Data Length Control                      */
+    uint32_t PDCM:1;                    /**< bit:     16  DMAC Mode                                */
+    uint32_t SYNCDIS:1;                 /**< bit:     17  Synchronization Disable                  */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINMR_OFFSET                     (0x54)                                        /**<  (US_LINMR) LIN Mode Register  Offset */
+
+#define US_LINMR_NACT_Pos                   0                                              /**< (US_LINMR) LIN Node Action Position */
+#define US_LINMR_NACT_Msk                   (_U_(0x3) << US_LINMR_NACT_Pos)                /**< (US_LINMR) LIN Node Action Mask */
+#define US_LINMR_NACT(value)                (US_LINMR_NACT_Msk & ((value) << US_LINMR_NACT_Pos))
+#define   US_LINMR_NACT_PUBLISH_Val         _U_(0x0)                                       /**< (US_LINMR) The USART transmits the response.  */
+#define   US_LINMR_NACT_SUBSCRIBE_Val       _U_(0x1)                                       /**< (US_LINMR) The USART receives the response.  */
+#define   US_LINMR_NACT_IGNORE_Val          _U_(0x2)                                       /**< (US_LINMR) The USART does not transmit and does not receive the response.  */
+#define US_LINMR_NACT_PUBLISH               (US_LINMR_NACT_PUBLISH_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART transmits the response. Position  */
+#define US_LINMR_NACT_SUBSCRIBE             (US_LINMR_NACT_SUBSCRIBE_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART receives the response. Position  */
+#define US_LINMR_NACT_IGNORE                (US_LINMR_NACT_IGNORE_Val << US_LINMR_NACT_Pos)  /**< (US_LINMR) The USART does not transmit and does not receive the response. Position  */
+#define US_LINMR_PARDIS_Pos                 2                                              /**< (US_LINMR) Parity Disable Position */
+#define US_LINMR_PARDIS_Msk                 (_U_(0x1) << US_LINMR_PARDIS_Pos)              /**< (US_LINMR) Parity Disable Mask */
+#define US_LINMR_PARDIS                     US_LINMR_PARDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_PARDIS_Msk instead */
+#define US_LINMR_CHKDIS_Pos                 3                                              /**< (US_LINMR) Checksum Disable Position */
+#define US_LINMR_CHKDIS_Msk                 (_U_(0x1) << US_LINMR_CHKDIS_Pos)              /**< (US_LINMR) Checksum Disable Mask */
+#define US_LINMR_CHKDIS                     US_LINMR_CHKDIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_CHKDIS_Msk instead */
+#define US_LINMR_CHKTYP_Pos                 4                                              /**< (US_LINMR) Checksum Type Position */
+#define US_LINMR_CHKTYP_Msk                 (_U_(0x1) << US_LINMR_CHKTYP_Pos)              /**< (US_LINMR) Checksum Type Mask */
+#define US_LINMR_CHKTYP                     US_LINMR_CHKTYP_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_CHKTYP_Msk instead */
+#define US_LINMR_DLM_Pos                    5                                              /**< (US_LINMR) Data Length Mode Position */
+#define US_LINMR_DLM_Msk                    (_U_(0x1) << US_LINMR_DLM_Pos)                 /**< (US_LINMR) Data Length Mode Mask */
+#define US_LINMR_DLM                        US_LINMR_DLM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_DLM_Msk instead */
+#define US_LINMR_FSDIS_Pos                  6                                              /**< (US_LINMR) Frame Slot Mode Disable Position */
+#define US_LINMR_FSDIS_Msk                  (_U_(0x1) << US_LINMR_FSDIS_Pos)               /**< (US_LINMR) Frame Slot Mode Disable Mask */
+#define US_LINMR_FSDIS                      US_LINMR_FSDIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_FSDIS_Msk instead */
+#define US_LINMR_WKUPTYP_Pos                7                                              /**< (US_LINMR) Wakeup Signal Type Position */
+#define US_LINMR_WKUPTYP_Msk                (_U_(0x1) << US_LINMR_WKUPTYP_Pos)             /**< (US_LINMR) Wakeup Signal Type Mask */
+#define US_LINMR_WKUPTYP                    US_LINMR_WKUPTYP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_WKUPTYP_Msk instead */
+#define US_LINMR_DLC_Pos                    8                                              /**< (US_LINMR) Data Length Control Position */
+#define US_LINMR_DLC_Msk                    (_U_(0xFF) << US_LINMR_DLC_Pos)                /**< (US_LINMR) Data Length Control Mask */
+#define US_LINMR_DLC(value)                 (US_LINMR_DLC_Msk & ((value) << US_LINMR_DLC_Pos))
+#define US_LINMR_PDCM_Pos                   16                                             /**< (US_LINMR) DMAC Mode Position */
+#define US_LINMR_PDCM_Msk                   (_U_(0x1) << US_LINMR_PDCM_Pos)                /**< (US_LINMR) DMAC Mode Mask */
+#define US_LINMR_PDCM                       US_LINMR_PDCM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_PDCM_Msk instead */
+#define US_LINMR_SYNCDIS_Pos                17                                             /**< (US_LINMR) Synchronization Disable Position */
+#define US_LINMR_SYNCDIS_Msk                (_U_(0x1) << US_LINMR_SYNCDIS_Pos)             /**< (US_LINMR) Synchronization Disable Mask */
+#define US_LINMR_SYNCDIS                    US_LINMR_SYNCDIS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LINMR_SYNCDIS_Msk instead */
+#define US_LINMR_MASK                       _U_(0x3FFFF)                                   /**< \deprecated (US_LINMR) Register MASK  (Use US_LINMR_Msk instead)  */
+#define US_LINMR_Msk                        _U_(0x3FFFF)                                   /**< (US_LINMR) Register Mask  */
+
+
+/* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDCHR:8;                   /**< bit:   0..7  Identifier Character                     */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINIR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINIR_OFFSET                     (0x58)                                        /**<  (US_LINIR) LIN Identifier Register  Offset */
+
+#define US_LINIR_IDCHR_Pos                  0                                              /**< (US_LINIR) Identifier Character Position */
+#define US_LINIR_IDCHR_Msk                  (_U_(0xFF) << US_LINIR_IDCHR_Pos)              /**< (US_LINIR) Identifier Character Mask */
+#define US_LINIR_IDCHR(value)               (US_LINIR_IDCHR_Msk & ((value) << US_LINIR_IDCHR_Pos))
+#define US_LINIR_MASK                       _U_(0xFF)                                      /**< \deprecated (US_LINIR) Register MASK  (Use US_LINIR_Msk instead)  */
+#define US_LINIR_Msk                        _U_(0xFF)                                      /**< (US_LINIR) Register Mask  */
+
+
+/* -------- US_LINBRR : (USART Offset: 0x5c) (R/ 32) LIN Baud Rate Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LINCD:16;                  /**< bit:  0..15  Clock Divider after Synchronization      */
+    uint32_t LINFP:3;                   /**< bit: 16..18  Fractional Part after Synchronization    */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LINBRR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINBRR_OFFSET                    (0x5C)                                        /**<  (US_LINBRR) LIN Baud Rate Register  Offset */
+
+#define US_LINBRR_LINCD_Pos                 0                                              /**< (US_LINBRR) Clock Divider after Synchronization Position */
+#define US_LINBRR_LINCD_Msk                 (_U_(0xFFFF) << US_LINBRR_LINCD_Pos)           /**< (US_LINBRR) Clock Divider after Synchronization Mask */
+#define US_LINBRR_LINCD(value)              (US_LINBRR_LINCD_Msk & ((value) << US_LINBRR_LINCD_Pos))
+#define US_LINBRR_LINFP_Pos                 16                                             /**< (US_LINBRR) Fractional Part after Synchronization Position */
+#define US_LINBRR_LINFP_Msk                 (_U_(0x7) << US_LINBRR_LINFP_Pos)              /**< (US_LINBRR) Fractional Part after Synchronization Mask */
+#define US_LINBRR_LINFP(value)              (US_LINBRR_LINFP_Msk & ((value) << US_LINBRR_LINFP_Pos))
+#define US_LINBRR_MASK                      _U_(0x7FFFF)                                   /**< \deprecated (US_LINBRR) Register MASK  (Use US_LINBRR_Msk instead)  */
+#define US_LINBRR_Msk                       _U_(0x7FFFF)                                   /**< (US_LINBRR) Register Mask  */
+
+
+/* -------- US_LONMR : (USART Offset: 0x60) (R/W 32) LON Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t COMMT:1;                   /**< bit:      0  LON comm_type Parameter Value            */
+    uint32_t COLDET:1;                  /**< bit:      1  LON Collision Detection Feature          */
+    uint32_t TCOL:1;                    /**< bit:      2  Terminate Frame upon Collision Notification */
+    uint32_t CDTAIL:1;                  /**< bit:      3  LON Collision Detection on Frame Tail    */
+    uint32_t DMAM:1;                    /**< bit:      4  LON DMA Mode                             */
+    uint32_t LCDS:1;                    /**< bit:      5  LON Collision Detection Source           */
+    uint32_t :10;                       /**< bit:  6..15  Reserved */
+    uint32_t EOFS:8;                    /**< bit: 16..23  End of Frame Condition Size              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONMR_OFFSET                     (0x60)                                        /**<  (US_LONMR) LON Mode Register  Offset */
+
+#define US_LONMR_COMMT_Pos                  0                                              /**< (US_LONMR) LON comm_type Parameter Value Position */
+#define US_LONMR_COMMT_Msk                  (_U_(0x1) << US_LONMR_COMMT_Pos)               /**< (US_LONMR) LON comm_type Parameter Value Mask */
+#define US_LONMR_COMMT                      US_LONMR_COMMT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_COMMT_Msk instead */
+#define US_LONMR_COLDET_Pos                 1                                              /**< (US_LONMR) LON Collision Detection Feature Position */
+#define US_LONMR_COLDET_Msk                 (_U_(0x1) << US_LONMR_COLDET_Pos)              /**< (US_LONMR) LON Collision Detection Feature Mask */
+#define US_LONMR_COLDET                     US_LONMR_COLDET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_COLDET_Msk instead */
+#define US_LONMR_TCOL_Pos                   2                                              /**< (US_LONMR) Terminate Frame upon Collision Notification Position */
+#define US_LONMR_TCOL_Msk                   (_U_(0x1) << US_LONMR_TCOL_Pos)                /**< (US_LONMR) Terminate Frame upon Collision Notification Mask */
+#define US_LONMR_TCOL                       US_LONMR_TCOL_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_TCOL_Msk instead */
+#define US_LONMR_CDTAIL_Pos                 3                                              /**< (US_LONMR) LON Collision Detection on Frame Tail Position */
+#define US_LONMR_CDTAIL_Msk                 (_U_(0x1) << US_LONMR_CDTAIL_Pos)              /**< (US_LONMR) LON Collision Detection on Frame Tail Mask */
+#define US_LONMR_CDTAIL                     US_LONMR_CDTAIL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_CDTAIL_Msk instead */
+#define US_LONMR_DMAM_Pos                   4                                              /**< (US_LONMR) LON DMA Mode Position */
+#define US_LONMR_DMAM_Msk                   (_U_(0x1) << US_LONMR_DMAM_Pos)                /**< (US_LONMR) LON DMA Mode Mask */
+#define US_LONMR_DMAM                       US_LONMR_DMAM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_DMAM_Msk instead */
+#define US_LONMR_LCDS_Pos                   5                                              /**< (US_LONMR) LON Collision Detection Source Position */
+#define US_LONMR_LCDS_Msk                   (_U_(0x1) << US_LONMR_LCDS_Pos)                /**< (US_LONMR) LON Collision Detection Source Mask */
+#define US_LONMR_LCDS                       US_LONMR_LCDS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONMR_LCDS_Msk instead */
+#define US_LONMR_EOFS_Pos                   16                                             /**< (US_LONMR) End of Frame Condition Size Position */
+#define US_LONMR_EOFS_Msk                   (_U_(0xFF) << US_LONMR_EOFS_Pos)               /**< (US_LONMR) End of Frame Condition Size Mask */
+#define US_LONMR_EOFS(value)                (US_LONMR_EOFS_Msk & ((value) << US_LONMR_EOFS_Pos))
+#define US_LONMR_MASK                       _U_(0xFF003F)                                  /**< \deprecated (US_LONMR) Register MASK  (Use US_LONMR_Msk instead)  */
+#define US_LONMR_Msk                        _U_(0xFF003F)                                  /**< (US_LONMR) Register Mask  */
+
+
+/* -------- US_LONPR : (USART Offset: 0x64) (R/W 32) LON Preamble Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONPL:14;                  /**< bit:  0..13  LON Preamble Length                      */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONPR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONPR_OFFSET                     (0x64)                                        /**<  (US_LONPR) LON Preamble Register  Offset */
+
+#define US_LONPR_LONPL_Pos                  0                                              /**< (US_LONPR) LON Preamble Length Position */
+#define US_LONPR_LONPL_Msk                  (_U_(0x3FFF) << US_LONPR_LONPL_Pos)            /**< (US_LONPR) LON Preamble Length Mask */
+#define US_LONPR_LONPL(value)               (US_LONPR_LONPL_Msk & ((value) << US_LONPR_LONPL_Pos))
+#define US_LONPR_MASK                       _U_(0x3FFF)                                    /**< \deprecated (US_LONPR) Register MASK  (Use US_LONPR_Msk instead)  */
+#define US_LONPR_Msk                        _U_(0x3FFF)                                    /**< (US_LONPR) Register Mask  */
+
+
+/* -------- US_LONDL : (USART Offset: 0x68) (R/W 32) LON Data Length Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONDL:8;                   /**< bit:   0..7  LON Data Length                          */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONDL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONDL_OFFSET                     (0x68)                                        /**<  (US_LONDL) LON Data Length Register  Offset */
+
+#define US_LONDL_LONDL_Pos                  0                                              /**< (US_LONDL) LON Data Length Position */
+#define US_LONDL_LONDL_Msk                  (_U_(0xFF) << US_LONDL_LONDL_Pos)              /**< (US_LONDL) LON Data Length Mask */
+#define US_LONDL_LONDL(value)               (US_LONDL_LONDL_Msk & ((value) << US_LONDL_LONDL_Pos))
+#define US_LONDL_MASK                       _U_(0xFF)                                      /**< \deprecated (US_LONDL) Register MASK  (Use US_LONDL_Msk instead)  */
+#define US_LONDL_Msk                        _U_(0xFF)                                      /**< (US_LONDL) Register Mask  */
+
+
+/* -------- US_LONL2HDR : (USART Offset: 0x6c) (R/W 32) LON L2HDR Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BLI:6;                     /**< bit:   0..5  LON Backlog Increment                    */
+    uint32_t ALTP:1;                    /**< bit:      6  LON Alternate Path Bit                   */
+    uint32_t PB:1;                      /**< bit:      7  LON Priority Bit                         */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONL2HDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONL2HDR_OFFSET                  (0x6C)                                        /**<  (US_LONL2HDR) LON L2HDR Register  Offset */
+
+#define US_LONL2HDR_BLI_Pos                 0                                              /**< (US_LONL2HDR) LON Backlog Increment Position */
+#define US_LONL2HDR_BLI_Msk                 (_U_(0x3F) << US_LONL2HDR_BLI_Pos)             /**< (US_LONL2HDR) LON Backlog Increment Mask */
+#define US_LONL2HDR_BLI(value)              (US_LONL2HDR_BLI_Msk & ((value) << US_LONL2HDR_BLI_Pos))
+#define US_LONL2HDR_ALTP_Pos                6                                              /**< (US_LONL2HDR) LON Alternate Path Bit Position */
+#define US_LONL2HDR_ALTP_Msk                (_U_(0x1) << US_LONL2HDR_ALTP_Pos)             /**< (US_LONL2HDR) LON Alternate Path Bit Mask */
+#define US_LONL2HDR_ALTP                    US_LONL2HDR_ALTP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONL2HDR_ALTP_Msk instead */
+#define US_LONL2HDR_PB_Pos                  7                                              /**< (US_LONL2HDR) LON Priority Bit Position */
+#define US_LONL2HDR_PB_Msk                  (_U_(0x1) << US_LONL2HDR_PB_Pos)               /**< (US_LONL2HDR) LON Priority Bit Mask */
+#define US_LONL2HDR_PB                      US_LONL2HDR_PB_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_LONL2HDR_PB_Msk instead */
+#define US_LONL2HDR_MASK                    _U_(0xFF)                                      /**< \deprecated (US_LONL2HDR) Register MASK  (Use US_LONL2HDR_Msk instead)  */
+#define US_LONL2HDR_Msk                     _U_(0xFF)                                      /**< (US_LONL2HDR) Register Mask  */
+
+
+/* -------- US_LONBL : (USART Offset: 0x70) (R/ 32) LON Backlog Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t LONBL:6;                   /**< bit:   0..5  LON Node Backlog Value                   */
+    uint32_t :26;                       /**< bit:  6..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONBL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONBL_OFFSET                     (0x70)                                        /**<  (US_LONBL) LON Backlog Register  Offset */
+
+#define US_LONBL_LONBL_Pos                  0                                              /**< (US_LONBL) LON Node Backlog Value Position */
+#define US_LONBL_LONBL_Msk                  (_U_(0x3F) << US_LONBL_LONBL_Pos)              /**< (US_LONBL) LON Node Backlog Value Mask */
+#define US_LONBL_LONBL(value)               (US_LONBL_LONBL_Msk & ((value) << US_LONBL_LONBL_Pos))
+#define US_LONBL_MASK                       _U_(0x3F)                                      /**< \deprecated (US_LONBL) Register MASK  (Use US_LONBL_Msk instead)  */
+#define US_LONBL_Msk                        _U_(0x3F)                                      /**< (US_LONBL) Register Mask  */
+
+
+/* -------- US_LONB1TX : (USART Offset: 0x74) (R/W 32) LON Beta1 Tx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BETA1TX:24;                /**< bit:  0..23  LON Beta1 Length after Transmission      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONB1TX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONB1TX_OFFSET                   (0x74)                                        /**<  (US_LONB1TX) LON Beta1 Tx Register  Offset */
+
+#define US_LONB1TX_BETA1TX_Pos              0                                              /**< (US_LONB1TX) LON Beta1 Length after Transmission Position */
+#define US_LONB1TX_BETA1TX_Msk              (_U_(0xFFFFFF) << US_LONB1TX_BETA1TX_Pos)      /**< (US_LONB1TX) LON Beta1 Length after Transmission Mask */
+#define US_LONB1TX_BETA1TX(value)           (US_LONB1TX_BETA1TX_Msk & ((value) << US_LONB1TX_BETA1TX_Pos))
+#define US_LONB1TX_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (US_LONB1TX) Register MASK  (Use US_LONB1TX_Msk instead)  */
+#define US_LONB1TX_Msk                      _U_(0xFFFFFF)                                  /**< (US_LONB1TX) Register Mask  */
+
+
+/* -------- US_LONB1RX : (USART Offset: 0x78) (R/W 32) LON Beta1 Rx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BETA1RX:24;                /**< bit:  0..23  LON Beta1 Length after Reception         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONB1RX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONB1RX_OFFSET                   (0x78)                                        /**<  (US_LONB1RX) LON Beta1 Rx Register  Offset */
+
+#define US_LONB1RX_BETA1RX_Pos              0                                              /**< (US_LONB1RX) LON Beta1 Length after Reception Position */
+#define US_LONB1RX_BETA1RX_Msk              (_U_(0xFFFFFF) << US_LONB1RX_BETA1RX_Pos)      /**< (US_LONB1RX) LON Beta1 Length after Reception Mask */
+#define US_LONB1RX_BETA1RX(value)           (US_LONB1RX_BETA1RX_Msk & ((value) << US_LONB1RX_BETA1RX_Pos))
+#define US_LONB1RX_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (US_LONB1RX) Register MASK  (Use US_LONB1RX_Msk instead)  */
+#define US_LONB1RX_Msk                      _U_(0xFFFFFF)                                  /**< (US_LONB1RX) Register Mask  */
+
+
+/* -------- US_LONPRIO : (USART Offset: 0x7c) (R/W 32) LON Priority Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PSNB:7;                    /**< bit:   0..6  LON Priority Slot Number                 */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t NPS:7;                     /**< bit:  8..14  LON Node Priority Slot                   */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_LONPRIO_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LONPRIO_OFFSET                   (0x7C)                                        /**<  (US_LONPRIO) LON Priority Register  Offset */
+
+#define US_LONPRIO_PSNB_Pos                 0                                              /**< (US_LONPRIO) LON Priority Slot Number Position */
+#define US_LONPRIO_PSNB_Msk                 (_U_(0x7F) << US_LONPRIO_PSNB_Pos)             /**< (US_LONPRIO) LON Priority Slot Number Mask */
+#define US_LONPRIO_PSNB(value)              (US_LONPRIO_PSNB_Msk & ((value) << US_LONPRIO_PSNB_Pos))
+#define US_LONPRIO_NPS_Pos                  8                                              /**< (US_LONPRIO) LON Node Priority Slot Position */
+#define US_LONPRIO_NPS_Msk                  (_U_(0x7F) << US_LONPRIO_NPS_Pos)              /**< (US_LONPRIO) LON Node Priority Slot Mask */
+#define US_LONPRIO_NPS(value)               (US_LONPRIO_NPS_Msk & ((value) << US_LONPRIO_NPS_Pos))
+#define US_LONPRIO_MASK                     _U_(0x7F7F)                                    /**< \deprecated (US_LONPRIO) Register MASK  (Use US_LONPRIO_Msk instead)  */
+#define US_LONPRIO_Msk                      _U_(0x7F7F)                                    /**< (US_LONPRIO) Register Mask  */
+
+
+/* -------- US_IDTTX : (USART Offset: 0x80) (R/W 32) LON IDT Tx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDTTX:24;                  /**< bit:  0..23  LON Indeterminate Time after Transmission (comm_type = 1 mode only) */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDTTX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDTTX_OFFSET                     (0x80)                                        /**<  (US_IDTTX) LON IDT Tx Register  Offset */
+
+#define US_IDTTX_IDTTX_Pos                  0                                              /**< (US_IDTTX) LON Indeterminate Time after Transmission (comm_type = 1 mode only) Position */
+#define US_IDTTX_IDTTX_Msk                  (_U_(0xFFFFFF) << US_IDTTX_IDTTX_Pos)          /**< (US_IDTTX) LON Indeterminate Time after Transmission (comm_type = 1 mode only) Mask */
+#define US_IDTTX_IDTTX(value)               (US_IDTTX_IDTTX_Msk & ((value) << US_IDTTX_IDTTX_Pos))
+#define US_IDTTX_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (US_IDTTX) Register MASK  (Use US_IDTTX_Msk instead)  */
+#define US_IDTTX_Msk                        _U_(0xFFFFFF)                                  /**< (US_IDTTX) Register Mask  */
+
+
+/* -------- US_IDTRX : (USART Offset: 0x84) (R/W 32) LON IDT Rx Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IDTRX:24;                  /**< bit:  0..23  LON Indeterminate Time after Reception (comm_type = 1 mode only) */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_IDTRX_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDTRX_OFFSET                     (0x84)                                        /**<  (US_IDTRX) LON IDT Rx Register  Offset */
+
+#define US_IDTRX_IDTRX_Pos                  0                                              /**< (US_IDTRX) LON Indeterminate Time after Reception (comm_type = 1 mode only) Position */
+#define US_IDTRX_IDTRX_Msk                  (_U_(0xFFFFFF) << US_IDTRX_IDTRX_Pos)          /**< (US_IDTRX) LON Indeterminate Time after Reception (comm_type = 1 mode only) Mask */
+#define US_IDTRX_IDTRX(value)               (US_IDTRX_IDTRX_Msk & ((value) << US_IDTRX_IDTRX_Pos))
+#define US_IDTRX_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (US_IDTRX) Register MASK  (Use US_IDTRX_Msk instead)  */
+#define US_IDTRX_Msk                        _U_(0xFFFFFF)                                  /**< (US_IDTRX) Register Mask  */
+
+
+/* -------- US_ICDIFF : (USART Offset: 0x88) (R/W 32) IC DIFF Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ICDIFF:4;                  /**< bit:   0..3  IC Differentiator Number                 */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_ICDIFF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_ICDIFF_OFFSET                    (0x88)                                        /**<  (US_ICDIFF) IC DIFF Register  Offset */
+
+#define US_ICDIFF_ICDIFF_Pos                0                                              /**< (US_ICDIFF) IC Differentiator Number Position */
+#define US_ICDIFF_ICDIFF_Msk                (_U_(0xF) << US_ICDIFF_ICDIFF_Pos)             /**< (US_ICDIFF) IC Differentiator Number Mask */
+#define US_ICDIFF_ICDIFF(value)             (US_ICDIFF_ICDIFF_Msk & ((value) << US_ICDIFF_ICDIFF_Pos))
+#define US_ICDIFF_MASK                      _U_(0x0F)                                      /**< \deprecated (US_ICDIFF) Register MASK  (Use US_ICDIFF_Msk instead)  */
+#define US_ICDIFF_Msk                       _U_(0x0F)                                      /**< (US_ICDIFF) Register Mask  */
+
+
+/* -------- US_WPMR : (USART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_WPMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPMR_OFFSET                      (0xE4)                                        /**<  (US_WPMR) Write Protection Mode Register  Offset */
+
+#define US_WPMR_WPEN_Pos                    0                                              /**< (US_WPMR) Write Protection Enable Position */
+#define US_WPMR_WPEN_Msk                    (_U_(0x1) << US_WPMR_WPEN_Pos)                 /**< (US_WPMR) Write Protection Enable Mask */
+#define US_WPMR_WPEN                        US_WPMR_WPEN_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_WPMR_WPEN_Msk instead */
+#define US_WPMR_WPKEY_Pos                   8                                              /**< (US_WPMR) Write Protection Key Position */
+#define US_WPMR_WPKEY_Msk                   (_U_(0xFFFFFF) << US_WPMR_WPKEY_Pos)           /**< (US_WPMR) Write Protection Key Mask */
+#define US_WPMR_WPKEY(value)                (US_WPMR_WPKEY_Msk & ((value) << US_WPMR_WPKEY_Pos))
+#define   US_WPMR_WPKEY_PASSWD_Val          _U_(0x555341)                                  /**< (US_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
+#define US_WPMR_WPKEY_PASSWD                (US_WPMR_WPKEY_PASSWD_Val << US_WPMR_WPKEY_Pos)  /**< (US_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define US_WPMR_MASK                        _U_(0xFFFFFF01)                                /**< \deprecated (US_WPMR) Register MASK  (Use US_WPMR_Msk instead)  */
+#define US_WPMR_Msk                         _U_(0xFFFFFF01)                                /**< (US_WPMR) Register Mask  */
+
+
+/* -------- US_WPSR : (USART Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
+    uint32_t :7;                        /**< bit:   1..7  Reserved */
+    uint32_t WPVSRC:16;                 /**< bit:  8..23  Write Protection Violation Source        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} US_WPSR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPSR_OFFSET                      (0xE8)                                        /**<  (US_WPSR) Write Protection Status Register  Offset */
+
+#define US_WPSR_WPVS_Pos                    0                                              /**< (US_WPSR) Write Protection Violation Status Position */
+#define US_WPSR_WPVS_Msk                    (_U_(0x1) << US_WPSR_WPVS_Pos)                 /**< (US_WPSR) Write Protection Violation Status Mask */
+#define US_WPSR_WPVS                        US_WPSR_WPVS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_WPSR_WPVS_Msk instead */
+#define US_WPSR_WPVSRC_Pos                  8                                              /**< (US_WPSR) Write Protection Violation Source Position */
+#define US_WPSR_WPVSRC_Msk                  (_U_(0xFFFF) << US_WPSR_WPVSRC_Pos)            /**< (US_WPSR) Write Protection Violation Source Mask */
+#define US_WPSR_WPVSRC(value)               (US_WPSR_WPVSRC_Msk & ((value) << US_WPSR_WPVSRC_Pos))
+#define US_WPSR_MASK                        _U_(0xFFFF01)                                  /**< \deprecated (US_WPSR) Register MASK  (Use US_WPSR_Msk instead)  */
+#define US_WPSR_Msk                         _U_(0xFFFF01)                                  /**< (US_WPSR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief USART hardware registers */
+typedef struct {  
+  __O  uint32_t US_CR;          /**< (USART Offset: 0x00) Control Register */
+  __IO uint32_t US_MR;          /**< (USART Offset: 0x04) Mode Register */
+  __O  uint32_t US_IER;         /**< (USART Offset: 0x08) Interrupt Enable Register */
+  __O  uint32_t US_IDR;         /**< (USART Offset: 0x0C) Interrupt Disable Register */
+  __I  uint32_t US_IMR;         /**< (USART Offset: 0x10) Interrupt Mask Register */
+  __I  uint32_t US_CSR;         /**< (USART Offset: 0x14) Channel Status Register */
+  __I  uint32_t US_RHR;         /**< (USART Offset: 0x18) Receive Holding Register */
+  __O  uint32_t US_THR;         /**< (USART Offset: 0x1C) Transmit Holding Register */
+  __IO uint32_t US_BRGR;        /**< (USART Offset: 0x20) Baud Rate Generator Register */
+  __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Timeout Register */
+  __IO uint32_t US_TTGR;        /**< (USART Offset: 0x28) Transmitter Timeguard Register */
+  __I  uint8_t                        Reserved1[20];
+  __IO uint32_t US_FIDI;        /**< (USART Offset: 0x40) FI DI Ratio Register */
+  __I  uint32_t US_NER;         /**< (USART Offset: 0x44) Number of Errors Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO uint32_t US_IF;          /**< (USART Offset: 0x4C) IrDA Filter Register */
+  __IO uint32_t US_MAN;         /**< (USART Offset: 0x50) Manchester Configuration Register */
+  __IO uint32_t US_LINMR;       /**< (USART Offset: 0x54) LIN Mode Register */
+  __IO uint32_t US_LINIR;       /**< (USART Offset: 0x58) LIN Identifier Register */
+  __I  uint32_t US_LINBRR;      /**< (USART Offset: 0x5C) LIN Baud Rate Register */
+  __IO uint32_t US_LONMR;       /**< (USART Offset: 0x60) LON Mode Register */
+  __IO uint32_t US_LONPR;       /**< (USART Offset: 0x64) LON Preamble Register */
+  __IO uint32_t US_LONDL;       /**< (USART Offset: 0x68) LON Data Length Register */
+  __IO uint32_t US_LONL2HDR;    /**< (USART Offset: 0x6C) LON L2HDR Register */
+  __I  uint32_t US_LONBL;       /**< (USART Offset: 0x70) LON Backlog Register */
+  __IO uint32_t US_LONB1TX;     /**< (USART Offset: 0x74) LON Beta1 Tx Register */
+  __IO uint32_t US_LONB1RX;     /**< (USART Offset: 0x78) LON Beta1 Rx Register */
+  __IO uint32_t US_LONPRIO;     /**< (USART Offset: 0x7C) LON Priority Register */
+  __IO uint32_t US_IDTTX;       /**< (USART Offset: 0x80) LON IDT Tx Register */
+  __IO uint32_t US_IDTRX;       /**< (USART Offset: 0x84) LON IDT Rx Register */
+  __IO uint32_t US_ICDIFF;      /**< (USART Offset: 0x88) IC DIFF Register */
+  __I  uint8_t                        Reserved3[88];
+  __IO uint32_t US_WPMR;        /**< (USART Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t US_WPSR;        /**< (USART Offset: 0xE8) Write Protection Status Register */
+} Usart;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief USART hardware registers */
+typedef struct {  
+  __O  US_CR_Type                     US_CR;          /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO US_MR_Type                     US_MR;          /**< Offset: 0x04 (R/W  32) Mode Register */
+  __O  US_IER_Type                    US_IER;         /**< Offset: 0x08 ( /W  32) Interrupt Enable Register */
+  __O  US_IDR_Type                    US_IDR;         /**< Offset: 0x0C ( /W  32) Interrupt Disable Register */
+  __I  US_IMR_Type                    US_IMR;         /**< Offset: 0x10 (R/   32) Interrupt Mask Register */
+  __I  US_CSR_Type                    US_CSR;         /**< Offset: 0x14 (R/   32) Channel Status Register */
+  __I  US_RHR_Type                    US_RHR;         /**< Offset: 0x18 (R/   32) Receive Holding Register */
+  __O  US_THR_Type                    US_THR;         /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
+  __IO US_BRGR_Type                   US_BRGR;        /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
+  __IO US_RTOR_Type                   US_RTOR;        /**< Offset: 0x24 (R/W  32) Receiver Timeout Register */
+  __IO US_TTGR_Type                   US_TTGR;        /**< Offset: 0x28 (R/W  32) Transmitter Timeguard Register */
+  __I  uint8_t                        Reserved1[20];
+  __IO US_FIDI_Type                   US_FIDI;        /**< Offset: 0x40 (R/W  32) FI DI Ratio Register */
+  __I  US_NER_Type                    US_NER;         /**< Offset: 0x44 (R/   32) Number of Errors Register */
+  __I  uint8_t                        Reserved2[4];
+  __IO US_IF_Type                     US_IF;          /**< Offset: 0x4C (R/W  32) IrDA Filter Register */
+  __IO US_MAN_Type                    US_MAN;         /**< Offset: 0x50 (R/W  32) Manchester Configuration Register */
+  __IO US_LINMR_Type                  US_LINMR;       /**< Offset: 0x54 (R/W  32) LIN Mode Register */
+  __IO US_LINIR_Type                  US_LINIR;       /**< Offset: 0x58 (R/W  32) LIN Identifier Register */
+  __I  US_LINBRR_Type                 US_LINBRR;      /**< Offset: 0x5C (R/   32) LIN Baud Rate Register */
+  __IO US_LONMR_Type                  US_LONMR;       /**< Offset: 0x60 (R/W  32) LON Mode Register */
+  __IO US_LONPR_Type                  US_LONPR;       /**< Offset: 0x64 (R/W  32) LON Preamble Register */
+  __IO US_LONDL_Type                  US_LONDL;       /**< Offset: 0x68 (R/W  32) LON Data Length Register */
+  __IO US_LONL2HDR_Type               US_LONL2HDR;    /**< Offset: 0x6C (R/W  32) LON L2HDR Register */
+  __I  US_LONBL_Type                  US_LONBL;       /**< Offset: 0x70 (R/   32) LON Backlog Register */
+  __IO US_LONB1TX_Type                US_LONB1TX;     /**< Offset: 0x74 (R/W  32) LON Beta1 Tx Register */
+  __IO US_LONB1RX_Type                US_LONB1RX;     /**< Offset: 0x78 (R/W  32) LON Beta1 Rx Register */
+  __IO US_LONPRIO_Type                US_LONPRIO;     /**< Offset: 0x7C (R/W  32) LON Priority Register */
+  __IO US_IDTTX_Type                  US_IDTTX;       /**< Offset: 0x80 (R/W  32) LON IDT Tx Register */
+  __IO US_IDTRX_Type                  US_IDTRX;       /**< Offset: 0x84 (R/W  32) LON IDT Rx Register */
+  __IO US_ICDIFF_Type                 US_ICDIFF;      /**< Offset: 0x88 (R/W  32) IC DIFF Register */
+  __I  uint8_t                        Reserved3[88];
+  __IO US_WPMR_Type                   US_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
+  __I  US_WPSR_Type                   US_WPSR;        /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
+} Usart;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Universal Synchronous Asynchronous Receiver Transmitter */
+
+#endif /* _SAMV71_USART_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/usbhs.h
+++ b/asf/sam/include/samv71b/component/usbhs.h
@@ -1,0 +1,4534 @@
+/**
+ * \file
+ *
+ * \brief Component description for USBHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USBHS_COMPONENT_H_
+#define _SAMV71_USBHS_COMPONENT_H_
+#define _SAMV71_USBHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 USB High-Speed Interface
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USBHS */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define USBHS_11292                      /**< (USBHS) Module ID */
+#define REV_USBHS G                      /**< (USBHS) Module revision */
+
+/* -------- USBHS_DEVDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Device DMA Channel Next Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMANXTDSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_DEVDMANXTDSC) Device DMA Channel Next Descriptor Address Register  Offset */
+
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Position */
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Mask */
+#define USBHS_DEVDMANXTDSC_NXT_DSC_ADD(value) (USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Msk & ((value) << USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos))
+#define USBHS_DEVDMANXTDSC_MASK             _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_DEVDMANXTDSC) Register MASK  (Use USBHS_DEVDMANXTDSC_Msk instead)  */
+#define USBHS_DEVDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMANXTDSC) Register Mask  */
+
+
+/* -------- USBHS_DEVDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Device DMA Channel Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMAADDRESS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_DEVDMAADDRESS) Device DMA Channel Address Register  Offset */
+
+#define USBHS_DEVDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_DEVDMAADDRESS) Buffer Address Position */
+#define USBHS_DEVDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_DEVDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_DEVDMAADDRESS) Buffer Address Mask */
+#define USBHS_DEVDMAADDRESS_BUFF_ADD(value) (USBHS_DEVDMAADDRESS_BUFF_ADD_Msk & ((value) << USBHS_DEVDMAADDRESS_BUFF_ADD_Pos))
+#define USBHS_DEVDMAADDRESS_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_DEVDMAADDRESS) Register MASK  (Use USBHS_DEVDMAADDRESS_Msk instead)  */
+#define USBHS_DEVDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMAADDRESS) Register Mask  */
+
+
+/* -------- USBHS_DEVDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Device DMA Channel Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
+    uint32_t LDNXT_DSC:1;               /**< bit:      1  Load Next Channel Transfer Descriptor Enable Command */
+    uint32_t END_TR_EN:1;               /**< bit:      2  End of Transfer Enable Control (OUT transfers only) */
+    uint32_t END_B_EN:1;                /**< bit:      3  End of Buffer Enable Control             */
+    uint32_t END_TR_IT:1;               /**< bit:      4  End of Transfer Interrupt Enable         */
+    uint32_t END_BUFFIT:1;              /**< bit:      5  End of Buffer Interrupt Enable           */
+    uint32_t DESC_LD_IT:1;              /**< bit:      6  Descriptor Loaded Interrupt Enable       */
+    uint32_t BURST_LCK:1;               /**< bit:      7  Burst Lock Enable                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t BUFF_LENGTH:16;            /**< bit: 16..31  Buffer Byte Length (Write-only)          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMACONTROL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_DEVDMACONTROL) Device DMA Channel Control Register  Offset */
+
+#define USBHS_DEVDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_DEVDMACONTROL) Channel Enable Command Position */
+#define USBHS_DEVDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_DEVDMACONTROL) Channel Enable Command Mask */
+#define USBHS_DEVDMACONTROL_CHANN_ENB       USBHS_DEVDMACONTROL_CHANN_ENB_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_CHANN_ENB_Msk instead */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC_Pos   1                                              /**< (USBHS_DEVDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Position */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_LDNXT_DSC_Pos)  /**< (USBHS_DEVDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Mask */
+#define USBHS_DEVDMACONTROL_LDNXT_DSC       USBHS_DEVDMACONTROL_LDNXT_DSC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_LDNXT_DSC_Msk instead */
+#define USBHS_DEVDMACONTROL_END_TR_EN_Pos   2                                              /**< (USBHS_DEVDMACONTROL) End of Transfer Enable Control (OUT transfers only) Position */
+#define USBHS_DEVDMACONTROL_END_TR_EN_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_END_TR_EN_Pos)  /**< (USBHS_DEVDMACONTROL) End of Transfer Enable Control (OUT transfers only) Mask */
+#define USBHS_DEVDMACONTROL_END_TR_EN       USBHS_DEVDMACONTROL_END_TR_EN_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_TR_EN_Msk instead */
+#define USBHS_DEVDMACONTROL_END_B_EN_Pos    3                                              /**< (USBHS_DEVDMACONTROL) End of Buffer Enable Control Position */
+#define USBHS_DEVDMACONTROL_END_B_EN_Msk    (_U_(0x1) << USBHS_DEVDMACONTROL_END_B_EN_Pos)  /**< (USBHS_DEVDMACONTROL) End of Buffer Enable Control Mask */
+#define USBHS_DEVDMACONTROL_END_B_EN        USBHS_DEVDMACONTROL_END_B_EN_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_B_EN_Msk instead */
+#define USBHS_DEVDMACONTROL_END_TR_IT_Pos   4                                              /**< (USBHS_DEVDMACONTROL) End of Transfer Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_END_TR_IT_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_END_TR_IT_Pos)  /**< (USBHS_DEVDMACONTROL) End of Transfer Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_END_TR_IT       USBHS_DEVDMACONTROL_END_TR_IT_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_TR_IT_Msk instead */
+#define USBHS_DEVDMACONTROL_END_BUFFIT_Pos  5                                              /**< (USBHS_DEVDMACONTROL) End of Buffer Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_END_BUFFIT_Msk  (_U_(0x1) << USBHS_DEVDMACONTROL_END_BUFFIT_Pos)  /**< (USBHS_DEVDMACONTROL) End of Buffer Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_END_BUFFIT      USBHS_DEVDMACONTROL_END_BUFFIT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_END_BUFFIT_Msk instead */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT_Pos  6                                              /**< (USBHS_DEVDMACONTROL) Descriptor Loaded Interrupt Enable Position */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT_Msk  (_U_(0x1) << USBHS_DEVDMACONTROL_DESC_LD_IT_Pos)  /**< (USBHS_DEVDMACONTROL) Descriptor Loaded Interrupt Enable Mask */
+#define USBHS_DEVDMACONTROL_DESC_LD_IT      USBHS_DEVDMACONTROL_DESC_LD_IT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_DESC_LD_IT_Msk instead */
+#define USBHS_DEVDMACONTROL_BURST_LCK_Pos   7                                              /**< (USBHS_DEVDMACONTROL) Burst Lock Enable Position */
+#define USBHS_DEVDMACONTROL_BURST_LCK_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_BURST_LCK_Pos)  /**< (USBHS_DEVDMACONTROL) Burst Lock Enable Mask */
+#define USBHS_DEVDMACONTROL_BURST_LCK       USBHS_DEVDMACONTROL_BURST_LCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMACONTROL_BURST_LCK_Msk instead */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos 16                                             /**< (USBHS_DEVDMACONTROL) Buffer Byte Length (Write-only) Position */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH_Msk (_U_(0xFFFF) << USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos)  /**< (USBHS_DEVDMACONTROL) Buffer Byte Length (Write-only) Mask */
+#define USBHS_DEVDMACONTROL_BUFF_LENGTH(value) (USBHS_DEVDMACONTROL_BUFF_LENGTH_Msk & ((value) << USBHS_DEVDMACONTROL_BUFF_LENGTH_Pos))
+#define USBHS_DEVDMACONTROL_MASK            _U_(0xFFFF00FF)                                /**< \deprecated (USBHS_DEVDMACONTROL) Register MASK  (Use USBHS_DEVDMACONTROL_Msk instead)  */
+#define USBHS_DEVDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_DEVDMACONTROL) Register Mask  */
+
+
+/* -------- USBHS_DEVDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Device DMA Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
+    uint32_t CHANN_ACT:1;               /**< bit:      1  Channel Active Status                    */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t END_TR_ST:1;               /**< bit:      4  End of Channel Transfer Status           */
+    uint32_t END_BF_ST:1;               /**< bit:      5  End of Channel Buffer Status             */
+    uint32_t DESC_LDST:1;               /**< bit:      6  Descriptor Loaded Status                 */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t BUFF_COUNT:16;             /**< bit: 16..31  Buffer Byte Count                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVDMASTATUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_DEVDMASTATUS) Device DMA Channel Status Register  Offset */
+
+#define USBHS_DEVDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_DEVDMASTATUS) Channel Enable Status Position */
+#define USBHS_DEVDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_DEVDMASTATUS) Channel Enable Status Mask */
+#define USBHS_DEVDMASTATUS_CHANN_ENB        USBHS_DEVDMASTATUS_CHANN_ENB_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_CHANN_ENB_Msk instead */
+#define USBHS_DEVDMASTATUS_CHANN_ACT_Pos    1                                              /**< (USBHS_DEVDMASTATUS) Channel Active Status Position */
+#define USBHS_DEVDMASTATUS_CHANN_ACT_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_CHANN_ACT_Pos)  /**< (USBHS_DEVDMASTATUS) Channel Active Status Mask */
+#define USBHS_DEVDMASTATUS_CHANN_ACT        USBHS_DEVDMASTATUS_CHANN_ACT_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_CHANN_ACT_Msk instead */
+#define USBHS_DEVDMASTATUS_END_TR_ST_Pos    4                                              /**< (USBHS_DEVDMASTATUS) End of Channel Transfer Status Position */
+#define USBHS_DEVDMASTATUS_END_TR_ST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_END_TR_ST_Pos)  /**< (USBHS_DEVDMASTATUS) End of Channel Transfer Status Mask */
+#define USBHS_DEVDMASTATUS_END_TR_ST        USBHS_DEVDMASTATUS_END_TR_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_END_TR_ST_Msk instead */
+#define USBHS_DEVDMASTATUS_END_BF_ST_Pos    5                                              /**< (USBHS_DEVDMASTATUS) End of Channel Buffer Status Position */
+#define USBHS_DEVDMASTATUS_END_BF_ST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_END_BF_ST_Pos)  /**< (USBHS_DEVDMASTATUS) End of Channel Buffer Status Mask */
+#define USBHS_DEVDMASTATUS_END_BF_ST        USBHS_DEVDMASTATUS_END_BF_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_END_BF_ST_Msk instead */
+#define USBHS_DEVDMASTATUS_DESC_LDST_Pos    6                                              /**< (USBHS_DEVDMASTATUS) Descriptor Loaded Status Position */
+#define USBHS_DEVDMASTATUS_DESC_LDST_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_DESC_LDST_Pos)  /**< (USBHS_DEVDMASTATUS) Descriptor Loaded Status Mask */
+#define USBHS_DEVDMASTATUS_DESC_LDST        USBHS_DEVDMASTATUS_DESC_LDST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVDMASTATUS_DESC_LDST_Msk instead */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT_Pos   16                                             /**< (USBHS_DEVDMASTATUS) Buffer Byte Count Position */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT_Msk   (_U_(0xFFFF) << USBHS_DEVDMASTATUS_BUFF_COUNT_Pos)  /**< (USBHS_DEVDMASTATUS) Buffer Byte Count Mask */
+#define USBHS_DEVDMASTATUS_BUFF_COUNT(value) (USBHS_DEVDMASTATUS_BUFF_COUNT_Msk & ((value) << USBHS_DEVDMASTATUS_BUFF_COUNT_Pos))
+#define USBHS_DEVDMASTATUS_MASK             _U_(0xFFFF0073)                                /**< \deprecated (USBHS_DEVDMASTATUS) Register MASK  (Use USBHS_DEVDMASTATUS_Msk instead)  */
+#define USBHS_DEVDMASTATUS_Msk              _U_(0xFFFF0073)                                /**< (USBHS_DEVDMASTATUS) Register Mask  */
+
+
+/* -------- USBHS_HSTDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Host DMA Channel Next Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMANXTDSC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_HSTDMANXTDSC) Host DMA Channel Next Descriptor Address Register  Offset */
+
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Position */
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Mask */
+#define USBHS_HSTDMANXTDSC_NXT_DSC_ADD(value) (USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Msk & ((value) << USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos))
+#define USBHS_HSTDMANXTDSC_MASK             _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_HSTDMANXTDSC) Register MASK  (Use USBHS_HSTDMANXTDSC_Msk instead)  */
+#define USBHS_HSTDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMANXTDSC) Register Mask  */
+
+
+/* -------- USBHS_HSTDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Host DMA Channel Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMAADDRESS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_HSTDMAADDRESS) Host DMA Channel Address Register  Offset */
+
+#define USBHS_HSTDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_HSTDMAADDRESS) Buffer Address Position */
+#define USBHS_HSTDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_HSTDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_HSTDMAADDRESS) Buffer Address Mask */
+#define USBHS_HSTDMAADDRESS_BUFF_ADD(value) (USBHS_HSTDMAADDRESS_BUFF_ADD_Msk & ((value) << USBHS_HSTDMAADDRESS_BUFF_ADD_Pos))
+#define USBHS_HSTDMAADDRESS_MASK            _U_(0xFFFFFFFF)                                /**< \deprecated (USBHS_HSTDMAADDRESS) Register MASK  (Use USBHS_HSTDMAADDRESS_Msk instead)  */
+#define USBHS_HSTDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMAADDRESS) Register Mask  */
+
+
+/* -------- USBHS_HSTDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Host DMA Channel Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
+    uint32_t LDNXT_DSC:1;               /**< bit:      1  Load Next Channel Transfer Descriptor Enable Command */
+    uint32_t END_TR_EN:1;               /**< bit:      2  End of Transfer Enable Control (OUT transfers only) */
+    uint32_t END_B_EN:1;                /**< bit:      3  End of Buffer Enable Control             */
+    uint32_t END_TR_IT:1;               /**< bit:      4  End of Transfer Interrupt Enable         */
+    uint32_t END_BUFFIT:1;              /**< bit:      5  End of Buffer Interrupt Enable           */
+    uint32_t DESC_LD_IT:1;              /**< bit:      6  Descriptor Loaded Interrupt Enable       */
+    uint32_t BURST_LCK:1;               /**< bit:      7  Burst Lock Enable                        */
+    uint32_t :8;                        /**< bit:  8..15  Reserved */
+    uint32_t BUFF_LENGTH:16;            /**< bit: 16..31  Buffer Byte Length (Write-only)          */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMACONTROL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_HSTDMACONTROL) Host DMA Channel Control Register  Offset */
+
+#define USBHS_HSTDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_HSTDMACONTROL) Channel Enable Command Position */
+#define USBHS_HSTDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_HSTDMACONTROL) Channel Enable Command Mask */
+#define USBHS_HSTDMACONTROL_CHANN_ENB       USBHS_HSTDMACONTROL_CHANN_ENB_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_CHANN_ENB_Msk instead */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC_Pos   1                                              /**< (USBHS_HSTDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Position */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_LDNXT_DSC_Pos)  /**< (USBHS_HSTDMACONTROL) Load Next Channel Transfer Descriptor Enable Command Mask */
+#define USBHS_HSTDMACONTROL_LDNXT_DSC       USBHS_HSTDMACONTROL_LDNXT_DSC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_LDNXT_DSC_Msk instead */
+#define USBHS_HSTDMACONTROL_END_TR_EN_Pos   2                                              /**< (USBHS_HSTDMACONTROL) End of Transfer Enable Control (OUT transfers only) Position */
+#define USBHS_HSTDMACONTROL_END_TR_EN_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_END_TR_EN_Pos)  /**< (USBHS_HSTDMACONTROL) End of Transfer Enable Control (OUT transfers only) Mask */
+#define USBHS_HSTDMACONTROL_END_TR_EN       USBHS_HSTDMACONTROL_END_TR_EN_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_TR_EN_Msk instead */
+#define USBHS_HSTDMACONTROL_END_B_EN_Pos    3                                              /**< (USBHS_HSTDMACONTROL) End of Buffer Enable Control Position */
+#define USBHS_HSTDMACONTROL_END_B_EN_Msk    (_U_(0x1) << USBHS_HSTDMACONTROL_END_B_EN_Pos)  /**< (USBHS_HSTDMACONTROL) End of Buffer Enable Control Mask */
+#define USBHS_HSTDMACONTROL_END_B_EN        USBHS_HSTDMACONTROL_END_B_EN_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_B_EN_Msk instead */
+#define USBHS_HSTDMACONTROL_END_TR_IT_Pos   4                                              /**< (USBHS_HSTDMACONTROL) End of Transfer Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_END_TR_IT_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_END_TR_IT_Pos)  /**< (USBHS_HSTDMACONTROL) End of Transfer Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_END_TR_IT       USBHS_HSTDMACONTROL_END_TR_IT_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_TR_IT_Msk instead */
+#define USBHS_HSTDMACONTROL_END_BUFFIT_Pos  5                                              /**< (USBHS_HSTDMACONTROL) End of Buffer Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_END_BUFFIT_Msk  (_U_(0x1) << USBHS_HSTDMACONTROL_END_BUFFIT_Pos)  /**< (USBHS_HSTDMACONTROL) End of Buffer Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_END_BUFFIT      USBHS_HSTDMACONTROL_END_BUFFIT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_END_BUFFIT_Msk instead */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT_Pos  6                                              /**< (USBHS_HSTDMACONTROL) Descriptor Loaded Interrupt Enable Position */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT_Msk  (_U_(0x1) << USBHS_HSTDMACONTROL_DESC_LD_IT_Pos)  /**< (USBHS_HSTDMACONTROL) Descriptor Loaded Interrupt Enable Mask */
+#define USBHS_HSTDMACONTROL_DESC_LD_IT      USBHS_HSTDMACONTROL_DESC_LD_IT_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_DESC_LD_IT_Msk instead */
+#define USBHS_HSTDMACONTROL_BURST_LCK_Pos   7                                              /**< (USBHS_HSTDMACONTROL) Burst Lock Enable Position */
+#define USBHS_HSTDMACONTROL_BURST_LCK_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_BURST_LCK_Pos)  /**< (USBHS_HSTDMACONTROL) Burst Lock Enable Mask */
+#define USBHS_HSTDMACONTROL_BURST_LCK       USBHS_HSTDMACONTROL_BURST_LCK_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMACONTROL_BURST_LCK_Msk instead */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos 16                                             /**< (USBHS_HSTDMACONTROL) Buffer Byte Length (Write-only) Position */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH_Msk (_U_(0xFFFF) << USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos)  /**< (USBHS_HSTDMACONTROL) Buffer Byte Length (Write-only) Mask */
+#define USBHS_HSTDMACONTROL_BUFF_LENGTH(value) (USBHS_HSTDMACONTROL_BUFF_LENGTH_Msk & ((value) << USBHS_HSTDMACONTROL_BUFF_LENGTH_Pos))
+#define USBHS_HSTDMACONTROL_MASK            _U_(0xFFFF00FF)                                /**< \deprecated (USBHS_HSTDMACONTROL) Register MASK  (Use USBHS_HSTDMACONTROL_Msk instead)  */
+#define USBHS_HSTDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_HSTDMACONTROL) Register Mask  */
+
+
+/* -------- USBHS_HSTDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Host DMA Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
+    uint32_t CHANN_ACT:1;               /**< bit:      1  Channel Active Status                    */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t END_TR_ST:1;               /**< bit:      4  End of Channel Transfer Status           */
+    uint32_t END_BF_ST:1;               /**< bit:      5  End of Channel Buffer Status             */
+    uint32_t DESC_LDST:1;               /**< bit:      6  Descriptor Loaded Status                 */
+    uint32_t :9;                        /**< bit:  7..15  Reserved */
+    uint32_t BUFF_COUNT:16;             /**< bit: 16..31  Buffer Byte Count                        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTDMASTATUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_HSTDMASTATUS) Host DMA Channel Status Register  Offset */
+
+#define USBHS_HSTDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_HSTDMASTATUS) Channel Enable Status Position */
+#define USBHS_HSTDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_HSTDMASTATUS) Channel Enable Status Mask */
+#define USBHS_HSTDMASTATUS_CHANN_ENB        USBHS_HSTDMASTATUS_CHANN_ENB_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_CHANN_ENB_Msk instead */
+#define USBHS_HSTDMASTATUS_CHANN_ACT_Pos    1                                              /**< (USBHS_HSTDMASTATUS) Channel Active Status Position */
+#define USBHS_HSTDMASTATUS_CHANN_ACT_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_CHANN_ACT_Pos)  /**< (USBHS_HSTDMASTATUS) Channel Active Status Mask */
+#define USBHS_HSTDMASTATUS_CHANN_ACT        USBHS_HSTDMASTATUS_CHANN_ACT_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_CHANN_ACT_Msk instead */
+#define USBHS_HSTDMASTATUS_END_TR_ST_Pos    4                                              /**< (USBHS_HSTDMASTATUS) End of Channel Transfer Status Position */
+#define USBHS_HSTDMASTATUS_END_TR_ST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_END_TR_ST_Pos)  /**< (USBHS_HSTDMASTATUS) End of Channel Transfer Status Mask */
+#define USBHS_HSTDMASTATUS_END_TR_ST        USBHS_HSTDMASTATUS_END_TR_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_END_TR_ST_Msk instead */
+#define USBHS_HSTDMASTATUS_END_BF_ST_Pos    5                                              /**< (USBHS_HSTDMASTATUS) End of Channel Buffer Status Position */
+#define USBHS_HSTDMASTATUS_END_BF_ST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_END_BF_ST_Pos)  /**< (USBHS_HSTDMASTATUS) End of Channel Buffer Status Mask */
+#define USBHS_HSTDMASTATUS_END_BF_ST        USBHS_HSTDMASTATUS_END_BF_ST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_END_BF_ST_Msk instead */
+#define USBHS_HSTDMASTATUS_DESC_LDST_Pos    6                                              /**< (USBHS_HSTDMASTATUS) Descriptor Loaded Status Position */
+#define USBHS_HSTDMASTATUS_DESC_LDST_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_DESC_LDST_Pos)  /**< (USBHS_HSTDMASTATUS) Descriptor Loaded Status Mask */
+#define USBHS_HSTDMASTATUS_DESC_LDST        USBHS_HSTDMASTATUS_DESC_LDST_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTDMASTATUS_DESC_LDST_Msk instead */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT_Pos   16                                             /**< (USBHS_HSTDMASTATUS) Buffer Byte Count Position */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT_Msk   (_U_(0xFFFF) << USBHS_HSTDMASTATUS_BUFF_COUNT_Pos)  /**< (USBHS_HSTDMASTATUS) Buffer Byte Count Mask */
+#define USBHS_HSTDMASTATUS_BUFF_COUNT(value) (USBHS_HSTDMASTATUS_BUFF_COUNT_Msk & ((value) << USBHS_HSTDMASTATUS_BUFF_COUNT_Pos))
+#define USBHS_HSTDMASTATUS_MASK             _U_(0xFFFF0073)                                /**< \deprecated (USBHS_HSTDMASTATUS) Register MASK  (Use USBHS_HSTDMASTATUS_Msk instead)  */
+#define USBHS_HSTDMASTATUS_Msk              _U_(0xFFFF0073)                                /**< (USBHS_HSTDMASTATUS) Register Mask  */
+
+
+/* -------- USBHS_DEVCTRL : (USBHS Offset: 0x00) (R/W 32) Device General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UADD:7;                    /**< bit:   0..6  USB Address                              */
+    uint32_t ADDEN:1;                   /**< bit:      7  Address Enable                           */
+    uint32_t DETACH:1;                  /**< bit:      8  Detach                                   */
+    uint32_t RMWKUP:1;                  /**< bit:      9  Remote Wake-Up                           */
+    uint32_t SPDCONF:2;                 /**< bit: 10..11  Mode Configuration                       */
+    uint32_t LS:1;                      /**< bit:     12  Low-Speed Mode Force                     */
+    uint32_t TSTJ:1;                    /**< bit:     13  Test mode J                              */
+    uint32_t TSTK:1;                    /**< bit:     14  Test mode K                              */
+    uint32_t TSTPCKT:1;                 /**< bit:     15  Test packet mode                         */
+    uint32_t OPMODE2:1;                 /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t OPMODE:1;                  /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVCTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVCTRL_OFFSET                (0x00)                                        /**<  (USBHS_DEVCTRL) Device General Control Register  Offset */
+
+#define USBHS_DEVCTRL_UADD_Pos              0                                              /**< (USBHS_DEVCTRL) USB Address Position */
+#define USBHS_DEVCTRL_UADD_Msk              (_U_(0x7F) << USBHS_DEVCTRL_UADD_Pos)          /**< (USBHS_DEVCTRL) USB Address Mask */
+#define USBHS_DEVCTRL_UADD(value)           (USBHS_DEVCTRL_UADD_Msk & ((value) << USBHS_DEVCTRL_UADD_Pos))
+#define USBHS_DEVCTRL_ADDEN_Pos             7                                              /**< (USBHS_DEVCTRL) Address Enable Position */
+#define USBHS_DEVCTRL_ADDEN_Msk             (_U_(0x1) << USBHS_DEVCTRL_ADDEN_Pos)          /**< (USBHS_DEVCTRL) Address Enable Mask */
+#define USBHS_DEVCTRL_ADDEN                 USBHS_DEVCTRL_ADDEN_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_ADDEN_Msk instead */
+#define USBHS_DEVCTRL_DETACH_Pos            8                                              /**< (USBHS_DEVCTRL) Detach Position */
+#define USBHS_DEVCTRL_DETACH_Msk            (_U_(0x1) << USBHS_DEVCTRL_DETACH_Pos)         /**< (USBHS_DEVCTRL) Detach Mask */
+#define USBHS_DEVCTRL_DETACH                USBHS_DEVCTRL_DETACH_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_DETACH_Msk instead */
+#define USBHS_DEVCTRL_RMWKUP_Pos            9                                              /**< (USBHS_DEVCTRL) Remote Wake-Up Position */
+#define USBHS_DEVCTRL_RMWKUP_Msk            (_U_(0x1) << USBHS_DEVCTRL_RMWKUP_Pos)         /**< (USBHS_DEVCTRL) Remote Wake-Up Mask */
+#define USBHS_DEVCTRL_RMWKUP                USBHS_DEVCTRL_RMWKUP_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_RMWKUP_Msk instead */
+#define USBHS_DEVCTRL_SPDCONF_Pos           10                                             /**< (USBHS_DEVCTRL) Mode Configuration Position */
+#define USBHS_DEVCTRL_SPDCONF_Msk           (_U_(0x3) << USBHS_DEVCTRL_SPDCONF_Pos)        /**< (USBHS_DEVCTRL) Mode Configuration Mask */
+#define USBHS_DEVCTRL_SPDCONF(value)        (USBHS_DEVCTRL_SPDCONF_Msk & ((value) << USBHS_DEVCTRL_SPDCONF_Pos))
+#define   USBHS_DEVCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable.  */
+#define   USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_DEVCTRL) Forced high speed.  */
+#define   USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability.  */
+#define USBHS_DEVCTRL_SPDCONF_NORMAL        (USBHS_DEVCTRL_SPDCONF_NORMAL_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable. Position  */
+#define USBHS_DEVCTRL_SPDCONF_LOW_POWER     (USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_HIGH_SPEED    (USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) Forced high speed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_FORCED_FS     (USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability. Position  */
+#define USBHS_DEVCTRL_LS_Pos                12                                             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Position */
+#define USBHS_DEVCTRL_LS_Msk                (_U_(0x1) << USBHS_DEVCTRL_LS_Pos)             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Mask */
+#define USBHS_DEVCTRL_LS                    USBHS_DEVCTRL_LS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_LS_Msk instead */
+#define USBHS_DEVCTRL_TSTJ_Pos              13                                             /**< (USBHS_DEVCTRL) Test mode J Position */
+#define USBHS_DEVCTRL_TSTJ_Msk              (_U_(0x1) << USBHS_DEVCTRL_TSTJ_Pos)           /**< (USBHS_DEVCTRL) Test mode J Mask */
+#define USBHS_DEVCTRL_TSTJ                  USBHS_DEVCTRL_TSTJ_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTJ_Msk instead */
+#define USBHS_DEVCTRL_TSTK_Pos              14                                             /**< (USBHS_DEVCTRL) Test mode K Position */
+#define USBHS_DEVCTRL_TSTK_Msk              (_U_(0x1) << USBHS_DEVCTRL_TSTK_Pos)           /**< (USBHS_DEVCTRL) Test mode K Mask */
+#define USBHS_DEVCTRL_TSTK                  USBHS_DEVCTRL_TSTK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTK_Msk instead */
+#define USBHS_DEVCTRL_TSTPCKT_Pos           15                                             /**< (USBHS_DEVCTRL) Test packet mode Position */
+#define USBHS_DEVCTRL_TSTPCKT_Msk           (_U_(0x1) << USBHS_DEVCTRL_TSTPCKT_Pos)        /**< (USBHS_DEVCTRL) Test packet mode Mask */
+#define USBHS_DEVCTRL_TSTPCKT               USBHS_DEVCTRL_TSTPCKT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_TSTPCKT_Msk instead */
+#define USBHS_DEVCTRL_OPMODE2_Pos           16                                             /**< (USBHS_DEVCTRL) Specific Operational mode Position */
+#define USBHS_DEVCTRL_OPMODE2_Msk           (_U_(0x1) << USBHS_DEVCTRL_OPMODE2_Pos)        /**< (USBHS_DEVCTRL) Specific Operational mode Mask */
+#define USBHS_DEVCTRL_OPMODE2               USBHS_DEVCTRL_OPMODE2_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_OPMODE2_Msk instead */
+#define USBHS_DEVCTRL_MASK                  _U_(0x1FFFF)                                   /**< \deprecated (USBHS_DEVCTRL) Register MASK  (Use USBHS_DEVCTRL_Msk instead)  */
+#define USBHS_DEVCTRL_Msk                   _U_(0x1FFFF)                                   /**< (USBHS_DEVCTRL) Register Mask  */
+
+#define USBHS_DEVCTRL_OPMODE_Pos            16                                             /**< (USBHS_DEVCTRL Position) Specific Operational mode */
+#define USBHS_DEVCTRL_OPMODE_Msk            (_U_(0x1) << USBHS_DEVCTRL_OPMODE_Pos)         /**< (USBHS_DEVCTRL Mask) OPMODE */
+#define USBHS_DEVCTRL_OPMODE(value)         (USBHS_DEVCTRL_OPMODE_Msk & ((value) << USBHS_DEVCTRL_OPMODE_Pos))  
+
+/* -------- USBHS_DEVISR : (USBHS Offset: 0x04) (R/ 32) Device Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSP:1;                    /**< bit:      0  Suspend Interrupt                        */
+    uint32_t MSOF:1;                    /**< bit:      1  Micro Start of Frame Interrupt           */
+    uint32_t SOF:1;                     /**< bit:      2  Start of Frame Interrupt                 */
+    uint32_t EORST:1;                   /**< bit:      3  End of Reset Interrupt                   */
+    uint32_t WAKEUP:1;                  /**< bit:      4  Wake-Up Interrupt                        */
+    uint32_t EORSM:1;                   /**< bit:      5  End of Resume Interrupt                  */
+    uint32_t UPRSM:1;                   /**< bit:      6  Upstream Resume Interrupt                */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt                     */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt                     */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt                     */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt                     */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt                     */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt                     */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt                     */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt                     */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt                     */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt                     */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt                  */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt                  */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt                  */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt                  */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt                  */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt                  */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt                     */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVISR_OFFSET                 (0x04)                                        /**<  (USBHS_DEVISR) Device Global Interrupt Status Register  Offset */
+
+#define USBHS_DEVISR_SUSP_Pos               0                                              /**< (USBHS_DEVISR) Suspend Interrupt Position */
+#define USBHS_DEVISR_SUSP_Msk               (_U_(0x1) << USBHS_DEVISR_SUSP_Pos)            /**< (USBHS_DEVISR) Suspend Interrupt Mask */
+#define USBHS_DEVISR_SUSP                   USBHS_DEVISR_SUSP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_SUSP_Msk instead */
+#define USBHS_DEVISR_MSOF_Pos               1                                              /**< (USBHS_DEVISR) Micro Start of Frame Interrupt Position */
+#define USBHS_DEVISR_MSOF_Msk               (_U_(0x1) << USBHS_DEVISR_MSOF_Pos)            /**< (USBHS_DEVISR) Micro Start of Frame Interrupt Mask */
+#define USBHS_DEVISR_MSOF                   USBHS_DEVISR_MSOF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_MSOF_Msk instead */
+#define USBHS_DEVISR_SOF_Pos                2                                              /**< (USBHS_DEVISR) Start of Frame Interrupt Position */
+#define USBHS_DEVISR_SOF_Msk                (_U_(0x1) << USBHS_DEVISR_SOF_Pos)             /**< (USBHS_DEVISR) Start of Frame Interrupt Mask */
+#define USBHS_DEVISR_SOF                    USBHS_DEVISR_SOF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_SOF_Msk instead */
+#define USBHS_DEVISR_EORST_Pos              3                                              /**< (USBHS_DEVISR) End of Reset Interrupt Position */
+#define USBHS_DEVISR_EORST_Msk              (_U_(0x1) << USBHS_DEVISR_EORST_Pos)           /**< (USBHS_DEVISR) End of Reset Interrupt Mask */
+#define USBHS_DEVISR_EORST                  USBHS_DEVISR_EORST_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_EORST_Msk instead */
+#define USBHS_DEVISR_WAKEUP_Pos             4                                              /**< (USBHS_DEVISR) Wake-Up Interrupt Position */
+#define USBHS_DEVISR_WAKEUP_Msk             (_U_(0x1) << USBHS_DEVISR_WAKEUP_Pos)          /**< (USBHS_DEVISR) Wake-Up Interrupt Mask */
+#define USBHS_DEVISR_WAKEUP                 USBHS_DEVISR_WAKEUP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_WAKEUP_Msk instead */
+#define USBHS_DEVISR_EORSM_Pos              5                                              /**< (USBHS_DEVISR) End of Resume Interrupt Position */
+#define USBHS_DEVISR_EORSM_Msk              (_U_(0x1) << USBHS_DEVISR_EORSM_Pos)           /**< (USBHS_DEVISR) End of Resume Interrupt Mask */
+#define USBHS_DEVISR_EORSM                  USBHS_DEVISR_EORSM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_EORSM_Msk instead */
+#define USBHS_DEVISR_UPRSM_Pos              6                                              /**< (USBHS_DEVISR) Upstream Resume Interrupt Position */
+#define USBHS_DEVISR_UPRSM_Msk              (_U_(0x1) << USBHS_DEVISR_UPRSM_Pos)           /**< (USBHS_DEVISR) Upstream Resume Interrupt Mask */
+#define USBHS_DEVISR_UPRSM                  USBHS_DEVISR_UPRSM_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_UPRSM_Msk instead */
+#define USBHS_DEVISR_PEP_0_Pos              12                                             /**< (USBHS_DEVISR) Endpoint 0 Interrupt Position */
+#define USBHS_DEVISR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_0_Pos)           /**< (USBHS_DEVISR) Endpoint 0 Interrupt Mask */
+#define USBHS_DEVISR_PEP_0                  USBHS_DEVISR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_0_Msk instead */
+#define USBHS_DEVISR_PEP_1_Pos              13                                             /**< (USBHS_DEVISR) Endpoint 1 Interrupt Position */
+#define USBHS_DEVISR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_1_Pos)           /**< (USBHS_DEVISR) Endpoint 1 Interrupt Mask */
+#define USBHS_DEVISR_PEP_1                  USBHS_DEVISR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_1_Msk instead */
+#define USBHS_DEVISR_PEP_2_Pos              14                                             /**< (USBHS_DEVISR) Endpoint 2 Interrupt Position */
+#define USBHS_DEVISR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_2_Pos)           /**< (USBHS_DEVISR) Endpoint 2 Interrupt Mask */
+#define USBHS_DEVISR_PEP_2                  USBHS_DEVISR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_2_Msk instead */
+#define USBHS_DEVISR_PEP_3_Pos              15                                             /**< (USBHS_DEVISR) Endpoint 3 Interrupt Position */
+#define USBHS_DEVISR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_3_Pos)           /**< (USBHS_DEVISR) Endpoint 3 Interrupt Mask */
+#define USBHS_DEVISR_PEP_3                  USBHS_DEVISR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_3_Msk instead */
+#define USBHS_DEVISR_PEP_4_Pos              16                                             /**< (USBHS_DEVISR) Endpoint 4 Interrupt Position */
+#define USBHS_DEVISR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_4_Pos)           /**< (USBHS_DEVISR) Endpoint 4 Interrupt Mask */
+#define USBHS_DEVISR_PEP_4                  USBHS_DEVISR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_4_Msk instead */
+#define USBHS_DEVISR_PEP_5_Pos              17                                             /**< (USBHS_DEVISR) Endpoint 5 Interrupt Position */
+#define USBHS_DEVISR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_5_Pos)           /**< (USBHS_DEVISR) Endpoint 5 Interrupt Mask */
+#define USBHS_DEVISR_PEP_5                  USBHS_DEVISR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_5_Msk instead */
+#define USBHS_DEVISR_PEP_6_Pos              18                                             /**< (USBHS_DEVISR) Endpoint 6 Interrupt Position */
+#define USBHS_DEVISR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_6_Pos)           /**< (USBHS_DEVISR) Endpoint 6 Interrupt Mask */
+#define USBHS_DEVISR_PEP_6                  USBHS_DEVISR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_6_Msk instead */
+#define USBHS_DEVISR_PEP_7_Pos              19                                             /**< (USBHS_DEVISR) Endpoint 7 Interrupt Position */
+#define USBHS_DEVISR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_7_Pos)           /**< (USBHS_DEVISR) Endpoint 7 Interrupt Mask */
+#define USBHS_DEVISR_PEP_7                  USBHS_DEVISR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_7_Msk instead */
+#define USBHS_DEVISR_PEP_8_Pos              20                                             /**< (USBHS_DEVISR) Endpoint 8 Interrupt Position */
+#define USBHS_DEVISR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_8_Pos)           /**< (USBHS_DEVISR) Endpoint 8 Interrupt Mask */
+#define USBHS_DEVISR_PEP_8                  USBHS_DEVISR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_8_Msk instead */
+#define USBHS_DEVISR_PEP_9_Pos              21                                             /**< (USBHS_DEVISR) Endpoint 9 Interrupt Position */
+#define USBHS_DEVISR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_9_Pos)           /**< (USBHS_DEVISR) Endpoint 9 Interrupt Mask */
+#define USBHS_DEVISR_PEP_9                  USBHS_DEVISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_9_Msk instead */
+#define USBHS_DEVISR_DMA_1_Pos              25                                             /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Position */
+#define USBHS_DEVISR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_1_Pos)           /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Mask */
+#define USBHS_DEVISR_DMA_1                  USBHS_DEVISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_1_Msk instead */
+#define USBHS_DEVISR_DMA_2_Pos              26                                             /**< (USBHS_DEVISR) DMA Channel 2 Interrupt Position */
+#define USBHS_DEVISR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_2_Pos)           /**< (USBHS_DEVISR) DMA Channel 2 Interrupt Mask */
+#define USBHS_DEVISR_DMA_2                  USBHS_DEVISR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_2_Msk instead */
+#define USBHS_DEVISR_DMA_3_Pos              27                                             /**< (USBHS_DEVISR) DMA Channel 3 Interrupt Position */
+#define USBHS_DEVISR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_3_Pos)           /**< (USBHS_DEVISR) DMA Channel 3 Interrupt Mask */
+#define USBHS_DEVISR_DMA_3                  USBHS_DEVISR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_3_Msk instead */
+#define USBHS_DEVISR_DMA_4_Pos              28                                             /**< (USBHS_DEVISR) DMA Channel 4 Interrupt Position */
+#define USBHS_DEVISR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_4_Pos)           /**< (USBHS_DEVISR) DMA Channel 4 Interrupt Mask */
+#define USBHS_DEVISR_DMA_4                  USBHS_DEVISR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_4_Msk instead */
+#define USBHS_DEVISR_DMA_5_Pos              29                                             /**< (USBHS_DEVISR) DMA Channel 5 Interrupt Position */
+#define USBHS_DEVISR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_5_Pos)           /**< (USBHS_DEVISR) DMA Channel 5 Interrupt Mask */
+#define USBHS_DEVISR_DMA_5                  USBHS_DEVISR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_5_Msk instead */
+#define USBHS_DEVISR_DMA_6_Pos              30                                             /**< (USBHS_DEVISR) DMA Channel 6 Interrupt Position */
+#define USBHS_DEVISR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_6_Pos)           /**< (USBHS_DEVISR) DMA Channel 6 Interrupt Mask */
+#define USBHS_DEVISR_DMA_6                  USBHS_DEVISR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_6_Msk instead */
+#define USBHS_DEVISR_DMA_7_Pos              31                                             /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Position */
+#define USBHS_DEVISR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_7_Pos)           /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Mask */
+#define USBHS_DEVISR_DMA_7                  USBHS_DEVISR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_7_Msk instead */
+#define USBHS_DEVISR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVISR) Register MASK  (Use USBHS_DEVISR_Msk instead)  */
+#define USBHS_DEVISR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVISR) Register Mask  */
+
+#define USBHS_DEVISR_PEP__Pos               12                                             /**< (USBHS_DEVISR Position) Endpoint x Interrupt */
+#define USBHS_DEVISR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVISR_PEP__Pos)          /**< (USBHS_DEVISR Mask) PEP_ */
+#define USBHS_DEVISR_PEP_(value)            (USBHS_DEVISR_PEP__Msk & ((value) << USBHS_DEVISR_PEP__Pos))  
+#define USBHS_DEVISR_DMA__Pos               25                                             /**< (USBHS_DEVISR Position) DMA Channel 7 Interrupt */
+#define USBHS_DEVISR_DMA__Msk               (_U_(0x7F) << USBHS_DEVISR_DMA__Pos)           /**< (USBHS_DEVISR Mask) DMA_ */
+#define USBHS_DEVISR_DMA_(value)            (USBHS_DEVISR_DMA__Msk & ((value) << USBHS_DEVISR_DMA__Pos))  
+
+/* -------- USBHS_DEVICR : (USBHS Offset: 0x08) (/W 32) Device Global Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPC:1;                   /**< bit:      0  Suspend Interrupt Clear                  */
+    uint32_t MSOFC:1;                   /**< bit:      1  Micro Start of Frame Interrupt Clear     */
+    uint32_t SOFC:1;                    /**< bit:      2  Start of Frame Interrupt Clear           */
+    uint32_t EORSTC:1;                  /**< bit:      3  End of Reset Interrupt Clear             */
+    uint32_t WAKEUPC:1;                 /**< bit:      4  Wake-Up Interrupt Clear                  */
+    uint32_t EORSMC:1;                  /**< bit:      5  End of Resume Interrupt Clear            */
+    uint32_t UPRSMC:1;                  /**< bit:      6  Upstream Resume Interrupt Clear          */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVICR_OFFSET                 (0x08)                                        /**<  (USBHS_DEVICR) Device Global Interrupt Clear Register  Offset */
+
+#define USBHS_DEVICR_SUSPC_Pos              0                                              /**< (USBHS_DEVICR) Suspend Interrupt Clear Position */
+#define USBHS_DEVICR_SUSPC_Msk              (_U_(0x1) << USBHS_DEVICR_SUSPC_Pos)           /**< (USBHS_DEVICR) Suspend Interrupt Clear Mask */
+#define USBHS_DEVICR_SUSPC                  USBHS_DEVICR_SUSPC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_SUSPC_Msk instead */
+#define USBHS_DEVICR_MSOFC_Pos              1                                              /**< (USBHS_DEVICR) Micro Start of Frame Interrupt Clear Position */
+#define USBHS_DEVICR_MSOFC_Msk              (_U_(0x1) << USBHS_DEVICR_MSOFC_Pos)           /**< (USBHS_DEVICR) Micro Start of Frame Interrupt Clear Mask */
+#define USBHS_DEVICR_MSOFC                  USBHS_DEVICR_MSOFC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_MSOFC_Msk instead */
+#define USBHS_DEVICR_SOFC_Pos               2                                              /**< (USBHS_DEVICR) Start of Frame Interrupt Clear Position */
+#define USBHS_DEVICR_SOFC_Msk               (_U_(0x1) << USBHS_DEVICR_SOFC_Pos)            /**< (USBHS_DEVICR) Start of Frame Interrupt Clear Mask */
+#define USBHS_DEVICR_SOFC                   USBHS_DEVICR_SOFC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_SOFC_Msk instead */
+#define USBHS_DEVICR_EORSTC_Pos             3                                              /**< (USBHS_DEVICR) End of Reset Interrupt Clear Position */
+#define USBHS_DEVICR_EORSTC_Msk             (_U_(0x1) << USBHS_DEVICR_EORSTC_Pos)          /**< (USBHS_DEVICR) End of Reset Interrupt Clear Mask */
+#define USBHS_DEVICR_EORSTC                 USBHS_DEVICR_EORSTC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_EORSTC_Msk instead */
+#define USBHS_DEVICR_WAKEUPC_Pos            4                                              /**< (USBHS_DEVICR) Wake-Up Interrupt Clear Position */
+#define USBHS_DEVICR_WAKEUPC_Msk            (_U_(0x1) << USBHS_DEVICR_WAKEUPC_Pos)         /**< (USBHS_DEVICR) Wake-Up Interrupt Clear Mask */
+#define USBHS_DEVICR_WAKEUPC                USBHS_DEVICR_WAKEUPC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_WAKEUPC_Msk instead */
+#define USBHS_DEVICR_EORSMC_Pos             5                                              /**< (USBHS_DEVICR) End of Resume Interrupt Clear Position */
+#define USBHS_DEVICR_EORSMC_Msk             (_U_(0x1) << USBHS_DEVICR_EORSMC_Pos)          /**< (USBHS_DEVICR) End of Resume Interrupt Clear Mask */
+#define USBHS_DEVICR_EORSMC                 USBHS_DEVICR_EORSMC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_EORSMC_Msk instead */
+#define USBHS_DEVICR_UPRSMC_Pos             6                                              /**< (USBHS_DEVICR) Upstream Resume Interrupt Clear Position */
+#define USBHS_DEVICR_UPRSMC_Msk             (_U_(0x1) << USBHS_DEVICR_UPRSMC_Pos)          /**< (USBHS_DEVICR) Upstream Resume Interrupt Clear Mask */
+#define USBHS_DEVICR_UPRSMC                 USBHS_DEVICR_UPRSMC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVICR_UPRSMC_Msk instead */
+#define USBHS_DEVICR_MASK                   _U_(0x7F)                                      /**< \deprecated (USBHS_DEVICR) Register MASK  (Use USBHS_DEVICR_Msk instead)  */
+#define USBHS_DEVICR_Msk                    _U_(0x7F)                                      /**< (USBHS_DEVICR) Register Mask  */
+
+
+/* -------- USBHS_DEVIFR : (USBHS Offset: 0x0c) (/W 32) Device Global Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPS:1;                   /**< bit:      0  Suspend Interrupt Set                    */
+    uint32_t MSOFS:1;                   /**< bit:      1  Micro Start of Frame Interrupt Set       */
+    uint32_t SOFS:1;                    /**< bit:      2  Start of Frame Interrupt Set             */
+    uint32_t EORSTS:1;                  /**< bit:      3  End of Reset Interrupt Set               */
+    uint32_t WAKEUPS:1;                 /**< bit:      4  Wake-Up Interrupt Set                    */
+    uint32_t EORSMS:1;                  /**< bit:      5  End of Resume Interrupt Set              */
+    uint32_t UPRSMS:1;                  /**< bit:      6  Upstream Resume Interrupt Set            */
+    uint32_t :18;                       /**< bit:  7..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Set              */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Set              */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Set              */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Set              */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Set              */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Set              */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Set              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :25;                       /**< bit:  0..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Set              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIFR_OFFSET                 (0x0C)                                        /**<  (USBHS_DEVIFR) Device Global Interrupt Set Register  Offset */
+
+#define USBHS_DEVIFR_SUSPS_Pos              0                                              /**< (USBHS_DEVIFR) Suspend Interrupt Set Position */
+#define USBHS_DEVIFR_SUSPS_Msk              (_U_(0x1) << USBHS_DEVIFR_SUSPS_Pos)           /**< (USBHS_DEVIFR) Suspend Interrupt Set Mask */
+#define USBHS_DEVIFR_SUSPS                  USBHS_DEVIFR_SUSPS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_SUSPS_Msk instead */
+#define USBHS_DEVIFR_MSOFS_Pos              1                                              /**< (USBHS_DEVIFR) Micro Start of Frame Interrupt Set Position */
+#define USBHS_DEVIFR_MSOFS_Msk              (_U_(0x1) << USBHS_DEVIFR_MSOFS_Pos)           /**< (USBHS_DEVIFR) Micro Start of Frame Interrupt Set Mask */
+#define USBHS_DEVIFR_MSOFS                  USBHS_DEVIFR_MSOFS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_MSOFS_Msk instead */
+#define USBHS_DEVIFR_SOFS_Pos               2                                              /**< (USBHS_DEVIFR) Start of Frame Interrupt Set Position */
+#define USBHS_DEVIFR_SOFS_Msk               (_U_(0x1) << USBHS_DEVIFR_SOFS_Pos)            /**< (USBHS_DEVIFR) Start of Frame Interrupt Set Mask */
+#define USBHS_DEVIFR_SOFS                   USBHS_DEVIFR_SOFS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_SOFS_Msk instead */
+#define USBHS_DEVIFR_EORSTS_Pos             3                                              /**< (USBHS_DEVIFR) End of Reset Interrupt Set Position */
+#define USBHS_DEVIFR_EORSTS_Msk             (_U_(0x1) << USBHS_DEVIFR_EORSTS_Pos)          /**< (USBHS_DEVIFR) End of Reset Interrupt Set Mask */
+#define USBHS_DEVIFR_EORSTS                 USBHS_DEVIFR_EORSTS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_EORSTS_Msk instead */
+#define USBHS_DEVIFR_WAKEUPS_Pos            4                                              /**< (USBHS_DEVIFR) Wake-Up Interrupt Set Position */
+#define USBHS_DEVIFR_WAKEUPS_Msk            (_U_(0x1) << USBHS_DEVIFR_WAKEUPS_Pos)         /**< (USBHS_DEVIFR) Wake-Up Interrupt Set Mask */
+#define USBHS_DEVIFR_WAKEUPS                USBHS_DEVIFR_WAKEUPS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_WAKEUPS_Msk instead */
+#define USBHS_DEVIFR_EORSMS_Pos             5                                              /**< (USBHS_DEVIFR) End of Resume Interrupt Set Position */
+#define USBHS_DEVIFR_EORSMS_Msk             (_U_(0x1) << USBHS_DEVIFR_EORSMS_Pos)          /**< (USBHS_DEVIFR) End of Resume Interrupt Set Mask */
+#define USBHS_DEVIFR_EORSMS                 USBHS_DEVIFR_EORSMS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_EORSMS_Msk instead */
+#define USBHS_DEVIFR_UPRSMS_Pos             6                                              /**< (USBHS_DEVIFR) Upstream Resume Interrupt Set Position */
+#define USBHS_DEVIFR_UPRSMS_Msk             (_U_(0x1) << USBHS_DEVIFR_UPRSMS_Pos)          /**< (USBHS_DEVIFR) Upstream Resume Interrupt Set Mask */
+#define USBHS_DEVIFR_UPRSMS                 USBHS_DEVIFR_UPRSMS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_UPRSMS_Msk instead */
+#define USBHS_DEVIFR_DMA_1_Pos              25                                             /**< (USBHS_DEVIFR) DMA Channel 1 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_1_Pos)           /**< (USBHS_DEVIFR) DMA Channel 1 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_1                  USBHS_DEVIFR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_1_Msk instead */
+#define USBHS_DEVIFR_DMA_2_Pos              26                                             /**< (USBHS_DEVIFR) DMA Channel 2 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_2_Pos)           /**< (USBHS_DEVIFR) DMA Channel 2 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_2                  USBHS_DEVIFR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_2_Msk instead */
+#define USBHS_DEVIFR_DMA_3_Pos              27                                             /**< (USBHS_DEVIFR) DMA Channel 3 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_3_Pos)           /**< (USBHS_DEVIFR) DMA Channel 3 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_3                  USBHS_DEVIFR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_3_Msk instead */
+#define USBHS_DEVIFR_DMA_4_Pos              28                                             /**< (USBHS_DEVIFR) DMA Channel 4 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_4_Pos)           /**< (USBHS_DEVIFR) DMA Channel 4 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_4                  USBHS_DEVIFR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_4_Msk instead */
+#define USBHS_DEVIFR_DMA_5_Pos              29                                             /**< (USBHS_DEVIFR) DMA Channel 5 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_5_Pos)           /**< (USBHS_DEVIFR) DMA Channel 5 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_5                  USBHS_DEVIFR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_5_Msk instead */
+#define USBHS_DEVIFR_DMA_6_Pos              30                                             /**< (USBHS_DEVIFR) DMA Channel 6 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_6_Pos)           /**< (USBHS_DEVIFR) DMA Channel 6 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_6                  USBHS_DEVIFR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_6_Msk instead */
+#define USBHS_DEVIFR_DMA_7_Pos              31                                             /**< (USBHS_DEVIFR) DMA Channel 7 Interrupt Set Position */
+#define USBHS_DEVIFR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIFR_DMA_7_Pos)           /**< (USBHS_DEVIFR) DMA Channel 7 Interrupt Set Mask */
+#define USBHS_DEVIFR_DMA_7                  USBHS_DEVIFR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIFR_DMA_7_Msk instead */
+#define USBHS_DEVIFR_MASK                   _U_(0xFE00007F)                                /**< \deprecated (USBHS_DEVIFR) Register MASK  (Use USBHS_DEVIFR_Msk instead)  */
+#define USBHS_DEVIFR_Msk                    _U_(0xFE00007F)                                /**< (USBHS_DEVIFR) Register Mask  */
+
+#define USBHS_DEVIFR_DMA__Pos               25                                             /**< (USBHS_DEVIFR Position) DMA Channel 7 Interrupt Set */
+#define USBHS_DEVIFR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIFR_DMA__Pos)           /**< (USBHS_DEVIFR Mask) DMA_ */
+#define USBHS_DEVIFR_DMA_(value)            (USBHS_DEVIFR_DMA__Msk & ((value) << USBHS_DEVIFR_DMA__Pos))  
+
+/* -------- USBHS_DEVIMR : (USBHS Offset: 0x10) (R/ 32) Device Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPE:1;                   /**< bit:      0  Suspend Interrupt Mask                   */
+    uint32_t MSOFE:1;                   /**< bit:      1  Micro Start of Frame Interrupt Mask      */
+    uint32_t SOFE:1;                    /**< bit:      2  Start of Frame Interrupt Mask            */
+    uint32_t EORSTE:1;                  /**< bit:      3  End of Reset Interrupt Mask              */
+    uint32_t WAKEUPE:1;                 /**< bit:      4  Wake-Up Interrupt Mask                   */
+    uint32_t EORSME:1;                  /**< bit:      5  End of Resume Interrupt Mask             */
+    uint32_t UPRSME:1;                  /**< bit:      6  Upstream Resume Interrupt Mask           */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Mask                */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Mask                */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Mask                */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Mask                */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Mask                */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Mask                */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Mask                */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Mask                */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Mask                */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Mask                */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Mask             */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Mask             */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Mask             */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Mask             */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Mask             */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Mask             */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Mask             */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Mask                */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Mask             */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIMR_OFFSET                 (0x10)                                        /**<  (USBHS_DEVIMR) Device Global Interrupt Mask Register  Offset */
+
+#define USBHS_DEVIMR_SUSPE_Pos              0                                              /**< (USBHS_DEVIMR) Suspend Interrupt Mask Position */
+#define USBHS_DEVIMR_SUSPE_Msk              (_U_(0x1) << USBHS_DEVIMR_SUSPE_Pos)           /**< (USBHS_DEVIMR) Suspend Interrupt Mask Mask */
+#define USBHS_DEVIMR_SUSPE                  USBHS_DEVIMR_SUSPE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_SUSPE_Msk instead */
+#define USBHS_DEVIMR_MSOFE_Pos              1                                              /**< (USBHS_DEVIMR) Micro Start of Frame Interrupt Mask Position */
+#define USBHS_DEVIMR_MSOFE_Msk              (_U_(0x1) << USBHS_DEVIMR_MSOFE_Pos)           /**< (USBHS_DEVIMR) Micro Start of Frame Interrupt Mask Mask */
+#define USBHS_DEVIMR_MSOFE                  USBHS_DEVIMR_MSOFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_MSOFE_Msk instead */
+#define USBHS_DEVIMR_SOFE_Pos               2                                              /**< (USBHS_DEVIMR) Start of Frame Interrupt Mask Position */
+#define USBHS_DEVIMR_SOFE_Msk               (_U_(0x1) << USBHS_DEVIMR_SOFE_Pos)            /**< (USBHS_DEVIMR) Start of Frame Interrupt Mask Mask */
+#define USBHS_DEVIMR_SOFE                   USBHS_DEVIMR_SOFE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_SOFE_Msk instead */
+#define USBHS_DEVIMR_EORSTE_Pos             3                                              /**< (USBHS_DEVIMR) End of Reset Interrupt Mask Position */
+#define USBHS_DEVIMR_EORSTE_Msk             (_U_(0x1) << USBHS_DEVIMR_EORSTE_Pos)          /**< (USBHS_DEVIMR) End of Reset Interrupt Mask Mask */
+#define USBHS_DEVIMR_EORSTE                 USBHS_DEVIMR_EORSTE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_EORSTE_Msk instead */
+#define USBHS_DEVIMR_WAKEUPE_Pos            4                                              /**< (USBHS_DEVIMR) Wake-Up Interrupt Mask Position */
+#define USBHS_DEVIMR_WAKEUPE_Msk            (_U_(0x1) << USBHS_DEVIMR_WAKEUPE_Pos)         /**< (USBHS_DEVIMR) Wake-Up Interrupt Mask Mask */
+#define USBHS_DEVIMR_WAKEUPE                USBHS_DEVIMR_WAKEUPE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_WAKEUPE_Msk instead */
+#define USBHS_DEVIMR_EORSME_Pos             5                                              /**< (USBHS_DEVIMR) End of Resume Interrupt Mask Position */
+#define USBHS_DEVIMR_EORSME_Msk             (_U_(0x1) << USBHS_DEVIMR_EORSME_Pos)          /**< (USBHS_DEVIMR) End of Resume Interrupt Mask Mask */
+#define USBHS_DEVIMR_EORSME                 USBHS_DEVIMR_EORSME_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_EORSME_Msk instead */
+#define USBHS_DEVIMR_UPRSME_Pos             6                                              /**< (USBHS_DEVIMR) Upstream Resume Interrupt Mask Position */
+#define USBHS_DEVIMR_UPRSME_Msk             (_U_(0x1) << USBHS_DEVIMR_UPRSME_Pos)          /**< (USBHS_DEVIMR) Upstream Resume Interrupt Mask Mask */
+#define USBHS_DEVIMR_UPRSME                 USBHS_DEVIMR_UPRSME_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_UPRSME_Msk instead */
+#define USBHS_DEVIMR_PEP_0_Pos              12                                             /**< (USBHS_DEVIMR) Endpoint 0 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_0_Pos)           /**< (USBHS_DEVIMR) Endpoint 0 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_0                  USBHS_DEVIMR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_0_Msk instead */
+#define USBHS_DEVIMR_PEP_1_Pos              13                                             /**< (USBHS_DEVIMR) Endpoint 1 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_1_Pos)           /**< (USBHS_DEVIMR) Endpoint 1 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_1                  USBHS_DEVIMR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_1_Msk instead */
+#define USBHS_DEVIMR_PEP_2_Pos              14                                             /**< (USBHS_DEVIMR) Endpoint 2 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_2_Pos)           /**< (USBHS_DEVIMR) Endpoint 2 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_2                  USBHS_DEVIMR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_2_Msk instead */
+#define USBHS_DEVIMR_PEP_3_Pos              15                                             /**< (USBHS_DEVIMR) Endpoint 3 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_3_Pos)           /**< (USBHS_DEVIMR) Endpoint 3 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_3                  USBHS_DEVIMR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_3_Msk instead */
+#define USBHS_DEVIMR_PEP_4_Pos              16                                             /**< (USBHS_DEVIMR) Endpoint 4 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_4_Pos)           /**< (USBHS_DEVIMR) Endpoint 4 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_4                  USBHS_DEVIMR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_4_Msk instead */
+#define USBHS_DEVIMR_PEP_5_Pos              17                                             /**< (USBHS_DEVIMR) Endpoint 5 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_5_Pos)           /**< (USBHS_DEVIMR) Endpoint 5 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_5                  USBHS_DEVIMR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_5_Msk instead */
+#define USBHS_DEVIMR_PEP_6_Pos              18                                             /**< (USBHS_DEVIMR) Endpoint 6 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_6_Pos)           /**< (USBHS_DEVIMR) Endpoint 6 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_6                  USBHS_DEVIMR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_6_Msk instead */
+#define USBHS_DEVIMR_PEP_7_Pos              19                                             /**< (USBHS_DEVIMR) Endpoint 7 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_7_Pos)           /**< (USBHS_DEVIMR) Endpoint 7 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_7                  USBHS_DEVIMR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_7_Msk instead */
+#define USBHS_DEVIMR_PEP_8_Pos              20                                             /**< (USBHS_DEVIMR) Endpoint 8 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_8_Pos)           /**< (USBHS_DEVIMR) Endpoint 8 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_8                  USBHS_DEVIMR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_8_Msk instead */
+#define USBHS_DEVIMR_PEP_9_Pos              21                                             /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Position */
+#define USBHS_DEVIMR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_9_Pos)           /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Mask */
+#define USBHS_DEVIMR_PEP_9                  USBHS_DEVIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_9_Msk instead */
+#define USBHS_DEVIMR_DMA_1_Pos              25                                             /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_1_Pos)           /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_1                  USBHS_DEVIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_1_Msk instead */
+#define USBHS_DEVIMR_DMA_2_Pos              26                                             /**< (USBHS_DEVIMR) DMA Channel 2 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_2_Pos)           /**< (USBHS_DEVIMR) DMA Channel 2 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_2                  USBHS_DEVIMR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_2_Msk instead */
+#define USBHS_DEVIMR_DMA_3_Pos              27                                             /**< (USBHS_DEVIMR) DMA Channel 3 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_3_Pos)           /**< (USBHS_DEVIMR) DMA Channel 3 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_3                  USBHS_DEVIMR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_3_Msk instead */
+#define USBHS_DEVIMR_DMA_4_Pos              28                                             /**< (USBHS_DEVIMR) DMA Channel 4 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_4_Pos)           /**< (USBHS_DEVIMR) DMA Channel 4 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_4                  USBHS_DEVIMR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_4_Msk instead */
+#define USBHS_DEVIMR_DMA_5_Pos              29                                             /**< (USBHS_DEVIMR) DMA Channel 5 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_5_Pos)           /**< (USBHS_DEVIMR) DMA Channel 5 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_5                  USBHS_DEVIMR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_5_Msk instead */
+#define USBHS_DEVIMR_DMA_6_Pos              30                                             /**< (USBHS_DEVIMR) DMA Channel 6 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_6_Pos)           /**< (USBHS_DEVIMR) DMA Channel 6 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_6                  USBHS_DEVIMR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_6_Msk instead */
+#define USBHS_DEVIMR_DMA_7_Pos              31                                             /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Position */
+#define USBHS_DEVIMR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_7_Pos)           /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Mask */
+#define USBHS_DEVIMR_DMA_7                  USBHS_DEVIMR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_7_Msk instead */
+#define USBHS_DEVIMR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIMR) Register MASK  (Use USBHS_DEVIMR_Msk instead)  */
+#define USBHS_DEVIMR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIMR) Register Mask  */
+
+#define USBHS_DEVIMR_PEP__Pos               12                                             /**< (USBHS_DEVIMR Position) Endpoint x Interrupt Mask */
+#define USBHS_DEVIMR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIMR_PEP__Pos)          /**< (USBHS_DEVIMR Mask) PEP_ */
+#define USBHS_DEVIMR_PEP_(value)            (USBHS_DEVIMR_PEP__Msk & ((value) << USBHS_DEVIMR_PEP__Pos))  
+#define USBHS_DEVIMR_DMA__Pos               25                                             /**< (USBHS_DEVIMR Position) DMA Channel 7 Interrupt Mask */
+#define USBHS_DEVIMR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIMR_DMA__Pos)           /**< (USBHS_DEVIMR Mask) DMA_ */
+#define USBHS_DEVIMR_DMA_(value)            (USBHS_DEVIMR_DMA__Msk & ((value) << USBHS_DEVIMR_DMA__Pos))  
+
+/* -------- USBHS_DEVIDR : (USBHS Offset: 0x14) (/W 32) Device Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPEC:1;                  /**< bit:      0  Suspend Interrupt Disable                */
+    uint32_t MSOFEC:1;                  /**< bit:      1  Micro Start of Frame Interrupt Disable   */
+    uint32_t SOFEC:1;                   /**< bit:      2  Start of Frame Interrupt Disable         */
+    uint32_t EORSTEC:1;                 /**< bit:      3  End of Reset Interrupt Disable           */
+    uint32_t WAKEUPEC:1;                /**< bit:      4  Wake-Up Interrupt Disable                */
+    uint32_t EORSMEC:1;                 /**< bit:      5  End of Resume Interrupt Disable          */
+    uint32_t UPRSMEC:1;                 /**< bit:      6  Upstream Resume Interrupt Disable        */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Disable             */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Disable             */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Disable             */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Disable             */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Disable             */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Disable             */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Disable             */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Disable             */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Disable             */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Disable             */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Disable          */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Disable          */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Disable          */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Disable          */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Disable          */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Disable          */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Disable          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Disable             */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Disable          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIDR_OFFSET                 (0x14)                                        /**<  (USBHS_DEVIDR) Device Global Interrupt Disable Register  Offset */
+
+#define USBHS_DEVIDR_SUSPEC_Pos             0                                              /**< (USBHS_DEVIDR) Suspend Interrupt Disable Position */
+#define USBHS_DEVIDR_SUSPEC_Msk             (_U_(0x1) << USBHS_DEVIDR_SUSPEC_Pos)          /**< (USBHS_DEVIDR) Suspend Interrupt Disable Mask */
+#define USBHS_DEVIDR_SUSPEC                 USBHS_DEVIDR_SUSPEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_SUSPEC_Msk instead */
+#define USBHS_DEVIDR_MSOFEC_Pos             1                                              /**< (USBHS_DEVIDR) Micro Start of Frame Interrupt Disable Position */
+#define USBHS_DEVIDR_MSOFEC_Msk             (_U_(0x1) << USBHS_DEVIDR_MSOFEC_Pos)          /**< (USBHS_DEVIDR) Micro Start of Frame Interrupt Disable Mask */
+#define USBHS_DEVIDR_MSOFEC                 USBHS_DEVIDR_MSOFEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_MSOFEC_Msk instead */
+#define USBHS_DEVIDR_SOFEC_Pos              2                                              /**< (USBHS_DEVIDR) Start of Frame Interrupt Disable Position */
+#define USBHS_DEVIDR_SOFEC_Msk              (_U_(0x1) << USBHS_DEVIDR_SOFEC_Pos)           /**< (USBHS_DEVIDR) Start of Frame Interrupt Disable Mask */
+#define USBHS_DEVIDR_SOFEC                  USBHS_DEVIDR_SOFEC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_SOFEC_Msk instead */
+#define USBHS_DEVIDR_EORSTEC_Pos            3                                              /**< (USBHS_DEVIDR) End of Reset Interrupt Disable Position */
+#define USBHS_DEVIDR_EORSTEC_Msk            (_U_(0x1) << USBHS_DEVIDR_EORSTEC_Pos)         /**< (USBHS_DEVIDR) End of Reset Interrupt Disable Mask */
+#define USBHS_DEVIDR_EORSTEC                USBHS_DEVIDR_EORSTEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_EORSTEC_Msk instead */
+#define USBHS_DEVIDR_WAKEUPEC_Pos           4                                              /**< (USBHS_DEVIDR) Wake-Up Interrupt Disable Position */
+#define USBHS_DEVIDR_WAKEUPEC_Msk           (_U_(0x1) << USBHS_DEVIDR_WAKEUPEC_Pos)        /**< (USBHS_DEVIDR) Wake-Up Interrupt Disable Mask */
+#define USBHS_DEVIDR_WAKEUPEC               USBHS_DEVIDR_WAKEUPEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_WAKEUPEC_Msk instead */
+#define USBHS_DEVIDR_EORSMEC_Pos            5                                              /**< (USBHS_DEVIDR) End of Resume Interrupt Disable Position */
+#define USBHS_DEVIDR_EORSMEC_Msk            (_U_(0x1) << USBHS_DEVIDR_EORSMEC_Pos)         /**< (USBHS_DEVIDR) End of Resume Interrupt Disable Mask */
+#define USBHS_DEVIDR_EORSMEC                USBHS_DEVIDR_EORSMEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_EORSMEC_Msk instead */
+#define USBHS_DEVIDR_UPRSMEC_Pos            6                                              /**< (USBHS_DEVIDR) Upstream Resume Interrupt Disable Position */
+#define USBHS_DEVIDR_UPRSMEC_Msk            (_U_(0x1) << USBHS_DEVIDR_UPRSMEC_Pos)         /**< (USBHS_DEVIDR) Upstream Resume Interrupt Disable Mask */
+#define USBHS_DEVIDR_UPRSMEC                USBHS_DEVIDR_UPRSMEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_UPRSMEC_Msk instead */
+#define USBHS_DEVIDR_PEP_0_Pos              12                                             /**< (USBHS_DEVIDR) Endpoint 0 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_0_Pos)           /**< (USBHS_DEVIDR) Endpoint 0 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_0                  USBHS_DEVIDR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_0_Msk instead */
+#define USBHS_DEVIDR_PEP_1_Pos              13                                             /**< (USBHS_DEVIDR) Endpoint 1 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_1_Pos)           /**< (USBHS_DEVIDR) Endpoint 1 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_1                  USBHS_DEVIDR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_1_Msk instead */
+#define USBHS_DEVIDR_PEP_2_Pos              14                                             /**< (USBHS_DEVIDR) Endpoint 2 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_2_Pos)           /**< (USBHS_DEVIDR) Endpoint 2 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_2                  USBHS_DEVIDR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_2_Msk instead */
+#define USBHS_DEVIDR_PEP_3_Pos              15                                             /**< (USBHS_DEVIDR) Endpoint 3 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_3_Pos)           /**< (USBHS_DEVIDR) Endpoint 3 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_3                  USBHS_DEVIDR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_3_Msk instead */
+#define USBHS_DEVIDR_PEP_4_Pos              16                                             /**< (USBHS_DEVIDR) Endpoint 4 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_4_Pos)           /**< (USBHS_DEVIDR) Endpoint 4 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_4                  USBHS_DEVIDR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_4_Msk instead */
+#define USBHS_DEVIDR_PEP_5_Pos              17                                             /**< (USBHS_DEVIDR) Endpoint 5 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_5_Pos)           /**< (USBHS_DEVIDR) Endpoint 5 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_5                  USBHS_DEVIDR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_5_Msk instead */
+#define USBHS_DEVIDR_PEP_6_Pos              18                                             /**< (USBHS_DEVIDR) Endpoint 6 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_6_Pos)           /**< (USBHS_DEVIDR) Endpoint 6 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_6                  USBHS_DEVIDR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_6_Msk instead */
+#define USBHS_DEVIDR_PEP_7_Pos              19                                             /**< (USBHS_DEVIDR) Endpoint 7 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_7_Pos)           /**< (USBHS_DEVIDR) Endpoint 7 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_7                  USBHS_DEVIDR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_7_Msk instead */
+#define USBHS_DEVIDR_PEP_8_Pos              20                                             /**< (USBHS_DEVIDR) Endpoint 8 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_8_Pos)           /**< (USBHS_DEVIDR) Endpoint 8 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_8                  USBHS_DEVIDR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_8_Msk instead */
+#define USBHS_DEVIDR_PEP_9_Pos              21                                             /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Position */
+#define USBHS_DEVIDR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_9_Pos)           /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Mask */
+#define USBHS_DEVIDR_PEP_9                  USBHS_DEVIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_9_Msk instead */
+#define USBHS_DEVIDR_DMA_1_Pos              25                                             /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_1_Pos)           /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_1                  USBHS_DEVIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_1_Msk instead */
+#define USBHS_DEVIDR_DMA_2_Pos              26                                             /**< (USBHS_DEVIDR) DMA Channel 2 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_2_Pos)           /**< (USBHS_DEVIDR) DMA Channel 2 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_2                  USBHS_DEVIDR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_2_Msk instead */
+#define USBHS_DEVIDR_DMA_3_Pos              27                                             /**< (USBHS_DEVIDR) DMA Channel 3 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_3_Pos)           /**< (USBHS_DEVIDR) DMA Channel 3 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_3                  USBHS_DEVIDR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_3_Msk instead */
+#define USBHS_DEVIDR_DMA_4_Pos              28                                             /**< (USBHS_DEVIDR) DMA Channel 4 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_4_Pos)           /**< (USBHS_DEVIDR) DMA Channel 4 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_4                  USBHS_DEVIDR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_4_Msk instead */
+#define USBHS_DEVIDR_DMA_5_Pos              29                                             /**< (USBHS_DEVIDR) DMA Channel 5 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_5_Pos)           /**< (USBHS_DEVIDR) DMA Channel 5 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_5                  USBHS_DEVIDR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_5_Msk instead */
+#define USBHS_DEVIDR_DMA_6_Pos              30                                             /**< (USBHS_DEVIDR) DMA Channel 6 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_6_Pos)           /**< (USBHS_DEVIDR) DMA Channel 6 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_6                  USBHS_DEVIDR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_6_Msk instead */
+#define USBHS_DEVIDR_DMA_7_Pos              31                                             /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Position */
+#define USBHS_DEVIDR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_7_Pos)           /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Mask */
+#define USBHS_DEVIDR_DMA_7                  USBHS_DEVIDR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_7_Msk instead */
+#define USBHS_DEVIDR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIDR) Register MASK  (Use USBHS_DEVIDR_Msk instead)  */
+#define USBHS_DEVIDR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIDR) Register Mask  */
+
+#define USBHS_DEVIDR_PEP__Pos               12                                             /**< (USBHS_DEVIDR Position) Endpoint x Interrupt Disable */
+#define USBHS_DEVIDR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIDR_PEP__Pos)          /**< (USBHS_DEVIDR Mask) PEP_ */
+#define USBHS_DEVIDR_PEP_(value)            (USBHS_DEVIDR_PEP__Msk & ((value) << USBHS_DEVIDR_PEP__Pos))  
+#define USBHS_DEVIDR_DMA__Pos               25                                             /**< (USBHS_DEVIDR Position) DMA Channel 7 Interrupt Disable */
+#define USBHS_DEVIDR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIDR_DMA__Pos)           /**< (USBHS_DEVIDR Mask) DMA_ */
+#define USBHS_DEVIDR_DMA_(value)            (USBHS_DEVIDR_DMA__Msk & ((value) << USBHS_DEVIDR_DMA__Pos))  
+
+/* -------- USBHS_DEVIER : (USBHS Offset: 0x18) (/W 32) Device Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUSPES:1;                  /**< bit:      0  Suspend Interrupt Enable                 */
+    uint32_t MSOFES:1;                  /**< bit:      1  Micro Start of Frame Interrupt Enable    */
+    uint32_t SOFES:1;                   /**< bit:      2  Start of Frame Interrupt Enable          */
+    uint32_t EORSTES:1;                 /**< bit:      3  End of Reset Interrupt Enable            */
+    uint32_t WAKEUPES:1;                /**< bit:      4  Wake-Up Interrupt Enable                 */
+    uint32_t EORSMES:1;                 /**< bit:      5  End of Resume Interrupt Enable           */
+    uint32_t UPRSMES:1;                 /**< bit:      6  Upstream Resume Interrupt Enable         */
+    uint32_t :5;                        /**< bit:  7..11  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:     12  Endpoint 0 Interrupt Enable              */
+    uint32_t PEP_1:1;                   /**< bit:     13  Endpoint 1 Interrupt Enable              */
+    uint32_t PEP_2:1;                   /**< bit:     14  Endpoint 2 Interrupt Enable              */
+    uint32_t PEP_3:1;                   /**< bit:     15  Endpoint 3 Interrupt Enable              */
+    uint32_t PEP_4:1;                   /**< bit:     16  Endpoint 4 Interrupt Enable              */
+    uint32_t PEP_5:1;                   /**< bit:     17  Endpoint 5 Interrupt Enable              */
+    uint32_t PEP_6:1;                   /**< bit:     18  Endpoint 6 Interrupt Enable              */
+    uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Enable              */
+    uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Enable              */
+    uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Enable              */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
+    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :12;                       /**< bit:  0..11  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Enable              */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVIER_OFFSET                 (0x18)                                        /**<  (USBHS_DEVIER) Device Global Interrupt Enable Register  Offset */
+
+#define USBHS_DEVIER_SUSPES_Pos             0                                              /**< (USBHS_DEVIER) Suspend Interrupt Enable Position */
+#define USBHS_DEVIER_SUSPES_Msk             (_U_(0x1) << USBHS_DEVIER_SUSPES_Pos)          /**< (USBHS_DEVIER) Suspend Interrupt Enable Mask */
+#define USBHS_DEVIER_SUSPES                 USBHS_DEVIER_SUSPES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_SUSPES_Msk instead */
+#define USBHS_DEVIER_MSOFES_Pos             1                                              /**< (USBHS_DEVIER) Micro Start of Frame Interrupt Enable Position */
+#define USBHS_DEVIER_MSOFES_Msk             (_U_(0x1) << USBHS_DEVIER_MSOFES_Pos)          /**< (USBHS_DEVIER) Micro Start of Frame Interrupt Enable Mask */
+#define USBHS_DEVIER_MSOFES                 USBHS_DEVIER_MSOFES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_MSOFES_Msk instead */
+#define USBHS_DEVIER_SOFES_Pos              2                                              /**< (USBHS_DEVIER) Start of Frame Interrupt Enable Position */
+#define USBHS_DEVIER_SOFES_Msk              (_U_(0x1) << USBHS_DEVIER_SOFES_Pos)           /**< (USBHS_DEVIER) Start of Frame Interrupt Enable Mask */
+#define USBHS_DEVIER_SOFES                  USBHS_DEVIER_SOFES_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_SOFES_Msk instead */
+#define USBHS_DEVIER_EORSTES_Pos            3                                              /**< (USBHS_DEVIER) End of Reset Interrupt Enable Position */
+#define USBHS_DEVIER_EORSTES_Msk            (_U_(0x1) << USBHS_DEVIER_EORSTES_Pos)         /**< (USBHS_DEVIER) End of Reset Interrupt Enable Mask */
+#define USBHS_DEVIER_EORSTES                USBHS_DEVIER_EORSTES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_EORSTES_Msk instead */
+#define USBHS_DEVIER_WAKEUPES_Pos           4                                              /**< (USBHS_DEVIER) Wake-Up Interrupt Enable Position */
+#define USBHS_DEVIER_WAKEUPES_Msk           (_U_(0x1) << USBHS_DEVIER_WAKEUPES_Pos)        /**< (USBHS_DEVIER) Wake-Up Interrupt Enable Mask */
+#define USBHS_DEVIER_WAKEUPES               USBHS_DEVIER_WAKEUPES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_WAKEUPES_Msk instead */
+#define USBHS_DEVIER_EORSMES_Pos            5                                              /**< (USBHS_DEVIER) End of Resume Interrupt Enable Position */
+#define USBHS_DEVIER_EORSMES_Msk            (_U_(0x1) << USBHS_DEVIER_EORSMES_Pos)         /**< (USBHS_DEVIER) End of Resume Interrupt Enable Mask */
+#define USBHS_DEVIER_EORSMES                USBHS_DEVIER_EORSMES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_EORSMES_Msk instead */
+#define USBHS_DEVIER_UPRSMES_Pos            6                                              /**< (USBHS_DEVIER) Upstream Resume Interrupt Enable Position */
+#define USBHS_DEVIER_UPRSMES_Msk            (_U_(0x1) << USBHS_DEVIER_UPRSMES_Pos)         /**< (USBHS_DEVIER) Upstream Resume Interrupt Enable Mask */
+#define USBHS_DEVIER_UPRSMES                USBHS_DEVIER_UPRSMES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_UPRSMES_Msk instead */
+#define USBHS_DEVIER_PEP_0_Pos              12                                             /**< (USBHS_DEVIER) Endpoint 0 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_0_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_0_Pos)           /**< (USBHS_DEVIER) Endpoint 0 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_0                  USBHS_DEVIER_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_0_Msk instead */
+#define USBHS_DEVIER_PEP_1_Pos              13                                             /**< (USBHS_DEVIER) Endpoint 1 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_1_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_1_Pos)           /**< (USBHS_DEVIER) Endpoint 1 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_1                  USBHS_DEVIER_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_1_Msk instead */
+#define USBHS_DEVIER_PEP_2_Pos              14                                             /**< (USBHS_DEVIER) Endpoint 2 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_2_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_2_Pos)           /**< (USBHS_DEVIER) Endpoint 2 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_2                  USBHS_DEVIER_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_2_Msk instead */
+#define USBHS_DEVIER_PEP_3_Pos              15                                             /**< (USBHS_DEVIER) Endpoint 3 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_3_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_3_Pos)           /**< (USBHS_DEVIER) Endpoint 3 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_3                  USBHS_DEVIER_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_3_Msk instead */
+#define USBHS_DEVIER_PEP_4_Pos              16                                             /**< (USBHS_DEVIER) Endpoint 4 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_4_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_4_Pos)           /**< (USBHS_DEVIER) Endpoint 4 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_4                  USBHS_DEVIER_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_4_Msk instead */
+#define USBHS_DEVIER_PEP_5_Pos              17                                             /**< (USBHS_DEVIER) Endpoint 5 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_5_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_5_Pos)           /**< (USBHS_DEVIER) Endpoint 5 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_5                  USBHS_DEVIER_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_5_Msk instead */
+#define USBHS_DEVIER_PEP_6_Pos              18                                             /**< (USBHS_DEVIER) Endpoint 6 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_6_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_6_Pos)           /**< (USBHS_DEVIER) Endpoint 6 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_6                  USBHS_DEVIER_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_6_Msk instead */
+#define USBHS_DEVIER_PEP_7_Pos              19                                             /**< (USBHS_DEVIER) Endpoint 7 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_7_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_7_Pos)           /**< (USBHS_DEVIER) Endpoint 7 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_7                  USBHS_DEVIER_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_7_Msk instead */
+#define USBHS_DEVIER_PEP_8_Pos              20                                             /**< (USBHS_DEVIER) Endpoint 8 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_8_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_8_Pos)           /**< (USBHS_DEVIER) Endpoint 8 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_8                  USBHS_DEVIER_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_8_Msk instead */
+#define USBHS_DEVIER_PEP_9_Pos              21                                             /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Position */
+#define USBHS_DEVIER_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_9_Pos)           /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Mask */
+#define USBHS_DEVIER_PEP_9                  USBHS_DEVIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_9_Msk instead */
+#define USBHS_DEVIER_DMA_1_Pos              25                                             /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_1_Pos)           /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_1                  USBHS_DEVIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_1_Msk instead */
+#define USBHS_DEVIER_DMA_2_Pos              26                                             /**< (USBHS_DEVIER) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_2_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_2_Pos)           /**< (USBHS_DEVIER) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_2                  USBHS_DEVIER_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_2_Msk instead */
+#define USBHS_DEVIER_DMA_3_Pos              27                                             /**< (USBHS_DEVIER) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_3_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_3_Pos)           /**< (USBHS_DEVIER) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_3                  USBHS_DEVIER_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_3_Msk instead */
+#define USBHS_DEVIER_DMA_4_Pos              28                                             /**< (USBHS_DEVIER) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_4_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_4_Pos)           /**< (USBHS_DEVIER) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_4                  USBHS_DEVIER_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_4_Msk instead */
+#define USBHS_DEVIER_DMA_5_Pos              29                                             /**< (USBHS_DEVIER) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_5_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_5_Pos)           /**< (USBHS_DEVIER) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_5                  USBHS_DEVIER_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_5_Msk instead */
+#define USBHS_DEVIER_DMA_6_Pos              30                                             /**< (USBHS_DEVIER) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_6_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_6_Pos)           /**< (USBHS_DEVIER) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_6                  USBHS_DEVIER_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_6_Msk instead */
+#define USBHS_DEVIER_DMA_7_Pos              31                                             /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_DEVIER_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_7_Pos)           /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_DEVIER_DMA_7                  USBHS_DEVIER_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_7_Msk instead */
+#define USBHS_DEVIER_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIER) Register MASK  (Use USBHS_DEVIER_Msk instead)  */
+#define USBHS_DEVIER_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIER) Register Mask  */
+
+#define USBHS_DEVIER_PEP__Pos               12                                             /**< (USBHS_DEVIER Position) Endpoint x Interrupt Enable */
+#define USBHS_DEVIER_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIER_PEP__Pos)          /**< (USBHS_DEVIER Mask) PEP_ */
+#define USBHS_DEVIER_PEP_(value)            (USBHS_DEVIER_PEP__Msk & ((value) << USBHS_DEVIER_PEP__Pos))  
+#define USBHS_DEVIER_DMA__Pos               25                                             /**< (USBHS_DEVIER Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_DEVIER_DMA__Msk               (_U_(0x7F) << USBHS_DEVIER_DMA__Pos)           /**< (USBHS_DEVIER Mask) DMA_ */
+#define USBHS_DEVIER_DMA_(value)            (USBHS_DEVIER_DMA__Msk & ((value) << USBHS_DEVIER_DMA__Pos))  
+
+/* -------- USBHS_DEVEPT : (USBHS Offset: 0x1c) (R/W 32) Device Endpoint Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EPEN0:1;                   /**< bit:      0  Endpoint 0 Enable                        */
+    uint32_t EPEN1:1;                   /**< bit:      1  Endpoint 1 Enable                        */
+    uint32_t EPEN2:1;                   /**< bit:      2  Endpoint 2 Enable                        */
+    uint32_t EPEN3:1;                   /**< bit:      3  Endpoint 3 Enable                        */
+    uint32_t EPEN4:1;                   /**< bit:      4  Endpoint 4 Enable                        */
+    uint32_t EPEN5:1;                   /**< bit:      5  Endpoint 5 Enable                        */
+    uint32_t EPEN6:1;                   /**< bit:      6  Endpoint 6 Enable                        */
+    uint32_t EPEN7:1;                   /**< bit:      7  Endpoint 7 Enable                        */
+    uint32_t EPEN8:1;                   /**< bit:      8  Endpoint 8 Enable                        */
+    uint32_t EPEN9:1;                   /**< bit:      9  Endpoint 9 Enable                        */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t EPRST0:1;                  /**< bit:     16  Endpoint 0 Reset                         */
+    uint32_t EPRST1:1;                  /**< bit:     17  Endpoint 1 Reset                         */
+    uint32_t EPRST2:1;                  /**< bit:     18  Endpoint 2 Reset                         */
+    uint32_t EPRST3:1;                  /**< bit:     19  Endpoint 3 Reset                         */
+    uint32_t EPRST4:1;                  /**< bit:     20  Endpoint 4 Reset                         */
+    uint32_t EPRST5:1;                  /**< bit:     21  Endpoint 5 Reset                         */
+    uint32_t EPRST6:1;                  /**< bit:     22  Endpoint 6 Reset                         */
+    uint32_t EPRST7:1;                  /**< bit:     23  Endpoint 7 Reset                         */
+    uint32_t EPRST8:1;                  /**< bit:     24  Endpoint 8 Reset                         */
+    uint32_t EPRST9:1;                  /**< bit:     25  Endpoint 9 Reset                         */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EPEN:10;                   /**< bit:   0..9  Endpoint x Enable                        */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
+    uint32_t EPRST:10;                  /**< bit: 16..25  Endpoint 9 Reset                         */
+    uint32_t :6;                        /**< bit: 26..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPT_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPT_OFFSET                 (0x1C)                                        /**<  (USBHS_DEVEPT) Device Endpoint Register  Offset */
+
+#define USBHS_DEVEPT_EPEN0_Pos              0                                              /**< (USBHS_DEVEPT) Endpoint 0 Enable Position */
+#define USBHS_DEVEPT_EPEN0_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN0_Pos)           /**< (USBHS_DEVEPT) Endpoint 0 Enable Mask */
+#define USBHS_DEVEPT_EPEN0                  USBHS_DEVEPT_EPEN0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN0_Msk instead */
+#define USBHS_DEVEPT_EPEN1_Pos              1                                              /**< (USBHS_DEVEPT) Endpoint 1 Enable Position */
+#define USBHS_DEVEPT_EPEN1_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN1_Pos)           /**< (USBHS_DEVEPT) Endpoint 1 Enable Mask */
+#define USBHS_DEVEPT_EPEN1                  USBHS_DEVEPT_EPEN1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN1_Msk instead */
+#define USBHS_DEVEPT_EPEN2_Pos              2                                              /**< (USBHS_DEVEPT) Endpoint 2 Enable Position */
+#define USBHS_DEVEPT_EPEN2_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN2_Pos)           /**< (USBHS_DEVEPT) Endpoint 2 Enable Mask */
+#define USBHS_DEVEPT_EPEN2                  USBHS_DEVEPT_EPEN2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN2_Msk instead */
+#define USBHS_DEVEPT_EPEN3_Pos              3                                              /**< (USBHS_DEVEPT) Endpoint 3 Enable Position */
+#define USBHS_DEVEPT_EPEN3_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN3_Pos)           /**< (USBHS_DEVEPT) Endpoint 3 Enable Mask */
+#define USBHS_DEVEPT_EPEN3                  USBHS_DEVEPT_EPEN3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN3_Msk instead */
+#define USBHS_DEVEPT_EPEN4_Pos              4                                              /**< (USBHS_DEVEPT) Endpoint 4 Enable Position */
+#define USBHS_DEVEPT_EPEN4_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN4_Pos)           /**< (USBHS_DEVEPT) Endpoint 4 Enable Mask */
+#define USBHS_DEVEPT_EPEN4                  USBHS_DEVEPT_EPEN4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN4_Msk instead */
+#define USBHS_DEVEPT_EPEN5_Pos              5                                              /**< (USBHS_DEVEPT) Endpoint 5 Enable Position */
+#define USBHS_DEVEPT_EPEN5_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN5_Pos)           /**< (USBHS_DEVEPT) Endpoint 5 Enable Mask */
+#define USBHS_DEVEPT_EPEN5                  USBHS_DEVEPT_EPEN5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN5_Msk instead */
+#define USBHS_DEVEPT_EPEN6_Pos              6                                              /**< (USBHS_DEVEPT) Endpoint 6 Enable Position */
+#define USBHS_DEVEPT_EPEN6_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN6_Pos)           /**< (USBHS_DEVEPT) Endpoint 6 Enable Mask */
+#define USBHS_DEVEPT_EPEN6                  USBHS_DEVEPT_EPEN6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN6_Msk instead */
+#define USBHS_DEVEPT_EPEN7_Pos              7                                              /**< (USBHS_DEVEPT) Endpoint 7 Enable Position */
+#define USBHS_DEVEPT_EPEN7_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN7_Pos)           /**< (USBHS_DEVEPT) Endpoint 7 Enable Mask */
+#define USBHS_DEVEPT_EPEN7                  USBHS_DEVEPT_EPEN7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN7_Msk instead */
+#define USBHS_DEVEPT_EPEN8_Pos              8                                              /**< (USBHS_DEVEPT) Endpoint 8 Enable Position */
+#define USBHS_DEVEPT_EPEN8_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN8_Pos)           /**< (USBHS_DEVEPT) Endpoint 8 Enable Mask */
+#define USBHS_DEVEPT_EPEN8                  USBHS_DEVEPT_EPEN8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN8_Msk instead */
+#define USBHS_DEVEPT_EPEN9_Pos              9                                              /**< (USBHS_DEVEPT) Endpoint 9 Enable Position */
+#define USBHS_DEVEPT_EPEN9_Msk              (_U_(0x1) << USBHS_DEVEPT_EPEN9_Pos)           /**< (USBHS_DEVEPT) Endpoint 9 Enable Mask */
+#define USBHS_DEVEPT_EPEN9                  USBHS_DEVEPT_EPEN9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPEN9_Msk instead */
+#define USBHS_DEVEPT_EPRST0_Pos             16                                             /**< (USBHS_DEVEPT) Endpoint 0 Reset Position */
+#define USBHS_DEVEPT_EPRST0_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST0_Pos)          /**< (USBHS_DEVEPT) Endpoint 0 Reset Mask */
+#define USBHS_DEVEPT_EPRST0                 USBHS_DEVEPT_EPRST0_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST0_Msk instead */
+#define USBHS_DEVEPT_EPRST1_Pos             17                                             /**< (USBHS_DEVEPT) Endpoint 1 Reset Position */
+#define USBHS_DEVEPT_EPRST1_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST1_Pos)          /**< (USBHS_DEVEPT) Endpoint 1 Reset Mask */
+#define USBHS_DEVEPT_EPRST1                 USBHS_DEVEPT_EPRST1_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST1_Msk instead */
+#define USBHS_DEVEPT_EPRST2_Pos             18                                             /**< (USBHS_DEVEPT) Endpoint 2 Reset Position */
+#define USBHS_DEVEPT_EPRST2_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST2_Pos)          /**< (USBHS_DEVEPT) Endpoint 2 Reset Mask */
+#define USBHS_DEVEPT_EPRST2                 USBHS_DEVEPT_EPRST2_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST2_Msk instead */
+#define USBHS_DEVEPT_EPRST3_Pos             19                                             /**< (USBHS_DEVEPT) Endpoint 3 Reset Position */
+#define USBHS_DEVEPT_EPRST3_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST3_Pos)          /**< (USBHS_DEVEPT) Endpoint 3 Reset Mask */
+#define USBHS_DEVEPT_EPRST3                 USBHS_DEVEPT_EPRST3_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST3_Msk instead */
+#define USBHS_DEVEPT_EPRST4_Pos             20                                             /**< (USBHS_DEVEPT) Endpoint 4 Reset Position */
+#define USBHS_DEVEPT_EPRST4_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST4_Pos)          /**< (USBHS_DEVEPT) Endpoint 4 Reset Mask */
+#define USBHS_DEVEPT_EPRST4                 USBHS_DEVEPT_EPRST4_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST4_Msk instead */
+#define USBHS_DEVEPT_EPRST5_Pos             21                                             /**< (USBHS_DEVEPT) Endpoint 5 Reset Position */
+#define USBHS_DEVEPT_EPRST5_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST5_Pos)          /**< (USBHS_DEVEPT) Endpoint 5 Reset Mask */
+#define USBHS_DEVEPT_EPRST5                 USBHS_DEVEPT_EPRST5_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST5_Msk instead */
+#define USBHS_DEVEPT_EPRST6_Pos             22                                             /**< (USBHS_DEVEPT) Endpoint 6 Reset Position */
+#define USBHS_DEVEPT_EPRST6_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST6_Pos)          /**< (USBHS_DEVEPT) Endpoint 6 Reset Mask */
+#define USBHS_DEVEPT_EPRST6                 USBHS_DEVEPT_EPRST6_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST6_Msk instead */
+#define USBHS_DEVEPT_EPRST7_Pos             23                                             /**< (USBHS_DEVEPT) Endpoint 7 Reset Position */
+#define USBHS_DEVEPT_EPRST7_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST7_Pos)          /**< (USBHS_DEVEPT) Endpoint 7 Reset Mask */
+#define USBHS_DEVEPT_EPRST7                 USBHS_DEVEPT_EPRST7_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST7_Msk instead */
+#define USBHS_DEVEPT_EPRST8_Pos             24                                             /**< (USBHS_DEVEPT) Endpoint 8 Reset Position */
+#define USBHS_DEVEPT_EPRST8_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST8_Pos)          /**< (USBHS_DEVEPT) Endpoint 8 Reset Mask */
+#define USBHS_DEVEPT_EPRST8                 USBHS_DEVEPT_EPRST8_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST8_Msk instead */
+#define USBHS_DEVEPT_EPRST9_Pos             25                                             /**< (USBHS_DEVEPT) Endpoint 9 Reset Position */
+#define USBHS_DEVEPT_EPRST9_Msk             (_U_(0x1) << USBHS_DEVEPT_EPRST9_Pos)          /**< (USBHS_DEVEPT) Endpoint 9 Reset Mask */
+#define USBHS_DEVEPT_EPRST9                 USBHS_DEVEPT_EPRST9_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPT_EPRST9_Msk instead */
+#define USBHS_DEVEPT_MASK                   _U_(0x3FF03FF)                                 /**< \deprecated (USBHS_DEVEPT) Register MASK  (Use USBHS_DEVEPT_Msk instead)  */
+#define USBHS_DEVEPT_Msk                    _U_(0x3FF03FF)                                 /**< (USBHS_DEVEPT) Register Mask  */
+
+#define USBHS_DEVEPT_EPEN_Pos               0                                              /**< (USBHS_DEVEPT Position) Endpoint x Enable */
+#define USBHS_DEVEPT_EPEN_Msk               (_U_(0x3FF) << USBHS_DEVEPT_EPEN_Pos)          /**< (USBHS_DEVEPT Mask) EPEN */
+#define USBHS_DEVEPT_EPEN(value)            (USBHS_DEVEPT_EPEN_Msk & ((value) << USBHS_DEVEPT_EPEN_Pos))  
+#define USBHS_DEVEPT_EPRST_Pos              16                                             /**< (USBHS_DEVEPT Position) Endpoint 9 Reset */
+#define USBHS_DEVEPT_EPRST_Msk              (_U_(0x3FF) << USBHS_DEVEPT_EPRST_Pos)         /**< (USBHS_DEVEPT Mask) EPRST */
+#define USBHS_DEVEPT_EPRST(value)           (USBHS_DEVEPT_EPRST_Msk & ((value) << USBHS_DEVEPT_EPRST_Pos))  
+
+/* -------- USBHS_DEVFNUM : (USBHS Offset: 0x20) (R/ 32) Device Frame Number Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
+    uint32_t FNUM:11;                   /**< bit:  3..13  Frame Number                             */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t FNCERR:1;                  /**< bit:     15  Frame Number CRC Error                   */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVFNUM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVFNUM_OFFSET                (0x20)                                        /**<  (USBHS_DEVFNUM) Device Frame Number Register  Offset */
+
+#define USBHS_DEVFNUM_MFNUM_Pos             0                                              /**< (USBHS_DEVFNUM) Micro Frame Number Position */
+#define USBHS_DEVFNUM_MFNUM_Msk             (_U_(0x7) << USBHS_DEVFNUM_MFNUM_Pos)          /**< (USBHS_DEVFNUM) Micro Frame Number Mask */
+#define USBHS_DEVFNUM_MFNUM(value)          (USBHS_DEVFNUM_MFNUM_Msk & ((value) << USBHS_DEVFNUM_MFNUM_Pos))
+#define USBHS_DEVFNUM_FNUM_Pos              3                                              /**< (USBHS_DEVFNUM) Frame Number Position */
+#define USBHS_DEVFNUM_FNUM_Msk              (_U_(0x7FF) << USBHS_DEVFNUM_FNUM_Pos)         /**< (USBHS_DEVFNUM) Frame Number Mask */
+#define USBHS_DEVFNUM_FNUM(value)           (USBHS_DEVFNUM_FNUM_Msk & ((value) << USBHS_DEVFNUM_FNUM_Pos))
+#define USBHS_DEVFNUM_FNCERR_Pos            15                                             /**< (USBHS_DEVFNUM) Frame Number CRC Error Position */
+#define USBHS_DEVFNUM_FNCERR_Msk            (_U_(0x1) << USBHS_DEVFNUM_FNCERR_Pos)         /**< (USBHS_DEVFNUM) Frame Number CRC Error Mask */
+#define USBHS_DEVFNUM_FNCERR                USBHS_DEVFNUM_FNCERR_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVFNUM_FNCERR_Msk instead */
+#define USBHS_DEVFNUM_MASK                  _U_(0xBFFF)                                    /**< \deprecated (USBHS_DEVFNUM) Register MASK  (Use USBHS_DEVFNUM_Msk instead)  */
+#define USBHS_DEVFNUM_Msk                   _U_(0xBFFF)                                    /**< (USBHS_DEVFNUM) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTCFG : (USBHS Offset: 0x100) (R/W 32) Device Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ALLOC:1;                   /**< bit:      1  Endpoint Memory Allocate                 */
+    uint32_t EPBK:2;                    /**< bit:   2..3  Endpoint Banks                           */
+    uint32_t EPSIZE:3;                  /**< bit:   4..6  Endpoint Size                            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t EPDIR:1;                   /**< bit:      8  Endpoint Direction                       */
+    uint32_t AUTOSW:1;                  /**< bit:      9  Automatic Switch                         */
+    uint32_t :1;                        /**< bit:     10  Reserved */
+    uint32_t EPTYPE:2;                  /**< bit: 11..12  Endpoint Type                            */
+    uint32_t NBTRANS:2;                 /**< bit: 13..14  Number of transactions per microframe for isochronous endpoint */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTCFG_OFFSET              (0x100)                                       /**<  (USBHS_DEVEPTCFG) Device Endpoint Configuration Register  Offset */
+
+#define USBHS_DEVEPTCFG_ALLOC_Pos           1                                              /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Position */
+#define USBHS_DEVEPTCFG_ALLOC_Msk           (_U_(0x1) << USBHS_DEVEPTCFG_ALLOC_Pos)        /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Mask */
+#define USBHS_DEVEPTCFG_ALLOC               USBHS_DEVEPTCFG_ALLOC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_ALLOC_Msk instead */
+#define USBHS_DEVEPTCFG_EPBK_Pos            2                                              /**< (USBHS_DEVEPTCFG) Endpoint Banks Position */
+#define USBHS_DEVEPTCFG_EPBK_Msk            (_U_(0x3) << USBHS_DEVEPTCFG_EPBK_Pos)         /**< (USBHS_DEVEPTCFG) Endpoint Banks Mask */
+#define USBHS_DEVEPTCFG_EPBK(value)         (USBHS_DEVEPTCFG_EPBK_Msk & ((value) << USBHS_DEVEPTCFG_EPBK_Pos))
+#define   USBHS_DEVEPTCFG_EPBK_1_BANK_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Single-bank endpoint  */
+#define   USBHS_DEVEPTCFG_EPBK_2_BANK_Val   _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Double-bank endpoint  */
+#define   USBHS_DEVEPTCFG_EPBK_3_BANK_Val   _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Triple-bank endpoint  */
+#define USBHS_DEVEPTCFG_EPBK_1_BANK         (USBHS_DEVEPTCFG_EPBK_1_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Single-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPBK_2_BANK         (USBHS_DEVEPTCFG_EPBK_2_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Double-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPBK_3_BANK         (USBHS_DEVEPTCFG_EPBK_3_BANK_Val << USBHS_DEVEPTCFG_EPBK_Pos)  /**< (USBHS_DEVEPTCFG) Triple-bank endpoint Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_Pos          4                                              /**< (USBHS_DEVEPTCFG) Endpoint Size Position */
+#define USBHS_DEVEPTCFG_EPSIZE_Msk          (_U_(0x7) << USBHS_DEVEPTCFG_EPSIZE_Pos)       /**< (USBHS_DEVEPTCFG) Endpoint Size Mask */
+#define USBHS_DEVEPTCFG_EPSIZE(value)       (USBHS_DEVEPTCFG_EPSIZE_Msk & ((value) << USBHS_DEVEPTCFG_EPSIZE_Pos))
+#define   USBHS_DEVEPTCFG_EPSIZE_8_BYTE_Val _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) 8 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_16_BYTE_Val _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) 16 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_32_BYTE_Val _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) 32 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_64_BYTE_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) 64 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_128_BYTE_Val _U_(0x4)                                       /**< (USBHS_DEVEPTCFG) 128 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_256_BYTE_Val _U_(0x5)                                       /**< (USBHS_DEVEPTCFG) 256 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_512_BYTE_Val _U_(0x6)                                       /**< (USBHS_DEVEPTCFG) 512 bytes  */
+#define   USBHS_DEVEPTCFG_EPSIZE_1024_BYTE_Val _U_(0x7)                                       /**< (USBHS_DEVEPTCFG) 1024 bytes  */
+#define USBHS_DEVEPTCFG_EPSIZE_8_BYTE       (USBHS_DEVEPTCFG_EPSIZE_8_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 8 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_16_BYTE      (USBHS_DEVEPTCFG_EPSIZE_16_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 16 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_32_BYTE      (USBHS_DEVEPTCFG_EPSIZE_32_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 32 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_64_BYTE      (USBHS_DEVEPTCFG_EPSIZE_64_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 64 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_128_BYTE     (USBHS_DEVEPTCFG_EPSIZE_128_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 128 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_256_BYTE     (USBHS_DEVEPTCFG_EPSIZE_256_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 256 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_512_BYTE     (USBHS_DEVEPTCFG_EPSIZE_512_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 512 bytes Position  */
+#define USBHS_DEVEPTCFG_EPSIZE_1024_BYTE    (USBHS_DEVEPTCFG_EPSIZE_1024_BYTE_Val << USBHS_DEVEPTCFG_EPSIZE_Pos)  /**< (USBHS_DEVEPTCFG) 1024 bytes Position  */
+#define USBHS_DEVEPTCFG_EPDIR_Pos           8                                              /**< (USBHS_DEVEPTCFG) Endpoint Direction Position */
+#define USBHS_DEVEPTCFG_EPDIR_Msk           (_U_(0x1) << USBHS_DEVEPTCFG_EPDIR_Pos)        /**< (USBHS_DEVEPTCFG) Endpoint Direction Mask */
+#define USBHS_DEVEPTCFG_EPDIR               USBHS_DEVEPTCFG_EPDIR_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_EPDIR_Msk instead */
+#define   USBHS_DEVEPTCFG_EPDIR_OUT_Val     _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) The endpoint direction is OUT.  */
+#define   USBHS_DEVEPTCFG_EPDIR_IN_Val      _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) The endpoint direction is IN (nor for control endpoints).  */
+#define USBHS_DEVEPTCFG_EPDIR_OUT           (USBHS_DEVEPTCFG_EPDIR_OUT_Val << USBHS_DEVEPTCFG_EPDIR_Pos)  /**< (USBHS_DEVEPTCFG) The endpoint direction is OUT. Position  */
+#define USBHS_DEVEPTCFG_EPDIR_IN            (USBHS_DEVEPTCFG_EPDIR_IN_Val << USBHS_DEVEPTCFG_EPDIR_Pos)  /**< (USBHS_DEVEPTCFG) The endpoint direction is IN (nor for control endpoints). Position  */
+#define USBHS_DEVEPTCFG_AUTOSW_Pos          9                                              /**< (USBHS_DEVEPTCFG) Automatic Switch Position */
+#define USBHS_DEVEPTCFG_AUTOSW_Msk          (_U_(0x1) << USBHS_DEVEPTCFG_AUTOSW_Pos)       /**< (USBHS_DEVEPTCFG) Automatic Switch Mask */
+#define USBHS_DEVEPTCFG_AUTOSW              USBHS_DEVEPTCFG_AUTOSW_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTCFG_AUTOSW_Msk instead */
+#define USBHS_DEVEPTCFG_EPTYPE_Pos          11                                             /**< (USBHS_DEVEPTCFG) Endpoint Type Position */
+#define USBHS_DEVEPTCFG_EPTYPE_Msk          (_U_(0x3) << USBHS_DEVEPTCFG_EPTYPE_Pos)       /**< (USBHS_DEVEPTCFG) Endpoint Type Mask */
+#define USBHS_DEVEPTCFG_EPTYPE(value)       (USBHS_DEVEPTCFG_EPTYPE_Msk & ((value) << USBHS_DEVEPTCFG_EPTYPE_Pos))
+#define   USBHS_DEVEPTCFG_EPTYPE_CTRL_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Control  */
+#define   USBHS_DEVEPTCFG_EPTYPE_ISO_Val    _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Isochronous  */
+#define   USBHS_DEVEPTCFG_EPTYPE_BLK_Val    _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Bulk  */
+#define   USBHS_DEVEPTCFG_EPTYPE_INTRPT_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) Interrupt  */
+#define USBHS_DEVEPTCFG_EPTYPE_CTRL         (USBHS_DEVEPTCFG_EPTYPE_CTRL_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Control Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_ISO          (USBHS_DEVEPTCFG_EPTYPE_ISO_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Isochronous Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_BLK          (USBHS_DEVEPTCFG_EPTYPE_BLK_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Bulk Position  */
+#define USBHS_DEVEPTCFG_EPTYPE_INTRPT       (USBHS_DEVEPTCFG_EPTYPE_INTRPT_Val << USBHS_DEVEPTCFG_EPTYPE_Pos)  /**< (USBHS_DEVEPTCFG) Interrupt Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_Pos         13                                             /**< (USBHS_DEVEPTCFG) Number of transactions per microframe for isochronous endpoint Position */
+#define USBHS_DEVEPTCFG_NBTRANS_Msk         (_U_(0x3) << USBHS_DEVEPTCFG_NBTRANS_Pos)      /**< (USBHS_DEVEPTCFG) Number of transactions per microframe for isochronous endpoint Mask */
+#define USBHS_DEVEPTCFG_NBTRANS(value)      (USBHS_DEVEPTCFG_NBTRANS_Msk & ((value) << USBHS_DEVEPTCFG_NBTRANS_Pos))
+#define   USBHS_DEVEPTCFG_NBTRANS_0_TRANS_Val _U_(0x0)                                       /**< (USBHS_DEVEPTCFG) Reserved to endpoint that does not have the high-bandwidth isochronous capability.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_1_TRANS_Val _U_(0x1)                                       /**< (USBHS_DEVEPTCFG) Default value: one transaction per microframe.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_2_TRANS_Val _U_(0x2)                                       /**< (USBHS_DEVEPTCFG) Two transactions per microframe. This endpoint should be configured as double-bank.  */
+#define   USBHS_DEVEPTCFG_NBTRANS_3_TRANS_Val _U_(0x3)                                       /**< (USBHS_DEVEPTCFG) Three transactions per microframe. This endpoint should be configured as triple-bank.  */
+#define USBHS_DEVEPTCFG_NBTRANS_0_TRANS     (USBHS_DEVEPTCFG_NBTRANS_0_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Reserved to endpoint that does not have the high-bandwidth isochronous capability. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_1_TRANS     (USBHS_DEVEPTCFG_NBTRANS_1_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Default value: one transaction per microframe. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_2_TRANS     (USBHS_DEVEPTCFG_NBTRANS_2_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Two transactions per microframe. This endpoint should be configured as double-bank. Position  */
+#define USBHS_DEVEPTCFG_NBTRANS_3_TRANS     (USBHS_DEVEPTCFG_NBTRANS_3_TRANS_Val << USBHS_DEVEPTCFG_NBTRANS_Pos)  /**< (USBHS_DEVEPTCFG) Three transactions per microframe. This endpoint should be configured as triple-bank. Position  */
+#define USBHS_DEVEPTCFG_MASK                _U_(0x7B7E)                                    /**< \deprecated (USBHS_DEVEPTCFG) Register MASK  (Use USBHS_DEVEPTCFG_Msk instead)  */
+#define USBHS_DEVEPTCFG_Msk                 _U_(0x7B7E)                                    /**< (USBHS_DEVEPTCFG) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTISR : (USBHS Offset: 0x130) (R/ 32) Device Endpoint Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINI:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
+    uint32_t RXOUTI:1;                  /**< bit:      1  Received OUT Data Interrupt              */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKET:1;             /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t NBUSYBK:2;                 /**< bit: 12..13  Number of Busy Banks                     */
+    uint32_t CURRBK:2;                  /**< bit: 14..15  Current Bank                             */
+    uint32_t RWALL:1;                   /**< bit:     16  Read/Write Allowed                       */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t CFGOK:1;                   /**< bit:     18  Configuration OK Status                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t BYCT:11;                   /**< bit: 20..30  Byte Count                               */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t HBISOINERRI:1;             /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt */
+    uint32_t HBISOFLUSHI:1;             /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRI:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :3;                        /**< bit:   7..9  Reserved */
+    uint32_t ERRORTRANS:1;              /**< bit:     10  High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTISR_OFFSET              (0x130)                                       /**<  (USBHS_DEVEPTISR) Device Endpoint Interrupt Status Register  Offset */
+
+#define USBHS_DEVEPTISR_TXINI_Pos           0                                              /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Position */
+#define USBHS_DEVEPTISR_TXINI_Msk           (_U_(0x1) << USBHS_DEVEPTISR_TXINI_Pos)        /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Mask */
+#define USBHS_DEVEPTISR_TXINI               USBHS_DEVEPTISR_TXINI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_TXINI_Msk instead */
+#define USBHS_DEVEPTISR_RXOUTI_Pos          1                                              /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Position */
+#define USBHS_DEVEPTISR_RXOUTI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_RXOUTI_Pos)       /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Mask */
+#define USBHS_DEVEPTISR_RXOUTI              USBHS_DEVEPTISR_RXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXOUTI_Msk instead */
+#define USBHS_DEVEPTISR_OVERFI_Pos          5                                              /**< (USBHS_DEVEPTISR) Overflow Interrupt Position */
+#define USBHS_DEVEPTISR_OVERFI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_OVERFI_Pos)       /**< (USBHS_DEVEPTISR) Overflow Interrupt Mask */
+#define USBHS_DEVEPTISR_OVERFI              USBHS_DEVEPTISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_OVERFI_Msk instead */
+#define USBHS_DEVEPTISR_SHORTPACKET_Pos     7                                              /**< (USBHS_DEVEPTISR) Short Packet Interrupt Position */
+#define USBHS_DEVEPTISR_SHORTPACKET_Msk     (_U_(0x1) << USBHS_DEVEPTISR_SHORTPACKET_Pos)  /**< (USBHS_DEVEPTISR) Short Packet Interrupt Mask */
+#define USBHS_DEVEPTISR_SHORTPACKET         USBHS_DEVEPTISR_SHORTPACKET_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_SHORTPACKET_Msk instead */
+#define USBHS_DEVEPTISR_DTSEQ_Pos           8                                              /**< (USBHS_DEVEPTISR) Data Toggle Sequence Position */
+#define USBHS_DEVEPTISR_DTSEQ_Msk           (_U_(0x3) << USBHS_DEVEPTISR_DTSEQ_Pos)        /**< (USBHS_DEVEPTISR) Data Toggle Sequence Mask */
+#define USBHS_DEVEPTISR_DTSEQ(value)        (USBHS_DEVEPTISR_DTSEQ_Msk & ((value) << USBHS_DEVEPTISR_DTSEQ_Pos))
+#define   USBHS_DEVEPTISR_DTSEQ_DATA0_Val   _U_(0x0)                                       /**< (USBHS_DEVEPTISR) Data0 toggle sequence  */
+#define   USBHS_DEVEPTISR_DTSEQ_DATA1_Val   _U_(0x1)                                       /**< (USBHS_DEVEPTISR) Data1 toggle sequence  */
+#define   USBHS_DEVEPTISR_DTSEQ_DATA2_Val   _U_(0x2)                                       /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint  */
+#define   USBHS_DEVEPTISR_DTSEQ_MDATA_Val   _U_(0x3)                                       /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA0         (USBHS_DEVEPTISR_DTSEQ_DATA0_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Data0 toggle sequence Position  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA1         (USBHS_DEVEPTISR_DTSEQ_DATA1_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Data1 toggle sequence Position  */
+#define USBHS_DEVEPTISR_DTSEQ_DATA2         (USBHS_DEVEPTISR_DTSEQ_DATA2_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint Position  */
+#define USBHS_DEVEPTISR_DTSEQ_MDATA         (USBHS_DEVEPTISR_DTSEQ_MDATA_Val << USBHS_DEVEPTISR_DTSEQ_Pos)  /**< (USBHS_DEVEPTISR) Reserved for high-bandwidth isochronous endpoint Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_Pos         12                                             /**< (USBHS_DEVEPTISR) Number of Busy Banks Position */
+#define USBHS_DEVEPTISR_NBUSYBK_Msk         (_U_(0x3) << USBHS_DEVEPTISR_NBUSYBK_Pos)      /**< (USBHS_DEVEPTISR) Number of Busy Banks Mask */
+#define USBHS_DEVEPTISR_NBUSYBK(value)      (USBHS_DEVEPTISR_NBUSYBK_Msk & ((value) << USBHS_DEVEPTISR_NBUSYBK_Pos))
+#define   USBHS_DEVEPTISR_NBUSYBK_0_BUSY_Val _U_(0x0)                                       /**< (USBHS_DEVEPTISR) 0 busy bank (all banks free)  */
+#define   USBHS_DEVEPTISR_NBUSYBK_1_BUSY_Val _U_(0x1)                                       /**< (USBHS_DEVEPTISR) 1 busy bank  */
+#define   USBHS_DEVEPTISR_NBUSYBK_2_BUSY_Val _U_(0x2)                                       /**< (USBHS_DEVEPTISR) 2 busy banks  */
+#define   USBHS_DEVEPTISR_NBUSYBK_3_BUSY_Val _U_(0x3)                                       /**< (USBHS_DEVEPTISR) 3 busy banks  */
+#define USBHS_DEVEPTISR_NBUSYBK_0_BUSY      (USBHS_DEVEPTISR_NBUSYBK_0_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 0 busy bank (all banks free) Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_1_BUSY      (USBHS_DEVEPTISR_NBUSYBK_1_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 1 busy bank Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_2_BUSY      (USBHS_DEVEPTISR_NBUSYBK_2_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 2 busy banks Position  */
+#define USBHS_DEVEPTISR_NBUSYBK_3_BUSY      (USBHS_DEVEPTISR_NBUSYBK_3_BUSY_Val << USBHS_DEVEPTISR_NBUSYBK_Pos)  /**< (USBHS_DEVEPTISR) 3 busy banks Position  */
+#define USBHS_DEVEPTISR_CURRBK_Pos          14                                             /**< (USBHS_DEVEPTISR) Current Bank Position */
+#define USBHS_DEVEPTISR_CURRBK_Msk          (_U_(0x3) << USBHS_DEVEPTISR_CURRBK_Pos)       /**< (USBHS_DEVEPTISR) Current Bank Mask */
+#define USBHS_DEVEPTISR_CURRBK(value)       (USBHS_DEVEPTISR_CURRBK_Msk & ((value) << USBHS_DEVEPTISR_CURRBK_Pos))
+#define   USBHS_DEVEPTISR_CURRBK_BANK0_Val  _U_(0x0)                                       /**< (USBHS_DEVEPTISR) Current bank is bank0  */
+#define   USBHS_DEVEPTISR_CURRBK_BANK1_Val  _U_(0x1)                                       /**< (USBHS_DEVEPTISR) Current bank is bank1  */
+#define   USBHS_DEVEPTISR_CURRBK_BANK2_Val  _U_(0x2)                                       /**< (USBHS_DEVEPTISR) Current bank is bank2  */
+#define USBHS_DEVEPTISR_CURRBK_BANK0        (USBHS_DEVEPTISR_CURRBK_BANK0_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank0 Position  */
+#define USBHS_DEVEPTISR_CURRBK_BANK1        (USBHS_DEVEPTISR_CURRBK_BANK1_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank1 Position  */
+#define USBHS_DEVEPTISR_CURRBK_BANK2        (USBHS_DEVEPTISR_CURRBK_BANK2_Val << USBHS_DEVEPTISR_CURRBK_Pos)  /**< (USBHS_DEVEPTISR) Current bank is bank2 Position  */
+#define USBHS_DEVEPTISR_RWALL_Pos           16                                             /**< (USBHS_DEVEPTISR) Read/Write Allowed Position */
+#define USBHS_DEVEPTISR_RWALL_Msk           (_U_(0x1) << USBHS_DEVEPTISR_RWALL_Pos)        /**< (USBHS_DEVEPTISR) Read/Write Allowed Mask */
+#define USBHS_DEVEPTISR_RWALL               USBHS_DEVEPTISR_RWALL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RWALL_Msk instead */
+#define USBHS_DEVEPTISR_CFGOK_Pos           18                                             /**< (USBHS_DEVEPTISR) Configuration OK Status Position */
+#define USBHS_DEVEPTISR_CFGOK_Msk           (_U_(0x1) << USBHS_DEVEPTISR_CFGOK_Pos)        /**< (USBHS_DEVEPTISR) Configuration OK Status Mask */
+#define USBHS_DEVEPTISR_CFGOK               USBHS_DEVEPTISR_CFGOK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CFGOK_Msk instead */
+#define USBHS_DEVEPTISR_BYCT_Pos            20                                             /**< (USBHS_DEVEPTISR) Byte Count Position */
+#define USBHS_DEVEPTISR_BYCT_Msk            (_U_(0x7FF) << USBHS_DEVEPTISR_BYCT_Pos)       /**< (USBHS_DEVEPTISR) Byte Count Mask */
+#define USBHS_DEVEPTISR_BYCT(value)         (USBHS_DEVEPTISR_BYCT_Msk & ((value) << USBHS_DEVEPTISR_BYCT_Pos))
+#define USBHS_DEVEPTISR_MASK                _U_(0x7FF5F3A3)                                /**< \deprecated (USBHS_DEVEPTISR) Register MASK  (Use USBHS_DEVEPTISR_Msk instead)  */
+#define USBHS_DEVEPTISR_Msk                 _U_(0x7FF5F3A3)                                /**< (USBHS_DEVEPTISR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI_Pos     2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_CTRL_RXSTPI_Pos)  /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI         USBHS_DEVEPTISR_CTRL_RXSTPI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI_Pos    3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk    (_U_(0x1) << USBHS_DEVEPTISR_CTRL_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI        USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_NAKINI_Pos     4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_NAKINI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_CTRL_NAKINI_Pos)  /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_NAKINI         USBHS_DEVEPTISR_CTRL_NAKINI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI_Pos   6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_CTRL_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI       USBHS_DEVEPTISR_CTRL_STALLEDI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR_Pos    17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk    (_U_(0x1) << USBHS_DEVEPTISR_CTRL_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR        USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_MASK           _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_CTRL) Register MASK  (Use USBHS_DEVEPTISR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTISR_CTRL_Msk            _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTISR_ISO_UNDERFI_Pos     2                                              /**< (USBHS_DEVEPTISR) Underflow Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_UNDERFI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_ISO_UNDERFI_Pos)  /**< (USBHS_DEVEPTISR) Underflow Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_UNDERFI         USBHS_DEVEPTISR_ISO_UNDERFI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_UNDERFI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI_Pos 3                                              /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Underflow Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk (_U_(0x1) << USBHS_DEVEPTISR_ISO_HBISOINERRI_Pos)  /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Underflow Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI     USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Pos 4                                              /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Flush Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk (_U_(0x1) << USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Pos)  /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Flush Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI     USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_CRCERRI_Pos     6                                              /**< (USBHS_DEVEPTISR) CRC Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_CRCERRI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_ISO_CRCERRI_Pos)  /**< (USBHS_DEVEPTISR) CRC Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_CRCERRI         USBHS_DEVEPTISR_ISO_CRCERRI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_CRCERRI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS_Pos  10                                             /**< (USBHS_DEVEPTISR) High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk  (_U_(0x1) << USBHS_DEVEPTISR_ISO_ERRORTRANS_Pos)  /**< (USBHS_DEVEPTISR) High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS      USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk instead */
+#define USBHS_DEVEPTISR_ISO_MASK            _U_(0x45C)                                     /**< \deprecated (USBHS_DEVEPTISR_ISO) Register MASK  (Use USBHS_DEVEPTISR_ISO_Msk instead)  */
+#define USBHS_DEVEPTISR_ISO_Msk             _U_(0x45C)                                     /**< (USBHS_DEVEPTISR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTISR_BLK_RXSTPI_Pos      2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_RXSTPI_Msk      (_U_(0x1) << USBHS_DEVEPTISR_BLK_RXSTPI_Pos)   /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_RXSTPI          USBHS_DEVEPTISR_BLK_RXSTPI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI_Pos     3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_BLK_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI         USBHS_DEVEPTISR_BLK_NAKOUTI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_NAKINI_Pos      4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_NAKINI_Msk      (_U_(0x1) << USBHS_DEVEPTISR_BLK_NAKINI_Pos)   /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_NAKINI          USBHS_DEVEPTISR_BLK_NAKINI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_STALLEDI_Pos    6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_STALLEDI_Msk    (_U_(0x1) << USBHS_DEVEPTISR_BLK_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_STALLEDI        USBHS_DEVEPTISR_BLK_STALLEDI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR_Pos     17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR_Msk     (_U_(0x1) << USBHS_DEVEPTISR_BLK_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR         USBHS_DEVEPTISR_BLK_CTRLDIR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_BLK_MASK            _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_BLK) Register MASK  (Use USBHS_DEVEPTISR_BLK_Msk instead)  */
+#define USBHS_DEVEPTISR_BLK_Msk             _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI_Pos   2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_RXSTPI_Pos)  /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI       USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI_Pos  3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk  (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI      USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI_Pos   4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_NAKINI_Pos)  /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI       USBHS_DEVEPTISR_INTRPT_NAKINI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI_Pos 6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI     USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR_Pos  17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk  (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR      USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_MASK         _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_INTRPT) Register MASK  (Use USBHS_DEVEPTISR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTISR_INTRPT_Msk          _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTICR : (USBHS Offset: 0x160) (/W 32) Device Endpoint Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINIC:1;                  /**< bit:      0  Transmitted IN Data Interrupt Clear      */
+    uint32_t RXOUTIC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETC:1;            /**< bit:      7  Short Packet Interrupt Clear             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t HBISOINERRIC:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Clear */
+    uint32_t HBISOFLUSHIC:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Clear */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRIC:1;                /**< bit:      6  CRC Error Interrupt Clear                */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTICR_OFFSET              (0x160)                                       /**<  (USBHS_DEVEPTICR) Device Endpoint Interrupt Clear Register  Offset */
+
+#define USBHS_DEVEPTICR_TXINIC_Pos          0                                              /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Position */
+#define USBHS_DEVEPTICR_TXINIC_Msk          (_U_(0x1) << USBHS_DEVEPTICR_TXINIC_Pos)       /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_TXINIC              USBHS_DEVEPTICR_TXINIC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_TXINIC_Msk instead */
+#define USBHS_DEVEPTICR_RXOUTIC_Pos         1                                              /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Position */
+#define USBHS_DEVEPTICR_RXOUTIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_RXOUTIC_Pos)      /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_RXOUTIC             USBHS_DEVEPTICR_RXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_OVERFIC_Pos         5                                              /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Position */
+#define USBHS_DEVEPTICR_OVERFIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_OVERFIC_Pos)      /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_OVERFIC             USBHS_DEVEPTICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_OVERFIC_Msk instead */
+#define USBHS_DEVEPTICR_SHORTPACKETC_Pos    7                                              /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Position */
+#define USBHS_DEVEPTICR_SHORTPACKETC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_SHORTPACKETC_Pos)  /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_SHORTPACKETC        USBHS_DEVEPTICR_SHORTPACKETC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_SHORTPACKETC_Msk instead */
+#define USBHS_DEVEPTICR_MASK                _U_(0xA3)                                      /**< \deprecated (USBHS_DEVEPTICR) Register MASK  (Use USBHS_DEVEPTICR_Msk instead)  */
+#define USBHS_DEVEPTICR_Msk                 _U_(0xA3)                                      /**< (USBHS_DEVEPTICR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC_Pos    2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_CTRL_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC        USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC_Pos   3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk   (_U_(0x1) << USBHS_DEVEPTICR_CTRL_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC       USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC_Pos    4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_CTRL_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC        USBHS_DEVEPTICR_CTRL_NAKINIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC_Pos  6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_CTRL_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC      USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_MASK           _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_CTRL) Register MASK  (Use USBHS_DEVEPTICR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTICR_CTRL_Msk            _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC_Pos    2                                              /**< (USBHS_DEVEPTICR) Underflow Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_ISO_UNDERFIC_Pos)  /**< (USBHS_DEVEPTICR) Underflow Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC        USBHS_DEVEPTICR_ISO_UNDERFIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_UNDERFIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC_Pos 3                                              /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_ISO_HBISOINERRIC_Pos)  /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC    USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Pos 4                                              /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Flush Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Pos)  /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Flush Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC    USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC_Pos    6                                              /**< (USBHS_DEVEPTICR) CRC Error Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_ISO_CRCERRIC_Pos)  /**< (USBHS_DEVEPTICR) CRC Error Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC        USBHS_DEVEPTICR_ISO_CRCERRIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_CRCERRIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_ISO) Register MASK  (Use USBHS_DEVEPTICR_ISO_Msk instead)  */
+#define USBHS_DEVEPTICR_ISO_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC_Pos     2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC_Msk     (_U_(0x1) << USBHS_DEVEPTICR_BLK_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC         USBHS_DEVEPTICR_BLK_RXSTPIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC_Pos    3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_BLK_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC        USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_NAKINIC_Pos     4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_NAKINIC_Msk     (_U_(0x1) << USBHS_DEVEPTICR_BLK_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_NAKINIC         USBHS_DEVEPTICR_BLK_NAKINIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC_Pos   6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC_Msk   (_U_(0x1) << USBHS_DEVEPTICR_BLK_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC       USBHS_DEVEPTICR_BLK_STALLEDIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_BLK) Register MASK  (Use USBHS_DEVEPTICR_BLK_Msk instead)  */
+#define USBHS_DEVEPTICR_BLK_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC_Pos  2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC      USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Pos 3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC     USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC_Pos  4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC      USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC_Pos 6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC    USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_MASK         _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_INTRPT) Register MASK  (Use USBHS_DEVEPTICR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTICR_INTRPT_Msk          _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIFR : (USBHS Offset: 0x190) (/W 32) Device Endpoint Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINIS:1;                  /**< bit:      0  Transmitted IN Data Interrupt Set        */
+    uint32_t RXOUTIS:1;                 /**< bit:      1  Received OUT Data Interrupt Set          */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETS:1;            /**< bit:      7  Short Packet Interrupt Set               */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Interrupt Set       */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t HBISOINERRIS:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Set */
+    uint32_t HBISOFLUSHIS:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Set */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRIS:1;                /**< bit:      6  CRC Error Interrupt Set                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIFR_OFFSET              (0x190)                                       /**<  (USBHS_DEVEPTIFR) Device Endpoint Interrupt Set Register  Offset */
+
+#define USBHS_DEVEPTIFR_TXINIS_Pos          0                                              /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Position */
+#define USBHS_DEVEPTIFR_TXINIS_Msk          (_U_(0x1) << USBHS_DEVEPTIFR_TXINIS_Pos)       /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_TXINIS              USBHS_DEVEPTIFR_TXINIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_TXINIS_Msk instead */
+#define USBHS_DEVEPTIFR_RXOUTIS_Pos         1                                              /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Position */
+#define USBHS_DEVEPTIFR_RXOUTIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_RXOUTIS_Pos)      /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_RXOUTIS             USBHS_DEVEPTIFR_RXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_OVERFIS_Pos         5                                              /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Position */
+#define USBHS_DEVEPTIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_OVERFIS_Pos)      /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_OVERFIS             USBHS_DEVEPTIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_OVERFIS_Msk instead */
+#define USBHS_DEVEPTIFR_SHORTPACKETS_Pos    7                                              /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Position */
+#define USBHS_DEVEPTIFR_SHORTPACKETS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_SHORTPACKETS_Pos)  /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_SHORTPACKETS        USBHS_DEVEPTIFR_SHORTPACKETS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_SHORTPACKETS_Msk instead */
+#define USBHS_DEVEPTIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_DEVEPTIFR_NBUSYBKS_Pos)     /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NBUSYBKS            USBHS_DEVEPTIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NBUSYBKS_Msk instead */
+#define USBHS_DEVEPTIFR_MASK                _U_(0x10A3)                                    /**< \deprecated (USBHS_DEVEPTIFR) Register MASK  (Use USBHS_DEVEPTIFR_Msk instead)  */
+#define USBHS_DEVEPTIFR_Msk                 _U_(0x10A3)                                    /**< (USBHS_DEVEPTIFR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS_Pos    2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS        USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Pos   3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk   (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS       USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS_Pos    4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS        USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS_Pos  6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS      USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_MASK           _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_CTRL) Register MASK  (Use USBHS_DEVEPTIFR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIFR_CTRL_Msk            _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS_Pos    2                                              /**< (USBHS_DEVEPTIFR) Underflow Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_ISO_UNDERFIS_Pos)  /**< (USBHS_DEVEPTIFR) Underflow Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS        USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Pos 3                                              /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Underflow Error Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Pos)  /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Underflow Error Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS    USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Pos 4                                              /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Flush Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Pos)  /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Flush Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS    USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS_Pos    6                                              /**< (USBHS_DEVEPTIFR) CRC Error Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_ISO_CRCERRIS_Pos)  /**< (USBHS_DEVEPTIFR) CRC Error Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS        USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_ISO) Register MASK  (Use USBHS_DEVEPTIFR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIFR_ISO_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS_Pos     2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk     (_U_(0x1) << USBHS_DEVEPTIFR_BLK_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS         USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS_Pos    3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_BLK_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS        USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS_Pos     4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS_Msk     (_U_(0x1) << USBHS_DEVEPTIFR_BLK_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS         USBHS_DEVEPTIFR_BLK_NAKINIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS_Pos   6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk   (_U_(0x1) << USBHS_DEVEPTIFR_BLK_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS       USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_BLK) Register MASK  (Use USBHS_DEVEPTIFR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIFR_BLK_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Pos  2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS      USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Pos 3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS     USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS_Pos  4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS      USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Pos 6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS    USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_MASK         _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_INTRPT) Register MASK  (Use USBHS_DEVEPTIFR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIFR_INTRPT_Msk          _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIMR : (USBHS Offset: 0x1c0) (R/ 32) Device Endpoint Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINE:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
+    uint32_t RXOUTE:1;                  /**< bit:      1  Received OUT Data Interrupt              */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFE:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETE:1;            /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt           */
+    uint32_t KILLBK:1;                  /**< bit:     13  Kill IN Bank                             */
+    uint32_t FIFOCON:1;                 /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMA:1;               /**< bit:     16  Endpoint Interrupts Disable HDMA Request */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFE:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t HBISOINERRE:1;             /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt */
+    uint32_t HBISOFLUSHE:1;             /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRE:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDATAE:1;                  /**< bit:      8  MData Interrupt                          */
+    uint32_t DATAXE:1;                  /**< bit:      9  DataX Interrupt                          */
+    uint32_t ERRORTRANSE:1;             /**< bit:     10  Transaction Error Interrupt              */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIMR_OFFSET              (0x1C0)                                       /**<  (USBHS_DEVEPTIMR) Device Endpoint Interrupt Mask Register  Offset */
+
+#define USBHS_DEVEPTIMR_TXINE_Pos           0                                              /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Position */
+#define USBHS_DEVEPTIMR_TXINE_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_TXINE_Pos)        /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Mask */
+#define USBHS_DEVEPTIMR_TXINE               USBHS_DEVEPTIMR_TXINE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_TXINE_Msk instead */
+#define USBHS_DEVEPTIMR_RXOUTE_Pos          1                                              /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Position */
+#define USBHS_DEVEPTIMR_RXOUTE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_RXOUTE_Pos)       /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Mask */
+#define USBHS_DEVEPTIMR_RXOUTE              USBHS_DEVEPTIMR_RXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_OVERFE_Pos          5                                              /**< (USBHS_DEVEPTIMR) Overflow Interrupt Position */
+#define USBHS_DEVEPTIMR_OVERFE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_OVERFE_Pos)       /**< (USBHS_DEVEPTIMR) Overflow Interrupt Mask */
+#define USBHS_DEVEPTIMR_OVERFE              USBHS_DEVEPTIMR_OVERFE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_OVERFE_Msk instead */
+#define USBHS_DEVEPTIMR_SHORTPACKETE_Pos    7                                              /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Position */
+#define USBHS_DEVEPTIMR_SHORTPACKETE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_SHORTPACKETE_Pos)  /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Mask */
+#define USBHS_DEVEPTIMR_SHORTPACKETE        USBHS_DEVEPTIMR_SHORTPACKETE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_SHORTPACKETE_Msk instead */
+#define USBHS_DEVEPTIMR_NBUSYBKE_Pos        12                                             /**< (USBHS_DEVEPTIMR) Number of Busy Banks Interrupt Position */
+#define USBHS_DEVEPTIMR_NBUSYBKE_Msk        (_U_(0x1) << USBHS_DEVEPTIMR_NBUSYBKE_Pos)     /**< (USBHS_DEVEPTIMR) Number of Busy Banks Interrupt Mask */
+#define USBHS_DEVEPTIMR_NBUSYBKE            USBHS_DEVEPTIMR_NBUSYBKE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NBUSYBKE_Msk instead */
+#define USBHS_DEVEPTIMR_KILLBK_Pos          13                                             /**< (USBHS_DEVEPTIMR) Kill IN Bank Position */
+#define USBHS_DEVEPTIMR_KILLBK_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_KILLBK_Pos)       /**< (USBHS_DEVEPTIMR) Kill IN Bank Mask */
+#define USBHS_DEVEPTIMR_KILLBK              USBHS_DEVEPTIMR_KILLBK_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_KILLBK_Msk instead */
+#define USBHS_DEVEPTIMR_FIFOCON_Pos         14                                             /**< (USBHS_DEVEPTIMR) FIFO Control Position */
+#define USBHS_DEVEPTIMR_FIFOCON_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_FIFOCON_Pos)      /**< (USBHS_DEVEPTIMR) FIFO Control Mask */
+#define USBHS_DEVEPTIMR_FIFOCON             USBHS_DEVEPTIMR_FIFOCON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_FIFOCON_Msk instead */
+#define USBHS_DEVEPTIMR_EPDISHDMA_Pos       16                                             /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Position */
+#define USBHS_DEVEPTIMR_EPDISHDMA_Msk       (_U_(0x1) << USBHS_DEVEPTIMR_EPDISHDMA_Pos)    /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Mask */
+#define USBHS_DEVEPTIMR_EPDISHDMA           USBHS_DEVEPTIMR_EPDISHDMA_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_EPDISHDMA_Msk instead */
+#define USBHS_DEVEPTIMR_RSTDT_Pos           18                                             /**< (USBHS_DEVEPTIMR) Reset Data Toggle Position */
+#define USBHS_DEVEPTIMR_RSTDT_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_RSTDT_Pos)        /**< (USBHS_DEVEPTIMR) Reset Data Toggle Mask */
+#define USBHS_DEVEPTIMR_RSTDT               USBHS_DEVEPTIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RSTDT_Msk instead */
+#define USBHS_DEVEPTIMR_MASK                _U_(0x570A3)                                   /**< \deprecated (USBHS_DEVEPTIMR) Register MASK  (Use USBHS_DEVEPTIMR_Msk instead)  */
+#define USBHS_DEVEPTIMR_Msk                 _U_(0x570A3)                                   /**< (USBHS_DEVEPTIMR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE_Pos     2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_RXSTPE_Pos)  /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE         USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE_Pos    3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE        USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE_Pos     4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NAKINE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE         USBHS_DEVEPTIMR_CTRL_NAKINE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE_Pos   6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE       USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS_Pos    17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS        USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ_Pos    19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ        USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_CTRL) Register MASK  (Use USBHS_DEVEPTIMR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIMR_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE_Pos     2                                              /**< (USBHS_DEVEPTIMR) Underflow Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_ISO_UNDERFE_Pos)  /**< (USBHS_DEVEPTIMR) Underflow Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE         USBHS_DEVEPTIMR_ISO_UNDERFE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_UNDERFE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE_Pos 3                                              /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Underflow Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_HBISOINERRE_Pos)  /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Underflow Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE     USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Pos 4                                              /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Flush Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Pos)  /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Flush Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE     USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE_Pos     6                                              /**< (USBHS_DEVEPTIMR) CRC Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_ISO_CRCERRE_Pos)  /**< (USBHS_DEVEPTIMR) CRC Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE         USBHS_DEVEPTIMR_ISO_CRCERRE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_CRCERRE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_MDATAE_Pos      8                                              /**< (USBHS_DEVEPTIMR) MData Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_MDATAE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_ISO_MDATAE_Pos)   /**< (USBHS_DEVEPTIMR) MData Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_MDATAE          USBHS_DEVEPTIMR_ISO_MDATAE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_MDATAE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_DATAXE_Pos      9                                              /**< (USBHS_DEVEPTIMR) DataX Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_DATAXE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_ISO_DATAXE_Pos)   /**< (USBHS_DEVEPTIMR) DataX Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_DATAXE          USBHS_DEVEPTIMR_ISO_DATAXE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_DATAXE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Pos 10                                             /**< (USBHS_DEVEPTIMR) Transaction Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Pos)  /**< (USBHS_DEVEPTIMR) Transaction Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE     USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_MASK            _U_(0x75C)                                     /**< \deprecated (USBHS_DEVEPTIMR_ISO) Register MASK  (Use USBHS_DEVEPTIMR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIMR_ISO_Msk             _U_(0x75C)                                     /**< (USBHS_DEVEPTIMR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE_Pos      2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_BLK_RXSTPE_Pos)   /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE          USBHS_DEVEPTIMR_BLK_RXSTPE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE_Pos     3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE         USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NAKINE_Pos      4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_NAKINE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NAKINE_Pos)   /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_NAKINE          USBHS_DEVEPTIMR_BLK_NAKINE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE_Pos    6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_BLK_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE        USBHS_DEVEPTIMR_BLK_STALLEDE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS_Pos     17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS         USBHS_DEVEPTIMR_BLK_NYETDIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ_Pos     19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ         USBHS_DEVEPTIMR_BLK_STALLRQ_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_BLK) Register MASK  (Use USBHS_DEVEPTIMR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIMR_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE_Pos   2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_RXSTPE_Pos)  /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE       USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Pos  3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE      USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE_Pos   4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NAKINE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE       USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE_Pos 6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE     USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS_Pos  17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS      USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ_Pos  19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ      USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_INTRPT) Register MASK  (Use USBHS_DEVEPTIMR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIMR_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIER : (USBHS Offset: 0x1f0) (/W 32) Device Endpoint Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINES:1;                  /**< bit:      0  Transmitted IN Data Interrupt Enable     */
+    uint32_t RXOUTES:1;                 /**< bit:      1  Received OUT Data Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFES:1;                 /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETES:1;           /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Interrupt Enable    */
+    uint32_t KILLBKS:1;                 /**< bit:     13  Kill IN Bank                             */
+    uint32_t FIFOCONS:1;                /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMAS:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Enable */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFES:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t HBISOINERRES:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Enable */
+    uint32_t HBISOFLUSHES:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Enable */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRES:1;                /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDATAES:1;                 /**< bit:      8  MData Interrupt Enable                   */
+    uint32_t DATAXES:1;                 /**< bit:      9  DataX Interrupt Enable                   */
+    uint32_t ERRORTRANSES:1;            /**< bit:     10  Transaction Error Interrupt Enable       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIER_OFFSET              (0x1F0)                                       /**<  (USBHS_DEVEPTIER) Device Endpoint Interrupt Enable Register  Offset */
+
+#define USBHS_DEVEPTIER_TXINES_Pos          0                                              /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Position */
+#define USBHS_DEVEPTIER_TXINES_Msk          (_U_(0x1) << USBHS_DEVEPTIER_TXINES_Pos)       /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_TXINES              USBHS_DEVEPTIER_TXINES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_TXINES_Msk instead */
+#define USBHS_DEVEPTIER_RXOUTES_Pos         1                                              /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Position */
+#define USBHS_DEVEPTIER_RXOUTES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_RXOUTES_Pos)      /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_RXOUTES             USBHS_DEVEPTIER_RXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXOUTES_Msk instead */
+#define USBHS_DEVEPTIER_OVERFES_Pos         5                                              /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Position */
+#define USBHS_DEVEPTIER_OVERFES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_OVERFES_Pos)      /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_OVERFES             USBHS_DEVEPTIER_OVERFES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_OVERFES_Msk instead */
+#define USBHS_DEVEPTIER_SHORTPACKETES_Pos   7                                              /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Position */
+#define USBHS_DEVEPTIER_SHORTPACKETES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_SHORTPACKETES_Pos)  /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_SHORTPACKETES       USBHS_DEVEPTIER_SHORTPACKETES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_SHORTPACKETES_Msk instead */
+#define USBHS_DEVEPTIER_NBUSYBKES_Pos       12                                             /**< (USBHS_DEVEPTIER) Number of Busy Banks Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NBUSYBKES_Msk       (_U_(0x1) << USBHS_DEVEPTIER_NBUSYBKES_Pos)    /**< (USBHS_DEVEPTIER) Number of Busy Banks Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NBUSYBKES           USBHS_DEVEPTIER_NBUSYBKES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NBUSYBKES_Msk instead */
+#define USBHS_DEVEPTIER_KILLBKS_Pos         13                                             /**< (USBHS_DEVEPTIER) Kill IN Bank Position */
+#define USBHS_DEVEPTIER_KILLBKS_Msk         (_U_(0x1) << USBHS_DEVEPTIER_KILLBKS_Pos)      /**< (USBHS_DEVEPTIER) Kill IN Bank Mask */
+#define USBHS_DEVEPTIER_KILLBKS             USBHS_DEVEPTIER_KILLBKS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_KILLBKS_Msk instead */
+#define USBHS_DEVEPTIER_FIFOCONS_Pos        14                                             /**< (USBHS_DEVEPTIER) FIFO Control Position */
+#define USBHS_DEVEPTIER_FIFOCONS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_FIFOCONS_Pos)     /**< (USBHS_DEVEPTIER) FIFO Control Mask */
+#define USBHS_DEVEPTIER_FIFOCONS            USBHS_DEVEPTIER_FIFOCONS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_FIFOCONS_Msk instead */
+#define USBHS_DEVEPTIER_EPDISHDMAS_Pos      16                                             /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Position */
+#define USBHS_DEVEPTIER_EPDISHDMAS_Msk      (_U_(0x1) << USBHS_DEVEPTIER_EPDISHDMAS_Pos)   /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_DEVEPTIER_EPDISHDMAS          USBHS_DEVEPTIER_EPDISHDMAS_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_EPDISHDMAS_Msk instead */
+#define USBHS_DEVEPTIER_RSTDTS_Pos          18                                             /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Position */
+#define USBHS_DEVEPTIER_RSTDTS_Msk          (_U_(0x1) << USBHS_DEVEPTIER_RSTDTS_Pos)       /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Mask */
+#define USBHS_DEVEPTIER_RSTDTS              USBHS_DEVEPTIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RSTDTS_Msk instead */
+#define USBHS_DEVEPTIER_MASK                _U_(0x570A3)                                   /**< \deprecated (USBHS_DEVEPTIER) Register MASK  (Use USBHS_DEVEPTIER_Msk instead)  */
+#define USBHS_DEVEPTIER_Msk                 _U_(0x570A3)                                   /**< (USBHS_DEVEPTIER) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES_Pos    2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_CTRL_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES        USBHS_DEVEPTIER_CTRL_RXSTPES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES_Pos   3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES       USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NAKINES_Pos    4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NAKINES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NAKINES        USBHS_DEVEPTIER_CTRL_NAKINES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES_Pos  6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_CTRL_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES      USBHS_DEVEPTIER_CTRL_STALLEDES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS_Pos   17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS       USBHS_DEVEPTIER_CTRL_NYETDISS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS_Pos   19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS       USBHS_DEVEPTIER_CTRL_STALLRQS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_CTRL) Register MASK  (Use USBHS_DEVEPTIER_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIER_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIER_ISO_UNDERFES_Pos    2                                              /**< (USBHS_DEVEPTIER) Underflow Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_UNDERFES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_ISO_UNDERFES_Pos)  /**< (USBHS_DEVEPTIER) Underflow Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_UNDERFES        USBHS_DEVEPTIER_ISO_UNDERFES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_UNDERFES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES_Pos 3                                              /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Underflow Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_HBISOINERRES_Pos)  /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Underflow Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES    USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Pos 4                                              /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Flush Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Pos)  /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Flush Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES    USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_CRCERRES_Pos    6                                              /**< (USBHS_DEVEPTIER) CRC Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_CRCERRES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_ISO_CRCERRES_Pos)  /**< (USBHS_DEVEPTIER) CRC Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_CRCERRES        USBHS_DEVEPTIER_ISO_CRCERRES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_CRCERRES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_MDATAES_Pos     8                                              /**< (USBHS_DEVEPTIER) MData Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_MDATAES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_ISO_MDATAES_Pos)  /**< (USBHS_DEVEPTIER) MData Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_MDATAES         USBHS_DEVEPTIER_ISO_MDATAES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_MDATAES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_DATAXES_Pos     9                                              /**< (USBHS_DEVEPTIER) DataX Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_DATAXES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_ISO_DATAXES_Pos)  /**< (USBHS_DEVEPTIER) DataX Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_DATAXES         USBHS_DEVEPTIER_ISO_DATAXES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_DATAXES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES_Pos 10                                             /**< (USBHS_DEVEPTIER) Transaction Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_ERRORTRANSES_Pos)  /**< (USBHS_DEVEPTIER) Transaction Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES    USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_MASK            _U_(0x75C)                                     /**< \deprecated (USBHS_DEVEPTIER_ISO) Register MASK  (Use USBHS_DEVEPTIER_ISO_Msk instead)  */
+#define USBHS_DEVEPTIER_ISO_Msk             _U_(0x75C)                                     /**< (USBHS_DEVEPTIER_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIER_BLK_RXSTPES_Pos     2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_RXSTPES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_BLK_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_RXSTPES         USBHS_DEVEPTIER_BLK_RXSTPES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES_Pos    3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES        USBHS_DEVEPTIER_BLK_NAKOUTES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NAKINES_Pos     4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_NAKINES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_BLK_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NAKINES         USBHS_DEVEPTIER_BLK_NAKINES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_STALLEDES_Pos   6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_STALLEDES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_BLK_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_STALLEDES       USBHS_DEVEPTIER_BLK_STALLEDES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NYETDISS_Pos    17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_BLK_NYETDISS_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NYETDISS        USBHS_DEVEPTIER_BLK_NYETDISS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_BLK_STALLRQS_Pos    19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_BLK_STALLRQS_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_BLK_STALLRQS        USBHS_DEVEPTIER_BLK_STALLRQS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_BLK) Register MASK  (Use USBHS_DEVEPTIER_BLK_Msk instead)  */
+#define USBHS_DEVEPTIER_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES_Pos  2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES      USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES_Pos 3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES     USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES_Pos  4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES      USBHS_DEVEPTIER_INTRPT_NAKINES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES_Pos 6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES    USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS_Pos 17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS     USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS_Pos 19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS     USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_INTRPT) Register MASK  (Use USBHS_DEVEPTIER_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIER_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_DEVEPTIDR : (USBHS Offset: 0x220) (/W 32) Device Endpoint Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXINEC:1;                  /**< bit:      0  Transmitted IN Interrupt Clear           */
+    uint32_t RXOUTEC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
+    uint32_t OVERFEC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETEC:1;           /**< bit:      7  Shortpacket Interrupt Clear              */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Interrupt Clear     */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCONC:1;                /**< bit:     14  FIFO Control Clear                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t EPDISHDMAC:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Clear */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFEC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t HBISOINERREC:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Clear */
+    uint32_t HBISOFLUSHEC:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Clear */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t MDATAEC:1;                 /**< bit:      8  MData Interrupt Clear                    */
+    uint32_t DATAXEC:1;                 /**< bit:      9  DataX Interrupt Clear                    */
+    uint32_t ERRORTRANSEC:1;            /**< bit:     10  Transaction Error Interrupt Clear        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_DEVEPTIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_DEVEPTIDR_OFFSET              (0x220)                                       /**<  (USBHS_DEVEPTIDR) Device Endpoint Interrupt Disable Register  Offset */
+
+#define USBHS_DEVEPTIDR_TXINEC_Pos          0                                              /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_TXINEC_Msk          (_U_(0x1) << USBHS_DEVEPTIDR_TXINEC_Pos)       /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_TXINEC              USBHS_DEVEPTIDR_TXINEC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_TXINEC_Msk instead */
+#define USBHS_DEVEPTIDR_RXOUTEC_Pos         1                                              /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_RXOUTEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_RXOUTEC_Pos)      /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_RXOUTEC             USBHS_DEVEPTIDR_RXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_OVERFEC_Pos         5                                              /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_OVERFEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_OVERFEC_Pos)      /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_OVERFEC             USBHS_DEVEPTIDR_OVERFEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_OVERFEC_Msk instead */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC_Pos   7                                              /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_SHORTPACKETEC_Pos)  /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_SHORTPACKETEC       USBHS_DEVEPTIDR_SHORTPACKETEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_SHORTPACKETEC_Msk instead */
+#define USBHS_DEVEPTIDR_NBUSYBKEC_Pos       12                                             /**< (USBHS_DEVEPTIDR) Number of Busy Banks Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NBUSYBKEC_Msk       (_U_(0x1) << USBHS_DEVEPTIDR_NBUSYBKEC_Pos)    /**< (USBHS_DEVEPTIDR) Number of Busy Banks Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NBUSYBKEC           USBHS_DEVEPTIDR_NBUSYBKEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NBUSYBKEC_Msk instead */
+#define USBHS_DEVEPTIDR_FIFOCONC_Pos        14                                             /**< (USBHS_DEVEPTIDR) FIFO Control Clear Position */
+#define USBHS_DEVEPTIDR_FIFOCONC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_FIFOCONC_Pos)     /**< (USBHS_DEVEPTIDR) FIFO Control Clear Mask */
+#define USBHS_DEVEPTIDR_FIFOCONC            USBHS_DEVEPTIDR_FIFOCONC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_FIFOCONC_Msk instead */
+#define USBHS_DEVEPTIDR_EPDISHDMAC_Pos      16                                             /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Position */
+#define USBHS_DEVEPTIDR_EPDISHDMAC_Msk      (_U_(0x1) << USBHS_DEVEPTIDR_EPDISHDMAC_Pos)   /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Mask */
+#define USBHS_DEVEPTIDR_EPDISHDMAC          USBHS_DEVEPTIDR_EPDISHDMAC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_EPDISHDMAC_Msk instead */
+#define USBHS_DEVEPTIDR_MASK                _U_(0x150A3)                                   /**< \deprecated (USBHS_DEVEPTIDR) Register MASK  (Use USBHS_DEVEPTIDR_Msk instead)  */
+#define USBHS_DEVEPTIDR_Msk                 _U_(0x150A3)                                   /**< (USBHS_DEVEPTIDR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC_Pos    2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC        USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Pos   3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC       USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC_Pos    4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC        USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC_Pos  6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC      USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC_Pos   17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC       USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC_Pos   19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC       USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_CTRL) Register MASK  (Use USBHS_DEVEPTIDR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIDR_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC_Pos    2                                              /**< (USBHS_DEVEPTIDR) Underflow Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_ISO_UNDERFEC_Pos)  /**< (USBHS_DEVEPTIDR) Underflow Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC        USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC_Pos 3                                              /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_HBISOINERREC_Pos)  /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC    USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Pos 4                                              /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Flush Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Pos)  /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Flush Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC    USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC_Pos     8                                              /**< (USBHS_DEVEPTIDR) MData Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_ISO_MDATAEC_Pos)  /**< (USBHS_DEVEPTIDR) MData Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC         USBHS_DEVEPTIDR_ISO_MDATAEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_MDATAEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC_Pos     9                                              /**< (USBHS_DEVEPTIDR) DataX Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_ISO_DATAXEC_Pos)  /**< (USBHS_DEVEPTIDR) DataX Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC         USBHS_DEVEPTIDR_ISO_DATAXEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_DATAXEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Pos 10                                             /**< (USBHS_DEVEPTIDR) Transaction Error Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Pos)  /**< (USBHS_DEVEPTIDR) Transaction Error Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC    USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_MASK            _U_(0x71C)                                     /**< \deprecated (USBHS_DEVEPTIDR_ISO) Register MASK  (Use USBHS_DEVEPTIDR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIDR_ISO_Msk             _U_(0x71C)                                     /**< (USBHS_DEVEPTIDR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC_Pos     2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_BLK_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC         USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC_Pos    3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC        USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC_Pos     4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC         USBHS_DEVEPTIDR_BLK_NAKINEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC_Pos   6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_BLK_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC       USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC_Pos    17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC        USBHS_DEVEPTIDR_BLK_NYETDISC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC_Pos    19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC        USBHS_DEVEPTIDR_BLK_STALLRQC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_BLK) Register MASK  (Use USBHS_DEVEPTIDR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIDR_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Pos  2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC      USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Pos 3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC     USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC_Pos  4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC      USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Pos 6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC    USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC_Pos 17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC     USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC_Pos 19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC     USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_INTRPT) Register MASK  (Use USBHS_DEVEPTIDR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIDR_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTCTRL : (USBHS Offset: 0x400) (R/W 32) Host General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t SOFE:1;                    /**< bit:      8  Start of Frame Generation Enable         */
+    uint32_t RESET:1;                   /**< bit:      9  Send USB Reset                           */
+    uint32_t RESUME:1;                  /**< bit:     10  Send USB Resume                          */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t SPDCONF:2;                 /**< bit: 12..13  Mode Configuration                       */
+    uint32_t :18;                       /**< bit: 14..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTCTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTCTRL_OFFSET                (0x400)                                       /**<  (USBHS_HSTCTRL) Host General Control Register  Offset */
+
+#define USBHS_HSTCTRL_SOFE_Pos              8                                              /**< (USBHS_HSTCTRL) Start of Frame Generation Enable Position */
+#define USBHS_HSTCTRL_SOFE_Msk              (_U_(0x1) << USBHS_HSTCTRL_SOFE_Pos)           /**< (USBHS_HSTCTRL) Start of Frame Generation Enable Mask */
+#define USBHS_HSTCTRL_SOFE                  USBHS_HSTCTRL_SOFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_SOFE_Msk instead */
+#define USBHS_HSTCTRL_RESET_Pos             9                                              /**< (USBHS_HSTCTRL) Send USB Reset Position */
+#define USBHS_HSTCTRL_RESET_Msk             (_U_(0x1) << USBHS_HSTCTRL_RESET_Pos)          /**< (USBHS_HSTCTRL) Send USB Reset Mask */
+#define USBHS_HSTCTRL_RESET                 USBHS_HSTCTRL_RESET_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_RESET_Msk instead */
+#define USBHS_HSTCTRL_RESUME_Pos            10                                             /**< (USBHS_HSTCTRL) Send USB Resume Position */
+#define USBHS_HSTCTRL_RESUME_Msk            (_U_(0x1) << USBHS_HSTCTRL_RESUME_Pos)         /**< (USBHS_HSTCTRL) Send USB Resume Mask */
+#define USBHS_HSTCTRL_RESUME                USBHS_HSTCTRL_RESUME_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTCTRL_RESUME_Msk instead */
+#define USBHS_HSTCTRL_SPDCONF_Pos           12                                             /**< (USBHS_HSTCTRL) Mode Configuration Position */
+#define USBHS_HSTCTRL_SPDCONF_Msk           (_U_(0x3) << USBHS_HSTCTRL_SPDCONF_Pos)        /**< (USBHS_HSTCTRL) Mode Configuration Mask */
+#define USBHS_HSTCTRL_SPDCONF(value)        (USBHS_HSTCTRL_SPDCONF_Msk & ((value) << USBHS_HSTCTRL_SPDCONF_Pos))
+#define   USBHS_HSTCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable.  */
+#define   USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_HSTCTRL) Forced high speed.  */
+#define   USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability.  */
+#define USBHS_HSTCTRL_SPDCONF_NORMAL        (USBHS_HSTCTRL_SPDCONF_NORMAL_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable. Position  */
+#define USBHS_HSTCTRL_SPDCONF_LOW_POWER     (USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_HIGH_SPEED    (USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) Forced high speed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_FORCED_FS     (USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability. Position  */
+#define USBHS_HSTCTRL_MASK                  _U_(0x3700)                                    /**< \deprecated (USBHS_HSTCTRL) Register MASK  (Use USBHS_HSTCTRL_Msk instead)  */
+#define USBHS_HSTCTRL_Msk                   _U_(0x3700)                                    /**< (USBHS_HSTCTRL) Register Mask  */
+
+
+/* -------- USBHS_HSTISR : (USBHS Offset: 0x404) (R/ 32) Host Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNI:1;                  /**< bit:      0  Device Connection Interrupt              */
+    uint32_t DDISCI:1;                  /**< bit:      1  Device Disconnection Interrupt           */
+    uint32_t RSTI:1;                    /**< bit:      2  USB Reset Sent Interrupt                 */
+    uint32_t RSMEDI:1;                  /**< bit:      3  Downstream Resume Sent Interrupt         */
+    uint32_t RXRSMI:1;                  /**< bit:      4  Upstream Resume Received Interrupt       */
+    uint32_t HSOFI:1;                   /**< bit:      5  Host Start of Frame Interrupt            */
+    uint32_t HWUPI:1;                   /**< bit:      6  Host Wake-Up Interrupt                   */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt                         */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt                         */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt                         */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt                         */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt                         */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt                         */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt                         */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt                         */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt                         */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt                         */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt                  */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt                  */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt                  */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt                  */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt                  */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt                  */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt                  */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt                         */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt                  */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTISR_OFFSET                 (0x404)                                       /**<  (USBHS_HSTISR) Host Global Interrupt Status Register  Offset */
+
+#define USBHS_HSTISR_DCONNI_Pos             0                                              /**< (USBHS_HSTISR) Device Connection Interrupt Position */
+#define USBHS_HSTISR_DCONNI_Msk             (_U_(0x1) << USBHS_HSTISR_DCONNI_Pos)          /**< (USBHS_HSTISR) Device Connection Interrupt Mask */
+#define USBHS_HSTISR_DCONNI                 USBHS_HSTISR_DCONNI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DCONNI_Msk instead */
+#define USBHS_HSTISR_DDISCI_Pos             1                                              /**< (USBHS_HSTISR) Device Disconnection Interrupt Position */
+#define USBHS_HSTISR_DDISCI_Msk             (_U_(0x1) << USBHS_HSTISR_DDISCI_Pos)          /**< (USBHS_HSTISR) Device Disconnection Interrupt Mask */
+#define USBHS_HSTISR_DDISCI                 USBHS_HSTISR_DDISCI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DDISCI_Msk instead */
+#define USBHS_HSTISR_RSTI_Pos               2                                              /**< (USBHS_HSTISR) USB Reset Sent Interrupt Position */
+#define USBHS_HSTISR_RSTI_Msk               (_U_(0x1) << USBHS_HSTISR_RSTI_Pos)            /**< (USBHS_HSTISR) USB Reset Sent Interrupt Mask */
+#define USBHS_HSTISR_RSTI                   USBHS_HSTISR_RSTI_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RSTI_Msk instead */
+#define USBHS_HSTISR_RSMEDI_Pos             3                                              /**< (USBHS_HSTISR) Downstream Resume Sent Interrupt Position */
+#define USBHS_HSTISR_RSMEDI_Msk             (_U_(0x1) << USBHS_HSTISR_RSMEDI_Pos)          /**< (USBHS_HSTISR) Downstream Resume Sent Interrupt Mask */
+#define USBHS_HSTISR_RSMEDI                 USBHS_HSTISR_RSMEDI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RSMEDI_Msk instead */
+#define USBHS_HSTISR_RXRSMI_Pos             4                                              /**< (USBHS_HSTISR) Upstream Resume Received Interrupt Position */
+#define USBHS_HSTISR_RXRSMI_Msk             (_U_(0x1) << USBHS_HSTISR_RXRSMI_Pos)          /**< (USBHS_HSTISR) Upstream Resume Received Interrupt Mask */
+#define USBHS_HSTISR_RXRSMI                 USBHS_HSTISR_RXRSMI_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_RXRSMI_Msk instead */
+#define USBHS_HSTISR_HSOFI_Pos              5                                              /**< (USBHS_HSTISR) Host Start of Frame Interrupt Position */
+#define USBHS_HSTISR_HSOFI_Msk              (_U_(0x1) << USBHS_HSTISR_HSOFI_Pos)           /**< (USBHS_HSTISR) Host Start of Frame Interrupt Mask */
+#define USBHS_HSTISR_HSOFI                  USBHS_HSTISR_HSOFI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_HSOFI_Msk instead */
+#define USBHS_HSTISR_HWUPI_Pos              6                                              /**< (USBHS_HSTISR) Host Wake-Up Interrupt Position */
+#define USBHS_HSTISR_HWUPI_Msk              (_U_(0x1) << USBHS_HSTISR_HWUPI_Pos)           /**< (USBHS_HSTISR) Host Wake-Up Interrupt Mask */
+#define USBHS_HSTISR_HWUPI                  USBHS_HSTISR_HWUPI_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_HWUPI_Msk instead */
+#define USBHS_HSTISR_PEP_0_Pos              8                                              /**< (USBHS_HSTISR) Pipe 0 Interrupt Position */
+#define USBHS_HSTISR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_0_Pos)           /**< (USBHS_HSTISR) Pipe 0 Interrupt Mask */
+#define USBHS_HSTISR_PEP_0                  USBHS_HSTISR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_0_Msk instead */
+#define USBHS_HSTISR_PEP_1_Pos              9                                              /**< (USBHS_HSTISR) Pipe 1 Interrupt Position */
+#define USBHS_HSTISR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_1_Pos)           /**< (USBHS_HSTISR) Pipe 1 Interrupt Mask */
+#define USBHS_HSTISR_PEP_1                  USBHS_HSTISR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_1_Msk instead */
+#define USBHS_HSTISR_PEP_2_Pos              10                                             /**< (USBHS_HSTISR) Pipe 2 Interrupt Position */
+#define USBHS_HSTISR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_2_Pos)           /**< (USBHS_HSTISR) Pipe 2 Interrupt Mask */
+#define USBHS_HSTISR_PEP_2                  USBHS_HSTISR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_2_Msk instead */
+#define USBHS_HSTISR_PEP_3_Pos              11                                             /**< (USBHS_HSTISR) Pipe 3 Interrupt Position */
+#define USBHS_HSTISR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_3_Pos)           /**< (USBHS_HSTISR) Pipe 3 Interrupt Mask */
+#define USBHS_HSTISR_PEP_3                  USBHS_HSTISR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_3_Msk instead */
+#define USBHS_HSTISR_PEP_4_Pos              12                                             /**< (USBHS_HSTISR) Pipe 4 Interrupt Position */
+#define USBHS_HSTISR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_4_Pos)           /**< (USBHS_HSTISR) Pipe 4 Interrupt Mask */
+#define USBHS_HSTISR_PEP_4                  USBHS_HSTISR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_4_Msk instead */
+#define USBHS_HSTISR_PEP_5_Pos              13                                             /**< (USBHS_HSTISR) Pipe 5 Interrupt Position */
+#define USBHS_HSTISR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_5_Pos)           /**< (USBHS_HSTISR) Pipe 5 Interrupt Mask */
+#define USBHS_HSTISR_PEP_5                  USBHS_HSTISR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_5_Msk instead */
+#define USBHS_HSTISR_PEP_6_Pos              14                                             /**< (USBHS_HSTISR) Pipe 6 Interrupt Position */
+#define USBHS_HSTISR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_6_Pos)           /**< (USBHS_HSTISR) Pipe 6 Interrupt Mask */
+#define USBHS_HSTISR_PEP_6                  USBHS_HSTISR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_6_Msk instead */
+#define USBHS_HSTISR_PEP_7_Pos              15                                             /**< (USBHS_HSTISR) Pipe 7 Interrupt Position */
+#define USBHS_HSTISR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_7_Pos)           /**< (USBHS_HSTISR) Pipe 7 Interrupt Mask */
+#define USBHS_HSTISR_PEP_7                  USBHS_HSTISR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_7_Msk instead */
+#define USBHS_HSTISR_PEP_8_Pos              16                                             /**< (USBHS_HSTISR) Pipe 8 Interrupt Position */
+#define USBHS_HSTISR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_8_Pos)           /**< (USBHS_HSTISR) Pipe 8 Interrupt Mask */
+#define USBHS_HSTISR_PEP_8                  USBHS_HSTISR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_8_Msk instead */
+#define USBHS_HSTISR_PEP_9_Pos              17                                             /**< (USBHS_HSTISR) Pipe 9 Interrupt Position */
+#define USBHS_HSTISR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_9_Pos)           /**< (USBHS_HSTISR) Pipe 9 Interrupt Mask */
+#define USBHS_HSTISR_PEP_9                  USBHS_HSTISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_9_Msk instead */
+#define USBHS_HSTISR_DMA_0_Pos              25                                             /**< (USBHS_HSTISR) DMA Channel 0 Interrupt Position */
+#define USBHS_HSTISR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_0_Pos)           /**< (USBHS_HSTISR) DMA Channel 0 Interrupt Mask */
+#define USBHS_HSTISR_DMA_0                  USBHS_HSTISR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_0_Msk instead */
+#define USBHS_HSTISR_DMA_1_Pos              26                                             /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Position */
+#define USBHS_HSTISR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_1_Pos)           /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Mask */
+#define USBHS_HSTISR_DMA_1                  USBHS_HSTISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_1_Msk instead */
+#define USBHS_HSTISR_DMA_2_Pos              27                                             /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Position */
+#define USBHS_HSTISR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_2_Pos)           /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Mask */
+#define USBHS_HSTISR_DMA_2                  USBHS_HSTISR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_2_Msk instead */
+#define USBHS_HSTISR_DMA_3_Pos              28                                             /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Position */
+#define USBHS_HSTISR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_3_Pos)           /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Mask */
+#define USBHS_HSTISR_DMA_3                  USBHS_HSTISR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_3_Msk instead */
+#define USBHS_HSTISR_DMA_4_Pos              29                                             /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Position */
+#define USBHS_HSTISR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_4_Pos)           /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Mask */
+#define USBHS_HSTISR_DMA_4                  USBHS_HSTISR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_4_Msk instead */
+#define USBHS_HSTISR_DMA_5_Pos              30                                             /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Position */
+#define USBHS_HSTISR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_5_Pos)           /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Mask */
+#define USBHS_HSTISR_DMA_5                  USBHS_HSTISR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_5_Msk instead */
+#define USBHS_HSTISR_DMA_6_Pos              31                                             /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Position */
+#define USBHS_HSTISR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_6_Pos)           /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Mask */
+#define USBHS_HSTISR_DMA_6                  USBHS_HSTISR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_6_Msk instead */
+#define USBHS_HSTISR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTISR) Register MASK  (Use USBHS_HSTISR_Msk instead)  */
+#define USBHS_HSTISR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTISR) Register Mask  */
+
+#define USBHS_HSTISR_PEP__Pos               8                                              /**< (USBHS_HSTISR Position) Pipe x Interrupt */
+#define USBHS_HSTISR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTISR_PEP__Pos)          /**< (USBHS_HSTISR Mask) PEP_ */
+#define USBHS_HSTISR_PEP_(value)            (USBHS_HSTISR_PEP__Msk & ((value) << USBHS_HSTISR_PEP__Pos))  
+#define USBHS_HSTISR_DMA__Pos               25                                             /**< (USBHS_HSTISR Position) DMA Channel 6 Interrupt */
+#define USBHS_HSTISR_DMA__Msk               (_U_(0x7F) << USBHS_HSTISR_DMA__Pos)           /**< (USBHS_HSTISR Mask) DMA_ */
+#define USBHS_HSTISR_DMA_(value)            (USBHS_HSTISR_DMA__Msk & ((value) << USBHS_HSTISR_DMA__Pos))  
+
+/* -------- USBHS_HSTICR : (USBHS Offset: 0x408) (/W 32) Host Global Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIC:1;                 /**< bit:      0  Device Connection Interrupt Clear        */
+    uint32_t DDISCIC:1;                 /**< bit:      1  Device Disconnection Interrupt Clear     */
+    uint32_t RSTIC:1;                   /**< bit:      2  USB Reset Sent Interrupt Clear           */
+    uint32_t RSMEDIC:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Clear   */
+    uint32_t RXRSMIC:1;                 /**< bit:      4  Upstream Resume Received Interrupt Clear */
+    uint32_t HSOFIC:1;                  /**< bit:      5  Host Start of Frame Interrupt Clear      */
+    uint32_t HWUPIC:1;                  /**< bit:      6  Host Wake-Up Interrupt Clear             */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTICR_OFFSET                 (0x408)                                       /**<  (USBHS_HSTICR) Host Global Interrupt Clear Register  Offset */
+
+#define USBHS_HSTICR_DCONNIC_Pos            0                                              /**< (USBHS_HSTICR) Device Connection Interrupt Clear Position */
+#define USBHS_HSTICR_DCONNIC_Msk            (_U_(0x1) << USBHS_HSTICR_DCONNIC_Pos)         /**< (USBHS_HSTICR) Device Connection Interrupt Clear Mask */
+#define USBHS_HSTICR_DCONNIC                USBHS_HSTICR_DCONNIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_DCONNIC_Msk instead */
+#define USBHS_HSTICR_DDISCIC_Pos            1                                              /**< (USBHS_HSTICR) Device Disconnection Interrupt Clear Position */
+#define USBHS_HSTICR_DDISCIC_Msk            (_U_(0x1) << USBHS_HSTICR_DDISCIC_Pos)         /**< (USBHS_HSTICR) Device Disconnection Interrupt Clear Mask */
+#define USBHS_HSTICR_DDISCIC                USBHS_HSTICR_DDISCIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_DDISCIC_Msk instead */
+#define USBHS_HSTICR_RSTIC_Pos              2                                              /**< (USBHS_HSTICR) USB Reset Sent Interrupt Clear Position */
+#define USBHS_HSTICR_RSTIC_Msk              (_U_(0x1) << USBHS_HSTICR_RSTIC_Pos)           /**< (USBHS_HSTICR) USB Reset Sent Interrupt Clear Mask */
+#define USBHS_HSTICR_RSTIC                  USBHS_HSTICR_RSTIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RSTIC_Msk instead */
+#define USBHS_HSTICR_RSMEDIC_Pos            3                                              /**< (USBHS_HSTICR) Downstream Resume Sent Interrupt Clear Position */
+#define USBHS_HSTICR_RSMEDIC_Msk            (_U_(0x1) << USBHS_HSTICR_RSMEDIC_Pos)         /**< (USBHS_HSTICR) Downstream Resume Sent Interrupt Clear Mask */
+#define USBHS_HSTICR_RSMEDIC                USBHS_HSTICR_RSMEDIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RSMEDIC_Msk instead */
+#define USBHS_HSTICR_RXRSMIC_Pos            4                                              /**< (USBHS_HSTICR) Upstream Resume Received Interrupt Clear Position */
+#define USBHS_HSTICR_RXRSMIC_Msk            (_U_(0x1) << USBHS_HSTICR_RXRSMIC_Pos)         /**< (USBHS_HSTICR) Upstream Resume Received Interrupt Clear Mask */
+#define USBHS_HSTICR_RXRSMIC                USBHS_HSTICR_RXRSMIC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_RXRSMIC_Msk instead */
+#define USBHS_HSTICR_HSOFIC_Pos             5                                              /**< (USBHS_HSTICR) Host Start of Frame Interrupt Clear Position */
+#define USBHS_HSTICR_HSOFIC_Msk             (_U_(0x1) << USBHS_HSTICR_HSOFIC_Pos)          /**< (USBHS_HSTICR) Host Start of Frame Interrupt Clear Mask */
+#define USBHS_HSTICR_HSOFIC                 USBHS_HSTICR_HSOFIC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_HSOFIC_Msk instead */
+#define USBHS_HSTICR_HWUPIC_Pos             6                                              /**< (USBHS_HSTICR) Host Wake-Up Interrupt Clear Position */
+#define USBHS_HSTICR_HWUPIC_Msk             (_U_(0x1) << USBHS_HSTICR_HWUPIC_Pos)          /**< (USBHS_HSTICR) Host Wake-Up Interrupt Clear Mask */
+#define USBHS_HSTICR_HWUPIC                 USBHS_HSTICR_HWUPIC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTICR_HWUPIC_Msk instead */
+#define USBHS_HSTICR_MASK                   _U_(0x7F)                                      /**< \deprecated (USBHS_HSTICR) Register MASK  (Use USBHS_HSTICR_Msk instead)  */
+#define USBHS_HSTICR_Msk                    _U_(0x7F)                                      /**< (USBHS_HSTICR) Register Mask  */
+
+
+/* -------- USBHS_HSTIFR : (USBHS Offset: 0x40c) (/W 32) Host Global Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIS:1;                 /**< bit:      0  Device Connection Interrupt Set          */
+    uint32_t DDISCIS:1;                 /**< bit:      1  Device Disconnection Interrupt Set       */
+    uint32_t RSTIS:1;                   /**< bit:      2  USB Reset Sent Interrupt Set             */
+    uint32_t RSMEDIS:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Set     */
+    uint32_t RXRSMIS:1;                 /**< bit:      4  Upstream Resume Received Interrupt Set   */
+    uint32_t HSOFIS:1;                  /**< bit:      5  Host Start of Frame Interrupt Set        */
+    uint32_t HWUPIS:1;                  /**< bit:      6  Host Wake-Up Interrupt Set               */
+    uint32_t :18;                       /**< bit:  7..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Set              */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Set              */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Set              */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Set              */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Set              */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Set              */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Set              */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :25;                       /**< bit:  0..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Set              */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIFR_OFFSET                 (0x40C)                                       /**<  (USBHS_HSTIFR) Host Global Interrupt Set Register  Offset */
+
+#define USBHS_HSTIFR_DCONNIS_Pos            0                                              /**< (USBHS_HSTIFR) Device Connection Interrupt Set Position */
+#define USBHS_HSTIFR_DCONNIS_Msk            (_U_(0x1) << USBHS_HSTIFR_DCONNIS_Pos)         /**< (USBHS_HSTIFR) Device Connection Interrupt Set Mask */
+#define USBHS_HSTIFR_DCONNIS                USBHS_HSTIFR_DCONNIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DCONNIS_Msk instead */
+#define USBHS_HSTIFR_DDISCIS_Pos            1                                              /**< (USBHS_HSTIFR) Device Disconnection Interrupt Set Position */
+#define USBHS_HSTIFR_DDISCIS_Msk            (_U_(0x1) << USBHS_HSTIFR_DDISCIS_Pos)         /**< (USBHS_HSTIFR) Device Disconnection Interrupt Set Mask */
+#define USBHS_HSTIFR_DDISCIS                USBHS_HSTIFR_DDISCIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DDISCIS_Msk instead */
+#define USBHS_HSTIFR_RSTIS_Pos              2                                              /**< (USBHS_HSTIFR) USB Reset Sent Interrupt Set Position */
+#define USBHS_HSTIFR_RSTIS_Msk              (_U_(0x1) << USBHS_HSTIFR_RSTIS_Pos)           /**< (USBHS_HSTIFR) USB Reset Sent Interrupt Set Mask */
+#define USBHS_HSTIFR_RSTIS                  USBHS_HSTIFR_RSTIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RSTIS_Msk instead */
+#define USBHS_HSTIFR_RSMEDIS_Pos            3                                              /**< (USBHS_HSTIFR) Downstream Resume Sent Interrupt Set Position */
+#define USBHS_HSTIFR_RSMEDIS_Msk            (_U_(0x1) << USBHS_HSTIFR_RSMEDIS_Pos)         /**< (USBHS_HSTIFR) Downstream Resume Sent Interrupt Set Mask */
+#define USBHS_HSTIFR_RSMEDIS                USBHS_HSTIFR_RSMEDIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RSMEDIS_Msk instead */
+#define USBHS_HSTIFR_RXRSMIS_Pos            4                                              /**< (USBHS_HSTIFR) Upstream Resume Received Interrupt Set Position */
+#define USBHS_HSTIFR_RXRSMIS_Msk            (_U_(0x1) << USBHS_HSTIFR_RXRSMIS_Pos)         /**< (USBHS_HSTIFR) Upstream Resume Received Interrupt Set Mask */
+#define USBHS_HSTIFR_RXRSMIS                USBHS_HSTIFR_RXRSMIS_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_RXRSMIS_Msk instead */
+#define USBHS_HSTIFR_HSOFIS_Pos             5                                              /**< (USBHS_HSTIFR) Host Start of Frame Interrupt Set Position */
+#define USBHS_HSTIFR_HSOFIS_Msk             (_U_(0x1) << USBHS_HSTIFR_HSOFIS_Pos)          /**< (USBHS_HSTIFR) Host Start of Frame Interrupt Set Mask */
+#define USBHS_HSTIFR_HSOFIS                 USBHS_HSTIFR_HSOFIS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_HSOFIS_Msk instead */
+#define USBHS_HSTIFR_HWUPIS_Pos             6                                              /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Position */
+#define USBHS_HSTIFR_HWUPIS_Msk             (_U_(0x1) << USBHS_HSTIFR_HWUPIS_Pos)          /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Mask */
+#define USBHS_HSTIFR_HWUPIS                 USBHS_HSTIFR_HWUPIS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_HWUPIS_Msk instead */
+#define USBHS_HSTIFR_DMA_0_Pos              25                                             /**< (USBHS_HSTIFR) DMA Channel 0 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_0_Pos)           /**< (USBHS_HSTIFR) DMA Channel 0 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_0                  USBHS_HSTIFR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_0_Msk instead */
+#define USBHS_HSTIFR_DMA_1_Pos              26                                             /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_1_Pos)           /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_1                  USBHS_HSTIFR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_1_Msk instead */
+#define USBHS_HSTIFR_DMA_2_Pos              27                                             /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_2_Pos)           /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_2                  USBHS_HSTIFR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_2_Msk instead */
+#define USBHS_HSTIFR_DMA_3_Pos              28                                             /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_3_Pos)           /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_3                  USBHS_HSTIFR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_3_Msk instead */
+#define USBHS_HSTIFR_DMA_4_Pos              29                                             /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_4_Pos)           /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_4                  USBHS_HSTIFR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_4_Msk instead */
+#define USBHS_HSTIFR_DMA_5_Pos              30                                             /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_5_Pos)           /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_5                  USBHS_HSTIFR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_5_Msk instead */
+#define USBHS_HSTIFR_DMA_6_Pos              31                                             /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_6_Pos)           /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_6                  USBHS_HSTIFR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_6_Msk instead */
+#define USBHS_HSTIFR_MASK                   _U_(0xFE00007F)                                /**< \deprecated (USBHS_HSTIFR) Register MASK  (Use USBHS_HSTIFR_Msk instead)  */
+#define USBHS_HSTIFR_Msk                    _U_(0xFE00007F)                                /**< (USBHS_HSTIFR) Register Mask  */
+
+#define USBHS_HSTIFR_DMA__Pos               25                                             /**< (USBHS_HSTIFR Position) DMA Channel 6 Interrupt Set */
+#define USBHS_HSTIFR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIFR_DMA__Pos)           /**< (USBHS_HSTIFR Mask) DMA_ */
+#define USBHS_HSTIFR_DMA_(value)            (USBHS_HSTIFR_DMA__Msk & ((value) << USBHS_HSTIFR_DMA__Pos))  
+
+/* -------- USBHS_HSTIMR : (USBHS Offset: 0x410) (R/ 32) Host Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIE:1;                 /**< bit:      0  Device Connection Interrupt Enable       */
+    uint32_t DDISCIE:1;                 /**< bit:      1  Device Disconnection Interrupt Enable    */
+    uint32_t RSTIE:1;                   /**< bit:      2  USB Reset Sent Interrupt Enable          */
+    uint32_t RSMEDIE:1;                 /**< bit:      3  Downstream Resume Sent Interrupt Enable  */
+    uint32_t RXRSMIE:1;                 /**< bit:      4  Upstream Resume Received Interrupt Enable */
+    uint32_t HSOFIE:1;                  /**< bit:      5  Host Start of Frame Interrupt Enable     */
+    uint32_t HWUPIE:1;                  /**< bit:      6  Host Wake-Up Interrupt Enable            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Enable                  */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Enable                  */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Enable                  */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Enable                  */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Enable                  */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Enable                  */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Enable                  */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Enable           */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIMR_OFFSET                 (0x410)                                       /**<  (USBHS_HSTIMR) Host Global Interrupt Mask Register  Offset */
+
+#define USBHS_HSTIMR_DCONNIE_Pos            0                                              /**< (USBHS_HSTIMR) Device Connection Interrupt Enable Position */
+#define USBHS_HSTIMR_DCONNIE_Msk            (_U_(0x1) << USBHS_HSTIMR_DCONNIE_Pos)         /**< (USBHS_HSTIMR) Device Connection Interrupt Enable Mask */
+#define USBHS_HSTIMR_DCONNIE                USBHS_HSTIMR_DCONNIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DCONNIE_Msk instead */
+#define USBHS_HSTIMR_DDISCIE_Pos            1                                              /**< (USBHS_HSTIMR) Device Disconnection Interrupt Enable Position */
+#define USBHS_HSTIMR_DDISCIE_Msk            (_U_(0x1) << USBHS_HSTIMR_DDISCIE_Pos)         /**< (USBHS_HSTIMR) Device Disconnection Interrupt Enable Mask */
+#define USBHS_HSTIMR_DDISCIE                USBHS_HSTIMR_DDISCIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DDISCIE_Msk instead */
+#define USBHS_HSTIMR_RSTIE_Pos              2                                              /**< (USBHS_HSTIMR) USB Reset Sent Interrupt Enable Position */
+#define USBHS_HSTIMR_RSTIE_Msk              (_U_(0x1) << USBHS_HSTIMR_RSTIE_Pos)           /**< (USBHS_HSTIMR) USB Reset Sent Interrupt Enable Mask */
+#define USBHS_HSTIMR_RSTIE                  USBHS_HSTIMR_RSTIE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RSTIE_Msk instead */
+#define USBHS_HSTIMR_RSMEDIE_Pos            3                                              /**< (USBHS_HSTIMR) Downstream Resume Sent Interrupt Enable Position */
+#define USBHS_HSTIMR_RSMEDIE_Msk            (_U_(0x1) << USBHS_HSTIMR_RSMEDIE_Pos)         /**< (USBHS_HSTIMR) Downstream Resume Sent Interrupt Enable Mask */
+#define USBHS_HSTIMR_RSMEDIE                USBHS_HSTIMR_RSMEDIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RSMEDIE_Msk instead */
+#define USBHS_HSTIMR_RXRSMIE_Pos            4                                              /**< (USBHS_HSTIMR) Upstream Resume Received Interrupt Enable Position */
+#define USBHS_HSTIMR_RXRSMIE_Msk            (_U_(0x1) << USBHS_HSTIMR_RXRSMIE_Pos)         /**< (USBHS_HSTIMR) Upstream Resume Received Interrupt Enable Mask */
+#define USBHS_HSTIMR_RXRSMIE                USBHS_HSTIMR_RXRSMIE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_RXRSMIE_Msk instead */
+#define USBHS_HSTIMR_HSOFIE_Pos             5                                              /**< (USBHS_HSTIMR) Host Start of Frame Interrupt Enable Position */
+#define USBHS_HSTIMR_HSOFIE_Msk             (_U_(0x1) << USBHS_HSTIMR_HSOFIE_Pos)          /**< (USBHS_HSTIMR) Host Start of Frame Interrupt Enable Mask */
+#define USBHS_HSTIMR_HSOFIE                 USBHS_HSTIMR_HSOFIE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_HSOFIE_Msk instead */
+#define USBHS_HSTIMR_HWUPIE_Pos             6                                              /**< (USBHS_HSTIMR) Host Wake-Up Interrupt Enable Position */
+#define USBHS_HSTIMR_HWUPIE_Msk             (_U_(0x1) << USBHS_HSTIMR_HWUPIE_Pos)          /**< (USBHS_HSTIMR) Host Wake-Up Interrupt Enable Mask */
+#define USBHS_HSTIMR_HWUPIE                 USBHS_HSTIMR_HWUPIE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_HWUPIE_Msk instead */
+#define USBHS_HSTIMR_PEP_0_Pos              8                                              /**< (USBHS_HSTIMR) Pipe 0 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_0_Pos)           /**< (USBHS_HSTIMR) Pipe 0 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_0                  USBHS_HSTIMR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_0_Msk instead */
+#define USBHS_HSTIMR_PEP_1_Pos              9                                              /**< (USBHS_HSTIMR) Pipe 1 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_1_Pos)           /**< (USBHS_HSTIMR) Pipe 1 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_1                  USBHS_HSTIMR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_1_Msk instead */
+#define USBHS_HSTIMR_PEP_2_Pos              10                                             /**< (USBHS_HSTIMR) Pipe 2 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_2_Pos)           /**< (USBHS_HSTIMR) Pipe 2 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_2                  USBHS_HSTIMR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_2_Msk instead */
+#define USBHS_HSTIMR_PEP_3_Pos              11                                             /**< (USBHS_HSTIMR) Pipe 3 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_3_Pos)           /**< (USBHS_HSTIMR) Pipe 3 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_3                  USBHS_HSTIMR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_3_Msk instead */
+#define USBHS_HSTIMR_PEP_4_Pos              12                                             /**< (USBHS_HSTIMR) Pipe 4 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_4_Pos)           /**< (USBHS_HSTIMR) Pipe 4 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_4                  USBHS_HSTIMR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_4_Msk instead */
+#define USBHS_HSTIMR_PEP_5_Pos              13                                             /**< (USBHS_HSTIMR) Pipe 5 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_5_Pos)           /**< (USBHS_HSTIMR) Pipe 5 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_5                  USBHS_HSTIMR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_5_Msk instead */
+#define USBHS_HSTIMR_PEP_6_Pos              14                                             /**< (USBHS_HSTIMR) Pipe 6 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_6_Pos)           /**< (USBHS_HSTIMR) Pipe 6 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_6                  USBHS_HSTIMR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_6_Msk instead */
+#define USBHS_HSTIMR_PEP_7_Pos              15                                             /**< (USBHS_HSTIMR) Pipe 7 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_7_Pos)           /**< (USBHS_HSTIMR) Pipe 7 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_7                  USBHS_HSTIMR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_7_Msk instead */
+#define USBHS_HSTIMR_PEP_8_Pos              16                                             /**< (USBHS_HSTIMR) Pipe 8 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_8_Pos)           /**< (USBHS_HSTIMR) Pipe 8 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_8                  USBHS_HSTIMR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_8_Msk instead */
+#define USBHS_HSTIMR_PEP_9_Pos              17                                             /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Position */
+#define USBHS_HSTIMR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_9_Pos)           /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Mask */
+#define USBHS_HSTIMR_PEP_9                  USBHS_HSTIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_9_Msk instead */
+#define USBHS_HSTIMR_DMA_0_Pos              25                                             /**< (USBHS_HSTIMR) DMA Channel 0 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_0_Pos)           /**< (USBHS_HSTIMR) DMA Channel 0 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_0                  USBHS_HSTIMR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_0_Msk instead */
+#define USBHS_HSTIMR_DMA_1_Pos              26                                             /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_1_Pos)           /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_1                  USBHS_HSTIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_1_Msk instead */
+#define USBHS_HSTIMR_DMA_2_Pos              27                                             /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_2_Pos)           /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_2                  USBHS_HSTIMR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_2_Msk instead */
+#define USBHS_HSTIMR_DMA_3_Pos              28                                             /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_3_Pos)           /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_3                  USBHS_HSTIMR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_3_Msk instead */
+#define USBHS_HSTIMR_DMA_4_Pos              29                                             /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_4_Pos)           /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_4                  USBHS_HSTIMR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_4_Msk instead */
+#define USBHS_HSTIMR_DMA_5_Pos              30                                             /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_5_Pos)           /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_5                  USBHS_HSTIMR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_5_Msk instead */
+#define USBHS_HSTIMR_DMA_6_Pos              31                                             /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_6_Pos)           /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_6                  USBHS_HSTIMR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_6_Msk instead */
+#define USBHS_HSTIMR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIMR) Register MASK  (Use USBHS_HSTIMR_Msk instead)  */
+#define USBHS_HSTIMR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIMR) Register Mask  */
+
+#define USBHS_HSTIMR_PEP__Pos               8                                              /**< (USBHS_HSTIMR Position) Pipe x Interrupt Enable */
+#define USBHS_HSTIMR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIMR_PEP__Pos)          /**< (USBHS_HSTIMR Mask) PEP_ */
+#define USBHS_HSTIMR_PEP_(value)            (USBHS_HSTIMR_PEP__Msk & ((value) << USBHS_HSTIMR_PEP__Pos))  
+#define USBHS_HSTIMR_DMA__Pos               25                                             /**< (USBHS_HSTIMR Position) DMA Channel 6 Interrupt Enable */
+#define USBHS_HSTIMR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIMR_DMA__Pos)           /**< (USBHS_HSTIMR Mask) DMA_ */
+#define USBHS_HSTIMR_DMA_(value)            (USBHS_HSTIMR_DMA__Msk & ((value) << USBHS_HSTIMR_DMA__Pos))  
+
+/* -------- USBHS_HSTIDR : (USBHS Offset: 0x414) (/W 32) Host Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIEC:1;                /**< bit:      0  Device Connection Interrupt Disable      */
+    uint32_t DDISCIEC:1;                /**< bit:      1  Device Disconnection Interrupt Disable   */
+    uint32_t RSTIEC:1;                  /**< bit:      2  USB Reset Sent Interrupt Disable         */
+    uint32_t RSMEDIEC:1;                /**< bit:      3  Downstream Resume Sent Interrupt Disable */
+    uint32_t RXRSMIEC:1;                /**< bit:      4  Upstream Resume Received Interrupt Disable */
+    uint32_t HSOFIEC:1;                 /**< bit:      5  Host Start of Frame Interrupt Disable    */
+    uint32_t HWUPIEC:1;                 /**< bit:      6  Host Wake-Up Interrupt Disable           */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Disable                 */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Disable                 */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Disable                 */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Disable                 */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Disable                 */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Disable                 */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Disable                 */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Disable                 */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Disable                 */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Disable                 */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Disable          */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Disable          */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Disable          */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Disable          */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Disable          */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Disable          */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Disable          */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Disable                 */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Disable          */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIDR_OFFSET                 (0x414)                                       /**<  (USBHS_HSTIDR) Host Global Interrupt Disable Register  Offset */
+
+#define USBHS_HSTIDR_DCONNIEC_Pos           0                                              /**< (USBHS_HSTIDR) Device Connection Interrupt Disable Position */
+#define USBHS_HSTIDR_DCONNIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_DCONNIEC_Pos)        /**< (USBHS_HSTIDR) Device Connection Interrupt Disable Mask */
+#define USBHS_HSTIDR_DCONNIEC               USBHS_HSTIDR_DCONNIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DCONNIEC_Msk instead */
+#define USBHS_HSTIDR_DDISCIEC_Pos           1                                              /**< (USBHS_HSTIDR) Device Disconnection Interrupt Disable Position */
+#define USBHS_HSTIDR_DDISCIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_DDISCIEC_Pos)        /**< (USBHS_HSTIDR) Device Disconnection Interrupt Disable Mask */
+#define USBHS_HSTIDR_DDISCIEC               USBHS_HSTIDR_DDISCIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DDISCIEC_Msk instead */
+#define USBHS_HSTIDR_RSTIEC_Pos             2                                              /**< (USBHS_HSTIDR) USB Reset Sent Interrupt Disable Position */
+#define USBHS_HSTIDR_RSTIEC_Msk             (_U_(0x1) << USBHS_HSTIDR_RSTIEC_Pos)          /**< (USBHS_HSTIDR) USB Reset Sent Interrupt Disable Mask */
+#define USBHS_HSTIDR_RSTIEC                 USBHS_HSTIDR_RSTIEC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RSTIEC_Msk instead */
+#define USBHS_HSTIDR_RSMEDIEC_Pos           3                                              /**< (USBHS_HSTIDR) Downstream Resume Sent Interrupt Disable Position */
+#define USBHS_HSTIDR_RSMEDIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_RSMEDIEC_Pos)        /**< (USBHS_HSTIDR) Downstream Resume Sent Interrupt Disable Mask */
+#define USBHS_HSTIDR_RSMEDIEC               USBHS_HSTIDR_RSMEDIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RSMEDIEC_Msk instead */
+#define USBHS_HSTIDR_RXRSMIEC_Pos           4                                              /**< (USBHS_HSTIDR) Upstream Resume Received Interrupt Disable Position */
+#define USBHS_HSTIDR_RXRSMIEC_Msk           (_U_(0x1) << USBHS_HSTIDR_RXRSMIEC_Pos)        /**< (USBHS_HSTIDR) Upstream Resume Received Interrupt Disable Mask */
+#define USBHS_HSTIDR_RXRSMIEC               USBHS_HSTIDR_RXRSMIEC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_RXRSMIEC_Msk instead */
+#define USBHS_HSTIDR_HSOFIEC_Pos            5                                              /**< (USBHS_HSTIDR) Host Start of Frame Interrupt Disable Position */
+#define USBHS_HSTIDR_HSOFIEC_Msk            (_U_(0x1) << USBHS_HSTIDR_HSOFIEC_Pos)         /**< (USBHS_HSTIDR) Host Start of Frame Interrupt Disable Mask */
+#define USBHS_HSTIDR_HSOFIEC                USBHS_HSTIDR_HSOFIEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_HSOFIEC_Msk instead */
+#define USBHS_HSTIDR_HWUPIEC_Pos            6                                              /**< (USBHS_HSTIDR) Host Wake-Up Interrupt Disable Position */
+#define USBHS_HSTIDR_HWUPIEC_Msk            (_U_(0x1) << USBHS_HSTIDR_HWUPIEC_Pos)         /**< (USBHS_HSTIDR) Host Wake-Up Interrupt Disable Mask */
+#define USBHS_HSTIDR_HWUPIEC                USBHS_HSTIDR_HWUPIEC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_HWUPIEC_Msk instead */
+#define USBHS_HSTIDR_PEP_0_Pos              8                                              /**< (USBHS_HSTIDR) Pipe 0 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_0_Pos)           /**< (USBHS_HSTIDR) Pipe 0 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_0                  USBHS_HSTIDR_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_0_Msk instead */
+#define USBHS_HSTIDR_PEP_1_Pos              9                                              /**< (USBHS_HSTIDR) Pipe 1 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_1_Pos)           /**< (USBHS_HSTIDR) Pipe 1 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_1                  USBHS_HSTIDR_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_1_Msk instead */
+#define USBHS_HSTIDR_PEP_2_Pos              10                                             /**< (USBHS_HSTIDR) Pipe 2 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_2_Pos)           /**< (USBHS_HSTIDR) Pipe 2 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_2                  USBHS_HSTIDR_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_2_Msk instead */
+#define USBHS_HSTIDR_PEP_3_Pos              11                                             /**< (USBHS_HSTIDR) Pipe 3 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_3_Pos)           /**< (USBHS_HSTIDR) Pipe 3 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_3                  USBHS_HSTIDR_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_3_Msk instead */
+#define USBHS_HSTIDR_PEP_4_Pos              12                                             /**< (USBHS_HSTIDR) Pipe 4 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_4_Pos)           /**< (USBHS_HSTIDR) Pipe 4 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_4                  USBHS_HSTIDR_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_4_Msk instead */
+#define USBHS_HSTIDR_PEP_5_Pos              13                                             /**< (USBHS_HSTIDR) Pipe 5 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_5_Pos)           /**< (USBHS_HSTIDR) Pipe 5 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_5                  USBHS_HSTIDR_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_5_Msk instead */
+#define USBHS_HSTIDR_PEP_6_Pos              14                                             /**< (USBHS_HSTIDR) Pipe 6 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_6_Pos)           /**< (USBHS_HSTIDR) Pipe 6 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_6                  USBHS_HSTIDR_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_6_Msk instead */
+#define USBHS_HSTIDR_PEP_7_Pos              15                                             /**< (USBHS_HSTIDR) Pipe 7 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_7_Pos)           /**< (USBHS_HSTIDR) Pipe 7 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_7                  USBHS_HSTIDR_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_7_Msk instead */
+#define USBHS_HSTIDR_PEP_8_Pos              16                                             /**< (USBHS_HSTIDR) Pipe 8 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_8_Pos)           /**< (USBHS_HSTIDR) Pipe 8 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_8                  USBHS_HSTIDR_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_8_Msk instead */
+#define USBHS_HSTIDR_PEP_9_Pos              17                                             /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Position */
+#define USBHS_HSTIDR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_9_Pos)           /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Mask */
+#define USBHS_HSTIDR_PEP_9                  USBHS_HSTIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_9_Msk instead */
+#define USBHS_HSTIDR_DMA_0_Pos              25                                             /**< (USBHS_HSTIDR) DMA Channel 0 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_0_Pos)           /**< (USBHS_HSTIDR) DMA Channel 0 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_0                  USBHS_HSTIDR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_0_Msk instead */
+#define USBHS_HSTIDR_DMA_1_Pos              26                                             /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_1_Pos)           /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_1                  USBHS_HSTIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_1_Msk instead */
+#define USBHS_HSTIDR_DMA_2_Pos              27                                             /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_2_Pos)           /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_2                  USBHS_HSTIDR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_2_Msk instead */
+#define USBHS_HSTIDR_DMA_3_Pos              28                                             /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_3_Pos)           /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_3                  USBHS_HSTIDR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_3_Msk instead */
+#define USBHS_HSTIDR_DMA_4_Pos              29                                             /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_4_Pos)           /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_4                  USBHS_HSTIDR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_4_Msk instead */
+#define USBHS_HSTIDR_DMA_5_Pos              30                                             /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_5_Pos)           /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_5                  USBHS_HSTIDR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_5_Msk instead */
+#define USBHS_HSTIDR_DMA_6_Pos              31                                             /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_6_Pos)           /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_6                  USBHS_HSTIDR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_6_Msk instead */
+#define USBHS_HSTIDR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIDR) Register MASK  (Use USBHS_HSTIDR_Msk instead)  */
+#define USBHS_HSTIDR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIDR) Register Mask  */
+
+#define USBHS_HSTIDR_PEP__Pos               8                                              /**< (USBHS_HSTIDR Position) Pipe x Interrupt Disable */
+#define USBHS_HSTIDR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIDR_PEP__Pos)          /**< (USBHS_HSTIDR Mask) PEP_ */
+#define USBHS_HSTIDR_PEP_(value)            (USBHS_HSTIDR_PEP__Msk & ((value) << USBHS_HSTIDR_PEP__Pos))  
+#define USBHS_HSTIDR_DMA__Pos               25                                             /**< (USBHS_HSTIDR Position) DMA Channel 6 Interrupt Disable */
+#define USBHS_HSTIDR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIDR_DMA__Pos)           /**< (USBHS_HSTIDR Mask) DMA_ */
+#define USBHS_HSTIDR_DMA_(value)            (USBHS_HSTIDR_DMA__Msk & ((value) << USBHS_HSTIDR_DMA__Pos))  
+
+/* -------- USBHS_HSTIER : (USBHS Offset: 0x418) (/W 32) Host Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DCONNIES:1;                /**< bit:      0  Device Connection Interrupt Enable       */
+    uint32_t DDISCIES:1;                /**< bit:      1  Device Disconnection Interrupt Enable    */
+    uint32_t RSTIES:1;                  /**< bit:      2  USB Reset Sent Interrupt Enable          */
+    uint32_t RSMEDIES:1;                /**< bit:      3  Downstream Resume Sent Interrupt Enable  */
+    uint32_t RXRSMIES:1;                /**< bit:      4  Upstream Resume Received Interrupt Enable */
+    uint32_t HSOFIES:1;                 /**< bit:      5  Host Start of Frame Interrupt Enable     */
+    uint32_t HWUPIES:1;                 /**< bit:      6  Host Wake-Up Interrupt Enable            */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PEP_0:1;                   /**< bit:      8  Pipe 0 Interrupt Enable                  */
+    uint32_t PEP_1:1;                   /**< bit:      9  Pipe 1 Interrupt Enable                  */
+    uint32_t PEP_2:1;                   /**< bit:     10  Pipe 2 Interrupt Enable                  */
+    uint32_t PEP_3:1;                   /**< bit:     11  Pipe 3 Interrupt Enable                  */
+    uint32_t PEP_4:1;                   /**< bit:     12  Pipe 4 Interrupt Enable                  */
+    uint32_t PEP_5:1;                   /**< bit:     13  Pipe 5 Interrupt Enable                  */
+    uint32_t PEP_6:1;                   /**< bit:     14  Pipe 6 Interrupt Enable                  */
+    uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
+    uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
+    uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Enable           */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Enable           */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Enable           */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTIER_OFFSET                 (0x418)                                       /**<  (USBHS_HSTIER) Host Global Interrupt Enable Register  Offset */
+
+#define USBHS_HSTIER_DCONNIES_Pos           0                                              /**< (USBHS_HSTIER) Device Connection Interrupt Enable Position */
+#define USBHS_HSTIER_DCONNIES_Msk           (_U_(0x1) << USBHS_HSTIER_DCONNIES_Pos)        /**< (USBHS_HSTIER) Device Connection Interrupt Enable Mask */
+#define USBHS_HSTIER_DCONNIES               USBHS_HSTIER_DCONNIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DCONNIES_Msk instead */
+#define USBHS_HSTIER_DDISCIES_Pos           1                                              /**< (USBHS_HSTIER) Device Disconnection Interrupt Enable Position */
+#define USBHS_HSTIER_DDISCIES_Msk           (_U_(0x1) << USBHS_HSTIER_DDISCIES_Pos)        /**< (USBHS_HSTIER) Device Disconnection Interrupt Enable Mask */
+#define USBHS_HSTIER_DDISCIES               USBHS_HSTIER_DDISCIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DDISCIES_Msk instead */
+#define USBHS_HSTIER_RSTIES_Pos             2                                              /**< (USBHS_HSTIER) USB Reset Sent Interrupt Enable Position */
+#define USBHS_HSTIER_RSTIES_Msk             (_U_(0x1) << USBHS_HSTIER_RSTIES_Pos)          /**< (USBHS_HSTIER) USB Reset Sent Interrupt Enable Mask */
+#define USBHS_HSTIER_RSTIES                 USBHS_HSTIER_RSTIES_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RSTIES_Msk instead */
+#define USBHS_HSTIER_RSMEDIES_Pos           3                                              /**< (USBHS_HSTIER) Downstream Resume Sent Interrupt Enable Position */
+#define USBHS_HSTIER_RSMEDIES_Msk           (_U_(0x1) << USBHS_HSTIER_RSMEDIES_Pos)        /**< (USBHS_HSTIER) Downstream Resume Sent Interrupt Enable Mask */
+#define USBHS_HSTIER_RSMEDIES               USBHS_HSTIER_RSMEDIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RSMEDIES_Msk instead */
+#define USBHS_HSTIER_RXRSMIES_Pos           4                                              /**< (USBHS_HSTIER) Upstream Resume Received Interrupt Enable Position */
+#define USBHS_HSTIER_RXRSMIES_Msk           (_U_(0x1) << USBHS_HSTIER_RXRSMIES_Pos)        /**< (USBHS_HSTIER) Upstream Resume Received Interrupt Enable Mask */
+#define USBHS_HSTIER_RXRSMIES               USBHS_HSTIER_RXRSMIES_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_RXRSMIES_Msk instead */
+#define USBHS_HSTIER_HSOFIES_Pos            5                                              /**< (USBHS_HSTIER) Host Start of Frame Interrupt Enable Position */
+#define USBHS_HSTIER_HSOFIES_Msk            (_U_(0x1) << USBHS_HSTIER_HSOFIES_Pos)         /**< (USBHS_HSTIER) Host Start of Frame Interrupt Enable Mask */
+#define USBHS_HSTIER_HSOFIES                USBHS_HSTIER_HSOFIES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_HSOFIES_Msk instead */
+#define USBHS_HSTIER_HWUPIES_Pos            6                                              /**< (USBHS_HSTIER) Host Wake-Up Interrupt Enable Position */
+#define USBHS_HSTIER_HWUPIES_Msk            (_U_(0x1) << USBHS_HSTIER_HWUPIES_Pos)         /**< (USBHS_HSTIER) Host Wake-Up Interrupt Enable Mask */
+#define USBHS_HSTIER_HWUPIES                USBHS_HSTIER_HWUPIES_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_HWUPIES_Msk instead */
+#define USBHS_HSTIER_PEP_0_Pos              8                                              /**< (USBHS_HSTIER) Pipe 0 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_0_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_0_Pos)           /**< (USBHS_HSTIER) Pipe 0 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_0                  USBHS_HSTIER_PEP_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_0_Msk instead */
+#define USBHS_HSTIER_PEP_1_Pos              9                                              /**< (USBHS_HSTIER) Pipe 1 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_1_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_1_Pos)           /**< (USBHS_HSTIER) Pipe 1 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_1                  USBHS_HSTIER_PEP_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_1_Msk instead */
+#define USBHS_HSTIER_PEP_2_Pos              10                                             /**< (USBHS_HSTIER) Pipe 2 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_2_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_2_Pos)           /**< (USBHS_HSTIER) Pipe 2 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_2                  USBHS_HSTIER_PEP_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_2_Msk instead */
+#define USBHS_HSTIER_PEP_3_Pos              11                                             /**< (USBHS_HSTIER) Pipe 3 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_3_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_3_Pos)           /**< (USBHS_HSTIER) Pipe 3 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_3                  USBHS_HSTIER_PEP_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_3_Msk instead */
+#define USBHS_HSTIER_PEP_4_Pos              12                                             /**< (USBHS_HSTIER) Pipe 4 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_4_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_4_Pos)           /**< (USBHS_HSTIER) Pipe 4 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_4                  USBHS_HSTIER_PEP_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_4_Msk instead */
+#define USBHS_HSTIER_PEP_5_Pos              13                                             /**< (USBHS_HSTIER) Pipe 5 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_5_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_5_Pos)           /**< (USBHS_HSTIER) Pipe 5 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_5                  USBHS_HSTIER_PEP_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_5_Msk instead */
+#define USBHS_HSTIER_PEP_6_Pos              14                                             /**< (USBHS_HSTIER) Pipe 6 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_6_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_6_Pos)           /**< (USBHS_HSTIER) Pipe 6 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_6                  USBHS_HSTIER_PEP_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_6_Msk instead */
+#define USBHS_HSTIER_PEP_7_Pos              15                                             /**< (USBHS_HSTIER) Pipe 7 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_7_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_7_Pos)           /**< (USBHS_HSTIER) Pipe 7 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_7                  USBHS_HSTIER_PEP_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_7_Msk instead */
+#define USBHS_HSTIER_PEP_8_Pos              16                                             /**< (USBHS_HSTIER) Pipe 8 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_8_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_8_Pos)           /**< (USBHS_HSTIER) Pipe 8 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_8                  USBHS_HSTIER_PEP_8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_8_Msk instead */
+#define USBHS_HSTIER_PEP_9_Pos              17                                             /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Position */
+#define USBHS_HSTIER_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_9_Pos)           /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Mask */
+#define USBHS_HSTIER_PEP_9                  USBHS_HSTIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_9_Msk instead */
+#define USBHS_HSTIER_DMA_0_Pos              25                                             /**< (USBHS_HSTIER) DMA Channel 0 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_0_Pos)           /**< (USBHS_HSTIER) DMA Channel 0 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_0                  USBHS_HSTIER_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_0_Msk instead */
+#define USBHS_HSTIER_DMA_1_Pos              26                                             /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_1_Pos)           /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_1                  USBHS_HSTIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_1_Msk instead */
+#define USBHS_HSTIER_DMA_2_Pos              27                                             /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_2_Pos)           /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_2                  USBHS_HSTIER_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_2_Msk instead */
+#define USBHS_HSTIER_DMA_3_Pos              28                                             /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_3_Pos)           /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_3                  USBHS_HSTIER_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_3_Msk instead */
+#define USBHS_HSTIER_DMA_4_Pos              29                                             /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_4_Pos)           /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_4                  USBHS_HSTIER_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_4_Msk instead */
+#define USBHS_HSTIER_DMA_5_Pos              30                                             /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_5_Pos)           /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_5                  USBHS_HSTIER_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_5_Msk instead */
+#define USBHS_HSTIER_DMA_6_Pos              31                                             /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_6_Pos)           /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_6                  USBHS_HSTIER_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_6_Msk instead */
+#define USBHS_HSTIER_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIER) Register MASK  (Use USBHS_HSTIER_Msk instead)  */
+#define USBHS_HSTIER_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIER) Register Mask  */
+
+#define USBHS_HSTIER_PEP__Pos               8                                              /**< (USBHS_HSTIER Position) Pipe x Interrupt Enable */
+#define USBHS_HSTIER_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIER_PEP__Pos)          /**< (USBHS_HSTIER Mask) PEP_ */
+#define USBHS_HSTIER_PEP_(value)            (USBHS_HSTIER_PEP__Msk & ((value) << USBHS_HSTIER_PEP__Pos))  
+#define USBHS_HSTIER_DMA__Pos               25                                             /**< (USBHS_HSTIER Position) DMA Channel 6 Interrupt Enable */
+#define USBHS_HSTIER_DMA__Msk               (_U_(0x7F) << USBHS_HSTIER_DMA__Pos)           /**< (USBHS_HSTIER Mask) DMA_ */
+#define USBHS_HSTIER_DMA_(value)            (USBHS_HSTIER_DMA__Msk & ((value) << USBHS_HSTIER_DMA__Pos))  
+
+/* -------- USBHS_HSTPIP : (USBHS Offset: 0x41c) (R/W 32) Host Pipe Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PEN0:1;                    /**< bit:      0  Pipe 0 Enable                            */
+    uint32_t PEN1:1;                    /**< bit:      1  Pipe 1 Enable                            */
+    uint32_t PEN2:1;                    /**< bit:      2  Pipe 2 Enable                            */
+    uint32_t PEN3:1;                    /**< bit:      3  Pipe 3 Enable                            */
+    uint32_t PEN4:1;                    /**< bit:      4  Pipe 4 Enable                            */
+    uint32_t PEN5:1;                    /**< bit:      5  Pipe 5 Enable                            */
+    uint32_t PEN6:1;                    /**< bit:      6  Pipe 6 Enable                            */
+    uint32_t PEN7:1;                    /**< bit:      7  Pipe 7 Enable                            */
+    uint32_t PEN8:1;                    /**< bit:      8  Pipe 8 Enable                            */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PRST0:1;                   /**< bit:     16  Pipe 0 Reset                             */
+    uint32_t PRST1:1;                   /**< bit:     17  Pipe 1 Reset                             */
+    uint32_t PRST2:1;                   /**< bit:     18  Pipe 2 Reset                             */
+    uint32_t PRST3:1;                   /**< bit:     19  Pipe 3 Reset                             */
+    uint32_t PRST4:1;                   /**< bit:     20  Pipe 4 Reset                             */
+    uint32_t PRST5:1;                   /**< bit:     21  Pipe 5 Reset                             */
+    uint32_t PRST6:1;                   /**< bit:     22  Pipe 6 Reset                             */
+    uint32_t PRST7:1;                   /**< bit:     23  Pipe 7 Reset                             */
+    uint32_t PRST8:1;                   /**< bit:     24  Pipe 8 Reset                             */
+    uint32_t :7;                        /**< bit: 25..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t PEN:9;                     /**< bit:   0..8  Pipe x Enable                            */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PRST:9;                    /**< bit: 16..24  Pipe 8 Reset                             */
+    uint32_t :7;                        /**< bit: 25..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIP_OFFSET                 (0x41C)                                       /**<  (USBHS_HSTPIP) Host Pipe Register  Offset */
+
+#define USBHS_HSTPIP_PEN0_Pos               0                                              /**< (USBHS_HSTPIP) Pipe 0 Enable Position */
+#define USBHS_HSTPIP_PEN0_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN0_Pos)            /**< (USBHS_HSTPIP) Pipe 0 Enable Mask */
+#define USBHS_HSTPIP_PEN0                   USBHS_HSTPIP_PEN0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN0_Msk instead */
+#define USBHS_HSTPIP_PEN1_Pos               1                                              /**< (USBHS_HSTPIP) Pipe 1 Enable Position */
+#define USBHS_HSTPIP_PEN1_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN1_Pos)            /**< (USBHS_HSTPIP) Pipe 1 Enable Mask */
+#define USBHS_HSTPIP_PEN1                   USBHS_HSTPIP_PEN1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN1_Msk instead */
+#define USBHS_HSTPIP_PEN2_Pos               2                                              /**< (USBHS_HSTPIP) Pipe 2 Enable Position */
+#define USBHS_HSTPIP_PEN2_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN2_Pos)            /**< (USBHS_HSTPIP) Pipe 2 Enable Mask */
+#define USBHS_HSTPIP_PEN2                   USBHS_HSTPIP_PEN2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN2_Msk instead */
+#define USBHS_HSTPIP_PEN3_Pos               3                                              /**< (USBHS_HSTPIP) Pipe 3 Enable Position */
+#define USBHS_HSTPIP_PEN3_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN3_Pos)            /**< (USBHS_HSTPIP) Pipe 3 Enable Mask */
+#define USBHS_HSTPIP_PEN3                   USBHS_HSTPIP_PEN3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN3_Msk instead */
+#define USBHS_HSTPIP_PEN4_Pos               4                                              /**< (USBHS_HSTPIP) Pipe 4 Enable Position */
+#define USBHS_HSTPIP_PEN4_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN4_Pos)            /**< (USBHS_HSTPIP) Pipe 4 Enable Mask */
+#define USBHS_HSTPIP_PEN4                   USBHS_HSTPIP_PEN4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN4_Msk instead */
+#define USBHS_HSTPIP_PEN5_Pos               5                                              /**< (USBHS_HSTPIP) Pipe 5 Enable Position */
+#define USBHS_HSTPIP_PEN5_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN5_Pos)            /**< (USBHS_HSTPIP) Pipe 5 Enable Mask */
+#define USBHS_HSTPIP_PEN5                   USBHS_HSTPIP_PEN5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN5_Msk instead */
+#define USBHS_HSTPIP_PEN6_Pos               6                                              /**< (USBHS_HSTPIP) Pipe 6 Enable Position */
+#define USBHS_HSTPIP_PEN6_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN6_Pos)            /**< (USBHS_HSTPIP) Pipe 6 Enable Mask */
+#define USBHS_HSTPIP_PEN6                   USBHS_HSTPIP_PEN6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN6_Msk instead */
+#define USBHS_HSTPIP_PEN7_Pos               7                                              /**< (USBHS_HSTPIP) Pipe 7 Enable Position */
+#define USBHS_HSTPIP_PEN7_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN7_Pos)            /**< (USBHS_HSTPIP) Pipe 7 Enable Mask */
+#define USBHS_HSTPIP_PEN7                   USBHS_HSTPIP_PEN7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN7_Msk instead */
+#define USBHS_HSTPIP_PEN8_Pos               8                                              /**< (USBHS_HSTPIP) Pipe 8 Enable Position */
+#define USBHS_HSTPIP_PEN8_Msk               (_U_(0x1) << USBHS_HSTPIP_PEN8_Pos)            /**< (USBHS_HSTPIP) Pipe 8 Enable Mask */
+#define USBHS_HSTPIP_PEN8                   USBHS_HSTPIP_PEN8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PEN8_Msk instead */
+#define USBHS_HSTPIP_PRST0_Pos              16                                             /**< (USBHS_HSTPIP) Pipe 0 Reset Position */
+#define USBHS_HSTPIP_PRST0_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST0_Pos)           /**< (USBHS_HSTPIP) Pipe 0 Reset Mask */
+#define USBHS_HSTPIP_PRST0                  USBHS_HSTPIP_PRST0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST0_Msk instead */
+#define USBHS_HSTPIP_PRST1_Pos              17                                             /**< (USBHS_HSTPIP) Pipe 1 Reset Position */
+#define USBHS_HSTPIP_PRST1_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST1_Pos)           /**< (USBHS_HSTPIP) Pipe 1 Reset Mask */
+#define USBHS_HSTPIP_PRST1                  USBHS_HSTPIP_PRST1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST1_Msk instead */
+#define USBHS_HSTPIP_PRST2_Pos              18                                             /**< (USBHS_HSTPIP) Pipe 2 Reset Position */
+#define USBHS_HSTPIP_PRST2_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST2_Pos)           /**< (USBHS_HSTPIP) Pipe 2 Reset Mask */
+#define USBHS_HSTPIP_PRST2                  USBHS_HSTPIP_PRST2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST2_Msk instead */
+#define USBHS_HSTPIP_PRST3_Pos              19                                             /**< (USBHS_HSTPIP) Pipe 3 Reset Position */
+#define USBHS_HSTPIP_PRST3_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST3_Pos)           /**< (USBHS_HSTPIP) Pipe 3 Reset Mask */
+#define USBHS_HSTPIP_PRST3                  USBHS_HSTPIP_PRST3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST3_Msk instead */
+#define USBHS_HSTPIP_PRST4_Pos              20                                             /**< (USBHS_HSTPIP) Pipe 4 Reset Position */
+#define USBHS_HSTPIP_PRST4_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST4_Pos)           /**< (USBHS_HSTPIP) Pipe 4 Reset Mask */
+#define USBHS_HSTPIP_PRST4                  USBHS_HSTPIP_PRST4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST4_Msk instead */
+#define USBHS_HSTPIP_PRST5_Pos              21                                             /**< (USBHS_HSTPIP) Pipe 5 Reset Position */
+#define USBHS_HSTPIP_PRST5_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST5_Pos)           /**< (USBHS_HSTPIP) Pipe 5 Reset Mask */
+#define USBHS_HSTPIP_PRST5                  USBHS_HSTPIP_PRST5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST5_Msk instead */
+#define USBHS_HSTPIP_PRST6_Pos              22                                             /**< (USBHS_HSTPIP) Pipe 6 Reset Position */
+#define USBHS_HSTPIP_PRST6_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST6_Pos)           /**< (USBHS_HSTPIP) Pipe 6 Reset Mask */
+#define USBHS_HSTPIP_PRST6                  USBHS_HSTPIP_PRST6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST6_Msk instead */
+#define USBHS_HSTPIP_PRST7_Pos              23                                             /**< (USBHS_HSTPIP) Pipe 7 Reset Position */
+#define USBHS_HSTPIP_PRST7_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST7_Pos)           /**< (USBHS_HSTPIP) Pipe 7 Reset Mask */
+#define USBHS_HSTPIP_PRST7                  USBHS_HSTPIP_PRST7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST7_Msk instead */
+#define USBHS_HSTPIP_PRST8_Pos              24                                             /**< (USBHS_HSTPIP) Pipe 8 Reset Position */
+#define USBHS_HSTPIP_PRST8_Msk              (_U_(0x1) << USBHS_HSTPIP_PRST8_Pos)           /**< (USBHS_HSTPIP) Pipe 8 Reset Mask */
+#define USBHS_HSTPIP_PRST8                  USBHS_HSTPIP_PRST8_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIP_PRST8_Msk instead */
+#define USBHS_HSTPIP_MASK                   _U_(0x1FF01FF)                                 /**< \deprecated (USBHS_HSTPIP) Register MASK  (Use USBHS_HSTPIP_Msk instead)  */
+#define USBHS_HSTPIP_Msk                    _U_(0x1FF01FF)                                 /**< (USBHS_HSTPIP) Register Mask  */
+
+#define USBHS_HSTPIP_PEN_Pos                0                                              /**< (USBHS_HSTPIP Position) Pipe x Enable */
+#define USBHS_HSTPIP_PEN_Msk                (_U_(0x1FF) << USBHS_HSTPIP_PEN_Pos)           /**< (USBHS_HSTPIP Mask) PEN */
+#define USBHS_HSTPIP_PEN(value)             (USBHS_HSTPIP_PEN_Msk & ((value) << USBHS_HSTPIP_PEN_Pos))  
+#define USBHS_HSTPIP_PRST_Pos               16                                             /**< (USBHS_HSTPIP Position) Pipe 8 Reset */
+#define USBHS_HSTPIP_PRST_Msk               (_U_(0x1FF) << USBHS_HSTPIP_PRST_Pos)          /**< (USBHS_HSTPIP Mask) PRST */
+#define USBHS_HSTPIP_PRST(value)            (USBHS_HSTPIP_PRST_Msk & ((value) << USBHS_HSTPIP_PRST_Pos))  
+
+/* -------- USBHS_HSTFNUM : (USBHS Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
+    uint32_t FNUM:11;                   /**< bit:  3..13  Frame Number                             */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t FLENHIGH:8;                /**< bit: 16..23  Frame Length                             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTFNUM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTFNUM_OFFSET                (0x420)                                       /**<  (USBHS_HSTFNUM) Host Frame Number Register  Offset */
+
+#define USBHS_HSTFNUM_MFNUM_Pos             0                                              /**< (USBHS_HSTFNUM) Micro Frame Number Position */
+#define USBHS_HSTFNUM_MFNUM_Msk             (_U_(0x7) << USBHS_HSTFNUM_MFNUM_Pos)          /**< (USBHS_HSTFNUM) Micro Frame Number Mask */
+#define USBHS_HSTFNUM_MFNUM(value)          (USBHS_HSTFNUM_MFNUM_Msk & ((value) << USBHS_HSTFNUM_MFNUM_Pos))
+#define USBHS_HSTFNUM_FNUM_Pos              3                                              /**< (USBHS_HSTFNUM) Frame Number Position */
+#define USBHS_HSTFNUM_FNUM_Msk              (_U_(0x7FF) << USBHS_HSTFNUM_FNUM_Pos)         /**< (USBHS_HSTFNUM) Frame Number Mask */
+#define USBHS_HSTFNUM_FNUM(value)           (USBHS_HSTFNUM_FNUM_Msk & ((value) << USBHS_HSTFNUM_FNUM_Pos))
+#define USBHS_HSTFNUM_FLENHIGH_Pos          16                                             /**< (USBHS_HSTFNUM) Frame Length Position */
+#define USBHS_HSTFNUM_FLENHIGH_Msk          (_U_(0xFF) << USBHS_HSTFNUM_FLENHIGH_Pos)      /**< (USBHS_HSTFNUM) Frame Length Mask */
+#define USBHS_HSTFNUM_FLENHIGH(value)       (USBHS_HSTFNUM_FLENHIGH_Msk & ((value) << USBHS_HSTFNUM_FLENHIGH_Pos))
+#define USBHS_HSTFNUM_MASK                  _U_(0xFF3FFF)                                  /**< \deprecated (USBHS_HSTFNUM) Register MASK  (Use USBHS_HSTFNUM_Msk instead)  */
+#define USBHS_HSTFNUM_Msk                   _U_(0xFF3FFF)                                  /**< (USBHS_HSTFNUM) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR1 : (USBHS Offset: 0x424) (R/W 32) Host Address 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP0:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP1:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HSTADDRP2:7;               /**< bit: 16..22  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t HSTADDRP3:7;               /**< bit: 24..30  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR1_OFFSET               (0x424)                                       /**<  (USBHS_HSTADDR1) Host Address 1 Register  Offset */
+
+#define USBHS_HSTADDR1_HSTADDRP0_Pos        0                                              /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP0_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP0_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP0(value)     (USBHS_HSTADDR1_HSTADDRP0_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP0_Pos))
+#define USBHS_HSTADDR1_HSTADDRP1_Pos        8                                              /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP1_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP1_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP1(value)     (USBHS_HSTADDR1_HSTADDRP1_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP1_Pos))
+#define USBHS_HSTADDR1_HSTADDRP2_Pos        16                                             /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP2_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP2_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP2(value)     (USBHS_HSTADDR1_HSTADDRP2_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP2_Pos))
+#define USBHS_HSTADDR1_HSTADDRP3_Pos        24                                             /**< (USBHS_HSTADDR1) USB Host Address Position */
+#define USBHS_HSTADDR1_HSTADDRP3_Msk        (_U_(0x7F) << USBHS_HSTADDR1_HSTADDRP3_Pos)    /**< (USBHS_HSTADDR1) USB Host Address Mask */
+#define USBHS_HSTADDR1_HSTADDRP3(value)     (USBHS_HSTADDR1_HSTADDRP3_Msk & ((value) << USBHS_HSTADDR1_HSTADDRP3_Pos))
+#define USBHS_HSTADDR1_MASK                 _U_(0x7F7F7F7F)                                /**< \deprecated (USBHS_HSTADDR1) Register MASK  (Use USBHS_HSTADDR1_Msk instead)  */
+#define USBHS_HSTADDR1_Msk                  _U_(0x7F7F7F7F)                                /**< (USBHS_HSTADDR1) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR2 : (USBHS Offset: 0x428) (R/W 32) Host Address 2 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP4:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP5:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t HSTADDRP6:7;               /**< bit: 16..22  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     23  Reserved */
+    uint32_t HSTADDRP7:7;               /**< bit: 24..30  USB Host Address                         */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR2_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR2_OFFSET               (0x428)                                       /**<  (USBHS_HSTADDR2) Host Address 2 Register  Offset */
+
+#define USBHS_HSTADDR2_HSTADDRP4_Pos        0                                              /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP4_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP4_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP4(value)     (USBHS_HSTADDR2_HSTADDRP4_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP4_Pos))
+#define USBHS_HSTADDR2_HSTADDRP5_Pos        8                                              /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP5_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP5_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP5(value)     (USBHS_HSTADDR2_HSTADDRP5_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP5_Pos))
+#define USBHS_HSTADDR2_HSTADDRP6_Pos        16                                             /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP6_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP6_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP6(value)     (USBHS_HSTADDR2_HSTADDRP6_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP6_Pos))
+#define USBHS_HSTADDR2_HSTADDRP7_Pos        24                                             /**< (USBHS_HSTADDR2) USB Host Address Position */
+#define USBHS_HSTADDR2_HSTADDRP7_Msk        (_U_(0x7F) << USBHS_HSTADDR2_HSTADDRP7_Pos)    /**< (USBHS_HSTADDR2) USB Host Address Mask */
+#define USBHS_HSTADDR2_HSTADDRP7(value)     (USBHS_HSTADDR2_HSTADDRP7_Msk & ((value) << USBHS_HSTADDR2_HSTADDRP7_Pos))
+#define USBHS_HSTADDR2_MASK                 _U_(0x7F7F7F7F)                                /**< \deprecated (USBHS_HSTADDR2) Register MASK  (Use USBHS_HSTADDR2_Msk instead)  */
+#define USBHS_HSTADDR2_Msk                  _U_(0x7F7F7F7F)                                /**< (USBHS_HSTADDR2) Register Mask  */
+
+
+/* -------- USBHS_HSTADDR3 : (USBHS Offset: 0x42c) (R/W 32) Host Address 3 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t HSTADDRP8:7;               /**< bit:   0..6  USB Host Address                         */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t HSTADDRP9:7;               /**< bit:  8..14  USB Host Address                         */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTADDR3_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTADDR3_OFFSET               (0x42C)                                       /**<  (USBHS_HSTADDR3) Host Address 3 Register  Offset */
+
+#define USBHS_HSTADDR3_HSTADDRP8_Pos        0                                              /**< (USBHS_HSTADDR3) USB Host Address Position */
+#define USBHS_HSTADDR3_HSTADDRP8_Msk        (_U_(0x7F) << USBHS_HSTADDR3_HSTADDRP8_Pos)    /**< (USBHS_HSTADDR3) USB Host Address Mask */
+#define USBHS_HSTADDR3_HSTADDRP8(value)     (USBHS_HSTADDR3_HSTADDRP8_Msk & ((value) << USBHS_HSTADDR3_HSTADDRP8_Pos))
+#define USBHS_HSTADDR3_HSTADDRP9_Pos        8                                              /**< (USBHS_HSTADDR3) USB Host Address Position */
+#define USBHS_HSTADDR3_HSTADDRP9_Msk        (_U_(0x7F) << USBHS_HSTADDR3_HSTADDRP9_Pos)    /**< (USBHS_HSTADDR3) USB Host Address Mask */
+#define USBHS_HSTADDR3_HSTADDRP9(value)     (USBHS_HSTADDR3_HSTADDRP9_Msk & ((value) << USBHS_HSTADDR3_HSTADDRP9_Pos))
+#define USBHS_HSTADDR3_MASK                 _U_(0x7F7F)                                    /**< \deprecated (USBHS_HSTADDR3) Register MASK  (Use USBHS_HSTADDR3_Msk instead)  */
+#define USBHS_HSTADDR3_Msk                  _U_(0x7F7F)                                    /**< (USBHS_HSTADDR3) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPCFG : (USBHS Offset: 0x500) (R/W 32) Host Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :1;                        /**< bit:      0  Reserved */
+    uint32_t ALLOC:1;                   /**< bit:      1  Pipe Memory Allocate                     */
+    uint32_t PBK:2;                     /**< bit:   2..3  Pipe Banks                               */
+    uint32_t PSIZE:3;                   /**< bit:   4..6  Pipe Size                                */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t PTOKEN:2;                  /**< bit:   8..9  Pipe Token                               */
+    uint32_t AUTOSW:1;                  /**< bit:     10  Automatic Switch                         */
+    uint32_t :1;                        /**< bit:     11  Reserved */
+    uint32_t PTYPE:2;                   /**< bit: 12..13  Pipe Type                                */
+    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t PEPNUM:4;                  /**< bit: 16..19  Pipe Endpoint Number                     */
+    uint32_t :4;                        /**< bit: 20..23  Reserved */
+    uint32_t INTFRQ:8;                  /**< bit: 24..31  Pipe Interrupt Request Frequency         */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL_BULK mode
+    uint32_t :20;                       /**< bit:  0..19  Reserved */
+    uint32_t PINGEN:1;                  /**< bit:     20  Ping Enable                              */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t BINTERVAL:8;               /**< bit: 24..31  bInterval Parameter for the Bulk-Out/Ping Transaction */
+  } CTRL_BULK;                                /**< Structure used for CTRL_BULK mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPCFG_OFFSET              (0x500)                                       /**<  (USBHS_HSTPIPCFG) Host Pipe Configuration Register  Offset */
+
+#define USBHS_HSTPIPCFG_ALLOC_Pos           1                                              /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Position */
+#define USBHS_HSTPIPCFG_ALLOC_Msk           (_U_(0x1) << USBHS_HSTPIPCFG_ALLOC_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Mask */
+#define USBHS_HSTPIPCFG_ALLOC               USBHS_HSTPIPCFG_ALLOC_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_ALLOC_Msk instead */
+#define USBHS_HSTPIPCFG_PBK_Pos             2                                              /**< (USBHS_HSTPIPCFG) Pipe Banks Position */
+#define USBHS_HSTPIPCFG_PBK_Msk             (_U_(0x3) << USBHS_HSTPIPCFG_PBK_Pos)          /**< (USBHS_HSTPIPCFG) Pipe Banks Mask */
+#define USBHS_HSTPIPCFG_PBK(value)          (USBHS_HSTPIPCFG_PBK_Msk & ((value) << USBHS_HSTPIPCFG_PBK_Pos))
+#define   USBHS_HSTPIPCFG_PBK_1_BANK_Val    _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) Single-bank pipe  */
+#define   USBHS_HSTPIPCFG_PBK_2_BANK_Val    _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) Double-bank pipe  */
+#define   USBHS_HSTPIPCFG_PBK_3_BANK_Val    _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) Triple-bank pipe  */
+#define USBHS_HSTPIPCFG_PBK_1_BANK          (USBHS_HSTPIPCFG_PBK_1_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Single-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PBK_2_BANK          (USBHS_HSTPIPCFG_PBK_2_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Double-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PBK_3_BANK          (USBHS_HSTPIPCFG_PBK_3_BANK_Val << USBHS_HSTPIPCFG_PBK_Pos)  /**< (USBHS_HSTPIPCFG) Triple-bank pipe Position  */
+#define USBHS_HSTPIPCFG_PSIZE_Pos           4                                              /**< (USBHS_HSTPIPCFG) Pipe Size Position */
+#define USBHS_HSTPIPCFG_PSIZE_Msk           (_U_(0x7) << USBHS_HSTPIPCFG_PSIZE_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Size Mask */
+#define USBHS_HSTPIPCFG_PSIZE(value)        (USBHS_HSTPIPCFG_PSIZE_Msk & ((value) << USBHS_HSTPIPCFG_PSIZE_Pos))
+#define   USBHS_HSTPIPCFG_PSIZE_8_BYTE_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) 8 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_16_BYTE_Val _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) 16 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_32_BYTE_Val _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) 32 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_64_BYTE_Val _U_(0x3)                                       /**< (USBHS_HSTPIPCFG) 64 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_128_BYTE_Val _U_(0x4)                                       /**< (USBHS_HSTPIPCFG) 128 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_256_BYTE_Val _U_(0x5)                                       /**< (USBHS_HSTPIPCFG) 256 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_512_BYTE_Val _U_(0x6)                                       /**< (USBHS_HSTPIPCFG) 512 bytes  */
+#define   USBHS_HSTPIPCFG_PSIZE_1024_BYTE_Val _U_(0x7)                                       /**< (USBHS_HSTPIPCFG) 1024 bytes  */
+#define USBHS_HSTPIPCFG_PSIZE_8_BYTE        (USBHS_HSTPIPCFG_PSIZE_8_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 8 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_16_BYTE       (USBHS_HSTPIPCFG_PSIZE_16_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 16 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_32_BYTE       (USBHS_HSTPIPCFG_PSIZE_32_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 32 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_64_BYTE       (USBHS_HSTPIPCFG_PSIZE_64_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 64 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_128_BYTE      (USBHS_HSTPIPCFG_PSIZE_128_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 128 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_256_BYTE      (USBHS_HSTPIPCFG_PSIZE_256_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 256 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_512_BYTE      (USBHS_HSTPIPCFG_PSIZE_512_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 512 bytes Position  */
+#define USBHS_HSTPIPCFG_PSIZE_1024_BYTE     (USBHS_HSTPIPCFG_PSIZE_1024_BYTE_Val << USBHS_HSTPIPCFG_PSIZE_Pos)  /**< (USBHS_HSTPIPCFG) 1024 bytes Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_Pos          8                                              /**< (USBHS_HSTPIPCFG) Pipe Token Position */
+#define USBHS_HSTPIPCFG_PTOKEN_Msk          (_U_(0x3) << USBHS_HSTPIPCFG_PTOKEN_Pos)       /**< (USBHS_HSTPIPCFG) Pipe Token Mask */
+#define USBHS_HSTPIPCFG_PTOKEN(value)       (USBHS_HSTPIPCFG_PTOKEN_Msk & ((value) << USBHS_HSTPIPCFG_PTOKEN_Pos))
+#define   USBHS_HSTPIPCFG_PTOKEN_SETUP_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) SETUP  */
+#define   USBHS_HSTPIPCFG_PTOKEN_IN_Val     _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) IN  */
+#define   USBHS_HSTPIPCFG_PTOKEN_OUT_Val    _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) OUT  */
+#define USBHS_HSTPIPCFG_PTOKEN_SETUP        (USBHS_HSTPIPCFG_PTOKEN_SETUP_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) SETUP Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_IN           (USBHS_HSTPIPCFG_PTOKEN_IN_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) IN Position  */
+#define USBHS_HSTPIPCFG_PTOKEN_OUT          (USBHS_HSTPIPCFG_PTOKEN_OUT_Val << USBHS_HSTPIPCFG_PTOKEN_Pos)  /**< (USBHS_HSTPIPCFG) OUT Position  */
+#define USBHS_HSTPIPCFG_AUTOSW_Pos          10                                             /**< (USBHS_HSTPIPCFG) Automatic Switch Position */
+#define USBHS_HSTPIPCFG_AUTOSW_Msk          (_U_(0x1) << USBHS_HSTPIPCFG_AUTOSW_Pos)       /**< (USBHS_HSTPIPCFG) Automatic Switch Mask */
+#define USBHS_HSTPIPCFG_AUTOSW              USBHS_HSTPIPCFG_AUTOSW_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_AUTOSW_Msk instead */
+#define USBHS_HSTPIPCFG_PTYPE_Pos           12                                             /**< (USBHS_HSTPIPCFG) Pipe Type Position */
+#define USBHS_HSTPIPCFG_PTYPE_Msk           (_U_(0x3) << USBHS_HSTPIPCFG_PTYPE_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Type Mask */
+#define USBHS_HSTPIPCFG_PTYPE(value)        (USBHS_HSTPIPCFG_PTYPE_Msk & ((value) << USBHS_HSTPIPCFG_PTYPE_Pos))
+#define   USBHS_HSTPIPCFG_PTYPE_CTRL_Val    _U_(0x0)                                       /**< (USBHS_HSTPIPCFG) Control  */
+#define   USBHS_HSTPIPCFG_PTYPE_ISO_Val     _U_(0x1)                                       /**< (USBHS_HSTPIPCFG) Isochronous  */
+#define   USBHS_HSTPIPCFG_PTYPE_BLK_Val     _U_(0x2)                                       /**< (USBHS_HSTPIPCFG) Bulk  */
+#define   USBHS_HSTPIPCFG_PTYPE_INTRPT_Val  _U_(0x3)                                       /**< (USBHS_HSTPIPCFG) Interrupt  */
+#define USBHS_HSTPIPCFG_PTYPE_CTRL          (USBHS_HSTPIPCFG_PTYPE_CTRL_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Control Position  */
+#define USBHS_HSTPIPCFG_PTYPE_ISO           (USBHS_HSTPIPCFG_PTYPE_ISO_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Isochronous Position  */
+#define USBHS_HSTPIPCFG_PTYPE_BLK           (USBHS_HSTPIPCFG_PTYPE_BLK_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Bulk Position  */
+#define USBHS_HSTPIPCFG_PTYPE_INTRPT        (USBHS_HSTPIPCFG_PTYPE_INTRPT_Val << USBHS_HSTPIPCFG_PTYPE_Pos)  /**< (USBHS_HSTPIPCFG) Interrupt Position  */
+#define USBHS_HSTPIPCFG_PEPNUM_Pos          16                                             /**< (USBHS_HSTPIPCFG) Pipe Endpoint Number Position */
+#define USBHS_HSTPIPCFG_PEPNUM_Msk          (_U_(0xF) << USBHS_HSTPIPCFG_PEPNUM_Pos)       /**< (USBHS_HSTPIPCFG) Pipe Endpoint Number Mask */
+#define USBHS_HSTPIPCFG_PEPNUM(value)       (USBHS_HSTPIPCFG_PEPNUM_Msk & ((value) << USBHS_HSTPIPCFG_PEPNUM_Pos))
+#define USBHS_HSTPIPCFG_INTFRQ_Pos          24                                             /**< (USBHS_HSTPIPCFG) Pipe Interrupt Request Frequency Position */
+#define USBHS_HSTPIPCFG_INTFRQ_Msk          (_U_(0xFF) << USBHS_HSTPIPCFG_INTFRQ_Pos)      /**< (USBHS_HSTPIPCFG) Pipe Interrupt Request Frequency Mask */
+#define USBHS_HSTPIPCFG_INTFRQ(value)       (USBHS_HSTPIPCFG_INTFRQ_Msk & ((value) << USBHS_HSTPIPCFG_INTFRQ_Pos))
+#define USBHS_HSTPIPCFG_MASK                _U_(0xFF0F377E)                                /**< \deprecated (USBHS_HSTPIPCFG) Register MASK  (Use USBHS_HSTPIPCFG_Msk instead)  */
+#define USBHS_HSTPIPCFG_Msk                 _U_(0xFF0F377E)                                /**< (USBHS_HSTPIPCFG) Register Mask  */
+
+/* CTRL_BULK mode */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Pos 20                                             /**< (USBHS_HSTPIPCFG) Ping Enable Position */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk (_U_(0x1) << USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Pos)  /**< (USBHS_HSTPIPCFG) Ping Enable Mask */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN    USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk instead */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos 24                                             /**< (USBHS_HSTPIPCFG) bInterval Parameter for the Bulk-Out/Ping Transaction Position */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Msk (_U_(0xFF) << USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos)  /**< (USBHS_HSTPIPCFG) bInterval Parameter for the Bulk-Out/Ping Transaction Mask */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL(value) (USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Msk & ((value) << USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos))
+#define USBHS_HSTPIPCFG_CTRL_BULK_MASK      _U_(0xFF100000)                                /**< \deprecated (USBHS_HSTPIPCFG_CTRL_BULK) Register MASK  (Use USBHS_HSTPIPCFG_CTRL_BULK_Msk instead)  */
+#define USBHS_HSTPIPCFG_CTRL_BULK_Msk       _U_(0xFF100000)                                /**< (USBHS_HSTPIPCFG_CTRL_BULK) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPISR : (USBHS Offset: 0x530) (R/ 32) Host Pipe Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINI:1;                   /**< bit:      0  Received IN Data Interrupt               */
+    uint32_t TXOUTI:1;                  /**< bit:      1  Transmitted OUT Data Interrupt           */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t PERRI:1;                   /**< bit:      3  Pipe Error Interrupt                     */
+    uint32_t NAKEDI:1;                  /**< bit:      4  NAKed Interrupt                          */
+    uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETI:1;            /**< bit:      7  Short Packet Interrupt                   */
+    uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
+    uint32_t :2;                        /**< bit: 10..11  Reserved */
+    uint32_t NBUSYBK:2;                 /**< bit: 12..13  Number of Busy Banks                     */
+    uint32_t CURRBK:2;                  /**< bit: 14..15  Current Bank                             */
+    uint32_t RWALL:1;                   /**< bit:     16  Read/Write Allowed                       */
+    uint32_t :1;                        /**< bit:     17  Reserved */
+    uint32_t CFGOK:1;                   /**< bit:     18  Configuration OK Status                  */
+    uint32_t :1;                        /**< bit:     19  Reserved */
+    uint32_t PBYCT:11;                  /**< bit: 20..30  Pipe Byte Count                          */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRI:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPISR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPISR_OFFSET              (0x530)                                       /**<  (USBHS_HSTPIPISR) Host Pipe Status Register  Offset */
+
+#define USBHS_HSTPIPISR_RXINI_Pos           0                                              /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Position */
+#define USBHS_HSTPIPISR_RXINI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_RXINI_Pos)        /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Mask */
+#define USBHS_HSTPIPISR_RXINI               USBHS_HSTPIPISR_RXINI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RXINI_Msk instead */
+#define USBHS_HSTPIPISR_TXOUTI_Pos          1                                              /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Position */
+#define USBHS_HSTPIPISR_TXOUTI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_TXOUTI_Pos)       /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Mask */
+#define USBHS_HSTPIPISR_TXOUTI              USBHS_HSTPIPISR_TXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXOUTI_Msk instead */
+#define USBHS_HSTPIPISR_PERRI_Pos           3                                              /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Position */
+#define USBHS_HSTPIPISR_PERRI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_PERRI_Pos)        /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Mask */
+#define USBHS_HSTPIPISR_PERRI               USBHS_HSTPIPISR_PERRI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_PERRI_Msk instead */
+#define USBHS_HSTPIPISR_NAKEDI_Pos          4                                              /**< (USBHS_HSTPIPISR) NAKed Interrupt Position */
+#define USBHS_HSTPIPISR_NAKEDI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_NAKEDI_Pos)       /**< (USBHS_HSTPIPISR) NAKed Interrupt Mask */
+#define USBHS_HSTPIPISR_NAKEDI              USBHS_HSTPIPISR_NAKEDI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_NAKEDI_Msk instead */
+#define USBHS_HSTPIPISR_OVERFI_Pos          5                                              /**< (USBHS_HSTPIPISR) Overflow Interrupt Position */
+#define USBHS_HSTPIPISR_OVERFI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_OVERFI_Pos)       /**< (USBHS_HSTPIPISR) Overflow Interrupt Mask */
+#define USBHS_HSTPIPISR_OVERFI              USBHS_HSTPIPISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_OVERFI_Msk instead */
+#define USBHS_HSTPIPISR_SHORTPACKETI_Pos    7                                              /**< (USBHS_HSTPIPISR) Short Packet Interrupt Position */
+#define USBHS_HSTPIPISR_SHORTPACKETI_Msk    (_U_(0x1) << USBHS_HSTPIPISR_SHORTPACKETI_Pos)  /**< (USBHS_HSTPIPISR) Short Packet Interrupt Mask */
+#define USBHS_HSTPIPISR_SHORTPACKETI        USBHS_HSTPIPISR_SHORTPACKETI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_SHORTPACKETI_Msk instead */
+#define USBHS_HSTPIPISR_DTSEQ_Pos           8                                              /**< (USBHS_HSTPIPISR) Data Toggle Sequence Position */
+#define USBHS_HSTPIPISR_DTSEQ_Msk           (_U_(0x3) << USBHS_HSTPIPISR_DTSEQ_Pos)        /**< (USBHS_HSTPIPISR) Data Toggle Sequence Mask */
+#define USBHS_HSTPIPISR_DTSEQ(value)        (USBHS_HSTPIPISR_DTSEQ_Msk & ((value) << USBHS_HSTPIPISR_DTSEQ_Pos))
+#define   USBHS_HSTPIPISR_DTSEQ_DATA0_Val   _U_(0x0)                                       /**< (USBHS_HSTPIPISR) Data0 toggle sequence  */
+#define   USBHS_HSTPIPISR_DTSEQ_DATA1_Val   _U_(0x1)                                       /**< (USBHS_HSTPIPISR) Data1 toggle sequence  */
+#define USBHS_HSTPIPISR_DTSEQ_DATA0         (USBHS_HSTPIPISR_DTSEQ_DATA0_Val << USBHS_HSTPIPISR_DTSEQ_Pos)  /**< (USBHS_HSTPIPISR) Data0 toggle sequence Position  */
+#define USBHS_HSTPIPISR_DTSEQ_DATA1         (USBHS_HSTPIPISR_DTSEQ_DATA1_Val << USBHS_HSTPIPISR_DTSEQ_Pos)  /**< (USBHS_HSTPIPISR) Data1 toggle sequence Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_Pos         12                                             /**< (USBHS_HSTPIPISR) Number of Busy Banks Position */
+#define USBHS_HSTPIPISR_NBUSYBK_Msk         (_U_(0x3) << USBHS_HSTPIPISR_NBUSYBK_Pos)      /**< (USBHS_HSTPIPISR) Number of Busy Banks Mask */
+#define USBHS_HSTPIPISR_NBUSYBK(value)      (USBHS_HSTPIPISR_NBUSYBK_Msk & ((value) << USBHS_HSTPIPISR_NBUSYBK_Pos))
+#define   USBHS_HSTPIPISR_NBUSYBK_0_BUSY_Val _U_(0x0)                                       /**< (USBHS_HSTPIPISR) 0 busy bank (all banks free)  */
+#define   USBHS_HSTPIPISR_NBUSYBK_1_BUSY_Val _U_(0x1)                                       /**< (USBHS_HSTPIPISR) 1 busy bank  */
+#define   USBHS_HSTPIPISR_NBUSYBK_2_BUSY_Val _U_(0x2)                                       /**< (USBHS_HSTPIPISR) 2 busy banks  */
+#define   USBHS_HSTPIPISR_NBUSYBK_3_BUSY_Val _U_(0x3)                                       /**< (USBHS_HSTPIPISR) 3 busy banks  */
+#define USBHS_HSTPIPISR_NBUSYBK_0_BUSY      (USBHS_HSTPIPISR_NBUSYBK_0_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 0 busy bank (all banks free) Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_1_BUSY      (USBHS_HSTPIPISR_NBUSYBK_1_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 1 busy bank Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_2_BUSY      (USBHS_HSTPIPISR_NBUSYBK_2_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 2 busy banks Position  */
+#define USBHS_HSTPIPISR_NBUSYBK_3_BUSY      (USBHS_HSTPIPISR_NBUSYBK_3_BUSY_Val << USBHS_HSTPIPISR_NBUSYBK_Pos)  /**< (USBHS_HSTPIPISR) 3 busy banks Position  */
+#define USBHS_HSTPIPISR_CURRBK_Pos          14                                             /**< (USBHS_HSTPIPISR) Current Bank Position */
+#define USBHS_HSTPIPISR_CURRBK_Msk          (_U_(0x3) << USBHS_HSTPIPISR_CURRBK_Pos)       /**< (USBHS_HSTPIPISR) Current Bank Mask */
+#define USBHS_HSTPIPISR_CURRBK(value)       (USBHS_HSTPIPISR_CURRBK_Msk & ((value) << USBHS_HSTPIPISR_CURRBK_Pos))
+#define   USBHS_HSTPIPISR_CURRBK_BANK0_Val  _U_(0x0)                                       /**< (USBHS_HSTPIPISR) Current bank is bank0  */
+#define   USBHS_HSTPIPISR_CURRBK_BANK1_Val  _U_(0x1)                                       /**< (USBHS_HSTPIPISR) Current bank is bank1  */
+#define   USBHS_HSTPIPISR_CURRBK_BANK2_Val  _U_(0x2)                                       /**< (USBHS_HSTPIPISR) Current bank is bank2  */
+#define USBHS_HSTPIPISR_CURRBK_BANK0        (USBHS_HSTPIPISR_CURRBK_BANK0_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank0 Position  */
+#define USBHS_HSTPIPISR_CURRBK_BANK1        (USBHS_HSTPIPISR_CURRBK_BANK1_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank1 Position  */
+#define USBHS_HSTPIPISR_CURRBK_BANK2        (USBHS_HSTPIPISR_CURRBK_BANK2_Val << USBHS_HSTPIPISR_CURRBK_Pos)  /**< (USBHS_HSTPIPISR) Current bank is bank2 Position  */
+#define USBHS_HSTPIPISR_RWALL_Pos           16                                             /**< (USBHS_HSTPIPISR) Read/Write Allowed Position */
+#define USBHS_HSTPIPISR_RWALL_Msk           (_U_(0x1) << USBHS_HSTPIPISR_RWALL_Pos)        /**< (USBHS_HSTPIPISR) Read/Write Allowed Mask */
+#define USBHS_HSTPIPISR_RWALL               USBHS_HSTPIPISR_RWALL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RWALL_Msk instead */
+#define USBHS_HSTPIPISR_CFGOK_Pos           18                                             /**< (USBHS_HSTPIPISR) Configuration OK Status Position */
+#define USBHS_HSTPIPISR_CFGOK_Msk           (_U_(0x1) << USBHS_HSTPIPISR_CFGOK_Pos)        /**< (USBHS_HSTPIPISR) Configuration OK Status Mask */
+#define USBHS_HSTPIPISR_CFGOK               USBHS_HSTPIPISR_CFGOK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CFGOK_Msk instead */
+#define USBHS_HSTPIPISR_PBYCT_Pos           20                                             /**< (USBHS_HSTPIPISR) Pipe Byte Count Position */
+#define USBHS_HSTPIPISR_PBYCT_Msk           (_U_(0x7FF) << USBHS_HSTPIPISR_PBYCT_Pos)      /**< (USBHS_HSTPIPISR) Pipe Byte Count Mask */
+#define USBHS_HSTPIPISR_PBYCT(value)        (USBHS_HSTPIPISR_PBYCT_Msk & ((value) << USBHS_HSTPIPISR_PBYCT_Pos))
+#define USBHS_HSTPIPISR_MASK                _U_(0x7FF5F3BB)                                /**< \deprecated (USBHS_HSTPIPISR) Register MASK  (Use USBHS_HSTPIPISR_Msk instead)  */
+#define USBHS_HSTPIPISR_Msk                 _U_(0x7FF5F3BB)                                /**< (USBHS_HSTPIPISR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI_Pos     2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_CTRL_TXSTPI_Pos)  /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI         USBHS_HSTPIPISR_CTRL_TXSTPI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CTRL_TXSTPI_Msk instead */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI_Pos  6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk  (_U_(0x1) << USBHS_HSTPIPISR_CTRL_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI      USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_CTRL) Register MASK  (Use USBHS_HSTPIPISR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPISR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPISR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPISR_ISO_UNDERFI_Pos     2                                              /**< (USBHS_HSTPIPISR) Underflow Interrupt Position */
+#define USBHS_HSTPIPISR_ISO_UNDERFI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_ISO_UNDERFI_Pos)  /**< (USBHS_HSTPIPISR) Underflow Interrupt Mask */
+#define USBHS_HSTPIPISR_ISO_UNDERFI         USBHS_HSTPIPISR_ISO_UNDERFI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_ISO_UNDERFI_Msk instead */
+#define USBHS_HSTPIPISR_ISO_CRCERRI_Pos     6                                              /**< (USBHS_HSTPIPISR) CRC Error Interrupt Position */
+#define USBHS_HSTPIPISR_ISO_CRCERRI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_ISO_CRCERRI_Pos)  /**< (USBHS_HSTPIPISR) CRC Error Interrupt Mask */
+#define USBHS_HSTPIPISR_ISO_CRCERRI         USBHS_HSTPIPISR_ISO_CRCERRI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_ISO_CRCERRI_Msk instead */
+#define USBHS_HSTPIPISR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_ISO) Register MASK  (Use USBHS_HSTPIPISR_ISO_Msk instead)  */
+#define USBHS_HSTPIPISR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPISR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPISR_BLK_TXSTPI_Pos      2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_BLK_TXSTPI_Msk      (_U_(0x1) << USBHS_HSTPIPISR_BLK_TXSTPI_Pos)   /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_BLK_TXSTPI          USBHS_HSTPIPISR_BLK_TXSTPI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_BLK_TXSTPI_Msk instead */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI_Pos   6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk   (_U_(0x1) << USBHS_HSTPIPISR_BLK_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI       USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_BLK) Register MASK  (Use USBHS_HSTPIPISR_BLK_Msk instead)  */
+#define USBHS_HSTPIPISR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPISR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI_Pos  2                                              /**< (USBHS_HSTPIPISR) Underflow Interrupt Position */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk  (_U_(0x1) << USBHS_HSTPIPISR_INTRPT_UNDERFI_Pos)  /**< (USBHS_HSTPIPISR) Underflow Interrupt Mask */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI      USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk instead */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Pos 6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk (_U_(0x1) << USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI    USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_INTRPT) Register MASK  (Use USBHS_HSTPIPISR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPISR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPISR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPICR : (USBHS Offset: 0x560) (/W 32) Host Pipe Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINIC:1;                  /**< bit:      0  Received IN Data Interrupt Clear         */
+    uint32_t TXOUTIC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Clear     */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t NAKEDIC:1;                 /**< bit:      4  NAKed Interrupt Clear                    */
+    uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETIC:1;           /**< bit:      7  Short Packet Interrupt Clear             */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRIC:1;                /**< bit:      6  CRC Error Interrupt Clear                */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPICR_OFFSET              (0x560)                                       /**<  (USBHS_HSTPIPICR) Host Pipe Clear Register  Offset */
+
+#define USBHS_HSTPIPICR_RXINIC_Pos          0                                              /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Position */
+#define USBHS_HSTPIPICR_RXINIC_Msk          (_U_(0x1) << USBHS_HSTPIPICR_RXINIC_Pos)       /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_RXINIC              USBHS_HSTPIPICR_RXINIC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_RXINIC_Msk instead */
+#define USBHS_HSTPIPICR_TXOUTIC_Pos         1                                              /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Position */
+#define USBHS_HSTPIPICR_TXOUTIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_TXOUTIC_Pos)      /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_TXOUTIC             USBHS_HSTPIPICR_TXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXOUTIC_Msk instead */
+#define USBHS_HSTPIPICR_NAKEDIC_Pos         4                                              /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_NAKEDIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_NAKEDIC_Pos)      /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_NAKEDIC             USBHS_HSTPIPICR_NAKEDIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_NAKEDIC_Msk instead */
+#define USBHS_HSTPIPICR_OVERFIC_Pos         5                                              /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_OVERFIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_OVERFIC_Pos)      /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_OVERFIC             USBHS_HSTPIPICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_OVERFIC_Msk instead */
+#define USBHS_HSTPIPICR_SHORTPACKETIC_Pos   7                                              /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Position */
+#define USBHS_HSTPIPICR_SHORTPACKETIC_Msk   (_U_(0x1) << USBHS_HSTPIPICR_SHORTPACKETIC_Pos)  /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_SHORTPACKETIC       USBHS_HSTPIPICR_SHORTPACKETIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_SHORTPACKETIC_Msk instead */
+#define USBHS_HSTPIPICR_MASK                _U_(0xB3)                                      /**< \deprecated (USBHS_HSTPIPICR) Register MASK  (Use USBHS_HSTPIPICR_Msk instead)  */
+#define USBHS_HSTPIPICR_Msk                 _U_(0xB3)                                      /**< (USBHS_HSTPIPICR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC_Pos    2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_CTRL_TXSTPIC_Pos)  /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC        USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Pos 6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC     USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_CTRL) Register MASK  (Use USBHS_HSTPIPICR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPICR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPICR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC_Pos    2                                              /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_ISO_UNDERFIC_Pos)  /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC        USBHS_HSTPIPICR_ISO_UNDERFIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_ISO_UNDERFIC_Msk instead */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC_Pos    6                                              /**< (USBHS_HSTPIPICR) CRC Error Interrupt Clear Position */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_ISO_CRCERRIC_Pos)  /**< (USBHS_HSTPIPICR) CRC Error Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC        USBHS_HSTPIPICR_ISO_CRCERRIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_ISO_CRCERRIC_Msk instead */
+#define USBHS_HSTPIPICR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_ISO) Register MASK  (Use USBHS_HSTPIPICR_ISO_Msk instead)  */
+#define USBHS_HSTPIPICR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPICR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC_Pos     2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC_Msk     (_U_(0x1) << USBHS_HSTPIPICR_BLK_TXSTPIC_Pos)  /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC         USBHS_HSTPIPICR_BLK_TXSTPIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_BLK_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC_Pos  6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk  (_U_(0x1) << USBHS_HSTPIPICR_BLK_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC      USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_BLK) Register MASK  (Use USBHS_HSTPIPICR_BLK_Msk instead)  */
+#define USBHS_HSTPIPICR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPICR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC_Pos 2                                              /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_INTRPT_UNDERFIC_Pos)  /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC     USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk instead */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Pos 6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC   USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_INTRPT) Register MASK  (Use USBHS_HSTPIPICR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPICR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPICR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIFR : (USBHS Offset: 0x590) (/W 32) Host Pipe Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINIS:1;                  /**< bit:      0  Received IN Data Interrupt Set           */
+    uint32_t TXOUTIS:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Set       */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t PERRIS:1;                  /**< bit:      3  Pipe Error Interrupt Set                 */
+    uint32_t NAKEDIS:1;                 /**< bit:      4  NAKed Interrupt Set                      */
+    uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETIS:1;           /**< bit:      7  Short Packet Interrupt Set               */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Set                 */
+    uint32_t :19;                       /**< bit: 13..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRIS:1;                /**< bit:      6  CRC Error Interrupt Set                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIFR_OFFSET              (0x590)                                       /**<  (USBHS_HSTPIPIFR) Host Pipe Set Register  Offset */
+
+#define USBHS_HSTPIPIFR_RXINIS_Pos          0                                              /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Position */
+#define USBHS_HSTPIPIFR_RXINIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_RXINIS_Pos)       /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_RXINIS              USBHS_HSTPIPIFR_RXINIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_RXINIS_Msk instead */
+#define USBHS_HSTPIPIFR_TXOUTIS_Pos         1                                              /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Position */
+#define USBHS_HSTPIPIFR_TXOUTIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_TXOUTIS_Pos)      /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_TXOUTIS             USBHS_HSTPIPIFR_TXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXOUTIS_Msk instead */
+#define USBHS_HSTPIPIFR_PERRIS_Pos          3                                              /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Position */
+#define USBHS_HSTPIPIFR_PERRIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_PERRIS_Pos)       /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_PERRIS              USBHS_HSTPIPIFR_PERRIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_PERRIS_Msk instead */
+#define USBHS_HSTPIPIFR_NAKEDIS_Pos         4                                              /**< (USBHS_HSTPIPIFR) NAKed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_NAKEDIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_NAKEDIS_Pos)      /**< (USBHS_HSTPIPIFR) NAKed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_NAKEDIS             USBHS_HSTPIPIFR_NAKEDIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_NAKEDIS_Msk instead */
+#define USBHS_HSTPIPIFR_OVERFIS_Pos         5                                              /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_OVERFIS_Pos)      /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_OVERFIS             USBHS_HSTPIPIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_OVERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS_Pos   7                                              /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Position */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS_Msk   (_U_(0x1) << USBHS_HSTPIPIFR_SHORTPACKETIS_Pos)  /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_SHORTPACKETIS       USBHS_HSTPIPIFR_SHORTPACKETIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_SHORTPACKETIS_Msk instead */
+#define USBHS_HSTPIPIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Position */
+#define USBHS_HSTPIPIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_HSTPIPIFR_NBUSYBKS_Pos)     /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Mask */
+#define USBHS_HSTPIPIFR_NBUSYBKS            USBHS_HSTPIPIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_NBUSYBKS_Msk instead */
+#define USBHS_HSTPIPIFR_MASK                _U_(0x10BB)                                    /**< \deprecated (USBHS_HSTPIPIFR) Register MASK  (Use USBHS_HSTPIPIFR_Msk instead)  */
+#define USBHS_HSTPIPIFR_Msk                 _U_(0x10BB)                                    /**< (USBHS_HSTPIPIFR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS_Pos    2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_CTRL_TXSTPIS_Pos)  /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS        USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Pos 6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS     USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_CTRL) Register MASK  (Use USBHS_HSTPIPIFR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIFR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS_Pos    2                                              /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_ISO_UNDERFIS_Pos)  /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS        USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS_Pos    6                                              /**< (USBHS_HSTPIPIFR) CRC Error Interrupt Set Position */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_ISO_CRCERRIS_Pos)  /**< (USBHS_HSTPIPIFR) CRC Error Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS        USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk instead */
+#define USBHS_HSTPIPIFR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_ISO) Register MASK  (Use USBHS_HSTPIPIFR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIFR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS_Pos     2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk     (_U_(0x1) << USBHS_HSTPIPIFR_BLK_TXSTPIS_Pos)  /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS         USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Pos  6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk  (_U_(0x1) << USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS      USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_BLK) Register MASK  (Use USBHS_HSTPIPIFR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIFR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Pos 2                                              /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Pos)  /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS     USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Pos 6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS   USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_INTRPT) Register MASK  (Use USBHS_HSTPIPIFR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIFR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIMR : (USBHS Offset: 0x5c0) (R/ 32) Host Pipe Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINE:1;                   /**< bit:      0  Received IN Data Interrupt Enable        */
+    uint32_t TXOUTE:1;                  /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t PERRE:1;                   /**< bit:      3  Pipe Error Interrupt Enable              */
+    uint32_t NAKEDE:1;                  /**< bit:      4  NAKed Interrupt Enable                   */
+    uint32_t OVERFIE:1;                 /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETIE:1;           /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt Enable    */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCON:1;                 /**< bit:     14  FIFO Control                             */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PDISHDMA:1;                /**< bit:     16  Pipe Interrupts Disable HDMA Request Enable */
+    uint32_t PFREEZE:1;                 /**< bit:     17  Pipe Freeze                              */
+    uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIE:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRE:1;                 /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIE:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIMR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIMR_OFFSET              (0x5C0)                                       /**<  (USBHS_HSTPIPIMR) Host Pipe Mask Register  Offset */
+
+#define USBHS_HSTPIPIMR_RXINE_Pos           0                                              /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_RXINE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RXINE_Pos)        /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_RXINE               USBHS_HSTPIPIMR_RXINE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RXINE_Msk instead */
+#define USBHS_HSTPIPIMR_TXOUTE_Pos          1                                              /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_TXOUTE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_TXOUTE_Pos)       /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_TXOUTE              USBHS_HSTPIPIMR_TXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXOUTE_Msk instead */
+#define USBHS_HSTPIPIMR_PERRE_Pos           3                                              /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_PERRE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_PERRE_Pos)        /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_PERRE               USBHS_HSTPIPIMR_PERRE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PERRE_Msk instead */
+#define USBHS_HSTPIPIMR_NAKEDE_Pos          4                                              /**< (USBHS_HSTPIPIMR) NAKed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_NAKEDE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_NAKEDE_Pos)       /**< (USBHS_HSTPIPIMR) NAKed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_NAKEDE              USBHS_HSTPIPIMR_NAKEDE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_NAKEDE_Msk instead */
+#define USBHS_HSTPIPIMR_OVERFIE_Pos         5                                              /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_OVERFIE_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_OVERFIE_Pos)      /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_OVERFIE             USBHS_HSTPIPIMR_OVERFIE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_OVERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE_Pos   7                                              /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE_Msk   (_U_(0x1) << USBHS_HSTPIPIMR_SHORTPACKETIE_Pos)  /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_SHORTPACKETIE       USBHS_HSTPIPIMR_SHORTPACKETIE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_SHORTPACKETIE_Msk instead */
+#define USBHS_HSTPIPIMR_NBUSYBKE_Pos        12                                             /**< (USBHS_HSTPIPIMR) Number of Busy Banks Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_NBUSYBKE_Msk        (_U_(0x1) << USBHS_HSTPIPIMR_NBUSYBKE_Pos)     /**< (USBHS_HSTPIPIMR) Number of Busy Banks Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_NBUSYBKE            USBHS_HSTPIPIMR_NBUSYBKE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_NBUSYBKE_Msk instead */
+#define USBHS_HSTPIPIMR_FIFOCON_Pos         14                                             /**< (USBHS_HSTPIPIMR) FIFO Control Position */
+#define USBHS_HSTPIPIMR_FIFOCON_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_FIFOCON_Pos)      /**< (USBHS_HSTPIPIMR) FIFO Control Mask */
+#define USBHS_HSTPIPIMR_FIFOCON             USBHS_HSTPIPIMR_FIFOCON_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_FIFOCON_Msk instead */
+#define USBHS_HSTPIPIMR_PDISHDMA_Pos        16                                             /**< (USBHS_HSTPIPIMR) Pipe Interrupts Disable HDMA Request Enable Position */
+#define USBHS_HSTPIPIMR_PDISHDMA_Msk        (_U_(0x1) << USBHS_HSTPIPIMR_PDISHDMA_Pos)     /**< (USBHS_HSTPIPIMR) Pipe Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_HSTPIPIMR_PDISHDMA            USBHS_HSTPIPIMR_PDISHDMA_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PDISHDMA_Msk instead */
+#define USBHS_HSTPIPIMR_PFREEZE_Pos         17                                             /**< (USBHS_HSTPIPIMR) Pipe Freeze Position */
+#define USBHS_HSTPIPIMR_PFREEZE_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_PFREEZE_Pos)      /**< (USBHS_HSTPIPIMR) Pipe Freeze Mask */
+#define USBHS_HSTPIPIMR_PFREEZE             USBHS_HSTPIPIMR_PFREEZE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PFREEZE_Msk instead */
+#define USBHS_HSTPIPIMR_RSTDT_Pos           18                                             /**< (USBHS_HSTPIPIMR) Reset Data Toggle Position */
+#define USBHS_HSTPIPIMR_RSTDT_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RSTDT_Pos)        /**< (USBHS_HSTPIPIMR) Reset Data Toggle Mask */
+#define USBHS_HSTPIPIMR_RSTDT               USBHS_HSTPIPIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RSTDT_Msk instead */
+#define USBHS_HSTPIPIMR_MASK                _U_(0x750BB)                                   /**< \deprecated (USBHS_HSTPIPIMR) Register MASK  (Use USBHS_HSTPIPIMR_Msk instead)  */
+#define USBHS_HSTPIPIMR_Msk                 _U_(0x750BB)                                   /**< (USBHS_HSTPIPIMR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE_Pos     2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk     (_U_(0x1) << USBHS_HSTPIPIMR_CTRL_TXSTPE_Pos)  /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE         USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk instead */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Pos  6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk  (_U_(0x1) << USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE      USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_CTRL) Register MASK  (Use USBHS_HSTPIPIMR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIMR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE_Pos    2                                              /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk    (_U_(0x1) << USBHS_HSTPIPIMR_ISO_UNDERFIE_Pos)  /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE        USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE_Pos     6                                              /**< (USBHS_HSTPIPIMR) CRC Error Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE_Msk     (_U_(0x1) << USBHS_HSTPIPIMR_ISO_CRCERRE_Pos)  /**< (USBHS_HSTPIPIMR) CRC Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE         USBHS_HSTPIPIMR_ISO_CRCERRE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_ISO_CRCERRE_Msk instead */
+#define USBHS_HSTPIPIMR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_ISO) Register MASK  (Use USBHS_HSTPIPIMR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIMR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE_Pos      2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE_Msk      (_U_(0x1) << USBHS_HSTPIPIMR_BLK_TXSTPE_Pos)   /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE          USBHS_HSTPIPIMR_BLK_TXSTPE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_BLK_TXSTPE_Msk instead */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE_Pos   6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk   (_U_(0x1) << USBHS_HSTPIPIMR_BLK_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE       USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_BLK) Register MASK  (Use USBHS_HSTPIPIMR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIMR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Pos 2                                              /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk (_U_(0x1) << USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Pos)  /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE     USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Pos 6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk (_U_(0x1) << USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE    USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_INTRPT) Register MASK  (Use USBHS_HSTPIPIMR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIMR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIER : (USBHS Offset: 0x5f0) (/W 32) Host Pipe Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINES:1;                  /**< bit:      0  Received IN Data Interrupt Enable        */
+    uint32_t TXOUTES:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t PERRES:1;                  /**< bit:      3  Pipe Error Interrupt Enable              */
+    uint32_t NAKEDES:1;                 /**< bit:      4  NAKed Interrupt Enable                   */
+    uint32_t OVERFIES:1;                /**< bit:      5  Overflow Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETIES:1;          /**< bit:      7  Short Packet Interrupt Enable            */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Enable              */
+    uint32_t :3;                        /**< bit: 13..15  Reserved */
+    uint32_t PDISHDMAS:1;               /**< bit:     16  Pipe Interrupts Disable HDMA Request Enable */
+    uint32_t PFREEZES:1;                /**< bit:     17  Pipe Freeze Enable                       */
+    uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIES:1;               /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRES:1;                /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIES:1;               /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIER_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIER_OFFSET              (0x5F0)                                       /**<  (USBHS_HSTPIPIER) Host Pipe Enable Register  Offset */
+
+#define USBHS_HSTPIPIER_RXINES_Pos          0                                              /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Position */
+#define USBHS_HSTPIPIER_RXINES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RXINES_Pos)       /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_RXINES              USBHS_HSTPIPIER_RXINES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RXINES_Msk instead */
+#define USBHS_HSTPIPIER_TXOUTES_Pos         1                                              /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Position */
+#define USBHS_HSTPIPIER_TXOUTES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_TXOUTES_Pos)      /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_TXOUTES             USBHS_HSTPIPIER_TXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXOUTES_Msk instead */
+#define USBHS_HSTPIPIER_PERRES_Pos          3                                              /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Position */
+#define USBHS_HSTPIPIER_PERRES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_PERRES_Pos)       /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_PERRES              USBHS_HSTPIPIER_PERRES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PERRES_Msk instead */
+#define USBHS_HSTPIPIER_NAKEDES_Pos         4                                              /**< (USBHS_HSTPIPIER) NAKed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_NAKEDES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_NAKEDES_Pos)      /**< (USBHS_HSTPIPIER) NAKed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_NAKEDES             USBHS_HSTPIPIER_NAKEDES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_NAKEDES_Msk instead */
+#define USBHS_HSTPIPIER_OVERFIES_Pos        5                                              /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_OVERFIES_Msk        (_U_(0x1) << USBHS_HSTPIPIER_OVERFIES_Pos)     /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_OVERFIES            USBHS_HSTPIPIER_OVERFIES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_OVERFIES_Msk instead */
+#define USBHS_HSTPIPIER_SHORTPACKETIES_Pos  7                                              /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Position */
+#define USBHS_HSTPIPIER_SHORTPACKETIES_Msk  (_U_(0x1) << USBHS_HSTPIPIER_SHORTPACKETIES_Pos)  /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_SHORTPACKETIES      USBHS_HSTPIPIER_SHORTPACKETIES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_SHORTPACKETIES_Msk instead */
+#define USBHS_HSTPIPIER_NBUSYBKES_Pos       12                                             /**< (USBHS_HSTPIPIER) Number of Busy Banks Enable Position */
+#define USBHS_HSTPIPIER_NBUSYBKES_Msk       (_U_(0x1) << USBHS_HSTPIPIER_NBUSYBKES_Pos)    /**< (USBHS_HSTPIPIER) Number of Busy Banks Enable Mask */
+#define USBHS_HSTPIPIER_NBUSYBKES           USBHS_HSTPIPIER_NBUSYBKES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_NBUSYBKES_Msk instead */
+#define USBHS_HSTPIPIER_PDISHDMAS_Pos       16                                             /**< (USBHS_HSTPIPIER) Pipe Interrupts Disable HDMA Request Enable Position */
+#define USBHS_HSTPIPIER_PDISHDMAS_Msk       (_U_(0x1) << USBHS_HSTPIPIER_PDISHDMAS_Pos)    /**< (USBHS_HSTPIPIER) Pipe Interrupts Disable HDMA Request Enable Mask */
+#define USBHS_HSTPIPIER_PDISHDMAS           USBHS_HSTPIPIER_PDISHDMAS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PDISHDMAS_Msk instead */
+#define USBHS_HSTPIPIER_PFREEZES_Pos        17                                             /**< (USBHS_HSTPIPIER) Pipe Freeze Enable Position */
+#define USBHS_HSTPIPIER_PFREEZES_Msk        (_U_(0x1) << USBHS_HSTPIPIER_PFREEZES_Pos)     /**< (USBHS_HSTPIPIER) Pipe Freeze Enable Mask */
+#define USBHS_HSTPIPIER_PFREEZES            USBHS_HSTPIPIER_PFREEZES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PFREEZES_Msk instead */
+#define USBHS_HSTPIPIER_RSTDTS_Pos          18                                             /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Position */
+#define USBHS_HSTPIPIER_RSTDTS_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RSTDTS_Pos)       /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Mask */
+#define USBHS_HSTPIPIER_RSTDTS              USBHS_HSTPIPIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RSTDTS_Msk instead */
+#define USBHS_HSTPIPIER_MASK                _U_(0x710BB)                                   /**< \deprecated (USBHS_HSTPIPIER) Register MASK  (Use USBHS_HSTPIPIER_Msk instead)  */
+#define USBHS_HSTPIPIER_Msk                 _U_(0x710BB)                                   /**< (USBHS_HSTPIPIER) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES_Pos    2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES_Msk    (_U_(0x1) << USBHS_HSTPIPIER_CTRL_TXSTPES_Pos)  /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES        USBHS_HSTPIPIER_CTRL_TXSTPES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_CTRL_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES_Pos 6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk (_U_(0x1) << USBHS_HSTPIPIER_CTRL_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES     USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_CTRL) Register MASK  (Use USBHS_HSTPIPIER_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIER_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIER_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES_Pos   2                                              /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES_Msk   (_U_(0x1) << USBHS_HSTPIPIER_ISO_UNDERFIES_Pos)  /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES       USBHS_HSTPIPIER_ISO_UNDERFIES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_ISO_UNDERFIES_Msk instead */
+#define USBHS_HSTPIPIER_ISO_CRCERRES_Pos    6                                              /**< (USBHS_HSTPIPIER) CRC Error Interrupt Enable Position */
+#define USBHS_HSTPIPIER_ISO_CRCERRES_Msk    (_U_(0x1) << USBHS_HSTPIPIER_ISO_CRCERRES_Pos)  /**< (USBHS_HSTPIPIER) CRC Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_ISO_CRCERRES        USBHS_HSTPIPIER_ISO_CRCERRES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_ISO_CRCERRES_Msk instead */
+#define USBHS_HSTPIPIER_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_ISO) Register MASK  (Use USBHS_HSTPIPIER_ISO_Msk instead)  */
+#define USBHS_HSTPIPIER_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIER_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIER_BLK_TXSTPES_Pos     2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_BLK_TXSTPES_Msk     (_U_(0x1) << USBHS_HSTPIPIER_BLK_TXSTPES_Pos)  /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_BLK_TXSTPES         USBHS_HSTPIPIER_BLK_TXSTPES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_BLK_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES_Pos  6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk  (_U_(0x1) << USBHS_HSTPIPIER_BLK_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES      USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_BLK) Register MASK  (Use USBHS_HSTPIPIER_BLK_Msk instead)  */
+#define USBHS_HSTPIPIER_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIER_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES_Pos 2                                              /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk (_U_(0x1) << USBHS_HSTPIPIER_INTRPT_UNDERFIES_Pos)  /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES    USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk instead */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Pos 6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk (_U_(0x1) << USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES   USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_INTRPT) Register MASK  (Use USBHS_HSTPIPIER_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIER_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIER_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPIDR : (USBHS Offset: 0x620) (/W 32) Host Pipe Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXINEC:1;                  /**< bit:      0  Received IN Data Interrupt Disable       */
+    uint32_t TXOUTEC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Disable   */
+    uint32_t :1;                        /**< bit:      2  Reserved */
+    uint32_t PERREC:1;                  /**< bit:      3  Pipe Error Interrupt Disable             */
+    uint32_t NAKEDEC:1;                 /**< bit:      4  NAKed Interrupt Disable                  */
+    uint32_t OVERFIEC:1;                /**< bit:      5  Overflow Interrupt Disable               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
+    uint32_t SHORTPACKETIEC:1;          /**< bit:      7  Short Packet Interrupt Disable           */
+    uint32_t :4;                        /**< bit:  8..11  Reserved */
+    uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Disable             */
+    uint32_t :1;                        /**< bit:     13  Reserved */
+    uint32_t FIFOCONC:1;                /**< bit:     14  FIFO Control Disable                     */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PDISHDMAC:1;               /**< bit:     16  Pipe Interrupts Disable HDMA Request Disable */
+    uint32_t PFREEZEC:1;                /**< bit:     17  Pipe Freeze Disable                      */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIEC:1;               /**< bit:      2  Underflow Interrupt Disable              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERREC:1;                /**< bit:      6  CRC Error Interrupt Disable              */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIEC:1;               /**< bit:      2  Underflow Interrupt Disable              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPIDR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPIDR_OFFSET              (0x620)                                       /**<  (USBHS_HSTPIPIDR) Host Pipe Disable Register  Offset */
+
+#define USBHS_HSTPIPIDR_RXINEC_Pos          0                                              /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_RXINEC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_RXINEC_Pos)       /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_RXINEC              USBHS_HSTPIPIDR_RXINEC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_RXINEC_Msk instead */
+#define USBHS_HSTPIPIDR_TXOUTEC_Pos         1                                              /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_TXOUTEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_TXOUTEC_Pos)      /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_TXOUTEC             USBHS_HSTPIPIDR_TXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXOUTEC_Msk instead */
+#define USBHS_HSTPIPIDR_PERREC_Pos          3                                              /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_PERREC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_PERREC_Pos)       /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_PERREC              USBHS_HSTPIPIDR_PERREC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PERREC_Msk instead */
+#define USBHS_HSTPIPIDR_NAKEDEC_Pos         4                                              /**< (USBHS_HSTPIPIDR) NAKed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_NAKEDEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_NAKEDEC_Pos)      /**< (USBHS_HSTPIPIDR) NAKed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_NAKEDEC             USBHS_HSTPIPIDR_NAKEDEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_NAKEDEC_Msk instead */
+#define USBHS_HSTPIPIDR_OVERFIEC_Pos        5                                              /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_OVERFIEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_OVERFIEC_Pos)     /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_OVERFIEC            USBHS_HSTPIPIDR_OVERFIEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_OVERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos  7                                              /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk  (_U_(0x1) << USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos)  /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_SHORTPACKETIEC      USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk instead */
+#define USBHS_HSTPIPIDR_NBUSYBKEC_Pos       12                                             /**< (USBHS_HSTPIPIDR) Number of Busy Banks Disable Position */
+#define USBHS_HSTPIPIDR_NBUSYBKEC_Msk       (_U_(0x1) << USBHS_HSTPIPIDR_NBUSYBKEC_Pos)    /**< (USBHS_HSTPIPIDR) Number of Busy Banks Disable Mask */
+#define USBHS_HSTPIPIDR_NBUSYBKEC           USBHS_HSTPIPIDR_NBUSYBKEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_NBUSYBKEC_Msk instead */
+#define USBHS_HSTPIPIDR_FIFOCONC_Pos        14                                             /**< (USBHS_HSTPIPIDR) FIFO Control Disable Position */
+#define USBHS_HSTPIPIDR_FIFOCONC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_FIFOCONC_Pos)     /**< (USBHS_HSTPIPIDR) FIFO Control Disable Mask */
+#define USBHS_HSTPIPIDR_FIFOCONC            USBHS_HSTPIPIDR_FIFOCONC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_FIFOCONC_Msk instead */
+#define USBHS_HSTPIPIDR_PDISHDMAC_Pos       16                                             /**< (USBHS_HSTPIPIDR) Pipe Interrupts Disable HDMA Request Disable Position */
+#define USBHS_HSTPIPIDR_PDISHDMAC_Msk       (_U_(0x1) << USBHS_HSTPIPIDR_PDISHDMAC_Pos)    /**< (USBHS_HSTPIPIDR) Pipe Interrupts Disable HDMA Request Disable Mask */
+#define USBHS_HSTPIPIDR_PDISHDMAC           USBHS_HSTPIPIDR_PDISHDMAC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PDISHDMAC_Msk instead */
+#define USBHS_HSTPIPIDR_PFREEZEC_Pos        17                                             /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Position */
+#define USBHS_HSTPIPIDR_PFREEZEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_PFREEZEC_Pos)     /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Mask */
+#define USBHS_HSTPIPIDR_PFREEZEC            USBHS_HSTPIPIDR_PFREEZEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PFREEZEC_Msk instead */
+#define USBHS_HSTPIPIDR_MASK                _U_(0x350BB)                                   /**< \deprecated (USBHS_HSTPIPIDR) Register MASK  (Use USBHS_HSTPIPIDR_Msk instead)  */
+#define USBHS_HSTPIPIDR_Msk                 _U_(0x350BB)                                   /**< (USBHS_HSTPIPIDR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC_Pos    2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk    (_U_(0x1) << USBHS_HSTPIPIDR_CTRL_TXSTPEC_Pos)  /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC        USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Pos 6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC     USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_CTRL) Register MASK  (Use USBHS_HSTPIPIDR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIDR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC_Pos   2                                              /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk   (_U_(0x1) << USBHS_HSTPIPIDR_ISO_UNDERFIEC_Pos)  /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC       USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC_Pos    6                                              /**< (USBHS_HSTPIPIDR) CRC Error Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC_Msk    (_U_(0x1) << USBHS_HSTPIPIDR_ISO_CRCERREC_Pos)  /**< (USBHS_HSTPIPIDR) CRC Error Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC        USBHS_HSTPIPIDR_ISO_CRCERREC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_ISO_CRCERREC_Msk instead */
+#define USBHS_HSTPIPIDR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_ISO) Register MASK  (Use USBHS_HSTPIPIDR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIDR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC_Pos     2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk     (_U_(0x1) << USBHS_HSTPIPIDR_BLK_TXSTPEC_Pos)  /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC         USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Pos  6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk  (_U_(0x1) << USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC      USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_BLK) Register MASK  (Use USBHS_HSTPIPIDR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIDR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Pos 2                                              /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Pos)  /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC    USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Pos 6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC   USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_INTRPT) Register MASK  (Use USBHS_HSTPIPIDR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIDR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_INTRPT) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPINRQ : (USBHS Offset: 0x650) (R/W 32) Host Pipe IN Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t INRQ:8;                    /**< bit:   0..7  IN Request Number before Freeze          */
+    uint32_t INMODE:1;                  /**< bit:      8  IN Request Mode                          */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPINRQ_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPINRQ_OFFSET             (0x650)                                       /**<  (USBHS_HSTPIPINRQ) Host Pipe IN Request Register  Offset */
+
+#define USBHS_HSTPIPINRQ_INRQ_Pos           0                                              /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Position */
+#define USBHS_HSTPIPINRQ_INRQ_Msk           (_U_(0xFF) << USBHS_HSTPIPINRQ_INRQ_Pos)       /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Mask */
+#define USBHS_HSTPIPINRQ_INRQ(value)        (USBHS_HSTPIPINRQ_INRQ_Msk & ((value) << USBHS_HSTPIPINRQ_INRQ_Pos))
+#define USBHS_HSTPIPINRQ_INMODE_Pos         8                                              /**< (USBHS_HSTPIPINRQ) IN Request Mode Position */
+#define USBHS_HSTPIPINRQ_INMODE_Msk         (_U_(0x1) << USBHS_HSTPIPINRQ_INMODE_Pos)      /**< (USBHS_HSTPIPINRQ) IN Request Mode Mask */
+#define USBHS_HSTPIPINRQ_INMODE             USBHS_HSTPIPINRQ_INMODE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPINRQ_INMODE_Msk instead */
+#define USBHS_HSTPIPINRQ_MASK               _U_(0x1FF)                                     /**< \deprecated (USBHS_HSTPIPINRQ) Register MASK  (Use USBHS_HSTPIPINRQ_Msk instead)  */
+#define USBHS_HSTPIPINRQ_Msk                _U_(0x1FF)                                     /**< (USBHS_HSTPIPINRQ) Register Mask  */
+
+
+/* -------- USBHS_HSTPIPERR : (USBHS Offset: 0x680) (R/W 32) Host Pipe Error Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DATATGL:1;                 /**< bit:      0  Data Toggle Error                        */
+    uint32_t DATAPID:1;                 /**< bit:      1  Data PID Error                           */
+    uint32_t PID:1;                     /**< bit:      2  Data PID Error                           */
+    uint32_t TIMEOUT:1;                 /**< bit:      3  Time-Out Error                           */
+    uint32_t CRC16:1;                   /**< bit:      4  CRC16 Error                              */
+    uint32_t COUNTER:2;                 /**< bit:   5..6  Error Counter                            */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CRC:1;                     /**< bit:      4  CRCx6 Error                              */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_HSTPIPERR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_HSTPIPERR_OFFSET              (0x680)                                       /**<  (USBHS_HSTPIPERR) Host Pipe Error Register  Offset */
+
+#define USBHS_HSTPIPERR_DATATGL_Pos         0                                              /**< (USBHS_HSTPIPERR) Data Toggle Error Position */
+#define USBHS_HSTPIPERR_DATATGL_Msk         (_U_(0x1) << USBHS_HSTPIPERR_DATATGL_Pos)      /**< (USBHS_HSTPIPERR) Data Toggle Error Mask */
+#define USBHS_HSTPIPERR_DATATGL             USBHS_HSTPIPERR_DATATGL_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_DATATGL_Msk instead */
+#define USBHS_HSTPIPERR_DATAPID_Pos         1                                              /**< (USBHS_HSTPIPERR) Data PID Error Position */
+#define USBHS_HSTPIPERR_DATAPID_Msk         (_U_(0x1) << USBHS_HSTPIPERR_DATAPID_Pos)      /**< (USBHS_HSTPIPERR) Data PID Error Mask */
+#define USBHS_HSTPIPERR_DATAPID             USBHS_HSTPIPERR_DATAPID_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_DATAPID_Msk instead */
+#define USBHS_HSTPIPERR_PID_Pos             2                                              /**< (USBHS_HSTPIPERR) Data PID Error Position */
+#define USBHS_HSTPIPERR_PID_Msk             (_U_(0x1) << USBHS_HSTPIPERR_PID_Pos)          /**< (USBHS_HSTPIPERR) Data PID Error Mask */
+#define USBHS_HSTPIPERR_PID                 USBHS_HSTPIPERR_PID_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_PID_Msk instead */
+#define USBHS_HSTPIPERR_TIMEOUT_Pos         3                                              /**< (USBHS_HSTPIPERR) Time-Out Error Position */
+#define USBHS_HSTPIPERR_TIMEOUT_Msk         (_U_(0x1) << USBHS_HSTPIPERR_TIMEOUT_Pos)      /**< (USBHS_HSTPIPERR) Time-Out Error Mask */
+#define USBHS_HSTPIPERR_TIMEOUT             USBHS_HSTPIPERR_TIMEOUT_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_TIMEOUT_Msk instead */
+#define USBHS_HSTPIPERR_CRC16_Pos           4                                              /**< (USBHS_HSTPIPERR) CRC16 Error Position */
+#define USBHS_HSTPIPERR_CRC16_Msk           (_U_(0x1) << USBHS_HSTPIPERR_CRC16_Pos)        /**< (USBHS_HSTPIPERR) CRC16 Error Mask */
+#define USBHS_HSTPIPERR_CRC16               USBHS_HSTPIPERR_CRC16_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPERR_CRC16_Msk instead */
+#define USBHS_HSTPIPERR_COUNTER_Pos         5                                              /**< (USBHS_HSTPIPERR) Error Counter Position */
+#define USBHS_HSTPIPERR_COUNTER_Msk         (_U_(0x3) << USBHS_HSTPIPERR_COUNTER_Pos)      /**< (USBHS_HSTPIPERR) Error Counter Mask */
+#define USBHS_HSTPIPERR_COUNTER(value)      (USBHS_HSTPIPERR_COUNTER_Msk & ((value) << USBHS_HSTPIPERR_COUNTER_Pos))
+#define USBHS_HSTPIPERR_MASK                _U_(0x7F)                                      /**< \deprecated (USBHS_HSTPIPERR) Register MASK  (Use USBHS_HSTPIPERR_Msk instead)  */
+#define USBHS_HSTPIPERR_Msk                 _U_(0x7F)                                      /**< (USBHS_HSTPIPERR) Register Mask  */
+
+#define USBHS_HSTPIPERR_CRC_Pos             4                                              /**< (USBHS_HSTPIPERR Position) CRCx6 Error */
+#define USBHS_HSTPIPERR_CRC_Msk             (_U_(0x1) << USBHS_HSTPIPERR_CRC_Pos)          /**< (USBHS_HSTPIPERR Mask) CRC */
+#define USBHS_HSTPIPERR_CRC(value)          (USBHS_HSTPIPERR_CRC_Msk & ((value) << USBHS_HSTPIPERR_CRC_Pos))  
+
+/* -------- USBHS_CTRL : (USBHS Offset: 0x800) (R/W 32) General Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRE:1;                  /**< bit:      4  Remote Device Connection Error Interrupt Enable */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t VBUSHWC:1;                 /**< bit:      8  VBUS Hardware Control                    */
+    uint32_t :5;                        /**< bit:  9..13  Reserved */
+    uint32_t FRZCLK:1;                  /**< bit:     14  Freeze USB Clock                         */
+    uint32_t USBE:1;                    /**< bit:     15  USBHS Enable                             */
+    uint32_t :8;                        /**< bit: 16..23  Reserved */
+    uint32_t UID:1;                     /**< bit:     24  UID Pin Enable                           */
+    uint32_t UIMOD:1;                   /**< bit:     25  USBHS Mode                               */
+    uint32_t :6;                        /**< bit: 26..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_CTRL_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_CTRL_OFFSET                   (0x800)                                       /**<  (USBHS_CTRL) General Control Register  Offset */
+
+#define USBHS_CTRL_RDERRE_Pos               4                                              /**< (USBHS_CTRL) Remote Device Connection Error Interrupt Enable Position */
+#define USBHS_CTRL_RDERRE_Msk               (_U_(0x1) << USBHS_CTRL_RDERRE_Pos)            /**< (USBHS_CTRL) Remote Device Connection Error Interrupt Enable Mask */
+#define USBHS_CTRL_RDERRE                   USBHS_CTRL_RDERRE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_RDERRE_Msk instead */
+#define USBHS_CTRL_VBUSHWC_Pos              8                                              /**< (USBHS_CTRL) VBUS Hardware Control Position */
+#define USBHS_CTRL_VBUSHWC_Msk              (_U_(0x1) << USBHS_CTRL_VBUSHWC_Pos)           /**< (USBHS_CTRL) VBUS Hardware Control Mask */
+#define USBHS_CTRL_VBUSHWC                  USBHS_CTRL_VBUSHWC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_VBUSHWC_Msk instead */
+#define USBHS_CTRL_FRZCLK_Pos               14                                             /**< (USBHS_CTRL) Freeze USB Clock Position */
+#define USBHS_CTRL_FRZCLK_Msk               (_U_(0x1) << USBHS_CTRL_FRZCLK_Pos)            /**< (USBHS_CTRL) Freeze USB Clock Mask */
+#define USBHS_CTRL_FRZCLK                   USBHS_CTRL_FRZCLK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_FRZCLK_Msk instead */
+#define USBHS_CTRL_USBE_Pos                 15                                             /**< (USBHS_CTRL) USBHS Enable Position */
+#define USBHS_CTRL_USBE_Msk                 (_U_(0x1) << USBHS_CTRL_USBE_Pos)              /**< (USBHS_CTRL) USBHS Enable Mask */
+#define USBHS_CTRL_USBE                     USBHS_CTRL_USBE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_USBE_Msk instead */
+#define USBHS_CTRL_UID_Pos                  24                                             /**< (USBHS_CTRL) UID Pin Enable Position */
+#define USBHS_CTRL_UID_Msk                  (_U_(0x1) << USBHS_CTRL_UID_Pos)               /**< (USBHS_CTRL) UID Pin Enable Mask */
+#define USBHS_CTRL_UID                      USBHS_CTRL_UID_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UID_Msk instead */
+#define USBHS_CTRL_UIMOD_Pos                25                                             /**< (USBHS_CTRL) USBHS Mode Position */
+#define USBHS_CTRL_UIMOD_Msk                (_U_(0x1) << USBHS_CTRL_UIMOD_Pos)             /**< (USBHS_CTRL) USBHS Mode Mask */
+#define USBHS_CTRL_UIMOD                    USBHS_CTRL_UIMOD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UIMOD_Msk instead */
+#define   USBHS_CTRL_UIMOD_HOST_Val         _U_(0x0)                                       /**< (USBHS_CTRL) The module is in USB Host mode.  */
+#define   USBHS_CTRL_UIMOD_DEVICE_Val       _U_(0x1)                                       /**< (USBHS_CTRL) The module is in USB Device mode.  */
+#define USBHS_CTRL_UIMOD_HOST               (USBHS_CTRL_UIMOD_HOST_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Host mode. Position  */
+#define USBHS_CTRL_UIMOD_DEVICE             (USBHS_CTRL_UIMOD_DEVICE_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Device mode. Position  */
+#define USBHS_CTRL_MASK                     _U_(0x300C110)                                 /**< \deprecated (USBHS_CTRL) Register MASK  (Use USBHS_CTRL_Msk instead)  */
+#define USBHS_CTRL_Msk                      _U_(0x300C110)                                 /**< (USBHS_CTRL) Register Mask  */
+
+
+/* -------- USBHS_SR : (USBHS Offset: 0x804) (R/ 32) General Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRI:1;                  /**< bit:      4  Remote Device Connection Error Interrupt (Host mode only) */
+    uint32_t :7;                        /**< bit:  5..11  Reserved */
+    uint32_t SPEED:2;                   /**< bit: 12..13  Speed Status (Device mode only)          */
+    uint32_t CLKUSABLE:1;               /**< bit:     14  UTMI Clock Usable                        */
+    uint32_t :17;                       /**< bit: 15..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SR_OFFSET                     (0x804)                                       /**<  (USBHS_SR) General Status Register  Offset */
+
+#define USBHS_SR_RDERRI_Pos                 4                                              /**< (USBHS_SR) Remote Device Connection Error Interrupt (Host mode only) Position */
+#define USBHS_SR_RDERRI_Msk                 (_U_(0x1) << USBHS_SR_RDERRI_Pos)              /**< (USBHS_SR) Remote Device Connection Error Interrupt (Host mode only) Mask */
+#define USBHS_SR_RDERRI                     USBHS_SR_RDERRI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SR_RDERRI_Msk instead */
+#define USBHS_SR_SPEED_Pos                  12                                             /**< (USBHS_SR) Speed Status (Device mode only) Position */
+#define USBHS_SR_SPEED_Msk                  (_U_(0x3) << USBHS_SR_SPEED_Pos)               /**< (USBHS_SR) Speed Status (Device mode only) Mask */
+#define USBHS_SR_SPEED(value)               (USBHS_SR_SPEED_Msk & ((value) << USBHS_SR_SPEED_Pos))
+#define   USBHS_SR_SPEED_FULL_SPEED_Val     _U_(0x0)                                       /**< (USBHS_SR) Full-Speed mode  */
+#define   USBHS_SR_SPEED_HIGH_SPEED_Val     _U_(0x1)                                       /**< (USBHS_SR) High-Speed mode  */
+#define   USBHS_SR_SPEED_LOW_SPEED_Val      _U_(0x2)                                       /**< (USBHS_SR) Low-Speed mode  */
+#define USBHS_SR_SPEED_FULL_SPEED           (USBHS_SR_SPEED_FULL_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) Full-Speed mode Position  */
+#define USBHS_SR_SPEED_HIGH_SPEED           (USBHS_SR_SPEED_HIGH_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) High-Speed mode Position  */
+#define USBHS_SR_SPEED_LOW_SPEED            (USBHS_SR_SPEED_LOW_SPEED_Val << USBHS_SR_SPEED_Pos)  /**< (USBHS_SR) Low-Speed mode Position  */
+#define USBHS_SR_CLKUSABLE_Pos              14                                             /**< (USBHS_SR) UTMI Clock Usable Position */
+#define USBHS_SR_CLKUSABLE_Msk              (_U_(0x1) << USBHS_SR_CLKUSABLE_Pos)           /**< (USBHS_SR) UTMI Clock Usable Mask */
+#define USBHS_SR_CLKUSABLE                  USBHS_SR_CLKUSABLE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SR_CLKUSABLE_Msk instead */
+#define USBHS_SR_MASK                       _U_(0x7010)                                    /**< \deprecated (USBHS_SR) Register MASK  (Use USBHS_SR_Msk instead)  */
+#define USBHS_SR_Msk                        _U_(0x7010)                                    /**< (USBHS_SR) Register Mask  */
+
+
+/* -------- USBHS_SCR : (USBHS Offset: 0x808) (/W 32) General Status Clear Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRIC:1;                 /**< bit:      4  Remote Device Connection Error Interrupt Clear */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SCR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SCR_OFFSET                    (0x808)                                       /**<  (USBHS_SCR) General Status Clear Register  Offset */
+
+#define USBHS_SCR_RDERRIC_Pos               4                                              /**< (USBHS_SCR) Remote Device Connection Error Interrupt Clear Position */
+#define USBHS_SCR_RDERRIC_Msk               (_U_(0x1) << USBHS_SCR_RDERRIC_Pos)            /**< (USBHS_SCR) Remote Device Connection Error Interrupt Clear Mask */
+#define USBHS_SCR_RDERRIC                   USBHS_SCR_RDERRIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SCR_RDERRIC_Msk instead */
+#define USBHS_SCR_MASK                      _U_(0x10)                                      /**< \deprecated (USBHS_SCR) Register MASK  (Use USBHS_SCR_Msk instead)  */
+#define USBHS_SCR_Msk                       _U_(0x10)                                      /**< (USBHS_SCR) Register Mask  */
+
+
+/* -------- USBHS_SFR : (USBHS Offset: 0x80c) (/W 32) General Status Set Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t RDERRIS:1;                 /**< bit:      4  Remote Device Connection Error Interrupt Set */
+    uint32_t :4;                        /**< bit:   5..8  Reserved */
+    uint32_t VBUSRQS:1;                 /**< bit:      9  VBUS Request Set                         */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} USBHS_SFR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBHS_SFR_OFFSET                    (0x80C)                                       /**<  (USBHS_SFR) General Status Set Register  Offset */
+
+#define USBHS_SFR_RDERRIS_Pos               4                                              /**< (USBHS_SFR) Remote Device Connection Error Interrupt Set Position */
+#define USBHS_SFR_RDERRIS_Msk               (_U_(0x1) << USBHS_SFR_RDERRIS_Pos)            /**< (USBHS_SFR) Remote Device Connection Error Interrupt Set Mask */
+#define USBHS_SFR_RDERRIS                   USBHS_SFR_RDERRIS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SFR_RDERRIS_Msk instead */
+#define USBHS_SFR_VBUSRQS_Pos               9                                              /**< (USBHS_SFR) VBUS Request Set Position */
+#define USBHS_SFR_VBUSRQS_Msk               (_U_(0x1) << USBHS_SFR_VBUSRQS_Pos)            /**< (USBHS_SFR) VBUS Request Set Mask */
+#define USBHS_SFR_VBUSRQS                   USBHS_SFR_VBUSRQS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_SFR_VBUSRQS_Msk instead */
+#define USBHS_SFR_MASK                      _U_(0x210)                                     /**< \deprecated (USBHS_SFR) Register MASK  (Use USBHS_SFR_Msk instead)  */
+#define USBHS_SFR_Msk                       _U_(0x210)                                     /**< (USBHS_SFR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief USBHS_DEVDMA hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_DEVDMANXTDSC; /**< (USBHS_DEVDMA Offset: 0x00) Device DMA Channel Next Descriptor Address Register */
+  __IO uint32_t USBHS_DEVDMAADDRESS; /**< (USBHS_DEVDMA Offset: 0x04) Device DMA Channel Address Register */
+  __IO uint32_t USBHS_DEVDMACONTROL; /**< (USBHS_DEVDMA Offset: 0x08) Device DMA Channel Control Register */
+  __IO uint32_t USBHS_DEVDMASTATUS; /**< (USBHS_DEVDMA Offset: 0x0C) Device DMA Channel Status Register */
+} UsbhsDevdma;
+
+/** \brief USBHS_HSTDMA hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_HSTDMANXTDSC; /**< (USBHS_HSTDMA Offset: 0x00) Host DMA Channel Next Descriptor Address Register */
+  __IO uint32_t USBHS_HSTDMAADDRESS; /**< (USBHS_HSTDMA Offset: 0x04) Host DMA Channel Address Register */
+  __IO uint32_t USBHS_HSTDMACONTROL; /**< (USBHS_HSTDMA Offset: 0x08) Host DMA Channel Control Register */
+  __IO uint32_t USBHS_HSTDMASTATUS; /**< (USBHS_HSTDMA Offset: 0x0C) Host DMA Channel Status Register */
+} UsbhsHstdma;
+
+#define USBHSDEVDMA_NUMBER 7
+#define USBHSHSTDMA_NUMBER 7
+/** \brief USBHS hardware registers */
+typedef struct {  
+  __IO uint32_t USBHS_DEVCTRL;  /**< (USBHS Offset: 0x00) Device General Control Register */
+  __I  uint32_t USBHS_DEVISR;   /**< (USBHS Offset: 0x04) Device Global Interrupt Status Register */
+  __O  uint32_t USBHS_DEVICR;   /**< (USBHS Offset: 0x08) Device Global Interrupt Clear Register */
+  __O  uint32_t USBHS_DEVIFR;   /**< (USBHS Offset: 0x0C) Device Global Interrupt Set Register */
+  __I  uint32_t USBHS_DEVIMR;   /**< (USBHS Offset: 0x10) Device Global Interrupt Mask Register */
+  __O  uint32_t USBHS_DEVIDR;   /**< (USBHS Offset: 0x14) Device Global Interrupt Disable Register */
+  __O  uint32_t USBHS_DEVIER;   /**< (USBHS Offset: 0x18) Device Global Interrupt Enable Register */
+  __IO uint32_t USBHS_DEVEPT;   /**< (USBHS Offset: 0x1C) Device Endpoint Register */
+  __I  uint32_t USBHS_DEVFNUM;  /**< (USBHS Offset: 0x20) Device Frame Number Register */
+  __I  uint8_t                        Reserved1[220];
+  __IO uint32_t USBHS_DEVEPTCFG[10]; /**< (USBHS Offset: 0x100) Device Endpoint Configuration Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  uint32_t USBHS_DEVEPTISR[10]; /**< (USBHS Offset: 0x130) Device Endpoint Interrupt Status Register */
+  __I  uint8_t                        Reserved3[8];
+  __O  uint32_t USBHS_DEVEPTICR[10]; /**< (USBHS Offset: 0x160) Device Endpoint Interrupt Clear Register */
+  __I  uint8_t                        Reserved4[8];
+  __O  uint32_t USBHS_DEVEPTIFR[10]; /**< (USBHS Offset: 0x190) Device Endpoint Interrupt Set Register */
+  __I  uint8_t                        Reserved5[8];
+  __I  uint32_t USBHS_DEVEPTIMR[10]; /**< (USBHS Offset: 0x1C0) Device Endpoint Interrupt Mask Register */
+  __I  uint8_t                        Reserved6[8];
+  __O  uint32_t USBHS_DEVEPTIER[10]; /**< (USBHS Offset: 0x1F0) Device Endpoint Interrupt Enable Register */
+  __I  uint8_t                        Reserved7[8];
+  __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Interrupt Disable Register */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved9[128];
+  __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
+  __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
+  __O  uint32_t USBHS_HSTICR;   /**< (USBHS Offset: 0x408) Host Global Interrupt Clear Register */
+  __O  uint32_t USBHS_HSTIFR;   /**< (USBHS Offset: 0x40C) Host Global Interrupt Set Register */
+  __I  uint32_t USBHS_HSTIMR;   /**< (USBHS Offset: 0x410) Host Global Interrupt Mask Register */
+  __O  uint32_t USBHS_HSTIDR;   /**< (USBHS Offset: 0x414) Host Global Interrupt Disable Register */
+  __O  uint32_t USBHS_HSTIER;   /**< (USBHS Offset: 0x418) Host Global Interrupt Enable Register */
+  __IO uint32_t USBHS_HSTPIP;   /**< (USBHS Offset: 0x41C) Host Pipe Register */
+  __IO uint32_t USBHS_HSTFNUM;  /**< (USBHS Offset: 0x420) Host Frame Number Register */
+  __IO uint32_t USBHS_HSTADDR1; /**< (USBHS Offset: 0x424) Host Address 1 Register */
+  __IO uint32_t USBHS_HSTADDR2; /**< (USBHS Offset: 0x428) Host Address 2 Register */
+  __IO uint32_t USBHS_HSTADDR3; /**< (USBHS Offset: 0x42C) Host Address 3 Register */
+  __I  uint8_t                        Reserved10[208];
+  __IO uint32_t USBHS_HSTPIPCFG[10]; /**< (USBHS Offset: 0x500) Host Pipe Configuration Register */
+  __I  uint8_t                        Reserved11[8];
+  __I  uint32_t USBHS_HSTPIPISR[10]; /**< (USBHS Offset: 0x530) Host Pipe Status Register */
+  __I  uint8_t                        Reserved12[8];
+  __O  uint32_t USBHS_HSTPIPICR[10]; /**< (USBHS Offset: 0x560) Host Pipe Clear Register */
+  __I  uint8_t                        Reserved13[8];
+  __O  uint32_t USBHS_HSTPIPIFR[10]; /**< (USBHS Offset: 0x590) Host Pipe Set Register */
+  __I  uint8_t                        Reserved14[8];
+  __I  uint32_t USBHS_HSTPIPIMR[10]; /**< (USBHS Offset: 0x5C0) Host Pipe Mask Register */
+  __I  uint8_t                        Reserved15[8];
+  __O  uint32_t USBHS_HSTPIPIER[10]; /**< (USBHS Offset: 0x5F0) Host Pipe Enable Register */
+  __I  uint8_t                        Reserved16[8];
+  __O  uint32_t USBHS_HSTPIPIDR[10]; /**< (USBHS Offset: 0x620) Host Pipe Disable Register */
+  __I  uint8_t                        Reserved17[8];
+  __IO uint32_t USBHS_HSTPIPINRQ[10]; /**< (USBHS Offset: 0x650) Host Pipe IN Request Register */
+  __I  uint8_t                        Reserved18[8];
+  __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved20[128];
+  __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
+  __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
+  __O  uint32_t USBHS_SCR;      /**< (USBHS Offset: 0x808) General Status Clear Register */
+  __O  uint32_t USBHS_SFR;      /**< (USBHS Offset: 0x80C) General Status Set Register */
+} Usbhs;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief USBHS_DEVDMA hardware registers */
+typedef struct {  
+  __IO USBHS_DEVDMANXTDSC_Type        USBHS_DEVDMANXTDSC; /**< Offset: 0x00 (R/W  32) Device DMA Channel Next Descriptor Address Register */
+  __IO USBHS_DEVDMAADDRESS_Type       USBHS_DEVDMAADDRESS; /**< Offset: 0x04 (R/W  32) Device DMA Channel Address Register */
+  __IO USBHS_DEVDMACONTROL_Type       USBHS_DEVDMACONTROL; /**< Offset: 0x08 (R/W  32) Device DMA Channel Control Register */
+  __IO USBHS_DEVDMASTATUS_Type        USBHS_DEVDMASTATUS; /**< Offset: 0x0C (R/W  32) Device DMA Channel Status Register */
+} UsbhsDevdma;
+
+/** \brief USBHS_HSTDMA hardware registers */
+typedef struct {  
+  __IO USBHS_HSTDMANXTDSC_Type        USBHS_HSTDMANXTDSC; /**< Offset: 0x00 (R/W  32) Host DMA Channel Next Descriptor Address Register */
+  __IO USBHS_HSTDMAADDRESS_Type       USBHS_HSTDMAADDRESS; /**< Offset: 0x04 (R/W  32) Host DMA Channel Address Register */
+  __IO USBHS_HSTDMACONTROL_Type       USBHS_HSTDMACONTROL; /**< Offset: 0x08 (R/W  32) Host DMA Channel Control Register */
+  __IO USBHS_HSTDMASTATUS_Type        USBHS_HSTDMASTATUS; /**< Offset: 0x0C (R/W  32) Host DMA Channel Status Register */
+} UsbhsHstdma;
+
+/** \brief USBHS hardware registers */
+typedef struct {  
+  __IO USBHS_DEVCTRL_Type             USBHS_DEVCTRL;  /**< Offset: 0x00 (R/W  32) Device General Control Register */
+  __I  USBHS_DEVISR_Type              USBHS_DEVISR;   /**< Offset: 0x04 (R/   32) Device Global Interrupt Status Register */
+  __O  USBHS_DEVICR_Type              USBHS_DEVICR;   /**< Offset: 0x08 ( /W  32) Device Global Interrupt Clear Register */
+  __O  USBHS_DEVIFR_Type              USBHS_DEVIFR;   /**< Offset: 0x0C ( /W  32) Device Global Interrupt Set Register */
+  __I  USBHS_DEVIMR_Type              USBHS_DEVIMR;   /**< Offset: 0x10 (R/   32) Device Global Interrupt Mask Register */
+  __O  USBHS_DEVIDR_Type              USBHS_DEVIDR;   /**< Offset: 0x14 ( /W  32) Device Global Interrupt Disable Register */
+  __O  USBHS_DEVIER_Type              USBHS_DEVIER;   /**< Offset: 0x18 ( /W  32) Device Global Interrupt Enable Register */
+  __IO USBHS_DEVEPT_Type              USBHS_DEVEPT;   /**< Offset: 0x1C (R/W  32) Device Endpoint Register */
+  __I  USBHS_DEVFNUM_Type             USBHS_DEVFNUM;  /**< Offset: 0x20 (R/   32) Device Frame Number Register */
+  __I  uint8_t                        Reserved1[220];
+  __IO USBHS_DEVEPTCFG_Type           USBHS_DEVEPTCFG[10]; /**< Offset: 0x100 (R/W  32) Device Endpoint Configuration Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  USBHS_DEVEPTISR_Type           USBHS_DEVEPTISR[10]; /**< Offset: 0x130 (R/   32) Device Endpoint Interrupt Status Register */
+  __I  uint8_t                        Reserved3[8];
+  __O  USBHS_DEVEPTICR_Type           USBHS_DEVEPTICR[10]; /**< Offset: 0x160 ( /W  32) Device Endpoint Interrupt Clear Register */
+  __I  uint8_t                        Reserved4[8];
+  __O  USBHS_DEVEPTIFR_Type           USBHS_DEVEPTIFR[10]; /**< Offset: 0x190 ( /W  32) Device Endpoint Interrupt Set Register */
+  __I  uint8_t                        Reserved5[8];
+  __I  USBHS_DEVEPTIMR_Type           USBHS_DEVEPTIMR[10]; /**< Offset: 0x1C0 (R/   32) Device Endpoint Interrupt Mask Register */
+  __I  uint8_t                        Reserved6[8];
+  __O  USBHS_DEVEPTIER_Type           USBHS_DEVEPTIER[10]; /**< Offset: 0x1F0 ( /W  32) Device Endpoint Interrupt Enable Register */
+  __I  uint8_t                        Reserved7[8];
+  __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Interrupt Disable Register */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved9[128];
+  __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
+  __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */
+  __O  USBHS_HSTICR_Type              USBHS_HSTICR;   /**< Offset: 0x408 ( /W  32) Host Global Interrupt Clear Register */
+  __O  USBHS_HSTIFR_Type              USBHS_HSTIFR;   /**< Offset: 0x40C ( /W  32) Host Global Interrupt Set Register */
+  __I  USBHS_HSTIMR_Type              USBHS_HSTIMR;   /**< Offset: 0x410 (R/   32) Host Global Interrupt Mask Register */
+  __O  USBHS_HSTIDR_Type              USBHS_HSTIDR;   /**< Offset: 0x414 ( /W  32) Host Global Interrupt Disable Register */
+  __O  USBHS_HSTIER_Type              USBHS_HSTIER;   /**< Offset: 0x418 ( /W  32) Host Global Interrupt Enable Register */
+  __IO USBHS_HSTPIP_Type              USBHS_HSTPIP;   /**< Offset: 0x41C (R/W  32) Host Pipe Register */
+  __IO USBHS_HSTFNUM_Type             USBHS_HSTFNUM;  /**< Offset: 0x420 (R/W  32) Host Frame Number Register */
+  __IO USBHS_HSTADDR1_Type            USBHS_HSTADDR1; /**< Offset: 0x424 (R/W  32) Host Address 1 Register */
+  __IO USBHS_HSTADDR2_Type            USBHS_HSTADDR2; /**< Offset: 0x428 (R/W  32) Host Address 2 Register */
+  __IO USBHS_HSTADDR3_Type            USBHS_HSTADDR3; /**< Offset: 0x42C (R/W  32) Host Address 3 Register */
+  __I  uint8_t                        Reserved10[208];
+  __IO USBHS_HSTPIPCFG_Type           USBHS_HSTPIPCFG[10]; /**< Offset: 0x500 (R/W  32) Host Pipe Configuration Register */
+  __I  uint8_t                        Reserved11[8];
+  __I  USBHS_HSTPIPISR_Type           USBHS_HSTPIPISR[10]; /**< Offset: 0x530 (R/   32) Host Pipe Status Register */
+  __I  uint8_t                        Reserved12[8];
+  __O  USBHS_HSTPIPICR_Type           USBHS_HSTPIPICR[10]; /**< Offset: 0x560 ( /W  32) Host Pipe Clear Register */
+  __I  uint8_t                        Reserved13[8];
+  __O  USBHS_HSTPIPIFR_Type           USBHS_HSTPIPIFR[10]; /**< Offset: 0x590 ( /W  32) Host Pipe Set Register */
+  __I  uint8_t                        Reserved14[8];
+  __I  USBHS_HSTPIPIMR_Type           USBHS_HSTPIPIMR[10]; /**< Offset: 0x5C0 (R/   32) Host Pipe Mask Register */
+  __I  uint8_t                        Reserved15[8];
+  __O  USBHS_HSTPIPIER_Type           USBHS_HSTPIPIER[10]; /**< Offset: 0x5F0 ( /W  32) Host Pipe Enable Register */
+  __I  uint8_t                        Reserved16[8];
+  __O  USBHS_HSTPIPIDR_Type           USBHS_HSTPIPIDR[10]; /**< Offset: 0x620 ( /W  32) Host Pipe Disable Register */
+  __I  uint8_t                        Reserved17[8];
+  __IO USBHS_HSTPIPINRQ_Type          USBHS_HSTPIPINRQ[10]; /**< Offset: 0x650 (R/W  32) Host Pipe IN Request Register */
+  __I  uint8_t                        Reserved18[8];
+  __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved20[128];
+  __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
+  __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */
+  __O  USBHS_SCR_Type                 USBHS_SCR;      /**< Offset: 0x808 ( /W  32) General Status Clear Register */
+  __O  USBHS_SFR_Type                 USBHS_SFR;      /**< Offset: 0x80C ( /W  32) General Status Set Register */
+} Usbhs;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of USB High-Speed Interface */
+
+#endif /* _SAMV71_USBHS_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/utmi.h
+++ b/asf/sam/include/samv71b/component/utmi.h
@@ -1,0 +1,143 @@
+/**
+ * \file
+ *
+ * \brief Component description for UTMI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UTMI_COMPONENT_H_
+#define _SAMV71_UTMI_COMPONENT_H_
+#define _SAMV71_UTMI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 USB Transmitter Interface Macrocell
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR UTMI */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define UTMI_11300                      /**< (UTMI) Module ID */
+#define REV_UTMI A                      /**< (UTMI) Module revision */
+
+/* -------- UTMI_OHCIICR : (UTMI Offset: 0x10) (R/W 32) OHCI Interrupt Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RES0:1;                    /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :3;                        /**< bit:   1..3  Reserved */
+    uint32_t ARIE:1;                    /**< bit:      4  OHCI Asynchronous Resume Interrupt Enable */
+    uint32_t APPSTART:1;                /**< bit:      5  Reserved                                 */
+    uint32_t :17;                       /**< bit:  6..22  Reserved */
+    uint32_t UDPPUDIS:1;                /**< bit:     23  USB Device Pull-up Disable               */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :31;                       /**< bit:  1..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} UTMI_OHCIICR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UTMI_OHCIICR_OFFSET                 (0x10)                                        /**<  (UTMI_OHCIICR) OHCI Interrupt Configuration Register  Offset */
+
+#define UTMI_OHCIICR_RES0_Pos               0                                              /**< (UTMI_OHCIICR) USB PORTx Reset Position */
+#define UTMI_OHCIICR_RES0_Msk               (_U_(0x1) << UTMI_OHCIICR_RES0_Pos)            /**< (UTMI_OHCIICR) USB PORTx Reset Mask */
+#define UTMI_OHCIICR_RES0                   UTMI_OHCIICR_RES0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_RES0_Msk instead */
+#define UTMI_OHCIICR_ARIE_Pos               4                                              /**< (UTMI_OHCIICR) OHCI Asynchronous Resume Interrupt Enable Position */
+#define UTMI_OHCIICR_ARIE_Msk               (_U_(0x1) << UTMI_OHCIICR_ARIE_Pos)            /**< (UTMI_OHCIICR) OHCI Asynchronous Resume Interrupt Enable Mask */
+#define UTMI_OHCIICR_ARIE                   UTMI_OHCIICR_ARIE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_ARIE_Msk instead */
+#define UTMI_OHCIICR_APPSTART_Pos           5                                              /**< (UTMI_OHCIICR) Reserved Position */
+#define UTMI_OHCIICR_APPSTART_Msk           (_U_(0x1) << UTMI_OHCIICR_APPSTART_Pos)        /**< (UTMI_OHCIICR) Reserved Mask */
+#define UTMI_OHCIICR_APPSTART               UTMI_OHCIICR_APPSTART_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_APPSTART_Msk instead */
+#define UTMI_OHCIICR_UDPPUDIS_Pos           23                                             /**< (UTMI_OHCIICR) USB Device Pull-up Disable Position */
+#define UTMI_OHCIICR_UDPPUDIS_Msk           (_U_(0x1) << UTMI_OHCIICR_UDPPUDIS_Pos)        /**< (UTMI_OHCIICR) USB Device Pull-up Disable Mask */
+#define UTMI_OHCIICR_UDPPUDIS               UTMI_OHCIICR_UDPPUDIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use UTMI_OHCIICR_UDPPUDIS_Msk instead */
+#define UTMI_OHCIICR_MASK                   _U_(0x800031)                                  /**< \deprecated (UTMI_OHCIICR) Register MASK  (Use UTMI_OHCIICR_Msk instead)  */
+#define UTMI_OHCIICR_Msk                    _U_(0x800031)                                  /**< (UTMI_OHCIICR) Register Mask  */
+
+#define UTMI_OHCIICR_RES_Pos                0                                              /**< (UTMI_OHCIICR Position) USB PORTx Reset */
+#define UTMI_OHCIICR_RES_Msk                (_U_(0x1) << UTMI_OHCIICR_RES_Pos)             /**< (UTMI_OHCIICR Mask) RES */
+#define UTMI_OHCIICR_RES(value)             (UTMI_OHCIICR_RES_Msk & ((value) << UTMI_OHCIICR_RES_Pos))  
+
+/* -------- UTMI_CKTRIM : (UTMI Offset: 0x30) (R/W 32) UTMI Clock Trimming Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t FREQ:2;                    /**< bit:   0..1  UTMI Reference Clock Frequency           */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} UTMI_CKTRIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define UTMI_CKTRIM_OFFSET                  (0x30)                                        /**<  (UTMI_CKTRIM) UTMI Clock Trimming Register  Offset */
+
+#define UTMI_CKTRIM_FREQ_Pos                0                                              /**< (UTMI_CKTRIM) UTMI Reference Clock Frequency Position */
+#define UTMI_CKTRIM_FREQ_Msk                (_U_(0x3) << UTMI_CKTRIM_FREQ_Pos)             /**< (UTMI_CKTRIM) UTMI Reference Clock Frequency Mask */
+#define UTMI_CKTRIM_FREQ(value)             (UTMI_CKTRIM_FREQ_Msk & ((value) << UTMI_CKTRIM_FREQ_Pos))
+#define   UTMI_CKTRIM_FREQ_XTAL12_Val       _U_(0x0)                                       /**< (UTMI_CKTRIM) 12 MHz reference clock  */
+#define   UTMI_CKTRIM_FREQ_XTAL16_Val       _U_(0x1)                                       /**< (UTMI_CKTRIM) 16 MHz reference clock  */
+#define UTMI_CKTRIM_FREQ_XTAL12             (UTMI_CKTRIM_FREQ_XTAL12_Val << UTMI_CKTRIM_FREQ_Pos)  /**< (UTMI_CKTRIM) 12 MHz reference clock Position  */
+#define UTMI_CKTRIM_FREQ_XTAL16             (UTMI_CKTRIM_FREQ_XTAL16_Val << UTMI_CKTRIM_FREQ_Pos)  /**< (UTMI_CKTRIM) 16 MHz reference clock Position  */
+#define UTMI_CKTRIM_MASK                    _U_(0x03)                                      /**< \deprecated (UTMI_CKTRIM) Register MASK  (Use UTMI_CKTRIM_Msk instead)  */
+#define UTMI_CKTRIM_Msk                     _U_(0x03)                                      /**< (UTMI_CKTRIM) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief UTMI hardware registers */
+typedef struct {  
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t UTMI_OHCIICR;   /**< (UTMI Offset: 0x10) OHCI Interrupt Configuration Register */
+  __I  uint8_t                        Reserved2[28];
+  __IO uint32_t UTMI_CKTRIM;    /**< (UTMI Offset: 0x30) UTMI Clock Trimming Register */
+} Utmi;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief UTMI hardware registers */
+typedef struct {  
+  __I  uint8_t                        Reserved1[16];
+  __IO UTMI_OHCIICR_Type              UTMI_OHCIICR;   /**< Offset: 0x10 (R/W  32) OHCI Interrupt Configuration Register */
+  __I  uint8_t                        Reserved2[28];
+  __IO UTMI_CKTRIM_Type               UTMI_CKTRIM;    /**< Offset: 0x30 (R/W  32) UTMI Clock Trimming Register */
+} Utmi;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of USB Transmitter Interface Macrocell */
+
+#endif /* _SAMV71_UTMI_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/wdt.h
+++ b/asf/sam/include/samv71b/component/wdt.h
@@ -1,0 +1,173 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_WDT_COMPONENT_H_
+#define _SAMV71_WDT_COMPONENT_H_
+#define _SAMV71_WDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Watchdog Timer
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define WDT_6080                       /**< (WDT) Module ID */
+#define REV_WDT N                      /**< (WDT) Module revision */
+
+/* -------- WDT_CR : (WDT Offset: 0x00) (/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
+    uint32_t :23;                       /**< bit:  1..23  Reserved */
+    uint32_t KEY:8;                     /**< bit: 24..31  Password                                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_CR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CR_OFFSET                       (0x00)                                        /**<  (WDT_CR) Control Register  Offset */
+
+#define WDT_CR_WDRSTT_Pos                   0                                              /**< (WDT_CR) Watchdog Restart Position */
+#define WDT_CR_WDRSTT_Msk                   (_U_(0x1) << WDT_CR_WDRSTT_Pos)                /**< (WDT_CR) Watchdog Restart Mask */
+#define WDT_CR_WDRSTT                       WDT_CR_WDRSTT_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_CR_WDRSTT_Msk instead */
+#define WDT_CR_KEY_Pos                      24                                             /**< (WDT_CR) Password Position */
+#define WDT_CR_KEY_Msk                      (_U_(0xFF) << WDT_CR_KEY_Pos)                  /**< (WDT_CR) Password Mask */
+#define WDT_CR_KEY(value)                   (WDT_CR_KEY_Msk & ((value) << WDT_CR_KEY_Pos))
+#define   WDT_CR_KEY_PASSWD_Val             _U_(0xA5)                                      /**< (WDT_CR) Writing any other value in this field aborts the write operation.  */
+#define WDT_CR_KEY_PASSWD                   (WDT_CR_KEY_PASSWD_Val << WDT_CR_KEY_Pos)      /**< (WDT_CR) Writing any other value in this field aborts the write operation. Position  */
+#define WDT_CR_MASK                         _U_(0xFF000001)                                /**< \deprecated (WDT_CR) Register MASK  (Use WDT_CR_Msk instead)  */
+#define WDT_CR_Msk                          _U_(0xFF000001)                                /**< (WDT_CR) Register Mask  */
+
+
+/* -------- WDT_MR : (WDT Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
+    uint32_t WDFIEN:1;                  /**< bit:     12  Watchdog Fault Interrupt Enable          */
+    uint32_t WDRSTEN:1;                 /**< bit:     13  Watchdog Reset Enable                    */
+    uint32_t :1;                        /**< bit:     14  Reserved */
+    uint32_t WDDIS:1;                   /**< bit:     15  Watchdog Disable                         */
+    uint32_t WDD:12;                    /**< bit: 16..27  Watchdog Delta Value                     */
+    uint32_t WDDBGHLT:1;                /**< bit:     28  Watchdog Debug Halt                      */
+    uint32_t WDIDLEHLT:1;               /**< bit:     29  Watchdog Idle Halt                       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_MR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_MR_OFFSET                       (0x04)                                        /**<  (WDT_MR) Mode Register  Offset */
+
+#define WDT_MR_WDV_Pos                      0                                              /**< (WDT_MR) Watchdog Counter Value Position */
+#define WDT_MR_WDV_Msk                      (_U_(0xFFF) << WDT_MR_WDV_Pos)                 /**< (WDT_MR) Watchdog Counter Value Mask */
+#define WDT_MR_WDV(value)                   (WDT_MR_WDV_Msk & ((value) << WDT_MR_WDV_Pos))
+#define WDT_MR_WDFIEN_Pos                   12                                             /**< (WDT_MR) Watchdog Fault Interrupt Enable Position */
+#define WDT_MR_WDFIEN_Msk                   (_U_(0x1) << WDT_MR_WDFIEN_Pos)                /**< (WDT_MR) Watchdog Fault Interrupt Enable Mask */
+#define WDT_MR_WDFIEN                       WDT_MR_WDFIEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDFIEN_Msk instead */
+#define WDT_MR_WDRSTEN_Pos                  13                                             /**< (WDT_MR) Watchdog Reset Enable Position */
+#define WDT_MR_WDRSTEN_Msk                  (_U_(0x1) << WDT_MR_WDRSTEN_Pos)               /**< (WDT_MR) Watchdog Reset Enable Mask */
+#define WDT_MR_WDRSTEN                      WDT_MR_WDRSTEN_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDRSTEN_Msk instead */
+#define WDT_MR_WDDIS_Pos                    15                                             /**< (WDT_MR) Watchdog Disable Position */
+#define WDT_MR_WDDIS_Msk                    (_U_(0x1) << WDT_MR_WDDIS_Pos)                 /**< (WDT_MR) Watchdog Disable Mask */
+#define WDT_MR_WDDIS                        WDT_MR_WDDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDDIS_Msk instead */
+#define WDT_MR_WDD_Pos                      16                                             /**< (WDT_MR) Watchdog Delta Value Position */
+#define WDT_MR_WDD_Msk                      (_U_(0xFFF) << WDT_MR_WDD_Pos)                 /**< (WDT_MR) Watchdog Delta Value Mask */
+#define WDT_MR_WDD(value)                   (WDT_MR_WDD_Msk & ((value) << WDT_MR_WDD_Pos))
+#define WDT_MR_WDDBGHLT_Pos                 28                                             /**< (WDT_MR) Watchdog Debug Halt Position */
+#define WDT_MR_WDDBGHLT_Msk                 (_U_(0x1) << WDT_MR_WDDBGHLT_Pos)              /**< (WDT_MR) Watchdog Debug Halt Mask */
+#define WDT_MR_WDDBGHLT                     WDT_MR_WDDBGHLT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDDBGHLT_Msk instead */
+#define WDT_MR_WDIDLEHLT_Pos                29                                             /**< (WDT_MR) Watchdog Idle Halt Position */
+#define WDT_MR_WDIDLEHLT_Msk                (_U_(0x1) << WDT_MR_WDIDLEHLT_Pos)             /**< (WDT_MR) Watchdog Idle Halt Mask */
+#define WDT_MR_WDIDLEHLT                    WDT_MR_WDIDLEHLT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_MR_WDIDLEHLT_Msk instead */
+#define WDT_MR_MASK                         _U_(0x3FFFBFFF)                                /**< \deprecated (WDT_MR) Register MASK  (Use WDT_MR_Msk instead)  */
+#define WDT_MR_Msk                          _U_(0x3FFFBFFF)                                /**< (WDT_MR) Register Mask  */
+
+
+/* -------- WDT_SR : (WDT Offset: 0x08) (R/ 32) Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow (cleared on read)     */
+    uint32_t WDERR:1;                   /**< bit:      1  Watchdog Error (cleared on read)         */
+    uint32_t :30;                       /**< bit:  2..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} WDT_SR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SR_OFFSET                       (0x08)                                        /**<  (WDT_SR) Status Register  Offset */
+
+#define WDT_SR_WDUNF_Pos                    0                                              /**< (WDT_SR) Watchdog Underflow (cleared on read) Position */
+#define WDT_SR_WDUNF_Msk                    (_U_(0x1) << WDT_SR_WDUNF_Pos)                 /**< (WDT_SR) Watchdog Underflow (cleared on read) Mask */
+#define WDT_SR_WDUNF                        WDT_SR_WDUNF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SR_WDUNF_Msk instead */
+#define WDT_SR_WDERR_Pos                    1                                              /**< (WDT_SR) Watchdog Error (cleared on read) Position */
+#define WDT_SR_WDERR_Msk                    (_U_(0x1) << WDT_SR_WDERR_Pos)                 /**< (WDT_SR) Watchdog Error (cleared on read) Mask */
+#define WDT_SR_WDERR                        WDT_SR_WDERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use WDT_SR_WDERR_Msk instead */
+#define WDT_SR_MASK                         _U_(0x03)                                      /**< \deprecated (WDT_SR) Register MASK  (Use WDT_SR_Msk instead)  */
+#define WDT_SR_Msk                          _U_(0x03)                                      /**< (WDT_SR) Register Mask  */
+
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief WDT hardware registers */
+typedef struct {  
+  __O  uint32_t WDT_CR;         /**< (WDT Offset: 0x00) Control Register */
+  __IO uint32_t WDT_MR;         /**< (WDT Offset: 0x04) Mode Register */
+  __I  uint32_t WDT_SR;         /**< (WDT Offset: 0x08) Status Register */
+} Wdt;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief WDT hardware registers */
+typedef struct {  
+  __O  WDT_CR_Type                    WDT_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
+  __IO WDT_MR_Type                    WDT_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
+  __I  WDT_SR_Type                    WDT_SR;         /**< Offset: 0x08 (R/   32) Status Register */
+} Wdt;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Watchdog Timer */
+
+#endif /* _SAMV71_WDT_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/component/xdmac.h
+++ b/asf/sam/include/samv71b/component/xdmac.h
@@ -1,0 +1,2621 @@
+/**
+ * \file
+ *
+ * \brief Component description for XDMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_XDMAC_COMPONENT_H_
+#define _SAMV71_XDMAC_COMPONENT_H_
+#define _SAMV71_XDMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
+
+/** \addtogroup SAMV_SAMV71 Extensible DMA Controller
+ *  @{
+ */
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR XDMAC */
+/* ========================================================================== */
+#ifndef COMPONENT_TYPEDEF_STYLE
+  #define COMPONENT_TYPEDEF_STYLE 'R'  /**< Defines default style of typedefs for the component header files ('R' = RFO, 'N' = NTO)*/
+#endif
+
+#define XDMAC_11161                      /**< (XDMAC) Module ID */
+#define REV_XDMAC K                      /**< (XDMAC) Module revision */
+
+/* -------- XDMAC_CIE : (XDMAC Offset: 0x00) (/W 32) Channel Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIE:1;                     /**< bit:      0  End of Block Interrupt Enable Bit        */
+    uint32_t LIE:1;                     /**< bit:      1  End of Linked List Interrupt Enable Bit  */
+    uint32_t DIE:1;                     /**< bit:      2  End of Disable Interrupt Enable Bit      */
+    uint32_t FIE:1;                     /**< bit:      3  End of Flush Interrupt Enable Bit        */
+    uint32_t RBIE:1;                    /**< bit:      4  Read Bus Error Interrupt Enable Bit      */
+    uint32_t WBIE:1;                    /**< bit:      5  Write Bus Error Interrupt Enable Bit     */
+    uint32_t ROIE:1;                    /**< bit:      6  Request Overflow Error Interrupt Enable Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIE_OFFSET                    (0x00)                                        /**<  (XDMAC_CIE) Channel Interrupt Enable Register  Offset */
+
+#define XDMAC_CIE_BIE_Pos                   0                                              /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Position */
+#define XDMAC_CIE_BIE_Msk                   (_U_(0x1) << XDMAC_CIE_BIE_Pos)                /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Mask */
+#define XDMAC_CIE_BIE                       XDMAC_CIE_BIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_BIE_Msk instead */
+#define XDMAC_CIE_LIE_Pos                   1                                              /**< (XDMAC_CIE) End of Linked List Interrupt Enable Bit Position */
+#define XDMAC_CIE_LIE_Msk                   (_U_(0x1) << XDMAC_CIE_LIE_Pos)                /**< (XDMAC_CIE) End of Linked List Interrupt Enable Bit Mask */
+#define XDMAC_CIE_LIE                       XDMAC_CIE_LIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_LIE_Msk instead */
+#define XDMAC_CIE_DIE_Pos                   2                                              /**< (XDMAC_CIE) End of Disable Interrupt Enable Bit Position */
+#define XDMAC_CIE_DIE_Msk                   (_U_(0x1) << XDMAC_CIE_DIE_Pos)                /**< (XDMAC_CIE) End of Disable Interrupt Enable Bit Mask */
+#define XDMAC_CIE_DIE                       XDMAC_CIE_DIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_DIE_Msk instead */
+#define XDMAC_CIE_FIE_Pos                   3                                              /**< (XDMAC_CIE) End of Flush Interrupt Enable Bit Position */
+#define XDMAC_CIE_FIE_Msk                   (_U_(0x1) << XDMAC_CIE_FIE_Pos)                /**< (XDMAC_CIE) End of Flush Interrupt Enable Bit Mask */
+#define XDMAC_CIE_FIE                       XDMAC_CIE_FIE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_FIE_Msk instead */
+#define XDMAC_CIE_RBIE_Pos                  4                                              /**< (XDMAC_CIE) Read Bus Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_RBIE_Msk                  (_U_(0x1) << XDMAC_CIE_RBIE_Pos)               /**< (XDMAC_CIE) Read Bus Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_RBIE                      XDMAC_CIE_RBIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_RBIE_Msk instead */
+#define XDMAC_CIE_WBIE_Pos                  5                                              /**< (XDMAC_CIE) Write Bus Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_WBIE_Msk                  (_U_(0x1) << XDMAC_CIE_WBIE_Pos)               /**< (XDMAC_CIE) Write Bus Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_WBIE                      XDMAC_CIE_WBIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_WBIE_Msk instead */
+#define XDMAC_CIE_ROIE_Pos                  6                                              /**< (XDMAC_CIE) Request Overflow Error Interrupt Enable Bit Position */
+#define XDMAC_CIE_ROIE_Msk                  (_U_(0x1) << XDMAC_CIE_ROIE_Pos)               /**< (XDMAC_CIE) Request Overflow Error Interrupt Enable Bit Mask */
+#define XDMAC_CIE_ROIE                      XDMAC_CIE_ROIE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIE_ROIE_Msk instead */
+#define XDMAC_CIE_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIE) Register MASK  (Use XDMAC_CIE_Msk instead)  */
+#define XDMAC_CIE_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIE) Register Mask  */
+
+
+/* -------- XDMAC_CID : (XDMAC Offset: 0x04) (/W 32) Channel Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BID:1;                     /**< bit:      0  End of Block Interrupt Disable Bit       */
+    uint32_t LID:1;                     /**< bit:      1  End of Linked List Interrupt Disable Bit */
+    uint32_t DID:1;                     /**< bit:      2  End of Disable Interrupt Disable Bit     */
+    uint32_t FID:1;                     /**< bit:      3  End of Flush Interrupt Disable Bit       */
+    uint32_t RBEID:1;                   /**< bit:      4  Read Bus Error Interrupt Disable Bit     */
+    uint32_t WBEID:1;                   /**< bit:      5  Write Bus Error Interrupt Disable Bit    */
+    uint32_t ROID:1;                    /**< bit:      6  Request Overflow Error Interrupt Disable Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CID_OFFSET                    (0x04)                                        /**<  (XDMAC_CID) Channel Interrupt Disable Register  Offset */
+
+#define XDMAC_CID_BID_Pos                   0                                              /**< (XDMAC_CID) End of Block Interrupt Disable Bit Position */
+#define XDMAC_CID_BID_Msk                   (_U_(0x1) << XDMAC_CID_BID_Pos)                /**< (XDMAC_CID) End of Block Interrupt Disable Bit Mask */
+#define XDMAC_CID_BID                       XDMAC_CID_BID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_BID_Msk instead */
+#define XDMAC_CID_LID_Pos                   1                                              /**< (XDMAC_CID) End of Linked List Interrupt Disable Bit Position */
+#define XDMAC_CID_LID_Msk                   (_U_(0x1) << XDMAC_CID_LID_Pos)                /**< (XDMAC_CID) End of Linked List Interrupt Disable Bit Mask */
+#define XDMAC_CID_LID                       XDMAC_CID_LID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_LID_Msk instead */
+#define XDMAC_CID_DID_Pos                   2                                              /**< (XDMAC_CID) End of Disable Interrupt Disable Bit Position */
+#define XDMAC_CID_DID_Msk                   (_U_(0x1) << XDMAC_CID_DID_Pos)                /**< (XDMAC_CID) End of Disable Interrupt Disable Bit Mask */
+#define XDMAC_CID_DID                       XDMAC_CID_DID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_DID_Msk instead */
+#define XDMAC_CID_FID_Pos                   3                                              /**< (XDMAC_CID) End of Flush Interrupt Disable Bit Position */
+#define XDMAC_CID_FID_Msk                   (_U_(0x1) << XDMAC_CID_FID_Pos)                /**< (XDMAC_CID) End of Flush Interrupt Disable Bit Mask */
+#define XDMAC_CID_FID                       XDMAC_CID_FID_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_FID_Msk instead */
+#define XDMAC_CID_RBEID_Pos                 4                                              /**< (XDMAC_CID) Read Bus Error Interrupt Disable Bit Position */
+#define XDMAC_CID_RBEID_Msk                 (_U_(0x1) << XDMAC_CID_RBEID_Pos)              /**< (XDMAC_CID) Read Bus Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_RBEID                     XDMAC_CID_RBEID_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_RBEID_Msk instead */
+#define XDMAC_CID_WBEID_Pos                 5                                              /**< (XDMAC_CID) Write Bus Error Interrupt Disable Bit Position */
+#define XDMAC_CID_WBEID_Msk                 (_U_(0x1) << XDMAC_CID_WBEID_Pos)              /**< (XDMAC_CID) Write Bus Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_WBEID                     XDMAC_CID_WBEID_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_WBEID_Msk instead */
+#define XDMAC_CID_ROID_Pos                  6                                              /**< (XDMAC_CID) Request Overflow Error Interrupt Disable Bit Position */
+#define XDMAC_CID_ROID_Msk                  (_U_(0x1) << XDMAC_CID_ROID_Pos)               /**< (XDMAC_CID) Request Overflow Error Interrupt Disable Bit Mask */
+#define XDMAC_CID_ROID                      XDMAC_CID_ROID_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CID_ROID_Msk instead */
+#define XDMAC_CID_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CID) Register MASK  (Use XDMAC_CID_Msk instead)  */
+#define XDMAC_CID_Msk                       _U_(0x7F)                                      /**< (XDMAC_CID) Register Mask  */
+
+
+/* -------- XDMAC_CIM : (XDMAC Offset: 0x08) (R/ 32) Channel Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIM:1;                     /**< bit:      0  End of Block Interrupt Mask Bit          */
+    uint32_t LIM:1;                     /**< bit:      1  End of Linked List Interrupt Mask Bit    */
+    uint32_t DIM:1;                     /**< bit:      2  End of Disable Interrupt Mask Bit        */
+    uint32_t FIM:1;                     /**< bit:      3  End of Flush Interrupt Mask Bit          */
+    uint32_t RBEIM:1;                   /**< bit:      4  Read Bus Error Interrupt Mask Bit        */
+    uint32_t WBEIM:1;                   /**< bit:      5  Write Bus Error Interrupt Mask Bit       */
+    uint32_t ROIM:1;                    /**< bit:      6  Request Overflow Error Interrupt Mask Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIM_OFFSET                    (0x08)                                        /**<  (XDMAC_CIM) Channel Interrupt Mask Register  Offset */
+
+#define XDMAC_CIM_BIM_Pos                   0                                              /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Position */
+#define XDMAC_CIM_BIM_Msk                   (_U_(0x1) << XDMAC_CIM_BIM_Pos)                /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Mask */
+#define XDMAC_CIM_BIM                       XDMAC_CIM_BIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_BIM_Msk instead */
+#define XDMAC_CIM_LIM_Pos                   1                                              /**< (XDMAC_CIM) End of Linked List Interrupt Mask Bit Position */
+#define XDMAC_CIM_LIM_Msk                   (_U_(0x1) << XDMAC_CIM_LIM_Pos)                /**< (XDMAC_CIM) End of Linked List Interrupt Mask Bit Mask */
+#define XDMAC_CIM_LIM                       XDMAC_CIM_LIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_LIM_Msk instead */
+#define XDMAC_CIM_DIM_Pos                   2                                              /**< (XDMAC_CIM) End of Disable Interrupt Mask Bit Position */
+#define XDMAC_CIM_DIM_Msk                   (_U_(0x1) << XDMAC_CIM_DIM_Pos)                /**< (XDMAC_CIM) End of Disable Interrupt Mask Bit Mask */
+#define XDMAC_CIM_DIM                       XDMAC_CIM_DIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_DIM_Msk instead */
+#define XDMAC_CIM_FIM_Pos                   3                                              /**< (XDMAC_CIM) End of Flush Interrupt Mask Bit Position */
+#define XDMAC_CIM_FIM_Msk                   (_U_(0x1) << XDMAC_CIM_FIM_Pos)                /**< (XDMAC_CIM) End of Flush Interrupt Mask Bit Mask */
+#define XDMAC_CIM_FIM                       XDMAC_CIM_FIM_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_FIM_Msk instead */
+#define XDMAC_CIM_RBEIM_Pos                 4                                              /**< (XDMAC_CIM) Read Bus Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_RBEIM_Msk                 (_U_(0x1) << XDMAC_CIM_RBEIM_Pos)              /**< (XDMAC_CIM) Read Bus Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_RBEIM                     XDMAC_CIM_RBEIM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_RBEIM_Msk instead */
+#define XDMAC_CIM_WBEIM_Pos                 5                                              /**< (XDMAC_CIM) Write Bus Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_WBEIM_Msk                 (_U_(0x1) << XDMAC_CIM_WBEIM_Pos)              /**< (XDMAC_CIM) Write Bus Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_WBEIM                     XDMAC_CIM_WBEIM_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_WBEIM_Msk instead */
+#define XDMAC_CIM_ROIM_Pos                  6                                              /**< (XDMAC_CIM) Request Overflow Error Interrupt Mask Bit Position */
+#define XDMAC_CIM_ROIM_Msk                  (_U_(0x1) << XDMAC_CIM_ROIM_Pos)               /**< (XDMAC_CIM) Request Overflow Error Interrupt Mask Bit Mask */
+#define XDMAC_CIM_ROIM                      XDMAC_CIM_ROIM_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIM_ROIM_Msk instead */
+#define XDMAC_CIM_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIM) Register MASK  (Use XDMAC_CIM_Msk instead)  */
+#define XDMAC_CIM_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIM) Register Mask  */
+
+
+/* -------- XDMAC_CIS : (XDMAC Offset: 0x0c) (R/ 32) Channel Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BIS:1;                     /**< bit:      0  End of Block Interrupt Status Bit        */
+    uint32_t LIS:1;                     /**< bit:      1  End of Linked List Interrupt Status Bit  */
+    uint32_t DIS:1;                     /**< bit:      2  End of Disable Interrupt Status Bit      */
+    uint32_t FIS:1;                     /**< bit:      3  End of Flush Interrupt Status Bit        */
+    uint32_t RBEIS:1;                   /**< bit:      4  Read Bus Error Interrupt Status Bit      */
+    uint32_t WBEIS:1;                   /**< bit:      5  Write Bus Error Interrupt Status Bit     */
+    uint32_t ROIS:1;                    /**< bit:      6  Request Overflow Error Interrupt Status Bit */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CIS_OFFSET                    (0x0C)                                        /**<  (XDMAC_CIS) Channel Interrupt Status Register  Offset */
+
+#define XDMAC_CIS_BIS_Pos                   0                                              /**< (XDMAC_CIS) End of Block Interrupt Status Bit Position */
+#define XDMAC_CIS_BIS_Msk                   (_U_(0x1) << XDMAC_CIS_BIS_Pos)                /**< (XDMAC_CIS) End of Block Interrupt Status Bit Mask */
+#define XDMAC_CIS_BIS                       XDMAC_CIS_BIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_BIS_Msk instead */
+#define XDMAC_CIS_LIS_Pos                   1                                              /**< (XDMAC_CIS) End of Linked List Interrupt Status Bit Position */
+#define XDMAC_CIS_LIS_Msk                   (_U_(0x1) << XDMAC_CIS_LIS_Pos)                /**< (XDMAC_CIS) End of Linked List Interrupt Status Bit Mask */
+#define XDMAC_CIS_LIS                       XDMAC_CIS_LIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_LIS_Msk instead */
+#define XDMAC_CIS_DIS_Pos                   2                                              /**< (XDMAC_CIS) End of Disable Interrupt Status Bit Position */
+#define XDMAC_CIS_DIS_Msk                   (_U_(0x1) << XDMAC_CIS_DIS_Pos)                /**< (XDMAC_CIS) End of Disable Interrupt Status Bit Mask */
+#define XDMAC_CIS_DIS                       XDMAC_CIS_DIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_DIS_Msk instead */
+#define XDMAC_CIS_FIS_Pos                   3                                              /**< (XDMAC_CIS) End of Flush Interrupt Status Bit Position */
+#define XDMAC_CIS_FIS_Msk                   (_U_(0x1) << XDMAC_CIS_FIS_Pos)                /**< (XDMAC_CIS) End of Flush Interrupt Status Bit Mask */
+#define XDMAC_CIS_FIS                       XDMAC_CIS_FIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_FIS_Msk instead */
+#define XDMAC_CIS_RBEIS_Pos                 4                                              /**< (XDMAC_CIS) Read Bus Error Interrupt Status Bit Position */
+#define XDMAC_CIS_RBEIS_Msk                 (_U_(0x1) << XDMAC_CIS_RBEIS_Pos)              /**< (XDMAC_CIS) Read Bus Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_RBEIS                     XDMAC_CIS_RBEIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_RBEIS_Msk instead */
+#define XDMAC_CIS_WBEIS_Pos                 5                                              /**< (XDMAC_CIS) Write Bus Error Interrupt Status Bit Position */
+#define XDMAC_CIS_WBEIS_Msk                 (_U_(0x1) << XDMAC_CIS_WBEIS_Pos)              /**< (XDMAC_CIS) Write Bus Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_WBEIS                     XDMAC_CIS_WBEIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_WBEIS_Msk instead */
+#define XDMAC_CIS_ROIS_Pos                  6                                              /**< (XDMAC_CIS) Request Overflow Error Interrupt Status Bit Position */
+#define XDMAC_CIS_ROIS_Msk                  (_U_(0x1) << XDMAC_CIS_ROIS_Pos)               /**< (XDMAC_CIS) Request Overflow Error Interrupt Status Bit Mask */
+#define XDMAC_CIS_ROIS                      XDMAC_CIS_ROIS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CIS_ROIS_Msk instead */
+#define XDMAC_CIS_MASK                      _U_(0x7F)                                      /**< \deprecated (XDMAC_CIS) Register MASK  (Use XDMAC_CIS_Msk instead)  */
+#define XDMAC_CIS_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIS) Register Mask  */
+
+
+/* -------- XDMAC_CSA : (XDMAC Offset: 0x10) (R/W 32) Channel Source Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SA:32;                     /**< bit:  0..31  Channel x Source Address                 */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CSA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CSA_OFFSET                    (0x10)                                        /**<  (XDMAC_CSA) Channel Source Address Register  Offset */
+
+#define XDMAC_CSA_SA_Pos                    0                                              /**< (XDMAC_CSA) Channel x Source Address Position */
+#define XDMAC_CSA_SA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CSA_SA_Pos)          /**< (XDMAC_CSA) Channel x Source Address Mask */
+#define XDMAC_CSA_SA(value)                 (XDMAC_CSA_SA_Msk & ((value) << XDMAC_CSA_SA_Pos))
+#define XDMAC_CSA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CSA) Register MASK  (Use XDMAC_CSA_Msk instead)  */
+#define XDMAC_CSA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CSA) Register Mask  */
+
+
+/* -------- XDMAC_CDA : (XDMAC Offset: 0x14) (R/W 32) Channel Destination Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DA:32;                     /**< bit:  0..31  Channel x Destination Address            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDA_OFFSET                    (0x14)                                        /**<  (XDMAC_CDA) Channel Destination Address Register  Offset */
+
+#define XDMAC_CDA_DA_Pos                    0                                              /**< (XDMAC_CDA) Channel x Destination Address Position */
+#define XDMAC_CDA_DA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CDA_DA_Pos)          /**< (XDMAC_CDA) Channel x Destination Address Mask */
+#define XDMAC_CDA_DA(value)                 (XDMAC_CDA_DA_Msk & ((value) << XDMAC_CDA_DA_Pos))
+#define XDMAC_CDA_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CDA) Register MASK  (Use XDMAC_CDA_Msk instead)  */
+#define XDMAC_CDA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CDA) Register Mask  */
+
+
+/* -------- XDMAC_CNDA : (XDMAC Offset: 0x18) (R/W 32) Channel Next Descriptor Address Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NDAIF:1;                   /**< bit:      0  Channel x Next Descriptor Interface      */
+    uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t NDA:30;                    /**< bit:  2..31  Channel x Next Descriptor Address        */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CNDA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CNDA_OFFSET                   (0x18)                                        /**<  (XDMAC_CNDA) Channel Next Descriptor Address Register  Offset */
+
+#define XDMAC_CNDA_NDAIF_Pos                0                                              /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Position */
+#define XDMAC_CNDA_NDAIF_Msk                (_U_(0x1) << XDMAC_CNDA_NDAIF_Pos)             /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Mask */
+#define XDMAC_CNDA_NDAIF                    XDMAC_CNDA_NDAIF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDA_NDAIF_Msk instead */
+#define XDMAC_CNDA_NDA_Pos                  2                                              /**< (XDMAC_CNDA) Channel x Next Descriptor Address Position */
+#define XDMAC_CNDA_NDA_Msk                  (_U_(0x3FFFFFFF) << XDMAC_CNDA_NDA_Pos)        /**< (XDMAC_CNDA) Channel x Next Descriptor Address Mask */
+#define XDMAC_CNDA_NDA(value)               (XDMAC_CNDA_NDA_Msk & ((value) << XDMAC_CNDA_NDA_Pos))
+#define XDMAC_CNDA_MASK                     _U_(0xFFFFFFFD)                                /**< \deprecated (XDMAC_CNDA) Register MASK  (Use XDMAC_CNDA_Msk instead)  */
+#define XDMAC_CNDA_Msk                      _U_(0xFFFFFFFD)                                /**< (XDMAC_CNDA) Register Mask  */
+
+
+/* -------- XDMAC_CNDC : (XDMAC Offset: 0x1c) (R/W 32) Channel Next Descriptor Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NDE:1;                     /**< bit:      0  Channel x Next Descriptor Enable         */
+    uint32_t NDSUP:1;                   /**< bit:      1  Channel x Next Descriptor Source Update  */
+    uint32_t NDDUP:1;                   /**< bit:      2  Channel x Next Descriptor Destination Update */
+    uint32_t NDVIEW:2;                  /**< bit:   3..4  Channel x Next Descriptor View           */
+    uint32_t :27;                       /**< bit:  5..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CNDC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CNDC_OFFSET                   (0x1C)                                        /**<  (XDMAC_CNDC) Channel Next Descriptor Control Register  Offset */
+
+#define XDMAC_CNDC_NDE_Pos                  0                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Position */
+#define XDMAC_CNDC_NDE_Msk                  (_U_(0x1) << XDMAC_CNDC_NDE_Pos)               /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Mask */
+#define XDMAC_CNDC_NDE                      XDMAC_CNDC_NDE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDE_Msk instead */
+#define   XDMAC_CNDC_NDE_DSCR_FETCH_DIS_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Descriptor fetch is disabled.  */
+#define   XDMAC_CNDC_NDE_DSCR_FETCH_EN_Val  _U_(0x1)                                       /**< (XDMAC_CNDC) Descriptor fetch is enabled.  */
+#define XDMAC_CNDC_NDE_DSCR_FETCH_DIS       (XDMAC_CNDC_NDE_DSCR_FETCH_DIS_Val << XDMAC_CNDC_NDE_Pos)  /**< (XDMAC_CNDC) Descriptor fetch is disabled. Position  */
+#define XDMAC_CNDC_NDE_DSCR_FETCH_EN        (XDMAC_CNDC_NDE_DSCR_FETCH_EN_Val << XDMAC_CNDC_NDE_Pos)  /**< (XDMAC_CNDC) Descriptor fetch is enabled. Position  */
+#define XDMAC_CNDC_NDSUP_Pos                1                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Source Update Position */
+#define XDMAC_CNDC_NDSUP_Msk                (_U_(0x1) << XDMAC_CNDC_NDSUP_Pos)             /**< (XDMAC_CNDC) Channel x Next Descriptor Source Update Mask */
+#define XDMAC_CNDC_NDSUP                    XDMAC_CNDC_NDSUP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDSUP_Msk instead */
+#define   XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Source parameters remain unchanged.  */
+#define   XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED_Val _U_(0x1)                                       /**< (XDMAC_CNDC) Source parameters are updated when the descriptor is retrieved.  */
+#define XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED (XDMAC_CNDC_NDSUP_SRC_PARAMS_UNCHANGED_Val << XDMAC_CNDC_NDSUP_Pos)  /**< (XDMAC_CNDC) Source parameters remain unchanged. Position  */
+#define XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED (XDMAC_CNDC_NDSUP_SRC_PARAMS_UPDATED_Val << XDMAC_CNDC_NDSUP_Pos)  /**< (XDMAC_CNDC) Source parameters are updated when the descriptor is retrieved. Position  */
+#define XDMAC_CNDC_NDDUP_Pos                2                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Destination Update Position */
+#define XDMAC_CNDC_NDDUP_Msk                (_U_(0x1) << XDMAC_CNDC_NDDUP_Pos)             /**< (XDMAC_CNDC) Channel x Next Descriptor Destination Update Mask */
+#define XDMAC_CNDC_NDDUP                    XDMAC_CNDC_NDDUP_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CNDC_NDDUP_Msk instead */
+#define   XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED_Val _U_(0x0)                                       /**< (XDMAC_CNDC) Destination parameters remain unchanged.  */
+#define   XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED_Val _U_(0x1)                                       /**< (XDMAC_CNDC) Destination parameters are updated when the descriptor is retrieved.  */
+#define XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED (XDMAC_CNDC_NDDUP_DST_PARAMS_UNCHANGED_Val << XDMAC_CNDC_NDDUP_Pos)  /**< (XDMAC_CNDC) Destination parameters remain unchanged. Position  */
+#define XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED (XDMAC_CNDC_NDDUP_DST_PARAMS_UPDATED_Val << XDMAC_CNDC_NDDUP_Pos)  /**< (XDMAC_CNDC) Destination parameters are updated when the descriptor is retrieved. Position  */
+#define XDMAC_CNDC_NDVIEW_Pos               3                                              /**< (XDMAC_CNDC) Channel x Next Descriptor View Position */
+#define XDMAC_CNDC_NDVIEW_Msk               (_U_(0x3) << XDMAC_CNDC_NDVIEW_Pos)            /**< (XDMAC_CNDC) Channel x Next Descriptor View Mask */
+#define XDMAC_CNDC_NDVIEW(value)            (XDMAC_CNDC_NDVIEW_Msk & ((value) << XDMAC_CNDC_NDVIEW_Pos))
+#define   XDMAC_CNDC_NDVIEW_NDV0_Val        _U_(0x0)                                       /**< (XDMAC_CNDC) Next Descriptor View 0  */
+#define   XDMAC_CNDC_NDVIEW_NDV1_Val        _U_(0x1)                                       /**< (XDMAC_CNDC) Next Descriptor View 1  */
+#define   XDMAC_CNDC_NDVIEW_NDV2_Val        _U_(0x2)                                       /**< (XDMAC_CNDC) Next Descriptor View 2  */
+#define   XDMAC_CNDC_NDVIEW_NDV3_Val        _U_(0x3)                                       /**< (XDMAC_CNDC) Next Descriptor View 3  */
+#define XDMAC_CNDC_NDVIEW_NDV0              (XDMAC_CNDC_NDVIEW_NDV0_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 0 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV1              (XDMAC_CNDC_NDVIEW_NDV1_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 1 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV2              (XDMAC_CNDC_NDVIEW_NDV2_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 2 Position  */
+#define XDMAC_CNDC_NDVIEW_NDV3              (XDMAC_CNDC_NDVIEW_NDV3_Val << XDMAC_CNDC_NDVIEW_Pos)  /**< (XDMAC_CNDC) Next Descriptor View 3 Position  */
+#define XDMAC_CNDC_MASK                     _U_(0x1F)                                      /**< \deprecated (XDMAC_CNDC) Register MASK  (Use XDMAC_CNDC_Msk instead)  */
+#define XDMAC_CNDC_Msk                      _U_(0x1F)                                      /**< (XDMAC_CNDC) Register Mask  */
+
+
+/* -------- XDMAC_CUBC : (XDMAC Offset: 0x20) (R/W 32) Channel Microblock Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t UBLEN:24;                  /**< bit:  0..23  Channel x Microblock Length              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CUBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CUBC_OFFSET                   (0x20)                                        /**<  (XDMAC_CUBC) Channel Microblock Control Register  Offset */
+
+#define XDMAC_CUBC_UBLEN_Pos                0                                              /**< (XDMAC_CUBC) Channel x Microblock Length Position */
+#define XDMAC_CUBC_UBLEN_Msk                (_U_(0xFFFFFF) << XDMAC_CUBC_UBLEN_Pos)        /**< (XDMAC_CUBC) Channel x Microblock Length Mask */
+#define XDMAC_CUBC_UBLEN(value)             (XDMAC_CUBC_UBLEN_Msk & ((value) << XDMAC_CUBC_UBLEN_Pos))
+#define XDMAC_CUBC_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CUBC) Register MASK  (Use XDMAC_CUBC_Msk instead)  */
+#define XDMAC_CUBC_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CUBC) Register Mask  */
+
+
+/* -------- XDMAC_CBC : (XDMAC Offset: 0x24) (R/W 32) Channel Block Control Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t BLEN:12;                   /**< bit:  0..11  Channel x Block Length                   */
+    uint32_t :20;                       /**< bit: 12..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CBC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CBC_OFFSET                    (0x24)                                        /**<  (XDMAC_CBC) Channel Block Control Register  Offset */
+
+#define XDMAC_CBC_BLEN_Pos                  0                                              /**< (XDMAC_CBC) Channel x Block Length Position */
+#define XDMAC_CBC_BLEN_Msk                  (_U_(0xFFF) << XDMAC_CBC_BLEN_Pos)             /**< (XDMAC_CBC) Channel x Block Length Mask */
+#define XDMAC_CBC_BLEN(value)               (XDMAC_CBC_BLEN_Msk & ((value) << XDMAC_CBC_BLEN_Pos))
+#define XDMAC_CBC_MASK                      _U_(0xFFF)                                     /**< \deprecated (XDMAC_CBC) Register MASK  (Use XDMAC_CBC_Msk instead)  */
+#define XDMAC_CBC_Msk                       _U_(0xFFF)                                     /**< (XDMAC_CBC) Register Mask  */
+
+
+/* -------- XDMAC_CC : (XDMAC Offset: 0x28) (R/W 32) Channel Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TYPE:1;                    /**< bit:      0  Channel x Transfer Type                  */
+    uint32_t MBSIZE:2;                  /**< bit:   1..2  Channel x Memory Burst Size              */
+    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t DSYNC:1;                   /**< bit:      4  Channel x Synchronization                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t SWREQ:1;                   /**< bit:      6  Channel x Software Request Trigger       */
+    uint32_t MEMSET:1;                  /**< bit:      7  Channel x Fill Block of memory           */
+    uint32_t CSIZE:3;                   /**< bit:  8..10  Channel x Chunk Size                     */
+    uint32_t DWIDTH:2;                  /**< bit: 11..12  Channel x Data Width                     */
+    uint32_t SIF:1;                     /**< bit:     13  Channel x Source Interface Identifier    */
+    uint32_t DIF:1;                     /**< bit:     14  Channel x Destination Interface Identifier */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t SAM:2;                     /**< bit: 16..17  Channel x Source Addressing Mode         */
+    uint32_t DAM:2;                     /**< bit: 18..19  Channel x Destination Addressing Mode    */
+    uint32_t :1;                        /**< bit:     20  Reserved */
+    uint32_t INITD:1;                   /**< bit:     21  Channel Initialization Terminated (this bit is read-only) */
+    uint32_t RDIP:1;                    /**< bit:     22  Read in Progress (this bit is read-only) */
+    uint32_t WRIP:1;                    /**< bit:     23  Write in Progress (this bit is read-only) */
+    uint32_t PERID:7;                   /**< bit: 24..30  Channel x Peripheral Hardware Request Line Identifier */
+    uint32_t :1;                        /**< bit:     31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CC_OFFSET                     (0x28)                                        /**<  (XDMAC_CC) Channel Configuration Register  Offset */
+
+#define XDMAC_CC_TYPE_Pos                   0                                              /**< (XDMAC_CC) Channel x Transfer Type Position */
+#define XDMAC_CC_TYPE_Msk                   (_U_(0x1) << XDMAC_CC_TYPE_Pos)                /**< (XDMAC_CC) Channel x Transfer Type Mask */
+#define XDMAC_CC_TYPE                       XDMAC_CC_TYPE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_TYPE_Msk instead */
+#define   XDMAC_CC_TYPE_MEM_TRAN_Val        _U_(0x0)                                       /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer).  */
+#define   XDMAC_CC_TYPE_PER_TRAN_Val        _U_(0x1)                                       /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer).  */
+#define XDMAC_CC_TYPE_MEM_TRAN              (XDMAC_CC_TYPE_MEM_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer). Position  */
+#define XDMAC_CC_TYPE_PER_TRAN              (XDMAC_CC_TYPE_PER_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer). Position  */
+#define XDMAC_CC_MBSIZE_Pos                 1                                              /**< (XDMAC_CC) Channel x Memory Burst Size Position */
+#define XDMAC_CC_MBSIZE_Msk                 (_U_(0x3) << XDMAC_CC_MBSIZE_Pos)              /**< (XDMAC_CC) Channel x Memory Burst Size Mask */
+#define XDMAC_CC_MBSIZE(value)              (XDMAC_CC_MBSIZE_Msk & ((value) << XDMAC_CC_MBSIZE_Pos))
+#define   XDMAC_CC_MBSIZE_SINGLE_Val        _U_(0x0)                                       /**< (XDMAC_CC) The memory burst size is set to one.  */
+#define   XDMAC_CC_MBSIZE_FOUR_Val          _U_(0x1)                                       /**< (XDMAC_CC) The memory burst size is set to four.  */
+#define   XDMAC_CC_MBSIZE_EIGHT_Val         _U_(0x2)                                       /**< (XDMAC_CC) The memory burst size is set to eight.  */
+#define   XDMAC_CC_MBSIZE_SIXTEEN_Val       _U_(0x3)                                       /**< (XDMAC_CC) The memory burst size is set to sixteen.  */
+#define XDMAC_CC_MBSIZE_SINGLE              (XDMAC_CC_MBSIZE_SINGLE_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to one. Position  */
+#define XDMAC_CC_MBSIZE_FOUR                (XDMAC_CC_MBSIZE_FOUR_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to four. Position  */
+#define XDMAC_CC_MBSIZE_EIGHT               (XDMAC_CC_MBSIZE_EIGHT_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to eight. Position  */
+#define XDMAC_CC_MBSIZE_SIXTEEN             (XDMAC_CC_MBSIZE_SIXTEEN_Val << XDMAC_CC_MBSIZE_Pos)  /**< (XDMAC_CC) The memory burst size is set to sixteen. Position  */
+#define XDMAC_CC_DSYNC_Pos                  4                                              /**< (XDMAC_CC) Channel x Synchronization Position */
+#define XDMAC_CC_DSYNC_Msk                  (_U_(0x1) << XDMAC_CC_DSYNC_Pos)               /**< (XDMAC_CC) Channel x Synchronization Mask */
+#define XDMAC_CC_DSYNC                      XDMAC_CC_DSYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_DSYNC_Msk instead */
+#define   XDMAC_CC_DSYNC_PER2MEM_Val        _U_(0x0)                                       /**< (XDMAC_CC) Peripheral-to-memory transfer.  */
+#define   XDMAC_CC_DSYNC_MEM2PER_Val        _U_(0x1)                                       /**< (XDMAC_CC) Memory-to-peripheral transfer.  */
+#define XDMAC_CC_DSYNC_PER2MEM              (XDMAC_CC_DSYNC_PER2MEM_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Peripheral-to-memory transfer. Position  */
+#define XDMAC_CC_DSYNC_MEM2PER              (XDMAC_CC_DSYNC_MEM2PER_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Memory-to-peripheral transfer. Position  */
+#define XDMAC_CC_SWREQ_Pos                  6                                              /**< (XDMAC_CC) Channel x Software Request Trigger Position */
+#define XDMAC_CC_SWREQ_Msk                  (_U_(0x1) << XDMAC_CC_SWREQ_Pos)               /**< (XDMAC_CC) Channel x Software Request Trigger Mask */
+#define XDMAC_CC_SWREQ                      XDMAC_CC_SWREQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_SWREQ_Msk instead */
+#define   XDMAC_CC_SWREQ_HWR_CONNECTED_Val  _U_(0x0)                                       /**< (XDMAC_CC) Hardware request line is connected to the peripheral request line.  */
+#define   XDMAC_CC_SWREQ_SWR_CONNECTED_Val  _U_(0x1)                                       /**< (XDMAC_CC) Software request is connected to the peripheral request line.  */
+#define XDMAC_CC_SWREQ_HWR_CONNECTED        (XDMAC_CC_SWREQ_HWR_CONNECTED_Val << XDMAC_CC_SWREQ_Pos)  /**< (XDMAC_CC) Hardware request line is connected to the peripheral request line. Position  */
+#define XDMAC_CC_SWREQ_SWR_CONNECTED        (XDMAC_CC_SWREQ_SWR_CONNECTED_Val << XDMAC_CC_SWREQ_Pos)  /**< (XDMAC_CC) Software request is connected to the peripheral request line. Position  */
+#define XDMAC_CC_MEMSET_Pos                 7                                              /**< (XDMAC_CC) Channel x Fill Block of memory Position */
+#define XDMAC_CC_MEMSET_Msk                 (_U_(0x1) << XDMAC_CC_MEMSET_Pos)              /**< (XDMAC_CC) Channel x Fill Block of memory Mask */
+#define XDMAC_CC_MEMSET                     XDMAC_CC_MEMSET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_MEMSET_Msk instead */
+#define   XDMAC_CC_MEMSET_NORMAL_MODE_Val   _U_(0x0)                                       /**< (XDMAC_CC) Memset is not activated.  */
+#define   XDMAC_CC_MEMSET_HW_MODE_Val       _U_(0x1)                                       /**< (XDMAC_CC) Sets the block of memory pointed by DA field to the specified value. This operation is performed on 8-, 16- or 32-bit basis.  */
+#define XDMAC_CC_MEMSET_NORMAL_MODE         (XDMAC_CC_MEMSET_NORMAL_MODE_Val << XDMAC_CC_MEMSET_Pos)  /**< (XDMAC_CC) Memset is not activated. Position  */
+#define XDMAC_CC_MEMSET_HW_MODE             (XDMAC_CC_MEMSET_HW_MODE_Val << XDMAC_CC_MEMSET_Pos)  /**< (XDMAC_CC) Sets the block of memory pointed by DA field to the specified value. This operation is performed on 8-, 16- or 32-bit basis. Position  */
+#define XDMAC_CC_CSIZE_Pos                  8                                              /**< (XDMAC_CC) Channel x Chunk Size Position */
+#define XDMAC_CC_CSIZE_Msk                  (_U_(0x7) << XDMAC_CC_CSIZE_Pos)               /**< (XDMAC_CC) Channel x Chunk Size Mask */
+#define XDMAC_CC_CSIZE(value)               (XDMAC_CC_CSIZE_Msk & ((value) << XDMAC_CC_CSIZE_Pos))
+#define   XDMAC_CC_CSIZE_CHK_1_Val          _U_(0x0)                                       /**< (XDMAC_CC) 1 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_2_Val          _U_(0x1)                                       /**< (XDMAC_CC) 2 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_4_Val          _U_(0x2)                                       /**< (XDMAC_CC) 4 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_8_Val          _U_(0x3)                                       /**< (XDMAC_CC) 8 data transferred  */
+#define   XDMAC_CC_CSIZE_CHK_16_Val         _U_(0x4)                                       /**< (XDMAC_CC) 16 data transferred  */
+#define XDMAC_CC_CSIZE_CHK_1                (XDMAC_CC_CSIZE_CHK_1_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 1 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_2                (XDMAC_CC_CSIZE_CHK_2_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 2 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_4                (XDMAC_CC_CSIZE_CHK_4_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 4 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_8                (XDMAC_CC_CSIZE_CHK_8_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 8 data transferred Position  */
+#define XDMAC_CC_CSIZE_CHK_16               (XDMAC_CC_CSIZE_CHK_16_Val << XDMAC_CC_CSIZE_Pos)  /**< (XDMAC_CC) 16 data transferred Position  */
+#define XDMAC_CC_DWIDTH_Pos                 11                                             /**< (XDMAC_CC) Channel x Data Width Position */
+#define XDMAC_CC_DWIDTH_Msk                 (_U_(0x3) << XDMAC_CC_DWIDTH_Pos)              /**< (XDMAC_CC) Channel x Data Width Mask */
+#define XDMAC_CC_DWIDTH(value)              (XDMAC_CC_DWIDTH_Msk & ((value) << XDMAC_CC_DWIDTH_Pos))
+#define   XDMAC_CC_DWIDTH_BYTE_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data size is set to 8 bits  */
+#define   XDMAC_CC_DWIDTH_HALFWORD_Val      _U_(0x1)                                       /**< (XDMAC_CC) The data size is set to 16 bits  */
+#define   XDMAC_CC_DWIDTH_WORD_Val          _U_(0x2)                                       /**< (XDMAC_CC) The data size is set to 32 bits  */
+#define XDMAC_CC_DWIDTH_BYTE                (XDMAC_CC_DWIDTH_BYTE_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 8 bits Position  */
+#define XDMAC_CC_DWIDTH_HALFWORD            (XDMAC_CC_DWIDTH_HALFWORD_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 16 bits Position  */
+#define XDMAC_CC_DWIDTH_WORD                (XDMAC_CC_DWIDTH_WORD_Val << XDMAC_CC_DWIDTH_Pos)  /**< (XDMAC_CC) The data size is set to 32 bits Position  */
+#define XDMAC_CC_SIF_Pos                    13                                             /**< (XDMAC_CC) Channel x Source Interface Identifier Position */
+#define XDMAC_CC_SIF_Msk                    (_U_(0x1) << XDMAC_CC_SIF_Pos)                 /**< (XDMAC_CC) Channel x Source Interface Identifier Mask */
+#define XDMAC_CC_SIF                        XDMAC_CC_SIF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_SIF_Msk instead */
+#define   XDMAC_CC_SIF_AHB_IF0_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data is read through the system bus interface 0.  */
+#define   XDMAC_CC_SIF_AHB_IF1_Val          _U_(0x1)                                       /**< (XDMAC_CC) The data is read through the system bus interface 1.  */
+#define XDMAC_CC_SIF_AHB_IF0                (XDMAC_CC_SIF_AHB_IF0_Val << XDMAC_CC_SIF_Pos)  /**< (XDMAC_CC) The data is read through the system bus interface 0. Position  */
+#define XDMAC_CC_SIF_AHB_IF1                (XDMAC_CC_SIF_AHB_IF1_Val << XDMAC_CC_SIF_Pos)  /**< (XDMAC_CC) The data is read through the system bus interface 1. Position  */
+#define XDMAC_CC_DIF_Pos                    14                                             /**< (XDMAC_CC) Channel x Destination Interface Identifier Position */
+#define XDMAC_CC_DIF_Msk                    (_U_(0x1) << XDMAC_CC_DIF_Pos)                 /**< (XDMAC_CC) Channel x Destination Interface Identifier Mask */
+#define XDMAC_CC_DIF                        XDMAC_CC_DIF_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_DIF_Msk instead */
+#define   XDMAC_CC_DIF_AHB_IF0_Val          _U_(0x0)                                       /**< (XDMAC_CC) The data is written through the system bus interface 0.  */
+#define   XDMAC_CC_DIF_AHB_IF1_Val          _U_(0x1)                                       /**< (XDMAC_CC) The data is written though the system bus interface 1.  */
+#define XDMAC_CC_DIF_AHB_IF0                (XDMAC_CC_DIF_AHB_IF0_Val << XDMAC_CC_DIF_Pos)  /**< (XDMAC_CC) The data is written through the system bus interface 0. Position  */
+#define XDMAC_CC_DIF_AHB_IF1                (XDMAC_CC_DIF_AHB_IF1_Val << XDMAC_CC_DIF_Pos)  /**< (XDMAC_CC) The data is written though the system bus interface 1. Position  */
+#define XDMAC_CC_SAM_Pos                    16                                             /**< (XDMAC_CC) Channel x Source Addressing Mode Position */
+#define XDMAC_CC_SAM_Msk                    (_U_(0x3) << XDMAC_CC_SAM_Pos)                 /**< (XDMAC_CC) Channel x Source Addressing Mode Mask */
+#define XDMAC_CC_SAM(value)                 (XDMAC_CC_SAM_Msk & ((value) << XDMAC_CC_SAM_Pos))
+#define   XDMAC_CC_SAM_FIXED_AM_Val         _U_(0x0)                                       /**< (XDMAC_CC) The address remains unchanged.  */
+#define   XDMAC_CC_SAM_INCREMENTED_AM_Val   _U_(0x1)                                       /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size).  */
+#define   XDMAC_CC_SAM_UBS_AM_Val           _U_(0x2)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary.  */
+#define   XDMAC_CC_SAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary.  */
+#define XDMAC_CC_SAM_FIXED_AM               (XDMAC_CC_SAM_FIXED_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The address remains unchanged. Position  */
+#define XDMAC_CC_SAM_INCREMENTED_AM         (XDMAC_CC_SAM_INCREMENTED_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size). Position  */
+#define XDMAC_CC_SAM_UBS_AM                 (XDMAC_CC_SAM_UBS_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary. Position  */
+#define XDMAC_CC_SAM_UBS_DS_AM              (XDMAC_CC_SAM_UBS_DS_AM_Val << XDMAC_CC_SAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary. Position  */
+#define XDMAC_CC_DAM_Pos                    18                                             /**< (XDMAC_CC) Channel x Destination Addressing Mode Position */
+#define XDMAC_CC_DAM_Msk                    (_U_(0x3) << XDMAC_CC_DAM_Pos)                 /**< (XDMAC_CC) Channel x Destination Addressing Mode Mask */
+#define XDMAC_CC_DAM(value)                 (XDMAC_CC_DAM_Msk & ((value) << XDMAC_CC_DAM_Pos))
+#define   XDMAC_CC_DAM_FIXED_AM_Val         _U_(0x0)                                       /**< (XDMAC_CC) The address remains unchanged.  */
+#define   XDMAC_CC_DAM_INCREMENTED_AM_Val   _U_(0x1)                                       /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size).  */
+#define   XDMAC_CC_DAM_UBS_AM_Val           _U_(0x2)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary.  */
+#define   XDMAC_CC_DAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary.  */
+#define XDMAC_CC_DAM_FIXED_AM               (XDMAC_CC_DAM_FIXED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The address remains unchanged. Position  */
+#define XDMAC_CC_DAM_INCREMENTED_AM         (XDMAC_CC_DAM_INCREMENTED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size). Position  */
+#define XDMAC_CC_DAM_UBS_AM                 (XDMAC_CC_DAM_UBS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary. Position  */
+#define XDMAC_CC_DAM_UBS_DS_AM              (XDMAC_CC_DAM_UBS_DS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary. Position  */
+#define XDMAC_CC_INITD_Pos                  21                                             /**< (XDMAC_CC) Channel Initialization Terminated (this bit is read-only) Position */
+#define XDMAC_CC_INITD_Msk                  (_U_(0x1) << XDMAC_CC_INITD_Pos)               /**< (XDMAC_CC) Channel Initialization Terminated (this bit is read-only) Mask */
+#define XDMAC_CC_INITD                      XDMAC_CC_INITD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_INITD_Msk instead */
+#define   XDMAC_CC_INITD_IN_PROGRESS_Val    _U_(0x0)                                       /**< (XDMAC_CC) Channel initialization is in progress.  */
+#define   XDMAC_CC_INITD_TERMINATED_Val     _U_(0x1)                                       /**< (XDMAC_CC) Channel initialization is completed.  */
+#define XDMAC_CC_INITD_IN_PROGRESS          (XDMAC_CC_INITD_IN_PROGRESS_Val << XDMAC_CC_INITD_Pos)  /**< (XDMAC_CC) Channel initialization is in progress. Position  */
+#define XDMAC_CC_INITD_TERMINATED           (XDMAC_CC_INITD_TERMINATED_Val << XDMAC_CC_INITD_Pos)  /**< (XDMAC_CC) Channel initialization is completed. Position  */
+#define XDMAC_CC_RDIP_Pos                   22                                             /**< (XDMAC_CC) Read in Progress (this bit is read-only) Position */
+#define XDMAC_CC_RDIP_Msk                   (_U_(0x1) << XDMAC_CC_RDIP_Pos)                /**< (XDMAC_CC) Read in Progress (this bit is read-only) Mask */
+#define XDMAC_CC_RDIP                       XDMAC_CC_RDIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_RDIP_Msk instead */
+#define   XDMAC_CC_RDIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active read transaction on the bus.  */
+#define   XDMAC_CC_RDIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A read transaction is in progress.  */
+#define XDMAC_CC_RDIP_DONE                  (XDMAC_CC_RDIP_DONE_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) No active read transaction on the bus. Position  */
+#define XDMAC_CC_RDIP_IN_PROGRESS           (XDMAC_CC_RDIP_IN_PROGRESS_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) A read transaction is in progress. Position  */
+#define XDMAC_CC_WRIP_Pos                   23                                             /**< (XDMAC_CC) Write in Progress (this bit is read-only) Position */
+#define XDMAC_CC_WRIP_Msk                   (_U_(0x1) << XDMAC_CC_WRIP_Pos)                /**< (XDMAC_CC) Write in Progress (this bit is read-only) Mask */
+#define XDMAC_CC_WRIP                       XDMAC_CC_WRIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_WRIP_Msk instead */
+#define   XDMAC_CC_WRIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active write transaction on the bus.  */
+#define   XDMAC_CC_WRIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A write transaction is in progress.  */
+#define XDMAC_CC_WRIP_DONE                  (XDMAC_CC_WRIP_DONE_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) No active write transaction on the bus. Position  */
+#define XDMAC_CC_WRIP_IN_PROGRESS           (XDMAC_CC_WRIP_IN_PROGRESS_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) A write transaction is in progress. Position  */
+#define XDMAC_CC_PERID_Pos                  24                                             /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Position */
+#define XDMAC_CC_PERID_Msk                  (_U_(0x7F) << XDMAC_CC_PERID_Pos)              /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Mask */
+#define XDMAC_CC_PERID(value)               (XDMAC_CC_PERID_Msk & ((value) << XDMAC_CC_PERID_Pos))
+#define   XDMAC_CC_PERID_HSMCI_Val          _U_(0x0)                                       /**< (XDMAC_CC) HSMCI  */
+#define   XDMAC_CC_PERID_SPI0_TX_Val        _U_(0x1)                                       /**< (XDMAC_CC) SPI0_TX  */
+#define   XDMAC_CC_PERID_SPI0_RX_Val        _U_(0x2)                                       /**< (XDMAC_CC) SPI0_RX  */
+#define   XDMAC_CC_PERID_SPI1_TX_Val        _U_(0x3)                                       /**< (XDMAC_CC) SPI1_TX  */
+#define   XDMAC_CC_PERID_SPI1_RX_Val        _U_(0x4)                                       /**< (XDMAC_CC) SPI1_RX  */
+#define   XDMAC_CC_PERID_QSPI_TX_Val        _U_(0x5)                                       /**< (XDMAC_CC) QSPI_TX  */
+#define   XDMAC_CC_PERID_QSPI_RX_Val        _U_(0x6)                                       /**< (XDMAC_CC) QSPI_RX  */
+#define   XDMAC_CC_PERID_USART0_TX_Val      _U_(0x7)                                       /**< (XDMAC_CC) USART0_TX  */
+#define   XDMAC_CC_PERID_USART0_RX_Val      _U_(0x8)                                       /**< (XDMAC_CC) USART0_RX  */
+#define   XDMAC_CC_PERID_USART1_TX_Val      _U_(0x9)                                       /**< (XDMAC_CC) USART1_TX  */
+#define   XDMAC_CC_PERID_USART1_RX_Val      _U_(0xA)                                       /**< (XDMAC_CC) USART1_RX  */
+#define   XDMAC_CC_PERID_USART2_TX_Val      _U_(0xB)                                       /**< (XDMAC_CC) USART2_TX  */
+#define   XDMAC_CC_PERID_USART2_RX_Val      _U_(0xC)                                       /**< (XDMAC_CC) USART2_RX  */
+#define   XDMAC_CC_PERID_PWM0_Val           _U_(0xD)                                       /**< (XDMAC_CC) PWM0  */
+#define   XDMAC_CC_PERID_TWIHS0_TX_Val      _U_(0xE)                                       /**< (XDMAC_CC) TWIHS0_TX  */
+#define   XDMAC_CC_PERID_TWIHS0_RX_Val      _U_(0xF)                                       /**< (XDMAC_CC) TWIHS0_RX  */
+#define   XDMAC_CC_PERID_TWIHS1_TX_Val      _U_(0x10)                                      /**< (XDMAC_CC) TWIHS1_TX  */
+#define   XDMAC_CC_PERID_TWIHS1_RX_Val      _U_(0x11)                                      /**< (XDMAC_CC) TWIHS1_RX  */
+#define   XDMAC_CC_PERID_TWIHS2_TX_Val      _U_(0x12)                                      /**< (XDMAC_CC) TWIHS2_TX  */
+#define   XDMAC_CC_PERID_TWIHS2_RX_Val      _U_(0x13)                                      /**< (XDMAC_CC) TWIHS2_RX  */
+#define   XDMAC_CC_PERID_UART0_TX_Val       _U_(0x14)                                      /**< (XDMAC_CC) UART0_TX  */
+#define   XDMAC_CC_PERID_UART0_RX_Val       _U_(0x15)                                      /**< (XDMAC_CC) UART0_RX  */
+#define   XDMAC_CC_PERID_UART1_TX_Val       _U_(0x16)                                      /**< (XDMAC_CC) UART1_TX  */
+#define   XDMAC_CC_PERID_UART1_RX_Val       _U_(0x17)                                      /**< (XDMAC_CC) UART1_RX  */
+#define   XDMAC_CC_PERID_UART2_TX_Val       _U_(0x18)                                      /**< (XDMAC_CC) UART2_TX  */
+#define   XDMAC_CC_PERID_UART2_RX_Val       _U_(0x19)                                      /**< (XDMAC_CC) UART2_RX  */
+#define   XDMAC_CC_PERID_UART3_TX_Val       _U_(0x1A)                                      /**< (XDMAC_CC) UART3_TX  */
+#define   XDMAC_CC_PERID_UART3_RX_Val       _U_(0x1B)                                      /**< (XDMAC_CC) UART3_RX  */
+#define   XDMAC_CC_PERID_UART4_TX_Val       _U_(0x1C)                                      /**< (XDMAC_CC) UART4_TX  */
+#define   XDMAC_CC_PERID_UART4_RX_Val       _U_(0x1D)                                      /**< (XDMAC_CC) UART4_RX  */
+#define   XDMAC_CC_PERID_DACC0_Val          _U_(0x1E)                                      /**< (XDMAC_CC) DACC0  */
+#define   XDMAC_CC_PERID_DACC1_Val          _U_(0x1F)                                      /**< (XDMAC_CC) DACC1  */
+#define   XDMAC_CC_PERID_SSC_TX_Val         _U_(0x20)                                      /**< (XDMAC_CC) SSC_TX  */
+#define   XDMAC_CC_PERID_SSC_RX_Val         _U_(0x21)                                      /**< (XDMAC_CC) SSC_RX  */
+#define   XDMAC_CC_PERID_PIOA_Val           _U_(0x22)                                      /**< (XDMAC_CC) PIOA  */
+#define   XDMAC_CC_PERID_AFEC0_Val          _U_(0x23)                                      /**< (XDMAC_CC) AFEC0  */
+#define   XDMAC_CC_PERID_AFEC1_Val          _U_(0x24)                                      /**< (XDMAC_CC) AFEC1  */
+#define   XDMAC_CC_PERID_AES_TX_Val         _U_(0x25)                                      /**< (XDMAC_CC) AES_TX  */
+#define   XDMAC_CC_PERID_AES_RX_Val         _U_(0x26)                                      /**< (XDMAC_CC) AES_RX  */
+#define   XDMAC_CC_PERID_PWM1_Val           _U_(0x27)                                      /**< (XDMAC_CC) PWM1  */
+#define   XDMAC_CC_PERID_TC0_Val            _U_(0x28)                                      /**< (XDMAC_CC) TC0  */
+#define   XDMAC_CC_PERID_TC3_Val            _U_(0x29)                                      /**< (XDMAC_CC) TC3  */
+#define   XDMAC_CC_PERID_TC6_Val            _U_(0x2A)                                      /**< (XDMAC_CC) TC6  */
+#define   XDMAC_CC_PERID_TC9_Val            _U_(0x2B)                                      /**< (XDMAC_CC) TC9  */
+#define   XDMAC_CC_PERID_I2SC0_TX_LEFT_Val  _U_(0x2C)                                      /**< (XDMAC_CC) I2SC0_TX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC0_RX_LEFT_Val  _U_(0x2D)                                      /**< (XDMAC_CC) I2SC0_RX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC1_TX_LEFT_Val  _U_(0x2E)                                      /**< (XDMAC_CC) I2SC1_TX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC1_RX_LEFT_Val  _U_(0x2F)                                      /**< (XDMAC_CC) I2SC1_RX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC0_TX_RIGHT_Val _U_(0x30)                                      /**< (XDMAC_CC) I2SC0_TX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC0_RX_RIGHT_Val _U_(0x31)                                      /**< (XDMAC_CC) I2SC0_RX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC1_TX_RIGHT_Val _U_(0x32)                                      /**< (XDMAC_CC) I2SC1_TX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC1_RX_RIGHT_Val _U_(0x33)                                      /**< (XDMAC_CC) I2SC1_RX_RIGHT  */
+#define XDMAC_CC_PERID_HSMCI                (XDMAC_CC_PERID_HSMCI_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) HSMCI Position  */
+#define XDMAC_CC_PERID_SPI0_TX              (XDMAC_CC_PERID_SPI0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI0_TX Position  */
+#define XDMAC_CC_PERID_SPI0_RX              (XDMAC_CC_PERID_SPI0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI0_RX Position  */
+#define XDMAC_CC_PERID_SPI1_TX              (XDMAC_CC_PERID_SPI1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI1_TX Position  */
+#define XDMAC_CC_PERID_SPI1_RX              (XDMAC_CC_PERID_SPI1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI1_RX Position  */
+#define XDMAC_CC_PERID_QSPI_TX              (XDMAC_CC_PERID_QSPI_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) QSPI_TX Position  */
+#define XDMAC_CC_PERID_QSPI_RX              (XDMAC_CC_PERID_QSPI_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) QSPI_RX Position  */
+#define XDMAC_CC_PERID_USART0_TX            (XDMAC_CC_PERID_USART0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART0_TX Position  */
+#define XDMAC_CC_PERID_USART0_RX            (XDMAC_CC_PERID_USART0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART0_RX Position  */
+#define XDMAC_CC_PERID_USART1_TX            (XDMAC_CC_PERID_USART1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART1_TX Position  */
+#define XDMAC_CC_PERID_USART1_RX            (XDMAC_CC_PERID_USART1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART1_RX Position  */
+#define XDMAC_CC_PERID_USART2_TX            (XDMAC_CC_PERID_USART2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART2_TX Position  */
+#define XDMAC_CC_PERID_USART2_RX            (XDMAC_CC_PERID_USART2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART2_RX Position  */
+#define XDMAC_CC_PERID_PWM0                 (XDMAC_CC_PERID_PWM0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PWM0 Position  */
+#define XDMAC_CC_PERID_TWIHS0_TX            (XDMAC_CC_PERID_TWIHS0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS0_TX Position  */
+#define XDMAC_CC_PERID_TWIHS0_RX            (XDMAC_CC_PERID_TWIHS0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS0_RX Position  */
+#define XDMAC_CC_PERID_TWIHS1_TX            (XDMAC_CC_PERID_TWIHS1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS1_TX Position  */
+#define XDMAC_CC_PERID_TWIHS1_RX            (XDMAC_CC_PERID_TWIHS1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS1_RX Position  */
+#define XDMAC_CC_PERID_TWIHS2_TX            (XDMAC_CC_PERID_TWIHS2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS2_TX Position  */
+#define XDMAC_CC_PERID_TWIHS2_RX            (XDMAC_CC_PERID_TWIHS2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS2_RX Position  */
+#define XDMAC_CC_PERID_UART0_TX             (XDMAC_CC_PERID_UART0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART0_TX Position  */
+#define XDMAC_CC_PERID_UART0_RX             (XDMAC_CC_PERID_UART0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART0_RX Position  */
+#define XDMAC_CC_PERID_UART1_TX             (XDMAC_CC_PERID_UART1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART1_TX Position  */
+#define XDMAC_CC_PERID_UART1_RX             (XDMAC_CC_PERID_UART1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART1_RX Position  */
+#define XDMAC_CC_PERID_UART2_TX             (XDMAC_CC_PERID_UART2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART2_TX Position  */
+#define XDMAC_CC_PERID_UART2_RX             (XDMAC_CC_PERID_UART2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART2_RX Position  */
+#define XDMAC_CC_PERID_UART3_TX             (XDMAC_CC_PERID_UART3_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART3_TX Position  */
+#define XDMAC_CC_PERID_UART3_RX             (XDMAC_CC_PERID_UART3_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART3_RX Position  */
+#define XDMAC_CC_PERID_UART4_TX             (XDMAC_CC_PERID_UART4_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART4_TX Position  */
+#define XDMAC_CC_PERID_UART4_RX             (XDMAC_CC_PERID_UART4_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART4_RX Position  */
+#define XDMAC_CC_PERID_DACC0                (XDMAC_CC_PERID_DACC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) DACC0 Position  */
+#define XDMAC_CC_PERID_DACC1                (XDMAC_CC_PERID_DACC1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) DACC1 Position  */
+#define XDMAC_CC_PERID_SSC_TX               (XDMAC_CC_PERID_SSC_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SSC_TX Position  */
+#define XDMAC_CC_PERID_SSC_RX               (XDMAC_CC_PERID_SSC_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SSC_RX Position  */
+#define XDMAC_CC_PERID_PIOA                 (XDMAC_CC_PERID_PIOA_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PIOA Position  */
+#define XDMAC_CC_PERID_AFEC0                (XDMAC_CC_PERID_AFEC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AFEC0 Position  */
+#define XDMAC_CC_PERID_AFEC1                (XDMAC_CC_PERID_AFEC1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AFEC1 Position  */
+#define XDMAC_CC_PERID_AES_TX               (XDMAC_CC_PERID_AES_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AES_TX Position  */
+#define XDMAC_CC_PERID_AES_RX               (XDMAC_CC_PERID_AES_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AES_RX Position  */
+#define XDMAC_CC_PERID_PWM1                 (XDMAC_CC_PERID_PWM1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PWM1 Position  */
+#define XDMAC_CC_PERID_TC0                  (XDMAC_CC_PERID_TC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC0 Position  */
+#define XDMAC_CC_PERID_TC3                  (XDMAC_CC_PERID_TC3_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC3 Position  */
+#define XDMAC_CC_PERID_TC6                  (XDMAC_CC_PERID_TC6_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC6 Position  */
+#define XDMAC_CC_PERID_TC9                  (XDMAC_CC_PERID_TC9_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC9 Position  */
+#define XDMAC_CC_PERID_I2SC0_TX_LEFT        (XDMAC_CC_PERID_I2SC0_TX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_TX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC0_RX_LEFT        (XDMAC_CC_PERID_I2SC0_RX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_RX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC1_TX_LEFT        (XDMAC_CC_PERID_I2SC1_TX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_TX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC1_RX_LEFT        (XDMAC_CC_PERID_I2SC1_RX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_RX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC0_TX_RIGHT       (XDMAC_CC_PERID_I2SC0_TX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_TX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC0_RX_RIGHT       (XDMAC_CC_PERID_I2SC0_RX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_RX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC1_TX_RIGHT       (XDMAC_CC_PERID_I2SC1_TX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_TX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC1_RX_RIGHT       (XDMAC_CC_PERID_I2SC1_RX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_RX_RIGHT Position  */
+#define XDMAC_CC_MASK                       _U_(0x7FEF7FD7)                                /**< \deprecated (XDMAC_CC) Register MASK  (Use XDMAC_CC_Msk instead)  */
+#define XDMAC_CC_Msk                        _U_(0x7FEF7FD7)                                /**< (XDMAC_CC) Register Mask  */
+
+
+/* -------- XDMAC_CDS_MSP : (XDMAC Offset: 0x2c) (R/W 32) Channel Data Stride Memory Set Pattern -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SDS_MSP:16;                /**< bit:  0..15  Channel x Source Data stride or Memory Set Pattern */
+    uint32_t DDS_MSP:16;                /**< bit: 16..31  Channel x Destination Data Stride or Memory Set Pattern */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDS_MSP_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDS_MSP_OFFSET                (0x2C)                                        /**<  (XDMAC_CDS_MSP) Channel Data Stride Memory Set Pattern  Offset */
+
+#define XDMAC_CDS_MSP_SDS_MSP_Pos           0                                              /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Position */
+#define XDMAC_CDS_MSP_SDS_MSP_Msk           (_U_(0xFFFF) << XDMAC_CDS_MSP_SDS_MSP_Pos)     /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Mask */
+#define XDMAC_CDS_MSP_SDS_MSP(value)        (XDMAC_CDS_MSP_SDS_MSP_Msk & ((value) << XDMAC_CDS_MSP_SDS_MSP_Pos))
+#define XDMAC_CDS_MSP_DDS_MSP_Pos           16                                             /**< (XDMAC_CDS_MSP) Channel x Destination Data Stride or Memory Set Pattern Position */
+#define XDMAC_CDS_MSP_DDS_MSP_Msk           (_U_(0xFFFF) << XDMAC_CDS_MSP_DDS_MSP_Pos)     /**< (XDMAC_CDS_MSP) Channel x Destination Data Stride or Memory Set Pattern Mask */
+#define XDMAC_CDS_MSP_DDS_MSP(value)        (XDMAC_CDS_MSP_DDS_MSP_Msk & ((value) << XDMAC_CDS_MSP_DDS_MSP_Pos))
+#define XDMAC_CDS_MSP_MASK                  _U_(0xFFFFFFFF)                                /**< \deprecated (XDMAC_CDS_MSP) Register MASK  (Use XDMAC_CDS_MSP_Msk instead)  */
+#define XDMAC_CDS_MSP_Msk                   _U_(0xFFFFFFFF)                                /**< (XDMAC_CDS_MSP) Register Mask  */
+
+
+/* -------- XDMAC_CSUS : (XDMAC Offset: 0x30) (R/W 32) Channel Source Microblock Stride -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SUBS:24;                   /**< bit:  0..23  Channel x Source Microblock Stride       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CSUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CSUS_OFFSET                   (0x30)                                        /**<  (XDMAC_CSUS) Channel Source Microblock Stride  Offset */
+
+#define XDMAC_CSUS_SUBS_Pos                 0                                              /**< (XDMAC_CSUS) Channel x Source Microblock Stride Position */
+#define XDMAC_CSUS_SUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CSUS_SUBS_Pos)         /**< (XDMAC_CSUS) Channel x Source Microblock Stride Mask */
+#define XDMAC_CSUS_SUBS(value)              (XDMAC_CSUS_SUBS_Msk & ((value) << XDMAC_CSUS_SUBS_Pos))
+#define XDMAC_CSUS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CSUS) Register MASK  (Use XDMAC_CSUS_Msk instead)  */
+#define XDMAC_CSUS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CSUS) Register Mask  */
+
+
+/* -------- XDMAC_CDUS : (XDMAC Offset: 0x34) (R/W 32) Channel Destination Microblock Stride -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DUBS:24;                   /**< bit:  0..23  Channel x Destination Microblock Stride  */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_CDUS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_CDUS_OFFSET                   (0x34)                                        /**<  (XDMAC_CDUS) Channel Destination Microblock Stride  Offset */
+
+#define XDMAC_CDUS_DUBS_Pos                 0                                              /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Position */
+#define XDMAC_CDUS_DUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CDUS_DUBS_Pos)         /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Mask */
+#define XDMAC_CDUS_DUBS(value)              (XDMAC_CDUS_DUBS_Msk & ((value) << XDMAC_CDUS_DUBS_Pos))
+#define XDMAC_CDUS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_CDUS) Register MASK  (Use XDMAC_CDUS_Msk instead)  */
+#define XDMAC_CDUS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CDUS) Register Mask  */
+
+
+/* -------- XDMAC_GTYPE : (XDMAC Offset: 0x00) (R/ 32) Global Type Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t NB_CH:5;                   /**< bit:   0..4  Number of Channels Minus One             */
+    uint32_t FIFO_SZ:11;                /**< bit:  5..15  Number of Bytes                          */
+    uint32_t NB_REQ:7;                  /**< bit: 16..22  Number of Peripheral Requests Minus One  */
+    uint32_t :9;                        /**< bit: 23..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GTYPE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GTYPE_OFFSET                  (0x00)                                        /**<  (XDMAC_GTYPE) Global Type Register  Offset */
+
+#define XDMAC_GTYPE_NB_CH_Pos               0                                              /**< (XDMAC_GTYPE) Number of Channels Minus One Position */
+#define XDMAC_GTYPE_NB_CH_Msk               (_U_(0x1F) << XDMAC_GTYPE_NB_CH_Pos)           /**< (XDMAC_GTYPE) Number of Channels Minus One Mask */
+#define XDMAC_GTYPE_NB_CH(value)            (XDMAC_GTYPE_NB_CH_Msk & ((value) << XDMAC_GTYPE_NB_CH_Pos))
+#define XDMAC_GTYPE_FIFO_SZ_Pos             5                                              /**< (XDMAC_GTYPE) Number of Bytes Position */
+#define XDMAC_GTYPE_FIFO_SZ_Msk             (_U_(0x7FF) << XDMAC_GTYPE_FIFO_SZ_Pos)        /**< (XDMAC_GTYPE) Number of Bytes Mask */
+#define XDMAC_GTYPE_FIFO_SZ(value)          (XDMAC_GTYPE_FIFO_SZ_Msk & ((value) << XDMAC_GTYPE_FIFO_SZ_Pos))
+#define XDMAC_GTYPE_NB_REQ_Pos              16                                             /**< (XDMAC_GTYPE) Number of Peripheral Requests Minus One Position */
+#define XDMAC_GTYPE_NB_REQ_Msk              (_U_(0x7F) << XDMAC_GTYPE_NB_REQ_Pos)          /**< (XDMAC_GTYPE) Number of Peripheral Requests Minus One Mask */
+#define XDMAC_GTYPE_NB_REQ(value)           (XDMAC_GTYPE_NB_REQ_Msk & ((value) << XDMAC_GTYPE_NB_REQ_Pos))
+#define XDMAC_GTYPE_MASK                    _U_(0x7FFFFF)                                  /**< \deprecated (XDMAC_GTYPE) Register MASK  (Use XDMAC_GTYPE_Msk instead)  */
+#define XDMAC_GTYPE_Msk                     _U_(0x7FFFFF)                                  /**< (XDMAC_GTYPE) Register Mask  */
+
+
+/* -------- XDMAC_GCFG : (XDMAC Offset: 0x04) (R/W 32) Global Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t CGDISREG:1;                /**< bit:      0  Configuration Registers Clock Gating Disable */
+    uint32_t CGDISPIPE:1;               /**< bit:      1  Pipeline Clock Gating Disable            */
+    uint32_t CGDISFIFO:1;               /**< bit:      2  FIFO Clock Gating Disable                */
+    uint32_t CGDISIF:1;                 /**< bit:      3  Bus Interface Clock Gating Disable       */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
+    uint32_t BXKBEN:1;                  /**< bit:      8  Boundary X Kilobyte Enable               */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GCFG_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GCFG_OFFSET                   (0x04)                                        /**<  (XDMAC_GCFG) Global Configuration Register  Offset */
+
+#define XDMAC_GCFG_CGDISREG_Pos             0                                              /**< (XDMAC_GCFG) Configuration Registers Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISREG_Msk             (_U_(0x1) << XDMAC_GCFG_CGDISREG_Pos)          /**< (XDMAC_GCFG) Configuration Registers Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISREG                 XDMAC_GCFG_CGDISREG_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISREG_Msk instead */
+#define XDMAC_GCFG_CGDISPIPE_Pos            1                                              /**< (XDMAC_GCFG) Pipeline Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISPIPE_Msk            (_U_(0x1) << XDMAC_GCFG_CGDISPIPE_Pos)         /**< (XDMAC_GCFG) Pipeline Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISPIPE                XDMAC_GCFG_CGDISPIPE_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISPIPE_Msk instead */
+#define XDMAC_GCFG_CGDISFIFO_Pos            2                                              /**< (XDMAC_GCFG) FIFO Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISFIFO_Msk            (_U_(0x1) << XDMAC_GCFG_CGDISFIFO_Pos)         /**< (XDMAC_GCFG) FIFO Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISFIFO                XDMAC_GCFG_CGDISFIFO_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISFIFO_Msk instead */
+#define XDMAC_GCFG_CGDISIF_Pos              3                                              /**< (XDMAC_GCFG) Bus Interface Clock Gating Disable Position */
+#define XDMAC_GCFG_CGDISIF_Msk              (_U_(0x1) << XDMAC_GCFG_CGDISIF_Pos)           /**< (XDMAC_GCFG) Bus Interface Clock Gating Disable Mask */
+#define XDMAC_GCFG_CGDISIF                  XDMAC_GCFG_CGDISIF_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_CGDISIF_Msk instead */
+#define XDMAC_GCFG_BXKBEN_Pos               8                                              /**< (XDMAC_GCFG) Boundary X Kilobyte Enable Position */
+#define XDMAC_GCFG_BXKBEN_Msk               (_U_(0x1) << XDMAC_GCFG_BXKBEN_Pos)            /**< (XDMAC_GCFG) Boundary X Kilobyte Enable Mask */
+#define XDMAC_GCFG_BXKBEN                   XDMAC_GCFG_BXKBEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GCFG_BXKBEN_Msk instead */
+#define XDMAC_GCFG_MASK                     _U_(0x10F)                                     /**< \deprecated (XDMAC_GCFG) Register MASK  (Use XDMAC_GCFG_Msk instead)  */
+#define XDMAC_GCFG_Msk                      _U_(0x10F)                                     /**< (XDMAC_GCFG) Register Mask  */
+
+
+/* -------- XDMAC_GWAC : (XDMAC Offset: 0x08) (R/W 32) Global Weighted Arbiter Configuration Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t PW0:4;                     /**< bit:   0..3  Pool Weight 0                            */
+    uint32_t PW1:4;                     /**< bit:   4..7  Pool Weight 1                            */
+    uint32_t PW2:4;                     /**< bit:  8..11  Pool Weight 2                            */
+    uint32_t PW3:4;                     /**< bit: 12..15  Pool Weight 3                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GWAC_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GWAC_OFFSET                   (0x08)                                        /**<  (XDMAC_GWAC) Global Weighted Arbiter Configuration Register  Offset */
+
+#define XDMAC_GWAC_PW0_Pos                  0                                              /**< (XDMAC_GWAC) Pool Weight 0 Position */
+#define XDMAC_GWAC_PW0_Msk                  (_U_(0xF) << XDMAC_GWAC_PW0_Pos)               /**< (XDMAC_GWAC) Pool Weight 0 Mask */
+#define XDMAC_GWAC_PW0(value)               (XDMAC_GWAC_PW0_Msk & ((value) << XDMAC_GWAC_PW0_Pos))
+#define XDMAC_GWAC_PW1_Pos                  4                                              /**< (XDMAC_GWAC) Pool Weight 1 Position */
+#define XDMAC_GWAC_PW1_Msk                  (_U_(0xF) << XDMAC_GWAC_PW1_Pos)               /**< (XDMAC_GWAC) Pool Weight 1 Mask */
+#define XDMAC_GWAC_PW1(value)               (XDMAC_GWAC_PW1_Msk & ((value) << XDMAC_GWAC_PW1_Pos))
+#define XDMAC_GWAC_PW2_Pos                  8                                              /**< (XDMAC_GWAC) Pool Weight 2 Position */
+#define XDMAC_GWAC_PW2_Msk                  (_U_(0xF) << XDMAC_GWAC_PW2_Pos)               /**< (XDMAC_GWAC) Pool Weight 2 Mask */
+#define XDMAC_GWAC_PW2(value)               (XDMAC_GWAC_PW2_Msk & ((value) << XDMAC_GWAC_PW2_Pos))
+#define XDMAC_GWAC_PW3_Pos                  12                                             /**< (XDMAC_GWAC) Pool Weight 3 Position */
+#define XDMAC_GWAC_PW3_Msk                  (_U_(0xF) << XDMAC_GWAC_PW3_Pos)               /**< (XDMAC_GWAC) Pool Weight 3 Mask */
+#define XDMAC_GWAC_PW3(value)               (XDMAC_GWAC_PW3_Msk & ((value) << XDMAC_GWAC_PW3_Pos))
+#define XDMAC_GWAC_MASK                     _U_(0xFFFF)                                    /**< \deprecated (XDMAC_GWAC) Register MASK  (Use XDMAC_GWAC_Msk instead)  */
+#define XDMAC_GWAC_Msk                      _U_(0xFFFF)                                    /**< (XDMAC_GWAC) Register Mask  */
+
+
+/* -------- XDMAC_GIE : (XDMAC Offset: 0x0c) (/W 32) Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IE0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Enable Bit     */
+    uint32_t IE1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Enable Bit     */
+    uint32_t IE2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Enable Bit     */
+    uint32_t IE3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Enable Bit     */
+    uint32_t IE4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Enable Bit     */
+    uint32_t IE5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Enable Bit     */
+    uint32_t IE6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Enable Bit     */
+    uint32_t IE7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Enable Bit     */
+    uint32_t IE8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Enable Bit     */
+    uint32_t IE9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Enable Bit     */
+    uint32_t IE10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Enable Bit    */
+    uint32_t IE11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Enable Bit    */
+    uint32_t IE12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Enable Bit    */
+    uint32_t IE13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Enable Bit    */
+    uint32_t IE14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Enable Bit    */
+    uint32_t IE15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Enable Bit    */
+    uint32_t IE16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Enable Bit    */
+    uint32_t IE17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Enable Bit    */
+    uint32_t IE18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Enable Bit    */
+    uint32_t IE19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Enable Bit    */
+    uint32_t IE20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Enable Bit    */
+    uint32_t IE21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Enable Bit    */
+    uint32_t IE22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Enable Bit    */
+    uint32_t IE23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Enable Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IE:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Enable Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIE_OFFSET                    (0x0C)                                        /**<  (XDMAC_GIE) Global Interrupt Enable Register  Offset */
+
+#define XDMAC_GIE_IE0_Pos                   0                                              /**< (XDMAC_GIE) XDMAC Channel 0 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE0_Msk                   (_U_(0x1) << XDMAC_GIE_IE0_Pos)                /**< (XDMAC_GIE) XDMAC Channel 0 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE0                       XDMAC_GIE_IE0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE0_Msk instead */
+#define XDMAC_GIE_IE1_Pos                   1                                              /**< (XDMAC_GIE) XDMAC Channel 1 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE1_Msk                   (_U_(0x1) << XDMAC_GIE_IE1_Pos)                /**< (XDMAC_GIE) XDMAC Channel 1 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE1                       XDMAC_GIE_IE1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE1_Msk instead */
+#define XDMAC_GIE_IE2_Pos                   2                                              /**< (XDMAC_GIE) XDMAC Channel 2 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE2_Msk                   (_U_(0x1) << XDMAC_GIE_IE2_Pos)                /**< (XDMAC_GIE) XDMAC Channel 2 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE2                       XDMAC_GIE_IE2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE2_Msk instead */
+#define XDMAC_GIE_IE3_Pos                   3                                              /**< (XDMAC_GIE) XDMAC Channel 3 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE3_Msk                   (_U_(0x1) << XDMAC_GIE_IE3_Pos)                /**< (XDMAC_GIE) XDMAC Channel 3 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE3                       XDMAC_GIE_IE3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE3_Msk instead */
+#define XDMAC_GIE_IE4_Pos                   4                                              /**< (XDMAC_GIE) XDMAC Channel 4 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE4_Msk                   (_U_(0x1) << XDMAC_GIE_IE4_Pos)                /**< (XDMAC_GIE) XDMAC Channel 4 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE4                       XDMAC_GIE_IE4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE4_Msk instead */
+#define XDMAC_GIE_IE5_Pos                   5                                              /**< (XDMAC_GIE) XDMAC Channel 5 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE5_Msk                   (_U_(0x1) << XDMAC_GIE_IE5_Pos)                /**< (XDMAC_GIE) XDMAC Channel 5 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE5                       XDMAC_GIE_IE5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE5_Msk instead */
+#define XDMAC_GIE_IE6_Pos                   6                                              /**< (XDMAC_GIE) XDMAC Channel 6 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE6_Msk                   (_U_(0x1) << XDMAC_GIE_IE6_Pos)                /**< (XDMAC_GIE) XDMAC Channel 6 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE6                       XDMAC_GIE_IE6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE6_Msk instead */
+#define XDMAC_GIE_IE7_Pos                   7                                              /**< (XDMAC_GIE) XDMAC Channel 7 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE7_Msk                   (_U_(0x1) << XDMAC_GIE_IE7_Pos)                /**< (XDMAC_GIE) XDMAC Channel 7 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE7                       XDMAC_GIE_IE7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE7_Msk instead */
+#define XDMAC_GIE_IE8_Pos                   8                                              /**< (XDMAC_GIE) XDMAC Channel 8 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE8_Msk                   (_U_(0x1) << XDMAC_GIE_IE8_Pos)                /**< (XDMAC_GIE) XDMAC Channel 8 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE8                       XDMAC_GIE_IE8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE8_Msk instead */
+#define XDMAC_GIE_IE9_Pos                   9                                              /**< (XDMAC_GIE) XDMAC Channel 9 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE9_Msk                   (_U_(0x1) << XDMAC_GIE_IE9_Pos)                /**< (XDMAC_GIE) XDMAC Channel 9 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE9                       XDMAC_GIE_IE9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE9_Msk instead */
+#define XDMAC_GIE_IE10_Pos                  10                                             /**< (XDMAC_GIE) XDMAC Channel 10 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE10_Msk                  (_U_(0x1) << XDMAC_GIE_IE10_Pos)               /**< (XDMAC_GIE) XDMAC Channel 10 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE10                      XDMAC_GIE_IE10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE10_Msk instead */
+#define XDMAC_GIE_IE11_Pos                  11                                             /**< (XDMAC_GIE) XDMAC Channel 11 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE11_Msk                  (_U_(0x1) << XDMAC_GIE_IE11_Pos)               /**< (XDMAC_GIE) XDMAC Channel 11 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE11                      XDMAC_GIE_IE11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE11_Msk instead */
+#define XDMAC_GIE_IE12_Pos                  12                                             /**< (XDMAC_GIE) XDMAC Channel 12 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE12_Msk                  (_U_(0x1) << XDMAC_GIE_IE12_Pos)               /**< (XDMAC_GIE) XDMAC Channel 12 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE12                      XDMAC_GIE_IE12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE12_Msk instead */
+#define XDMAC_GIE_IE13_Pos                  13                                             /**< (XDMAC_GIE) XDMAC Channel 13 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE13_Msk                  (_U_(0x1) << XDMAC_GIE_IE13_Pos)               /**< (XDMAC_GIE) XDMAC Channel 13 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE13                      XDMAC_GIE_IE13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE13_Msk instead */
+#define XDMAC_GIE_IE14_Pos                  14                                             /**< (XDMAC_GIE) XDMAC Channel 14 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE14_Msk                  (_U_(0x1) << XDMAC_GIE_IE14_Pos)               /**< (XDMAC_GIE) XDMAC Channel 14 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE14                      XDMAC_GIE_IE14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE14_Msk instead */
+#define XDMAC_GIE_IE15_Pos                  15                                             /**< (XDMAC_GIE) XDMAC Channel 15 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE15_Msk                  (_U_(0x1) << XDMAC_GIE_IE15_Pos)               /**< (XDMAC_GIE) XDMAC Channel 15 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE15                      XDMAC_GIE_IE15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE15_Msk instead */
+#define XDMAC_GIE_IE16_Pos                  16                                             /**< (XDMAC_GIE) XDMAC Channel 16 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE16_Msk                  (_U_(0x1) << XDMAC_GIE_IE16_Pos)               /**< (XDMAC_GIE) XDMAC Channel 16 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE16                      XDMAC_GIE_IE16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE16_Msk instead */
+#define XDMAC_GIE_IE17_Pos                  17                                             /**< (XDMAC_GIE) XDMAC Channel 17 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE17_Msk                  (_U_(0x1) << XDMAC_GIE_IE17_Pos)               /**< (XDMAC_GIE) XDMAC Channel 17 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE17                      XDMAC_GIE_IE17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE17_Msk instead */
+#define XDMAC_GIE_IE18_Pos                  18                                             /**< (XDMAC_GIE) XDMAC Channel 18 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE18_Msk                  (_U_(0x1) << XDMAC_GIE_IE18_Pos)               /**< (XDMAC_GIE) XDMAC Channel 18 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE18                      XDMAC_GIE_IE18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE18_Msk instead */
+#define XDMAC_GIE_IE19_Pos                  19                                             /**< (XDMAC_GIE) XDMAC Channel 19 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE19_Msk                  (_U_(0x1) << XDMAC_GIE_IE19_Pos)               /**< (XDMAC_GIE) XDMAC Channel 19 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE19                      XDMAC_GIE_IE19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE19_Msk instead */
+#define XDMAC_GIE_IE20_Pos                  20                                             /**< (XDMAC_GIE) XDMAC Channel 20 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE20_Msk                  (_U_(0x1) << XDMAC_GIE_IE20_Pos)               /**< (XDMAC_GIE) XDMAC Channel 20 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE20                      XDMAC_GIE_IE20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE20_Msk instead */
+#define XDMAC_GIE_IE21_Pos                  21                                             /**< (XDMAC_GIE) XDMAC Channel 21 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE21_Msk                  (_U_(0x1) << XDMAC_GIE_IE21_Pos)               /**< (XDMAC_GIE) XDMAC Channel 21 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE21                      XDMAC_GIE_IE21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE21_Msk instead */
+#define XDMAC_GIE_IE22_Pos                  22                                             /**< (XDMAC_GIE) XDMAC Channel 22 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE22_Msk                  (_U_(0x1) << XDMAC_GIE_IE22_Pos)               /**< (XDMAC_GIE) XDMAC Channel 22 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE22                      XDMAC_GIE_IE22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE22_Msk instead */
+#define XDMAC_GIE_IE23_Pos                  23                                             /**< (XDMAC_GIE) XDMAC Channel 23 Interrupt Enable Bit Position */
+#define XDMAC_GIE_IE23_Msk                  (_U_(0x1) << XDMAC_GIE_IE23_Pos)               /**< (XDMAC_GIE) XDMAC Channel 23 Interrupt Enable Bit Mask */
+#define XDMAC_GIE_IE23                      XDMAC_GIE_IE23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIE_IE23_Msk instead */
+#define XDMAC_GIE_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIE) Register MASK  (Use XDMAC_GIE_Msk instead)  */
+#define XDMAC_GIE_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIE) Register Mask  */
+
+#define XDMAC_GIE_IE_Pos                    0                                              /**< (XDMAC_GIE Position) XDMAC Channel 23 Interrupt Enable Bit */
+#define XDMAC_GIE_IE_Msk                    (_U_(0xFFFFFF) << XDMAC_GIE_IE_Pos)            /**< (XDMAC_GIE Mask) IE */
+#define XDMAC_GIE_IE(value)                 (XDMAC_GIE_IE_Msk & ((value) << XDMAC_GIE_IE_Pos))  
+
+/* -------- XDMAC_GID : (XDMAC Offset: 0x10) (/W 32) Global Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Disable Bit    */
+    uint32_t ID1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Disable Bit    */
+    uint32_t ID2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Disable Bit    */
+    uint32_t ID3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Disable Bit    */
+    uint32_t ID4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Disable Bit    */
+    uint32_t ID5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Disable Bit    */
+    uint32_t ID6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Disable Bit    */
+    uint32_t ID7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Disable Bit    */
+    uint32_t ID8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Disable Bit    */
+    uint32_t ID9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Disable Bit    */
+    uint32_t ID10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Disable Bit   */
+    uint32_t ID11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Disable Bit   */
+    uint32_t ID12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Disable Bit   */
+    uint32_t ID13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Disable Bit   */
+    uint32_t ID14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Disable Bit   */
+    uint32_t ID15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Disable Bit   */
+    uint32_t ID16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Disable Bit   */
+    uint32_t ID17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Disable Bit   */
+    uint32_t ID18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Disable Bit   */
+    uint32_t ID19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Disable Bit   */
+    uint32_t ID20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Disable Bit   */
+    uint32_t ID21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Disable Bit   */
+    uint32_t ID22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Disable Bit   */
+    uint32_t ID23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Disable Bit   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ID:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Disable Bit   */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GID_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GID_OFFSET                    (0x10)                                        /**<  (XDMAC_GID) Global Interrupt Disable Register  Offset */
+
+#define XDMAC_GID_ID0_Pos                   0                                              /**< (XDMAC_GID) XDMAC Channel 0 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID0_Msk                   (_U_(0x1) << XDMAC_GID_ID0_Pos)                /**< (XDMAC_GID) XDMAC Channel 0 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID0                       XDMAC_GID_ID0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID0_Msk instead */
+#define XDMAC_GID_ID1_Pos                   1                                              /**< (XDMAC_GID) XDMAC Channel 1 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID1_Msk                   (_U_(0x1) << XDMAC_GID_ID1_Pos)                /**< (XDMAC_GID) XDMAC Channel 1 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID1                       XDMAC_GID_ID1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID1_Msk instead */
+#define XDMAC_GID_ID2_Pos                   2                                              /**< (XDMAC_GID) XDMAC Channel 2 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID2_Msk                   (_U_(0x1) << XDMAC_GID_ID2_Pos)                /**< (XDMAC_GID) XDMAC Channel 2 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID2                       XDMAC_GID_ID2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID2_Msk instead */
+#define XDMAC_GID_ID3_Pos                   3                                              /**< (XDMAC_GID) XDMAC Channel 3 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID3_Msk                   (_U_(0x1) << XDMAC_GID_ID3_Pos)                /**< (XDMAC_GID) XDMAC Channel 3 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID3                       XDMAC_GID_ID3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID3_Msk instead */
+#define XDMAC_GID_ID4_Pos                   4                                              /**< (XDMAC_GID) XDMAC Channel 4 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID4_Msk                   (_U_(0x1) << XDMAC_GID_ID4_Pos)                /**< (XDMAC_GID) XDMAC Channel 4 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID4                       XDMAC_GID_ID4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID4_Msk instead */
+#define XDMAC_GID_ID5_Pos                   5                                              /**< (XDMAC_GID) XDMAC Channel 5 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID5_Msk                   (_U_(0x1) << XDMAC_GID_ID5_Pos)                /**< (XDMAC_GID) XDMAC Channel 5 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID5                       XDMAC_GID_ID5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID5_Msk instead */
+#define XDMAC_GID_ID6_Pos                   6                                              /**< (XDMAC_GID) XDMAC Channel 6 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID6_Msk                   (_U_(0x1) << XDMAC_GID_ID6_Pos)                /**< (XDMAC_GID) XDMAC Channel 6 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID6                       XDMAC_GID_ID6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID6_Msk instead */
+#define XDMAC_GID_ID7_Pos                   7                                              /**< (XDMAC_GID) XDMAC Channel 7 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID7_Msk                   (_U_(0x1) << XDMAC_GID_ID7_Pos)                /**< (XDMAC_GID) XDMAC Channel 7 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID7                       XDMAC_GID_ID7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID7_Msk instead */
+#define XDMAC_GID_ID8_Pos                   8                                              /**< (XDMAC_GID) XDMAC Channel 8 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID8_Msk                   (_U_(0x1) << XDMAC_GID_ID8_Pos)                /**< (XDMAC_GID) XDMAC Channel 8 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID8                       XDMAC_GID_ID8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID8_Msk instead */
+#define XDMAC_GID_ID9_Pos                   9                                              /**< (XDMAC_GID) XDMAC Channel 9 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID9_Msk                   (_U_(0x1) << XDMAC_GID_ID9_Pos)                /**< (XDMAC_GID) XDMAC Channel 9 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID9                       XDMAC_GID_ID9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID9_Msk instead */
+#define XDMAC_GID_ID10_Pos                  10                                             /**< (XDMAC_GID) XDMAC Channel 10 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID10_Msk                  (_U_(0x1) << XDMAC_GID_ID10_Pos)               /**< (XDMAC_GID) XDMAC Channel 10 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID10                      XDMAC_GID_ID10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID10_Msk instead */
+#define XDMAC_GID_ID11_Pos                  11                                             /**< (XDMAC_GID) XDMAC Channel 11 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID11_Msk                  (_U_(0x1) << XDMAC_GID_ID11_Pos)               /**< (XDMAC_GID) XDMAC Channel 11 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID11                      XDMAC_GID_ID11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID11_Msk instead */
+#define XDMAC_GID_ID12_Pos                  12                                             /**< (XDMAC_GID) XDMAC Channel 12 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID12_Msk                  (_U_(0x1) << XDMAC_GID_ID12_Pos)               /**< (XDMAC_GID) XDMAC Channel 12 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID12                      XDMAC_GID_ID12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID12_Msk instead */
+#define XDMAC_GID_ID13_Pos                  13                                             /**< (XDMAC_GID) XDMAC Channel 13 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID13_Msk                  (_U_(0x1) << XDMAC_GID_ID13_Pos)               /**< (XDMAC_GID) XDMAC Channel 13 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID13                      XDMAC_GID_ID13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID13_Msk instead */
+#define XDMAC_GID_ID14_Pos                  14                                             /**< (XDMAC_GID) XDMAC Channel 14 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID14_Msk                  (_U_(0x1) << XDMAC_GID_ID14_Pos)               /**< (XDMAC_GID) XDMAC Channel 14 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID14                      XDMAC_GID_ID14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID14_Msk instead */
+#define XDMAC_GID_ID15_Pos                  15                                             /**< (XDMAC_GID) XDMAC Channel 15 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID15_Msk                  (_U_(0x1) << XDMAC_GID_ID15_Pos)               /**< (XDMAC_GID) XDMAC Channel 15 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID15                      XDMAC_GID_ID15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID15_Msk instead */
+#define XDMAC_GID_ID16_Pos                  16                                             /**< (XDMAC_GID) XDMAC Channel 16 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID16_Msk                  (_U_(0x1) << XDMAC_GID_ID16_Pos)               /**< (XDMAC_GID) XDMAC Channel 16 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID16                      XDMAC_GID_ID16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID16_Msk instead */
+#define XDMAC_GID_ID17_Pos                  17                                             /**< (XDMAC_GID) XDMAC Channel 17 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID17_Msk                  (_U_(0x1) << XDMAC_GID_ID17_Pos)               /**< (XDMAC_GID) XDMAC Channel 17 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID17                      XDMAC_GID_ID17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID17_Msk instead */
+#define XDMAC_GID_ID18_Pos                  18                                             /**< (XDMAC_GID) XDMAC Channel 18 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID18_Msk                  (_U_(0x1) << XDMAC_GID_ID18_Pos)               /**< (XDMAC_GID) XDMAC Channel 18 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID18                      XDMAC_GID_ID18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID18_Msk instead */
+#define XDMAC_GID_ID19_Pos                  19                                             /**< (XDMAC_GID) XDMAC Channel 19 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID19_Msk                  (_U_(0x1) << XDMAC_GID_ID19_Pos)               /**< (XDMAC_GID) XDMAC Channel 19 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID19                      XDMAC_GID_ID19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID19_Msk instead */
+#define XDMAC_GID_ID20_Pos                  20                                             /**< (XDMAC_GID) XDMAC Channel 20 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID20_Msk                  (_U_(0x1) << XDMAC_GID_ID20_Pos)               /**< (XDMAC_GID) XDMAC Channel 20 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID20                      XDMAC_GID_ID20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID20_Msk instead */
+#define XDMAC_GID_ID21_Pos                  21                                             /**< (XDMAC_GID) XDMAC Channel 21 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID21_Msk                  (_U_(0x1) << XDMAC_GID_ID21_Pos)               /**< (XDMAC_GID) XDMAC Channel 21 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID21                      XDMAC_GID_ID21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID21_Msk instead */
+#define XDMAC_GID_ID22_Pos                  22                                             /**< (XDMAC_GID) XDMAC Channel 22 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID22_Msk                  (_U_(0x1) << XDMAC_GID_ID22_Pos)               /**< (XDMAC_GID) XDMAC Channel 22 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID22                      XDMAC_GID_ID22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID22_Msk instead */
+#define XDMAC_GID_ID23_Pos                  23                                             /**< (XDMAC_GID) XDMAC Channel 23 Interrupt Disable Bit Position */
+#define XDMAC_GID_ID23_Msk                  (_U_(0x1) << XDMAC_GID_ID23_Pos)               /**< (XDMAC_GID) XDMAC Channel 23 Interrupt Disable Bit Mask */
+#define XDMAC_GID_ID23                      XDMAC_GID_ID23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GID_ID23_Msk instead */
+#define XDMAC_GID_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GID) Register MASK  (Use XDMAC_GID_Msk instead)  */
+#define XDMAC_GID_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GID) Register Mask  */
+
+#define XDMAC_GID_ID_Pos                    0                                              /**< (XDMAC_GID Position) XDMAC Channel 23 Interrupt Disable Bit */
+#define XDMAC_GID_ID_Msk                    (_U_(0xFFFFFF) << XDMAC_GID_ID_Pos)            /**< (XDMAC_GID Mask) ID */
+#define XDMAC_GID_ID(value)                 (XDMAC_GID_ID_Msk & ((value) << XDMAC_GID_ID_Pos))  
+
+/* -------- XDMAC_GIM : (XDMAC Offset: 0x14) (R/ 32) Global Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IM0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Mask Bit       */
+    uint32_t IM1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Mask Bit       */
+    uint32_t IM2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Mask Bit       */
+    uint32_t IM3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Mask Bit       */
+    uint32_t IM4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Mask Bit       */
+    uint32_t IM5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Mask Bit       */
+    uint32_t IM6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Mask Bit       */
+    uint32_t IM7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Mask Bit       */
+    uint32_t IM8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Mask Bit       */
+    uint32_t IM9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Mask Bit       */
+    uint32_t IM10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Mask Bit      */
+    uint32_t IM11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Mask Bit      */
+    uint32_t IM12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Mask Bit      */
+    uint32_t IM13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Mask Bit      */
+    uint32_t IM14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Mask Bit      */
+    uint32_t IM15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Mask Bit      */
+    uint32_t IM16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Mask Bit      */
+    uint32_t IM17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Mask Bit      */
+    uint32_t IM18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Mask Bit      */
+    uint32_t IM19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Mask Bit      */
+    uint32_t IM20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Mask Bit      */
+    uint32_t IM21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Mask Bit      */
+    uint32_t IM22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Mask Bit      */
+    uint32_t IM23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Mask Bit      */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IM:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Mask Bit      */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIM_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIM_OFFSET                    (0x14)                                        /**<  (XDMAC_GIM) Global Interrupt Mask Register  Offset */
+
+#define XDMAC_GIM_IM0_Pos                   0                                              /**< (XDMAC_GIM) XDMAC Channel 0 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM0_Msk                   (_U_(0x1) << XDMAC_GIM_IM0_Pos)                /**< (XDMAC_GIM) XDMAC Channel 0 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM0                       XDMAC_GIM_IM0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM0_Msk instead */
+#define XDMAC_GIM_IM1_Pos                   1                                              /**< (XDMAC_GIM) XDMAC Channel 1 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM1_Msk                   (_U_(0x1) << XDMAC_GIM_IM1_Pos)                /**< (XDMAC_GIM) XDMAC Channel 1 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM1                       XDMAC_GIM_IM1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM1_Msk instead */
+#define XDMAC_GIM_IM2_Pos                   2                                              /**< (XDMAC_GIM) XDMAC Channel 2 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM2_Msk                   (_U_(0x1) << XDMAC_GIM_IM2_Pos)                /**< (XDMAC_GIM) XDMAC Channel 2 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM2                       XDMAC_GIM_IM2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM2_Msk instead */
+#define XDMAC_GIM_IM3_Pos                   3                                              /**< (XDMAC_GIM) XDMAC Channel 3 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM3_Msk                   (_U_(0x1) << XDMAC_GIM_IM3_Pos)                /**< (XDMAC_GIM) XDMAC Channel 3 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM3                       XDMAC_GIM_IM3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM3_Msk instead */
+#define XDMAC_GIM_IM4_Pos                   4                                              /**< (XDMAC_GIM) XDMAC Channel 4 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM4_Msk                   (_U_(0x1) << XDMAC_GIM_IM4_Pos)                /**< (XDMAC_GIM) XDMAC Channel 4 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM4                       XDMAC_GIM_IM4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM4_Msk instead */
+#define XDMAC_GIM_IM5_Pos                   5                                              /**< (XDMAC_GIM) XDMAC Channel 5 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM5_Msk                   (_U_(0x1) << XDMAC_GIM_IM5_Pos)                /**< (XDMAC_GIM) XDMAC Channel 5 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM5                       XDMAC_GIM_IM5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM5_Msk instead */
+#define XDMAC_GIM_IM6_Pos                   6                                              /**< (XDMAC_GIM) XDMAC Channel 6 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM6_Msk                   (_U_(0x1) << XDMAC_GIM_IM6_Pos)                /**< (XDMAC_GIM) XDMAC Channel 6 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM6                       XDMAC_GIM_IM6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM6_Msk instead */
+#define XDMAC_GIM_IM7_Pos                   7                                              /**< (XDMAC_GIM) XDMAC Channel 7 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM7_Msk                   (_U_(0x1) << XDMAC_GIM_IM7_Pos)                /**< (XDMAC_GIM) XDMAC Channel 7 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM7                       XDMAC_GIM_IM7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM7_Msk instead */
+#define XDMAC_GIM_IM8_Pos                   8                                              /**< (XDMAC_GIM) XDMAC Channel 8 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM8_Msk                   (_U_(0x1) << XDMAC_GIM_IM8_Pos)                /**< (XDMAC_GIM) XDMAC Channel 8 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM8                       XDMAC_GIM_IM8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM8_Msk instead */
+#define XDMAC_GIM_IM9_Pos                   9                                              /**< (XDMAC_GIM) XDMAC Channel 9 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM9_Msk                   (_U_(0x1) << XDMAC_GIM_IM9_Pos)                /**< (XDMAC_GIM) XDMAC Channel 9 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM9                       XDMAC_GIM_IM9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM9_Msk instead */
+#define XDMAC_GIM_IM10_Pos                  10                                             /**< (XDMAC_GIM) XDMAC Channel 10 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM10_Msk                  (_U_(0x1) << XDMAC_GIM_IM10_Pos)               /**< (XDMAC_GIM) XDMAC Channel 10 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM10                      XDMAC_GIM_IM10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM10_Msk instead */
+#define XDMAC_GIM_IM11_Pos                  11                                             /**< (XDMAC_GIM) XDMAC Channel 11 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM11_Msk                  (_U_(0x1) << XDMAC_GIM_IM11_Pos)               /**< (XDMAC_GIM) XDMAC Channel 11 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM11                      XDMAC_GIM_IM11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM11_Msk instead */
+#define XDMAC_GIM_IM12_Pos                  12                                             /**< (XDMAC_GIM) XDMAC Channel 12 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM12_Msk                  (_U_(0x1) << XDMAC_GIM_IM12_Pos)               /**< (XDMAC_GIM) XDMAC Channel 12 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM12                      XDMAC_GIM_IM12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM12_Msk instead */
+#define XDMAC_GIM_IM13_Pos                  13                                             /**< (XDMAC_GIM) XDMAC Channel 13 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM13_Msk                  (_U_(0x1) << XDMAC_GIM_IM13_Pos)               /**< (XDMAC_GIM) XDMAC Channel 13 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM13                      XDMAC_GIM_IM13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM13_Msk instead */
+#define XDMAC_GIM_IM14_Pos                  14                                             /**< (XDMAC_GIM) XDMAC Channel 14 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM14_Msk                  (_U_(0x1) << XDMAC_GIM_IM14_Pos)               /**< (XDMAC_GIM) XDMAC Channel 14 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM14                      XDMAC_GIM_IM14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM14_Msk instead */
+#define XDMAC_GIM_IM15_Pos                  15                                             /**< (XDMAC_GIM) XDMAC Channel 15 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM15_Msk                  (_U_(0x1) << XDMAC_GIM_IM15_Pos)               /**< (XDMAC_GIM) XDMAC Channel 15 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM15                      XDMAC_GIM_IM15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM15_Msk instead */
+#define XDMAC_GIM_IM16_Pos                  16                                             /**< (XDMAC_GIM) XDMAC Channel 16 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM16_Msk                  (_U_(0x1) << XDMAC_GIM_IM16_Pos)               /**< (XDMAC_GIM) XDMAC Channel 16 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM16                      XDMAC_GIM_IM16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM16_Msk instead */
+#define XDMAC_GIM_IM17_Pos                  17                                             /**< (XDMAC_GIM) XDMAC Channel 17 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM17_Msk                  (_U_(0x1) << XDMAC_GIM_IM17_Pos)               /**< (XDMAC_GIM) XDMAC Channel 17 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM17                      XDMAC_GIM_IM17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM17_Msk instead */
+#define XDMAC_GIM_IM18_Pos                  18                                             /**< (XDMAC_GIM) XDMAC Channel 18 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM18_Msk                  (_U_(0x1) << XDMAC_GIM_IM18_Pos)               /**< (XDMAC_GIM) XDMAC Channel 18 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM18                      XDMAC_GIM_IM18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM18_Msk instead */
+#define XDMAC_GIM_IM19_Pos                  19                                             /**< (XDMAC_GIM) XDMAC Channel 19 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM19_Msk                  (_U_(0x1) << XDMAC_GIM_IM19_Pos)               /**< (XDMAC_GIM) XDMAC Channel 19 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM19                      XDMAC_GIM_IM19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM19_Msk instead */
+#define XDMAC_GIM_IM20_Pos                  20                                             /**< (XDMAC_GIM) XDMAC Channel 20 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM20_Msk                  (_U_(0x1) << XDMAC_GIM_IM20_Pos)               /**< (XDMAC_GIM) XDMAC Channel 20 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM20                      XDMAC_GIM_IM20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM20_Msk instead */
+#define XDMAC_GIM_IM21_Pos                  21                                             /**< (XDMAC_GIM) XDMAC Channel 21 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM21_Msk                  (_U_(0x1) << XDMAC_GIM_IM21_Pos)               /**< (XDMAC_GIM) XDMAC Channel 21 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM21                      XDMAC_GIM_IM21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM21_Msk instead */
+#define XDMAC_GIM_IM22_Pos                  22                                             /**< (XDMAC_GIM) XDMAC Channel 22 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM22_Msk                  (_U_(0x1) << XDMAC_GIM_IM22_Pos)               /**< (XDMAC_GIM) XDMAC Channel 22 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM22                      XDMAC_GIM_IM22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM22_Msk instead */
+#define XDMAC_GIM_IM23_Pos                  23                                             /**< (XDMAC_GIM) XDMAC Channel 23 Interrupt Mask Bit Position */
+#define XDMAC_GIM_IM23_Msk                  (_U_(0x1) << XDMAC_GIM_IM23_Pos)               /**< (XDMAC_GIM) XDMAC Channel 23 Interrupt Mask Bit Mask */
+#define XDMAC_GIM_IM23                      XDMAC_GIM_IM23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIM_IM23_Msk instead */
+#define XDMAC_GIM_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIM) Register MASK  (Use XDMAC_GIM_Msk instead)  */
+#define XDMAC_GIM_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIM) Register Mask  */
+
+#define XDMAC_GIM_IM_Pos                    0                                              /**< (XDMAC_GIM Position) XDMAC Channel 23 Interrupt Mask Bit */
+#define XDMAC_GIM_IM_Msk                    (_U_(0xFFFFFF) << XDMAC_GIM_IM_Pos)            /**< (XDMAC_GIM Mask) IM */
+#define XDMAC_GIM_IM(value)                 (XDMAC_GIM_IM_Msk & ((value) << XDMAC_GIM_IM_Pos))  
+
+/* -------- XDMAC_GIS : (XDMAC Offset: 0x18) (R/ 32) Global Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t IS0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Status Bit     */
+    uint32_t IS1:1;                     /**< bit:      1  XDMAC Channel 1 Interrupt Status Bit     */
+    uint32_t IS2:1;                     /**< bit:      2  XDMAC Channel 2 Interrupt Status Bit     */
+    uint32_t IS3:1;                     /**< bit:      3  XDMAC Channel 3 Interrupt Status Bit     */
+    uint32_t IS4:1;                     /**< bit:      4  XDMAC Channel 4 Interrupt Status Bit     */
+    uint32_t IS5:1;                     /**< bit:      5  XDMAC Channel 5 Interrupt Status Bit     */
+    uint32_t IS6:1;                     /**< bit:      6  XDMAC Channel 6 Interrupt Status Bit     */
+    uint32_t IS7:1;                     /**< bit:      7  XDMAC Channel 7 Interrupt Status Bit     */
+    uint32_t IS8:1;                     /**< bit:      8  XDMAC Channel 8 Interrupt Status Bit     */
+    uint32_t IS9:1;                     /**< bit:      9  XDMAC Channel 9 Interrupt Status Bit     */
+    uint32_t IS10:1;                    /**< bit:     10  XDMAC Channel 10 Interrupt Status Bit    */
+    uint32_t IS11:1;                    /**< bit:     11  XDMAC Channel 11 Interrupt Status Bit    */
+    uint32_t IS12:1;                    /**< bit:     12  XDMAC Channel 12 Interrupt Status Bit    */
+    uint32_t IS13:1;                    /**< bit:     13  XDMAC Channel 13 Interrupt Status Bit    */
+    uint32_t IS14:1;                    /**< bit:     14  XDMAC Channel 14 Interrupt Status Bit    */
+    uint32_t IS15:1;                    /**< bit:     15  XDMAC Channel 15 Interrupt Status Bit    */
+    uint32_t IS16:1;                    /**< bit:     16  XDMAC Channel 16 Interrupt Status Bit    */
+    uint32_t IS17:1;                    /**< bit:     17  XDMAC Channel 17 Interrupt Status Bit    */
+    uint32_t IS18:1;                    /**< bit:     18  XDMAC Channel 18 Interrupt Status Bit    */
+    uint32_t IS19:1;                    /**< bit:     19  XDMAC Channel 19 Interrupt Status Bit    */
+    uint32_t IS20:1;                    /**< bit:     20  XDMAC Channel 20 Interrupt Status Bit    */
+    uint32_t IS21:1;                    /**< bit:     21  XDMAC Channel 21 Interrupt Status Bit    */
+    uint32_t IS22:1;                    /**< bit:     22  XDMAC Channel 22 Interrupt Status Bit    */
+    uint32_t IS23:1;                    /**< bit:     23  XDMAC Channel 23 Interrupt Status Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t IS:24;                     /**< bit:  0..23  XDMAC Channel 23 Interrupt Status Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GIS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GIS_OFFSET                    (0x18)                                        /**<  (XDMAC_GIS) Global Interrupt Status Register  Offset */
+
+#define XDMAC_GIS_IS0_Pos                   0                                              /**< (XDMAC_GIS) XDMAC Channel 0 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS0_Msk                   (_U_(0x1) << XDMAC_GIS_IS0_Pos)                /**< (XDMAC_GIS) XDMAC Channel 0 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS0                       XDMAC_GIS_IS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS0_Msk instead */
+#define XDMAC_GIS_IS1_Pos                   1                                              /**< (XDMAC_GIS) XDMAC Channel 1 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS1_Msk                   (_U_(0x1) << XDMAC_GIS_IS1_Pos)                /**< (XDMAC_GIS) XDMAC Channel 1 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS1                       XDMAC_GIS_IS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS1_Msk instead */
+#define XDMAC_GIS_IS2_Pos                   2                                              /**< (XDMAC_GIS) XDMAC Channel 2 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS2_Msk                   (_U_(0x1) << XDMAC_GIS_IS2_Pos)                /**< (XDMAC_GIS) XDMAC Channel 2 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS2                       XDMAC_GIS_IS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS2_Msk instead */
+#define XDMAC_GIS_IS3_Pos                   3                                              /**< (XDMAC_GIS) XDMAC Channel 3 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS3_Msk                   (_U_(0x1) << XDMAC_GIS_IS3_Pos)                /**< (XDMAC_GIS) XDMAC Channel 3 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS3                       XDMAC_GIS_IS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS3_Msk instead */
+#define XDMAC_GIS_IS4_Pos                   4                                              /**< (XDMAC_GIS) XDMAC Channel 4 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS4_Msk                   (_U_(0x1) << XDMAC_GIS_IS4_Pos)                /**< (XDMAC_GIS) XDMAC Channel 4 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS4                       XDMAC_GIS_IS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS4_Msk instead */
+#define XDMAC_GIS_IS5_Pos                   5                                              /**< (XDMAC_GIS) XDMAC Channel 5 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS5_Msk                   (_U_(0x1) << XDMAC_GIS_IS5_Pos)                /**< (XDMAC_GIS) XDMAC Channel 5 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS5                       XDMAC_GIS_IS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS5_Msk instead */
+#define XDMAC_GIS_IS6_Pos                   6                                              /**< (XDMAC_GIS) XDMAC Channel 6 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS6_Msk                   (_U_(0x1) << XDMAC_GIS_IS6_Pos)                /**< (XDMAC_GIS) XDMAC Channel 6 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS6                       XDMAC_GIS_IS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS6_Msk instead */
+#define XDMAC_GIS_IS7_Pos                   7                                              /**< (XDMAC_GIS) XDMAC Channel 7 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS7_Msk                   (_U_(0x1) << XDMAC_GIS_IS7_Pos)                /**< (XDMAC_GIS) XDMAC Channel 7 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS7                       XDMAC_GIS_IS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS7_Msk instead */
+#define XDMAC_GIS_IS8_Pos                   8                                              /**< (XDMAC_GIS) XDMAC Channel 8 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS8_Msk                   (_U_(0x1) << XDMAC_GIS_IS8_Pos)                /**< (XDMAC_GIS) XDMAC Channel 8 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS8                       XDMAC_GIS_IS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS8_Msk instead */
+#define XDMAC_GIS_IS9_Pos                   9                                              /**< (XDMAC_GIS) XDMAC Channel 9 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS9_Msk                   (_U_(0x1) << XDMAC_GIS_IS9_Pos)                /**< (XDMAC_GIS) XDMAC Channel 9 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS9                       XDMAC_GIS_IS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS9_Msk instead */
+#define XDMAC_GIS_IS10_Pos                  10                                             /**< (XDMAC_GIS) XDMAC Channel 10 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS10_Msk                  (_U_(0x1) << XDMAC_GIS_IS10_Pos)               /**< (XDMAC_GIS) XDMAC Channel 10 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS10                      XDMAC_GIS_IS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS10_Msk instead */
+#define XDMAC_GIS_IS11_Pos                  11                                             /**< (XDMAC_GIS) XDMAC Channel 11 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS11_Msk                  (_U_(0x1) << XDMAC_GIS_IS11_Pos)               /**< (XDMAC_GIS) XDMAC Channel 11 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS11                      XDMAC_GIS_IS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS11_Msk instead */
+#define XDMAC_GIS_IS12_Pos                  12                                             /**< (XDMAC_GIS) XDMAC Channel 12 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS12_Msk                  (_U_(0x1) << XDMAC_GIS_IS12_Pos)               /**< (XDMAC_GIS) XDMAC Channel 12 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS12                      XDMAC_GIS_IS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS12_Msk instead */
+#define XDMAC_GIS_IS13_Pos                  13                                             /**< (XDMAC_GIS) XDMAC Channel 13 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS13_Msk                  (_U_(0x1) << XDMAC_GIS_IS13_Pos)               /**< (XDMAC_GIS) XDMAC Channel 13 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS13                      XDMAC_GIS_IS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS13_Msk instead */
+#define XDMAC_GIS_IS14_Pos                  14                                             /**< (XDMAC_GIS) XDMAC Channel 14 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS14_Msk                  (_U_(0x1) << XDMAC_GIS_IS14_Pos)               /**< (XDMAC_GIS) XDMAC Channel 14 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS14                      XDMAC_GIS_IS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS14_Msk instead */
+#define XDMAC_GIS_IS15_Pos                  15                                             /**< (XDMAC_GIS) XDMAC Channel 15 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS15_Msk                  (_U_(0x1) << XDMAC_GIS_IS15_Pos)               /**< (XDMAC_GIS) XDMAC Channel 15 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS15                      XDMAC_GIS_IS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS15_Msk instead */
+#define XDMAC_GIS_IS16_Pos                  16                                             /**< (XDMAC_GIS) XDMAC Channel 16 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS16_Msk                  (_U_(0x1) << XDMAC_GIS_IS16_Pos)               /**< (XDMAC_GIS) XDMAC Channel 16 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS16                      XDMAC_GIS_IS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS16_Msk instead */
+#define XDMAC_GIS_IS17_Pos                  17                                             /**< (XDMAC_GIS) XDMAC Channel 17 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS17_Msk                  (_U_(0x1) << XDMAC_GIS_IS17_Pos)               /**< (XDMAC_GIS) XDMAC Channel 17 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS17                      XDMAC_GIS_IS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS17_Msk instead */
+#define XDMAC_GIS_IS18_Pos                  18                                             /**< (XDMAC_GIS) XDMAC Channel 18 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS18_Msk                  (_U_(0x1) << XDMAC_GIS_IS18_Pos)               /**< (XDMAC_GIS) XDMAC Channel 18 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS18                      XDMAC_GIS_IS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS18_Msk instead */
+#define XDMAC_GIS_IS19_Pos                  19                                             /**< (XDMAC_GIS) XDMAC Channel 19 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS19_Msk                  (_U_(0x1) << XDMAC_GIS_IS19_Pos)               /**< (XDMAC_GIS) XDMAC Channel 19 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS19                      XDMAC_GIS_IS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS19_Msk instead */
+#define XDMAC_GIS_IS20_Pos                  20                                             /**< (XDMAC_GIS) XDMAC Channel 20 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS20_Msk                  (_U_(0x1) << XDMAC_GIS_IS20_Pos)               /**< (XDMAC_GIS) XDMAC Channel 20 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS20                      XDMAC_GIS_IS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS20_Msk instead */
+#define XDMAC_GIS_IS21_Pos                  21                                             /**< (XDMAC_GIS) XDMAC Channel 21 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS21_Msk                  (_U_(0x1) << XDMAC_GIS_IS21_Pos)               /**< (XDMAC_GIS) XDMAC Channel 21 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS21                      XDMAC_GIS_IS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS21_Msk instead */
+#define XDMAC_GIS_IS22_Pos                  22                                             /**< (XDMAC_GIS) XDMAC Channel 22 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS22_Msk                  (_U_(0x1) << XDMAC_GIS_IS22_Pos)               /**< (XDMAC_GIS) XDMAC Channel 22 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS22                      XDMAC_GIS_IS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS22_Msk instead */
+#define XDMAC_GIS_IS23_Pos                  23                                             /**< (XDMAC_GIS) XDMAC Channel 23 Interrupt Status Bit Position */
+#define XDMAC_GIS_IS23_Msk                  (_U_(0x1) << XDMAC_GIS_IS23_Pos)               /**< (XDMAC_GIS) XDMAC Channel 23 Interrupt Status Bit Mask */
+#define XDMAC_GIS_IS23                      XDMAC_GIS_IS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GIS_IS23_Msk instead */
+#define XDMAC_GIS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GIS) Register MASK  (Use XDMAC_GIS_Msk instead)  */
+#define XDMAC_GIS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GIS) Register Mask  */
+
+#define XDMAC_GIS_IS_Pos                    0                                              /**< (XDMAC_GIS Position) XDMAC Channel 23 Interrupt Status Bit */
+#define XDMAC_GIS_IS_Msk                    (_U_(0xFFFFFF) << XDMAC_GIS_IS_Pos)            /**< (XDMAC_GIS Mask) IS */
+#define XDMAC_GIS_IS(value)                 (XDMAC_GIS_IS_Msk & ((value) << XDMAC_GIS_IS_Pos))  
+
+/* -------- XDMAC_GE : (XDMAC Offset: 0x1c) (/W 32) Global Channel Enable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EN0:1;                     /**< bit:      0  XDMAC Channel 0 Enable Bit               */
+    uint32_t EN1:1;                     /**< bit:      1  XDMAC Channel 1 Enable Bit               */
+    uint32_t EN2:1;                     /**< bit:      2  XDMAC Channel 2 Enable Bit               */
+    uint32_t EN3:1;                     /**< bit:      3  XDMAC Channel 3 Enable Bit               */
+    uint32_t EN4:1;                     /**< bit:      4  XDMAC Channel 4 Enable Bit               */
+    uint32_t EN5:1;                     /**< bit:      5  XDMAC Channel 5 Enable Bit               */
+    uint32_t EN6:1;                     /**< bit:      6  XDMAC Channel 6 Enable Bit               */
+    uint32_t EN7:1;                     /**< bit:      7  XDMAC Channel 7 Enable Bit               */
+    uint32_t EN8:1;                     /**< bit:      8  XDMAC Channel 8 Enable Bit               */
+    uint32_t EN9:1;                     /**< bit:      9  XDMAC Channel 9 Enable Bit               */
+    uint32_t EN10:1;                    /**< bit:     10  XDMAC Channel 10 Enable Bit              */
+    uint32_t EN11:1;                    /**< bit:     11  XDMAC Channel 11 Enable Bit              */
+    uint32_t EN12:1;                    /**< bit:     12  XDMAC Channel 12 Enable Bit              */
+    uint32_t EN13:1;                    /**< bit:     13  XDMAC Channel 13 Enable Bit              */
+    uint32_t EN14:1;                    /**< bit:     14  XDMAC Channel 14 Enable Bit              */
+    uint32_t EN15:1;                    /**< bit:     15  XDMAC Channel 15 Enable Bit              */
+    uint32_t EN16:1;                    /**< bit:     16  XDMAC Channel 16 Enable Bit              */
+    uint32_t EN17:1;                    /**< bit:     17  XDMAC Channel 17 Enable Bit              */
+    uint32_t EN18:1;                    /**< bit:     18  XDMAC Channel 18 Enable Bit              */
+    uint32_t EN19:1;                    /**< bit:     19  XDMAC Channel 19 Enable Bit              */
+    uint32_t EN20:1;                    /**< bit:     20  XDMAC Channel 20 Enable Bit              */
+    uint32_t EN21:1;                    /**< bit:     21  XDMAC Channel 21 Enable Bit              */
+    uint32_t EN22:1;                    /**< bit:     22  XDMAC Channel 22 Enable Bit              */
+    uint32_t EN23:1;                    /**< bit:     23  XDMAC Channel 23 Enable Bit              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t EN:24;                     /**< bit:  0..23  XDMAC Channel 23 Enable Bit              */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GE_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GE_OFFSET                     (0x1C)                                        /**<  (XDMAC_GE) Global Channel Enable Register  Offset */
+
+#define XDMAC_GE_EN0_Pos                    0                                              /**< (XDMAC_GE) XDMAC Channel 0 Enable Bit Position */
+#define XDMAC_GE_EN0_Msk                    (_U_(0x1) << XDMAC_GE_EN0_Pos)                 /**< (XDMAC_GE) XDMAC Channel 0 Enable Bit Mask */
+#define XDMAC_GE_EN0                        XDMAC_GE_EN0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN0_Msk instead */
+#define XDMAC_GE_EN1_Pos                    1                                              /**< (XDMAC_GE) XDMAC Channel 1 Enable Bit Position */
+#define XDMAC_GE_EN1_Msk                    (_U_(0x1) << XDMAC_GE_EN1_Pos)                 /**< (XDMAC_GE) XDMAC Channel 1 Enable Bit Mask */
+#define XDMAC_GE_EN1                        XDMAC_GE_EN1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN1_Msk instead */
+#define XDMAC_GE_EN2_Pos                    2                                              /**< (XDMAC_GE) XDMAC Channel 2 Enable Bit Position */
+#define XDMAC_GE_EN2_Msk                    (_U_(0x1) << XDMAC_GE_EN2_Pos)                 /**< (XDMAC_GE) XDMAC Channel 2 Enable Bit Mask */
+#define XDMAC_GE_EN2                        XDMAC_GE_EN2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN2_Msk instead */
+#define XDMAC_GE_EN3_Pos                    3                                              /**< (XDMAC_GE) XDMAC Channel 3 Enable Bit Position */
+#define XDMAC_GE_EN3_Msk                    (_U_(0x1) << XDMAC_GE_EN3_Pos)                 /**< (XDMAC_GE) XDMAC Channel 3 Enable Bit Mask */
+#define XDMAC_GE_EN3                        XDMAC_GE_EN3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN3_Msk instead */
+#define XDMAC_GE_EN4_Pos                    4                                              /**< (XDMAC_GE) XDMAC Channel 4 Enable Bit Position */
+#define XDMAC_GE_EN4_Msk                    (_U_(0x1) << XDMAC_GE_EN4_Pos)                 /**< (XDMAC_GE) XDMAC Channel 4 Enable Bit Mask */
+#define XDMAC_GE_EN4                        XDMAC_GE_EN4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN4_Msk instead */
+#define XDMAC_GE_EN5_Pos                    5                                              /**< (XDMAC_GE) XDMAC Channel 5 Enable Bit Position */
+#define XDMAC_GE_EN5_Msk                    (_U_(0x1) << XDMAC_GE_EN5_Pos)                 /**< (XDMAC_GE) XDMAC Channel 5 Enable Bit Mask */
+#define XDMAC_GE_EN5                        XDMAC_GE_EN5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN5_Msk instead */
+#define XDMAC_GE_EN6_Pos                    6                                              /**< (XDMAC_GE) XDMAC Channel 6 Enable Bit Position */
+#define XDMAC_GE_EN6_Msk                    (_U_(0x1) << XDMAC_GE_EN6_Pos)                 /**< (XDMAC_GE) XDMAC Channel 6 Enable Bit Mask */
+#define XDMAC_GE_EN6                        XDMAC_GE_EN6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN6_Msk instead */
+#define XDMAC_GE_EN7_Pos                    7                                              /**< (XDMAC_GE) XDMAC Channel 7 Enable Bit Position */
+#define XDMAC_GE_EN7_Msk                    (_U_(0x1) << XDMAC_GE_EN7_Pos)                 /**< (XDMAC_GE) XDMAC Channel 7 Enable Bit Mask */
+#define XDMAC_GE_EN7                        XDMAC_GE_EN7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN7_Msk instead */
+#define XDMAC_GE_EN8_Pos                    8                                              /**< (XDMAC_GE) XDMAC Channel 8 Enable Bit Position */
+#define XDMAC_GE_EN8_Msk                    (_U_(0x1) << XDMAC_GE_EN8_Pos)                 /**< (XDMAC_GE) XDMAC Channel 8 Enable Bit Mask */
+#define XDMAC_GE_EN8                        XDMAC_GE_EN8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN8_Msk instead */
+#define XDMAC_GE_EN9_Pos                    9                                              /**< (XDMAC_GE) XDMAC Channel 9 Enable Bit Position */
+#define XDMAC_GE_EN9_Msk                    (_U_(0x1) << XDMAC_GE_EN9_Pos)                 /**< (XDMAC_GE) XDMAC Channel 9 Enable Bit Mask */
+#define XDMAC_GE_EN9                        XDMAC_GE_EN9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN9_Msk instead */
+#define XDMAC_GE_EN10_Pos                   10                                             /**< (XDMAC_GE) XDMAC Channel 10 Enable Bit Position */
+#define XDMAC_GE_EN10_Msk                   (_U_(0x1) << XDMAC_GE_EN10_Pos)                /**< (XDMAC_GE) XDMAC Channel 10 Enable Bit Mask */
+#define XDMAC_GE_EN10                       XDMAC_GE_EN10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN10_Msk instead */
+#define XDMAC_GE_EN11_Pos                   11                                             /**< (XDMAC_GE) XDMAC Channel 11 Enable Bit Position */
+#define XDMAC_GE_EN11_Msk                   (_U_(0x1) << XDMAC_GE_EN11_Pos)                /**< (XDMAC_GE) XDMAC Channel 11 Enable Bit Mask */
+#define XDMAC_GE_EN11                       XDMAC_GE_EN11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN11_Msk instead */
+#define XDMAC_GE_EN12_Pos                   12                                             /**< (XDMAC_GE) XDMAC Channel 12 Enable Bit Position */
+#define XDMAC_GE_EN12_Msk                   (_U_(0x1) << XDMAC_GE_EN12_Pos)                /**< (XDMAC_GE) XDMAC Channel 12 Enable Bit Mask */
+#define XDMAC_GE_EN12                       XDMAC_GE_EN12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN12_Msk instead */
+#define XDMAC_GE_EN13_Pos                   13                                             /**< (XDMAC_GE) XDMAC Channel 13 Enable Bit Position */
+#define XDMAC_GE_EN13_Msk                   (_U_(0x1) << XDMAC_GE_EN13_Pos)                /**< (XDMAC_GE) XDMAC Channel 13 Enable Bit Mask */
+#define XDMAC_GE_EN13                       XDMAC_GE_EN13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN13_Msk instead */
+#define XDMAC_GE_EN14_Pos                   14                                             /**< (XDMAC_GE) XDMAC Channel 14 Enable Bit Position */
+#define XDMAC_GE_EN14_Msk                   (_U_(0x1) << XDMAC_GE_EN14_Pos)                /**< (XDMAC_GE) XDMAC Channel 14 Enable Bit Mask */
+#define XDMAC_GE_EN14                       XDMAC_GE_EN14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN14_Msk instead */
+#define XDMAC_GE_EN15_Pos                   15                                             /**< (XDMAC_GE) XDMAC Channel 15 Enable Bit Position */
+#define XDMAC_GE_EN15_Msk                   (_U_(0x1) << XDMAC_GE_EN15_Pos)                /**< (XDMAC_GE) XDMAC Channel 15 Enable Bit Mask */
+#define XDMAC_GE_EN15                       XDMAC_GE_EN15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN15_Msk instead */
+#define XDMAC_GE_EN16_Pos                   16                                             /**< (XDMAC_GE) XDMAC Channel 16 Enable Bit Position */
+#define XDMAC_GE_EN16_Msk                   (_U_(0x1) << XDMAC_GE_EN16_Pos)                /**< (XDMAC_GE) XDMAC Channel 16 Enable Bit Mask */
+#define XDMAC_GE_EN16                       XDMAC_GE_EN16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN16_Msk instead */
+#define XDMAC_GE_EN17_Pos                   17                                             /**< (XDMAC_GE) XDMAC Channel 17 Enable Bit Position */
+#define XDMAC_GE_EN17_Msk                   (_U_(0x1) << XDMAC_GE_EN17_Pos)                /**< (XDMAC_GE) XDMAC Channel 17 Enable Bit Mask */
+#define XDMAC_GE_EN17                       XDMAC_GE_EN17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN17_Msk instead */
+#define XDMAC_GE_EN18_Pos                   18                                             /**< (XDMAC_GE) XDMAC Channel 18 Enable Bit Position */
+#define XDMAC_GE_EN18_Msk                   (_U_(0x1) << XDMAC_GE_EN18_Pos)                /**< (XDMAC_GE) XDMAC Channel 18 Enable Bit Mask */
+#define XDMAC_GE_EN18                       XDMAC_GE_EN18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN18_Msk instead */
+#define XDMAC_GE_EN19_Pos                   19                                             /**< (XDMAC_GE) XDMAC Channel 19 Enable Bit Position */
+#define XDMAC_GE_EN19_Msk                   (_U_(0x1) << XDMAC_GE_EN19_Pos)                /**< (XDMAC_GE) XDMAC Channel 19 Enable Bit Mask */
+#define XDMAC_GE_EN19                       XDMAC_GE_EN19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN19_Msk instead */
+#define XDMAC_GE_EN20_Pos                   20                                             /**< (XDMAC_GE) XDMAC Channel 20 Enable Bit Position */
+#define XDMAC_GE_EN20_Msk                   (_U_(0x1) << XDMAC_GE_EN20_Pos)                /**< (XDMAC_GE) XDMAC Channel 20 Enable Bit Mask */
+#define XDMAC_GE_EN20                       XDMAC_GE_EN20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN20_Msk instead */
+#define XDMAC_GE_EN21_Pos                   21                                             /**< (XDMAC_GE) XDMAC Channel 21 Enable Bit Position */
+#define XDMAC_GE_EN21_Msk                   (_U_(0x1) << XDMAC_GE_EN21_Pos)                /**< (XDMAC_GE) XDMAC Channel 21 Enable Bit Mask */
+#define XDMAC_GE_EN21                       XDMAC_GE_EN21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN21_Msk instead */
+#define XDMAC_GE_EN22_Pos                   22                                             /**< (XDMAC_GE) XDMAC Channel 22 Enable Bit Position */
+#define XDMAC_GE_EN22_Msk                   (_U_(0x1) << XDMAC_GE_EN22_Pos)                /**< (XDMAC_GE) XDMAC Channel 22 Enable Bit Mask */
+#define XDMAC_GE_EN22                       XDMAC_GE_EN22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN22_Msk instead */
+#define XDMAC_GE_EN23_Pos                   23                                             /**< (XDMAC_GE) XDMAC Channel 23 Enable Bit Position */
+#define XDMAC_GE_EN23_Msk                   (_U_(0x1) << XDMAC_GE_EN23_Pos)                /**< (XDMAC_GE) XDMAC Channel 23 Enable Bit Mask */
+#define XDMAC_GE_EN23                       XDMAC_GE_EN23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GE_EN23_Msk instead */
+#define XDMAC_GE_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GE) Register MASK  (Use XDMAC_GE_Msk instead)  */
+#define XDMAC_GE_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GE) Register Mask  */
+
+#define XDMAC_GE_EN_Pos                     0                                              /**< (XDMAC_GE Position) XDMAC Channel 23 Enable Bit */
+#define XDMAC_GE_EN_Msk                     (_U_(0xFFFFFF) << XDMAC_GE_EN_Pos)             /**< (XDMAC_GE Mask) EN */
+#define XDMAC_GE_EN(value)                  (XDMAC_GE_EN_Msk & ((value) << XDMAC_GE_EN_Pos))  
+
+/* -------- XDMAC_GD : (XDMAC Offset: 0x20) (/W 32) Global Channel Disable Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DI0:1;                     /**< bit:      0  XDMAC Channel 0 Disable Bit              */
+    uint32_t DI1:1;                     /**< bit:      1  XDMAC Channel 1 Disable Bit              */
+    uint32_t DI2:1;                     /**< bit:      2  XDMAC Channel 2 Disable Bit              */
+    uint32_t DI3:1;                     /**< bit:      3  XDMAC Channel 3 Disable Bit              */
+    uint32_t DI4:1;                     /**< bit:      4  XDMAC Channel 4 Disable Bit              */
+    uint32_t DI5:1;                     /**< bit:      5  XDMAC Channel 5 Disable Bit              */
+    uint32_t DI6:1;                     /**< bit:      6  XDMAC Channel 6 Disable Bit              */
+    uint32_t DI7:1;                     /**< bit:      7  XDMAC Channel 7 Disable Bit              */
+    uint32_t DI8:1;                     /**< bit:      8  XDMAC Channel 8 Disable Bit              */
+    uint32_t DI9:1;                     /**< bit:      9  XDMAC Channel 9 Disable Bit              */
+    uint32_t DI10:1;                    /**< bit:     10  XDMAC Channel 10 Disable Bit             */
+    uint32_t DI11:1;                    /**< bit:     11  XDMAC Channel 11 Disable Bit             */
+    uint32_t DI12:1;                    /**< bit:     12  XDMAC Channel 12 Disable Bit             */
+    uint32_t DI13:1;                    /**< bit:     13  XDMAC Channel 13 Disable Bit             */
+    uint32_t DI14:1;                    /**< bit:     14  XDMAC Channel 14 Disable Bit             */
+    uint32_t DI15:1;                    /**< bit:     15  XDMAC Channel 15 Disable Bit             */
+    uint32_t DI16:1;                    /**< bit:     16  XDMAC Channel 16 Disable Bit             */
+    uint32_t DI17:1;                    /**< bit:     17  XDMAC Channel 17 Disable Bit             */
+    uint32_t DI18:1;                    /**< bit:     18  XDMAC Channel 18 Disable Bit             */
+    uint32_t DI19:1;                    /**< bit:     19  XDMAC Channel 19 Disable Bit             */
+    uint32_t DI20:1;                    /**< bit:     20  XDMAC Channel 20 Disable Bit             */
+    uint32_t DI21:1;                    /**< bit:     21  XDMAC Channel 21 Disable Bit             */
+    uint32_t DI22:1;                    /**< bit:     22  XDMAC Channel 22 Disable Bit             */
+    uint32_t DI23:1;                    /**< bit:     23  XDMAC Channel 23 Disable Bit             */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t DI:24;                     /**< bit:  0..23  XDMAC Channel 23 Disable Bit             */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GD_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GD_OFFSET                     (0x20)                                        /**<  (XDMAC_GD) Global Channel Disable Register  Offset */
+
+#define XDMAC_GD_DI0_Pos                    0                                              /**< (XDMAC_GD) XDMAC Channel 0 Disable Bit Position */
+#define XDMAC_GD_DI0_Msk                    (_U_(0x1) << XDMAC_GD_DI0_Pos)                 /**< (XDMAC_GD) XDMAC Channel 0 Disable Bit Mask */
+#define XDMAC_GD_DI0                        XDMAC_GD_DI0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI0_Msk instead */
+#define XDMAC_GD_DI1_Pos                    1                                              /**< (XDMAC_GD) XDMAC Channel 1 Disable Bit Position */
+#define XDMAC_GD_DI1_Msk                    (_U_(0x1) << XDMAC_GD_DI1_Pos)                 /**< (XDMAC_GD) XDMAC Channel 1 Disable Bit Mask */
+#define XDMAC_GD_DI1                        XDMAC_GD_DI1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI1_Msk instead */
+#define XDMAC_GD_DI2_Pos                    2                                              /**< (XDMAC_GD) XDMAC Channel 2 Disable Bit Position */
+#define XDMAC_GD_DI2_Msk                    (_U_(0x1) << XDMAC_GD_DI2_Pos)                 /**< (XDMAC_GD) XDMAC Channel 2 Disable Bit Mask */
+#define XDMAC_GD_DI2                        XDMAC_GD_DI2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI2_Msk instead */
+#define XDMAC_GD_DI3_Pos                    3                                              /**< (XDMAC_GD) XDMAC Channel 3 Disable Bit Position */
+#define XDMAC_GD_DI3_Msk                    (_U_(0x1) << XDMAC_GD_DI3_Pos)                 /**< (XDMAC_GD) XDMAC Channel 3 Disable Bit Mask */
+#define XDMAC_GD_DI3                        XDMAC_GD_DI3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI3_Msk instead */
+#define XDMAC_GD_DI4_Pos                    4                                              /**< (XDMAC_GD) XDMAC Channel 4 Disable Bit Position */
+#define XDMAC_GD_DI4_Msk                    (_U_(0x1) << XDMAC_GD_DI4_Pos)                 /**< (XDMAC_GD) XDMAC Channel 4 Disable Bit Mask */
+#define XDMAC_GD_DI4                        XDMAC_GD_DI4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI4_Msk instead */
+#define XDMAC_GD_DI5_Pos                    5                                              /**< (XDMAC_GD) XDMAC Channel 5 Disable Bit Position */
+#define XDMAC_GD_DI5_Msk                    (_U_(0x1) << XDMAC_GD_DI5_Pos)                 /**< (XDMAC_GD) XDMAC Channel 5 Disable Bit Mask */
+#define XDMAC_GD_DI5                        XDMAC_GD_DI5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI5_Msk instead */
+#define XDMAC_GD_DI6_Pos                    6                                              /**< (XDMAC_GD) XDMAC Channel 6 Disable Bit Position */
+#define XDMAC_GD_DI6_Msk                    (_U_(0x1) << XDMAC_GD_DI6_Pos)                 /**< (XDMAC_GD) XDMAC Channel 6 Disable Bit Mask */
+#define XDMAC_GD_DI6                        XDMAC_GD_DI6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI6_Msk instead */
+#define XDMAC_GD_DI7_Pos                    7                                              /**< (XDMAC_GD) XDMAC Channel 7 Disable Bit Position */
+#define XDMAC_GD_DI7_Msk                    (_U_(0x1) << XDMAC_GD_DI7_Pos)                 /**< (XDMAC_GD) XDMAC Channel 7 Disable Bit Mask */
+#define XDMAC_GD_DI7                        XDMAC_GD_DI7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI7_Msk instead */
+#define XDMAC_GD_DI8_Pos                    8                                              /**< (XDMAC_GD) XDMAC Channel 8 Disable Bit Position */
+#define XDMAC_GD_DI8_Msk                    (_U_(0x1) << XDMAC_GD_DI8_Pos)                 /**< (XDMAC_GD) XDMAC Channel 8 Disable Bit Mask */
+#define XDMAC_GD_DI8                        XDMAC_GD_DI8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI8_Msk instead */
+#define XDMAC_GD_DI9_Pos                    9                                              /**< (XDMAC_GD) XDMAC Channel 9 Disable Bit Position */
+#define XDMAC_GD_DI9_Msk                    (_U_(0x1) << XDMAC_GD_DI9_Pos)                 /**< (XDMAC_GD) XDMAC Channel 9 Disable Bit Mask */
+#define XDMAC_GD_DI9                        XDMAC_GD_DI9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI9_Msk instead */
+#define XDMAC_GD_DI10_Pos                   10                                             /**< (XDMAC_GD) XDMAC Channel 10 Disable Bit Position */
+#define XDMAC_GD_DI10_Msk                   (_U_(0x1) << XDMAC_GD_DI10_Pos)                /**< (XDMAC_GD) XDMAC Channel 10 Disable Bit Mask */
+#define XDMAC_GD_DI10                       XDMAC_GD_DI10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI10_Msk instead */
+#define XDMAC_GD_DI11_Pos                   11                                             /**< (XDMAC_GD) XDMAC Channel 11 Disable Bit Position */
+#define XDMAC_GD_DI11_Msk                   (_U_(0x1) << XDMAC_GD_DI11_Pos)                /**< (XDMAC_GD) XDMAC Channel 11 Disable Bit Mask */
+#define XDMAC_GD_DI11                       XDMAC_GD_DI11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI11_Msk instead */
+#define XDMAC_GD_DI12_Pos                   12                                             /**< (XDMAC_GD) XDMAC Channel 12 Disable Bit Position */
+#define XDMAC_GD_DI12_Msk                   (_U_(0x1) << XDMAC_GD_DI12_Pos)                /**< (XDMAC_GD) XDMAC Channel 12 Disable Bit Mask */
+#define XDMAC_GD_DI12                       XDMAC_GD_DI12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI12_Msk instead */
+#define XDMAC_GD_DI13_Pos                   13                                             /**< (XDMAC_GD) XDMAC Channel 13 Disable Bit Position */
+#define XDMAC_GD_DI13_Msk                   (_U_(0x1) << XDMAC_GD_DI13_Pos)                /**< (XDMAC_GD) XDMAC Channel 13 Disable Bit Mask */
+#define XDMAC_GD_DI13                       XDMAC_GD_DI13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI13_Msk instead */
+#define XDMAC_GD_DI14_Pos                   14                                             /**< (XDMAC_GD) XDMAC Channel 14 Disable Bit Position */
+#define XDMAC_GD_DI14_Msk                   (_U_(0x1) << XDMAC_GD_DI14_Pos)                /**< (XDMAC_GD) XDMAC Channel 14 Disable Bit Mask */
+#define XDMAC_GD_DI14                       XDMAC_GD_DI14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI14_Msk instead */
+#define XDMAC_GD_DI15_Pos                   15                                             /**< (XDMAC_GD) XDMAC Channel 15 Disable Bit Position */
+#define XDMAC_GD_DI15_Msk                   (_U_(0x1) << XDMAC_GD_DI15_Pos)                /**< (XDMAC_GD) XDMAC Channel 15 Disable Bit Mask */
+#define XDMAC_GD_DI15                       XDMAC_GD_DI15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI15_Msk instead */
+#define XDMAC_GD_DI16_Pos                   16                                             /**< (XDMAC_GD) XDMAC Channel 16 Disable Bit Position */
+#define XDMAC_GD_DI16_Msk                   (_U_(0x1) << XDMAC_GD_DI16_Pos)                /**< (XDMAC_GD) XDMAC Channel 16 Disable Bit Mask */
+#define XDMAC_GD_DI16                       XDMAC_GD_DI16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI16_Msk instead */
+#define XDMAC_GD_DI17_Pos                   17                                             /**< (XDMAC_GD) XDMAC Channel 17 Disable Bit Position */
+#define XDMAC_GD_DI17_Msk                   (_U_(0x1) << XDMAC_GD_DI17_Pos)                /**< (XDMAC_GD) XDMAC Channel 17 Disable Bit Mask */
+#define XDMAC_GD_DI17                       XDMAC_GD_DI17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI17_Msk instead */
+#define XDMAC_GD_DI18_Pos                   18                                             /**< (XDMAC_GD) XDMAC Channel 18 Disable Bit Position */
+#define XDMAC_GD_DI18_Msk                   (_U_(0x1) << XDMAC_GD_DI18_Pos)                /**< (XDMAC_GD) XDMAC Channel 18 Disable Bit Mask */
+#define XDMAC_GD_DI18                       XDMAC_GD_DI18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI18_Msk instead */
+#define XDMAC_GD_DI19_Pos                   19                                             /**< (XDMAC_GD) XDMAC Channel 19 Disable Bit Position */
+#define XDMAC_GD_DI19_Msk                   (_U_(0x1) << XDMAC_GD_DI19_Pos)                /**< (XDMAC_GD) XDMAC Channel 19 Disable Bit Mask */
+#define XDMAC_GD_DI19                       XDMAC_GD_DI19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI19_Msk instead */
+#define XDMAC_GD_DI20_Pos                   20                                             /**< (XDMAC_GD) XDMAC Channel 20 Disable Bit Position */
+#define XDMAC_GD_DI20_Msk                   (_U_(0x1) << XDMAC_GD_DI20_Pos)                /**< (XDMAC_GD) XDMAC Channel 20 Disable Bit Mask */
+#define XDMAC_GD_DI20                       XDMAC_GD_DI20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI20_Msk instead */
+#define XDMAC_GD_DI21_Pos                   21                                             /**< (XDMAC_GD) XDMAC Channel 21 Disable Bit Position */
+#define XDMAC_GD_DI21_Msk                   (_U_(0x1) << XDMAC_GD_DI21_Pos)                /**< (XDMAC_GD) XDMAC Channel 21 Disable Bit Mask */
+#define XDMAC_GD_DI21                       XDMAC_GD_DI21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI21_Msk instead */
+#define XDMAC_GD_DI22_Pos                   22                                             /**< (XDMAC_GD) XDMAC Channel 22 Disable Bit Position */
+#define XDMAC_GD_DI22_Msk                   (_U_(0x1) << XDMAC_GD_DI22_Pos)                /**< (XDMAC_GD) XDMAC Channel 22 Disable Bit Mask */
+#define XDMAC_GD_DI22                       XDMAC_GD_DI22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI22_Msk instead */
+#define XDMAC_GD_DI23_Pos                   23                                             /**< (XDMAC_GD) XDMAC Channel 23 Disable Bit Position */
+#define XDMAC_GD_DI23_Msk                   (_U_(0x1) << XDMAC_GD_DI23_Pos)                /**< (XDMAC_GD) XDMAC Channel 23 Disable Bit Mask */
+#define XDMAC_GD_DI23                       XDMAC_GD_DI23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GD_DI23_Msk instead */
+#define XDMAC_GD_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GD) Register MASK  (Use XDMAC_GD_Msk instead)  */
+#define XDMAC_GD_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GD) Register Mask  */
+
+#define XDMAC_GD_DI_Pos                     0                                              /**< (XDMAC_GD Position) XDMAC Channel 23 Disable Bit */
+#define XDMAC_GD_DI_Msk                     (_U_(0xFFFFFF) << XDMAC_GD_DI_Pos)             /**< (XDMAC_GD Mask) DI */
+#define XDMAC_GD_DI(value)                  (XDMAC_GD_DI_Msk & ((value) << XDMAC_GD_DI_Pos))  
+
+/* -------- XDMAC_GS : (XDMAC Offset: 0x24) (R/ 32) Global Channel Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ST0:1;                     /**< bit:      0  XDMAC Channel 0 Status Bit               */
+    uint32_t ST1:1;                     /**< bit:      1  XDMAC Channel 1 Status Bit               */
+    uint32_t ST2:1;                     /**< bit:      2  XDMAC Channel 2 Status Bit               */
+    uint32_t ST3:1;                     /**< bit:      3  XDMAC Channel 3 Status Bit               */
+    uint32_t ST4:1;                     /**< bit:      4  XDMAC Channel 4 Status Bit               */
+    uint32_t ST5:1;                     /**< bit:      5  XDMAC Channel 5 Status Bit               */
+    uint32_t ST6:1;                     /**< bit:      6  XDMAC Channel 6 Status Bit               */
+    uint32_t ST7:1;                     /**< bit:      7  XDMAC Channel 7 Status Bit               */
+    uint32_t ST8:1;                     /**< bit:      8  XDMAC Channel 8 Status Bit               */
+    uint32_t ST9:1;                     /**< bit:      9  XDMAC Channel 9 Status Bit               */
+    uint32_t ST10:1;                    /**< bit:     10  XDMAC Channel 10 Status Bit              */
+    uint32_t ST11:1;                    /**< bit:     11  XDMAC Channel 11 Status Bit              */
+    uint32_t ST12:1;                    /**< bit:     12  XDMAC Channel 12 Status Bit              */
+    uint32_t ST13:1;                    /**< bit:     13  XDMAC Channel 13 Status Bit              */
+    uint32_t ST14:1;                    /**< bit:     14  XDMAC Channel 14 Status Bit              */
+    uint32_t ST15:1;                    /**< bit:     15  XDMAC Channel 15 Status Bit              */
+    uint32_t ST16:1;                    /**< bit:     16  XDMAC Channel 16 Status Bit              */
+    uint32_t ST17:1;                    /**< bit:     17  XDMAC Channel 17 Status Bit              */
+    uint32_t ST18:1;                    /**< bit:     18  XDMAC Channel 18 Status Bit              */
+    uint32_t ST19:1;                    /**< bit:     19  XDMAC Channel 19 Status Bit              */
+    uint32_t ST20:1;                    /**< bit:     20  XDMAC Channel 20 Status Bit              */
+    uint32_t ST21:1;                    /**< bit:     21  XDMAC Channel 21 Status Bit              */
+    uint32_t ST22:1;                    /**< bit:     22  XDMAC Channel 22 Status Bit              */
+    uint32_t ST23:1;                    /**< bit:     23  XDMAC Channel 23 Status Bit              */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t ST:24;                     /**< bit:  0..23  XDMAC Channel 23 Status Bit              */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GS_OFFSET                     (0x24)                                        /**<  (XDMAC_GS) Global Channel Status Register  Offset */
+
+#define XDMAC_GS_ST0_Pos                    0                                              /**< (XDMAC_GS) XDMAC Channel 0 Status Bit Position */
+#define XDMAC_GS_ST0_Msk                    (_U_(0x1) << XDMAC_GS_ST0_Pos)                 /**< (XDMAC_GS) XDMAC Channel 0 Status Bit Mask */
+#define XDMAC_GS_ST0                        XDMAC_GS_ST0_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST0_Msk instead */
+#define XDMAC_GS_ST1_Pos                    1                                              /**< (XDMAC_GS) XDMAC Channel 1 Status Bit Position */
+#define XDMAC_GS_ST1_Msk                    (_U_(0x1) << XDMAC_GS_ST1_Pos)                 /**< (XDMAC_GS) XDMAC Channel 1 Status Bit Mask */
+#define XDMAC_GS_ST1                        XDMAC_GS_ST1_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST1_Msk instead */
+#define XDMAC_GS_ST2_Pos                    2                                              /**< (XDMAC_GS) XDMAC Channel 2 Status Bit Position */
+#define XDMAC_GS_ST2_Msk                    (_U_(0x1) << XDMAC_GS_ST2_Pos)                 /**< (XDMAC_GS) XDMAC Channel 2 Status Bit Mask */
+#define XDMAC_GS_ST2                        XDMAC_GS_ST2_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST2_Msk instead */
+#define XDMAC_GS_ST3_Pos                    3                                              /**< (XDMAC_GS) XDMAC Channel 3 Status Bit Position */
+#define XDMAC_GS_ST3_Msk                    (_U_(0x1) << XDMAC_GS_ST3_Pos)                 /**< (XDMAC_GS) XDMAC Channel 3 Status Bit Mask */
+#define XDMAC_GS_ST3                        XDMAC_GS_ST3_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST3_Msk instead */
+#define XDMAC_GS_ST4_Pos                    4                                              /**< (XDMAC_GS) XDMAC Channel 4 Status Bit Position */
+#define XDMAC_GS_ST4_Msk                    (_U_(0x1) << XDMAC_GS_ST4_Pos)                 /**< (XDMAC_GS) XDMAC Channel 4 Status Bit Mask */
+#define XDMAC_GS_ST4                        XDMAC_GS_ST4_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST4_Msk instead */
+#define XDMAC_GS_ST5_Pos                    5                                              /**< (XDMAC_GS) XDMAC Channel 5 Status Bit Position */
+#define XDMAC_GS_ST5_Msk                    (_U_(0x1) << XDMAC_GS_ST5_Pos)                 /**< (XDMAC_GS) XDMAC Channel 5 Status Bit Mask */
+#define XDMAC_GS_ST5                        XDMAC_GS_ST5_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST5_Msk instead */
+#define XDMAC_GS_ST6_Pos                    6                                              /**< (XDMAC_GS) XDMAC Channel 6 Status Bit Position */
+#define XDMAC_GS_ST6_Msk                    (_U_(0x1) << XDMAC_GS_ST6_Pos)                 /**< (XDMAC_GS) XDMAC Channel 6 Status Bit Mask */
+#define XDMAC_GS_ST6                        XDMAC_GS_ST6_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST6_Msk instead */
+#define XDMAC_GS_ST7_Pos                    7                                              /**< (XDMAC_GS) XDMAC Channel 7 Status Bit Position */
+#define XDMAC_GS_ST7_Msk                    (_U_(0x1) << XDMAC_GS_ST7_Pos)                 /**< (XDMAC_GS) XDMAC Channel 7 Status Bit Mask */
+#define XDMAC_GS_ST7                        XDMAC_GS_ST7_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST7_Msk instead */
+#define XDMAC_GS_ST8_Pos                    8                                              /**< (XDMAC_GS) XDMAC Channel 8 Status Bit Position */
+#define XDMAC_GS_ST8_Msk                    (_U_(0x1) << XDMAC_GS_ST8_Pos)                 /**< (XDMAC_GS) XDMAC Channel 8 Status Bit Mask */
+#define XDMAC_GS_ST8                        XDMAC_GS_ST8_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST8_Msk instead */
+#define XDMAC_GS_ST9_Pos                    9                                              /**< (XDMAC_GS) XDMAC Channel 9 Status Bit Position */
+#define XDMAC_GS_ST9_Msk                    (_U_(0x1) << XDMAC_GS_ST9_Pos)                 /**< (XDMAC_GS) XDMAC Channel 9 Status Bit Mask */
+#define XDMAC_GS_ST9                        XDMAC_GS_ST9_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST9_Msk instead */
+#define XDMAC_GS_ST10_Pos                   10                                             /**< (XDMAC_GS) XDMAC Channel 10 Status Bit Position */
+#define XDMAC_GS_ST10_Msk                   (_U_(0x1) << XDMAC_GS_ST10_Pos)                /**< (XDMAC_GS) XDMAC Channel 10 Status Bit Mask */
+#define XDMAC_GS_ST10                       XDMAC_GS_ST10_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST10_Msk instead */
+#define XDMAC_GS_ST11_Pos                   11                                             /**< (XDMAC_GS) XDMAC Channel 11 Status Bit Position */
+#define XDMAC_GS_ST11_Msk                   (_U_(0x1) << XDMAC_GS_ST11_Pos)                /**< (XDMAC_GS) XDMAC Channel 11 Status Bit Mask */
+#define XDMAC_GS_ST11                       XDMAC_GS_ST11_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST11_Msk instead */
+#define XDMAC_GS_ST12_Pos                   12                                             /**< (XDMAC_GS) XDMAC Channel 12 Status Bit Position */
+#define XDMAC_GS_ST12_Msk                   (_U_(0x1) << XDMAC_GS_ST12_Pos)                /**< (XDMAC_GS) XDMAC Channel 12 Status Bit Mask */
+#define XDMAC_GS_ST12                       XDMAC_GS_ST12_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST12_Msk instead */
+#define XDMAC_GS_ST13_Pos                   13                                             /**< (XDMAC_GS) XDMAC Channel 13 Status Bit Position */
+#define XDMAC_GS_ST13_Msk                   (_U_(0x1) << XDMAC_GS_ST13_Pos)                /**< (XDMAC_GS) XDMAC Channel 13 Status Bit Mask */
+#define XDMAC_GS_ST13                       XDMAC_GS_ST13_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST13_Msk instead */
+#define XDMAC_GS_ST14_Pos                   14                                             /**< (XDMAC_GS) XDMAC Channel 14 Status Bit Position */
+#define XDMAC_GS_ST14_Msk                   (_U_(0x1) << XDMAC_GS_ST14_Pos)                /**< (XDMAC_GS) XDMAC Channel 14 Status Bit Mask */
+#define XDMAC_GS_ST14                       XDMAC_GS_ST14_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST14_Msk instead */
+#define XDMAC_GS_ST15_Pos                   15                                             /**< (XDMAC_GS) XDMAC Channel 15 Status Bit Position */
+#define XDMAC_GS_ST15_Msk                   (_U_(0x1) << XDMAC_GS_ST15_Pos)                /**< (XDMAC_GS) XDMAC Channel 15 Status Bit Mask */
+#define XDMAC_GS_ST15                       XDMAC_GS_ST15_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST15_Msk instead */
+#define XDMAC_GS_ST16_Pos                   16                                             /**< (XDMAC_GS) XDMAC Channel 16 Status Bit Position */
+#define XDMAC_GS_ST16_Msk                   (_U_(0x1) << XDMAC_GS_ST16_Pos)                /**< (XDMAC_GS) XDMAC Channel 16 Status Bit Mask */
+#define XDMAC_GS_ST16                       XDMAC_GS_ST16_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST16_Msk instead */
+#define XDMAC_GS_ST17_Pos                   17                                             /**< (XDMAC_GS) XDMAC Channel 17 Status Bit Position */
+#define XDMAC_GS_ST17_Msk                   (_U_(0x1) << XDMAC_GS_ST17_Pos)                /**< (XDMAC_GS) XDMAC Channel 17 Status Bit Mask */
+#define XDMAC_GS_ST17                       XDMAC_GS_ST17_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST17_Msk instead */
+#define XDMAC_GS_ST18_Pos                   18                                             /**< (XDMAC_GS) XDMAC Channel 18 Status Bit Position */
+#define XDMAC_GS_ST18_Msk                   (_U_(0x1) << XDMAC_GS_ST18_Pos)                /**< (XDMAC_GS) XDMAC Channel 18 Status Bit Mask */
+#define XDMAC_GS_ST18                       XDMAC_GS_ST18_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST18_Msk instead */
+#define XDMAC_GS_ST19_Pos                   19                                             /**< (XDMAC_GS) XDMAC Channel 19 Status Bit Position */
+#define XDMAC_GS_ST19_Msk                   (_U_(0x1) << XDMAC_GS_ST19_Pos)                /**< (XDMAC_GS) XDMAC Channel 19 Status Bit Mask */
+#define XDMAC_GS_ST19                       XDMAC_GS_ST19_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST19_Msk instead */
+#define XDMAC_GS_ST20_Pos                   20                                             /**< (XDMAC_GS) XDMAC Channel 20 Status Bit Position */
+#define XDMAC_GS_ST20_Msk                   (_U_(0x1) << XDMAC_GS_ST20_Pos)                /**< (XDMAC_GS) XDMAC Channel 20 Status Bit Mask */
+#define XDMAC_GS_ST20                       XDMAC_GS_ST20_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST20_Msk instead */
+#define XDMAC_GS_ST21_Pos                   21                                             /**< (XDMAC_GS) XDMAC Channel 21 Status Bit Position */
+#define XDMAC_GS_ST21_Msk                   (_U_(0x1) << XDMAC_GS_ST21_Pos)                /**< (XDMAC_GS) XDMAC Channel 21 Status Bit Mask */
+#define XDMAC_GS_ST21                       XDMAC_GS_ST21_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST21_Msk instead */
+#define XDMAC_GS_ST22_Pos                   22                                             /**< (XDMAC_GS) XDMAC Channel 22 Status Bit Position */
+#define XDMAC_GS_ST22_Msk                   (_U_(0x1) << XDMAC_GS_ST22_Pos)                /**< (XDMAC_GS) XDMAC Channel 22 Status Bit Mask */
+#define XDMAC_GS_ST22                       XDMAC_GS_ST22_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST22_Msk instead */
+#define XDMAC_GS_ST23_Pos                   23                                             /**< (XDMAC_GS) XDMAC Channel 23 Status Bit Position */
+#define XDMAC_GS_ST23_Msk                   (_U_(0x1) << XDMAC_GS_ST23_Pos)                /**< (XDMAC_GS) XDMAC Channel 23 Status Bit Mask */
+#define XDMAC_GS_ST23                       XDMAC_GS_ST23_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GS_ST23_Msk instead */
+#define XDMAC_GS_MASK                       _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GS) Register MASK  (Use XDMAC_GS_Msk instead)  */
+#define XDMAC_GS_Msk                        _U_(0xFFFFFF)                                  /**< (XDMAC_GS) Register Mask  */
+
+#define XDMAC_GS_ST_Pos                     0                                              /**< (XDMAC_GS Position) XDMAC Channel 23 Status Bit */
+#define XDMAC_GS_ST_Msk                     (_U_(0xFFFFFF) << XDMAC_GS_ST_Pos)             /**< (XDMAC_GS Mask) ST */
+#define XDMAC_GS_ST(value)                  (XDMAC_GS_ST_Msk & ((value) << XDMAC_GS_ST_Pos))  
+
+/* -------- XDMAC_GRS : (XDMAC Offset: 0x28) (R/W 32) Global Channel Read Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RS0:1;                     /**< bit:      0  XDMAC Channel 0 Read Suspend Bit         */
+    uint32_t RS1:1;                     /**< bit:      1  XDMAC Channel 1 Read Suspend Bit         */
+    uint32_t RS2:1;                     /**< bit:      2  XDMAC Channel 2 Read Suspend Bit         */
+    uint32_t RS3:1;                     /**< bit:      3  XDMAC Channel 3 Read Suspend Bit         */
+    uint32_t RS4:1;                     /**< bit:      4  XDMAC Channel 4 Read Suspend Bit         */
+    uint32_t RS5:1;                     /**< bit:      5  XDMAC Channel 5 Read Suspend Bit         */
+    uint32_t RS6:1;                     /**< bit:      6  XDMAC Channel 6 Read Suspend Bit         */
+    uint32_t RS7:1;                     /**< bit:      7  XDMAC Channel 7 Read Suspend Bit         */
+    uint32_t RS8:1;                     /**< bit:      8  XDMAC Channel 8 Read Suspend Bit         */
+    uint32_t RS9:1;                     /**< bit:      9  XDMAC Channel 9 Read Suspend Bit         */
+    uint32_t RS10:1;                    /**< bit:     10  XDMAC Channel 10 Read Suspend Bit        */
+    uint32_t RS11:1;                    /**< bit:     11  XDMAC Channel 11 Read Suspend Bit        */
+    uint32_t RS12:1;                    /**< bit:     12  XDMAC Channel 12 Read Suspend Bit        */
+    uint32_t RS13:1;                    /**< bit:     13  XDMAC Channel 13 Read Suspend Bit        */
+    uint32_t RS14:1;                    /**< bit:     14  XDMAC Channel 14 Read Suspend Bit        */
+    uint32_t RS15:1;                    /**< bit:     15  XDMAC Channel 15 Read Suspend Bit        */
+    uint32_t RS16:1;                    /**< bit:     16  XDMAC Channel 16 Read Suspend Bit        */
+    uint32_t RS17:1;                    /**< bit:     17  XDMAC Channel 17 Read Suspend Bit        */
+    uint32_t RS18:1;                    /**< bit:     18  XDMAC Channel 18 Read Suspend Bit        */
+    uint32_t RS19:1;                    /**< bit:     19  XDMAC Channel 19 Read Suspend Bit        */
+    uint32_t RS20:1;                    /**< bit:     20  XDMAC Channel 20 Read Suspend Bit        */
+    uint32_t RS21:1;                    /**< bit:     21  XDMAC Channel 21 Read Suspend Bit        */
+    uint32_t RS22:1;                    /**< bit:     22  XDMAC Channel 22 Read Suspend Bit        */
+    uint32_t RS23:1;                    /**< bit:     23  XDMAC Channel 23 Read Suspend Bit        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RS:24;                     /**< bit:  0..23  XDMAC Channel 23 Read Suspend Bit        */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRS_OFFSET                    (0x28)                                        /**<  (XDMAC_GRS) Global Channel Read Suspend Register  Offset */
+
+#define XDMAC_GRS_RS0_Pos                   0                                              /**< (XDMAC_GRS) XDMAC Channel 0 Read Suspend Bit Position */
+#define XDMAC_GRS_RS0_Msk                   (_U_(0x1) << XDMAC_GRS_RS0_Pos)                /**< (XDMAC_GRS) XDMAC Channel 0 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS0                       XDMAC_GRS_RS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS0_Msk instead */
+#define XDMAC_GRS_RS1_Pos                   1                                              /**< (XDMAC_GRS) XDMAC Channel 1 Read Suspend Bit Position */
+#define XDMAC_GRS_RS1_Msk                   (_U_(0x1) << XDMAC_GRS_RS1_Pos)                /**< (XDMAC_GRS) XDMAC Channel 1 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS1                       XDMAC_GRS_RS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS1_Msk instead */
+#define XDMAC_GRS_RS2_Pos                   2                                              /**< (XDMAC_GRS) XDMAC Channel 2 Read Suspend Bit Position */
+#define XDMAC_GRS_RS2_Msk                   (_U_(0x1) << XDMAC_GRS_RS2_Pos)                /**< (XDMAC_GRS) XDMAC Channel 2 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS2                       XDMAC_GRS_RS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS2_Msk instead */
+#define XDMAC_GRS_RS3_Pos                   3                                              /**< (XDMAC_GRS) XDMAC Channel 3 Read Suspend Bit Position */
+#define XDMAC_GRS_RS3_Msk                   (_U_(0x1) << XDMAC_GRS_RS3_Pos)                /**< (XDMAC_GRS) XDMAC Channel 3 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS3                       XDMAC_GRS_RS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS3_Msk instead */
+#define XDMAC_GRS_RS4_Pos                   4                                              /**< (XDMAC_GRS) XDMAC Channel 4 Read Suspend Bit Position */
+#define XDMAC_GRS_RS4_Msk                   (_U_(0x1) << XDMAC_GRS_RS4_Pos)                /**< (XDMAC_GRS) XDMAC Channel 4 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS4                       XDMAC_GRS_RS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS4_Msk instead */
+#define XDMAC_GRS_RS5_Pos                   5                                              /**< (XDMAC_GRS) XDMAC Channel 5 Read Suspend Bit Position */
+#define XDMAC_GRS_RS5_Msk                   (_U_(0x1) << XDMAC_GRS_RS5_Pos)                /**< (XDMAC_GRS) XDMAC Channel 5 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS5                       XDMAC_GRS_RS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS5_Msk instead */
+#define XDMAC_GRS_RS6_Pos                   6                                              /**< (XDMAC_GRS) XDMAC Channel 6 Read Suspend Bit Position */
+#define XDMAC_GRS_RS6_Msk                   (_U_(0x1) << XDMAC_GRS_RS6_Pos)                /**< (XDMAC_GRS) XDMAC Channel 6 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS6                       XDMAC_GRS_RS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS6_Msk instead */
+#define XDMAC_GRS_RS7_Pos                   7                                              /**< (XDMAC_GRS) XDMAC Channel 7 Read Suspend Bit Position */
+#define XDMAC_GRS_RS7_Msk                   (_U_(0x1) << XDMAC_GRS_RS7_Pos)                /**< (XDMAC_GRS) XDMAC Channel 7 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS7                       XDMAC_GRS_RS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS7_Msk instead */
+#define XDMAC_GRS_RS8_Pos                   8                                              /**< (XDMAC_GRS) XDMAC Channel 8 Read Suspend Bit Position */
+#define XDMAC_GRS_RS8_Msk                   (_U_(0x1) << XDMAC_GRS_RS8_Pos)                /**< (XDMAC_GRS) XDMAC Channel 8 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS8                       XDMAC_GRS_RS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS8_Msk instead */
+#define XDMAC_GRS_RS9_Pos                   9                                              /**< (XDMAC_GRS) XDMAC Channel 9 Read Suspend Bit Position */
+#define XDMAC_GRS_RS9_Msk                   (_U_(0x1) << XDMAC_GRS_RS9_Pos)                /**< (XDMAC_GRS) XDMAC Channel 9 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS9                       XDMAC_GRS_RS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS9_Msk instead */
+#define XDMAC_GRS_RS10_Pos                  10                                             /**< (XDMAC_GRS) XDMAC Channel 10 Read Suspend Bit Position */
+#define XDMAC_GRS_RS10_Msk                  (_U_(0x1) << XDMAC_GRS_RS10_Pos)               /**< (XDMAC_GRS) XDMAC Channel 10 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS10                      XDMAC_GRS_RS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS10_Msk instead */
+#define XDMAC_GRS_RS11_Pos                  11                                             /**< (XDMAC_GRS) XDMAC Channel 11 Read Suspend Bit Position */
+#define XDMAC_GRS_RS11_Msk                  (_U_(0x1) << XDMAC_GRS_RS11_Pos)               /**< (XDMAC_GRS) XDMAC Channel 11 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS11                      XDMAC_GRS_RS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS11_Msk instead */
+#define XDMAC_GRS_RS12_Pos                  12                                             /**< (XDMAC_GRS) XDMAC Channel 12 Read Suspend Bit Position */
+#define XDMAC_GRS_RS12_Msk                  (_U_(0x1) << XDMAC_GRS_RS12_Pos)               /**< (XDMAC_GRS) XDMAC Channel 12 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS12                      XDMAC_GRS_RS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS12_Msk instead */
+#define XDMAC_GRS_RS13_Pos                  13                                             /**< (XDMAC_GRS) XDMAC Channel 13 Read Suspend Bit Position */
+#define XDMAC_GRS_RS13_Msk                  (_U_(0x1) << XDMAC_GRS_RS13_Pos)               /**< (XDMAC_GRS) XDMAC Channel 13 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS13                      XDMAC_GRS_RS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS13_Msk instead */
+#define XDMAC_GRS_RS14_Pos                  14                                             /**< (XDMAC_GRS) XDMAC Channel 14 Read Suspend Bit Position */
+#define XDMAC_GRS_RS14_Msk                  (_U_(0x1) << XDMAC_GRS_RS14_Pos)               /**< (XDMAC_GRS) XDMAC Channel 14 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS14                      XDMAC_GRS_RS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS14_Msk instead */
+#define XDMAC_GRS_RS15_Pos                  15                                             /**< (XDMAC_GRS) XDMAC Channel 15 Read Suspend Bit Position */
+#define XDMAC_GRS_RS15_Msk                  (_U_(0x1) << XDMAC_GRS_RS15_Pos)               /**< (XDMAC_GRS) XDMAC Channel 15 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS15                      XDMAC_GRS_RS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS15_Msk instead */
+#define XDMAC_GRS_RS16_Pos                  16                                             /**< (XDMAC_GRS) XDMAC Channel 16 Read Suspend Bit Position */
+#define XDMAC_GRS_RS16_Msk                  (_U_(0x1) << XDMAC_GRS_RS16_Pos)               /**< (XDMAC_GRS) XDMAC Channel 16 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS16                      XDMAC_GRS_RS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS16_Msk instead */
+#define XDMAC_GRS_RS17_Pos                  17                                             /**< (XDMAC_GRS) XDMAC Channel 17 Read Suspend Bit Position */
+#define XDMAC_GRS_RS17_Msk                  (_U_(0x1) << XDMAC_GRS_RS17_Pos)               /**< (XDMAC_GRS) XDMAC Channel 17 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS17                      XDMAC_GRS_RS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS17_Msk instead */
+#define XDMAC_GRS_RS18_Pos                  18                                             /**< (XDMAC_GRS) XDMAC Channel 18 Read Suspend Bit Position */
+#define XDMAC_GRS_RS18_Msk                  (_U_(0x1) << XDMAC_GRS_RS18_Pos)               /**< (XDMAC_GRS) XDMAC Channel 18 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS18                      XDMAC_GRS_RS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS18_Msk instead */
+#define XDMAC_GRS_RS19_Pos                  19                                             /**< (XDMAC_GRS) XDMAC Channel 19 Read Suspend Bit Position */
+#define XDMAC_GRS_RS19_Msk                  (_U_(0x1) << XDMAC_GRS_RS19_Pos)               /**< (XDMAC_GRS) XDMAC Channel 19 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS19                      XDMAC_GRS_RS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS19_Msk instead */
+#define XDMAC_GRS_RS20_Pos                  20                                             /**< (XDMAC_GRS) XDMAC Channel 20 Read Suspend Bit Position */
+#define XDMAC_GRS_RS20_Msk                  (_U_(0x1) << XDMAC_GRS_RS20_Pos)               /**< (XDMAC_GRS) XDMAC Channel 20 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS20                      XDMAC_GRS_RS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS20_Msk instead */
+#define XDMAC_GRS_RS21_Pos                  21                                             /**< (XDMAC_GRS) XDMAC Channel 21 Read Suspend Bit Position */
+#define XDMAC_GRS_RS21_Msk                  (_U_(0x1) << XDMAC_GRS_RS21_Pos)               /**< (XDMAC_GRS) XDMAC Channel 21 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS21                      XDMAC_GRS_RS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS21_Msk instead */
+#define XDMAC_GRS_RS22_Pos                  22                                             /**< (XDMAC_GRS) XDMAC Channel 22 Read Suspend Bit Position */
+#define XDMAC_GRS_RS22_Msk                  (_U_(0x1) << XDMAC_GRS_RS22_Pos)               /**< (XDMAC_GRS) XDMAC Channel 22 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS22                      XDMAC_GRS_RS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS22_Msk instead */
+#define XDMAC_GRS_RS23_Pos                  23                                             /**< (XDMAC_GRS) XDMAC Channel 23 Read Suspend Bit Position */
+#define XDMAC_GRS_RS23_Msk                  (_U_(0x1) << XDMAC_GRS_RS23_Pos)               /**< (XDMAC_GRS) XDMAC Channel 23 Read Suspend Bit Mask */
+#define XDMAC_GRS_RS23                      XDMAC_GRS_RS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRS_RS23_Msk instead */
+#define XDMAC_GRS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRS) Register MASK  (Use XDMAC_GRS_Msk instead)  */
+#define XDMAC_GRS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GRS) Register Mask  */
+
+#define XDMAC_GRS_RS_Pos                    0                                              /**< (XDMAC_GRS Position) XDMAC Channel 23 Read Suspend Bit */
+#define XDMAC_GRS_RS_Msk                    (_U_(0xFFFFFF) << XDMAC_GRS_RS_Pos)            /**< (XDMAC_GRS Mask) RS */
+#define XDMAC_GRS_RS(value)                 (XDMAC_GRS_RS_Msk & ((value) << XDMAC_GRS_RS_Pos))  
+
+/* -------- XDMAC_GWS : (XDMAC Offset: 0x2c) (R/W 32) Global Channel Write Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t WS0:1;                     /**< bit:      0  XDMAC Channel 0 Write Suspend Bit        */
+    uint32_t WS1:1;                     /**< bit:      1  XDMAC Channel 1 Write Suspend Bit        */
+    uint32_t WS2:1;                     /**< bit:      2  XDMAC Channel 2 Write Suspend Bit        */
+    uint32_t WS3:1;                     /**< bit:      3  XDMAC Channel 3 Write Suspend Bit        */
+    uint32_t WS4:1;                     /**< bit:      4  XDMAC Channel 4 Write Suspend Bit        */
+    uint32_t WS5:1;                     /**< bit:      5  XDMAC Channel 5 Write Suspend Bit        */
+    uint32_t WS6:1;                     /**< bit:      6  XDMAC Channel 6 Write Suspend Bit        */
+    uint32_t WS7:1;                     /**< bit:      7  XDMAC Channel 7 Write Suspend Bit        */
+    uint32_t WS8:1;                     /**< bit:      8  XDMAC Channel 8 Write Suspend Bit        */
+    uint32_t WS9:1;                     /**< bit:      9  XDMAC Channel 9 Write Suspend Bit        */
+    uint32_t WS10:1;                    /**< bit:     10  XDMAC Channel 10 Write Suspend Bit       */
+    uint32_t WS11:1;                    /**< bit:     11  XDMAC Channel 11 Write Suspend Bit       */
+    uint32_t WS12:1;                    /**< bit:     12  XDMAC Channel 12 Write Suspend Bit       */
+    uint32_t WS13:1;                    /**< bit:     13  XDMAC Channel 13 Write Suspend Bit       */
+    uint32_t WS14:1;                    /**< bit:     14  XDMAC Channel 14 Write Suspend Bit       */
+    uint32_t WS15:1;                    /**< bit:     15  XDMAC Channel 15 Write Suspend Bit       */
+    uint32_t WS16:1;                    /**< bit:     16  XDMAC Channel 16 Write Suspend Bit       */
+    uint32_t WS17:1;                    /**< bit:     17  XDMAC Channel 17 Write Suspend Bit       */
+    uint32_t WS18:1;                    /**< bit:     18  XDMAC Channel 18 Write Suspend Bit       */
+    uint32_t WS19:1;                    /**< bit:     19  XDMAC Channel 19 Write Suspend Bit       */
+    uint32_t WS20:1;                    /**< bit:     20  XDMAC Channel 20 Write Suspend Bit       */
+    uint32_t WS21:1;                    /**< bit:     21  XDMAC Channel 21 Write Suspend Bit       */
+    uint32_t WS22:1;                    /**< bit:     22  XDMAC Channel 22 Write Suspend Bit       */
+    uint32_t WS23:1;                    /**< bit:     23  XDMAC Channel 23 Write Suspend Bit       */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t WS:24;                     /**< bit:  0..23  XDMAC Channel 23 Write Suspend Bit       */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GWS_OFFSET                    (0x2C)                                        /**<  (XDMAC_GWS) Global Channel Write Suspend Register  Offset */
+
+#define XDMAC_GWS_WS0_Pos                   0                                              /**< (XDMAC_GWS) XDMAC Channel 0 Write Suspend Bit Position */
+#define XDMAC_GWS_WS0_Msk                   (_U_(0x1) << XDMAC_GWS_WS0_Pos)                /**< (XDMAC_GWS) XDMAC Channel 0 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS0                       XDMAC_GWS_WS0_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS0_Msk instead */
+#define XDMAC_GWS_WS1_Pos                   1                                              /**< (XDMAC_GWS) XDMAC Channel 1 Write Suspend Bit Position */
+#define XDMAC_GWS_WS1_Msk                   (_U_(0x1) << XDMAC_GWS_WS1_Pos)                /**< (XDMAC_GWS) XDMAC Channel 1 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS1                       XDMAC_GWS_WS1_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS1_Msk instead */
+#define XDMAC_GWS_WS2_Pos                   2                                              /**< (XDMAC_GWS) XDMAC Channel 2 Write Suspend Bit Position */
+#define XDMAC_GWS_WS2_Msk                   (_U_(0x1) << XDMAC_GWS_WS2_Pos)                /**< (XDMAC_GWS) XDMAC Channel 2 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS2                       XDMAC_GWS_WS2_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS2_Msk instead */
+#define XDMAC_GWS_WS3_Pos                   3                                              /**< (XDMAC_GWS) XDMAC Channel 3 Write Suspend Bit Position */
+#define XDMAC_GWS_WS3_Msk                   (_U_(0x1) << XDMAC_GWS_WS3_Pos)                /**< (XDMAC_GWS) XDMAC Channel 3 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS3                       XDMAC_GWS_WS3_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS3_Msk instead */
+#define XDMAC_GWS_WS4_Pos                   4                                              /**< (XDMAC_GWS) XDMAC Channel 4 Write Suspend Bit Position */
+#define XDMAC_GWS_WS4_Msk                   (_U_(0x1) << XDMAC_GWS_WS4_Pos)                /**< (XDMAC_GWS) XDMAC Channel 4 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS4                       XDMAC_GWS_WS4_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS4_Msk instead */
+#define XDMAC_GWS_WS5_Pos                   5                                              /**< (XDMAC_GWS) XDMAC Channel 5 Write Suspend Bit Position */
+#define XDMAC_GWS_WS5_Msk                   (_U_(0x1) << XDMAC_GWS_WS5_Pos)                /**< (XDMAC_GWS) XDMAC Channel 5 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS5                       XDMAC_GWS_WS5_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS5_Msk instead */
+#define XDMAC_GWS_WS6_Pos                   6                                              /**< (XDMAC_GWS) XDMAC Channel 6 Write Suspend Bit Position */
+#define XDMAC_GWS_WS6_Msk                   (_U_(0x1) << XDMAC_GWS_WS6_Pos)                /**< (XDMAC_GWS) XDMAC Channel 6 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS6                       XDMAC_GWS_WS6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS6_Msk instead */
+#define XDMAC_GWS_WS7_Pos                   7                                              /**< (XDMAC_GWS) XDMAC Channel 7 Write Suspend Bit Position */
+#define XDMAC_GWS_WS7_Msk                   (_U_(0x1) << XDMAC_GWS_WS7_Pos)                /**< (XDMAC_GWS) XDMAC Channel 7 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS7                       XDMAC_GWS_WS7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS7_Msk instead */
+#define XDMAC_GWS_WS8_Pos                   8                                              /**< (XDMAC_GWS) XDMAC Channel 8 Write Suspend Bit Position */
+#define XDMAC_GWS_WS8_Msk                   (_U_(0x1) << XDMAC_GWS_WS8_Pos)                /**< (XDMAC_GWS) XDMAC Channel 8 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS8                       XDMAC_GWS_WS8_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS8_Msk instead */
+#define XDMAC_GWS_WS9_Pos                   9                                              /**< (XDMAC_GWS) XDMAC Channel 9 Write Suspend Bit Position */
+#define XDMAC_GWS_WS9_Msk                   (_U_(0x1) << XDMAC_GWS_WS9_Pos)                /**< (XDMAC_GWS) XDMAC Channel 9 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS9                       XDMAC_GWS_WS9_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS9_Msk instead */
+#define XDMAC_GWS_WS10_Pos                  10                                             /**< (XDMAC_GWS) XDMAC Channel 10 Write Suspend Bit Position */
+#define XDMAC_GWS_WS10_Msk                  (_U_(0x1) << XDMAC_GWS_WS10_Pos)               /**< (XDMAC_GWS) XDMAC Channel 10 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS10                      XDMAC_GWS_WS10_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS10_Msk instead */
+#define XDMAC_GWS_WS11_Pos                  11                                             /**< (XDMAC_GWS) XDMAC Channel 11 Write Suspend Bit Position */
+#define XDMAC_GWS_WS11_Msk                  (_U_(0x1) << XDMAC_GWS_WS11_Pos)               /**< (XDMAC_GWS) XDMAC Channel 11 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS11                      XDMAC_GWS_WS11_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS11_Msk instead */
+#define XDMAC_GWS_WS12_Pos                  12                                             /**< (XDMAC_GWS) XDMAC Channel 12 Write Suspend Bit Position */
+#define XDMAC_GWS_WS12_Msk                  (_U_(0x1) << XDMAC_GWS_WS12_Pos)               /**< (XDMAC_GWS) XDMAC Channel 12 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS12                      XDMAC_GWS_WS12_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS12_Msk instead */
+#define XDMAC_GWS_WS13_Pos                  13                                             /**< (XDMAC_GWS) XDMAC Channel 13 Write Suspend Bit Position */
+#define XDMAC_GWS_WS13_Msk                  (_U_(0x1) << XDMAC_GWS_WS13_Pos)               /**< (XDMAC_GWS) XDMAC Channel 13 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS13                      XDMAC_GWS_WS13_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS13_Msk instead */
+#define XDMAC_GWS_WS14_Pos                  14                                             /**< (XDMAC_GWS) XDMAC Channel 14 Write Suspend Bit Position */
+#define XDMAC_GWS_WS14_Msk                  (_U_(0x1) << XDMAC_GWS_WS14_Pos)               /**< (XDMAC_GWS) XDMAC Channel 14 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS14                      XDMAC_GWS_WS14_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS14_Msk instead */
+#define XDMAC_GWS_WS15_Pos                  15                                             /**< (XDMAC_GWS) XDMAC Channel 15 Write Suspend Bit Position */
+#define XDMAC_GWS_WS15_Msk                  (_U_(0x1) << XDMAC_GWS_WS15_Pos)               /**< (XDMAC_GWS) XDMAC Channel 15 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS15                      XDMAC_GWS_WS15_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS15_Msk instead */
+#define XDMAC_GWS_WS16_Pos                  16                                             /**< (XDMAC_GWS) XDMAC Channel 16 Write Suspend Bit Position */
+#define XDMAC_GWS_WS16_Msk                  (_U_(0x1) << XDMAC_GWS_WS16_Pos)               /**< (XDMAC_GWS) XDMAC Channel 16 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS16                      XDMAC_GWS_WS16_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS16_Msk instead */
+#define XDMAC_GWS_WS17_Pos                  17                                             /**< (XDMAC_GWS) XDMAC Channel 17 Write Suspend Bit Position */
+#define XDMAC_GWS_WS17_Msk                  (_U_(0x1) << XDMAC_GWS_WS17_Pos)               /**< (XDMAC_GWS) XDMAC Channel 17 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS17                      XDMAC_GWS_WS17_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS17_Msk instead */
+#define XDMAC_GWS_WS18_Pos                  18                                             /**< (XDMAC_GWS) XDMAC Channel 18 Write Suspend Bit Position */
+#define XDMAC_GWS_WS18_Msk                  (_U_(0x1) << XDMAC_GWS_WS18_Pos)               /**< (XDMAC_GWS) XDMAC Channel 18 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS18                      XDMAC_GWS_WS18_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS18_Msk instead */
+#define XDMAC_GWS_WS19_Pos                  19                                             /**< (XDMAC_GWS) XDMAC Channel 19 Write Suspend Bit Position */
+#define XDMAC_GWS_WS19_Msk                  (_U_(0x1) << XDMAC_GWS_WS19_Pos)               /**< (XDMAC_GWS) XDMAC Channel 19 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS19                      XDMAC_GWS_WS19_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS19_Msk instead */
+#define XDMAC_GWS_WS20_Pos                  20                                             /**< (XDMAC_GWS) XDMAC Channel 20 Write Suspend Bit Position */
+#define XDMAC_GWS_WS20_Msk                  (_U_(0x1) << XDMAC_GWS_WS20_Pos)               /**< (XDMAC_GWS) XDMAC Channel 20 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS20                      XDMAC_GWS_WS20_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS20_Msk instead */
+#define XDMAC_GWS_WS21_Pos                  21                                             /**< (XDMAC_GWS) XDMAC Channel 21 Write Suspend Bit Position */
+#define XDMAC_GWS_WS21_Msk                  (_U_(0x1) << XDMAC_GWS_WS21_Pos)               /**< (XDMAC_GWS) XDMAC Channel 21 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS21                      XDMAC_GWS_WS21_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS21_Msk instead */
+#define XDMAC_GWS_WS22_Pos                  22                                             /**< (XDMAC_GWS) XDMAC Channel 22 Write Suspend Bit Position */
+#define XDMAC_GWS_WS22_Msk                  (_U_(0x1) << XDMAC_GWS_WS22_Pos)               /**< (XDMAC_GWS) XDMAC Channel 22 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS22                      XDMAC_GWS_WS22_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS22_Msk instead */
+#define XDMAC_GWS_WS23_Pos                  23                                             /**< (XDMAC_GWS) XDMAC Channel 23 Write Suspend Bit Position */
+#define XDMAC_GWS_WS23_Msk                  (_U_(0x1) << XDMAC_GWS_WS23_Pos)               /**< (XDMAC_GWS) XDMAC Channel 23 Write Suspend Bit Mask */
+#define XDMAC_GWS_WS23                      XDMAC_GWS_WS23_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GWS_WS23_Msk instead */
+#define XDMAC_GWS_MASK                      _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GWS) Register MASK  (Use XDMAC_GWS_Msk instead)  */
+#define XDMAC_GWS_Msk                       _U_(0xFFFFFF)                                  /**< (XDMAC_GWS) Register Mask  */
+
+#define XDMAC_GWS_WS_Pos                    0                                              /**< (XDMAC_GWS Position) XDMAC Channel 23 Write Suspend Bit */
+#define XDMAC_GWS_WS_Msk                    (_U_(0xFFFFFF) << XDMAC_GWS_WS_Pos)            /**< (XDMAC_GWS Mask) WS */
+#define XDMAC_GWS_WS(value)                 (XDMAC_GWS_WS_Msk & ((value) << XDMAC_GWS_WS_Pos))  
+
+/* -------- XDMAC_GRWS : (XDMAC Offset: 0x30) (/W 32) Global Channel Read Write Suspend Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RWS0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Suspend Bit   */
+    uint32_t RWS1:1;                    /**< bit:      1  XDMAC Channel 1 Read Write Suspend Bit   */
+    uint32_t RWS2:1;                    /**< bit:      2  XDMAC Channel 2 Read Write Suspend Bit   */
+    uint32_t RWS3:1;                    /**< bit:      3  XDMAC Channel 3 Read Write Suspend Bit   */
+    uint32_t RWS4:1;                    /**< bit:      4  XDMAC Channel 4 Read Write Suspend Bit   */
+    uint32_t RWS5:1;                    /**< bit:      5  XDMAC Channel 5 Read Write Suspend Bit   */
+    uint32_t RWS6:1;                    /**< bit:      6  XDMAC Channel 6 Read Write Suspend Bit   */
+    uint32_t RWS7:1;                    /**< bit:      7  XDMAC Channel 7 Read Write Suspend Bit   */
+    uint32_t RWS8:1;                    /**< bit:      8  XDMAC Channel 8 Read Write Suspend Bit   */
+    uint32_t RWS9:1;                    /**< bit:      9  XDMAC Channel 9 Read Write Suspend Bit   */
+    uint32_t RWS10:1;                   /**< bit:     10  XDMAC Channel 10 Read Write Suspend Bit  */
+    uint32_t RWS11:1;                   /**< bit:     11  XDMAC Channel 11 Read Write Suspend Bit  */
+    uint32_t RWS12:1;                   /**< bit:     12  XDMAC Channel 12 Read Write Suspend Bit  */
+    uint32_t RWS13:1;                   /**< bit:     13  XDMAC Channel 13 Read Write Suspend Bit  */
+    uint32_t RWS14:1;                   /**< bit:     14  XDMAC Channel 14 Read Write Suspend Bit  */
+    uint32_t RWS15:1;                   /**< bit:     15  XDMAC Channel 15 Read Write Suspend Bit  */
+    uint32_t RWS16:1;                   /**< bit:     16  XDMAC Channel 16 Read Write Suspend Bit  */
+    uint32_t RWS17:1;                   /**< bit:     17  XDMAC Channel 17 Read Write Suspend Bit  */
+    uint32_t RWS18:1;                   /**< bit:     18  XDMAC Channel 18 Read Write Suspend Bit  */
+    uint32_t RWS19:1;                   /**< bit:     19  XDMAC Channel 19 Read Write Suspend Bit  */
+    uint32_t RWS20:1;                   /**< bit:     20  XDMAC Channel 20 Read Write Suspend Bit  */
+    uint32_t RWS21:1;                   /**< bit:     21  XDMAC Channel 21 Read Write Suspend Bit  */
+    uint32_t RWS22:1;                   /**< bit:     22  XDMAC Channel 22 Read Write Suspend Bit  */
+    uint32_t RWS23:1;                   /**< bit:     23  XDMAC Channel 23 Read Write Suspend Bit  */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RWS:24;                    /**< bit:  0..23  XDMAC Channel 23 Read Write Suspend Bit  */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRWS_OFFSET                   (0x30)                                        /**<  (XDMAC_GRWS) Global Channel Read Write Suspend Register  Offset */
+
+#define XDMAC_GRWS_RWS0_Pos                 0                                              /**< (XDMAC_GRWS) XDMAC Channel 0 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS0_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS0_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 0 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS0                     XDMAC_GRWS_RWS0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS0_Msk instead */
+#define XDMAC_GRWS_RWS1_Pos                 1                                              /**< (XDMAC_GRWS) XDMAC Channel 1 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS1_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS1_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 1 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS1                     XDMAC_GRWS_RWS1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS1_Msk instead */
+#define XDMAC_GRWS_RWS2_Pos                 2                                              /**< (XDMAC_GRWS) XDMAC Channel 2 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS2_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS2_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 2 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS2                     XDMAC_GRWS_RWS2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS2_Msk instead */
+#define XDMAC_GRWS_RWS3_Pos                 3                                              /**< (XDMAC_GRWS) XDMAC Channel 3 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS3_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS3_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 3 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS3                     XDMAC_GRWS_RWS3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS3_Msk instead */
+#define XDMAC_GRWS_RWS4_Pos                 4                                              /**< (XDMAC_GRWS) XDMAC Channel 4 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS4_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS4_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 4 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS4                     XDMAC_GRWS_RWS4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS4_Msk instead */
+#define XDMAC_GRWS_RWS5_Pos                 5                                              /**< (XDMAC_GRWS) XDMAC Channel 5 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS5_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS5_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 5 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS5                     XDMAC_GRWS_RWS5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS5_Msk instead */
+#define XDMAC_GRWS_RWS6_Pos                 6                                              /**< (XDMAC_GRWS) XDMAC Channel 6 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS6_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS6_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 6 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS6                     XDMAC_GRWS_RWS6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS6_Msk instead */
+#define XDMAC_GRWS_RWS7_Pos                 7                                              /**< (XDMAC_GRWS) XDMAC Channel 7 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS7_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS7_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 7 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS7                     XDMAC_GRWS_RWS7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS7_Msk instead */
+#define XDMAC_GRWS_RWS8_Pos                 8                                              /**< (XDMAC_GRWS) XDMAC Channel 8 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS8_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS8_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 8 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS8                     XDMAC_GRWS_RWS8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS8_Msk instead */
+#define XDMAC_GRWS_RWS9_Pos                 9                                              /**< (XDMAC_GRWS) XDMAC Channel 9 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS9_Msk                 (_U_(0x1) << XDMAC_GRWS_RWS9_Pos)              /**< (XDMAC_GRWS) XDMAC Channel 9 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS9                     XDMAC_GRWS_RWS9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS9_Msk instead */
+#define XDMAC_GRWS_RWS10_Pos                10                                             /**< (XDMAC_GRWS) XDMAC Channel 10 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS10_Msk                (_U_(0x1) << XDMAC_GRWS_RWS10_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 10 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS10                    XDMAC_GRWS_RWS10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS10_Msk instead */
+#define XDMAC_GRWS_RWS11_Pos                11                                             /**< (XDMAC_GRWS) XDMAC Channel 11 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS11_Msk                (_U_(0x1) << XDMAC_GRWS_RWS11_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 11 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS11                    XDMAC_GRWS_RWS11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS11_Msk instead */
+#define XDMAC_GRWS_RWS12_Pos                12                                             /**< (XDMAC_GRWS) XDMAC Channel 12 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS12_Msk                (_U_(0x1) << XDMAC_GRWS_RWS12_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 12 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS12                    XDMAC_GRWS_RWS12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS12_Msk instead */
+#define XDMAC_GRWS_RWS13_Pos                13                                             /**< (XDMAC_GRWS) XDMAC Channel 13 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS13_Msk                (_U_(0x1) << XDMAC_GRWS_RWS13_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 13 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS13                    XDMAC_GRWS_RWS13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS13_Msk instead */
+#define XDMAC_GRWS_RWS14_Pos                14                                             /**< (XDMAC_GRWS) XDMAC Channel 14 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS14_Msk                (_U_(0x1) << XDMAC_GRWS_RWS14_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 14 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS14                    XDMAC_GRWS_RWS14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS14_Msk instead */
+#define XDMAC_GRWS_RWS15_Pos                15                                             /**< (XDMAC_GRWS) XDMAC Channel 15 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS15_Msk                (_U_(0x1) << XDMAC_GRWS_RWS15_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 15 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS15                    XDMAC_GRWS_RWS15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS15_Msk instead */
+#define XDMAC_GRWS_RWS16_Pos                16                                             /**< (XDMAC_GRWS) XDMAC Channel 16 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS16_Msk                (_U_(0x1) << XDMAC_GRWS_RWS16_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 16 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS16                    XDMAC_GRWS_RWS16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS16_Msk instead */
+#define XDMAC_GRWS_RWS17_Pos                17                                             /**< (XDMAC_GRWS) XDMAC Channel 17 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS17_Msk                (_U_(0x1) << XDMAC_GRWS_RWS17_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 17 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS17                    XDMAC_GRWS_RWS17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS17_Msk instead */
+#define XDMAC_GRWS_RWS18_Pos                18                                             /**< (XDMAC_GRWS) XDMAC Channel 18 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS18_Msk                (_U_(0x1) << XDMAC_GRWS_RWS18_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 18 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS18                    XDMAC_GRWS_RWS18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS18_Msk instead */
+#define XDMAC_GRWS_RWS19_Pos                19                                             /**< (XDMAC_GRWS) XDMAC Channel 19 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS19_Msk                (_U_(0x1) << XDMAC_GRWS_RWS19_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 19 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS19                    XDMAC_GRWS_RWS19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS19_Msk instead */
+#define XDMAC_GRWS_RWS20_Pos                20                                             /**< (XDMAC_GRWS) XDMAC Channel 20 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS20_Msk                (_U_(0x1) << XDMAC_GRWS_RWS20_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 20 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS20                    XDMAC_GRWS_RWS20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS20_Msk instead */
+#define XDMAC_GRWS_RWS21_Pos                21                                             /**< (XDMAC_GRWS) XDMAC Channel 21 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS21_Msk                (_U_(0x1) << XDMAC_GRWS_RWS21_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 21 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS21                    XDMAC_GRWS_RWS21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS21_Msk instead */
+#define XDMAC_GRWS_RWS22_Pos                22                                             /**< (XDMAC_GRWS) XDMAC Channel 22 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS22_Msk                (_U_(0x1) << XDMAC_GRWS_RWS22_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 22 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS22                    XDMAC_GRWS_RWS22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS22_Msk instead */
+#define XDMAC_GRWS_RWS23_Pos                23                                             /**< (XDMAC_GRWS) XDMAC Channel 23 Read Write Suspend Bit Position */
+#define XDMAC_GRWS_RWS23_Msk                (_U_(0x1) << XDMAC_GRWS_RWS23_Pos)             /**< (XDMAC_GRWS) XDMAC Channel 23 Read Write Suspend Bit Mask */
+#define XDMAC_GRWS_RWS23                    XDMAC_GRWS_RWS23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWS_RWS23_Msk instead */
+#define XDMAC_GRWS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRWS) Register MASK  (Use XDMAC_GRWS_Msk instead)  */
+#define XDMAC_GRWS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GRWS) Register Mask  */
+
+#define XDMAC_GRWS_RWS_Pos                  0                                              /**< (XDMAC_GRWS Position) XDMAC Channel 23 Read Write Suspend Bit */
+#define XDMAC_GRWS_RWS_Msk                  (_U_(0xFFFFFF) << XDMAC_GRWS_RWS_Pos)          /**< (XDMAC_GRWS Mask) RWS */
+#define XDMAC_GRWS_RWS(value)               (XDMAC_GRWS_RWS_Msk & ((value) << XDMAC_GRWS_RWS_Pos))  
+
+/* -------- XDMAC_GRWR : (XDMAC Offset: 0x34) (/W 32) Global Channel Read Write Resume Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RWR0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Resume Bit    */
+    uint32_t RWR1:1;                    /**< bit:      1  XDMAC Channel 1 Read Write Resume Bit    */
+    uint32_t RWR2:1;                    /**< bit:      2  XDMAC Channel 2 Read Write Resume Bit    */
+    uint32_t RWR3:1;                    /**< bit:      3  XDMAC Channel 3 Read Write Resume Bit    */
+    uint32_t RWR4:1;                    /**< bit:      4  XDMAC Channel 4 Read Write Resume Bit    */
+    uint32_t RWR5:1;                    /**< bit:      5  XDMAC Channel 5 Read Write Resume Bit    */
+    uint32_t RWR6:1;                    /**< bit:      6  XDMAC Channel 6 Read Write Resume Bit    */
+    uint32_t RWR7:1;                    /**< bit:      7  XDMAC Channel 7 Read Write Resume Bit    */
+    uint32_t RWR8:1;                    /**< bit:      8  XDMAC Channel 8 Read Write Resume Bit    */
+    uint32_t RWR9:1;                    /**< bit:      9  XDMAC Channel 9 Read Write Resume Bit    */
+    uint32_t RWR10:1;                   /**< bit:     10  XDMAC Channel 10 Read Write Resume Bit   */
+    uint32_t RWR11:1;                   /**< bit:     11  XDMAC Channel 11 Read Write Resume Bit   */
+    uint32_t RWR12:1;                   /**< bit:     12  XDMAC Channel 12 Read Write Resume Bit   */
+    uint32_t RWR13:1;                   /**< bit:     13  XDMAC Channel 13 Read Write Resume Bit   */
+    uint32_t RWR14:1;                   /**< bit:     14  XDMAC Channel 14 Read Write Resume Bit   */
+    uint32_t RWR15:1;                   /**< bit:     15  XDMAC Channel 15 Read Write Resume Bit   */
+    uint32_t RWR16:1;                   /**< bit:     16  XDMAC Channel 16 Read Write Resume Bit   */
+    uint32_t RWR17:1;                   /**< bit:     17  XDMAC Channel 17 Read Write Resume Bit   */
+    uint32_t RWR18:1;                   /**< bit:     18  XDMAC Channel 18 Read Write Resume Bit   */
+    uint32_t RWR19:1;                   /**< bit:     19  XDMAC Channel 19 Read Write Resume Bit   */
+    uint32_t RWR20:1;                   /**< bit:     20  XDMAC Channel 20 Read Write Resume Bit   */
+    uint32_t RWR21:1;                   /**< bit:     21  XDMAC Channel 21 Read Write Resume Bit   */
+    uint32_t RWR22:1;                   /**< bit:     22  XDMAC Channel 22 Read Write Resume Bit   */
+    uint32_t RWR23:1;                   /**< bit:     23  XDMAC Channel 23 Read Write Resume Bit   */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RWR:24;                    /**< bit:  0..23  XDMAC Channel 23 Read Write Resume Bit   */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GRWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GRWR_OFFSET                   (0x34)                                        /**<  (XDMAC_GRWR) Global Channel Read Write Resume Register  Offset */
+
+#define XDMAC_GRWR_RWR0_Pos                 0                                              /**< (XDMAC_GRWR) XDMAC Channel 0 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR0_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR0_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 0 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR0                     XDMAC_GRWR_RWR0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR0_Msk instead */
+#define XDMAC_GRWR_RWR1_Pos                 1                                              /**< (XDMAC_GRWR) XDMAC Channel 1 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR1_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR1_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 1 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR1                     XDMAC_GRWR_RWR1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR1_Msk instead */
+#define XDMAC_GRWR_RWR2_Pos                 2                                              /**< (XDMAC_GRWR) XDMAC Channel 2 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR2_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR2_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 2 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR2                     XDMAC_GRWR_RWR2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR2_Msk instead */
+#define XDMAC_GRWR_RWR3_Pos                 3                                              /**< (XDMAC_GRWR) XDMAC Channel 3 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR3_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR3_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 3 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR3                     XDMAC_GRWR_RWR3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR3_Msk instead */
+#define XDMAC_GRWR_RWR4_Pos                 4                                              /**< (XDMAC_GRWR) XDMAC Channel 4 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR4_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR4_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 4 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR4                     XDMAC_GRWR_RWR4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR4_Msk instead */
+#define XDMAC_GRWR_RWR5_Pos                 5                                              /**< (XDMAC_GRWR) XDMAC Channel 5 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR5_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR5_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 5 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR5                     XDMAC_GRWR_RWR5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR5_Msk instead */
+#define XDMAC_GRWR_RWR6_Pos                 6                                              /**< (XDMAC_GRWR) XDMAC Channel 6 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR6_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR6_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 6 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR6                     XDMAC_GRWR_RWR6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR6_Msk instead */
+#define XDMAC_GRWR_RWR7_Pos                 7                                              /**< (XDMAC_GRWR) XDMAC Channel 7 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR7_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR7_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 7 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR7                     XDMAC_GRWR_RWR7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR7_Msk instead */
+#define XDMAC_GRWR_RWR8_Pos                 8                                              /**< (XDMAC_GRWR) XDMAC Channel 8 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR8_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR8_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 8 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR8                     XDMAC_GRWR_RWR8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR8_Msk instead */
+#define XDMAC_GRWR_RWR9_Pos                 9                                              /**< (XDMAC_GRWR) XDMAC Channel 9 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR9_Msk                 (_U_(0x1) << XDMAC_GRWR_RWR9_Pos)              /**< (XDMAC_GRWR) XDMAC Channel 9 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR9                     XDMAC_GRWR_RWR9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR9_Msk instead */
+#define XDMAC_GRWR_RWR10_Pos                10                                             /**< (XDMAC_GRWR) XDMAC Channel 10 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR10_Msk                (_U_(0x1) << XDMAC_GRWR_RWR10_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 10 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR10                    XDMAC_GRWR_RWR10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR10_Msk instead */
+#define XDMAC_GRWR_RWR11_Pos                11                                             /**< (XDMAC_GRWR) XDMAC Channel 11 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR11_Msk                (_U_(0x1) << XDMAC_GRWR_RWR11_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 11 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR11                    XDMAC_GRWR_RWR11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR11_Msk instead */
+#define XDMAC_GRWR_RWR12_Pos                12                                             /**< (XDMAC_GRWR) XDMAC Channel 12 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR12_Msk                (_U_(0x1) << XDMAC_GRWR_RWR12_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 12 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR12                    XDMAC_GRWR_RWR12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR12_Msk instead */
+#define XDMAC_GRWR_RWR13_Pos                13                                             /**< (XDMAC_GRWR) XDMAC Channel 13 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR13_Msk                (_U_(0x1) << XDMAC_GRWR_RWR13_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 13 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR13                    XDMAC_GRWR_RWR13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR13_Msk instead */
+#define XDMAC_GRWR_RWR14_Pos                14                                             /**< (XDMAC_GRWR) XDMAC Channel 14 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR14_Msk                (_U_(0x1) << XDMAC_GRWR_RWR14_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 14 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR14                    XDMAC_GRWR_RWR14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR14_Msk instead */
+#define XDMAC_GRWR_RWR15_Pos                15                                             /**< (XDMAC_GRWR) XDMAC Channel 15 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR15_Msk                (_U_(0x1) << XDMAC_GRWR_RWR15_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 15 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR15                    XDMAC_GRWR_RWR15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR15_Msk instead */
+#define XDMAC_GRWR_RWR16_Pos                16                                             /**< (XDMAC_GRWR) XDMAC Channel 16 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR16_Msk                (_U_(0x1) << XDMAC_GRWR_RWR16_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 16 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR16                    XDMAC_GRWR_RWR16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR16_Msk instead */
+#define XDMAC_GRWR_RWR17_Pos                17                                             /**< (XDMAC_GRWR) XDMAC Channel 17 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR17_Msk                (_U_(0x1) << XDMAC_GRWR_RWR17_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 17 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR17                    XDMAC_GRWR_RWR17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR17_Msk instead */
+#define XDMAC_GRWR_RWR18_Pos                18                                             /**< (XDMAC_GRWR) XDMAC Channel 18 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR18_Msk                (_U_(0x1) << XDMAC_GRWR_RWR18_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 18 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR18                    XDMAC_GRWR_RWR18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR18_Msk instead */
+#define XDMAC_GRWR_RWR19_Pos                19                                             /**< (XDMAC_GRWR) XDMAC Channel 19 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR19_Msk                (_U_(0x1) << XDMAC_GRWR_RWR19_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 19 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR19                    XDMAC_GRWR_RWR19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR19_Msk instead */
+#define XDMAC_GRWR_RWR20_Pos                20                                             /**< (XDMAC_GRWR) XDMAC Channel 20 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR20_Msk                (_U_(0x1) << XDMAC_GRWR_RWR20_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 20 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR20                    XDMAC_GRWR_RWR20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR20_Msk instead */
+#define XDMAC_GRWR_RWR21_Pos                21                                             /**< (XDMAC_GRWR) XDMAC Channel 21 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR21_Msk                (_U_(0x1) << XDMAC_GRWR_RWR21_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 21 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR21                    XDMAC_GRWR_RWR21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR21_Msk instead */
+#define XDMAC_GRWR_RWR22_Pos                22                                             /**< (XDMAC_GRWR) XDMAC Channel 22 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR22_Msk                (_U_(0x1) << XDMAC_GRWR_RWR22_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 22 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR22                    XDMAC_GRWR_RWR22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR22_Msk instead */
+#define XDMAC_GRWR_RWR23_Pos                23                                             /**< (XDMAC_GRWR) XDMAC Channel 23 Read Write Resume Bit Position */
+#define XDMAC_GRWR_RWR23_Msk                (_U_(0x1) << XDMAC_GRWR_RWR23_Pos)             /**< (XDMAC_GRWR) XDMAC Channel 23 Read Write Resume Bit Mask */
+#define XDMAC_GRWR_RWR23                    XDMAC_GRWR_RWR23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GRWR_RWR23_Msk instead */
+#define XDMAC_GRWR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GRWR) Register MASK  (Use XDMAC_GRWR_Msk instead)  */
+#define XDMAC_GRWR_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GRWR) Register Mask  */
+
+#define XDMAC_GRWR_RWR_Pos                  0                                              /**< (XDMAC_GRWR Position) XDMAC Channel 23 Read Write Resume Bit */
+#define XDMAC_GRWR_RWR_Msk                  (_U_(0xFFFFFF) << XDMAC_GRWR_RWR_Pos)          /**< (XDMAC_GRWR Mask) RWR */
+#define XDMAC_GRWR_RWR(value)               (XDMAC_GRWR_RWR_Msk & ((value) << XDMAC_GRWR_RWR_Pos))  
+
+/* -------- XDMAC_GSWR : (XDMAC Offset: 0x38) (/W 32) Global Channel Software Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWREQ0:1;                  /**< bit:      0  XDMAC Channel 0 Software Request Bit     */
+    uint32_t SWREQ1:1;                  /**< bit:      1  XDMAC Channel 1 Software Request Bit     */
+    uint32_t SWREQ2:1;                  /**< bit:      2  XDMAC Channel 2 Software Request Bit     */
+    uint32_t SWREQ3:1;                  /**< bit:      3  XDMAC Channel 3 Software Request Bit     */
+    uint32_t SWREQ4:1;                  /**< bit:      4  XDMAC Channel 4 Software Request Bit     */
+    uint32_t SWREQ5:1;                  /**< bit:      5  XDMAC Channel 5 Software Request Bit     */
+    uint32_t SWREQ6:1;                  /**< bit:      6  XDMAC Channel 6 Software Request Bit     */
+    uint32_t SWREQ7:1;                  /**< bit:      7  XDMAC Channel 7 Software Request Bit     */
+    uint32_t SWREQ8:1;                  /**< bit:      8  XDMAC Channel 8 Software Request Bit     */
+    uint32_t SWREQ9:1;                  /**< bit:      9  XDMAC Channel 9 Software Request Bit     */
+    uint32_t SWREQ10:1;                 /**< bit:     10  XDMAC Channel 10 Software Request Bit    */
+    uint32_t SWREQ11:1;                 /**< bit:     11  XDMAC Channel 11 Software Request Bit    */
+    uint32_t SWREQ12:1;                 /**< bit:     12  XDMAC Channel 12 Software Request Bit    */
+    uint32_t SWREQ13:1;                 /**< bit:     13  XDMAC Channel 13 Software Request Bit    */
+    uint32_t SWREQ14:1;                 /**< bit:     14  XDMAC Channel 14 Software Request Bit    */
+    uint32_t SWREQ15:1;                 /**< bit:     15  XDMAC Channel 15 Software Request Bit    */
+    uint32_t SWREQ16:1;                 /**< bit:     16  XDMAC Channel 16 Software Request Bit    */
+    uint32_t SWREQ17:1;                 /**< bit:     17  XDMAC Channel 17 Software Request Bit    */
+    uint32_t SWREQ18:1;                 /**< bit:     18  XDMAC Channel 18 Software Request Bit    */
+    uint32_t SWREQ19:1;                 /**< bit:     19  XDMAC Channel 19 Software Request Bit    */
+    uint32_t SWREQ20:1;                 /**< bit:     20  XDMAC Channel 20 Software Request Bit    */
+    uint32_t SWREQ21:1;                 /**< bit:     21  XDMAC Channel 21 Software Request Bit    */
+    uint32_t SWREQ22:1;                 /**< bit:     22  XDMAC Channel 22 Software Request Bit    */
+    uint32_t SWREQ23:1;                 /**< bit:     23  XDMAC Channel 23 Software Request Bit    */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWREQ:24;                  /**< bit:  0..23  XDMAC Channel 23 Software Request Bit    */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWR_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWR_OFFSET                   (0x38)                                        /**<  (XDMAC_GSWR) Global Channel Software Request Register  Offset */
+
+#define XDMAC_GSWR_SWREQ0_Pos               0                                              /**< (XDMAC_GSWR) XDMAC Channel 0 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ0_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ0_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 0 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ0                   XDMAC_GSWR_SWREQ0_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ0_Msk instead */
+#define XDMAC_GSWR_SWREQ1_Pos               1                                              /**< (XDMAC_GSWR) XDMAC Channel 1 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ1_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ1_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 1 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ1                   XDMAC_GSWR_SWREQ1_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ1_Msk instead */
+#define XDMAC_GSWR_SWREQ2_Pos               2                                              /**< (XDMAC_GSWR) XDMAC Channel 2 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ2_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ2_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 2 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ2                   XDMAC_GSWR_SWREQ2_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ2_Msk instead */
+#define XDMAC_GSWR_SWREQ3_Pos               3                                              /**< (XDMAC_GSWR) XDMAC Channel 3 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ3_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ3_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 3 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ3                   XDMAC_GSWR_SWREQ3_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ3_Msk instead */
+#define XDMAC_GSWR_SWREQ4_Pos               4                                              /**< (XDMAC_GSWR) XDMAC Channel 4 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ4_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ4_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 4 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ4                   XDMAC_GSWR_SWREQ4_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ4_Msk instead */
+#define XDMAC_GSWR_SWREQ5_Pos               5                                              /**< (XDMAC_GSWR) XDMAC Channel 5 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ5_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ5_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 5 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ5                   XDMAC_GSWR_SWREQ5_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ5_Msk instead */
+#define XDMAC_GSWR_SWREQ6_Pos               6                                              /**< (XDMAC_GSWR) XDMAC Channel 6 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ6_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ6_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 6 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ6                   XDMAC_GSWR_SWREQ6_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ6_Msk instead */
+#define XDMAC_GSWR_SWREQ7_Pos               7                                              /**< (XDMAC_GSWR) XDMAC Channel 7 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ7_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ7_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 7 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ7                   XDMAC_GSWR_SWREQ7_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ7_Msk instead */
+#define XDMAC_GSWR_SWREQ8_Pos               8                                              /**< (XDMAC_GSWR) XDMAC Channel 8 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ8_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ8_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 8 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ8                   XDMAC_GSWR_SWREQ8_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ8_Msk instead */
+#define XDMAC_GSWR_SWREQ9_Pos               9                                              /**< (XDMAC_GSWR) XDMAC Channel 9 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ9_Msk               (_U_(0x1) << XDMAC_GSWR_SWREQ9_Pos)            /**< (XDMAC_GSWR) XDMAC Channel 9 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ9                   XDMAC_GSWR_SWREQ9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ9_Msk instead */
+#define XDMAC_GSWR_SWREQ10_Pos              10                                             /**< (XDMAC_GSWR) XDMAC Channel 10 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ10_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ10_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 10 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ10                  XDMAC_GSWR_SWREQ10_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ10_Msk instead */
+#define XDMAC_GSWR_SWREQ11_Pos              11                                             /**< (XDMAC_GSWR) XDMAC Channel 11 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ11_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ11_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 11 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ11                  XDMAC_GSWR_SWREQ11_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ11_Msk instead */
+#define XDMAC_GSWR_SWREQ12_Pos              12                                             /**< (XDMAC_GSWR) XDMAC Channel 12 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ12_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ12_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 12 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ12                  XDMAC_GSWR_SWREQ12_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ12_Msk instead */
+#define XDMAC_GSWR_SWREQ13_Pos              13                                             /**< (XDMAC_GSWR) XDMAC Channel 13 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ13_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ13_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 13 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ13                  XDMAC_GSWR_SWREQ13_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ13_Msk instead */
+#define XDMAC_GSWR_SWREQ14_Pos              14                                             /**< (XDMAC_GSWR) XDMAC Channel 14 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ14_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ14_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 14 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ14                  XDMAC_GSWR_SWREQ14_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ14_Msk instead */
+#define XDMAC_GSWR_SWREQ15_Pos              15                                             /**< (XDMAC_GSWR) XDMAC Channel 15 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ15_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ15_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 15 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ15                  XDMAC_GSWR_SWREQ15_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ15_Msk instead */
+#define XDMAC_GSWR_SWREQ16_Pos              16                                             /**< (XDMAC_GSWR) XDMAC Channel 16 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ16_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ16_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 16 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ16                  XDMAC_GSWR_SWREQ16_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ16_Msk instead */
+#define XDMAC_GSWR_SWREQ17_Pos              17                                             /**< (XDMAC_GSWR) XDMAC Channel 17 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ17_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ17_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 17 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ17                  XDMAC_GSWR_SWREQ17_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ17_Msk instead */
+#define XDMAC_GSWR_SWREQ18_Pos              18                                             /**< (XDMAC_GSWR) XDMAC Channel 18 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ18_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ18_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 18 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ18                  XDMAC_GSWR_SWREQ18_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ18_Msk instead */
+#define XDMAC_GSWR_SWREQ19_Pos              19                                             /**< (XDMAC_GSWR) XDMAC Channel 19 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ19_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ19_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 19 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ19                  XDMAC_GSWR_SWREQ19_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ19_Msk instead */
+#define XDMAC_GSWR_SWREQ20_Pos              20                                             /**< (XDMAC_GSWR) XDMAC Channel 20 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ20_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ20_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 20 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ20                  XDMAC_GSWR_SWREQ20_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ20_Msk instead */
+#define XDMAC_GSWR_SWREQ21_Pos              21                                             /**< (XDMAC_GSWR) XDMAC Channel 21 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ21_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ21_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 21 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ21                  XDMAC_GSWR_SWREQ21_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ21_Msk instead */
+#define XDMAC_GSWR_SWREQ22_Pos              22                                             /**< (XDMAC_GSWR) XDMAC Channel 22 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ22_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ22_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 22 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ22                  XDMAC_GSWR_SWREQ22_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ22_Msk instead */
+#define XDMAC_GSWR_SWREQ23_Pos              23                                             /**< (XDMAC_GSWR) XDMAC Channel 23 Software Request Bit Position */
+#define XDMAC_GSWR_SWREQ23_Msk              (_U_(0x1) << XDMAC_GSWR_SWREQ23_Pos)           /**< (XDMAC_GSWR) XDMAC Channel 23 Software Request Bit Mask */
+#define XDMAC_GSWR_SWREQ23                  XDMAC_GSWR_SWREQ23_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWR_SWREQ23_Msk instead */
+#define XDMAC_GSWR_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWR) Register MASK  (Use XDMAC_GSWR_Msk instead)  */
+#define XDMAC_GSWR_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWR) Register Mask  */
+
+#define XDMAC_GSWR_SWREQ_Pos                0                                              /**< (XDMAC_GSWR Position) XDMAC Channel 23 Software Request Bit */
+#define XDMAC_GSWR_SWREQ_Msk                (_U_(0xFFFFFF) << XDMAC_GSWR_SWREQ_Pos)        /**< (XDMAC_GSWR Mask) SWREQ */
+#define XDMAC_GSWR_SWREQ(value)             (XDMAC_GSWR_SWREQ_Msk & ((value) << XDMAC_GSWR_SWREQ_Pos))  
+
+/* -------- XDMAC_GSWS : (XDMAC Offset: 0x3c) (R/ 32) Global Channel Software Request Status Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWRS0:1;                   /**< bit:      0  XDMAC Channel 0 Software Request Status Bit */
+    uint32_t SWRS1:1;                   /**< bit:      1  XDMAC Channel 1 Software Request Status Bit */
+    uint32_t SWRS2:1;                   /**< bit:      2  XDMAC Channel 2 Software Request Status Bit */
+    uint32_t SWRS3:1;                   /**< bit:      3  XDMAC Channel 3 Software Request Status Bit */
+    uint32_t SWRS4:1;                   /**< bit:      4  XDMAC Channel 4 Software Request Status Bit */
+    uint32_t SWRS5:1;                   /**< bit:      5  XDMAC Channel 5 Software Request Status Bit */
+    uint32_t SWRS6:1;                   /**< bit:      6  XDMAC Channel 6 Software Request Status Bit */
+    uint32_t SWRS7:1;                   /**< bit:      7  XDMAC Channel 7 Software Request Status Bit */
+    uint32_t SWRS8:1;                   /**< bit:      8  XDMAC Channel 8 Software Request Status Bit */
+    uint32_t SWRS9:1;                   /**< bit:      9  XDMAC Channel 9 Software Request Status Bit */
+    uint32_t SWRS10:1;                  /**< bit:     10  XDMAC Channel 10 Software Request Status Bit */
+    uint32_t SWRS11:1;                  /**< bit:     11  XDMAC Channel 11 Software Request Status Bit */
+    uint32_t SWRS12:1;                  /**< bit:     12  XDMAC Channel 12 Software Request Status Bit */
+    uint32_t SWRS13:1;                  /**< bit:     13  XDMAC Channel 13 Software Request Status Bit */
+    uint32_t SWRS14:1;                  /**< bit:     14  XDMAC Channel 14 Software Request Status Bit */
+    uint32_t SWRS15:1;                  /**< bit:     15  XDMAC Channel 15 Software Request Status Bit */
+    uint32_t SWRS16:1;                  /**< bit:     16  XDMAC Channel 16 Software Request Status Bit */
+    uint32_t SWRS17:1;                  /**< bit:     17  XDMAC Channel 17 Software Request Status Bit */
+    uint32_t SWRS18:1;                  /**< bit:     18  XDMAC Channel 18 Software Request Status Bit */
+    uint32_t SWRS19:1;                  /**< bit:     19  XDMAC Channel 19 Software Request Status Bit */
+    uint32_t SWRS20:1;                  /**< bit:     20  XDMAC Channel 20 Software Request Status Bit */
+    uint32_t SWRS21:1;                  /**< bit:     21  XDMAC Channel 21 Software Request Status Bit */
+    uint32_t SWRS22:1;                  /**< bit:     22  XDMAC Channel 22 Software Request Status Bit */
+    uint32_t SWRS23:1;                  /**< bit:     23  XDMAC Channel 23 Software Request Status Bit */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWRS:24;                   /**< bit:  0..23  XDMAC Channel 23 Software Request Status Bit */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWS_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWS_OFFSET                   (0x3C)                                        /**<  (XDMAC_GSWS) Global Channel Software Request Status Register  Offset */
+
+#define XDMAC_GSWS_SWRS0_Pos                0                                              /**< (XDMAC_GSWS) XDMAC Channel 0 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS0_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS0_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 0 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS0                    XDMAC_GSWS_SWRS0_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS0_Msk instead */
+#define XDMAC_GSWS_SWRS1_Pos                1                                              /**< (XDMAC_GSWS) XDMAC Channel 1 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS1_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS1_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 1 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS1                    XDMAC_GSWS_SWRS1_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS1_Msk instead */
+#define XDMAC_GSWS_SWRS2_Pos                2                                              /**< (XDMAC_GSWS) XDMAC Channel 2 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS2_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS2_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 2 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS2                    XDMAC_GSWS_SWRS2_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS2_Msk instead */
+#define XDMAC_GSWS_SWRS3_Pos                3                                              /**< (XDMAC_GSWS) XDMAC Channel 3 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS3_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS3_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 3 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS3                    XDMAC_GSWS_SWRS3_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS3_Msk instead */
+#define XDMAC_GSWS_SWRS4_Pos                4                                              /**< (XDMAC_GSWS) XDMAC Channel 4 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS4_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS4_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 4 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS4                    XDMAC_GSWS_SWRS4_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS4_Msk instead */
+#define XDMAC_GSWS_SWRS5_Pos                5                                              /**< (XDMAC_GSWS) XDMAC Channel 5 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS5_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS5_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 5 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS5                    XDMAC_GSWS_SWRS5_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS5_Msk instead */
+#define XDMAC_GSWS_SWRS6_Pos                6                                              /**< (XDMAC_GSWS) XDMAC Channel 6 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS6_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS6_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 6 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS6                    XDMAC_GSWS_SWRS6_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS6_Msk instead */
+#define XDMAC_GSWS_SWRS7_Pos                7                                              /**< (XDMAC_GSWS) XDMAC Channel 7 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS7_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS7_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 7 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS7                    XDMAC_GSWS_SWRS7_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS7_Msk instead */
+#define XDMAC_GSWS_SWRS8_Pos                8                                              /**< (XDMAC_GSWS) XDMAC Channel 8 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS8_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS8_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 8 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS8                    XDMAC_GSWS_SWRS8_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS8_Msk instead */
+#define XDMAC_GSWS_SWRS9_Pos                9                                              /**< (XDMAC_GSWS) XDMAC Channel 9 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS9_Msk                (_U_(0x1) << XDMAC_GSWS_SWRS9_Pos)             /**< (XDMAC_GSWS) XDMAC Channel 9 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS9                    XDMAC_GSWS_SWRS9_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS9_Msk instead */
+#define XDMAC_GSWS_SWRS10_Pos               10                                             /**< (XDMAC_GSWS) XDMAC Channel 10 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS10_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS10_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 10 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS10                   XDMAC_GSWS_SWRS10_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS10_Msk instead */
+#define XDMAC_GSWS_SWRS11_Pos               11                                             /**< (XDMAC_GSWS) XDMAC Channel 11 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS11_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS11_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 11 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS11                   XDMAC_GSWS_SWRS11_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS11_Msk instead */
+#define XDMAC_GSWS_SWRS12_Pos               12                                             /**< (XDMAC_GSWS) XDMAC Channel 12 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS12_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS12_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 12 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS12                   XDMAC_GSWS_SWRS12_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS12_Msk instead */
+#define XDMAC_GSWS_SWRS13_Pos               13                                             /**< (XDMAC_GSWS) XDMAC Channel 13 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS13_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS13_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 13 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS13                   XDMAC_GSWS_SWRS13_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS13_Msk instead */
+#define XDMAC_GSWS_SWRS14_Pos               14                                             /**< (XDMAC_GSWS) XDMAC Channel 14 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS14_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS14_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 14 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS14                   XDMAC_GSWS_SWRS14_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS14_Msk instead */
+#define XDMAC_GSWS_SWRS15_Pos               15                                             /**< (XDMAC_GSWS) XDMAC Channel 15 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS15_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS15_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 15 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS15                   XDMAC_GSWS_SWRS15_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS15_Msk instead */
+#define XDMAC_GSWS_SWRS16_Pos               16                                             /**< (XDMAC_GSWS) XDMAC Channel 16 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS16_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS16_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 16 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS16                   XDMAC_GSWS_SWRS16_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS16_Msk instead */
+#define XDMAC_GSWS_SWRS17_Pos               17                                             /**< (XDMAC_GSWS) XDMAC Channel 17 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS17_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS17_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 17 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS17                   XDMAC_GSWS_SWRS17_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS17_Msk instead */
+#define XDMAC_GSWS_SWRS18_Pos               18                                             /**< (XDMAC_GSWS) XDMAC Channel 18 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS18_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS18_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 18 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS18                   XDMAC_GSWS_SWRS18_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS18_Msk instead */
+#define XDMAC_GSWS_SWRS19_Pos               19                                             /**< (XDMAC_GSWS) XDMAC Channel 19 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS19_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS19_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 19 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS19                   XDMAC_GSWS_SWRS19_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS19_Msk instead */
+#define XDMAC_GSWS_SWRS20_Pos               20                                             /**< (XDMAC_GSWS) XDMAC Channel 20 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS20_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS20_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 20 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS20                   XDMAC_GSWS_SWRS20_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS20_Msk instead */
+#define XDMAC_GSWS_SWRS21_Pos               21                                             /**< (XDMAC_GSWS) XDMAC Channel 21 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS21_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS21_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 21 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS21                   XDMAC_GSWS_SWRS21_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS21_Msk instead */
+#define XDMAC_GSWS_SWRS22_Pos               22                                             /**< (XDMAC_GSWS) XDMAC Channel 22 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS22_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS22_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 22 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS22                   XDMAC_GSWS_SWRS22_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS22_Msk instead */
+#define XDMAC_GSWS_SWRS23_Pos               23                                             /**< (XDMAC_GSWS) XDMAC Channel 23 Software Request Status Bit Position */
+#define XDMAC_GSWS_SWRS23_Msk               (_U_(0x1) << XDMAC_GSWS_SWRS23_Pos)            /**< (XDMAC_GSWS) XDMAC Channel 23 Software Request Status Bit Mask */
+#define XDMAC_GSWS_SWRS23                   XDMAC_GSWS_SWRS23_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWS_SWRS23_Msk instead */
+#define XDMAC_GSWS_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWS) Register MASK  (Use XDMAC_GSWS_Msk instead)  */
+#define XDMAC_GSWS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWS) Register Mask  */
+
+#define XDMAC_GSWS_SWRS_Pos                 0                                              /**< (XDMAC_GSWS Position) XDMAC Channel 23 Software Request Status Bit */
+#define XDMAC_GSWS_SWRS_Msk                 (_U_(0xFFFFFF) << XDMAC_GSWS_SWRS_Pos)         /**< (XDMAC_GSWS Mask) SWRS */
+#define XDMAC_GSWS_SWRS(value)              (XDMAC_GSWS_SWRS_Msk & ((value) << XDMAC_GSWS_SWRS_Pos))  
+
+/* -------- XDMAC_GSWF : (XDMAC Offset: 0x40) (/W 32) Global Channel Software Flush Request Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SWF0:1;                    /**< bit:      0  XDMAC Channel 0 Software Flush Request Bit */
+    uint32_t SWF1:1;                    /**< bit:      1  XDMAC Channel 1 Software Flush Request Bit */
+    uint32_t SWF2:1;                    /**< bit:      2  XDMAC Channel 2 Software Flush Request Bit */
+    uint32_t SWF3:1;                    /**< bit:      3  XDMAC Channel 3 Software Flush Request Bit */
+    uint32_t SWF4:1;                    /**< bit:      4  XDMAC Channel 4 Software Flush Request Bit */
+    uint32_t SWF5:1;                    /**< bit:      5  XDMAC Channel 5 Software Flush Request Bit */
+    uint32_t SWF6:1;                    /**< bit:      6  XDMAC Channel 6 Software Flush Request Bit */
+    uint32_t SWF7:1;                    /**< bit:      7  XDMAC Channel 7 Software Flush Request Bit */
+    uint32_t SWF8:1;                    /**< bit:      8  XDMAC Channel 8 Software Flush Request Bit */
+    uint32_t SWF9:1;                    /**< bit:      9  XDMAC Channel 9 Software Flush Request Bit */
+    uint32_t SWF10:1;                   /**< bit:     10  XDMAC Channel 10 Software Flush Request Bit */
+    uint32_t SWF11:1;                   /**< bit:     11  XDMAC Channel 11 Software Flush Request Bit */
+    uint32_t SWF12:1;                   /**< bit:     12  XDMAC Channel 12 Software Flush Request Bit */
+    uint32_t SWF13:1;                   /**< bit:     13  XDMAC Channel 13 Software Flush Request Bit */
+    uint32_t SWF14:1;                   /**< bit:     14  XDMAC Channel 14 Software Flush Request Bit */
+    uint32_t SWF15:1;                   /**< bit:     15  XDMAC Channel 15 Software Flush Request Bit */
+    uint32_t SWF16:1;                   /**< bit:     16  XDMAC Channel 16 Software Flush Request Bit */
+    uint32_t SWF17:1;                   /**< bit:     17  XDMAC Channel 17 Software Flush Request Bit */
+    uint32_t SWF18:1;                   /**< bit:     18  XDMAC Channel 18 Software Flush Request Bit */
+    uint32_t SWF19:1;                   /**< bit:     19  XDMAC Channel 19 Software Flush Request Bit */
+    uint32_t SWF20:1;                   /**< bit:     20  XDMAC Channel 20 Software Flush Request Bit */
+    uint32_t SWF21:1;                   /**< bit:     21  XDMAC Channel 21 Software Flush Request Bit */
+    uint32_t SWF22:1;                   /**< bit:     22  XDMAC Channel 22 Software Flush Request Bit */
+    uint32_t SWF23:1;                   /**< bit:     23  XDMAC Channel 23 Software Flush Request Bit */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t SWF:24;                    /**< bit:  0..23  XDMAC Channel 23 Software Flush Request Bit */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
+  uint32_t reg;                         /**< Type used for register access */
+} XDMAC_GSWF_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define XDMAC_GSWF_OFFSET                   (0x40)                                        /**<  (XDMAC_GSWF) Global Channel Software Flush Request Register  Offset */
+
+#define XDMAC_GSWF_SWF0_Pos                 0                                              /**< (XDMAC_GSWF) XDMAC Channel 0 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF0_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF0_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 0 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF0                     XDMAC_GSWF_SWF0_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF0_Msk instead */
+#define XDMAC_GSWF_SWF1_Pos                 1                                              /**< (XDMAC_GSWF) XDMAC Channel 1 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF1_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF1_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 1 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF1                     XDMAC_GSWF_SWF1_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF1_Msk instead */
+#define XDMAC_GSWF_SWF2_Pos                 2                                              /**< (XDMAC_GSWF) XDMAC Channel 2 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF2_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF2_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 2 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF2                     XDMAC_GSWF_SWF2_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF2_Msk instead */
+#define XDMAC_GSWF_SWF3_Pos                 3                                              /**< (XDMAC_GSWF) XDMAC Channel 3 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF3_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF3_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 3 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF3                     XDMAC_GSWF_SWF3_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF3_Msk instead */
+#define XDMAC_GSWF_SWF4_Pos                 4                                              /**< (XDMAC_GSWF) XDMAC Channel 4 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF4_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF4_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 4 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF4                     XDMAC_GSWF_SWF4_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF4_Msk instead */
+#define XDMAC_GSWF_SWF5_Pos                 5                                              /**< (XDMAC_GSWF) XDMAC Channel 5 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF5_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF5_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 5 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF5                     XDMAC_GSWF_SWF5_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF5_Msk instead */
+#define XDMAC_GSWF_SWF6_Pos                 6                                              /**< (XDMAC_GSWF) XDMAC Channel 6 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF6_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF6_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 6 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF6                     XDMAC_GSWF_SWF6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF6_Msk instead */
+#define XDMAC_GSWF_SWF7_Pos                 7                                              /**< (XDMAC_GSWF) XDMAC Channel 7 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF7_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF7_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 7 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF7                     XDMAC_GSWF_SWF7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF7_Msk instead */
+#define XDMAC_GSWF_SWF8_Pos                 8                                              /**< (XDMAC_GSWF) XDMAC Channel 8 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF8_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF8_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 8 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF8                     XDMAC_GSWF_SWF8_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF8_Msk instead */
+#define XDMAC_GSWF_SWF9_Pos                 9                                              /**< (XDMAC_GSWF) XDMAC Channel 9 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF9_Msk                 (_U_(0x1) << XDMAC_GSWF_SWF9_Pos)              /**< (XDMAC_GSWF) XDMAC Channel 9 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF9                     XDMAC_GSWF_SWF9_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF9_Msk instead */
+#define XDMAC_GSWF_SWF10_Pos                10                                             /**< (XDMAC_GSWF) XDMAC Channel 10 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF10_Msk                (_U_(0x1) << XDMAC_GSWF_SWF10_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 10 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF10                    XDMAC_GSWF_SWF10_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF10_Msk instead */
+#define XDMAC_GSWF_SWF11_Pos                11                                             /**< (XDMAC_GSWF) XDMAC Channel 11 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF11_Msk                (_U_(0x1) << XDMAC_GSWF_SWF11_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 11 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF11                    XDMAC_GSWF_SWF11_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF11_Msk instead */
+#define XDMAC_GSWF_SWF12_Pos                12                                             /**< (XDMAC_GSWF) XDMAC Channel 12 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF12_Msk                (_U_(0x1) << XDMAC_GSWF_SWF12_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 12 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF12                    XDMAC_GSWF_SWF12_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF12_Msk instead */
+#define XDMAC_GSWF_SWF13_Pos                13                                             /**< (XDMAC_GSWF) XDMAC Channel 13 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF13_Msk                (_U_(0x1) << XDMAC_GSWF_SWF13_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 13 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF13                    XDMAC_GSWF_SWF13_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF13_Msk instead */
+#define XDMAC_GSWF_SWF14_Pos                14                                             /**< (XDMAC_GSWF) XDMAC Channel 14 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF14_Msk                (_U_(0x1) << XDMAC_GSWF_SWF14_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 14 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF14                    XDMAC_GSWF_SWF14_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF14_Msk instead */
+#define XDMAC_GSWF_SWF15_Pos                15                                             /**< (XDMAC_GSWF) XDMAC Channel 15 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF15_Msk                (_U_(0x1) << XDMAC_GSWF_SWF15_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 15 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF15                    XDMAC_GSWF_SWF15_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF15_Msk instead */
+#define XDMAC_GSWF_SWF16_Pos                16                                             /**< (XDMAC_GSWF) XDMAC Channel 16 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF16_Msk                (_U_(0x1) << XDMAC_GSWF_SWF16_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 16 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF16                    XDMAC_GSWF_SWF16_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF16_Msk instead */
+#define XDMAC_GSWF_SWF17_Pos                17                                             /**< (XDMAC_GSWF) XDMAC Channel 17 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF17_Msk                (_U_(0x1) << XDMAC_GSWF_SWF17_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 17 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF17                    XDMAC_GSWF_SWF17_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF17_Msk instead */
+#define XDMAC_GSWF_SWF18_Pos                18                                             /**< (XDMAC_GSWF) XDMAC Channel 18 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF18_Msk                (_U_(0x1) << XDMAC_GSWF_SWF18_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 18 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF18                    XDMAC_GSWF_SWF18_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF18_Msk instead */
+#define XDMAC_GSWF_SWF19_Pos                19                                             /**< (XDMAC_GSWF) XDMAC Channel 19 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF19_Msk                (_U_(0x1) << XDMAC_GSWF_SWF19_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 19 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF19                    XDMAC_GSWF_SWF19_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF19_Msk instead */
+#define XDMAC_GSWF_SWF20_Pos                20                                             /**< (XDMAC_GSWF) XDMAC Channel 20 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF20_Msk                (_U_(0x1) << XDMAC_GSWF_SWF20_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 20 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF20                    XDMAC_GSWF_SWF20_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF20_Msk instead */
+#define XDMAC_GSWF_SWF21_Pos                21                                             /**< (XDMAC_GSWF) XDMAC Channel 21 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF21_Msk                (_U_(0x1) << XDMAC_GSWF_SWF21_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 21 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF21                    XDMAC_GSWF_SWF21_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF21_Msk instead */
+#define XDMAC_GSWF_SWF22_Pos                22                                             /**< (XDMAC_GSWF) XDMAC Channel 22 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF22_Msk                (_U_(0x1) << XDMAC_GSWF_SWF22_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 22 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF22                    XDMAC_GSWF_SWF22_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF22_Msk instead */
+#define XDMAC_GSWF_SWF23_Pos                23                                             /**< (XDMAC_GSWF) XDMAC Channel 23 Software Flush Request Bit Position */
+#define XDMAC_GSWF_SWF23_Msk                (_U_(0x1) << XDMAC_GSWF_SWF23_Pos)             /**< (XDMAC_GSWF) XDMAC Channel 23 Software Flush Request Bit Mask */
+#define XDMAC_GSWF_SWF23                    XDMAC_GSWF_SWF23_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_GSWF_SWF23_Msk instead */
+#define XDMAC_GSWF_MASK                     _U_(0xFFFFFF)                                  /**< \deprecated (XDMAC_GSWF) Register MASK  (Use XDMAC_GSWF_Msk instead)  */
+#define XDMAC_GSWF_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_GSWF) Register Mask  */
+
+#define XDMAC_GSWF_SWF_Pos                  0                                              /**< (XDMAC_GSWF Position) XDMAC Channel 23 Software Flush Request Bit */
+#define XDMAC_GSWF_SWF_Msk                  (_U_(0xFFFFFF) << XDMAC_GSWF_SWF_Pos)          /**< (XDMAC_GSWF Mask) SWF */
+#define XDMAC_GSWF_SWF(value)               (XDMAC_GSWF_SWF_Msk & ((value) << XDMAC_GSWF_SWF_Pos))  
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief XDMAC_CHID hardware registers */
+typedef struct {  
+  __O  uint32_t XDMAC_CIE;      /**< (XDMAC_CHID Offset: 0x00) Channel Interrupt Enable Register */
+  __O  uint32_t XDMAC_CID;      /**< (XDMAC_CHID Offset: 0x04) Channel Interrupt Disable Register */
+  __I  uint32_t XDMAC_CIM;      /**< (XDMAC_CHID Offset: 0x08) Channel Interrupt Mask Register */
+  __I  uint32_t XDMAC_CIS;      /**< (XDMAC_CHID Offset: 0x0C) Channel Interrupt Status Register */
+  __IO uint32_t XDMAC_CSA;      /**< (XDMAC_CHID Offset: 0x10) Channel Source Address Register */
+  __IO uint32_t XDMAC_CDA;      /**< (XDMAC_CHID Offset: 0x14) Channel Destination Address Register */
+  __IO uint32_t XDMAC_CNDA;     /**< (XDMAC_CHID Offset: 0x18) Channel Next Descriptor Address Register */
+  __IO uint32_t XDMAC_CNDC;     /**< (XDMAC_CHID Offset: 0x1C) Channel Next Descriptor Control Register */
+  __IO uint32_t XDMAC_CUBC;     /**< (XDMAC_CHID Offset: 0x20) Channel Microblock Control Register */
+  __IO uint32_t XDMAC_CBC;      /**< (XDMAC_CHID Offset: 0x24) Channel Block Control Register */
+  __IO uint32_t XDMAC_CC;       /**< (XDMAC_CHID Offset: 0x28) Channel Configuration Register */
+  __IO uint32_t XDMAC_CDS_MSP;  /**< (XDMAC_CHID Offset: 0x2C) Channel Data Stride Memory Set Pattern */
+  __IO uint32_t XDMAC_CSUS;     /**< (XDMAC_CHID Offset: 0x30) Channel Source Microblock Stride */
+  __IO uint32_t XDMAC_CDUS;     /**< (XDMAC_CHID Offset: 0x34) Channel Destination Microblock Stride */
+  __I  uint8_t                        Reserved1[8];
+} XdmacChid;
+
+#define XDMACCHID_NUMBER 24
+/** \brief XDMAC hardware registers */
+typedef struct {  
+  __I  uint32_t XDMAC_GTYPE;    /**< (XDMAC Offset: 0x00) Global Type Register */
+  __IO uint32_t XDMAC_GCFG;     /**< (XDMAC Offset: 0x04) Global Configuration Register */
+  __IO uint32_t XDMAC_GWAC;     /**< (XDMAC Offset: 0x08) Global Weighted Arbiter Configuration Register */
+  __O  uint32_t XDMAC_GIE;      /**< (XDMAC Offset: 0x0C) Global Interrupt Enable Register */
+  __O  uint32_t XDMAC_GID;      /**< (XDMAC Offset: 0x10) Global Interrupt Disable Register */
+  __I  uint32_t XDMAC_GIM;      /**< (XDMAC Offset: 0x14) Global Interrupt Mask Register */
+  __I  uint32_t XDMAC_GIS;      /**< (XDMAC Offset: 0x18) Global Interrupt Status Register */
+  __O  uint32_t XDMAC_GE;       /**< (XDMAC Offset: 0x1C) Global Channel Enable Register */
+  __O  uint32_t XDMAC_GD;       /**< (XDMAC Offset: 0x20) Global Channel Disable Register */
+  __I  uint32_t XDMAC_GS;       /**< (XDMAC Offset: 0x24) Global Channel Status Register */
+  __IO uint32_t XDMAC_GRS;      /**< (XDMAC Offset: 0x28) Global Channel Read Suspend Register */
+  __IO uint32_t XDMAC_GWS;      /**< (XDMAC Offset: 0x2C) Global Channel Write Suspend Register */
+  __O  uint32_t XDMAC_GRWS;     /**< (XDMAC Offset: 0x30) Global Channel Read Write Suspend Register */
+  __O  uint32_t XDMAC_GRWR;     /**< (XDMAC Offset: 0x34) Global Channel Read Write Resume Register */
+  __O  uint32_t XDMAC_GSWR;     /**< (XDMAC Offset: 0x38) Global Channel Software Request Register */
+  __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
+  __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register */
+} Xdmac;
+
+#elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief XDMAC_CHID hardware registers */
+typedef struct {  
+  __O  XDMAC_CIE_Type                 XDMAC_CIE;      /**< Offset: 0x00 ( /W  32) Channel Interrupt Enable Register */
+  __O  XDMAC_CID_Type                 XDMAC_CID;      /**< Offset: 0x04 ( /W  32) Channel Interrupt Disable Register */
+  __I  XDMAC_CIM_Type                 XDMAC_CIM;      /**< Offset: 0x08 (R/   32) Channel Interrupt Mask Register */
+  __I  XDMAC_CIS_Type                 XDMAC_CIS;      /**< Offset: 0x0C (R/   32) Channel Interrupt Status Register */
+  __IO XDMAC_CSA_Type                 XDMAC_CSA;      /**< Offset: 0x10 (R/W  32) Channel Source Address Register */
+  __IO XDMAC_CDA_Type                 XDMAC_CDA;      /**< Offset: 0x14 (R/W  32) Channel Destination Address Register */
+  __IO XDMAC_CNDA_Type                XDMAC_CNDA;     /**< Offset: 0x18 (R/W  32) Channel Next Descriptor Address Register */
+  __IO XDMAC_CNDC_Type                XDMAC_CNDC;     /**< Offset: 0x1C (R/W  32) Channel Next Descriptor Control Register */
+  __IO XDMAC_CUBC_Type                XDMAC_CUBC;     /**< Offset: 0x20 (R/W  32) Channel Microblock Control Register */
+  __IO XDMAC_CBC_Type                 XDMAC_CBC;      /**< Offset: 0x24 (R/W  32) Channel Block Control Register */
+  __IO XDMAC_CC_Type                  XDMAC_CC;       /**< Offset: 0x28 (R/W  32) Channel Configuration Register */
+  __IO XDMAC_CDS_MSP_Type             XDMAC_CDS_MSP;  /**< Offset: 0x2C (R/W  32) Channel Data Stride Memory Set Pattern */
+  __IO XDMAC_CSUS_Type                XDMAC_CSUS;     /**< Offset: 0x30 (R/W  32) Channel Source Microblock Stride */
+  __IO XDMAC_CDUS_Type                XDMAC_CDUS;     /**< Offset: 0x34 (R/W  32) Channel Destination Microblock Stride */
+  __I  uint8_t                        Reserved1[8];
+} XdmacChid;
+
+/** \brief XDMAC hardware registers */
+typedef struct {  
+  __I  XDMAC_GTYPE_Type               XDMAC_GTYPE;    /**< Offset: 0x00 (R/   32) Global Type Register */
+  __IO XDMAC_GCFG_Type                XDMAC_GCFG;     /**< Offset: 0x04 (R/W  32) Global Configuration Register */
+  __IO XDMAC_GWAC_Type                XDMAC_GWAC;     /**< Offset: 0x08 (R/W  32) Global Weighted Arbiter Configuration Register */
+  __O  XDMAC_GIE_Type                 XDMAC_GIE;      /**< Offset: 0x0C ( /W  32) Global Interrupt Enable Register */
+  __O  XDMAC_GID_Type                 XDMAC_GID;      /**< Offset: 0x10 ( /W  32) Global Interrupt Disable Register */
+  __I  XDMAC_GIM_Type                 XDMAC_GIM;      /**< Offset: 0x14 (R/   32) Global Interrupt Mask Register */
+  __I  XDMAC_GIS_Type                 XDMAC_GIS;      /**< Offset: 0x18 (R/   32) Global Interrupt Status Register */
+  __O  XDMAC_GE_Type                  XDMAC_GE;       /**< Offset: 0x1C ( /W  32) Global Channel Enable Register */
+  __O  XDMAC_GD_Type                  XDMAC_GD;       /**< Offset: 0x20 ( /W  32) Global Channel Disable Register */
+  __I  XDMAC_GS_Type                  XDMAC_GS;       /**< Offset: 0x24 (R/   32) Global Channel Status Register */
+  __IO XDMAC_GRS_Type                 XDMAC_GRS;      /**< Offset: 0x28 (R/W  32) Global Channel Read Suspend Register */
+  __IO XDMAC_GWS_Type                 XDMAC_GWS;      /**< Offset: 0x2C (R/W  32) Global Channel Write Suspend Register */
+  __O  XDMAC_GRWS_Type                XDMAC_GRWS;     /**< Offset: 0x30 ( /W  32) Global Channel Read Write Suspend Register */
+  __O  XDMAC_GRWR_Type                XDMAC_GRWR;     /**< Offset: 0x34 ( /W  32) Global Channel Read Write Resume Register */
+  __O  XDMAC_GSWR_Type                XDMAC_GSWR;     /**< Offset: 0x38 ( /W  32) Global Channel Software Request Register */
+  __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
+  __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register */
+} Xdmac;
+
+#else /* COMPONENT_TYPEDEF_STYLE */
+#error Unknown component typedef style
+#endif /* COMPONENT_TYPEDEF_STYLE */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Extensible DMA Controller */
+
+#endif /* _SAMV71_XDMAC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/instance/acc.h
+++ b/asf/sam/include/samv71b/instance/acc.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ACC_INSTANCE_H_
+#define _SAMV71_ACC_INSTANCE_H_
+
+/* ========== Register definition for ACC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ACC_CR              (0x40044000) /**< (ACC) Control Register */
+#define REG_ACC_MR              (0x40044004) /**< (ACC) Mode Register */
+#define REG_ACC_IER             (0x40044024) /**< (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR             (0x40044028) /**< (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR             (0x4004402C) /**< (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR             (0x40044030) /**< (ACC) Interrupt Status Register */
+#define REG_ACC_ACR             (0x40044094) /**< (ACC) Analog Control Register */
+#define REG_ACC_WPMR            (0x400440E4) /**< (ACC) Write Protection Mode Register */
+#define REG_ACC_WPSR            (0x400440E8) /**< (ACC) Write Protection Status Register */
+
+#else
+
+#define REG_ACC_CR              (*(__O  uint32_t*)0x40044000U) /**< (ACC) Control Register */
+#define REG_ACC_MR              (*(__IO uint32_t*)0x40044004U) /**< (ACC) Mode Register */
+#define REG_ACC_IER             (*(__O  uint32_t*)0x40044024U) /**< (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR             (*(__O  uint32_t*)0x40044028U) /**< (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR             (*(__I  uint32_t*)0x4004402CU) /**< (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR             (*(__I  uint32_t*)0x40044030U) /**< (ACC) Interrupt Status Register */
+#define REG_ACC_ACR             (*(__IO uint32_t*)0x40044094U) /**< (ACC) Analog Control Register */
+#define REG_ACC_WPMR            (*(__IO uint32_t*)0x400440E4U) /**< (ACC) Write Protection Mode Register */
+#define REG_ACC_WPSR            (*(__I  uint32_t*)0x400440E8U) /**< (ACC) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ACC peripheral ========== */
+#define ACC_INSTANCE_ID                          33         
+#define ACC_CLOCK_ID                             33         
+#define ACC_HAS_PLUS_COMPARATOR_SELECTION        1          
+#define ACC_HAS_MINUS_COMPARATOR_SELECTION       1          
+#define ACC_HAS_INVERTED_COMPARATOR              1          
+#define ACC_HAS_EDGETYPE_SELECTION               1          
+#define ACC_HAS_INTERRUPTS                       1          
+#define ACC_HAS_CURRENT_SELECTION                1          
+#define ACC_HAS_HYSTERESIS                       1          
+#define ACC_HAS_FAULT_ENABLE                     1          
+
+#endif /* _SAMV71_ACC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/aes.h
+++ b/asf/sam/include/samv71b/instance/aes.h
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AES
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_AES_INSTANCE_H_
+#define _SAMV71_AES_INSTANCE_H_
+
+/* ========== Register definition for AES peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AES_CR              (0x4006C000) /**< (AES) Control Register */
+#define REG_AES_MR              (0x4006C004) /**< (AES) Mode Register */
+#define REG_AES_IER             (0x4006C010) /**< (AES) Interrupt Enable Register */
+#define REG_AES_IDR             (0x4006C014) /**< (AES) Interrupt Disable Register */
+#define REG_AES_IMR             (0x4006C018) /**< (AES) Interrupt Mask Register */
+#define REG_AES_ISR             (0x4006C01C) /**< (AES) Interrupt Status Register */
+#define REG_AES_KEYWR           (0x4006C020) /**< (AES) Key Word Register */
+#define REG_AES_KEYWR0          (0x4006C020) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR1          (0x4006C024) /**< (AES) Key Word Register 1 */
+#define REG_AES_KEYWR2          (0x4006C028) /**< (AES) Key Word Register 2 */
+#define REG_AES_KEYWR3          (0x4006C02C) /**< (AES) Key Word Register 3 */
+#define REG_AES_KEYWR4          (0x4006C030) /**< (AES) Key Word Register 4 */
+#define REG_AES_KEYWR5          (0x4006C034) /**< (AES) Key Word Register 5 */
+#define REG_AES_KEYWR6          (0x4006C038) /**< (AES) Key Word Register 6 */
+#define REG_AES_KEYWR7          (0x4006C03C) /**< (AES) Key Word Register 7 */
+#define REG_AES_IDATAR          (0x4006C040) /**< (AES) Input Data Register */
+#define REG_AES_IDATAR0         (0x4006C040) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR1         (0x4006C044) /**< (AES) Input Data Register 1 */
+#define REG_AES_IDATAR2         (0x4006C048) /**< (AES) Input Data Register 2 */
+#define REG_AES_IDATAR3         (0x4006C04C) /**< (AES) Input Data Register 3 */
+#define REG_AES_ODATAR          (0x4006C050) /**< (AES) Output Data Register */
+#define REG_AES_ODATAR0         (0x4006C050) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR1         (0x4006C054) /**< (AES) Output Data Register 1 */
+#define REG_AES_ODATAR2         (0x4006C058) /**< (AES) Output Data Register 2 */
+#define REG_AES_ODATAR3         (0x4006C05C) /**< (AES) Output Data Register 3 */
+#define REG_AES_IVR             (0x4006C060) /**< (AES) Initialization Vector Register */
+#define REG_AES_IVR0            (0x4006C060) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR1            (0x4006C064) /**< (AES) Initialization Vector Register 1 */
+#define REG_AES_IVR2            (0x4006C068) /**< (AES) Initialization Vector Register 2 */
+#define REG_AES_IVR3            (0x4006C06C) /**< (AES) Initialization Vector Register 3 */
+#define REG_AES_AADLENR         (0x4006C070) /**< (AES) Additional Authenticated Data Length Register */
+#define REG_AES_CLENR           (0x4006C074) /**< (AES) Plaintext/Ciphertext Length Register */
+#define REG_AES_GHASHR          (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register */
+#define REG_AES_GHASHR0         (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR1         (0x4006C07C) /**< (AES) GCM Intermediate Hash Word Register 1 */
+#define REG_AES_GHASHR2         (0x4006C080) /**< (AES) GCM Intermediate Hash Word Register 2 */
+#define REG_AES_GHASHR3         (0x4006C084) /**< (AES) GCM Intermediate Hash Word Register 3 */
+#define REG_AES_TAGR            (0x4006C088) /**< (AES) GCM Authentication Tag Word Register */
+#define REG_AES_TAGR0           (0x4006C088) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR1           (0x4006C08C) /**< (AES) GCM Authentication Tag Word Register 1 */
+#define REG_AES_TAGR2           (0x4006C090) /**< (AES) GCM Authentication Tag Word Register 2 */
+#define REG_AES_TAGR3           (0x4006C094) /**< (AES) GCM Authentication Tag Word Register 3 */
+#define REG_AES_CTRR            (0x4006C098) /**< (AES) GCM Encryption Counter Value Register */
+#define REG_AES_GCMHR           (0x4006C09C) /**< (AES) GCM H Word Register */
+#define REG_AES_GCMHR0          (0x4006C09C) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR1          (0x4006C0A0) /**< (AES) GCM H Word Register 1 */
+#define REG_AES_GCMHR2          (0x4006C0A4) /**< (AES) GCM H Word Register 2 */
+#define REG_AES_GCMHR3          (0x4006C0A8) /**< (AES) GCM H Word Register 3 */
+
+#else
+
+#define REG_AES_CR              (*(__O  uint32_t*)0x4006C000U) /**< (AES) Control Register */
+#define REG_AES_MR              (*(__IO uint32_t*)0x4006C004U) /**< (AES) Mode Register */
+#define REG_AES_IER             (*(__O  uint32_t*)0x4006C010U) /**< (AES) Interrupt Enable Register */
+#define REG_AES_IDR             (*(__O  uint32_t*)0x4006C014U) /**< (AES) Interrupt Disable Register */
+#define REG_AES_IMR             (*(__I  uint32_t*)0x4006C018U) /**< (AES) Interrupt Mask Register */
+#define REG_AES_ISR             (*(__I  uint32_t*)0x4006C01CU) /**< (AES) Interrupt Status Register */
+#define REG_AES_KEYWR           (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register */
+#define REG_AES_KEYWR0          (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR1          (*(__O  uint32_t*)0x4006C024U) /**< (AES) Key Word Register 1 */
+#define REG_AES_KEYWR2          (*(__O  uint32_t*)0x4006C028U) /**< (AES) Key Word Register 2 */
+#define REG_AES_KEYWR3          (*(__O  uint32_t*)0x4006C02CU) /**< (AES) Key Word Register 3 */
+#define REG_AES_KEYWR4          (*(__O  uint32_t*)0x4006C030U) /**< (AES) Key Word Register 4 */
+#define REG_AES_KEYWR5          (*(__O  uint32_t*)0x4006C034U) /**< (AES) Key Word Register 5 */
+#define REG_AES_KEYWR6          (*(__O  uint32_t*)0x4006C038U) /**< (AES) Key Word Register 6 */
+#define REG_AES_KEYWR7          (*(__O  uint32_t*)0x4006C03CU) /**< (AES) Key Word Register 7 */
+#define REG_AES_IDATAR          (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register */
+#define REG_AES_IDATAR0         (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR1         (*(__O  uint32_t*)0x4006C044U) /**< (AES) Input Data Register 1 */
+#define REG_AES_IDATAR2         (*(__O  uint32_t*)0x4006C048U) /**< (AES) Input Data Register 2 */
+#define REG_AES_IDATAR3         (*(__O  uint32_t*)0x4006C04CU) /**< (AES) Input Data Register 3 */
+#define REG_AES_ODATAR          (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register */
+#define REG_AES_ODATAR0         (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR1         (*(__I  uint32_t*)0x4006C054U) /**< (AES) Output Data Register 1 */
+#define REG_AES_ODATAR2         (*(__I  uint32_t*)0x4006C058U) /**< (AES) Output Data Register 2 */
+#define REG_AES_ODATAR3         (*(__I  uint32_t*)0x4006C05CU) /**< (AES) Output Data Register 3 */
+#define REG_AES_IVR             (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register */
+#define REG_AES_IVR0            (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR1            (*(__O  uint32_t*)0x4006C064U) /**< (AES) Initialization Vector Register 1 */
+#define REG_AES_IVR2            (*(__O  uint32_t*)0x4006C068U) /**< (AES) Initialization Vector Register 2 */
+#define REG_AES_IVR3            (*(__O  uint32_t*)0x4006C06CU) /**< (AES) Initialization Vector Register 3 */
+#define REG_AES_AADLENR         (*(__IO uint32_t*)0x4006C070U) /**< (AES) Additional Authenticated Data Length Register */
+#define REG_AES_CLENR           (*(__IO uint32_t*)0x4006C074U) /**< (AES) Plaintext/Ciphertext Length Register */
+#define REG_AES_GHASHR          (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register */
+#define REG_AES_GHASHR0         (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR1         (*(__IO uint32_t*)0x4006C07CU) /**< (AES) GCM Intermediate Hash Word Register 1 */
+#define REG_AES_GHASHR2         (*(__IO uint32_t*)0x4006C080U) /**< (AES) GCM Intermediate Hash Word Register 2 */
+#define REG_AES_GHASHR3         (*(__IO uint32_t*)0x4006C084U) /**< (AES) GCM Intermediate Hash Word Register 3 */
+#define REG_AES_TAGR            (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register */
+#define REG_AES_TAGR0           (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR1           (*(__I  uint32_t*)0x4006C08CU) /**< (AES) GCM Authentication Tag Word Register 1 */
+#define REG_AES_TAGR2           (*(__I  uint32_t*)0x4006C090U) /**< (AES) GCM Authentication Tag Word Register 2 */
+#define REG_AES_TAGR3           (*(__I  uint32_t*)0x4006C094U) /**< (AES) GCM Authentication Tag Word Register 3 */
+#define REG_AES_CTRR            (*(__I  uint32_t*)0x4006C098U) /**< (AES) GCM Encryption Counter Value Register */
+#define REG_AES_GCMHR           (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register */
+#define REG_AES_GCMHR0          (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR1          (*(__IO uint32_t*)0x4006C0A0U) /**< (AES) GCM H Word Register 1 */
+#define REG_AES_GCMHR2          (*(__IO uint32_t*)0x4006C0A4U) /**< (AES) GCM H Word Register 2 */
+#define REG_AES_GCMHR3          (*(__IO uint32_t*)0x4006C0A8U) /**< (AES) GCM H Word Register 3 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AES peripheral ========== */
+#define AES_DMAC_ID_TX                           37         
+#define AES_DMAC_ID_RX                           38         
+#define AES_INSTANCE_ID                          56         
+#define AES_CLOCK_ID                             56         
+
+#endif /* _SAMV71_AES_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/afec0.h
+++ b/asf/sam/include/samv71b/instance/afec0.h
@@ -1,0 +1,113 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AFEC0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_AFEC0_INSTANCE_H_
+#define _SAMV71_AFEC0_INSTANCE_H_
+
+/* ========== Register definition for AFEC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AFEC0_CR            (0x4003C000) /**< (AFEC0) AFEC Control Register */
+#define REG_AFEC0_MR            (0x4003C004) /**< (AFEC0) AFEC Mode Register */
+#define REG_AFEC0_EMR           (0x4003C008) /**< (AFEC0) AFEC Extended Mode Register */
+#define REG_AFEC0_SEQ1R         (0x4003C00C) /**< (AFEC0) AFEC Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R         (0x4003C010) /**< (AFEC0) AFEC Channel Sequence 2 Register */
+#define REG_AFEC0_CHER          (0x4003C014) /**< (AFEC0) AFEC Channel Enable Register */
+#define REG_AFEC0_CHDR          (0x4003C018) /**< (AFEC0) AFEC Channel Disable Register */
+#define REG_AFEC0_CHSR          (0x4003C01C) /**< (AFEC0) AFEC Channel Status Register */
+#define REG_AFEC0_LCDR          (0x4003C020) /**< (AFEC0) AFEC Last Converted Data Register */
+#define REG_AFEC0_IER           (0x4003C024) /**< (AFEC0) AFEC Interrupt Enable Register */
+#define REG_AFEC0_IDR           (0x4003C028) /**< (AFEC0) AFEC Interrupt Disable Register */
+#define REG_AFEC0_IMR           (0x4003C02C) /**< (AFEC0) AFEC Interrupt Mask Register */
+#define REG_AFEC0_ISR           (0x4003C030) /**< (AFEC0) AFEC Interrupt Status Register */
+#define REG_AFEC0_OVER          (0x4003C04C) /**< (AFEC0) AFEC Overrun Status Register */
+#define REG_AFEC0_CWR           (0x4003C050) /**< (AFEC0) AFEC Compare Window Register */
+#define REG_AFEC0_CGR           (0x4003C054) /**< (AFEC0) AFEC Channel Gain Register */
+#define REG_AFEC0_DIFFR         (0x4003C060) /**< (AFEC0) AFEC Channel Differential Register */
+#define REG_AFEC0_CSELR         (0x4003C064) /**< (AFEC0) AFEC Channel Selection Register */
+#define REG_AFEC0_CDR           (0x4003C068) /**< (AFEC0) AFEC Channel Data Register */
+#define REG_AFEC0_COCR          (0x4003C06C) /**< (AFEC0) AFEC Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR        (0x4003C070) /**< (AFEC0) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR       (0x4003C074) /**< (AFEC0) AFEC Temperature Compare Window Register */
+#define REG_AFEC0_ACR           (0x4003C094) /**< (AFEC0) AFEC Analog Control Register */
+#define REG_AFEC0_SHMR          (0x4003C0A0) /**< (AFEC0) AFEC Sample & Hold Mode Register */
+#define REG_AFEC0_COSR          (0x4003C0D0) /**< (AFEC0) AFEC Correction Select Register */
+#define REG_AFEC0_CVR           (0x4003C0D4) /**< (AFEC0) AFEC Correction Values Register */
+#define REG_AFEC0_CECR          (0x4003C0D8) /**< (AFEC0) AFEC Channel Error Correction Register */
+#define REG_AFEC0_WPMR          (0x4003C0E4) /**< (AFEC0) AFEC Write Protection Mode Register */
+#define REG_AFEC0_WPSR          (0x4003C0E8) /**< (AFEC0) AFEC Write Protection Status Register */
+
+#else
+
+#define REG_AFEC0_CR            (*(__O  uint32_t*)0x4003C000U) /**< (AFEC0) AFEC Control Register */
+#define REG_AFEC0_MR            (*(__IO uint32_t*)0x4003C004U) /**< (AFEC0) AFEC Mode Register */
+#define REG_AFEC0_EMR           (*(__IO uint32_t*)0x4003C008U) /**< (AFEC0) AFEC Extended Mode Register */
+#define REG_AFEC0_SEQ1R         (*(__IO uint32_t*)0x4003C00CU) /**< (AFEC0) AFEC Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R         (*(__IO uint32_t*)0x4003C010U) /**< (AFEC0) AFEC Channel Sequence 2 Register */
+#define REG_AFEC0_CHER          (*(__O  uint32_t*)0x4003C014U) /**< (AFEC0) AFEC Channel Enable Register */
+#define REG_AFEC0_CHDR          (*(__O  uint32_t*)0x4003C018U) /**< (AFEC0) AFEC Channel Disable Register */
+#define REG_AFEC0_CHSR          (*(__I  uint32_t*)0x4003C01CU) /**< (AFEC0) AFEC Channel Status Register */
+#define REG_AFEC0_LCDR          (*(__I  uint32_t*)0x4003C020U) /**< (AFEC0) AFEC Last Converted Data Register */
+#define REG_AFEC0_IER           (*(__O  uint32_t*)0x4003C024U) /**< (AFEC0) AFEC Interrupt Enable Register */
+#define REG_AFEC0_IDR           (*(__O  uint32_t*)0x4003C028U) /**< (AFEC0) AFEC Interrupt Disable Register */
+#define REG_AFEC0_IMR           (*(__I  uint32_t*)0x4003C02CU) /**< (AFEC0) AFEC Interrupt Mask Register */
+#define REG_AFEC0_ISR           (*(__I  uint32_t*)0x4003C030U) /**< (AFEC0) AFEC Interrupt Status Register */
+#define REG_AFEC0_OVER          (*(__I  uint32_t*)0x4003C04CU) /**< (AFEC0) AFEC Overrun Status Register */
+#define REG_AFEC0_CWR           (*(__IO uint32_t*)0x4003C050U) /**< (AFEC0) AFEC Compare Window Register */
+#define REG_AFEC0_CGR           (*(__IO uint32_t*)0x4003C054U) /**< (AFEC0) AFEC Channel Gain Register */
+#define REG_AFEC0_DIFFR         (*(__IO uint32_t*)0x4003C060U) /**< (AFEC0) AFEC Channel Differential Register */
+#define REG_AFEC0_CSELR         (*(__IO uint32_t*)0x4003C064U) /**< (AFEC0) AFEC Channel Selection Register */
+#define REG_AFEC0_CDR           (*(__I  uint32_t*)0x4003C068U) /**< (AFEC0) AFEC Channel Data Register */
+#define REG_AFEC0_COCR          (*(__IO uint32_t*)0x4003C06CU) /**< (AFEC0) AFEC Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR        (*(__IO uint32_t*)0x4003C070U) /**< (AFEC0) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR       (*(__IO uint32_t*)0x4003C074U) /**< (AFEC0) AFEC Temperature Compare Window Register */
+#define REG_AFEC0_ACR           (*(__IO uint32_t*)0x4003C094U) /**< (AFEC0) AFEC Analog Control Register */
+#define REG_AFEC0_SHMR          (*(__IO uint32_t*)0x4003C0A0U) /**< (AFEC0) AFEC Sample & Hold Mode Register */
+#define REG_AFEC0_COSR          (*(__IO uint32_t*)0x4003C0D0U) /**< (AFEC0) AFEC Correction Select Register */
+#define REG_AFEC0_CVR           (*(__IO uint32_t*)0x4003C0D4U) /**< (AFEC0) AFEC Correction Values Register */
+#define REG_AFEC0_CECR          (*(__IO uint32_t*)0x4003C0D8U) /**< (AFEC0) AFEC Channel Error Correction Register */
+#define REG_AFEC0_WPMR          (*(__IO uint32_t*)0x4003C0E4U) /**< (AFEC0) AFEC Write Protection Mode Register */
+#define REG_AFEC0_WPSR          (*(__I  uint32_t*)0x4003C0E8U) /**< (AFEC0) AFEC Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AFEC0 peripheral ========== */
+#define AFEC0_DMAC_ID_RX                         35         
+#define AFEC0_INSTANCE_ID                        29         
+#define AFEC0_CLOCK_ID                           29         
+#define AFEC0_TRGSEL_AFEC_TRIG0                  0x0        /* External ADC Trigger Input (AFE0_ADTRG pin) */
+#define AFEC0_TRGSEL_AFEC_TRIG1                  0x1        /* TC0 Channel 0 Output (TIOA0) */
+#define AFEC0_TRGSEL_AFEC_TRIG2                  0x2        /* TC0 Channel 1 Output (TIOA1) */
+#define AFEC0_TRGSEL_AFEC_TRIG3                  0x3        /* TC0 Channel 2 Output (TIOA2) */
+#define AFEC0_TRGSEL_AFEC_TRIG4                  0x4        /* PWM0 event line 0 */
+#define AFEC0_TRGSEL_AFEC_TRIG5                  0x5        /* PWM0 event line 1 */
+#define AFEC0_TRGSEL_AFEC_TRIG6                  0x6        /* Analog Comparator Fault Output */
+
+#endif /* _SAMV71_AFEC0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/afec1.h
+++ b/asf/sam/include/samv71b/instance/afec1.h
@@ -1,0 +1,113 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AFEC1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_AFEC1_INSTANCE_H_
+#define _SAMV71_AFEC1_INSTANCE_H_
+
+/* ========== Register definition for AFEC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_AFEC1_CR            (0x40064000) /**< (AFEC1) AFEC Control Register */
+#define REG_AFEC1_MR            (0x40064004) /**< (AFEC1) AFEC Mode Register */
+#define REG_AFEC1_EMR           (0x40064008) /**< (AFEC1) AFEC Extended Mode Register */
+#define REG_AFEC1_SEQ1R         (0x4006400C) /**< (AFEC1) AFEC Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R         (0x40064010) /**< (AFEC1) AFEC Channel Sequence 2 Register */
+#define REG_AFEC1_CHER          (0x40064014) /**< (AFEC1) AFEC Channel Enable Register */
+#define REG_AFEC1_CHDR          (0x40064018) /**< (AFEC1) AFEC Channel Disable Register */
+#define REG_AFEC1_CHSR          (0x4006401C) /**< (AFEC1) AFEC Channel Status Register */
+#define REG_AFEC1_LCDR          (0x40064020) /**< (AFEC1) AFEC Last Converted Data Register */
+#define REG_AFEC1_IER           (0x40064024) /**< (AFEC1) AFEC Interrupt Enable Register */
+#define REG_AFEC1_IDR           (0x40064028) /**< (AFEC1) AFEC Interrupt Disable Register */
+#define REG_AFEC1_IMR           (0x4006402C) /**< (AFEC1) AFEC Interrupt Mask Register */
+#define REG_AFEC1_ISR           (0x40064030) /**< (AFEC1) AFEC Interrupt Status Register */
+#define REG_AFEC1_OVER          (0x4006404C) /**< (AFEC1) AFEC Overrun Status Register */
+#define REG_AFEC1_CWR           (0x40064050) /**< (AFEC1) AFEC Compare Window Register */
+#define REG_AFEC1_CGR           (0x40064054) /**< (AFEC1) AFEC Channel Gain Register */
+#define REG_AFEC1_DIFFR         (0x40064060) /**< (AFEC1) AFEC Channel Differential Register */
+#define REG_AFEC1_CSELR         (0x40064064) /**< (AFEC1) AFEC Channel Selection Register */
+#define REG_AFEC1_CDR           (0x40064068) /**< (AFEC1) AFEC Channel Data Register */
+#define REG_AFEC1_COCR          (0x4006406C) /**< (AFEC1) AFEC Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR        (0x40064070) /**< (AFEC1) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR       (0x40064074) /**< (AFEC1) AFEC Temperature Compare Window Register */
+#define REG_AFEC1_ACR           (0x40064094) /**< (AFEC1) AFEC Analog Control Register */
+#define REG_AFEC1_SHMR          (0x400640A0) /**< (AFEC1) AFEC Sample & Hold Mode Register */
+#define REG_AFEC1_COSR          (0x400640D0) /**< (AFEC1) AFEC Correction Select Register */
+#define REG_AFEC1_CVR           (0x400640D4) /**< (AFEC1) AFEC Correction Values Register */
+#define REG_AFEC1_CECR          (0x400640D8) /**< (AFEC1) AFEC Channel Error Correction Register */
+#define REG_AFEC1_WPMR          (0x400640E4) /**< (AFEC1) AFEC Write Protection Mode Register */
+#define REG_AFEC1_WPSR          (0x400640E8) /**< (AFEC1) AFEC Write Protection Status Register */
+
+#else
+
+#define REG_AFEC1_CR            (*(__O  uint32_t*)0x40064000U) /**< (AFEC1) AFEC Control Register */
+#define REG_AFEC1_MR            (*(__IO uint32_t*)0x40064004U) /**< (AFEC1) AFEC Mode Register */
+#define REG_AFEC1_EMR           (*(__IO uint32_t*)0x40064008U) /**< (AFEC1) AFEC Extended Mode Register */
+#define REG_AFEC1_SEQ1R         (*(__IO uint32_t*)0x4006400CU) /**< (AFEC1) AFEC Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R         (*(__IO uint32_t*)0x40064010U) /**< (AFEC1) AFEC Channel Sequence 2 Register */
+#define REG_AFEC1_CHER          (*(__O  uint32_t*)0x40064014U) /**< (AFEC1) AFEC Channel Enable Register */
+#define REG_AFEC1_CHDR          (*(__O  uint32_t*)0x40064018U) /**< (AFEC1) AFEC Channel Disable Register */
+#define REG_AFEC1_CHSR          (*(__I  uint32_t*)0x4006401CU) /**< (AFEC1) AFEC Channel Status Register */
+#define REG_AFEC1_LCDR          (*(__I  uint32_t*)0x40064020U) /**< (AFEC1) AFEC Last Converted Data Register */
+#define REG_AFEC1_IER           (*(__O  uint32_t*)0x40064024U) /**< (AFEC1) AFEC Interrupt Enable Register */
+#define REG_AFEC1_IDR           (*(__O  uint32_t*)0x40064028U) /**< (AFEC1) AFEC Interrupt Disable Register */
+#define REG_AFEC1_IMR           (*(__I  uint32_t*)0x4006402CU) /**< (AFEC1) AFEC Interrupt Mask Register */
+#define REG_AFEC1_ISR           (*(__I  uint32_t*)0x40064030U) /**< (AFEC1) AFEC Interrupt Status Register */
+#define REG_AFEC1_OVER          (*(__I  uint32_t*)0x4006404CU) /**< (AFEC1) AFEC Overrun Status Register */
+#define REG_AFEC1_CWR           (*(__IO uint32_t*)0x40064050U) /**< (AFEC1) AFEC Compare Window Register */
+#define REG_AFEC1_CGR           (*(__IO uint32_t*)0x40064054U) /**< (AFEC1) AFEC Channel Gain Register */
+#define REG_AFEC1_DIFFR         (*(__IO uint32_t*)0x40064060U) /**< (AFEC1) AFEC Channel Differential Register */
+#define REG_AFEC1_CSELR         (*(__IO uint32_t*)0x40064064U) /**< (AFEC1) AFEC Channel Selection Register */
+#define REG_AFEC1_CDR           (*(__I  uint32_t*)0x40064068U) /**< (AFEC1) AFEC Channel Data Register */
+#define REG_AFEC1_COCR          (*(__IO uint32_t*)0x4006406CU) /**< (AFEC1) AFEC Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR        (*(__IO uint32_t*)0x40064070U) /**< (AFEC1) AFEC Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR       (*(__IO uint32_t*)0x40064074U) /**< (AFEC1) AFEC Temperature Compare Window Register */
+#define REG_AFEC1_ACR           (*(__IO uint32_t*)0x40064094U) /**< (AFEC1) AFEC Analog Control Register */
+#define REG_AFEC1_SHMR          (*(__IO uint32_t*)0x400640A0U) /**< (AFEC1) AFEC Sample & Hold Mode Register */
+#define REG_AFEC1_COSR          (*(__IO uint32_t*)0x400640D0U) /**< (AFEC1) AFEC Correction Select Register */
+#define REG_AFEC1_CVR           (*(__IO uint32_t*)0x400640D4U) /**< (AFEC1) AFEC Correction Values Register */
+#define REG_AFEC1_CECR          (*(__IO uint32_t*)0x400640D8U) /**< (AFEC1) AFEC Channel Error Correction Register */
+#define REG_AFEC1_WPMR          (*(__IO uint32_t*)0x400640E4U) /**< (AFEC1) AFEC Write Protection Mode Register */
+#define REG_AFEC1_WPSR          (*(__I  uint32_t*)0x400640E8U) /**< (AFEC1) AFEC Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for AFEC1 peripheral ========== */
+#define AFEC1_DMAC_ID_RX                         36         
+#define AFEC1_INSTANCE_ID                        40         
+#define AFEC1_CLOCK_ID                           40         
+#define AFEC1_TRGSEL_AFEC_TRIG0                  0x0        /* External ADC Trigger Input (AFE1_ADTRG Pin) */
+#define AFEC1_TRGSEL_AFEC_TRIG1                  0x1        /* TC1 Channel 0 Output (TIOA3) */
+#define AFEC1_TRGSEL_AFEC_TRIG2                  0x2        /* TC1 Channel 1 Output (TIOA4) */
+#define AFEC1_TRGSEL_AFEC_TRIG3                  0x3        /* TC1 Channel 2 Output (TIOA5) */
+#define AFEC1_TRGSEL_AFEC_TRIG4                  0x4        /* PWM1 event line 0 */
+#define AFEC1_TRGSEL_AFEC_TRIG5                  0x5        /* PWM1 event line 1 */
+#define AFEC1_TRGSEL_AFEC_TRIG6                  0x6        /* Analog Comparator Fault Output */
+
+#endif /* _SAMV71_AFEC1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/chipid.h
+++ b/asf/sam/include/samv71b/instance/chipid.h
@@ -1,0 +1,46 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CHIPID
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_CHIPID_INSTANCE_H_
+#define _SAMV71_CHIPID_INSTANCE_H_
+
+/* ========== Register definition for CHIPID peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_CHIPID_CIDR         (0x400E0940) /**< (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID         (0x400E0944) /**< (CHIPID) Chip ID Extension Register */
+
+#else
+
+#define REG_CHIPID_CIDR         (*(__I  uint32_t*)0x400E0940U) /**< (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID         (*(__I  uint32_t*)0x400E0944U) /**< (CHIPID) Chip ID Extension Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_CHIPID_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/dacc.h
+++ b/asf/sam/include/samv71b/instance/dacc.h
@@ -1,0 +1,80 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DACC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_DACC_INSTANCE_H_
+#define _SAMV71_DACC_INSTANCE_H_
+
+/* ========== Register definition for DACC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_DACC_CR             (0x40040000) /**< (DACC) Control Register */
+#define REG_DACC_MR             (0x40040004) /**< (DACC) Mode Register */
+#define REG_DACC_TRIGR          (0x40040008) /**< (DACC) Trigger Register */
+#define REG_DACC_CHER           (0x40040010) /**< (DACC) Channel Enable Register */
+#define REG_DACC_CHDR           (0x40040014) /**< (DACC) Channel Disable Register */
+#define REG_DACC_CHSR           (0x40040018) /**< (DACC) Channel Status Register */
+#define REG_DACC_CDR            (0x4004001C) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR0           (0x4004001C) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR1           (0x40040020) /**< (DACC) Conversion Data Register 1 */
+#define REG_DACC_IER            (0x40040024) /**< (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR            (0x40040028) /**< (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR            (0x4004002C) /**< (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR            (0x40040030) /**< (DACC) Interrupt Status Register */
+#define REG_DACC_ACR            (0x40040094) /**< (DACC) Analog Current Register */
+#define REG_DACC_WPMR           (0x400400E4) /**< (DACC) Write Protection Mode Register */
+#define REG_DACC_WPSR           (0x400400E8) /**< (DACC) Write Protection Status Register */
+
+#else
+
+#define REG_DACC_CR             (*(__O  uint32_t*)0x40040000U) /**< (DACC) Control Register */
+#define REG_DACC_MR             (*(__IO uint32_t*)0x40040004U) /**< (DACC) Mode Register */
+#define REG_DACC_TRIGR          (*(__IO uint32_t*)0x40040008U) /**< (DACC) Trigger Register */
+#define REG_DACC_CHER           (*(__O  uint32_t*)0x40040010U) /**< (DACC) Channel Enable Register */
+#define REG_DACC_CHDR           (*(__O  uint32_t*)0x40040014U) /**< (DACC) Channel Disable Register */
+#define REG_DACC_CHSR           (*(__I  uint32_t*)0x40040018U) /**< (DACC) Channel Status Register */
+#define REG_DACC_CDR            (*(__O  uint32_t*)0x4004001CU) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR0           (*(__O  uint32_t*)0x4004001CU) /**< (DACC) Conversion Data Register 0 */
+#define REG_DACC_CDR1           (*(__O  uint32_t*)0x40040020U) /**< (DACC) Conversion Data Register 1 */
+#define REG_DACC_IER            (*(__O  uint32_t*)0x40040024U) /**< (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR            (*(__O  uint32_t*)0x40040028U) /**< (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR            (*(__I  uint32_t*)0x4004002CU) /**< (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR            (*(__I  uint32_t*)0x40040030U) /**< (DACC) Interrupt Status Register */
+#define REG_DACC_ACR            (*(__IO uint32_t*)0x40040094U) /**< (DACC) Analog Current Register */
+#define REG_DACC_WPMR           (*(__IO uint32_t*)0x400400E4U) /**< (DACC) Write Protection Mode Register */
+#define REG_DACC_WPSR           (*(__I  uint32_t*)0x400400E8U) /**< (DACC) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for DACC peripheral ========== */
+#define DACC_DMAC_ID_TX                          30         
+#define DACC_INSTANCE_ID                         30         
+#define DACC_CLOCK_ID                            30         
+
+#endif /* _SAMV71_DACC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/efc.h
+++ b/asf/sam/include/samv71b/instance/efc.h
@@ -1,0 +1,59 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EFC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_EFC_INSTANCE_H_
+#define _SAMV71_EFC_INSTANCE_H_
+
+/* ========== Register definition for EFC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_EEFC_FMR            (0x400E0C00) /**< (EFC) EEFC Flash Mode Register */
+#define REG_EEFC_FCR            (0x400E0C04) /**< (EFC) EEFC Flash Command Register */
+#define REG_EEFC_FSR            (0x400E0C08) /**< (EFC) EEFC Flash Status Register */
+#define REG_EEFC_FRR            (0x400E0C0C) /**< (EFC) EEFC Flash Result Register */
+#define REG_EEFC_WPMR           (0x400E0CE4) /**< (EFC) Write Protection Mode Register */
+
+#else
+
+#define REG_EEFC_FMR            (*(__IO uint32_t*)0x400E0C00U) /**< (EFC) EEFC Flash Mode Register */
+#define REG_EEFC_FCR            (*(__O  uint32_t*)0x400E0C04U) /**< (EFC) EEFC Flash Command Register */
+#define REG_EEFC_FSR            (*(__I  uint32_t*)0x400E0C08U) /**< (EFC) EEFC Flash Status Register */
+#define REG_EEFC_FRR            (*(__I  uint32_t*)0x400E0C0CU) /**< (EFC) EEFC Flash Result Register */
+#define REG_EEFC_WPMR           (*(__IO uint32_t*)0x400E0CE4U) /**< (EFC) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for EFC peripheral ========== */
+#define EFC_FLASH_SIZE                           2097152    
+#define EFC_PAGE_SIZE                            512        
+#define EFC_INSTANCE_ID                          6          
+#define EFC_PAGES_PR_REGION                      32         
+
+#endif /* _SAMV71_EFC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/gmac.h
+++ b/asf/sam/include/samv71b/instance/gmac.h
@@ -1,0 +1,489 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_GMAC_INSTANCE_H_
+#define _SAMV71_GMAC_INSTANCE_H_
+
+/* ========== Register definition for GMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GMAC_SAB1           (0x40050088) /**< (GMAC) Specific Address 1 Bottom Register 0 */
+#define REG_GMAC_SAT1           (0x4005008C) /**< (GMAC) Specific Address 1 Top Register 0 */
+#define REG_GMAC_SAB2           (0x40050090) /**< (GMAC) Specific Address 1 Bottom Register 1 */
+#define REG_GMAC_SAT2           (0x40050094) /**< (GMAC) Specific Address 1 Top Register 1 */
+#define REG_GMAC_SAB3           (0x40050098) /**< (GMAC) Specific Address 1 Bottom Register 2 */
+#define REG_GMAC_SAT3           (0x4005009C) /**< (GMAC) Specific Address 1 Top Register 2 */
+#define REG_GMAC_SAB4           (0x400500A0) /**< (GMAC) Specific Address 1 Bottom Register 3 */
+#define REG_GMAC_SAT4           (0x400500A4) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_ST2CW00        (0x40050700) /**< (GMAC) Screening Type 2 Compare Word 0 Register 0 */
+#define REG_GMAC_ST2CW10        (0x40050704) /**< (GMAC) Screening Type 2 Compare Word 1 Register 0 */
+#define REG_GMAC_ST2CW01        (0x40050708) /**< (GMAC) Screening Type 2 Compare Word 0 Register 1 */
+#define REG_GMAC_ST2CW11        (0x4005070C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 1 */
+#define REG_GMAC_ST2CW02        (0x40050710) /**< (GMAC) Screening Type 2 Compare Word 0 Register 2 */
+#define REG_GMAC_ST2CW12        (0x40050714) /**< (GMAC) Screening Type 2 Compare Word 1 Register 2 */
+#define REG_GMAC_ST2CW03        (0x40050718) /**< (GMAC) Screening Type 2 Compare Word 0 Register 3 */
+#define REG_GMAC_ST2CW13        (0x4005071C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 3 */
+#define REG_GMAC_ST2CW04        (0x40050720) /**< (GMAC) Screening Type 2 Compare Word 0 Register 4 */
+#define REG_GMAC_ST2CW14        (0x40050724) /**< (GMAC) Screening Type 2 Compare Word 1 Register 4 */
+#define REG_GMAC_ST2CW05        (0x40050728) /**< (GMAC) Screening Type 2 Compare Word 0 Register 5 */
+#define REG_GMAC_ST2CW15        (0x4005072C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 5 */
+#define REG_GMAC_ST2CW06        (0x40050730) /**< (GMAC) Screening Type 2 Compare Word 0 Register 6 */
+#define REG_GMAC_ST2CW16        (0x40050734) /**< (GMAC) Screening Type 2 Compare Word 1 Register 6 */
+#define REG_GMAC_ST2CW07        (0x40050738) /**< (GMAC) Screening Type 2 Compare Word 0 Register 7 */
+#define REG_GMAC_ST2CW17        (0x4005073C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 7 */
+#define REG_GMAC_ST2CW08        (0x40050740) /**< (GMAC) Screening Type 2 Compare Word 0 Register 8 */
+#define REG_GMAC_ST2CW18        (0x40050744) /**< (GMAC) Screening Type 2 Compare Word 1 Register 8 */
+#define REG_GMAC_ST2CW09        (0x40050748) /**< (GMAC) Screening Type 2 Compare Word 0 Register 9 */
+#define REG_GMAC_ST2CW19        (0x4005074C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 9 */
+#define REG_GMAC_ST2CW010       (0x40050750) /**< (GMAC) Screening Type 2 Compare Word 0 Register 10 */
+#define REG_GMAC_ST2CW110       (0x40050754) /**< (GMAC) Screening Type 2 Compare Word 1 Register 10 */
+#define REG_GMAC_ST2CW011       (0x40050758) /**< (GMAC) Screening Type 2 Compare Word 0 Register 11 */
+#define REG_GMAC_ST2CW111       (0x4005075C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 11 */
+#define REG_GMAC_ST2CW012       (0x40050760) /**< (GMAC) Screening Type 2 Compare Word 0 Register 12 */
+#define REG_GMAC_ST2CW112       (0x40050764) /**< (GMAC) Screening Type 2 Compare Word 1 Register 12 */
+#define REG_GMAC_ST2CW013       (0x40050768) /**< (GMAC) Screening Type 2 Compare Word 0 Register 13 */
+#define REG_GMAC_ST2CW113       (0x4005076C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 13 */
+#define REG_GMAC_ST2CW014       (0x40050770) /**< (GMAC) Screening Type 2 Compare Word 0 Register 14 */
+#define REG_GMAC_ST2CW114       (0x40050774) /**< (GMAC) Screening Type 2 Compare Word 1 Register 14 */
+#define REG_GMAC_ST2CW015       (0x40050778) /**< (GMAC) Screening Type 2 Compare Word 0 Register 15 */
+#define REG_GMAC_ST2CW115       (0x4005077C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 15 */
+#define REG_GMAC_ST2CW016       (0x40050780) /**< (GMAC) Screening Type 2 Compare Word 0 Register 16 */
+#define REG_GMAC_ST2CW116       (0x40050784) /**< (GMAC) Screening Type 2 Compare Word 1 Register 16 */
+#define REG_GMAC_ST2CW017       (0x40050788) /**< (GMAC) Screening Type 2 Compare Word 0 Register 17 */
+#define REG_GMAC_ST2CW117       (0x4005078C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 17 */
+#define REG_GMAC_ST2CW018       (0x40050790) /**< (GMAC) Screening Type 2 Compare Word 0 Register 18 */
+#define REG_GMAC_ST2CW118       (0x40050794) /**< (GMAC) Screening Type 2 Compare Word 1 Register 18 */
+#define REG_GMAC_ST2CW019       (0x40050798) /**< (GMAC) Screening Type 2 Compare Word 0 Register 19 */
+#define REG_GMAC_ST2CW119       (0x4005079C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 19 */
+#define REG_GMAC_ST2CW020       (0x400507A0) /**< (GMAC) Screening Type 2 Compare Word 0 Register 20 */
+#define REG_GMAC_ST2CW120       (0x400507A4) /**< (GMAC) Screening Type 2 Compare Word 1 Register 20 */
+#define REG_GMAC_ST2CW021       (0x400507A8) /**< (GMAC) Screening Type 2 Compare Word 0 Register 21 */
+#define REG_GMAC_ST2CW121       (0x400507AC) /**< (GMAC) Screening Type 2 Compare Word 1 Register 21 */
+#define REG_GMAC_ST2CW022       (0x400507B0) /**< (GMAC) Screening Type 2 Compare Word 0 Register 22 */
+#define REG_GMAC_ST2CW122       (0x400507B4) /**< (GMAC) Screening Type 2 Compare Word 1 Register 22 */
+#define REG_GMAC_ST2CW023       (0x400507B8) /**< (GMAC) Screening Type 2 Compare Word 0 Register 23 */
+#define REG_GMAC_ST2CW123       (0x400507BC) /**< (GMAC) Screening Type 2 Compare Word 1 Register 23 */
+#define REG_GMAC_NCR            (0x40050000) /**< (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR          (0x40050004) /**< (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR            (0x40050008) /**< (GMAC) Network Status Register */
+#define REG_GMAC_UR             (0x4005000C) /**< (GMAC) User Register */
+#define REG_GMAC_DCFGR          (0x40050010) /**< (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR            (0x40050014) /**< (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB           (0x40050018) /**< (GMAC) Receive Buffer Queue Base Address Register */
+#define REG_GMAC_TBQB           (0x4005001C) /**< (GMAC) Transmit Buffer Queue Base Address Register */
+#define REG_GMAC_RSR            (0x40050020) /**< (GMAC) Receive Status Register */
+#define REG_GMAC_ISR            (0x40050024) /**< (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER            (0x40050028) /**< (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR            (0x4005002C) /**< (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR            (0x40050030) /**< (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN            (0x40050034) /**< (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ            (0x40050038) /**< (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ            (0x4005003C) /**< (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_TPSF           (0x40050040) /**< (GMAC) TX Partial Store and Forward Register */
+#define REG_GMAC_RPSF           (0x40050044) /**< (GMAC) RX Partial Store and Forward Register */
+#define REG_GMAC_RJFML          (0x40050048) /**< (GMAC) RX Jumbo Frame Max Length Register */
+#define REG_GMAC_HRB            (0x40050080) /**< (GMAC) Hash Register Bottom */
+#define REG_GMAC_HRT            (0x40050084) /**< (GMAC) Hash Register Top */
+#define REG_GMAC_TIDM1          (0x400500A8) /**< (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_TIDM2          (0x400500AC) /**< (GMAC) Type ID Match 2 Register */
+#define REG_GMAC_TIDM3          (0x400500B0) /**< (GMAC) Type ID Match 3 Register */
+#define REG_GMAC_TIDM4          (0x400500B4) /**< (GMAC) Type ID Match 4 Register */
+#define REG_GMAC_WOL            (0x400500B8) /**< (GMAC) Wake on LAN Register */
+#define REG_GMAC_IPGS           (0x400500BC) /**< (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN          (0x400500C0) /**< (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP          (0x400500C4) /**< (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1          (0x400500C8) /**< (GMAC) Specific Address 1 Mask Bottom Register */
+#define REG_GMAC_SAMT1          (0x400500CC) /**< (GMAC) Specific Address 1 Mask Top Register */
+#define REG_GMAC_NSC            (0x400500DC) /**< (GMAC) 1588 Timer Nanosecond Comparison Register */
+#define REG_GMAC_SCL            (0x400500E0) /**< (GMAC) 1588 Timer Second Comparison Low Register */
+#define REG_GMAC_SCH            (0x400500E4) /**< (GMAC) 1588 Timer Second Comparison High Register */
+#define REG_GMAC_EFTSH          (0x400500E8) /**< (GMAC) PTP Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_EFRSH          (0x400500EC) /**< (GMAC) PTP Event Frame Received Seconds High Register */
+#define REG_GMAC_PEFTSH         (0x400500F0) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_PEFRSH         (0x400500F4) /**< (GMAC) PTP Peer Event Frame Received Seconds High Register */
+#define REG_GMAC_OTLO           (0x40050100) /**< (GMAC) Octets Transmitted Low Register */
+#define REG_GMAC_OTHI           (0x40050104) /**< (GMAC) Octets Transmitted High Register */
+#define REG_GMAC_FT             (0x40050108) /**< (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT           (0x4005010C) /**< (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT            (0x40050110) /**< (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT            (0x40050114) /**< (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64          (0x40050118) /**< (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127        (0x4005011C) /**< (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255        (0x40050120) /**< (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511        (0x40050124) /**< (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023       (0x40050128) /**< (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518       (0x4005012C) /**< (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518      (0x40050130) /**< (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR            (0x40050134) /**< (GMAC) Transmit Underruns Register */
+#define REG_GMAC_SCF            (0x40050138) /**< (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF            (0x4005013C) /**< (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC             (0x40050140) /**< (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC             (0x40050144) /**< (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF            (0x40050148) /**< (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE            (0x4005014C) /**< (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO           (0x40050150) /**< (GMAC) Octets Received Low Received Register */
+#define REG_GMAC_ORHI           (0x40050154) /**< (GMAC) Octets Received High Received Register */
+#define REG_GMAC_FR             (0x40050158) /**< (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR           (0x4005015C) /**< (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR            (0x40050160) /**< (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR            (0x40050164) /**< (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64          (0x40050168) /**< (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127        (0x4005016C) /**< (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255        (0x40050170) /**< (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511        (0x40050174) /**< (GMAC) 256 to 511 Byte Frames Received Register */
+#define REG_GMAC_TBFR1023       (0x40050178) /**< (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518       (0x4005017C) /**< (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR         (0x40050180) /**< (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR            (0x40050184) /**< (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR            (0x40050188) /**< (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR             (0x4005018C) /**< (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE           (0x40050190) /**< (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE           (0x40050194) /**< (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE            (0x40050198) /**< (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE             (0x4005019C) /**< (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE            (0x400501A0) /**< (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE            (0x400501A4) /**< (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE           (0x400501A8) /**< (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE            (0x400501AC) /**< (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE            (0x400501B0) /**< (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TISUBN         (0x400501BC) /**< (GMAC) 1588 Timer Increment Sub-nanoseconds Register */
+#define REG_GMAC_TSH            (0x400501C0) /**< (GMAC) 1588 Timer Seconds High Register */
+#define REG_GMAC_TSL            (0x400501D0) /**< (GMAC) 1588 Timer Seconds Low Register */
+#define REG_GMAC_TN             (0x400501D4) /**< (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA             (0x400501D8) /**< (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI             (0x400501DC) /**< (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTSL          (0x400501E0) /**< (GMAC) PTP Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_EFTN           (0x400501E4) /**< (GMAC) PTP Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_EFRSL          (0x400501E8) /**< (GMAC) PTP Event Frame Received Seconds Low Register */
+#define REG_GMAC_EFRN           (0x400501EC) /**< (GMAC) PTP Event Frame Received Nanoseconds Register */
+#define REG_GMAC_PEFTSL         (0x400501F0) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_PEFTN          (0x400501F4) /**< (GMAC) PTP Peer Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_PEFRSL         (0x400501F8) /**< (GMAC) PTP Peer Event Frame Received Seconds Low Register */
+#define REG_GMAC_PEFRN          (0x400501FC) /**< (GMAC) PTP Peer Event Frame Received Nanoseconds Register */
+#define REG_GMAC_RXLPI          (0x40050270) /**< (GMAC) Received LPI Transitions */
+#define REG_GMAC_RXLPITIME      (0x40050274) /**< (GMAC) Received LPI Time */
+#define REG_GMAC_TXLPI          (0x40050278) /**< (GMAC) Transmit LPI Transitions */
+#define REG_GMAC_TXLPITIME      (0x4005027C) /**< (GMAC) Transmit LPI Time */
+#define REG_GMAC_ISRPQ          (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) */
+#define REG_GMAC_ISRPQ0         (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 0 */
+#define REG_GMAC_ISRPQ1         (0x40050404) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 1 */
+#define REG_GMAC_ISRPQ2         (0x40050408) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 2 */
+#define REG_GMAC_ISRPQ3         (0x4005040C) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 3 */
+#define REG_GMAC_ISRPQ4         (0x40050410) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 4 */
+#define REG_GMAC_TBQBAPQ        (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_TBQBAPQ0       (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_TBQBAPQ1       (0x40050444) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_TBQBAPQ2       (0x40050448) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_TBQBAPQ3       (0x4005044C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_TBQBAPQ4       (0x40050450) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBQBAPQ        (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_RBQBAPQ0       (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBQBAPQ1       (0x40050484) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBQBAPQ2       (0x40050488) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBQBAPQ3       (0x4005048C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBQBAPQ4       (0x40050490) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBSRPQ         (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) */
+#define REG_GMAC_RBSRPQ0        (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBSRPQ1        (0x400504A4) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBSRPQ2        (0x400504A8) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBSRPQ3        (0x400504AC) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBSRPQ4        (0x400504B0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 4 */
+#define REG_GMAC_CBSCR          (0x400504BC) /**< (GMAC) Credit-Based Shaping Control Register */
+#define REG_GMAC_CBSISQA        (0x400504C0) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
+#define REG_GMAC_CBSISQB        (0x400504C4) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
+#define REG_GMAC_ST1RPQ         (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue */
+#define REG_GMAC_ST1RPQ0        (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue 0 */
+#define REG_GMAC_ST1RPQ1        (0x40050504) /**< (GMAC) Screening Type 1 Register Priority Queue 1 */
+#define REG_GMAC_ST1RPQ2        (0x40050508) /**< (GMAC) Screening Type 1 Register Priority Queue 2 */
+#define REG_GMAC_ST1RPQ3        (0x4005050C) /**< (GMAC) Screening Type 1 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ         (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue */
+#define REG_GMAC_ST2RPQ0        (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue 0 */
+#define REG_GMAC_ST2RPQ1        (0x40050544) /**< (GMAC) Screening Type 2 Register Priority Queue 1 */
+#define REG_GMAC_ST2RPQ2        (0x40050548) /**< (GMAC) Screening Type 2 Register Priority Queue 2 */
+#define REG_GMAC_ST2RPQ3        (0x4005054C) /**< (GMAC) Screening Type 2 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ4        (0x40050550) /**< (GMAC) Screening Type 2 Register Priority Queue 4 */
+#define REG_GMAC_ST2RPQ5        (0x40050554) /**< (GMAC) Screening Type 2 Register Priority Queue 5 */
+#define REG_GMAC_ST2RPQ6        (0x40050558) /**< (GMAC) Screening Type 2 Register Priority Queue 6 */
+#define REG_GMAC_ST2RPQ7        (0x4005055C) /**< (GMAC) Screening Type 2 Register Priority Queue 7 */
+#define REG_GMAC_IERPQ          (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) */
+#define REG_GMAC_IERPQ0         (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IERPQ1         (0x40050604) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IERPQ2         (0x40050608) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IERPQ3         (0x4005060C) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IERPQ4         (0x40050610) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IDRPQ          (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) */
+#define REG_GMAC_IDRPQ0         (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IDRPQ1         (0x40050624) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IDRPQ2         (0x40050628) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IDRPQ3         (0x4005062C) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IDRPQ4         (0x40050630) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IMRPQ          (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) */
+#define REG_GMAC_IMRPQ0         (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IMRPQ1         (0x40050644) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IMRPQ2         (0x40050648) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IMRPQ3         (0x4005064C) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IMRPQ4         (0x40050650) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 4 */
+#define REG_GMAC_ST2ER          (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register */
+#define REG_GMAC_ST2ER0         (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register 0 */
+#define REG_GMAC_ST2ER1         (0x400506E4) /**< (GMAC) Screening Type 2 Ethertype Register 1 */
+#define REG_GMAC_ST2ER2         (0x400506E8) /**< (GMAC) Screening Type 2 Ethertype Register 2 */
+#define REG_GMAC_ST2ER3         (0x400506EC) /**< (GMAC) Screening Type 2 Ethertype Register 3 */
+
+#else
+
+#define REG_GMAC_SAB1           (*(__IO uint32_t*)0x40050088U) /**< (GMAC) Specific Address 1 Bottom Register 0 */
+#define REG_GMAC_SAT1           (*(__IO uint32_t*)0x4005008CU) /**< (GMAC) Specific Address 1 Top Register 0 */
+#define REG_GMAC_SAB2           (*(__IO uint32_t*)0x40050090U) /**< (GMAC) Specific Address 1 Bottom Register 1 */
+#define REG_GMAC_SAT2           (*(__IO uint32_t*)0x40050094U) /**< (GMAC) Specific Address 1 Top Register 1 */
+#define REG_GMAC_SAB3           (*(__IO uint32_t*)0x40050098U) /**< (GMAC) Specific Address 1 Bottom Register 2 */
+#define REG_GMAC_SAT3           (*(__IO uint32_t*)0x4005009CU) /**< (GMAC) Specific Address 1 Top Register 2 */
+#define REG_GMAC_SAB4           (*(__IO uint32_t*)0x400500A0U) /**< (GMAC) Specific Address 1 Bottom Register 3 */
+#define REG_GMAC_SAT4           (*(__IO uint32_t*)0x400500A4U) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_ST2CW00        (*(__IO uint32_t*)0x40050700U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 0 */
+#define REG_GMAC_ST2CW10        (*(__IO uint32_t*)0x40050704U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 0 */
+#define REG_GMAC_ST2CW01        (*(__IO uint32_t*)0x40050708U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 1 */
+#define REG_GMAC_ST2CW11        (*(__IO uint32_t*)0x4005070CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 1 */
+#define REG_GMAC_ST2CW02        (*(__IO uint32_t*)0x40050710U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 2 */
+#define REG_GMAC_ST2CW12        (*(__IO uint32_t*)0x40050714U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 2 */
+#define REG_GMAC_ST2CW03        (*(__IO uint32_t*)0x40050718U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 3 */
+#define REG_GMAC_ST2CW13        (*(__IO uint32_t*)0x4005071CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 3 */
+#define REG_GMAC_ST2CW04        (*(__IO uint32_t*)0x40050720U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 4 */
+#define REG_GMAC_ST2CW14        (*(__IO uint32_t*)0x40050724U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 4 */
+#define REG_GMAC_ST2CW05        (*(__IO uint32_t*)0x40050728U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 5 */
+#define REG_GMAC_ST2CW15        (*(__IO uint32_t*)0x4005072CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 5 */
+#define REG_GMAC_ST2CW06        (*(__IO uint32_t*)0x40050730U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 6 */
+#define REG_GMAC_ST2CW16        (*(__IO uint32_t*)0x40050734U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 6 */
+#define REG_GMAC_ST2CW07        (*(__IO uint32_t*)0x40050738U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 7 */
+#define REG_GMAC_ST2CW17        (*(__IO uint32_t*)0x4005073CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 7 */
+#define REG_GMAC_ST2CW08        (*(__IO uint32_t*)0x40050740U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 8 */
+#define REG_GMAC_ST2CW18        (*(__IO uint32_t*)0x40050744U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 8 */
+#define REG_GMAC_ST2CW09        (*(__IO uint32_t*)0x40050748U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 9 */
+#define REG_GMAC_ST2CW19        (*(__IO uint32_t*)0x4005074CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 9 */
+#define REG_GMAC_ST2CW010       (*(__IO uint32_t*)0x40050750U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 10 */
+#define REG_GMAC_ST2CW110       (*(__IO uint32_t*)0x40050754U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 10 */
+#define REG_GMAC_ST2CW011       (*(__IO uint32_t*)0x40050758U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 11 */
+#define REG_GMAC_ST2CW111       (*(__IO uint32_t*)0x4005075CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 11 */
+#define REG_GMAC_ST2CW012       (*(__IO uint32_t*)0x40050760U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 12 */
+#define REG_GMAC_ST2CW112       (*(__IO uint32_t*)0x40050764U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 12 */
+#define REG_GMAC_ST2CW013       (*(__IO uint32_t*)0x40050768U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 13 */
+#define REG_GMAC_ST2CW113       (*(__IO uint32_t*)0x4005076CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 13 */
+#define REG_GMAC_ST2CW014       (*(__IO uint32_t*)0x40050770U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 14 */
+#define REG_GMAC_ST2CW114       (*(__IO uint32_t*)0x40050774U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 14 */
+#define REG_GMAC_ST2CW015       (*(__IO uint32_t*)0x40050778U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 15 */
+#define REG_GMAC_ST2CW115       (*(__IO uint32_t*)0x4005077CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 15 */
+#define REG_GMAC_ST2CW016       (*(__IO uint32_t*)0x40050780U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 16 */
+#define REG_GMAC_ST2CW116       (*(__IO uint32_t*)0x40050784U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 16 */
+#define REG_GMAC_ST2CW017       (*(__IO uint32_t*)0x40050788U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 17 */
+#define REG_GMAC_ST2CW117       (*(__IO uint32_t*)0x4005078CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 17 */
+#define REG_GMAC_ST2CW018       (*(__IO uint32_t*)0x40050790U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 18 */
+#define REG_GMAC_ST2CW118       (*(__IO uint32_t*)0x40050794U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 18 */
+#define REG_GMAC_ST2CW019       (*(__IO uint32_t*)0x40050798U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 19 */
+#define REG_GMAC_ST2CW119       (*(__IO uint32_t*)0x4005079CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 19 */
+#define REG_GMAC_ST2CW020       (*(__IO uint32_t*)0x400507A0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 20 */
+#define REG_GMAC_ST2CW120       (*(__IO uint32_t*)0x400507A4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 20 */
+#define REG_GMAC_ST2CW021       (*(__IO uint32_t*)0x400507A8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 21 */
+#define REG_GMAC_ST2CW121       (*(__IO uint32_t*)0x400507ACU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 21 */
+#define REG_GMAC_ST2CW022       (*(__IO uint32_t*)0x400507B0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 22 */
+#define REG_GMAC_ST2CW122       (*(__IO uint32_t*)0x400507B4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 22 */
+#define REG_GMAC_ST2CW023       (*(__IO uint32_t*)0x400507B8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 23 */
+#define REG_GMAC_ST2CW123       (*(__IO uint32_t*)0x400507BCU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 23 */
+#define REG_GMAC_NCR            (*(__IO uint32_t*)0x40050000U) /**< (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR          (*(__IO uint32_t*)0x40050004U) /**< (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR            (*(__I  uint32_t*)0x40050008U) /**< (GMAC) Network Status Register */
+#define REG_GMAC_UR             (*(__IO uint32_t*)0x4005000CU) /**< (GMAC) User Register */
+#define REG_GMAC_DCFGR          (*(__IO uint32_t*)0x40050010U) /**< (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR            (*(__IO uint32_t*)0x40050014U) /**< (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB           (*(__IO uint32_t*)0x40050018U) /**< (GMAC) Receive Buffer Queue Base Address Register */
+#define REG_GMAC_TBQB           (*(__IO uint32_t*)0x4005001CU) /**< (GMAC) Transmit Buffer Queue Base Address Register */
+#define REG_GMAC_RSR            (*(__IO uint32_t*)0x40050020U) /**< (GMAC) Receive Status Register */
+#define REG_GMAC_ISR            (*(__I  uint32_t*)0x40050024U) /**< (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER            (*(__O  uint32_t*)0x40050028U) /**< (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR            (*(__O  uint32_t*)0x4005002CU) /**< (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR            (*(__IO uint32_t*)0x40050030U) /**< (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN            (*(__IO uint32_t*)0x40050034U) /**< (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ            (*(__I  uint32_t*)0x40050038U) /**< (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ            (*(__IO uint32_t*)0x4005003CU) /**< (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_TPSF           (*(__IO uint32_t*)0x40050040U) /**< (GMAC) TX Partial Store and Forward Register */
+#define REG_GMAC_RPSF           (*(__IO uint32_t*)0x40050044U) /**< (GMAC) RX Partial Store and Forward Register */
+#define REG_GMAC_RJFML          (*(__IO uint32_t*)0x40050048U) /**< (GMAC) RX Jumbo Frame Max Length Register */
+#define REG_GMAC_HRB            (*(__IO uint32_t*)0x40050080U) /**< (GMAC) Hash Register Bottom */
+#define REG_GMAC_HRT            (*(__IO uint32_t*)0x40050084U) /**< (GMAC) Hash Register Top */
+#define REG_GMAC_TIDM1          (*(__IO uint32_t*)0x400500A8U) /**< (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_TIDM2          (*(__IO uint32_t*)0x400500ACU) /**< (GMAC) Type ID Match 2 Register */
+#define REG_GMAC_TIDM3          (*(__IO uint32_t*)0x400500B0U) /**< (GMAC) Type ID Match 3 Register */
+#define REG_GMAC_TIDM4          (*(__IO uint32_t*)0x400500B4U) /**< (GMAC) Type ID Match 4 Register */
+#define REG_GMAC_WOL            (*(__IO uint32_t*)0x400500B8U) /**< (GMAC) Wake on LAN Register */
+#define REG_GMAC_IPGS           (*(__IO uint32_t*)0x400500BCU) /**< (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN          (*(__IO uint32_t*)0x400500C0U) /**< (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP          (*(__IO uint32_t*)0x400500C4U) /**< (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1          (*(__IO uint32_t*)0x400500C8U) /**< (GMAC) Specific Address 1 Mask Bottom Register */
+#define REG_GMAC_SAMT1          (*(__IO uint32_t*)0x400500CCU) /**< (GMAC) Specific Address 1 Mask Top Register */
+#define REG_GMAC_NSC            (*(__IO uint32_t*)0x400500DCU) /**< (GMAC) 1588 Timer Nanosecond Comparison Register */
+#define REG_GMAC_SCL            (*(__IO uint32_t*)0x400500E0U) /**< (GMAC) 1588 Timer Second Comparison Low Register */
+#define REG_GMAC_SCH            (*(__IO uint32_t*)0x400500E4U) /**< (GMAC) 1588 Timer Second Comparison High Register */
+#define REG_GMAC_EFTSH          (*(__I  uint32_t*)0x400500E8U) /**< (GMAC) PTP Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_EFRSH          (*(__I  uint32_t*)0x400500ECU) /**< (GMAC) PTP Event Frame Received Seconds High Register */
+#define REG_GMAC_PEFTSH         (*(__I  uint32_t*)0x400500F0U) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds High Register */
+#define REG_GMAC_PEFRSH         (*(__I  uint32_t*)0x400500F4U) /**< (GMAC) PTP Peer Event Frame Received Seconds High Register */
+#define REG_GMAC_OTLO           (*(__I  uint32_t*)0x40050100U) /**< (GMAC) Octets Transmitted Low Register */
+#define REG_GMAC_OTHI           (*(__I  uint32_t*)0x40050104U) /**< (GMAC) Octets Transmitted High Register */
+#define REG_GMAC_FT             (*(__I  uint32_t*)0x40050108U) /**< (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT           (*(__I  uint32_t*)0x4005010CU) /**< (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT            (*(__I  uint32_t*)0x40050110U) /**< (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT            (*(__I  uint32_t*)0x40050114U) /**< (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64          (*(__I  uint32_t*)0x40050118U) /**< (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127        (*(__I  uint32_t*)0x4005011CU) /**< (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255        (*(__I  uint32_t*)0x40050120U) /**< (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511        (*(__I  uint32_t*)0x40050124U) /**< (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023       (*(__I  uint32_t*)0x40050128U) /**< (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518       (*(__I  uint32_t*)0x4005012CU) /**< (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518      (*(__I  uint32_t*)0x40050130U) /**< (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR            (*(__I  uint32_t*)0x40050134U) /**< (GMAC) Transmit Underruns Register */
+#define REG_GMAC_SCF            (*(__I  uint32_t*)0x40050138U) /**< (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF            (*(__I  uint32_t*)0x4005013CU) /**< (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC             (*(__I  uint32_t*)0x40050140U) /**< (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC             (*(__I  uint32_t*)0x40050144U) /**< (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF            (*(__I  uint32_t*)0x40050148U) /**< (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE            (*(__I  uint32_t*)0x4005014CU) /**< (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO           (*(__I  uint32_t*)0x40050150U) /**< (GMAC) Octets Received Low Received Register */
+#define REG_GMAC_ORHI           (*(__I  uint32_t*)0x40050154U) /**< (GMAC) Octets Received High Received Register */
+#define REG_GMAC_FR             (*(__I  uint32_t*)0x40050158U) /**< (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR           (*(__I  uint32_t*)0x4005015CU) /**< (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR            (*(__I  uint32_t*)0x40050160U) /**< (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR            (*(__I  uint32_t*)0x40050164U) /**< (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64          (*(__I  uint32_t*)0x40050168U) /**< (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127        (*(__I  uint32_t*)0x4005016CU) /**< (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255        (*(__I  uint32_t*)0x40050170U) /**< (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511        (*(__I  uint32_t*)0x40050174U) /**< (GMAC) 256 to 511 Byte Frames Received Register */
+#define REG_GMAC_TBFR1023       (*(__I  uint32_t*)0x40050178U) /**< (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518       (*(__I  uint32_t*)0x4005017CU) /**< (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR         (*(__I  uint32_t*)0x40050180U) /**< (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR            (*(__I  uint32_t*)0x40050184U) /**< (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR            (*(__I  uint32_t*)0x40050188U) /**< (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR             (*(__I  uint32_t*)0x4005018CU) /**< (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE           (*(__I  uint32_t*)0x40050190U) /**< (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE           (*(__I  uint32_t*)0x40050194U) /**< (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE            (*(__I  uint32_t*)0x40050198U) /**< (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE             (*(__I  uint32_t*)0x4005019CU) /**< (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE            (*(__I  uint32_t*)0x400501A0U) /**< (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE            (*(__I  uint32_t*)0x400501A4U) /**< (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE           (*(__I  uint32_t*)0x400501A8U) /**< (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE            (*(__I  uint32_t*)0x400501ACU) /**< (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE            (*(__I  uint32_t*)0x400501B0U) /**< (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TISUBN         (*(__IO uint32_t*)0x400501BCU) /**< (GMAC) 1588 Timer Increment Sub-nanoseconds Register */
+#define REG_GMAC_TSH            (*(__IO uint32_t*)0x400501C0U) /**< (GMAC) 1588 Timer Seconds High Register */
+#define REG_GMAC_TSL            (*(__IO uint32_t*)0x400501D0U) /**< (GMAC) 1588 Timer Seconds Low Register */
+#define REG_GMAC_TN             (*(__IO uint32_t*)0x400501D4U) /**< (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA             (*(__O  uint32_t*)0x400501D8U) /**< (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI             (*(__IO uint32_t*)0x400501DCU) /**< (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTSL          (*(__I  uint32_t*)0x400501E0U) /**< (GMAC) PTP Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_EFTN           (*(__I  uint32_t*)0x400501E4U) /**< (GMAC) PTP Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_EFRSL          (*(__I  uint32_t*)0x400501E8U) /**< (GMAC) PTP Event Frame Received Seconds Low Register */
+#define REG_GMAC_EFRN           (*(__I  uint32_t*)0x400501ECU) /**< (GMAC) PTP Event Frame Received Nanoseconds Register */
+#define REG_GMAC_PEFTSL         (*(__I  uint32_t*)0x400501F0U) /**< (GMAC) PTP Peer Event Frame Transmitted Seconds Low Register */
+#define REG_GMAC_PEFTN          (*(__I  uint32_t*)0x400501F4U) /**< (GMAC) PTP Peer Event Frame Transmitted Nanoseconds Register */
+#define REG_GMAC_PEFRSL         (*(__I  uint32_t*)0x400501F8U) /**< (GMAC) PTP Peer Event Frame Received Seconds Low Register */
+#define REG_GMAC_PEFRN          (*(__I  uint32_t*)0x400501FCU) /**< (GMAC) PTP Peer Event Frame Received Nanoseconds Register */
+#define REG_GMAC_RXLPI          (*(__I  uint32_t*)0x40050270U) /**< (GMAC) Received LPI Transitions */
+#define REG_GMAC_RXLPITIME      (*(__I  uint32_t*)0x40050274U) /**< (GMAC) Received LPI Time */
+#define REG_GMAC_TXLPI          (*(__I  uint32_t*)0x40050278U) /**< (GMAC) Transmit LPI Transitions */
+#define REG_GMAC_TXLPITIME      (*(__I  uint32_t*)0x4005027CU) /**< (GMAC) Transmit LPI Time */
+#define REG_GMAC_ISRPQ          (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) */
+#define REG_GMAC_ISRPQ0         (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 0 */
+#define REG_GMAC_ISRPQ1         (*(__I  uint32_t*)0x40050404U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 1 */
+#define REG_GMAC_ISRPQ2         (*(__I  uint32_t*)0x40050408U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 2 */
+#define REG_GMAC_ISRPQ3         (*(__I  uint32_t*)0x4005040CU) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 3 */
+#define REG_GMAC_ISRPQ4         (*(__I  uint32_t*)0x40050410U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 4 */
+#define REG_GMAC_TBQBAPQ        (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_TBQBAPQ0       (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_TBQBAPQ1       (*(__IO uint32_t*)0x40050444U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_TBQBAPQ2       (*(__IO uint32_t*)0x40050448U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_TBQBAPQ3       (*(__IO uint32_t*)0x4005044CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_TBQBAPQ4       (*(__IO uint32_t*)0x40050450U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBQBAPQ        (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_RBQBAPQ0       (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBQBAPQ1       (*(__IO uint32_t*)0x40050484U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBQBAPQ2       (*(__IO uint32_t*)0x40050488U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBQBAPQ3       (*(__IO uint32_t*)0x4005048CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBQBAPQ4       (*(__IO uint32_t*)0x40050490U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBSRPQ         (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) */
+#define REG_GMAC_RBSRPQ0        (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBSRPQ1        (*(__IO uint32_t*)0x400504A4U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBSRPQ2        (*(__IO uint32_t*)0x400504A8U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBSRPQ3        (*(__IO uint32_t*)0x400504ACU) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBSRPQ4        (*(__IO uint32_t*)0x400504B0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 4 */
+#define REG_GMAC_CBSCR          (*(__IO uint32_t*)0x400504BCU) /**< (GMAC) Credit-Based Shaping Control Register */
+#define REG_GMAC_CBSISQA        (*(__IO uint32_t*)0x400504C0U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
+#define REG_GMAC_CBSISQB        (*(__IO uint32_t*)0x400504C4U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
+#define REG_GMAC_ST1RPQ         (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue */
+#define REG_GMAC_ST1RPQ0        (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue 0 */
+#define REG_GMAC_ST1RPQ1        (*(__IO uint32_t*)0x40050504U) /**< (GMAC) Screening Type 1 Register Priority Queue 1 */
+#define REG_GMAC_ST1RPQ2        (*(__IO uint32_t*)0x40050508U) /**< (GMAC) Screening Type 1 Register Priority Queue 2 */
+#define REG_GMAC_ST1RPQ3        (*(__IO uint32_t*)0x4005050CU) /**< (GMAC) Screening Type 1 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ         (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue */
+#define REG_GMAC_ST2RPQ0        (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue 0 */
+#define REG_GMAC_ST2RPQ1        (*(__IO uint32_t*)0x40050544U) /**< (GMAC) Screening Type 2 Register Priority Queue 1 */
+#define REG_GMAC_ST2RPQ2        (*(__IO uint32_t*)0x40050548U) /**< (GMAC) Screening Type 2 Register Priority Queue 2 */
+#define REG_GMAC_ST2RPQ3        (*(__IO uint32_t*)0x4005054CU) /**< (GMAC) Screening Type 2 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ4        (*(__IO uint32_t*)0x40050550U) /**< (GMAC) Screening Type 2 Register Priority Queue 4 */
+#define REG_GMAC_ST2RPQ5        (*(__IO uint32_t*)0x40050554U) /**< (GMAC) Screening Type 2 Register Priority Queue 5 */
+#define REG_GMAC_ST2RPQ6        (*(__IO uint32_t*)0x40050558U) /**< (GMAC) Screening Type 2 Register Priority Queue 6 */
+#define REG_GMAC_ST2RPQ7        (*(__IO uint32_t*)0x4005055CU) /**< (GMAC) Screening Type 2 Register Priority Queue 7 */
+#define REG_GMAC_IERPQ          (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) */
+#define REG_GMAC_IERPQ0         (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IERPQ1         (*(__O  uint32_t*)0x40050604U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IERPQ2         (*(__O  uint32_t*)0x40050608U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IERPQ3         (*(__O  uint32_t*)0x4005060CU) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IERPQ4         (*(__O  uint32_t*)0x40050610U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IDRPQ          (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) */
+#define REG_GMAC_IDRPQ0         (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IDRPQ1         (*(__O  uint32_t*)0x40050624U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IDRPQ2         (*(__O  uint32_t*)0x40050628U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IDRPQ3         (*(__O  uint32_t*)0x4005062CU) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IDRPQ4         (*(__O  uint32_t*)0x40050630U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IMRPQ          (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) */
+#define REG_GMAC_IMRPQ0         (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IMRPQ1         (*(__IO uint32_t*)0x40050644U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IMRPQ2         (*(__IO uint32_t*)0x40050648U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IMRPQ3         (*(__IO uint32_t*)0x4005064CU) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IMRPQ4         (*(__IO uint32_t*)0x40050650U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 4 */
+#define REG_GMAC_ST2ER          (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register */
+#define REG_GMAC_ST2ER0         (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register 0 */
+#define REG_GMAC_ST2ER1         (*(__IO uint32_t*)0x400506E4U) /**< (GMAC) Screening Type 2 Ethertype Register 1 */
+#define REG_GMAC_ST2ER2         (*(__IO uint32_t*)0x400506E8U) /**< (GMAC) Screening Type 2 Ethertype Register 2 */
+#define REG_GMAC_ST2ER3         (*(__IO uint32_t*)0x400506ECU) /**< (GMAC) Screening Type 2 Ethertype Register 3 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for GMAC peripheral ========== */
+#define GMAC_INSTANCE_ID                         39         
+#define GMAC_CLOCK_ID                            39         
+
+#endif /* _SAMV71_GMAC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/gpbr.h
+++ b/asf/sam/include/samv71b/instance/gpbr.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GPBR
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_GPBR_INSTANCE_H_
+#define _SAMV71_GPBR_INSTANCE_H_
+
+/* ========== Register definition for GPBR peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_GPBR_SYS_GPBR       (0x400E1890) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR0      (0x400E1890) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR1      (0x400E1894) /**< (GPBR) General Purpose Backup Register 1 */
+#define REG_GPBR_SYS_GPBR2      (0x400E1898) /**< (GPBR) General Purpose Backup Register 2 */
+#define REG_GPBR_SYS_GPBR3      (0x400E189C) /**< (GPBR) General Purpose Backup Register 3 */
+#define REG_GPBR_SYS_GPBR4      (0x400E18A0) /**< (GPBR) General Purpose Backup Register 4 */
+#define REG_GPBR_SYS_GPBR5      (0x400E18A4) /**< (GPBR) General Purpose Backup Register 5 */
+#define REG_GPBR_SYS_GPBR6      (0x400E18A8) /**< (GPBR) General Purpose Backup Register 6 */
+#define REG_GPBR_SYS_GPBR7      (0x400E18AC) /**< (GPBR) General Purpose Backup Register 7 */
+
+#else
+
+#define REG_GPBR_SYS_GPBR       (*(__IO uint32_t*)0x400E1890U) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR0      (*(__IO uint32_t*)0x400E1890U) /**< (GPBR) General Purpose Backup Register 0 */
+#define REG_GPBR_SYS_GPBR1      (*(__IO uint32_t*)0x400E1894U) /**< (GPBR) General Purpose Backup Register 1 */
+#define REG_GPBR_SYS_GPBR2      (*(__IO uint32_t*)0x400E1898U) /**< (GPBR) General Purpose Backup Register 2 */
+#define REG_GPBR_SYS_GPBR3      (*(__IO uint32_t*)0x400E189CU) /**< (GPBR) General Purpose Backup Register 3 */
+#define REG_GPBR_SYS_GPBR4      (*(__IO uint32_t*)0x400E18A0U) /**< (GPBR) General Purpose Backup Register 4 */
+#define REG_GPBR_SYS_GPBR5      (*(__IO uint32_t*)0x400E18A4U) /**< (GPBR) General Purpose Backup Register 5 */
+#define REG_GPBR_SYS_GPBR6      (*(__IO uint32_t*)0x400E18A8U) /**< (GPBR) General Purpose Backup Register 6 */
+#define REG_GPBR_SYS_GPBR7      (*(__IO uint32_t*)0x400E18ACU) /**< (GPBR) General Purpose Backup Register 7 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_GPBR_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/hsmci.h
+++ b/asf/sam/include/samv71b/instance/hsmci.h
@@ -1,0 +1,609 @@
+/**
+ * \file
+ *
+ * \brief Instance description for HSMCI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_HSMCI_INSTANCE_H_
+#define _SAMV71_HSMCI_INSTANCE_H_
+
+/* ========== Register definition for HSMCI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_HSMCI_CR            (0x40000000) /**< (HSMCI) Control Register */
+#define REG_HSMCI_MR            (0x40000004) /**< (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR          (0x40000008) /**< (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR          (0x4000000C) /**< (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR          (0x40000010) /**< (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR          (0x40000014) /**< (HSMCI) Command Register */
+#define REG_HSMCI_BLKR          (0x40000018) /**< (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR         (0x4000001C) /**< (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR          (0x40000020) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR0         (0x40000020) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR1         (0x40000024) /**< (HSMCI) Response Register 1 */
+#define REG_HSMCI_RSPR2         (0x40000028) /**< (HSMCI) Response Register 2 */
+#define REG_HSMCI_RSPR3         (0x4000002C) /**< (HSMCI) Response Register 3 */
+#define REG_HSMCI_RDR           (0x40000030) /**< (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR           (0x40000034) /**< (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR            (0x40000040) /**< (HSMCI) Status Register */
+#define REG_HSMCI_IER           (0x40000044) /**< (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR           (0x40000048) /**< (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR           (0x4000004C) /**< (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_DMA           (0x40000050) /**< (HSMCI) DMA Configuration Register */
+#define REG_HSMCI_CFG           (0x40000054) /**< (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR          (0x400000E4) /**< (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR          (0x400000E8) /**< (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_FIFO          (0x40000200) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO0         (0x40000200) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO1         (0x40000204) /**< (HSMCI) FIFO Memory Aperture0 1 */
+#define REG_HSMCI_FIFO2         (0x40000208) /**< (HSMCI) FIFO Memory Aperture0 2 */
+#define REG_HSMCI_FIFO3         (0x4000020C) /**< (HSMCI) FIFO Memory Aperture0 3 */
+#define REG_HSMCI_FIFO4         (0x40000210) /**< (HSMCI) FIFO Memory Aperture0 4 */
+#define REG_HSMCI_FIFO5         (0x40000214) /**< (HSMCI) FIFO Memory Aperture0 5 */
+#define REG_HSMCI_FIFO6         (0x40000218) /**< (HSMCI) FIFO Memory Aperture0 6 */
+#define REG_HSMCI_FIFO7         (0x4000021C) /**< (HSMCI) FIFO Memory Aperture0 7 */
+#define REG_HSMCI_FIFO8         (0x40000220) /**< (HSMCI) FIFO Memory Aperture0 8 */
+#define REG_HSMCI_FIFO9         (0x40000224) /**< (HSMCI) FIFO Memory Aperture0 9 */
+#define REG_HSMCI_FIFO10        (0x40000228) /**< (HSMCI) FIFO Memory Aperture0 10 */
+#define REG_HSMCI_FIFO11        (0x4000022C) /**< (HSMCI) FIFO Memory Aperture0 11 */
+#define REG_HSMCI_FIFO12        (0x40000230) /**< (HSMCI) FIFO Memory Aperture0 12 */
+#define REG_HSMCI_FIFO13        (0x40000234) /**< (HSMCI) FIFO Memory Aperture0 13 */
+#define REG_HSMCI_FIFO14        (0x40000238) /**< (HSMCI) FIFO Memory Aperture0 14 */
+#define REG_HSMCI_FIFO15        (0x4000023C) /**< (HSMCI) FIFO Memory Aperture0 15 */
+#define REG_HSMCI_FIFO16        (0x40000240) /**< (HSMCI) FIFO Memory Aperture0 16 */
+#define REG_HSMCI_FIFO17        (0x40000244) /**< (HSMCI) FIFO Memory Aperture0 17 */
+#define REG_HSMCI_FIFO18        (0x40000248) /**< (HSMCI) FIFO Memory Aperture0 18 */
+#define REG_HSMCI_FIFO19        (0x4000024C) /**< (HSMCI) FIFO Memory Aperture0 19 */
+#define REG_HSMCI_FIFO20        (0x40000250) /**< (HSMCI) FIFO Memory Aperture0 20 */
+#define REG_HSMCI_FIFO21        (0x40000254) /**< (HSMCI) FIFO Memory Aperture0 21 */
+#define REG_HSMCI_FIFO22        (0x40000258) /**< (HSMCI) FIFO Memory Aperture0 22 */
+#define REG_HSMCI_FIFO23        (0x4000025C) /**< (HSMCI) FIFO Memory Aperture0 23 */
+#define REG_HSMCI_FIFO24        (0x40000260) /**< (HSMCI) FIFO Memory Aperture0 24 */
+#define REG_HSMCI_FIFO25        (0x40000264) /**< (HSMCI) FIFO Memory Aperture0 25 */
+#define REG_HSMCI_FIFO26        (0x40000268) /**< (HSMCI) FIFO Memory Aperture0 26 */
+#define REG_HSMCI_FIFO27        (0x4000026C) /**< (HSMCI) FIFO Memory Aperture0 27 */
+#define REG_HSMCI_FIFO28        (0x40000270) /**< (HSMCI) FIFO Memory Aperture0 28 */
+#define REG_HSMCI_FIFO29        (0x40000274) /**< (HSMCI) FIFO Memory Aperture0 29 */
+#define REG_HSMCI_FIFO30        (0x40000278) /**< (HSMCI) FIFO Memory Aperture0 30 */
+#define REG_HSMCI_FIFO31        (0x4000027C) /**< (HSMCI) FIFO Memory Aperture0 31 */
+#define REG_HSMCI_FIFO32        (0x40000280) /**< (HSMCI) FIFO Memory Aperture0 32 */
+#define REG_HSMCI_FIFO33        (0x40000284) /**< (HSMCI) FIFO Memory Aperture0 33 */
+#define REG_HSMCI_FIFO34        (0x40000288) /**< (HSMCI) FIFO Memory Aperture0 34 */
+#define REG_HSMCI_FIFO35        (0x4000028C) /**< (HSMCI) FIFO Memory Aperture0 35 */
+#define REG_HSMCI_FIFO36        (0x40000290) /**< (HSMCI) FIFO Memory Aperture0 36 */
+#define REG_HSMCI_FIFO37        (0x40000294) /**< (HSMCI) FIFO Memory Aperture0 37 */
+#define REG_HSMCI_FIFO38        (0x40000298) /**< (HSMCI) FIFO Memory Aperture0 38 */
+#define REG_HSMCI_FIFO39        (0x4000029C) /**< (HSMCI) FIFO Memory Aperture0 39 */
+#define REG_HSMCI_FIFO40        (0x400002A0) /**< (HSMCI) FIFO Memory Aperture0 40 */
+#define REG_HSMCI_FIFO41        (0x400002A4) /**< (HSMCI) FIFO Memory Aperture0 41 */
+#define REG_HSMCI_FIFO42        (0x400002A8) /**< (HSMCI) FIFO Memory Aperture0 42 */
+#define REG_HSMCI_FIFO43        (0x400002AC) /**< (HSMCI) FIFO Memory Aperture0 43 */
+#define REG_HSMCI_FIFO44        (0x400002B0) /**< (HSMCI) FIFO Memory Aperture0 44 */
+#define REG_HSMCI_FIFO45        (0x400002B4) /**< (HSMCI) FIFO Memory Aperture0 45 */
+#define REG_HSMCI_FIFO46        (0x400002B8) /**< (HSMCI) FIFO Memory Aperture0 46 */
+#define REG_HSMCI_FIFO47        (0x400002BC) /**< (HSMCI) FIFO Memory Aperture0 47 */
+#define REG_HSMCI_FIFO48        (0x400002C0) /**< (HSMCI) FIFO Memory Aperture0 48 */
+#define REG_HSMCI_FIFO49        (0x400002C4) /**< (HSMCI) FIFO Memory Aperture0 49 */
+#define REG_HSMCI_FIFO50        (0x400002C8) /**< (HSMCI) FIFO Memory Aperture0 50 */
+#define REG_HSMCI_FIFO51        (0x400002CC) /**< (HSMCI) FIFO Memory Aperture0 51 */
+#define REG_HSMCI_FIFO52        (0x400002D0) /**< (HSMCI) FIFO Memory Aperture0 52 */
+#define REG_HSMCI_FIFO53        (0x400002D4) /**< (HSMCI) FIFO Memory Aperture0 53 */
+#define REG_HSMCI_FIFO54        (0x400002D8) /**< (HSMCI) FIFO Memory Aperture0 54 */
+#define REG_HSMCI_FIFO55        (0x400002DC) /**< (HSMCI) FIFO Memory Aperture0 55 */
+#define REG_HSMCI_FIFO56        (0x400002E0) /**< (HSMCI) FIFO Memory Aperture0 56 */
+#define REG_HSMCI_FIFO57        (0x400002E4) /**< (HSMCI) FIFO Memory Aperture0 57 */
+#define REG_HSMCI_FIFO58        (0x400002E8) /**< (HSMCI) FIFO Memory Aperture0 58 */
+#define REG_HSMCI_FIFO59        (0x400002EC) /**< (HSMCI) FIFO Memory Aperture0 59 */
+#define REG_HSMCI_FIFO60        (0x400002F0) /**< (HSMCI) FIFO Memory Aperture0 60 */
+#define REG_HSMCI_FIFO61        (0x400002F4) /**< (HSMCI) FIFO Memory Aperture0 61 */
+#define REG_HSMCI_FIFO62        (0x400002F8) /**< (HSMCI) FIFO Memory Aperture0 62 */
+#define REG_HSMCI_FIFO63        (0x400002FC) /**< (HSMCI) FIFO Memory Aperture0 63 */
+#define REG_HSMCI_FIFO64        (0x40000300) /**< (HSMCI) FIFO Memory Aperture0 64 */
+#define REG_HSMCI_FIFO65        (0x40000304) /**< (HSMCI) FIFO Memory Aperture0 65 */
+#define REG_HSMCI_FIFO66        (0x40000308) /**< (HSMCI) FIFO Memory Aperture0 66 */
+#define REG_HSMCI_FIFO67        (0x4000030C) /**< (HSMCI) FIFO Memory Aperture0 67 */
+#define REG_HSMCI_FIFO68        (0x40000310) /**< (HSMCI) FIFO Memory Aperture0 68 */
+#define REG_HSMCI_FIFO69        (0x40000314) /**< (HSMCI) FIFO Memory Aperture0 69 */
+#define REG_HSMCI_FIFO70        (0x40000318) /**< (HSMCI) FIFO Memory Aperture0 70 */
+#define REG_HSMCI_FIFO71        (0x4000031C) /**< (HSMCI) FIFO Memory Aperture0 71 */
+#define REG_HSMCI_FIFO72        (0x40000320) /**< (HSMCI) FIFO Memory Aperture0 72 */
+#define REG_HSMCI_FIFO73        (0x40000324) /**< (HSMCI) FIFO Memory Aperture0 73 */
+#define REG_HSMCI_FIFO74        (0x40000328) /**< (HSMCI) FIFO Memory Aperture0 74 */
+#define REG_HSMCI_FIFO75        (0x4000032C) /**< (HSMCI) FIFO Memory Aperture0 75 */
+#define REG_HSMCI_FIFO76        (0x40000330) /**< (HSMCI) FIFO Memory Aperture0 76 */
+#define REG_HSMCI_FIFO77        (0x40000334) /**< (HSMCI) FIFO Memory Aperture0 77 */
+#define REG_HSMCI_FIFO78        (0x40000338) /**< (HSMCI) FIFO Memory Aperture0 78 */
+#define REG_HSMCI_FIFO79        (0x4000033C) /**< (HSMCI) FIFO Memory Aperture0 79 */
+#define REG_HSMCI_FIFO80        (0x40000340) /**< (HSMCI) FIFO Memory Aperture0 80 */
+#define REG_HSMCI_FIFO81        (0x40000344) /**< (HSMCI) FIFO Memory Aperture0 81 */
+#define REG_HSMCI_FIFO82        (0x40000348) /**< (HSMCI) FIFO Memory Aperture0 82 */
+#define REG_HSMCI_FIFO83        (0x4000034C) /**< (HSMCI) FIFO Memory Aperture0 83 */
+#define REG_HSMCI_FIFO84        (0x40000350) /**< (HSMCI) FIFO Memory Aperture0 84 */
+#define REG_HSMCI_FIFO85        (0x40000354) /**< (HSMCI) FIFO Memory Aperture0 85 */
+#define REG_HSMCI_FIFO86        (0x40000358) /**< (HSMCI) FIFO Memory Aperture0 86 */
+#define REG_HSMCI_FIFO87        (0x4000035C) /**< (HSMCI) FIFO Memory Aperture0 87 */
+#define REG_HSMCI_FIFO88        (0x40000360) /**< (HSMCI) FIFO Memory Aperture0 88 */
+#define REG_HSMCI_FIFO89        (0x40000364) /**< (HSMCI) FIFO Memory Aperture0 89 */
+#define REG_HSMCI_FIFO90        (0x40000368) /**< (HSMCI) FIFO Memory Aperture0 90 */
+#define REG_HSMCI_FIFO91        (0x4000036C) /**< (HSMCI) FIFO Memory Aperture0 91 */
+#define REG_HSMCI_FIFO92        (0x40000370) /**< (HSMCI) FIFO Memory Aperture0 92 */
+#define REG_HSMCI_FIFO93        (0x40000374) /**< (HSMCI) FIFO Memory Aperture0 93 */
+#define REG_HSMCI_FIFO94        (0x40000378) /**< (HSMCI) FIFO Memory Aperture0 94 */
+#define REG_HSMCI_FIFO95        (0x4000037C) /**< (HSMCI) FIFO Memory Aperture0 95 */
+#define REG_HSMCI_FIFO96        (0x40000380) /**< (HSMCI) FIFO Memory Aperture0 96 */
+#define REG_HSMCI_FIFO97        (0x40000384) /**< (HSMCI) FIFO Memory Aperture0 97 */
+#define REG_HSMCI_FIFO98        (0x40000388) /**< (HSMCI) FIFO Memory Aperture0 98 */
+#define REG_HSMCI_FIFO99        (0x4000038C) /**< (HSMCI) FIFO Memory Aperture0 99 */
+#define REG_HSMCI_FIFO100       (0x40000390) /**< (HSMCI) FIFO Memory Aperture0 100 */
+#define REG_HSMCI_FIFO101       (0x40000394) /**< (HSMCI) FIFO Memory Aperture0 101 */
+#define REG_HSMCI_FIFO102       (0x40000398) /**< (HSMCI) FIFO Memory Aperture0 102 */
+#define REG_HSMCI_FIFO103       (0x4000039C) /**< (HSMCI) FIFO Memory Aperture0 103 */
+#define REG_HSMCI_FIFO104       (0x400003A0) /**< (HSMCI) FIFO Memory Aperture0 104 */
+#define REG_HSMCI_FIFO105       (0x400003A4) /**< (HSMCI) FIFO Memory Aperture0 105 */
+#define REG_HSMCI_FIFO106       (0x400003A8) /**< (HSMCI) FIFO Memory Aperture0 106 */
+#define REG_HSMCI_FIFO107       (0x400003AC) /**< (HSMCI) FIFO Memory Aperture0 107 */
+#define REG_HSMCI_FIFO108       (0x400003B0) /**< (HSMCI) FIFO Memory Aperture0 108 */
+#define REG_HSMCI_FIFO109       (0x400003B4) /**< (HSMCI) FIFO Memory Aperture0 109 */
+#define REG_HSMCI_FIFO110       (0x400003B8) /**< (HSMCI) FIFO Memory Aperture0 110 */
+#define REG_HSMCI_FIFO111       (0x400003BC) /**< (HSMCI) FIFO Memory Aperture0 111 */
+#define REG_HSMCI_FIFO112       (0x400003C0) /**< (HSMCI) FIFO Memory Aperture0 112 */
+#define REG_HSMCI_FIFO113       (0x400003C4) /**< (HSMCI) FIFO Memory Aperture0 113 */
+#define REG_HSMCI_FIFO114       (0x400003C8) /**< (HSMCI) FIFO Memory Aperture0 114 */
+#define REG_HSMCI_FIFO115       (0x400003CC) /**< (HSMCI) FIFO Memory Aperture0 115 */
+#define REG_HSMCI_FIFO116       (0x400003D0) /**< (HSMCI) FIFO Memory Aperture0 116 */
+#define REG_HSMCI_FIFO117       (0x400003D4) /**< (HSMCI) FIFO Memory Aperture0 117 */
+#define REG_HSMCI_FIFO118       (0x400003D8) /**< (HSMCI) FIFO Memory Aperture0 118 */
+#define REG_HSMCI_FIFO119       (0x400003DC) /**< (HSMCI) FIFO Memory Aperture0 119 */
+#define REG_HSMCI_FIFO120       (0x400003E0) /**< (HSMCI) FIFO Memory Aperture0 120 */
+#define REG_HSMCI_FIFO121       (0x400003E4) /**< (HSMCI) FIFO Memory Aperture0 121 */
+#define REG_HSMCI_FIFO122       (0x400003E8) /**< (HSMCI) FIFO Memory Aperture0 122 */
+#define REG_HSMCI_FIFO123       (0x400003EC) /**< (HSMCI) FIFO Memory Aperture0 123 */
+#define REG_HSMCI_FIFO124       (0x400003F0) /**< (HSMCI) FIFO Memory Aperture0 124 */
+#define REG_HSMCI_FIFO125       (0x400003F4) /**< (HSMCI) FIFO Memory Aperture0 125 */
+#define REG_HSMCI_FIFO126       (0x400003F8) /**< (HSMCI) FIFO Memory Aperture0 126 */
+#define REG_HSMCI_FIFO127       (0x400003FC) /**< (HSMCI) FIFO Memory Aperture0 127 */
+#define REG_HSMCI_FIFO128       (0x40000400) /**< (HSMCI) FIFO Memory Aperture0 128 */
+#define REG_HSMCI_FIFO129       (0x40000404) /**< (HSMCI) FIFO Memory Aperture0 129 */
+#define REG_HSMCI_FIFO130       (0x40000408) /**< (HSMCI) FIFO Memory Aperture0 130 */
+#define REG_HSMCI_FIFO131       (0x4000040C) /**< (HSMCI) FIFO Memory Aperture0 131 */
+#define REG_HSMCI_FIFO132       (0x40000410) /**< (HSMCI) FIFO Memory Aperture0 132 */
+#define REG_HSMCI_FIFO133       (0x40000414) /**< (HSMCI) FIFO Memory Aperture0 133 */
+#define REG_HSMCI_FIFO134       (0x40000418) /**< (HSMCI) FIFO Memory Aperture0 134 */
+#define REG_HSMCI_FIFO135       (0x4000041C) /**< (HSMCI) FIFO Memory Aperture0 135 */
+#define REG_HSMCI_FIFO136       (0x40000420) /**< (HSMCI) FIFO Memory Aperture0 136 */
+#define REG_HSMCI_FIFO137       (0x40000424) /**< (HSMCI) FIFO Memory Aperture0 137 */
+#define REG_HSMCI_FIFO138       (0x40000428) /**< (HSMCI) FIFO Memory Aperture0 138 */
+#define REG_HSMCI_FIFO139       (0x4000042C) /**< (HSMCI) FIFO Memory Aperture0 139 */
+#define REG_HSMCI_FIFO140       (0x40000430) /**< (HSMCI) FIFO Memory Aperture0 140 */
+#define REG_HSMCI_FIFO141       (0x40000434) /**< (HSMCI) FIFO Memory Aperture0 141 */
+#define REG_HSMCI_FIFO142       (0x40000438) /**< (HSMCI) FIFO Memory Aperture0 142 */
+#define REG_HSMCI_FIFO143       (0x4000043C) /**< (HSMCI) FIFO Memory Aperture0 143 */
+#define REG_HSMCI_FIFO144       (0x40000440) /**< (HSMCI) FIFO Memory Aperture0 144 */
+#define REG_HSMCI_FIFO145       (0x40000444) /**< (HSMCI) FIFO Memory Aperture0 145 */
+#define REG_HSMCI_FIFO146       (0x40000448) /**< (HSMCI) FIFO Memory Aperture0 146 */
+#define REG_HSMCI_FIFO147       (0x4000044C) /**< (HSMCI) FIFO Memory Aperture0 147 */
+#define REG_HSMCI_FIFO148       (0x40000450) /**< (HSMCI) FIFO Memory Aperture0 148 */
+#define REG_HSMCI_FIFO149       (0x40000454) /**< (HSMCI) FIFO Memory Aperture0 149 */
+#define REG_HSMCI_FIFO150       (0x40000458) /**< (HSMCI) FIFO Memory Aperture0 150 */
+#define REG_HSMCI_FIFO151       (0x4000045C) /**< (HSMCI) FIFO Memory Aperture0 151 */
+#define REG_HSMCI_FIFO152       (0x40000460) /**< (HSMCI) FIFO Memory Aperture0 152 */
+#define REG_HSMCI_FIFO153       (0x40000464) /**< (HSMCI) FIFO Memory Aperture0 153 */
+#define REG_HSMCI_FIFO154       (0x40000468) /**< (HSMCI) FIFO Memory Aperture0 154 */
+#define REG_HSMCI_FIFO155       (0x4000046C) /**< (HSMCI) FIFO Memory Aperture0 155 */
+#define REG_HSMCI_FIFO156       (0x40000470) /**< (HSMCI) FIFO Memory Aperture0 156 */
+#define REG_HSMCI_FIFO157       (0x40000474) /**< (HSMCI) FIFO Memory Aperture0 157 */
+#define REG_HSMCI_FIFO158       (0x40000478) /**< (HSMCI) FIFO Memory Aperture0 158 */
+#define REG_HSMCI_FIFO159       (0x4000047C) /**< (HSMCI) FIFO Memory Aperture0 159 */
+#define REG_HSMCI_FIFO160       (0x40000480) /**< (HSMCI) FIFO Memory Aperture0 160 */
+#define REG_HSMCI_FIFO161       (0x40000484) /**< (HSMCI) FIFO Memory Aperture0 161 */
+#define REG_HSMCI_FIFO162       (0x40000488) /**< (HSMCI) FIFO Memory Aperture0 162 */
+#define REG_HSMCI_FIFO163       (0x4000048C) /**< (HSMCI) FIFO Memory Aperture0 163 */
+#define REG_HSMCI_FIFO164       (0x40000490) /**< (HSMCI) FIFO Memory Aperture0 164 */
+#define REG_HSMCI_FIFO165       (0x40000494) /**< (HSMCI) FIFO Memory Aperture0 165 */
+#define REG_HSMCI_FIFO166       (0x40000498) /**< (HSMCI) FIFO Memory Aperture0 166 */
+#define REG_HSMCI_FIFO167       (0x4000049C) /**< (HSMCI) FIFO Memory Aperture0 167 */
+#define REG_HSMCI_FIFO168       (0x400004A0) /**< (HSMCI) FIFO Memory Aperture0 168 */
+#define REG_HSMCI_FIFO169       (0x400004A4) /**< (HSMCI) FIFO Memory Aperture0 169 */
+#define REG_HSMCI_FIFO170       (0x400004A8) /**< (HSMCI) FIFO Memory Aperture0 170 */
+#define REG_HSMCI_FIFO171       (0x400004AC) /**< (HSMCI) FIFO Memory Aperture0 171 */
+#define REG_HSMCI_FIFO172       (0x400004B0) /**< (HSMCI) FIFO Memory Aperture0 172 */
+#define REG_HSMCI_FIFO173       (0x400004B4) /**< (HSMCI) FIFO Memory Aperture0 173 */
+#define REG_HSMCI_FIFO174       (0x400004B8) /**< (HSMCI) FIFO Memory Aperture0 174 */
+#define REG_HSMCI_FIFO175       (0x400004BC) /**< (HSMCI) FIFO Memory Aperture0 175 */
+#define REG_HSMCI_FIFO176       (0x400004C0) /**< (HSMCI) FIFO Memory Aperture0 176 */
+#define REG_HSMCI_FIFO177       (0x400004C4) /**< (HSMCI) FIFO Memory Aperture0 177 */
+#define REG_HSMCI_FIFO178       (0x400004C8) /**< (HSMCI) FIFO Memory Aperture0 178 */
+#define REG_HSMCI_FIFO179       (0x400004CC) /**< (HSMCI) FIFO Memory Aperture0 179 */
+#define REG_HSMCI_FIFO180       (0x400004D0) /**< (HSMCI) FIFO Memory Aperture0 180 */
+#define REG_HSMCI_FIFO181       (0x400004D4) /**< (HSMCI) FIFO Memory Aperture0 181 */
+#define REG_HSMCI_FIFO182       (0x400004D8) /**< (HSMCI) FIFO Memory Aperture0 182 */
+#define REG_HSMCI_FIFO183       (0x400004DC) /**< (HSMCI) FIFO Memory Aperture0 183 */
+#define REG_HSMCI_FIFO184       (0x400004E0) /**< (HSMCI) FIFO Memory Aperture0 184 */
+#define REG_HSMCI_FIFO185       (0x400004E4) /**< (HSMCI) FIFO Memory Aperture0 185 */
+#define REG_HSMCI_FIFO186       (0x400004E8) /**< (HSMCI) FIFO Memory Aperture0 186 */
+#define REG_HSMCI_FIFO187       (0x400004EC) /**< (HSMCI) FIFO Memory Aperture0 187 */
+#define REG_HSMCI_FIFO188       (0x400004F0) /**< (HSMCI) FIFO Memory Aperture0 188 */
+#define REG_HSMCI_FIFO189       (0x400004F4) /**< (HSMCI) FIFO Memory Aperture0 189 */
+#define REG_HSMCI_FIFO190       (0x400004F8) /**< (HSMCI) FIFO Memory Aperture0 190 */
+#define REG_HSMCI_FIFO191       (0x400004FC) /**< (HSMCI) FIFO Memory Aperture0 191 */
+#define REG_HSMCI_FIFO192       (0x40000500) /**< (HSMCI) FIFO Memory Aperture0 192 */
+#define REG_HSMCI_FIFO193       (0x40000504) /**< (HSMCI) FIFO Memory Aperture0 193 */
+#define REG_HSMCI_FIFO194       (0x40000508) /**< (HSMCI) FIFO Memory Aperture0 194 */
+#define REG_HSMCI_FIFO195       (0x4000050C) /**< (HSMCI) FIFO Memory Aperture0 195 */
+#define REG_HSMCI_FIFO196       (0x40000510) /**< (HSMCI) FIFO Memory Aperture0 196 */
+#define REG_HSMCI_FIFO197       (0x40000514) /**< (HSMCI) FIFO Memory Aperture0 197 */
+#define REG_HSMCI_FIFO198       (0x40000518) /**< (HSMCI) FIFO Memory Aperture0 198 */
+#define REG_HSMCI_FIFO199       (0x4000051C) /**< (HSMCI) FIFO Memory Aperture0 199 */
+#define REG_HSMCI_FIFO200       (0x40000520) /**< (HSMCI) FIFO Memory Aperture0 200 */
+#define REG_HSMCI_FIFO201       (0x40000524) /**< (HSMCI) FIFO Memory Aperture0 201 */
+#define REG_HSMCI_FIFO202       (0x40000528) /**< (HSMCI) FIFO Memory Aperture0 202 */
+#define REG_HSMCI_FIFO203       (0x4000052C) /**< (HSMCI) FIFO Memory Aperture0 203 */
+#define REG_HSMCI_FIFO204       (0x40000530) /**< (HSMCI) FIFO Memory Aperture0 204 */
+#define REG_HSMCI_FIFO205       (0x40000534) /**< (HSMCI) FIFO Memory Aperture0 205 */
+#define REG_HSMCI_FIFO206       (0x40000538) /**< (HSMCI) FIFO Memory Aperture0 206 */
+#define REG_HSMCI_FIFO207       (0x4000053C) /**< (HSMCI) FIFO Memory Aperture0 207 */
+#define REG_HSMCI_FIFO208       (0x40000540) /**< (HSMCI) FIFO Memory Aperture0 208 */
+#define REG_HSMCI_FIFO209       (0x40000544) /**< (HSMCI) FIFO Memory Aperture0 209 */
+#define REG_HSMCI_FIFO210       (0x40000548) /**< (HSMCI) FIFO Memory Aperture0 210 */
+#define REG_HSMCI_FIFO211       (0x4000054C) /**< (HSMCI) FIFO Memory Aperture0 211 */
+#define REG_HSMCI_FIFO212       (0x40000550) /**< (HSMCI) FIFO Memory Aperture0 212 */
+#define REG_HSMCI_FIFO213       (0x40000554) /**< (HSMCI) FIFO Memory Aperture0 213 */
+#define REG_HSMCI_FIFO214       (0x40000558) /**< (HSMCI) FIFO Memory Aperture0 214 */
+#define REG_HSMCI_FIFO215       (0x4000055C) /**< (HSMCI) FIFO Memory Aperture0 215 */
+#define REG_HSMCI_FIFO216       (0x40000560) /**< (HSMCI) FIFO Memory Aperture0 216 */
+#define REG_HSMCI_FIFO217       (0x40000564) /**< (HSMCI) FIFO Memory Aperture0 217 */
+#define REG_HSMCI_FIFO218       (0x40000568) /**< (HSMCI) FIFO Memory Aperture0 218 */
+#define REG_HSMCI_FIFO219       (0x4000056C) /**< (HSMCI) FIFO Memory Aperture0 219 */
+#define REG_HSMCI_FIFO220       (0x40000570) /**< (HSMCI) FIFO Memory Aperture0 220 */
+#define REG_HSMCI_FIFO221       (0x40000574) /**< (HSMCI) FIFO Memory Aperture0 221 */
+#define REG_HSMCI_FIFO222       (0x40000578) /**< (HSMCI) FIFO Memory Aperture0 222 */
+#define REG_HSMCI_FIFO223       (0x4000057C) /**< (HSMCI) FIFO Memory Aperture0 223 */
+#define REG_HSMCI_FIFO224       (0x40000580) /**< (HSMCI) FIFO Memory Aperture0 224 */
+#define REG_HSMCI_FIFO225       (0x40000584) /**< (HSMCI) FIFO Memory Aperture0 225 */
+#define REG_HSMCI_FIFO226       (0x40000588) /**< (HSMCI) FIFO Memory Aperture0 226 */
+#define REG_HSMCI_FIFO227       (0x4000058C) /**< (HSMCI) FIFO Memory Aperture0 227 */
+#define REG_HSMCI_FIFO228       (0x40000590) /**< (HSMCI) FIFO Memory Aperture0 228 */
+#define REG_HSMCI_FIFO229       (0x40000594) /**< (HSMCI) FIFO Memory Aperture0 229 */
+#define REG_HSMCI_FIFO230       (0x40000598) /**< (HSMCI) FIFO Memory Aperture0 230 */
+#define REG_HSMCI_FIFO231       (0x4000059C) /**< (HSMCI) FIFO Memory Aperture0 231 */
+#define REG_HSMCI_FIFO232       (0x400005A0) /**< (HSMCI) FIFO Memory Aperture0 232 */
+#define REG_HSMCI_FIFO233       (0x400005A4) /**< (HSMCI) FIFO Memory Aperture0 233 */
+#define REG_HSMCI_FIFO234       (0x400005A8) /**< (HSMCI) FIFO Memory Aperture0 234 */
+#define REG_HSMCI_FIFO235       (0x400005AC) /**< (HSMCI) FIFO Memory Aperture0 235 */
+#define REG_HSMCI_FIFO236       (0x400005B0) /**< (HSMCI) FIFO Memory Aperture0 236 */
+#define REG_HSMCI_FIFO237       (0x400005B4) /**< (HSMCI) FIFO Memory Aperture0 237 */
+#define REG_HSMCI_FIFO238       (0x400005B8) /**< (HSMCI) FIFO Memory Aperture0 238 */
+#define REG_HSMCI_FIFO239       (0x400005BC) /**< (HSMCI) FIFO Memory Aperture0 239 */
+#define REG_HSMCI_FIFO240       (0x400005C0) /**< (HSMCI) FIFO Memory Aperture0 240 */
+#define REG_HSMCI_FIFO241       (0x400005C4) /**< (HSMCI) FIFO Memory Aperture0 241 */
+#define REG_HSMCI_FIFO242       (0x400005C8) /**< (HSMCI) FIFO Memory Aperture0 242 */
+#define REG_HSMCI_FIFO243       (0x400005CC) /**< (HSMCI) FIFO Memory Aperture0 243 */
+#define REG_HSMCI_FIFO244       (0x400005D0) /**< (HSMCI) FIFO Memory Aperture0 244 */
+#define REG_HSMCI_FIFO245       (0x400005D4) /**< (HSMCI) FIFO Memory Aperture0 245 */
+#define REG_HSMCI_FIFO246       (0x400005D8) /**< (HSMCI) FIFO Memory Aperture0 246 */
+#define REG_HSMCI_FIFO247       (0x400005DC) /**< (HSMCI) FIFO Memory Aperture0 247 */
+#define REG_HSMCI_FIFO248       (0x400005E0) /**< (HSMCI) FIFO Memory Aperture0 248 */
+#define REG_HSMCI_FIFO249       (0x400005E4) /**< (HSMCI) FIFO Memory Aperture0 249 */
+#define REG_HSMCI_FIFO250       (0x400005E8) /**< (HSMCI) FIFO Memory Aperture0 250 */
+#define REG_HSMCI_FIFO251       (0x400005EC) /**< (HSMCI) FIFO Memory Aperture0 251 */
+#define REG_HSMCI_FIFO252       (0x400005F0) /**< (HSMCI) FIFO Memory Aperture0 252 */
+#define REG_HSMCI_FIFO253       (0x400005F4) /**< (HSMCI) FIFO Memory Aperture0 253 */
+#define REG_HSMCI_FIFO254       (0x400005F8) /**< (HSMCI) FIFO Memory Aperture0 254 */
+#define REG_HSMCI_FIFO255       (0x400005FC) /**< (HSMCI) FIFO Memory Aperture0 255 */
+
+#else
+
+#define REG_HSMCI_CR            (*(__O  uint32_t*)0x40000000U) /**< (HSMCI) Control Register */
+#define REG_HSMCI_MR            (*(__IO uint32_t*)0x40000004U) /**< (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR          (*(__IO uint32_t*)0x40000008U) /**< (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR          (*(__IO uint32_t*)0x4000000CU) /**< (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR          (*(__IO uint32_t*)0x40000010U) /**< (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR          (*(__O  uint32_t*)0x40000014U) /**< (HSMCI) Command Register */
+#define REG_HSMCI_BLKR          (*(__IO uint32_t*)0x40000018U) /**< (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR         (*(__IO uint32_t*)0x4000001CU) /**< (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR          (*(__I  uint32_t*)0x40000020U) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR0         (*(__I  uint32_t*)0x40000020U) /**< (HSMCI) Response Register 0 */
+#define REG_HSMCI_RSPR1         (*(__I  uint32_t*)0x40000024U) /**< (HSMCI) Response Register 1 */
+#define REG_HSMCI_RSPR2         (*(__I  uint32_t*)0x40000028U) /**< (HSMCI) Response Register 2 */
+#define REG_HSMCI_RSPR3         (*(__I  uint32_t*)0x4000002CU) /**< (HSMCI) Response Register 3 */
+#define REG_HSMCI_RDR           (*(__I  uint32_t*)0x40000030U) /**< (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR           (*(__O  uint32_t*)0x40000034U) /**< (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR            (*(__I  uint32_t*)0x40000040U) /**< (HSMCI) Status Register */
+#define REG_HSMCI_IER           (*(__O  uint32_t*)0x40000044U) /**< (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR           (*(__O  uint32_t*)0x40000048U) /**< (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR           (*(__I  uint32_t*)0x4000004CU) /**< (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_DMA           (*(__IO uint32_t*)0x40000050U) /**< (HSMCI) DMA Configuration Register */
+#define REG_HSMCI_CFG           (*(__IO uint32_t*)0x40000054U) /**< (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR          (*(__IO uint32_t*)0x400000E4U) /**< (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR          (*(__I  uint32_t*)0x400000E8U) /**< (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_FIFO          (*(__IO uint32_t*)0x40000200U) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO0         (*(__IO uint32_t*)0x40000200U) /**< (HSMCI) FIFO Memory Aperture0 0 */
+#define REG_HSMCI_FIFO1         (*(__IO uint32_t*)0x40000204U) /**< (HSMCI) FIFO Memory Aperture0 1 */
+#define REG_HSMCI_FIFO2         (*(__IO uint32_t*)0x40000208U) /**< (HSMCI) FIFO Memory Aperture0 2 */
+#define REG_HSMCI_FIFO3         (*(__IO uint32_t*)0x4000020CU) /**< (HSMCI) FIFO Memory Aperture0 3 */
+#define REG_HSMCI_FIFO4         (*(__IO uint32_t*)0x40000210U) /**< (HSMCI) FIFO Memory Aperture0 4 */
+#define REG_HSMCI_FIFO5         (*(__IO uint32_t*)0x40000214U) /**< (HSMCI) FIFO Memory Aperture0 5 */
+#define REG_HSMCI_FIFO6         (*(__IO uint32_t*)0x40000218U) /**< (HSMCI) FIFO Memory Aperture0 6 */
+#define REG_HSMCI_FIFO7         (*(__IO uint32_t*)0x4000021CU) /**< (HSMCI) FIFO Memory Aperture0 7 */
+#define REG_HSMCI_FIFO8         (*(__IO uint32_t*)0x40000220U) /**< (HSMCI) FIFO Memory Aperture0 8 */
+#define REG_HSMCI_FIFO9         (*(__IO uint32_t*)0x40000224U) /**< (HSMCI) FIFO Memory Aperture0 9 */
+#define REG_HSMCI_FIFO10        (*(__IO uint32_t*)0x40000228U) /**< (HSMCI) FIFO Memory Aperture0 10 */
+#define REG_HSMCI_FIFO11        (*(__IO uint32_t*)0x4000022CU) /**< (HSMCI) FIFO Memory Aperture0 11 */
+#define REG_HSMCI_FIFO12        (*(__IO uint32_t*)0x40000230U) /**< (HSMCI) FIFO Memory Aperture0 12 */
+#define REG_HSMCI_FIFO13        (*(__IO uint32_t*)0x40000234U) /**< (HSMCI) FIFO Memory Aperture0 13 */
+#define REG_HSMCI_FIFO14        (*(__IO uint32_t*)0x40000238U) /**< (HSMCI) FIFO Memory Aperture0 14 */
+#define REG_HSMCI_FIFO15        (*(__IO uint32_t*)0x4000023CU) /**< (HSMCI) FIFO Memory Aperture0 15 */
+#define REG_HSMCI_FIFO16        (*(__IO uint32_t*)0x40000240U) /**< (HSMCI) FIFO Memory Aperture0 16 */
+#define REG_HSMCI_FIFO17        (*(__IO uint32_t*)0x40000244U) /**< (HSMCI) FIFO Memory Aperture0 17 */
+#define REG_HSMCI_FIFO18        (*(__IO uint32_t*)0x40000248U) /**< (HSMCI) FIFO Memory Aperture0 18 */
+#define REG_HSMCI_FIFO19        (*(__IO uint32_t*)0x4000024CU) /**< (HSMCI) FIFO Memory Aperture0 19 */
+#define REG_HSMCI_FIFO20        (*(__IO uint32_t*)0x40000250U) /**< (HSMCI) FIFO Memory Aperture0 20 */
+#define REG_HSMCI_FIFO21        (*(__IO uint32_t*)0x40000254U) /**< (HSMCI) FIFO Memory Aperture0 21 */
+#define REG_HSMCI_FIFO22        (*(__IO uint32_t*)0x40000258U) /**< (HSMCI) FIFO Memory Aperture0 22 */
+#define REG_HSMCI_FIFO23        (*(__IO uint32_t*)0x4000025CU) /**< (HSMCI) FIFO Memory Aperture0 23 */
+#define REG_HSMCI_FIFO24        (*(__IO uint32_t*)0x40000260U) /**< (HSMCI) FIFO Memory Aperture0 24 */
+#define REG_HSMCI_FIFO25        (*(__IO uint32_t*)0x40000264U) /**< (HSMCI) FIFO Memory Aperture0 25 */
+#define REG_HSMCI_FIFO26        (*(__IO uint32_t*)0x40000268U) /**< (HSMCI) FIFO Memory Aperture0 26 */
+#define REG_HSMCI_FIFO27        (*(__IO uint32_t*)0x4000026CU) /**< (HSMCI) FIFO Memory Aperture0 27 */
+#define REG_HSMCI_FIFO28        (*(__IO uint32_t*)0x40000270U) /**< (HSMCI) FIFO Memory Aperture0 28 */
+#define REG_HSMCI_FIFO29        (*(__IO uint32_t*)0x40000274U) /**< (HSMCI) FIFO Memory Aperture0 29 */
+#define REG_HSMCI_FIFO30        (*(__IO uint32_t*)0x40000278U) /**< (HSMCI) FIFO Memory Aperture0 30 */
+#define REG_HSMCI_FIFO31        (*(__IO uint32_t*)0x4000027CU) /**< (HSMCI) FIFO Memory Aperture0 31 */
+#define REG_HSMCI_FIFO32        (*(__IO uint32_t*)0x40000280U) /**< (HSMCI) FIFO Memory Aperture0 32 */
+#define REG_HSMCI_FIFO33        (*(__IO uint32_t*)0x40000284U) /**< (HSMCI) FIFO Memory Aperture0 33 */
+#define REG_HSMCI_FIFO34        (*(__IO uint32_t*)0x40000288U) /**< (HSMCI) FIFO Memory Aperture0 34 */
+#define REG_HSMCI_FIFO35        (*(__IO uint32_t*)0x4000028CU) /**< (HSMCI) FIFO Memory Aperture0 35 */
+#define REG_HSMCI_FIFO36        (*(__IO uint32_t*)0x40000290U) /**< (HSMCI) FIFO Memory Aperture0 36 */
+#define REG_HSMCI_FIFO37        (*(__IO uint32_t*)0x40000294U) /**< (HSMCI) FIFO Memory Aperture0 37 */
+#define REG_HSMCI_FIFO38        (*(__IO uint32_t*)0x40000298U) /**< (HSMCI) FIFO Memory Aperture0 38 */
+#define REG_HSMCI_FIFO39        (*(__IO uint32_t*)0x4000029CU) /**< (HSMCI) FIFO Memory Aperture0 39 */
+#define REG_HSMCI_FIFO40        (*(__IO uint32_t*)0x400002A0U) /**< (HSMCI) FIFO Memory Aperture0 40 */
+#define REG_HSMCI_FIFO41        (*(__IO uint32_t*)0x400002A4U) /**< (HSMCI) FIFO Memory Aperture0 41 */
+#define REG_HSMCI_FIFO42        (*(__IO uint32_t*)0x400002A8U) /**< (HSMCI) FIFO Memory Aperture0 42 */
+#define REG_HSMCI_FIFO43        (*(__IO uint32_t*)0x400002ACU) /**< (HSMCI) FIFO Memory Aperture0 43 */
+#define REG_HSMCI_FIFO44        (*(__IO uint32_t*)0x400002B0U) /**< (HSMCI) FIFO Memory Aperture0 44 */
+#define REG_HSMCI_FIFO45        (*(__IO uint32_t*)0x400002B4U) /**< (HSMCI) FIFO Memory Aperture0 45 */
+#define REG_HSMCI_FIFO46        (*(__IO uint32_t*)0x400002B8U) /**< (HSMCI) FIFO Memory Aperture0 46 */
+#define REG_HSMCI_FIFO47        (*(__IO uint32_t*)0x400002BCU) /**< (HSMCI) FIFO Memory Aperture0 47 */
+#define REG_HSMCI_FIFO48        (*(__IO uint32_t*)0x400002C0U) /**< (HSMCI) FIFO Memory Aperture0 48 */
+#define REG_HSMCI_FIFO49        (*(__IO uint32_t*)0x400002C4U) /**< (HSMCI) FIFO Memory Aperture0 49 */
+#define REG_HSMCI_FIFO50        (*(__IO uint32_t*)0x400002C8U) /**< (HSMCI) FIFO Memory Aperture0 50 */
+#define REG_HSMCI_FIFO51        (*(__IO uint32_t*)0x400002CCU) /**< (HSMCI) FIFO Memory Aperture0 51 */
+#define REG_HSMCI_FIFO52        (*(__IO uint32_t*)0x400002D0U) /**< (HSMCI) FIFO Memory Aperture0 52 */
+#define REG_HSMCI_FIFO53        (*(__IO uint32_t*)0x400002D4U) /**< (HSMCI) FIFO Memory Aperture0 53 */
+#define REG_HSMCI_FIFO54        (*(__IO uint32_t*)0x400002D8U) /**< (HSMCI) FIFO Memory Aperture0 54 */
+#define REG_HSMCI_FIFO55        (*(__IO uint32_t*)0x400002DCU) /**< (HSMCI) FIFO Memory Aperture0 55 */
+#define REG_HSMCI_FIFO56        (*(__IO uint32_t*)0x400002E0U) /**< (HSMCI) FIFO Memory Aperture0 56 */
+#define REG_HSMCI_FIFO57        (*(__IO uint32_t*)0x400002E4U) /**< (HSMCI) FIFO Memory Aperture0 57 */
+#define REG_HSMCI_FIFO58        (*(__IO uint32_t*)0x400002E8U) /**< (HSMCI) FIFO Memory Aperture0 58 */
+#define REG_HSMCI_FIFO59        (*(__IO uint32_t*)0x400002ECU) /**< (HSMCI) FIFO Memory Aperture0 59 */
+#define REG_HSMCI_FIFO60        (*(__IO uint32_t*)0x400002F0U) /**< (HSMCI) FIFO Memory Aperture0 60 */
+#define REG_HSMCI_FIFO61        (*(__IO uint32_t*)0x400002F4U) /**< (HSMCI) FIFO Memory Aperture0 61 */
+#define REG_HSMCI_FIFO62        (*(__IO uint32_t*)0x400002F8U) /**< (HSMCI) FIFO Memory Aperture0 62 */
+#define REG_HSMCI_FIFO63        (*(__IO uint32_t*)0x400002FCU) /**< (HSMCI) FIFO Memory Aperture0 63 */
+#define REG_HSMCI_FIFO64        (*(__IO uint32_t*)0x40000300U) /**< (HSMCI) FIFO Memory Aperture0 64 */
+#define REG_HSMCI_FIFO65        (*(__IO uint32_t*)0x40000304U) /**< (HSMCI) FIFO Memory Aperture0 65 */
+#define REG_HSMCI_FIFO66        (*(__IO uint32_t*)0x40000308U) /**< (HSMCI) FIFO Memory Aperture0 66 */
+#define REG_HSMCI_FIFO67        (*(__IO uint32_t*)0x4000030CU) /**< (HSMCI) FIFO Memory Aperture0 67 */
+#define REG_HSMCI_FIFO68        (*(__IO uint32_t*)0x40000310U) /**< (HSMCI) FIFO Memory Aperture0 68 */
+#define REG_HSMCI_FIFO69        (*(__IO uint32_t*)0x40000314U) /**< (HSMCI) FIFO Memory Aperture0 69 */
+#define REG_HSMCI_FIFO70        (*(__IO uint32_t*)0x40000318U) /**< (HSMCI) FIFO Memory Aperture0 70 */
+#define REG_HSMCI_FIFO71        (*(__IO uint32_t*)0x4000031CU) /**< (HSMCI) FIFO Memory Aperture0 71 */
+#define REG_HSMCI_FIFO72        (*(__IO uint32_t*)0x40000320U) /**< (HSMCI) FIFO Memory Aperture0 72 */
+#define REG_HSMCI_FIFO73        (*(__IO uint32_t*)0x40000324U) /**< (HSMCI) FIFO Memory Aperture0 73 */
+#define REG_HSMCI_FIFO74        (*(__IO uint32_t*)0x40000328U) /**< (HSMCI) FIFO Memory Aperture0 74 */
+#define REG_HSMCI_FIFO75        (*(__IO uint32_t*)0x4000032CU) /**< (HSMCI) FIFO Memory Aperture0 75 */
+#define REG_HSMCI_FIFO76        (*(__IO uint32_t*)0x40000330U) /**< (HSMCI) FIFO Memory Aperture0 76 */
+#define REG_HSMCI_FIFO77        (*(__IO uint32_t*)0x40000334U) /**< (HSMCI) FIFO Memory Aperture0 77 */
+#define REG_HSMCI_FIFO78        (*(__IO uint32_t*)0x40000338U) /**< (HSMCI) FIFO Memory Aperture0 78 */
+#define REG_HSMCI_FIFO79        (*(__IO uint32_t*)0x4000033CU) /**< (HSMCI) FIFO Memory Aperture0 79 */
+#define REG_HSMCI_FIFO80        (*(__IO uint32_t*)0x40000340U) /**< (HSMCI) FIFO Memory Aperture0 80 */
+#define REG_HSMCI_FIFO81        (*(__IO uint32_t*)0x40000344U) /**< (HSMCI) FIFO Memory Aperture0 81 */
+#define REG_HSMCI_FIFO82        (*(__IO uint32_t*)0x40000348U) /**< (HSMCI) FIFO Memory Aperture0 82 */
+#define REG_HSMCI_FIFO83        (*(__IO uint32_t*)0x4000034CU) /**< (HSMCI) FIFO Memory Aperture0 83 */
+#define REG_HSMCI_FIFO84        (*(__IO uint32_t*)0x40000350U) /**< (HSMCI) FIFO Memory Aperture0 84 */
+#define REG_HSMCI_FIFO85        (*(__IO uint32_t*)0x40000354U) /**< (HSMCI) FIFO Memory Aperture0 85 */
+#define REG_HSMCI_FIFO86        (*(__IO uint32_t*)0x40000358U) /**< (HSMCI) FIFO Memory Aperture0 86 */
+#define REG_HSMCI_FIFO87        (*(__IO uint32_t*)0x4000035CU) /**< (HSMCI) FIFO Memory Aperture0 87 */
+#define REG_HSMCI_FIFO88        (*(__IO uint32_t*)0x40000360U) /**< (HSMCI) FIFO Memory Aperture0 88 */
+#define REG_HSMCI_FIFO89        (*(__IO uint32_t*)0x40000364U) /**< (HSMCI) FIFO Memory Aperture0 89 */
+#define REG_HSMCI_FIFO90        (*(__IO uint32_t*)0x40000368U) /**< (HSMCI) FIFO Memory Aperture0 90 */
+#define REG_HSMCI_FIFO91        (*(__IO uint32_t*)0x4000036CU) /**< (HSMCI) FIFO Memory Aperture0 91 */
+#define REG_HSMCI_FIFO92        (*(__IO uint32_t*)0x40000370U) /**< (HSMCI) FIFO Memory Aperture0 92 */
+#define REG_HSMCI_FIFO93        (*(__IO uint32_t*)0x40000374U) /**< (HSMCI) FIFO Memory Aperture0 93 */
+#define REG_HSMCI_FIFO94        (*(__IO uint32_t*)0x40000378U) /**< (HSMCI) FIFO Memory Aperture0 94 */
+#define REG_HSMCI_FIFO95        (*(__IO uint32_t*)0x4000037CU) /**< (HSMCI) FIFO Memory Aperture0 95 */
+#define REG_HSMCI_FIFO96        (*(__IO uint32_t*)0x40000380U) /**< (HSMCI) FIFO Memory Aperture0 96 */
+#define REG_HSMCI_FIFO97        (*(__IO uint32_t*)0x40000384U) /**< (HSMCI) FIFO Memory Aperture0 97 */
+#define REG_HSMCI_FIFO98        (*(__IO uint32_t*)0x40000388U) /**< (HSMCI) FIFO Memory Aperture0 98 */
+#define REG_HSMCI_FIFO99        (*(__IO uint32_t*)0x4000038CU) /**< (HSMCI) FIFO Memory Aperture0 99 */
+#define REG_HSMCI_FIFO100       (*(__IO uint32_t*)0x40000390U) /**< (HSMCI) FIFO Memory Aperture0 100 */
+#define REG_HSMCI_FIFO101       (*(__IO uint32_t*)0x40000394U) /**< (HSMCI) FIFO Memory Aperture0 101 */
+#define REG_HSMCI_FIFO102       (*(__IO uint32_t*)0x40000398U) /**< (HSMCI) FIFO Memory Aperture0 102 */
+#define REG_HSMCI_FIFO103       (*(__IO uint32_t*)0x4000039CU) /**< (HSMCI) FIFO Memory Aperture0 103 */
+#define REG_HSMCI_FIFO104       (*(__IO uint32_t*)0x400003A0U) /**< (HSMCI) FIFO Memory Aperture0 104 */
+#define REG_HSMCI_FIFO105       (*(__IO uint32_t*)0x400003A4U) /**< (HSMCI) FIFO Memory Aperture0 105 */
+#define REG_HSMCI_FIFO106       (*(__IO uint32_t*)0x400003A8U) /**< (HSMCI) FIFO Memory Aperture0 106 */
+#define REG_HSMCI_FIFO107       (*(__IO uint32_t*)0x400003ACU) /**< (HSMCI) FIFO Memory Aperture0 107 */
+#define REG_HSMCI_FIFO108       (*(__IO uint32_t*)0x400003B0U) /**< (HSMCI) FIFO Memory Aperture0 108 */
+#define REG_HSMCI_FIFO109       (*(__IO uint32_t*)0x400003B4U) /**< (HSMCI) FIFO Memory Aperture0 109 */
+#define REG_HSMCI_FIFO110       (*(__IO uint32_t*)0x400003B8U) /**< (HSMCI) FIFO Memory Aperture0 110 */
+#define REG_HSMCI_FIFO111       (*(__IO uint32_t*)0x400003BCU) /**< (HSMCI) FIFO Memory Aperture0 111 */
+#define REG_HSMCI_FIFO112       (*(__IO uint32_t*)0x400003C0U) /**< (HSMCI) FIFO Memory Aperture0 112 */
+#define REG_HSMCI_FIFO113       (*(__IO uint32_t*)0x400003C4U) /**< (HSMCI) FIFO Memory Aperture0 113 */
+#define REG_HSMCI_FIFO114       (*(__IO uint32_t*)0x400003C8U) /**< (HSMCI) FIFO Memory Aperture0 114 */
+#define REG_HSMCI_FIFO115       (*(__IO uint32_t*)0x400003CCU) /**< (HSMCI) FIFO Memory Aperture0 115 */
+#define REG_HSMCI_FIFO116       (*(__IO uint32_t*)0x400003D0U) /**< (HSMCI) FIFO Memory Aperture0 116 */
+#define REG_HSMCI_FIFO117       (*(__IO uint32_t*)0x400003D4U) /**< (HSMCI) FIFO Memory Aperture0 117 */
+#define REG_HSMCI_FIFO118       (*(__IO uint32_t*)0x400003D8U) /**< (HSMCI) FIFO Memory Aperture0 118 */
+#define REG_HSMCI_FIFO119       (*(__IO uint32_t*)0x400003DCU) /**< (HSMCI) FIFO Memory Aperture0 119 */
+#define REG_HSMCI_FIFO120       (*(__IO uint32_t*)0x400003E0U) /**< (HSMCI) FIFO Memory Aperture0 120 */
+#define REG_HSMCI_FIFO121       (*(__IO uint32_t*)0x400003E4U) /**< (HSMCI) FIFO Memory Aperture0 121 */
+#define REG_HSMCI_FIFO122       (*(__IO uint32_t*)0x400003E8U) /**< (HSMCI) FIFO Memory Aperture0 122 */
+#define REG_HSMCI_FIFO123       (*(__IO uint32_t*)0x400003ECU) /**< (HSMCI) FIFO Memory Aperture0 123 */
+#define REG_HSMCI_FIFO124       (*(__IO uint32_t*)0x400003F0U) /**< (HSMCI) FIFO Memory Aperture0 124 */
+#define REG_HSMCI_FIFO125       (*(__IO uint32_t*)0x400003F4U) /**< (HSMCI) FIFO Memory Aperture0 125 */
+#define REG_HSMCI_FIFO126       (*(__IO uint32_t*)0x400003F8U) /**< (HSMCI) FIFO Memory Aperture0 126 */
+#define REG_HSMCI_FIFO127       (*(__IO uint32_t*)0x400003FCU) /**< (HSMCI) FIFO Memory Aperture0 127 */
+#define REG_HSMCI_FIFO128       (*(__IO uint32_t*)0x40000400U) /**< (HSMCI) FIFO Memory Aperture0 128 */
+#define REG_HSMCI_FIFO129       (*(__IO uint32_t*)0x40000404U) /**< (HSMCI) FIFO Memory Aperture0 129 */
+#define REG_HSMCI_FIFO130       (*(__IO uint32_t*)0x40000408U) /**< (HSMCI) FIFO Memory Aperture0 130 */
+#define REG_HSMCI_FIFO131       (*(__IO uint32_t*)0x4000040CU) /**< (HSMCI) FIFO Memory Aperture0 131 */
+#define REG_HSMCI_FIFO132       (*(__IO uint32_t*)0x40000410U) /**< (HSMCI) FIFO Memory Aperture0 132 */
+#define REG_HSMCI_FIFO133       (*(__IO uint32_t*)0x40000414U) /**< (HSMCI) FIFO Memory Aperture0 133 */
+#define REG_HSMCI_FIFO134       (*(__IO uint32_t*)0x40000418U) /**< (HSMCI) FIFO Memory Aperture0 134 */
+#define REG_HSMCI_FIFO135       (*(__IO uint32_t*)0x4000041CU) /**< (HSMCI) FIFO Memory Aperture0 135 */
+#define REG_HSMCI_FIFO136       (*(__IO uint32_t*)0x40000420U) /**< (HSMCI) FIFO Memory Aperture0 136 */
+#define REG_HSMCI_FIFO137       (*(__IO uint32_t*)0x40000424U) /**< (HSMCI) FIFO Memory Aperture0 137 */
+#define REG_HSMCI_FIFO138       (*(__IO uint32_t*)0x40000428U) /**< (HSMCI) FIFO Memory Aperture0 138 */
+#define REG_HSMCI_FIFO139       (*(__IO uint32_t*)0x4000042CU) /**< (HSMCI) FIFO Memory Aperture0 139 */
+#define REG_HSMCI_FIFO140       (*(__IO uint32_t*)0x40000430U) /**< (HSMCI) FIFO Memory Aperture0 140 */
+#define REG_HSMCI_FIFO141       (*(__IO uint32_t*)0x40000434U) /**< (HSMCI) FIFO Memory Aperture0 141 */
+#define REG_HSMCI_FIFO142       (*(__IO uint32_t*)0x40000438U) /**< (HSMCI) FIFO Memory Aperture0 142 */
+#define REG_HSMCI_FIFO143       (*(__IO uint32_t*)0x4000043CU) /**< (HSMCI) FIFO Memory Aperture0 143 */
+#define REG_HSMCI_FIFO144       (*(__IO uint32_t*)0x40000440U) /**< (HSMCI) FIFO Memory Aperture0 144 */
+#define REG_HSMCI_FIFO145       (*(__IO uint32_t*)0x40000444U) /**< (HSMCI) FIFO Memory Aperture0 145 */
+#define REG_HSMCI_FIFO146       (*(__IO uint32_t*)0x40000448U) /**< (HSMCI) FIFO Memory Aperture0 146 */
+#define REG_HSMCI_FIFO147       (*(__IO uint32_t*)0x4000044CU) /**< (HSMCI) FIFO Memory Aperture0 147 */
+#define REG_HSMCI_FIFO148       (*(__IO uint32_t*)0x40000450U) /**< (HSMCI) FIFO Memory Aperture0 148 */
+#define REG_HSMCI_FIFO149       (*(__IO uint32_t*)0x40000454U) /**< (HSMCI) FIFO Memory Aperture0 149 */
+#define REG_HSMCI_FIFO150       (*(__IO uint32_t*)0x40000458U) /**< (HSMCI) FIFO Memory Aperture0 150 */
+#define REG_HSMCI_FIFO151       (*(__IO uint32_t*)0x4000045CU) /**< (HSMCI) FIFO Memory Aperture0 151 */
+#define REG_HSMCI_FIFO152       (*(__IO uint32_t*)0x40000460U) /**< (HSMCI) FIFO Memory Aperture0 152 */
+#define REG_HSMCI_FIFO153       (*(__IO uint32_t*)0x40000464U) /**< (HSMCI) FIFO Memory Aperture0 153 */
+#define REG_HSMCI_FIFO154       (*(__IO uint32_t*)0x40000468U) /**< (HSMCI) FIFO Memory Aperture0 154 */
+#define REG_HSMCI_FIFO155       (*(__IO uint32_t*)0x4000046CU) /**< (HSMCI) FIFO Memory Aperture0 155 */
+#define REG_HSMCI_FIFO156       (*(__IO uint32_t*)0x40000470U) /**< (HSMCI) FIFO Memory Aperture0 156 */
+#define REG_HSMCI_FIFO157       (*(__IO uint32_t*)0x40000474U) /**< (HSMCI) FIFO Memory Aperture0 157 */
+#define REG_HSMCI_FIFO158       (*(__IO uint32_t*)0x40000478U) /**< (HSMCI) FIFO Memory Aperture0 158 */
+#define REG_HSMCI_FIFO159       (*(__IO uint32_t*)0x4000047CU) /**< (HSMCI) FIFO Memory Aperture0 159 */
+#define REG_HSMCI_FIFO160       (*(__IO uint32_t*)0x40000480U) /**< (HSMCI) FIFO Memory Aperture0 160 */
+#define REG_HSMCI_FIFO161       (*(__IO uint32_t*)0x40000484U) /**< (HSMCI) FIFO Memory Aperture0 161 */
+#define REG_HSMCI_FIFO162       (*(__IO uint32_t*)0x40000488U) /**< (HSMCI) FIFO Memory Aperture0 162 */
+#define REG_HSMCI_FIFO163       (*(__IO uint32_t*)0x4000048CU) /**< (HSMCI) FIFO Memory Aperture0 163 */
+#define REG_HSMCI_FIFO164       (*(__IO uint32_t*)0x40000490U) /**< (HSMCI) FIFO Memory Aperture0 164 */
+#define REG_HSMCI_FIFO165       (*(__IO uint32_t*)0x40000494U) /**< (HSMCI) FIFO Memory Aperture0 165 */
+#define REG_HSMCI_FIFO166       (*(__IO uint32_t*)0x40000498U) /**< (HSMCI) FIFO Memory Aperture0 166 */
+#define REG_HSMCI_FIFO167       (*(__IO uint32_t*)0x4000049CU) /**< (HSMCI) FIFO Memory Aperture0 167 */
+#define REG_HSMCI_FIFO168       (*(__IO uint32_t*)0x400004A0U) /**< (HSMCI) FIFO Memory Aperture0 168 */
+#define REG_HSMCI_FIFO169       (*(__IO uint32_t*)0x400004A4U) /**< (HSMCI) FIFO Memory Aperture0 169 */
+#define REG_HSMCI_FIFO170       (*(__IO uint32_t*)0x400004A8U) /**< (HSMCI) FIFO Memory Aperture0 170 */
+#define REG_HSMCI_FIFO171       (*(__IO uint32_t*)0x400004ACU) /**< (HSMCI) FIFO Memory Aperture0 171 */
+#define REG_HSMCI_FIFO172       (*(__IO uint32_t*)0x400004B0U) /**< (HSMCI) FIFO Memory Aperture0 172 */
+#define REG_HSMCI_FIFO173       (*(__IO uint32_t*)0x400004B4U) /**< (HSMCI) FIFO Memory Aperture0 173 */
+#define REG_HSMCI_FIFO174       (*(__IO uint32_t*)0x400004B8U) /**< (HSMCI) FIFO Memory Aperture0 174 */
+#define REG_HSMCI_FIFO175       (*(__IO uint32_t*)0x400004BCU) /**< (HSMCI) FIFO Memory Aperture0 175 */
+#define REG_HSMCI_FIFO176       (*(__IO uint32_t*)0x400004C0U) /**< (HSMCI) FIFO Memory Aperture0 176 */
+#define REG_HSMCI_FIFO177       (*(__IO uint32_t*)0x400004C4U) /**< (HSMCI) FIFO Memory Aperture0 177 */
+#define REG_HSMCI_FIFO178       (*(__IO uint32_t*)0x400004C8U) /**< (HSMCI) FIFO Memory Aperture0 178 */
+#define REG_HSMCI_FIFO179       (*(__IO uint32_t*)0x400004CCU) /**< (HSMCI) FIFO Memory Aperture0 179 */
+#define REG_HSMCI_FIFO180       (*(__IO uint32_t*)0x400004D0U) /**< (HSMCI) FIFO Memory Aperture0 180 */
+#define REG_HSMCI_FIFO181       (*(__IO uint32_t*)0x400004D4U) /**< (HSMCI) FIFO Memory Aperture0 181 */
+#define REG_HSMCI_FIFO182       (*(__IO uint32_t*)0x400004D8U) /**< (HSMCI) FIFO Memory Aperture0 182 */
+#define REG_HSMCI_FIFO183       (*(__IO uint32_t*)0x400004DCU) /**< (HSMCI) FIFO Memory Aperture0 183 */
+#define REG_HSMCI_FIFO184       (*(__IO uint32_t*)0x400004E0U) /**< (HSMCI) FIFO Memory Aperture0 184 */
+#define REG_HSMCI_FIFO185       (*(__IO uint32_t*)0x400004E4U) /**< (HSMCI) FIFO Memory Aperture0 185 */
+#define REG_HSMCI_FIFO186       (*(__IO uint32_t*)0x400004E8U) /**< (HSMCI) FIFO Memory Aperture0 186 */
+#define REG_HSMCI_FIFO187       (*(__IO uint32_t*)0x400004ECU) /**< (HSMCI) FIFO Memory Aperture0 187 */
+#define REG_HSMCI_FIFO188       (*(__IO uint32_t*)0x400004F0U) /**< (HSMCI) FIFO Memory Aperture0 188 */
+#define REG_HSMCI_FIFO189       (*(__IO uint32_t*)0x400004F4U) /**< (HSMCI) FIFO Memory Aperture0 189 */
+#define REG_HSMCI_FIFO190       (*(__IO uint32_t*)0x400004F8U) /**< (HSMCI) FIFO Memory Aperture0 190 */
+#define REG_HSMCI_FIFO191       (*(__IO uint32_t*)0x400004FCU) /**< (HSMCI) FIFO Memory Aperture0 191 */
+#define REG_HSMCI_FIFO192       (*(__IO uint32_t*)0x40000500U) /**< (HSMCI) FIFO Memory Aperture0 192 */
+#define REG_HSMCI_FIFO193       (*(__IO uint32_t*)0x40000504U) /**< (HSMCI) FIFO Memory Aperture0 193 */
+#define REG_HSMCI_FIFO194       (*(__IO uint32_t*)0x40000508U) /**< (HSMCI) FIFO Memory Aperture0 194 */
+#define REG_HSMCI_FIFO195       (*(__IO uint32_t*)0x4000050CU) /**< (HSMCI) FIFO Memory Aperture0 195 */
+#define REG_HSMCI_FIFO196       (*(__IO uint32_t*)0x40000510U) /**< (HSMCI) FIFO Memory Aperture0 196 */
+#define REG_HSMCI_FIFO197       (*(__IO uint32_t*)0x40000514U) /**< (HSMCI) FIFO Memory Aperture0 197 */
+#define REG_HSMCI_FIFO198       (*(__IO uint32_t*)0x40000518U) /**< (HSMCI) FIFO Memory Aperture0 198 */
+#define REG_HSMCI_FIFO199       (*(__IO uint32_t*)0x4000051CU) /**< (HSMCI) FIFO Memory Aperture0 199 */
+#define REG_HSMCI_FIFO200       (*(__IO uint32_t*)0x40000520U) /**< (HSMCI) FIFO Memory Aperture0 200 */
+#define REG_HSMCI_FIFO201       (*(__IO uint32_t*)0x40000524U) /**< (HSMCI) FIFO Memory Aperture0 201 */
+#define REG_HSMCI_FIFO202       (*(__IO uint32_t*)0x40000528U) /**< (HSMCI) FIFO Memory Aperture0 202 */
+#define REG_HSMCI_FIFO203       (*(__IO uint32_t*)0x4000052CU) /**< (HSMCI) FIFO Memory Aperture0 203 */
+#define REG_HSMCI_FIFO204       (*(__IO uint32_t*)0x40000530U) /**< (HSMCI) FIFO Memory Aperture0 204 */
+#define REG_HSMCI_FIFO205       (*(__IO uint32_t*)0x40000534U) /**< (HSMCI) FIFO Memory Aperture0 205 */
+#define REG_HSMCI_FIFO206       (*(__IO uint32_t*)0x40000538U) /**< (HSMCI) FIFO Memory Aperture0 206 */
+#define REG_HSMCI_FIFO207       (*(__IO uint32_t*)0x4000053CU) /**< (HSMCI) FIFO Memory Aperture0 207 */
+#define REG_HSMCI_FIFO208       (*(__IO uint32_t*)0x40000540U) /**< (HSMCI) FIFO Memory Aperture0 208 */
+#define REG_HSMCI_FIFO209       (*(__IO uint32_t*)0x40000544U) /**< (HSMCI) FIFO Memory Aperture0 209 */
+#define REG_HSMCI_FIFO210       (*(__IO uint32_t*)0x40000548U) /**< (HSMCI) FIFO Memory Aperture0 210 */
+#define REG_HSMCI_FIFO211       (*(__IO uint32_t*)0x4000054CU) /**< (HSMCI) FIFO Memory Aperture0 211 */
+#define REG_HSMCI_FIFO212       (*(__IO uint32_t*)0x40000550U) /**< (HSMCI) FIFO Memory Aperture0 212 */
+#define REG_HSMCI_FIFO213       (*(__IO uint32_t*)0x40000554U) /**< (HSMCI) FIFO Memory Aperture0 213 */
+#define REG_HSMCI_FIFO214       (*(__IO uint32_t*)0x40000558U) /**< (HSMCI) FIFO Memory Aperture0 214 */
+#define REG_HSMCI_FIFO215       (*(__IO uint32_t*)0x4000055CU) /**< (HSMCI) FIFO Memory Aperture0 215 */
+#define REG_HSMCI_FIFO216       (*(__IO uint32_t*)0x40000560U) /**< (HSMCI) FIFO Memory Aperture0 216 */
+#define REG_HSMCI_FIFO217       (*(__IO uint32_t*)0x40000564U) /**< (HSMCI) FIFO Memory Aperture0 217 */
+#define REG_HSMCI_FIFO218       (*(__IO uint32_t*)0x40000568U) /**< (HSMCI) FIFO Memory Aperture0 218 */
+#define REG_HSMCI_FIFO219       (*(__IO uint32_t*)0x4000056CU) /**< (HSMCI) FIFO Memory Aperture0 219 */
+#define REG_HSMCI_FIFO220       (*(__IO uint32_t*)0x40000570U) /**< (HSMCI) FIFO Memory Aperture0 220 */
+#define REG_HSMCI_FIFO221       (*(__IO uint32_t*)0x40000574U) /**< (HSMCI) FIFO Memory Aperture0 221 */
+#define REG_HSMCI_FIFO222       (*(__IO uint32_t*)0x40000578U) /**< (HSMCI) FIFO Memory Aperture0 222 */
+#define REG_HSMCI_FIFO223       (*(__IO uint32_t*)0x4000057CU) /**< (HSMCI) FIFO Memory Aperture0 223 */
+#define REG_HSMCI_FIFO224       (*(__IO uint32_t*)0x40000580U) /**< (HSMCI) FIFO Memory Aperture0 224 */
+#define REG_HSMCI_FIFO225       (*(__IO uint32_t*)0x40000584U) /**< (HSMCI) FIFO Memory Aperture0 225 */
+#define REG_HSMCI_FIFO226       (*(__IO uint32_t*)0x40000588U) /**< (HSMCI) FIFO Memory Aperture0 226 */
+#define REG_HSMCI_FIFO227       (*(__IO uint32_t*)0x4000058CU) /**< (HSMCI) FIFO Memory Aperture0 227 */
+#define REG_HSMCI_FIFO228       (*(__IO uint32_t*)0x40000590U) /**< (HSMCI) FIFO Memory Aperture0 228 */
+#define REG_HSMCI_FIFO229       (*(__IO uint32_t*)0x40000594U) /**< (HSMCI) FIFO Memory Aperture0 229 */
+#define REG_HSMCI_FIFO230       (*(__IO uint32_t*)0x40000598U) /**< (HSMCI) FIFO Memory Aperture0 230 */
+#define REG_HSMCI_FIFO231       (*(__IO uint32_t*)0x4000059CU) /**< (HSMCI) FIFO Memory Aperture0 231 */
+#define REG_HSMCI_FIFO232       (*(__IO uint32_t*)0x400005A0U) /**< (HSMCI) FIFO Memory Aperture0 232 */
+#define REG_HSMCI_FIFO233       (*(__IO uint32_t*)0x400005A4U) /**< (HSMCI) FIFO Memory Aperture0 233 */
+#define REG_HSMCI_FIFO234       (*(__IO uint32_t*)0x400005A8U) /**< (HSMCI) FIFO Memory Aperture0 234 */
+#define REG_HSMCI_FIFO235       (*(__IO uint32_t*)0x400005ACU) /**< (HSMCI) FIFO Memory Aperture0 235 */
+#define REG_HSMCI_FIFO236       (*(__IO uint32_t*)0x400005B0U) /**< (HSMCI) FIFO Memory Aperture0 236 */
+#define REG_HSMCI_FIFO237       (*(__IO uint32_t*)0x400005B4U) /**< (HSMCI) FIFO Memory Aperture0 237 */
+#define REG_HSMCI_FIFO238       (*(__IO uint32_t*)0x400005B8U) /**< (HSMCI) FIFO Memory Aperture0 238 */
+#define REG_HSMCI_FIFO239       (*(__IO uint32_t*)0x400005BCU) /**< (HSMCI) FIFO Memory Aperture0 239 */
+#define REG_HSMCI_FIFO240       (*(__IO uint32_t*)0x400005C0U) /**< (HSMCI) FIFO Memory Aperture0 240 */
+#define REG_HSMCI_FIFO241       (*(__IO uint32_t*)0x400005C4U) /**< (HSMCI) FIFO Memory Aperture0 241 */
+#define REG_HSMCI_FIFO242       (*(__IO uint32_t*)0x400005C8U) /**< (HSMCI) FIFO Memory Aperture0 242 */
+#define REG_HSMCI_FIFO243       (*(__IO uint32_t*)0x400005CCU) /**< (HSMCI) FIFO Memory Aperture0 243 */
+#define REG_HSMCI_FIFO244       (*(__IO uint32_t*)0x400005D0U) /**< (HSMCI) FIFO Memory Aperture0 244 */
+#define REG_HSMCI_FIFO245       (*(__IO uint32_t*)0x400005D4U) /**< (HSMCI) FIFO Memory Aperture0 245 */
+#define REG_HSMCI_FIFO246       (*(__IO uint32_t*)0x400005D8U) /**< (HSMCI) FIFO Memory Aperture0 246 */
+#define REG_HSMCI_FIFO247       (*(__IO uint32_t*)0x400005DCU) /**< (HSMCI) FIFO Memory Aperture0 247 */
+#define REG_HSMCI_FIFO248       (*(__IO uint32_t*)0x400005E0U) /**< (HSMCI) FIFO Memory Aperture0 248 */
+#define REG_HSMCI_FIFO249       (*(__IO uint32_t*)0x400005E4U) /**< (HSMCI) FIFO Memory Aperture0 249 */
+#define REG_HSMCI_FIFO250       (*(__IO uint32_t*)0x400005E8U) /**< (HSMCI) FIFO Memory Aperture0 250 */
+#define REG_HSMCI_FIFO251       (*(__IO uint32_t*)0x400005ECU) /**< (HSMCI) FIFO Memory Aperture0 251 */
+#define REG_HSMCI_FIFO252       (*(__IO uint32_t*)0x400005F0U) /**< (HSMCI) FIFO Memory Aperture0 252 */
+#define REG_HSMCI_FIFO253       (*(__IO uint32_t*)0x400005F4U) /**< (HSMCI) FIFO Memory Aperture0 253 */
+#define REG_HSMCI_FIFO254       (*(__IO uint32_t*)0x400005F8U) /**< (HSMCI) FIFO Memory Aperture0 254 */
+#define REG_HSMCI_FIFO255       (*(__IO uint32_t*)0x400005FCU) /**< (HSMCI) FIFO Memory Aperture0 255 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for HSMCI peripheral ========== */
+#define HSMCI_DMAC_ID_RX                         0          
+#define HSMCI_DMAC_ID_TX                         0          
+#define HSMCI_INSTANCE_ID                        18         
+#define HSMCI_CLOCK_ID                           18         
+
+#endif /* _SAMV71_HSMCI_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/i2sc0.h
+++ b/asf/sam/include/samv71b/instance/i2sc0.h
@@ -1,0 +1,71 @@
+/**
+ * \file
+ *
+ * \brief Instance description for I2SC0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_I2SC0_INSTANCE_H_
+#define _SAMV71_I2SC0_INSTANCE_H_
+
+/* ========== Register definition for I2SC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_I2SC0_CR            (0x4008C000) /**< (I2SC0) Control Register */
+#define REG_I2SC0_MR            (0x4008C004) /**< (I2SC0) Mode Register */
+#define REG_I2SC0_SR            (0x4008C008) /**< (I2SC0) Status Register */
+#define REG_I2SC0_SCR           (0x4008C00C) /**< (I2SC0) Status Clear Register */
+#define REG_I2SC0_SSR           (0x4008C010) /**< (I2SC0) Status Set Register */
+#define REG_I2SC0_IER           (0x4008C014) /**< (I2SC0) Interrupt Enable Register */
+#define REG_I2SC0_IDR           (0x4008C018) /**< (I2SC0) Interrupt Disable Register */
+#define REG_I2SC0_IMR           (0x4008C01C) /**< (I2SC0) Interrupt Mask Register */
+#define REG_I2SC0_RHR           (0x4008C020) /**< (I2SC0) Receiver Holding Register */
+#define REG_I2SC0_THR           (0x4008C024) /**< (I2SC0) Transmitter Holding Register */
+
+#else
+
+#define REG_I2SC0_CR            (*(__O  uint32_t*)0x4008C000U) /**< (I2SC0) Control Register */
+#define REG_I2SC0_MR            (*(__IO uint32_t*)0x4008C004U) /**< (I2SC0) Mode Register */
+#define REG_I2SC0_SR            (*(__I  uint32_t*)0x4008C008U) /**< (I2SC0) Status Register */
+#define REG_I2SC0_SCR           (*(__O  uint32_t*)0x4008C00CU) /**< (I2SC0) Status Clear Register */
+#define REG_I2SC0_SSR           (*(__O  uint32_t*)0x4008C010U) /**< (I2SC0) Status Set Register */
+#define REG_I2SC0_IER           (*(__O  uint32_t*)0x4008C014U) /**< (I2SC0) Interrupt Enable Register */
+#define REG_I2SC0_IDR           (*(__O  uint32_t*)0x4008C018U) /**< (I2SC0) Interrupt Disable Register */
+#define REG_I2SC0_IMR           (*(__I  uint32_t*)0x4008C01CU) /**< (I2SC0) Interrupt Mask Register */
+#define REG_I2SC0_RHR           (*(__I  uint32_t*)0x4008C020U) /**< (I2SC0) Receiver Holding Register */
+#define REG_I2SC0_THR           (*(__O  uint32_t*)0x4008C024U) /**< (I2SC0) Transmitter Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for I2SC0 peripheral ========== */
+#define I2SC0_INSTANCE_ID                        69         
+#define I2SC0_CLOCK_ID                           69         
+#define I2SC0_DMAC_ID_TX_LEFT                    44         
+#define I2SC0_DMAC_ID_RX_LEFT                    45         
+#define I2SC0_DMAC_ID_TX_RIGHT                   48         
+#define I2SC0_DMAC_ID_RX_RIGHT                   49         
+
+#endif /* _SAMV71_I2SC0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/i2sc1.h
+++ b/asf/sam/include/samv71b/instance/i2sc1.h
@@ -1,0 +1,71 @@
+/**
+ * \file
+ *
+ * \brief Instance description for I2SC1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_I2SC1_INSTANCE_H_
+#define _SAMV71_I2SC1_INSTANCE_H_
+
+/* ========== Register definition for I2SC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_I2SC1_CR            (0x40090000) /**< (I2SC1) Control Register */
+#define REG_I2SC1_MR            (0x40090004) /**< (I2SC1) Mode Register */
+#define REG_I2SC1_SR            (0x40090008) /**< (I2SC1) Status Register */
+#define REG_I2SC1_SCR           (0x4009000C) /**< (I2SC1) Status Clear Register */
+#define REG_I2SC1_SSR           (0x40090010) /**< (I2SC1) Status Set Register */
+#define REG_I2SC1_IER           (0x40090014) /**< (I2SC1) Interrupt Enable Register */
+#define REG_I2SC1_IDR           (0x40090018) /**< (I2SC1) Interrupt Disable Register */
+#define REG_I2SC1_IMR           (0x4009001C) /**< (I2SC1) Interrupt Mask Register */
+#define REG_I2SC1_RHR           (0x40090020) /**< (I2SC1) Receiver Holding Register */
+#define REG_I2SC1_THR           (0x40090024) /**< (I2SC1) Transmitter Holding Register */
+
+#else
+
+#define REG_I2SC1_CR            (*(__O  uint32_t*)0x40090000U) /**< (I2SC1) Control Register */
+#define REG_I2SC1_MR            (*(__IO uint32_t*)0x40090004U) /**< (I2SC1) Mode Register */
+#define REG_I2SC1_SR            (*(__I  uint32_t*)0x40090008U) /**< (I2SC1) Status Register */
+#define REG_I2SC1_SCR           (*(__O  uint32_t*)0x4009000CU) /**< (I2SC1) Status Clear Register */
+#define REG_I2SC1_SSR           (*(__O  uint32_t*)0x40090010U) /**< (I2SC1) Status Set Register */
+#define REG_I2SC1_IER           (*(__O  uint32_t*)0x40090014U) /**< (I2SC1) Interrupt Enable Register */
+#define REG_I2SC1_IDR           (*(__O  uint32_t*)0x40090018U) /**< (I2SC1) Interrupt Disable Register */
+#define REG_I2SC1_IMR           (*(__I  uint32_t*)0x4009001CU) /**< (I2SC1) Interrupt Mask Register */
+#define REG_I2SC1_RHR           (*(__I  uint32_t*)0x40090020U) /**< (I2SC1) Receiver Holding Register */
+#define REG_I2SC1_THR           (*(__O  uint32_t*)0x40090024U) /**< (I2SC1) Transmitter Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for I2SC1 peripheral ========== */
+#define I2SC1_INSTANCE_ID                        70         
+#define I2SC1_CLOCK_ID                           70         
+#define I2SC1_DMAC_ID_TX_LEFT                    46         
+#define I2SC1_DMAC_ID_RX_LEFT                    47         
+#define I2SC1_DMAC_ID_TX_RIGHT                   50         
+#define I2SC1_DMAC_ID_RX_RIGHT                   51         
+
+#endif /* _SAMV71_I2SC1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/icm.h
+++ b/asf/sam/include/samv71b/instance/icm.h
@@ -1,0 +1,85 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ICM
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ICM_INSTANCE_H_
+#define _SAMV71_ICM_INSTANCE_H_
+
+/* ========== Register definition for ICM peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ICM_CFG             (0x40048000) /**< (ICM) Configuration Register */
+#define REG_ICM_CTRL            (0x40048004) /**< (ICM) Control Register */
+#define REG_ICM_SR              (0x40048008) /**< (ICM) Status Register */
+#define REG_ICM_IER             (0x40048010) /**< (ICM) Interrupt Enable Register */
+#define REG_ICM_IDR             (0x40048014) /**< (ICM) Interrupt Disable Register */
+#define REG_ICM_IMR             (0x40048018) /**< (ICM) Interrupt Mask Register */
+#define REG_ICM_ISR             (0x4004801C) /**< (ICM) Interrupt Status Register */
+#define REG_ICM_UASR            (0x40048020) /**< (ICM) Undefined Access Status Register */
+#define REG_ICM_DSCR            (0x40048030) /**< (ICM) Region Descriptor Area Start Address Register */
+#define REG_ICM_HASH            (0x40048034) /**< (ICM) Region Hash Area Start Address Register */
+#define REG_ICM_UIHVAL          (0x40048038) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL0         (0x40048038) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL1         (0x4004803C) /**< (ICM) User Initial Hash Value 0 Register 1 */
+#define REG_ICM_UIHVAL2         (0x40048040) /**< (ICM) User Initial Hash Value 0 Register 2 */
+#define REG_ICM_UIHVAL3         (0x40048044) /**< (ICM) User Initial Hash Value 0 Register 3 */
+#define REG_ICM_UIHVAL4         (0x40048048) /**< (ICM) User Initial Hash Value 0 Register 4 */
+#define REG_ICM_UIHVAL5         (0x4004804C) /**< (ICM) User Initial Hash Value 0 Register 5 */
+#define REG_ICM_UIHVAL6         (0x40048050) /**< (ICM) User Initial Hash Value 0 Register 6 */
+#define REG_ICM_UIHVAL7         (0x40048054) /**< (ICM) User Initial Hash Value 0 Register 7 */
+
+#else
+
+#define REG_ICM_CFG             (*(__IO uint32_t*)0x40048000U) /**< (ICM) Configuration Register */
+#define REG_ICM_CTRL            (*(__O  uint32_t*)0x40048004U) /**< (ICM) Control Register */
+#define REG_ICM_SR              (*(__I  uint32_t*)0x40048008U) /**< (ICM) Status Register */
+#define REG_ICM_IER             (*(__O  uint32_t*)0x40048010U) /**< (ICM) Interrupt Enable Register */
+#define REG_ICM_IDR             (*(__O  uint32_t*)0x40048014U) /**< (ICM) Interrupt Disable Register */
+#define REG_ICM_IMR             (*(__I  uint32_t*)0x40048018U) /**< (ICM) Interrupt Mask Register */
+#define REG_ICM_ISR             (*(__I  uint32_t*)0x4004801CU) /**< (ICM) Interrupt Status Register */
+#define REG_ICM_UASR            (*(__I  uint32_t*)0x40048020U) /**< (ICM) Undefined Access Status Register */
+#define REG_ICM_DSCR            (*(__IO uint32_t*)0x40048030U) /**< (ICM) Region Descriptor Area Start Address Register */
+#define REG_ICM_HASH            (*(__IO uint32_t*)0x40048034U) /**< (ICM) Region Hash Area Start Address Register */
+#define REG_ICM_UIHVAL          (*(__O  uint32_t*)0x40048038U) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL0         (*(__O  uint32_t*)0x40048038U) /**< (ICM) User Initial Hash Value 0 Register 0 */
+#define REG_ICM_UIHVAL1         (*(__O  uint32_t*)0x4004803CU) /**< (ICM) User Initial Hash Value 0 Register 1 */
+#define REG_ICM_UIHVAL2         (*(__O  uint32_t*)0x40048040U) /**< (ICM) User Initial Hash Value 0 Register 2 */
+#define REG_ICM_UIHVAL3         (*(__O  uint32_t*)0x40048044U) /**< (ICM) User Initial Hash Value 0 Register 3 */
+#define REG_ICM_UIHVAL4         (*(__O  uint32_t*)0x40048048U) /**< (ICM) User Initial Hash Value 0 Register 4 */
+#define REG_ICM_UIHVAL5         (*(__O  uint32_t*)0x4004804CU) /**< (ICM) User Initial Hash Value 0 Register 5 */
+#define REG_ICM_UIHVAL6         (*(__O  uint32_t*)0x40048050U) /**< (ICM) User Initial Hash Value 0 Register 6 */
+#define REG_ICM_UIHVAL7         (*(__O  uint32_t*)0x40048054U) /**< (ICM) User Initial Hash Value 0 Register 7 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ICM peripheral ========== */
+#define ICM_INSTANCE_ID                          32         
+#define ICM_CLOCK_ID                             32         
+
+#endif /* _SAMV71_ICM_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/isi.h
+++ b/asf/sam/include/samv71b/instance/isi.h
@@ -1,0 +1,97 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ISI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_ISI_INSTANCE_H_
+#define _SAMV71_ISI_INSTANCE_H_
+
+/* ========== Register definition for ISI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_ISI_CFG1            (0x4004C000) /**< (ISI) ISI Configuration 1 Register */
+#define REG_ISI_CFG2            (0x4004C004) /**< (ISI) ISI Configuration 2 Register */
+#define REG_ISI_PSIZE           (0x4004C008) /**< (ISI) ISI Preview Size Register */
+#define REG_ISI_PDECF           (0x4004C00C) /**< (ISI) ISI Preview Decimation Factor Register */
+#define REG_ISI_Y2R_SET0        (0x4004C010) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+#define REG_ISI_Y2R_SET1        (0x4004C014) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+#define REG_ISI_R2Y_SET0        (0x4004C018) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+#define REG_ISI_R2Y_SET1        (0x4004C01C) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+#define REG_ISI_R2Y_SET2        (0x4004C020) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+#define REG_ISI_CR              (0x4004C024) /**< (ISI) ISI Control Register */
+#define REG_ISI_SR              (0x4004C028) /**< (ISI) ISI Status Register */
+#define REG_ISI_IER             (0x4004C02C) /**< (ISI) ISI Interrupt Enable Register */
+#define REG_ISI_IDR             (0x4004C030) /**< (ISI) ISI Interrupt Disable Register */
+#define REG_ISI_IMR             (0x4004C034) /**< (ISI) ISI Interrupt Mask Register */
+#define REG_ISI_DMA_CHER        (0x4004C038) /**< (ISI) DMA Channel Enable Register */
+#define REG_ISI_DMA_CHDR        (0x4004C03C) /**< (ISI) DMA Channel Disable Register */
+#define REG_ISI_DMA_CHSR        (0x4004C040) /**< (ISI) DMA Channel Status Register */
+#define REG_ISI_DMA_P_ADDR      (0x4004C044) /**< (ISI) DMA Preview Base Address Register */
+#define REG_ISI_DMA_P_CTRL      (0x4004C048) /**< (ISI) DMA Preview Control Register */
+#define REG_ISI_DMA_P_DSCR      (0x4004C04C) /**< (ISI) DMA Preview Descriptor Address Register */
+#define REG_ISI_DMA_C_ADDR      (0x4004C050) /**< (ISI) DMA Codec Base Address Register */
+#define REG_ISI_DMA_C_CTRL      (0x4004C054) /**< (ISI) DMA Codec Control Register */
+#define REG_ISI_DMA_C_DSCR      (0x4004C058) /**< (ISI) DMA Codec Descriptor Address Register */
+#define REG_ISI_WPMR            (0x4004C0E4) /**< (ISI) Write Protection Mode Register */
+#define REG_ISI_WPSR            (0x4004C0E8) /**< (ISI) Write Protection Status Register */
+
+#else
+
+#define REG_ISI_CFG1            (*(__IO uint32_t*)0x4004C000U) /**< (ISI) ISI Configuration 1 Register */
+#define REG_ISI_CFG2            (*(__IO uint32_t*)0x4004C004U) /**< (ISI) ISI Configuration 2 Register */
+#define REG_ISI_PSIZE           (*(__IO uint32_t*)0x4004C008U) /**< (ISI) ISI Preview Size Register */
+#define REG_ISI_PDECF           (*(__IO uint32_t*)0x4004C00CU) /**< (ISI) ISI Preview Decimation Factor Register */
+#define REG_ISI_Y2R_SET0        (*(__IO uint32_t*)0x4004C010U) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 0 Register */
+#define REG_ISI_Y2R_SET1        (*(__IO uint32_t*)0x4004C014U) /**< (ISI) ISI Color Space Conversion YCrCb To RGB Set 1 Register */
+#define REG_ISI_R2Y_SET0        (*(__IO uint32_t*)0x4004C018U) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 0 Register */
+#define REG_ISI_R2Y_SET1        (*(__IO uint32_t*)0x4004C01CU) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 1 Register */
+#define REG_ISI_R2Y_SET2        (*(__IO uint32_t*)0x4004C020U) /**< (ISI) ISI Color Space Conversion RGB To YCrCb Set 2 Register */
+#define REG_ISI_CR              (*(__O  uint32_t*)0x4004C024U) /**< (ISI) ISI Control Register */
+#define REG_ISI_SR              (*(__I  uint32_t*)0x4004C028U) /**< (ISI) ISI Status Register */
+#define REG_ISI_IER             (*(__O  uint32_t*)0x4004C02CU) /**< (ISI) ISI Interrupt Enable Register */
+#define REG_ISI_IDR             (*(__O  uint32_t*)0x4004C030U) /**< (ISI) ISI Interrupt Disable Register */
+#define REG_ISI_IMR             (*(__I  uint32_t*)0x4004C034U) /**< (ISI) ISI Interrupt Mask Register */
+#define REG_ISI_DMA_CHER        (*(__O  uint32_t*)0x4004C038U) /**< (ISI) DMA Channel Enable Register */
+#define REG_ISI_DMA_CHDR        (*(__O  uint32_t*)0x4004C03CU) /**< (ISI) DMA Channel Disable Register */
+#define REG_ISI_DMA_CHSR        (*(__I  uint32_t*)0x4004C040U) /**< (ISI) DMA Channel Status Register */
+#define REG_ISI_DMA_P_ADDR      (*(__IO uint32_t*)0x4004C044U) /**< (ISI) DMA Preview Base Address Register */
+#define REG_ISI_DMA_P_CTRL      (*(__IO uint32_t*)0x4004C048U) /**< (ISI) DMA Preview Control Register */
+#define REG_ISI_DMA_P_DSCR      (*(__IO uint32_t*)0x4004C04CU) /**< (ISI) DMA Preview Descriptor Address Register */
+#define REG_ISI_DMA_C_ADDR      (*(__IO uint32_t*)0x4004C050U) /**< (ISI) DMA Codec Base Address Register */
+#define REG_ISI_DMA_C_CTRL      (*(__IO uint32_t*)0x4004C054U) /**< (ISI) DMA Codec Control Register */
+#define REG_ISI_DMA_C_DSCR      (*(__IO uint32_t*)0x4004C058U) /**< (ISI) DMA Codec Descriptor Address Register */
+#define REG_ISI_WPMR            (*(__IO uint32_t*)0x4004C0E4U) /**< (ISI) Write Protection Mode Register */
+#define REG_ISI_WPSR            (*(__I  uint32_t*)0x4004C0E8U) /**< (ISI) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for ISI peripheral ========== */
+#define ISI_INSTANCE_ID                          59         
+#define ISI_CLOCK_ID                             59         
+
+#endif /* _SAMV71_ISI_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/matrix.h
+++ b/asf/sam/include/samv71b/instance/matrix.h
@@ -1,0 +1,142 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MATRIX
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MATRIX_INSTANCE_H_
+#define _SAMV71_MATRIX_INSTANCE_H_
+
+/* ========== Register definition for MATRIX peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MATRIX_PRAS0        (0x40088080) /**< (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0        (0x40088084) /**< (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1        (0x40088088) /**< (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1        (0x4008808C) /**< (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2        (0x40088090) /**< (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2        (0x40088094) /**< (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3        (0x40088098) /**< (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3        (0x4008809C) /**< (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4        (0x400880A0) /**< (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4        (0x400880A4) /**< (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5        (0x400880A8) /**< (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5        (0x400880AC) /**< (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6        (0x400880B0) /**< (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6        (0x400880B4) /**< (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7        (0x400880B8) /**< (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7        (0x400880BC) /**< (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8        (0x400880C0) /**< (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8        (0x400880C4) /**< (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_MCFG         (0x40088000) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG0        (0x40088000) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG1        (0x40088004) /**< (MATRIX) Master Configuration Register 1 */
+#define REG_MATRIX_MCFG2        (0x40088008) /**< (MATRIX) Master Configuration Register 2 */
+#define REG_MATRIX_MCFG3        (0x4008800C) /**< (MATRIX) Master Configuration Register 3 */
+#define REG_MATRIX_MCFG4        (0x40088010) /**< (MATRIX) Master Configuration Register 4 */
+#define REG_MATRIX_MCFG5        (0x40088014) /**< (MATRIX) Master Configuration Register 5 */
+#define REG_MATRIX_MCFG6        (0x40088018) /**< (MATRIX) Master Configuration Register 6 */
+#define REG_MATRIX_MCFG7        (0x4008801C) /**< (MATRIX) Master Configuration Register 7 */
+#define REG_MATRIX_MCFG8        (0x40088020) /**< (MATRIX) Master Configuration Register 8 */
+#define REG_MATRIX_MCFG9        (0x40088024) /**< (MATRIX) Master Configuration Register 9 */
+#define REG_MATRIX_MCFG10       (0x40088028) /**< (MATRIX) Master Configuration Register 10 */
+#define REG_MATRIX_MCFG11       (0x4008802C) /**< (MATRIX) Master Configuration Register 11 */
+#define REG_MATRIX_MCFG12       (0x40088030) /**< (MATRIX) Master Configuration Register 12 */
+#define REG_MATRIX_SCFG         (0x40088040) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG0        (0x40088040) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG1        (0x40088044) /**< (MATRIX) Slave Configuration Register 1 */
+#define REG_MATRIX_SCFG2        (0x40088048) /**< (MATRIX) Slave Configuration Register 2 */
+#define REG_MATRIX_SCFG3        (0x4008804C) /**< (MATRIX) Slave Configuration Register 3 */
+#define REG_MATRIX_SCFG4        (0x40088050) /**< (MATRIX) Slave Configuration Register 4 */
+#define REG_MATRIX_SCFG5        (0x40088054) /**< (MATRIX) Slave Configuration Register 5 */
+#define REG_MATRIX_SCFG6        (0x40088058) /**< (MATRIX) Slave Configuration Register 6 */
+#define REG_MATRIX_SCFG7        (0x4008805C) /**< (MATRIX) Slave Configuration Register 7 */
+#define REG_MATRIX_SCFG8        (0x40088060) /**< (MATRIX) Slave Configuration Register 8 */
+#define REG_MATRIX_MRCR         (0x40088100) /**< (MATRIX) Master Remap Control Register */
+#define REG_CCFG_CAN0           (0x40088110) /**< (MATRIX) CAN0 Configuration Register */
+#define REG_CCFG_SYSIO          (0x40088114) /**< (MATRIX) System I/O and CAN1 Configuration Register */
+#define REG_CCFG_PCCR           (0x40088118) /**< (MATRIX) Peripheral Clock Configuration Register */
+#define REG_CCFG_DYNCKG         (0x4008811C) /**< (MATRIX) Dynamic Clock Gating Register */
+#define REG_CCFG_SMCNFCS        (0x40088124) /**< (MATRIX) SMC NAND Flash Chip Select Configuration Register */
+#define REG_MATRIX_WPMR         (0x400881E4) /**< (MATRIX) Write Protection Mode Register */
+#define REG_MATRIX_WPSR         (0x400881E8) /**< (MATRIX) Write Protection Status Register */
+
+#else
+
+#define REG_MATRIX_PRAS0        (*(__IO uint32_t*)0x40088080U) /**< (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0        (*(__IO uint32_t*)0x40088084U) /**< (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1        (*(__IO uint32_t*)0x40088088U) /**< (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1        (*(__IO uint32_t*)0x4008808CU) /**< (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2        (*(__IO uint32_t*)0x40088090U) /**< (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2        (*(__IO uint32_t*)0x40088094U) /**< (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3        (*(__IO uint32_t*)0x40088098U) /**< (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3        (*(__IO uint32_t*)0x4008809CU) /**< (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4        (*(__IO uint32_t*)0x400880A0U) /**< (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4        (*(__IO uint32_t*)0x400880A4U) /**< (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5        (*(__IO uint32_t*)0x400880A8U) /**< (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5        (*(__IO uint32_t*)0x400880ACU) /**< (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6        (*(__IO uint32_t*)0x400880B0U) /**< (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6        (*(__IO uint32_t*)0x400880B4U) /**< (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7        (*(__IO uint32_t*)0x400880B8U) /**< (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7        (*(__IO uint32_t*)0x400880BCU) /**< (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8        (*(__IO uint32_t*)0x400880C0U) /**< (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8        (*(__IO uint32_t*)0x400880C4U) /**< (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_MCFG         (*(__IO uint32_t*)0x40088000U) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG0        (*(__IO uint32_t*)0x40088000U) /**< (MATRIX) Master Configuration Register 0 */
+#define REG_MATRIX_MCFG1        (*(__IO uint32_t*)0x40088004U) /**< (MATRIX) Master Configuration Register 1 */
+#define REG_MATRIX_MCFG2        (*(__IO uint32_t*)0x40088008U) /**< (MATRIX) Master Configuration Register 2 */
+#define REG_MATRIX_MCFG3        (*(__IO uint32_t*)0x4008800CU) /**< (MATRIX) Master Configuration Register 3 */
+#define REG_MATRIX_MCFG4        (*(__IO uint32_t*)0x40088010U) /**< (MATRIX) Master Configuration Register 4 */
+#define REG_MATRIX_MCFG5        (*(__IO uint32_t*)0x40088014U) /**< (MATRIX) Master Configuration Register 5 */
+#define REG_MATRIX_MCFG6        (*(__IO uint32_t*)0x40088018U) /**< (MATRIX) Master Configuration Register 6 */
+#define REG_MATRIX_MCFG7        (*(__IO uint32_t*)0x4008801CU) /**< (MATRIX) Master Configuration Register 7 */
+#define REG_MATRIX_MCFG8        (*(__IO uint32_t*)0x40088020U) /**< (MATRIX) Master Configuration Register 8 */
+#define REG_MATRIX_MCFG9        (*(__IO uint32_t*)0x40088024U) /**< (MATRIX) Master Configuration Register 9 */
+#define REG_MATRIX_MCFG10       (*(__IO uint32_t*)0x40088028U) /**< (MATRIX) Master Configuration Register 10 */
+#define REG_MATRIX_MCFG11       (*(__IO uint32_t*)0x4008802CU) /**< (MATRIX) Master Configuration Register 11 */
+#define REG_MATRIX_MCFG12       (*(__IO uint32_t*)0x40088030U) /**< (MATRIX) Master Configuration Register 12 */
+#define REG_MATRIX_SCFG         (*(__IO uint32_t*)0x40088040U) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG0        (*(__IO uint32_t*)0x40088040U) /**< (MATRIX) Slave Configuration Register 0 */
+#define REG_MATRIX_SCFG1        (*(__IO uint32_t*)0x40088044U) /**< (MATRIX) Slave Configuration Register 1 */
+#define REG_MATRIX_SCFG2        (*(__IO uint32_t*)0x40088048U) /**< (MATRIX) Slave Configuration Register 2 */
+#define REG_MATRIX_SCFG3        (*(__IO uint32_t*)0x4008804CU) /**< (MATRIX) Slave Configuration Register 3 */
+#define REG_MATRIX_SCFG4        (*(__IO uint32_t*)0x40088050U) /**< (MATRIX) Slave Configuration Register 4 */
+#define REG_MATRIX_SCFG5        (*(__IO uint32_t*)0x40088054U) /**< (MATRIX) Slave Configuration Register 5 */
+#define REG_MATRIX_SCFG6        (*(__IO uint32_t*)0x40088058U) /**< (MATRIX) Slave Configuration Register 6 */
+#define REG_MATRIX_SCFG7        (*(__IO uint32_t*)0x4008805CU) /**< (MATRIX) Slave Configuration Register 7 */
+#define REG_MATRIX_SCFG8        (*(__IO uint32_t*)0x40088060U) /**< (MATRIX) Slave Configuration Register 8 */
+#define REG_MATRIX_MRCR         (*(__IO uint32_t*)0x40088100U) /**< (MATRIX) Master Remap Control Register */
+#define REG_CCFG_CAN0           (*(__IO uint32_t*)0x40088110U) /**< (MATRIX) CAN0 Configuration Register */
+#define REG_CCFG_SYSIO          (*(__IO uint32_t*)0x40088114U) /**< (MATRIX) System I/O and CAN1 Configuration Register */
+#define REG_CCFG_PCCR           (*(__IO uint32_t*)0x40088118U) /**< (MATRIX) Peripheral Clock Configuration Register */
+#define REG_CCFG_DYNCKG         (*(__IO uint32_t*)0x4008811CU) /**< (MATRIX) Dynamic Clock Gating Register */
+#define REG_CCFG_SMCNFCS        (*(__IO uint32_t*)0x40088124U) /**< (MATRIX) SMC NAND Flash Chip Select Configuration Register */
+#define REG_MATRIX_WPMR         (*(__IO uint32_t*)0x400881E4U) /**< (MATRIX) Write Protection Mode Register */
+#define REG_MATRIX_WPSR         (*(__I  uint32_t*)0x400881E8U) /**< (MATRIX) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_MATRIX_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/mcan0.h
+++ b/asf/sam/include/samv71b/instance/mcan0.h
@@ -1,0 +1,141 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCAN0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MCAN0_INSTANCE_H_
+#define _SAMV71_MCAN0_INSTANCE_H_
+
+/* ========== Register definition for MCAN0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCAN0_CREL          (0x40030000) /**< (MCAN0) Core Release Register */
+#define REG_MCAN0_ENDN          (0x40030004) /**< (MCAN0) Endian Register */
+#define REG_MCAN0_CUST          (0x40030008) /**< (MCAN0) Customer Register */
+#define REG_MCAN0_DBTP          (0x4003000C) /**< (MCAN0) Data Bit Timing and Prescaler Register */
+#define REG_MCAN0_TEST          (0x40030010) /**< (MCAN0) Test Register */
+#define REG_MCAN0_RWD           (0x40030014) /**< (MCAN0) RAM Watchdog Register */
+#define REG_MCAN0_CCCR          (0x40030018) /**< (MCAN0) CC Control Register */
+#define REG_MCAN0_NBTP          (0x4003001C) /**< (MCAN0) Nominal Bit Timing and Prescaler Register */
+#define REG_MCAN0_TSCC          (0x40030020) /**< (MCAN0) Timestamp Counter Configuration Register */
+#define REG_MCAN0_TSCV          (0x40030024) /**< (MCAN0) Timestamp Counter Value Register */
+#define REG_MCAN0_TOCC          (0x40030028) /**< (MCAN0) Timeout Counter Configuration Register */
+#define REG_MCAN0_TOCV          (0x4003002C) /**< (MCAN0) Timeout Counter Value Register */
+#define REG_MCAN0_ECR           (0x40030040) /**< (MCAN0) Error Counter Register */
+#define REG_MCAN0_PSR           (0x40030044) /**< (MCAN0) Protocol Status Register */
+#define REG_MCAN0_TDCR          (0x40030048) /**< (MCAN0) Transmit Delay Compensation Register */
+#define REG_MCAN0_IR            (0x40030050) /**< (MCAN0) Interrupt Register */
+#define REG_MCAN0_IE            (0x40030054) /**< (MCAN0) Interrupt Enable Register */
+#define REG_MCAN0_ILS           (0x40030058) /**< (MCAN0) Interrupt Line Select Register */
+#define REG_MCAN0_ILE           (0x4003005C) /**< (MCAN0) Interrupt Line Enable Register */
+#define REG_MCAN0_GFC           (0x40030080) /**< (MCAN0) Global Filter Configuration Register */
+#define REG_MCAN0_SIDFC         (0x40030084) /**< (MCAN0) Standard ID Filter Configuration Register */
+#define REG_MCAN0_XIDFC         (0x40030088) /**< (MCAN0) Extended ID Filter Configuration Register */
+#define REG_MCAN0_XIDAM         (0x40030090) /**< (MCAN0) Extended ID AND Mask Register */
+#define REG_MCAN0_HPMS          (0x40030094) /**< (MCAN0) High Priority Message Status Register */
+#define REG_MCAN0_NDAT1         (0x40030098) /**< (MCAN0) New Data 1 Register */
+#define REG_MCAN0_NDAT2         (0x4003009C) /**< (MCAN0) New Data 2 Register */
+#define REG_MCAN0_RXF0C         (0x400300A0) /**< (MCAN0) Receive FIFO 0 Configuration Register */
+#define REG_MCAN0_RXF0S         (0x400300A4) /**< (MCAN0) Receive FIFO 0 Status Register */
+#define REG_MCAN0_RXF0A         (0x400300A8) /**< (MCAN0) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN0_RXBC          (0x400300AC) /**< (MCAN0) Receive Rx Buffer Configuration Register */
+#define REG_MCAN0_RXF1C         (0x400300B0) /**< (MCAN0) Receive FIFO 1 Configuration Register */
+#define REG_MCAN0_RXF1S         (0x400300B4) /**< (MCAN0) Receive FIFO 1 Status Register */
+#define REG_MCAN0_RXF1A         (0x400300B8) /**< (MCAN0) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN0_RXESC         (0x400300BC) /**< (MCAN0) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN0_TXBC          (0x400300C0) /**< (MCAN0) Transmit Buffer Configuration Register */
+#define REG_MCAN0_TXFQS         (0x400300C4) /**< (MCAN0) Transmit FIFO/Queue Status Register */
+#define REG_MCAN0_TXESC         (0x400300C8) /**< (MCAN0) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN0_TXBRP         (0x400300CC) /**< (MCAN0) Transmit Buffer Request Pending Register */
+#define REG_MCAN0_TXBAR         (0x400300D0) /**< (MCAN0) Transmit Buffer Add Request Register */
+#define REG_MCAN0_TXBCR         (0x400300D4) /**< (MCAN0) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN0_TXBTO         (0x400300D8) /**< (MCAN0) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN0_TXBCF         (0x400300DC) /**< (MCAN0) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN0_TXBTIE        (0x400300E0) /**< (MCAN0) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN0_TXBCIE        (0x400300E4) /**< (MCAN0) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN0_TXEFC         (0x400300F0) /**< (MCAN0) Transmit Event FIFO Configuration Register */
+#define REG_MCAN0_TXEFS         (0x400300F4) /**< (MCAN0) Transmit Event FIFO Status Register */
+#define REG_MCAN0_TXEFA         (0x400300F8) /**< (MCAN0) Transmit Event FIFO Acknowledge Register */
+
+#else
+
+#define REG_MCAN0_CREL          (*(__I  uint32_t*)0x40030000U) /**< (MCAN0) Core Release Register */
+#define REG_MCAN0_ENDN          (*(__I  uint32_t*)0x40030004U) /**< (MCAN0) Endian Register */
+#define REG_MCAN0_CUST          (*(__IO uint32_t*)0x40030008U) /**< (MCAN0) Customer Register */
+#define REG_MCAN0_DBTP          (*(__IO uint32_t*)0x4003000CU) /**< (MCAN0) Data Bit Timing and Prescaler Register */
+#define REG_MCAN0_TEST          (*(__IO uint32_t*)0x40030010U) /**< (MCAN0) Test Register */
+#define REG_MCAN0_RWD           (*(__IO uint32_t*)0x40030014U) /**< (MCAN0) RAM Watchdog Register */
+#define REG_MCAN0_CCCR          (*(__IO uint32_t*)0x40030018U) /**< (MCAN0) CC Control Register */
+#define REG_MCAN0_NBTP          (*(__IO uint32_t*)0x4003001CU) /**< (MCAN0) Nominal Bit Timing and Prescaler Register */
+#define REG_MCAN0_TSCC          (*(__IO uint32_t*)0x40030020U) /**< (MCAN0) Timestamp Counter Configuration Register */
+#define REG_MCAN0_TSCV          (*(__IO uint32_t*)0x40030024U) /**< (MCAN0) Timestamp Counter Value Register */
+#define REG_MCAN0_TOCC          (*(__IO uint32_t*)0x40030028U) /**< (MCAN0) Timeout Counter Configuration Register */
+#define REG_MCAN0_TOCV          (*(__IO uint32_t*)0x4003002CU) /**< (MCAN0) Timeout Counter Value Register */
+#define REG_MCAN0_ECR           (*(__I  uint32_t*)0x40030040U) /**< (MCAN0) Error Counter Register */
+#define REG_MCAN0_PSR           (*(__I  uint32_t*)0x40030044U) /**< (MCAN0) Protocol Status Register */
+#define REG_MCAN0_TDCR          (*(__IO uint32_t*)0x40030048U) /**< (MCAN0) Transmit Delay Compensation Register */
+#define REG_MCAN0_IR            (*(__IO uint32_t*)0x40030050U) /**< (MCAN0) Interrupt Register */
+#define REG_MCAN0_IE            (*(__IO uint32_t*)0x40030054U) /**< (MCAN0) Interrupt Enable Register */
+#define REG_MCAN0_ILS           (*(__IO uint32_t*)0x40030058U) /**< (MCAN0) Interrupt Line Select Register */
+#define REG_MCAN0_ILE           (*(__IO uint32_t*)0x4003005CU) /**< (MCAN0) Interrupt Line Enable Register */
+#define REG_MCAN0_GFC           (*(__IO uint32_t*)0x40030080U) /**< (MCAN0) Global Filter Configuration Register */
+#define REG_MCAN0_SIDFC         (*(__IO uint32_t*)0x40030084U) /**< (MCAN0) Standard ID Filter Configuration Register */
+#define REG_MCAN0_XIDFC         (*(__IO uint32_t*)0x40030088U) /**< (MCAN0) Extended ID Filter Configuration Register */
+#define REG_MCAN0_XIDAM         (*(__IO uint32_t*)0x40030090U) /**< (MCAN0) Extended ID AND Mask Register */
+#define REG_MCAN0_HPMS          (*(__I  uint32_t*)0x40030094U) /**< (MCAN0) High Priority Message Status Register */
+#define REG_MCAN0_NDAT1         (*(__IO uint32_t*)0x40030098U) /**< (MCAN0) New Data 1 Register */
+#define REG_MCAN0_NDAT2         (*(__IO uint32_t*)0x4003009CU) /**< (MCAN0) New Data 2 Register */
+#define REG_MCAN0_RXF0C         (*(__IO uint32_t*)0x400300A0U) /**< (MCAN0) Receive FIFO 0 Configuration Register */
+#define REG_MCAN0_RXF0S         (*(__I  uint32_t*)0x400300A4U) /**< (MCAN0) Receive FIFO 0 Status Register */
+#define REG_MCAN0_RXF0A         (*(__IO uint32_t*)0x400300A8U) /**< (MCAN0) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN0_RXBC          (*(__IO uint32_t*)0x400300ACU) /**< (MCAN0) Receive Rx Buffer Configuration Register */
+#define REG_MCAN0_RXF1C         (*(__IO uint32_t*)0x400300B0U) /**< (MCAN0) Receive FIFO 1 Configuration Register */
+#define REG_MCAN0_RXF1S         (*(__I  uint32_t*)0x400300B4U) /**< (MCAN0) Receive FIFO 1 Status Register */
+#define REG_MCAN0_RXF1A         (*(__IO uint32_t*)0x400300B8U) /**< (MCAN0) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN0_RXESC         (*(__IO uint32_t*)0x400300BCU) /**< (MCAN0) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN0_TXBC          (*(__IO uint32_t*)0x400300C0U) /**< (MCAN0) Transmit Buffer Configuration Register */
+#define REG_MCAN0_TXFQS         (*(__I  uint32_t*)0x400300C4U) /**< (MCAN0) Transmit FIFO/Queue Status Register */
+#define REG_MCAN0_TXESC         (*(__IO uint32_t*)0x400300C8U) /**< (MCAN0) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN0_TXBRP         (*(__I  uint32_t*)0x400300CCU) /**< (MCAN0) Transmit Buffer Request Pending Register */
+#define REG_MCAN0_TXBAR         (*(__IO uint32_t*)0x400300D0U) /**< (MCAN0) Transmit Buffer Add Request Register */
+#define REG_MCAN0_TXBCR         (*(__IO uint32_t*)0x400300D4U) /**< (MCAN0) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN0_TXBTO         (*(__I  uint32_t*)0x400300D8U) /**< (MCAN0) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN0_TXBCF         (*(__I  uint32_t*)0x400300DCU) /**< (MCAN0) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN0_TXBTIE        (*(__IO uint32_t*)0x400300E0U) /**< (MCAN0) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN0_TXBCIE        (*(__IO uint32_t*)0x400300E4U) /**< (MCAN0) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN0_TXEFC         (*(__IO uint32_t*)0x400300F0U) /**< (MCAN0) Transmit Event FIFO Configuration Register */
+#define REG_MCAN0_TXEFS         (*(__I  uint32_t*)0x400300F4U) /**< (MCAN0) Transmit Event FIFO Status Register */
+#define REG_MCAN0_TXEFA         (*(__IO uint32_t*)0x400300F8U) /**< (MCAN0) Transmit Event FIFO Acknowledge Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCAN0 peripheral ========== */
+#define MCAN0_INSTANCE_ID                        35         
+#define MCAN0_CLOCK_ID                           35         
+
+#endif /* _SAMV71_MCAN0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/mcan1.h
+++ b/asf/sam/include/samv71b/instance/mcan1.h
@@ -1,0 +1,141 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCAN1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MCAN1_INSTANCE_H_
+#define _SAMV71_MCAN1_INSTANCE_H_
+
+/* ========== Register definition for MCAN1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MCAN1_CREL          (0x40034000) /**< (MCAN1) Core Release Register */
+#define REG_MCAN1_ENDN          (0x40034004) /**< (MCAN1) Endian Register */
+#define REG_MCAN1_CUST          (0x40034008) /**< (MCAN1) Customer Register */
+#define REG_MCAN1_DBTP          (0x4003400C) /**< (MCAN1) Data Bit Timing and Prescaler Register */
+#define REG_MCAN1_TEST          (0x40034010) /**< (MCAN1) Test Register */
+#define REG_MCAN1_RWD           (0x40034014) /**< (MCAN1) RAM Watchdog Register */
+#define REG_MCAN1_CCCR          (0x40034018) /**< (MCAN1) CC Control Register */
+#define REG_MCAN1_NBTP          (0x4003401C) /**< (MCAN1) Nominal Bit Timing and Prescaler Register */
+#define REG_MCAN1_TSCC          (0x40034020) /**< (MCAN1) Timestamp Counter Configuration Register */
+#define REG_MCAN1_TSCV          (0x40034024) /**< (MCAN1) Timestamp Counter Value Register */
+#define REG_MCAN1_TOCC          (0x40034028) /**< (MCAN1) Timeout Counter Configuration Register */
+#define REG_MCAN1_TOCV          (0x4003402C) /**< (MCAN1) Timeout Counter Value Register */
+#define REG_MCAN1_ECR           (0x40034040) /**< (MCAN1) Error Counter Register */
+#define REG_MCAN1_PSR           (0x40034044) /**< (MCAN1) Protocol Status Register */
+#define REG_MCAN1_TDCR          (0x40034048) /**< (MCAN1) Transmit Delay Compensation Register */
+#define REG_MCAN1_IR            (0x40034050) /**< (MCAN1) Interrupt Register */
+#define REG_MCAN1_IE            (0x40034054) /**< (MCAN1) Interrupt Enable Register */
+#define REG_MCAN1_ILS           (0x40034058) /**< (MCAN1) Interrupt Line Select Register */
+#define REG_MCAN1_ILE           (0x4003405C) /**< (MCAN1) Interrupt Line Enable Register */
+#define REG_MCAN1_GFC           (0x40034080) /**< (MCAN1) Global Filter Configuration Register */
+#define REG_MCAN1_SIDFC         (0x40034084) /**< (MCAN1) Standard ID Filter Configuration Register */
+#define REG_MCAN1_XIDFC         (0x40034088) /**< (MCAN1) Extended ID Filter Configuration Register */
+#define REG_MCAN1_XIDAM         (0x40034090) /**< (MCAN1) Extended ID AND Mask Register */
+#define REG_MCAN1_HPMS          (0x40034094) /**< (MCAN1) High Priority Message Status Register */
+#define REG_MCAN1_NDAT1         (0x40034098) /**< (MCAN1) New Data 1 Register */
+#define REG_MCAN1_NDAT2         (0x4003409C) /**< (MCAN1) New Data 2 Register */
+#define REG_MCAN1_RXF0C         (0x400340A0) /**< (MCAN1) Receive FIFO 0 Configuration Register */
+#define REG_MCAN1_RXF0S         (0x400340A4) /**< (MCAN1) Receive FIFO 0 Status Register */
+#define REG_MCAN1_RXF0A         (0x400340A8) /**< (MCAN1) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN1_RXBC          (0x400340AC) /**< (MCAN1) Receive Rx Buffer Configuration Register */
+#define REG_MCAN1_RXF1C         (0x400340B0) /**< (MCAN1) Receive FIFO 1 Configuration Register */
+#define REG_MCAN1_RXF1S         (0x400340B4) /**< (MCAN1) Receive FIFO 1 Status Register */
+#define REG_MCAN1_RXF1A         (0x400340B8) /**< (MCAN1) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN1_RXESC         (0x400340BC) /**< (MCAN1) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN1_TXBC          (0x400340C0) /**< (MCAN1) Transmit Buffer Configuration Register */
+#define REG_MCAN1_TXFQS         (0x400340C4) /**< (MCAN1) Transmit FIFO/Queue Status Register */
+#define REG_MCAN1_TXESC         (0x400340C8) /**< (MCAN1) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN1_TXBRP         (0x400340CC) /**< (MCAN1) Transmit Buffer Request Pending Register */
+#define REG_MCAN1_TXBAR         (0x400340D0) /**< (MCAN1) Transmit Buffer Add Request Register */
+#define REG_MCAN1_TXBCR         (0x400340D4) /**< (MCAN1) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN1_TXBTO         (0x400340D8) /**< (MCAN1) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN1_TXBCF         (0x400340DC) /**< (MCAN1) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN1_TXBTIE        (0x400340E0) /**< (MCAN1) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN1_TXBCIE        (0x400340E4) /**< (MCAN1) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN1_TXEFC         (0x400340F0) /**< (MCAN1) Transmit Event FIFO Configuration Register */
+#define REG_MCAN1_TXEFS         (0x400340F4) /**< (MCAN1) Transmit Event FIFO Status Register */
+#define REG_MCAN1_TXEFA         (0x400340F8) /**< (MCAN1) Transmit Event FIFO Acknowledge Register */
+
+#else
+
+#define REG_MCAN1_CREL          (*(__I  uint32_t*)0x40034000U) /**< (MCAN1) Core Release Register */
+#define REG_MCAN1_ENDN          (*(__I  uint32_t*)0x40034004U) /**< (MCAN1) Endian Register */
+#define REG_MCAN1_CUST          (*(__IO uint32_t*)0x40034008U) /**< (MCAN1) Customer Register */
+#define REG_MCAN1_DBTP          (*(__IO uint32_t*)0x4003400CU) /**< (MCAN1) Data Bit Timing and Prescaler Register */
+#define REG_MCAN1_TEST          (*(__IO uint32_t*)0x40034010U) /**< (MCAN1) Test Register */
+#define REG_MCAN1_RWD           (*(__IO uint32_t*)0x40034014U) /**< (MCAN1) RAM Watchdog Register */
+#define REG_MCAN1_CCCR          (*(__IO uint32_t*)0x40034018U) /**< (MCAN1) CC Control Register */
+#define REG_MCAN1_NBTP          (*(__IO uint32_t*)0x4003401CU) /**< (MCAN1) Nominal Bit Timing and Prescaler Register */
+#define REG_MCAN1_TSCC          (*(__IO uint32_t*)0x40034020U) /**< (MCAN1) Timestamp Counter Configuration Register */
+#define REG_MCAN1_TSCV          (*(__IO uint32_t*)0x40034024U) /**< (MCAN1) Timestamp Counter Value Register */
+#define REG_MCAN1_TOCC          (*(__IO uint32_t*)0x40034028U) /**< (MCAN1) Timeout Counter Configuration Register */
+#define REG_MCAN1_TOCV          (*(__IO uint32_t*)0x4003402CU) /**< (MCAN1) Timeout Counter Value Register */
+#define REG_MCAN1_ECR           (*(__I  uint32_t*)0x40034040U) /**< (MCAN1) Error Counter Register */
+#define REG_MCAN1_PSR           (*(__I  uint32_t*)0x40034044U) /**< (MCAN1) Protocol Status Register */
+#define REG_MCAN1_TDCR          (*(__IO uint32_t*)0x40034048U) /**< (MCAN1) Transmit Delay Compensation Register */
+#define REG_MCAN1_IR            (*(__IO uint32_t*)0x40034050U) /**< (MCAN1) Interrupt Register */
+#define REG_MCAN1_IE            (*(__IO uint32_t*)0x40034054U) /**< (MCAN1) Interrupt Enable Register */
+#define REG_MCAN1_ILS           (*(__IO uint32_t*)0x40034058U) /**< (MCAN1) Interrupt Line Select Register */
+#define REG_MCAN1_ILE           (*(__IO uint32_t*)0x4003405CU) /**< (MCAN1) Interrupt Line Enable Register */
+#define REG_MCAN1_GFC           (*(__IO uint32_t*)0x40034080U) /**< (MCAN1) Global Filter Configuration Register */
+#define REG_MCAN1_SIDFC         (*(__IO uint32_t*)0x40034084U) /**< (MCAN1) Standard ID Filter Configuration Register */
+#define REG_MCAN1_XIDFC         (*(__IO uint32_t*)0x40034088U) /**< (MCAN1) Extended ID Filter Configuration Register */
+#define REG_MCAN1_XIDAM         (*(__IO uint32_t*)0x40034090U) /**< (MCAN1) Extended ID AND Mask Register */
+#define REG_MCAN1_HPMS          (*(__I  uint32_t*)0x40034094U) /**< (MCAN1) High Priority Message Status Register */
+#define REG_MCAN1_NDAT1         (*(__IO uint32_t*)0x40034098U) /**< (MCAN1) New Data 1 Register */
+#define REG_MCAN1_NDAT2         (*(__IO uint32_t*)0x4003409CU) /**< (MCAN1) New Data 2 Register */
+#define REG_MCAN1_RXF0C         (*(__IO uint32_t*)0x400340A0U) /**< (MCAN1) Receive FIFO 0 Configuration Register */
+#define REG_MCAN1_RXF0S         (*(__I  uint32_t*)0x400340A4U) /**< (MCAN1) Receive FIFO 0 Status Register */
+#define REG_MCAN1_RXF0A         (*(__IO uint32_t*)0x400340A8U) /**< (MCAN1) Receive FIFO 0 Acknowledge Register */
+#define REG_MCAN1_RXBC          (*(__IO uint32_t*)0x400340ACU) /**< (MCAN1) Receive Rx Buffer Configuration Register */
+#define REG_MCAN1_RXF1C         (*(__IO uint32_t*)0x400340B0U) /**< (MCAN1) Receive FIFO 1 Configuration Register */
+#define REG_MCAN1_RXF1S         (*(__I  uint32_t*)0x400340B4U) /**< (MCAN1) Receive FIFO 1 Status Register */
+#define REG_MCAN1_RXF1A         (*(__IO uint32_t*)0x400340B8U) /**< (MCAN1) Receive FIFO 1 Acknowledge Register */
+#define REG_MCAN1_RXESC         (*(__IO uint32_t*)0x400340BCU) /**< (MCAN1) Receive Buffer / FIFO Element Size Configuration Register */
+#define REG_MCAN1_TXBC          (*(__IO uint32_t*)0x400340C0U) /**< (MCAN1) Transmit Buffer Configuration Register */
+#define REG_MCAN1_TXFQS         (*(__I  uint32_t*)0x400340C4U) /**< (MCAN1) Transmit FIFO/Queue Status Register */
+#define REG_MCAN1_TXESC         (*(__IO uint32_t*)0x400340C8U) /**< (MCAN1) Transmit Buffer Element Size Configuration Register */
+#define REG_MCAN1_TXBRP         (*(__I  uint32_t*)0x400340CCU) /**< (MCAN1) Transmit Buffer Request Pending Register */
+#define REG_MCAN1_TXBAR         (*(__IO uint32_t*)0x400340D0U) /**< (MCAN1) Transmit Buffer Add Request Register */
+#define REG_MCAN1_TXBCR         (*(__IO uint32_t*)0x400340D4U) /**< (MCAN1) Transmit Buffer Cancellation Request Register */
+#define REG_MCAN1_TXBTO         (*(__I  uint32_t*)0x400340D8U) /**< (MCAN1) Transmit Buffer Transmission Occurred Register */
+#define REG_MCAN1_TXBCF         (*(__I  uint32_t*)0x400340DCU) /**< (MCAN1) Transmit Buffer Cancellation Finished Register */
+#define REG_MCAN1_TXBTIE        (*(__IO uint32_t*)0x400340E0U) /**< (MCAN1) Transmit Buffer Transmission Interrupt Enable Register */
+#define REG_MCAN1_TXBCIE        (*(__IO uint32_t*)0x400340E4U) /**< (MCAN1) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+#define REG_MCAN1_TXEFC         (*(__IO uint32_t*)0x400340F0U) /**< (MCAN1) Transmit Event FIFO Configuration Register */
+#define REG_MCAN1_TXEFS         (*(__I  uint32_t*)0x400340F4U) /**< (MCAN1) Transmit Event FIFO Status Register */
+#define REG_MCAN1_TXEFA         (*(__IO uint32_t*)0x400340F8U) /**< (MCAN1) Transmit Event FIFO Acknowledge Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MCAN1 peripheral ========== */
+#define MCAN1_INSTANCE_ID                        37         
+#define MCAN1_CLOCK_ID                           37         
+
+#endif /* _SAMV71_MCAN1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/mlb.h
+++ b/asf/sam/include/samv71b/instance/mlb.h
@@ -1,0 +1,119 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MLB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_MLB_INSTANCE_H_
+#define _SAMV71_MLB_INSTANCE_H_
+
+/* ========== Register definition for MLB peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_MLB_MLBC0           (0x40068000) /**< (MLB) MediaLB Control 0 Register */
+#define REG_MLB_MS0             (0x4006800C) /**< (MLB) MediaLB Channel Status 0 Register */
+#define REG_MLB_MS1             (0x40068014) /**< (MLB) MediaLB Channel Status1 Register */
+#define REG_MLB_MSS             (0x40068020) /**< (MLB) MediaLB System Status Register */
+#define REG_MLB_MSD             (0x40068024) /**< (MLB) MediaLB System Data Register */
+#define REG_MLB_MIEN            (0x4006802C) /**< (MLB) MediaLB Interrupt Enable Register */
+#define REG_MLB_MLBC1           (0x4006803C) /**< (MLB) MediaLB Control 1 Register */
+#define REG_MLB_HCTL            (0x40068080) /**< (MLB) HBI Control Register */
+#define REG_MLB_HCMR            (0x40068088) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR0           (0x40068088) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR1           (0x4006808C) /**< (MLB) HBI Channel Mask 0 Register 1 */
+#define REG_MLB_HCER            (0x40068090) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER0           (0x40068090) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER1           (0x40068094) /**< (MLB) HBI Channel Error 0 Register 1 */
+#define REG_MLB_HCBR            (0x40068098) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR0           (0x40068098) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR1           (0x4006809C) /**< (MLB) HBI Channel Busy 0 Register 1 */
+#define REG_MLB_MDAT            (0x400680C0) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT0           (0x400680C0) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT1           (0x400680C4) /**< (MLB) MIF Data 0 Register 1 */
+#define REG_MLB_MDAT2           (0x400680C8) /**< (MLB) MIF Data 0 Register 2 */
+#define REG_MLB_MDAT3           (0x400680CC) /**< (MLB) MIF Data 0 Register 3 */
+#define REG_MLB_MDWE            (0x400680D0) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE0           (0x400680D0) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE1           (0x400680D4) /**< (MLB) MIF Data Write Enable 0 Register 1 */
+#define REG_MLB_MDWE2           (0x400680D8) /**< (MLB) MIF Data Write Enable 0 Register 2 */
+#define REG_MLB_MDWE3           (0x400680DC) /**< (MLB) MIF Data Write Enable 0 Register 3 */
+#define REG_MLB_MCTL            (0x400680E0) /**< (MLB) MIF Control Register */
+#define REG_MLB_MADR            (0x400680E4) /**< (MLB) MIF Address Register */
+#define REG_MLB_ACTL            (0x400683C0) /**< (MLB) AHB Control Register */
+#define REG_MLB_ACSR            (0x400683D0) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR0           (0x400683D0) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR1           (0x400683D4) /**< (MLB) AHB Channel Status 0 Register 1 */
+#define REG_MLB_ACMR            (0x400683D8) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR0           (0x400683D8) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR1           (0x400683DC) /**< (MLB) AHB Channel Mask 0 Register 1 */
+
+#else
+
+#define REG_MLB_MLBC0           (*(__IO uint32_t*)0x40068000U) /**< (MLB) MediaLB Control 0 Register */
+#define REG_MLB_MS0             (*(__IO uint32_t*)0x4006800CU) /**< (MLB) MediaLB Channel Status 0 Register */
+#define REG_MLB_MS1             (*(__IO uint32_t*)0x40068014U) /**< (MLB) MediaLB Channel Status1 Register */
+#define REG_MLB_MSS             (*(__IO uint32_t*)0x40068020U) /**< (MLB) MediaLB System Status Register */
+#define REG_MLB_MSD             (*(__I  uint32_t*)0x40068024U) /**< (MLB) MediaLB System Data Register */
+#define REG_MLB_MIEN            (*(__IO uint32_t*)0x4006802CU) /**< (MLB) MediaLB Interrupt Enable Register */
+#define REG_MLB_MLBC1           (*(__IO uint32_t*)0x4006803CU) /**< (MLB) MediaLB Control 1 Register */
+#define REG_MLB_HCTL            (*(__IO uint32_t*)0x40068080U) /**< (MLB) HBI Control Register */
+#define REG_MLB_HCMR            (*(__IO uint32_t*)0x40068088U) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR0           (*(__IO uint32_t*)0x40068088U) /**< (MLB) HBI Channel Mask 0 Register 0 */
+#define REG_MLB_HCMR1           (*(__IO uint32_t*)0x4006808CU) /**< (MLB) HBI Channel Mask 0 Register 1 */
+#define REG_MLB_HCER            (*(__I  uint32_t*)0x40068090U) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER0           (*(__I  uint32_t*)0x40068090U) /**< (MLB) HBI Channel Error 0 Register 0 */
+#define REG_MLB_HCER1           (*(__I  uint32_t*)0x40068094U) /**< (MLB) HBI Channel Error 0 Register 1 */
+#define REG_MLB_HCBR            (*(__I  uint32_t*)0x40068098U) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR0           (*(__I  uint32_t*)0x40068098U) /**< (MLB) HBI Channel Busy 0 Register 0 */
+#define REG_MLB_HCBR1           (*(__I  uint32_t*)0x4006809CU) /**< (MLB) HBI Channel Busy 0 Register 1 */
+#define REG_MLB_MDAT            (*(__IO uint32_t*)0x400680C0U) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT0           (*(__IO uint32_t*)0x400680C0U) /**< (MLB) MIF Data 0 Register 0 */
+#define REG_MLB_MDAT1           (*(__IO uint32_t*)0x400680C4U) /**< (MLB) MIF Data 0 Register 1 */
+#define REG_MLB_MDAT2           (*(__IO uint32_t*)0x400680C8U) /**< (MLB) MIF Data 0 Register 2 */
+#define REG_MLB_MDAT3           (*(__IO uint32_t*)0x400680CCU) /**< (MLB) MIF Data 0 Register 3 */
+#define REG_MLB_MDWE            (*(__IO uint32_t*)0x400680D0U) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE0           (*(__IO uint32_t*)0x400680D0U) /**< (MLB) MIF Data Write Enable 0 Register 0 */
+#define REG_MLB_MDWE1           (*(__IO uint32_t*)0x400680D4U) /**< (MLB) MIF Data Write Enable 0 Register 1 */
+#define REG_MLB_MDWE2           (*(__IO uint32_t*)0x400680D8U) /**< (MLB) MIF Data Write Enable 0 Register 2 */
+#define REG_MLB_MDWE3           (*(__IO uint32_t*)0x400680DCU) /**< (MLB) MIF Data Write Enable 0 Register 3 */
+#define REG_MLB_MCTL            (*(__IO uint32_t*)0x400680E0U) /**< (MLB) MIF Control Register */
+#define REG_MLB_MADR            (*(__IO uint32_t*)0x400680E4U) /**< (MLB) MIF Address Register */
+#define REG_MLB_ACTL            (*(__IO uint32_t*)0x400683C0U) /**< (MLB) AHB Control Register */
+#define REG_MLB_ACSR            (*(__IO uint32_t*)0x400683D0U) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR0           (*(__IO uint32_t*)0x400683D0U) /**< (MLB) AHB Channel Status 0 Register 0 */
+#define REG_MLB_ACSR1           (*(__IO uint32_t*)0x400683D4U) /**< (MLB) AHB Channel Status 0 Register 1 */
+#define REG_MLB_ACMR            (*(__IO uint32_t*)0x400683D8U) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR0           (*(__IO uint32_t*)0x400683D8U) /**< (MLB) AHB Channel Mask 0 Register 0 */
+#define REG_MLB_ACMR1           (*(__IO uint32_t*)0x400683DCU) /**< (MLB) AHB Channel Mask 0 Register 1 */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for MLB peripheral ========== */
+#define MLB_INSTANCE_ID                          53         
+#define MLB_CLOCK_ID                             53         
+
+#endif /* _SAMV71_MLB_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pioa.h
+++ b/asf/sam/include/samv71b/instance/pioa.h
@@ -1,0 +1,160 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOA
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIOA_INSTANCE_H_
+#define _SAMV71_PIOA_INSTANCE_H_
+
+/* ========== Register definition for PIOA peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOA_PER            (0x400E0E00) /**< (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR            (0x400E0E04) /**< (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR            (0x400E0E08) /**< (PIOA) PIO Status Register */
+#define REG_PIOA_OER            (0x400E0E10) /**< (PIOA) Output Enable Register */
+#define REG_PIOA_ODR            (0x400E0E14) /**< (PIOA) Output Disable Register */
+#define REG_PIOA_OSR            (0x400E0E18) /**< (PIOA) Output Status Register */
+#define REG_PIOA_IFER           (0x400E0E20) /**< (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR           (0x400E0E24) /**< (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR           (0x400E0E28) /**< (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR           (0x400E0E30) /**< (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR           (0x400E0E34) /**< (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR           (0x400E0E38) /**< (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR           (0x400E0E3C) /**< (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER            (0x400E0E40) /**< (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR            (0x400E0E44) /**< (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR            (0x400E0E48) /**< (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR            (0x400E0E4C) /**< (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER           (0x400E0E50) /**< (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR           (0x400E0E54) /**< (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR           (0x400E0E58) /**< (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR           (0x400E0E60) /**< (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER           (0x400E0E64) /**< (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR           (0x400E0E68) /**< (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR         (0x400E0E70) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR0        (0x400E0E70) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR1        (0x400E0E74) /**< (PIOA) Peripheral ABCD Select Register 1 */
+#define REG_PIOA_IFSCDR         (0x400E0E80) /**< (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER         (0x400E0E84) /**< (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR         (0x400E0E88) /**< (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR           (0x400E0E8C) /**< (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR          (0x400E0E90) /**< (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER          (0x400E0E94) /**< (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR          (0x400E0E98) /**< (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER           (0x400E0EA0) /**< (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR           (0x400E0EA4) /**< (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR           (0x400E0EA8) /**< (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER          (0x400E0EB0) /**< (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR          (0x400E0EB4) /**< (PIOA) Additional Interrupt Modes Disable Register */
+#define REG_PIOA_AIMMR          (0x400E0EB8) /**< (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR            (0x400E0EC0) /**< (PIOA) Edge Select Register */
+#define REG_PIOA_LSR            (0x400E0EC4) /**< (PIOA) Level Select Register */
+#define REG_PIOA_ELSR           (0x400E0EC8) /**< (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR         (0x400E0ED0) /**< (PIOA) Falling Edge/Low-Level Select Register */
+#define REG_PIOA_REHLSR         (0x400E0ED4) /**< (PIOA) Rising Edge/High-Level Select Register */
+#define REG_PIOA_FRLHSR         (0x400E0ED8) /**< (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR         (0x400E0EE0) /**< (PIOA) Lock Status */
+#define REG_PIOA_WPMR           (0x400E0EE4) /**< (PIOA) Write Protection Mode Register */
+#define REG_PIOA_WPSR           (0x400E0EE8) /**< (PIOA) Write Protection Status Register */
+#define REG_PIOA_SCHMITT        (0x400E0F00) /**< (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DRIVER         (0x400E0F18) /**< (PIOA) I/O Drive Register */
+#define REG_PIOA_PCMR           (0x400E0F50) /**< (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER          (0x400E0F54) /**< (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR          (0x400E0F58) /**< (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR          (0x400E0F5C) /**< (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR          (0x400E0F60) /**< (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR          (0x400E0F64) /**< (PIOA) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOA_PER            (*(__O  uint32_t*)0x400E0E00U) /**< (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR            (*(__O  uint32_t*)0x400E0E04U) /**< (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR            (*(__I  uint32_t*)0x400E0E08U) /**< (PIOA) PIO Status Register */
+#define REG_PIOA_OER            (*(__O  uint32_t*)0x400E0E10U) /**< (PIOA) Output Enable Register */
+#define REG_PIOA_ODR            (*(__O  uint32_t*)0x400E0E14U) /**< (PIOA) Output Disable Register */
+#define REG_PIOA_OSR            (*(__I  uint32_t*)0x400E0E18U) /**< (PIOA) Output Status Register */
+#define REG_PIOA_IFER           (*(__O  uint32_t*)0x400E0E20U) /**< (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR           (*(__O  uint32_t*)0x400E0E24U) /**< (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR           (*(__I  uint32_t*)0x400E0E28U) /**< (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR           (*(__O  uint32_t*)0x400E0E30U) /**< (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR           (*(__O  uint32_t*)0x400E0E34U) /**< (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR           (*(__IO uint32_t*)0x400E0E38U) /**< (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR           (*(__I  uint32_t*)0x400E0E3CU) /**< (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER            (*(__O  uint32_t*)0x400E0E40U) /**< (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR            (*(__O  uint32_t*)0x400E0E44U) /**< (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR            (*(__I  uint32_t*)0x400E0E48U) /**< (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR            (*(__I  uint32_t*)0x400E0E4CU) /**< (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER           (*(__O  uint32_t*)0x400E0E50U) /**< (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR           (*(__O  uint32_t*)0x400E0E54U) /**< (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR           (*(__I  uint32_t*)0x400E0E58U) /**< (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR           (*(__O  uint32_t*)0x400E0E60U) /**< (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER           (*(__O  uint32_t*)0x400E0E64U) /**< (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR           (*(__I  uint32_t*)0x400E0E68U) /**< (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR         (*(__IO uint32_t*)0x400E0E70U) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR0        (*(__IO uint32_t*)0x400E0E70U) /**< (PIOA) Peripheral ABCD Select Register 0 */
+#define REG_PIOA_ABCDSR1        (*(__IO uint32_t*)0x400E0E74U) /**< (PIOA) Peripheral ABCD Select Register 1 */
+#define REG_PIOA_IFSCDR         (*(__O  uint32_t*)0x400E0E80U) /**< (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER         (*(__O  uint32_t*)0x400E0E84U) /**< (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR         (*(__I  uint32_t*)0x400E0E88U) /**< (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR           (*(__IO uint32_t*)0x400E0E8CU) /**< (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR          (*(__O  uint32_t*)0x400E0E90U) /**< (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER          (*(__O  uint32_t*)0x400E0E94U) /**< (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR          (*(__I  uint32_t*)0x400E0E98U) /**< (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER           (*(__O  uint32_t*)0x400E0EA0U) /**< (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR           (*(__O  uint32_t*)0x400E0EA4U) /**< (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR           (*(__I  uint32_t*)0x400E0EA8U) /**< (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER          (*(__O  uint32_t*)0x400E0EB0U) /**< (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR          (*(__O  uint32_t*)0x400E0EB4U) /**< (PIOA) Additional Interrupt Modes Disable Register */
+#define REG_PIOA_AIMMR          (*(__I  uint32_t*)0x400E0EB8U) /**< (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR            (*(__O  uint32_t*)0x400E0EC0U) /**< (PIOA) Edge Select Register */
+#define REG_PIOA_LSR            (*(__O  uint32_t*)0x400E0EC4U) /**< (PIOA) Level Select Register */
+#define REG_PIOA_ELSR           (*(__I  uint32_t*)0x400E0EC8U) /**< (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR         (*(__O  uint32_t*)0x400E0ED0U) /**< (PIOA) Falling Edge/Low-Level Select Register */
+#define REG_PIOA_REHLSR         (*(__O  uint32_t*)0x400E0ED4U) /**< (PIOA) Rising Edge/High-Level Select Register */
+#define REG_PIOA_FRLHSR         (*(__I  uint32_t*)0x400E0ED8U) /**< (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR         (*(__I  uint32_t*)0x400E0EE0U) /**< (PIOA) Lock Status */
+#define REG_PIOA_WPMR           (*(__IO uint32_t*)0x400E0EE4U) /**< (PIOA) Write Protection Mode Register */
+#define REG_PIOA_WPSR           (*(__I  uint32_t*)0x400E0EE8U) /**< (PIOA) Write Protection Status Register */
+#define REG_PIOA_SCHMITT        (*(__IO uint32_t*)0x400E0F00U) /**< (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DRIVER         (*(__IO uint32_t*)0x400E0F18U) /**< (PIOA) I/O Drive Register */
+#define REG_PIOA_PCMR           (*(__IO uint32_t*)0x400E0F50U) /**< (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER          (*(__O  uint32_t*)0x400E0F54U) /**< (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR          (*(__O  uint32_t*)0x400E0F58U) /**< (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR          (*(__I  uint32_t*)0x400E0F5CU) /**< (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR          (*(__I  uint32_t*)0x400E0F60U) /**< (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR          (*(__I  uint32_t*)0x400E0F64U) /**< (PIOA) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOA peripheral ========== */
+#define PIOA_DMAC_ID_RX                          34         
+#define PIOA_INSTANCE_ID                         10         
+#define PIOA_CLOCK_ID                            10         
+
+#endif /* _SAMV71_PIOA_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/piob.h
+++ b/asf/sam/include/samv71b/instance/piob.h
@@ -1,0 +1,159 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOB
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIOB_INSTANCE_H_
+#define _SAMV71_PIOB_INSTANCE_H_
+
+/* ========== Register definition for PIOB peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOB_PER            (0x400E1000) /**< (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR            (0x400E1004) /**< (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR            (0x400E1008) /**< (PIOB) PIO Status Register */
+#define REG_PIOB_OER            (0x400E1010) /**< (PIOB) Output Enable Register */
+#define REG_PIOB_ODR            (0x400E1014) /**< (PIOB) Output Disable Register */
+#define REG_PIOB_OSR            (0x400E1018) /**< (PIOB) Output Status Register */
+#define REG_PIOB_IFER           (0x400E1020) /**< (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR           (0x400E1024) /**< (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR           (0x400E1028) /**< (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR           (0x400E1030) /**< (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR           (0x400E1034) /**< (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR           (0x400E1038) /**< (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR           (0x400E103C) /**< (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER            (0x400E1040) /**< (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR            (0x400E1044) /**< (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR            (0x400E1048) /**< (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR            (0x400E104C) /**< (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER           (0x400E1050) /**< (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR           (0x400E1054) /**< (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR           (0x400E1058) /**< (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR           (0x400E1060) /**< (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER           (0x400E1064) /**< (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR           (0x400E1068) /**< (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR         (0x400E1070) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR0        (0x400E1070) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR1        (0x400E1074) /**< (PIOB) Peripheral ABCD Select Register 1 */
+#define REG_PIOB_IFSCDR         (0x400E1080) /**< (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER         (0x400E1084) /**< (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR         (0x400E1088) /**< (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR           (0x400E108C) /**< (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR          (0x400E1090) /**< (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER          (0x400E1094) /**< (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR          (0x400E1098) /**< (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER           (0x400E10A0) /**< (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR           (0x400E10A4) /**< (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR           (0x400E10A8) /**< (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER          (0x400E10B0) /**< (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR          (0x400E10B4) /**< (PIOB) Additional Interrupt Modes Disable Register */
+#define REG_PIOB_AIMMR          (0x400E10B8) /**< (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR            (0x400E10C0) /**< (PIOB) Edge Select Register */
+#define REG_PIOB_LSR            (0x400E10C4) /**< (PIOB) Level Select Register */
+#define REG_PIOB_ELSR           (0x400E10C8) /**< (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR         (0x400E10D0) /**< (PIOB) Falling Edge/Low-Level Select Register */
+#define REG_PIOB_REHLSR         (0x400E10D4) /**< (PIOB) Rising Edge/High-Level Select Register */
+#define REG_PIOB_FRLHSR         (0x400E10D8) /**< (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR         (0x400E10E0) /**< (PIOB) Lock Status */
+#define REG_PIOB_WPMR           (0x400E10E4) /**< (PIOB) Write Protection Mode Register */
+#define REG_PIOB_WPSR           (0x400E10E8) /**< (PIOB) Write Protection Status Register */
+#define REG_PIOB_SCHMITT        (0x400E1100) /**< (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DRIVER         (0x400E1118) /**< (PIOB) I/O Drive Register */
+#define REG_PIOB_PCMR           (0x400E1150) /**< (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER          (0x400E1154) /**< (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR          (0x400E1158) /**< (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR          (0x400E115C) /**< (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR          (0x400E1160) /**< (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR          (0x400E1164) /**< (PIOB) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOB_PER            (*(__O  uint32_t*)0x400E1000U) /**< (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR            (*(__O  uint32_t*)0x400E1004U) /**< (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR            (*(__I  uint32_t*)0x400E1008U) /**< (PIOB) PIO Status Register */
+#define REG_PIOB_OER            (*(__O  uint32_t*)0x400E1010U) /**< (PIOB) Output Enable Register */
+#define REG_PIOB_ODR            (*(__O  uint32_t*)0x400E1014U) /**< (PIOB) Output Disable Register */
+#define REG_PIOB_OSR            (*(__I  uint32_t*)0x400E1018U) /**< (PIOB) Output Status Register */
+#define REG_PIOB_IFER           (*(__O  uint32_t*)0x400E1020U) /**< (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR           (*(__O  uint32_t*)0x400E1024U) /**< (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR           (*(__I  uint32_t*)0x400E1028U) /**< (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR           (*(__O  uint32_t*)0x400E1030U) /**< (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR           (*(__O  uint32_t*)0x400E1034U) /**< (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR           (*(__IO uint32_t*)0x400E1038U) /**< (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR           (*(__I  uint32_t*)0x400E103CU) /**< (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER            (*(__O  uint32_t*)0x400E1040U) /**< (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR            (*(__O  uint32_t*)0x400E1044U) /**< (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR            (*(__I  uint32_t*)0x400E1048U) /**< (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR            (*(__I  uint32_t*)0x400E104CU) /**< (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER           (*(__O  uint32_t*)0x400E1050U) /**< (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR           (*(__O  uint32_t*)0x400E1054U) /**< (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR           (*(__I  uint32_t*)0x400E1058U) /**< (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR           (*(__O  uint32_t*)0x400E1060U) /**< (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER           (*(__O  uint32_t*)0x400E1064U) /**< (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR           (*(__I  uint32_t*)0x400E1068U) /**< (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR         (*(__IO uint32_t*)0x400E1070U) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR0        (*(__IO uint32_t*)0x400E1070U) /**< (PIOB) Peripheral ABCD Select Register 0 */
+#define REG_PIOB_ABCDSR1        (*(__IO uint32_t*)0x400E1074U) /**< (PIOB) Peripheral ABCD Select Register 1 */
+#define REG_PIOB_IFSCDR         (*(__O  uint32_t*)0x400E1080U) /**< (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER         (*(__O  uint32_t*)0x400E1084U) /**< (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR         (*(__I  uint32_t*)0x400E1088U) /**< (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR           (*(__IO uint32_t*)0x400E108CU) /**< (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR          (*(__O  uint32_t*)0x400E1090U) /**< (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER          (*(__O  uint32_t*)0x400E1094U) /**< (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR          (*(__I  uint32_t*)0x400E1098U) /**< (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER           (*(__O  uint32_t*)0x400E10A0U) /**< (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR           (*(__O  uint32_t*)0x400E10A4U) /**< (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR           (*(__I  uint32_t*)0x400E10A8U) /**< (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER          (*(__O  uint32_t*)0x400E10B0U) /**< (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR          (*(__O  uint32_t*)0x400E10B4U) /**< (PIOB) Additional Interrupt Modes Disable Register */
+#define REG_PIOB_AIMMR          (*(__I  uint32_t*)0x400E10B8U) /**< (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR            (*(__O  uint32_t*)0x400E10C0U) /**< (PIOB) Edge Select Register */
+#define REG_PIOB_LSR            (*(__O  uint32_t*)0x400E10C4U) /**< (PIOB) Level Select Register */
+#define REG_PIOB_ELSR           (*(__I  uint32_t*)0x400E10C8U) /**< (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR         (*(__O  uint32_t*)0x400E10D0U) /**< (PIOB) Falling Edge/Low-Level Select Register */
+#define REG_PIOB_REHLSR         (*(__O  uint32_t*)0x400E10D4U) /**< (PIOB) Rising Edge/High-Level Select Register */
+#define REG_PIOB_FRLHSR         (*(__I  uint32_t*)0x400E10D8U) /**< (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR         (*(__I  uint32_t*)0x400E10E0U) /**< (PIOB) Lock Status */
+#define REG_PIOB_WPMR           (*(__IO uint32_t*)0x400E10E4U) /**< (PIOB) Write Protection Mode Register */
+#define REG_PIOB_WPSR           (*(__I  uint32_t*)0x400E10E8U) /**< (PIOB) Write Protection Status Register */
+#define REG_PIOB_SCHMITT        (*(__IO uint32_t*)0x400E1100U) /**< (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DRIVER         (*(__IO uint32_t*)0x400E1118U) /**< (PIOB) I/O Drive Register */
+#define REG_PIOB_PCMR           (*(__IO uint32_t*)0x400E1150U) /**< (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER          (*(__O  uint32_t*)0x400E1154U) /**< (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR          (*(__O  uint32_t*)0x400E1158U) /**< (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR          (*(__I  uint32_t*)0x400E115CU) /**< (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR          (*(__I  uint32_t*)0x400E1160U) /**< (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR          (*(__I  uint32_t*)0x400E1164U) /**< (PIOB) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOB peripheral ========== */
+#define PIOB_INSTANCE_ID                         11         
+#define PIOB_CLOCK_ID                            11         
+
+#endif /* _SAMV71_PIOB_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pioc.h
+++ b/asf/sam/include/samv71b/instance/pioc.h
@@ -1,0 +1,159 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIOC_INSTANCE_H_
+#define _SAMV71_PIOC_INSTANCE_H_
+
+/* ========== Register definition for PIOC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOC_PER            (0x400E1200) /**< (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR            (0x400E1204) /**< (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR            (0x400E1208) /**< (PIOC) PIO Status Register */
+#define REG_PIOC_OER            (0x400E1210) /**< (PIOC) Output Enable Register */
+#define REG_PIOC_ODR            (0x400E1214) /**< (PIOC) Output Disable Register */
+#define REG_PIOC_OSR            (0x400E1218) /**< (PIOC) Output Status Register */
+#define REG_PIOC_IFER           (0x400E1220) /**< (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR           (0x400E1224) /**< (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR           (0x400E1228) /**< (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR           (0x400E1230) /**< (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR           (0x400E1234) /**< (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR           (0x400E1238) /**< (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR           (0x400E123C) /**< (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER            (0x400E1240) /**< (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR            (0x400E1244) /**< (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR            (0x400E1248) /**< (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR            (0x400E124C) /**< (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER           (0x400E1250) /**< (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR           (0x400E1254) /**< (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR           (0x400E1258) /**< (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR           (0x400E1260) /**< (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER           (0x400E1264) /**< (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR           (0x400E1268) /**< (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR         (0x400E1270) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR0        (0x400E1270) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR1        (0x400E1274) /**< (PIOC) Peripheral ABCD Select Register 1 */
+#define REG_PIOC_IFSCDR         (0x400E1280) /**< (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER         (0x400E1284) /**< (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR         (0x400E1288) /**< (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR           (0x400E128C) /**< (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR          (0x400E1290) /**< (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER          (0x400E1294) /**< (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR          (0x400E1298) /**< (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER           (0x400E12A0) /**< (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR           (0x400E12A4) /**< (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR           (0x400E12A8) /**< (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER          (0x400E12B0) /**< (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR          (0x400E12B4) /**< (PIOC) Additional Interrupt Modes Disable Register */
+#define REG_PIOC_AIMMR          (0x400E12B8) /**< (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR            (0x400E12C0) /**< (PIOC) Edge Select Register */
+#define REG_PIOC_LSR            (0x400E12C4) /**< (PIOC) Level Select Register */
+#define REG_PIOC_ELSR           (0x400E12C8) /**< (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR         (0x400E12D0) /**< (PIOC) Falling Edge/Low-Level Select Register */
+#define REG_PIOC_REHLSR         (0x400E12D4) /**< (PIOC) Rising Edge/High-Level Select Register */
+#define REG_PIOC_FRLHSR         (0x400E12D8) /**< (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR         (0x400E12E0) /**< (PIOC) Lock Status */
+#define REG_PIOC_WPMR           (0x400E12E4) /**< (PIOC) Write Protection Mode Register */
+#define REG_PIOC_WPSR           (0x400E12E8) /**< (PIOC) Write Protection Status Register */
+#define REG_PIOC_SCHMITT        (0x400E1300) /**< (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DRIVER         (0x400E1318) /**< (PIOC) I/O Drive Register */
+#define REG_PIOC_PCMR           (0x400E1350) /**< (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER          (0x400E1354) /**< (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR          (0x400E1358) /**< (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR          (0x400E135C) /**< (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR          (0x400E1360) /**< (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR          (0x400E1364) /**< (PIOC) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOC_PER            (*(__O  uint32_t*)0x400E1200U) /**< (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR            (*(__O  uint32_t*)0x400E1204U) /**< (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR            (*(__I  uint32_t*)0x400E1208U) /**< (PIOC) PIO Status Register */
+#define REG_PIOC_OER            (*(__O  uint32_t*)0x400E1210U) /**< (PIOC) Output Enable Register */
+#define REG_PIOC_ODR            (*(__O  uint32_t*)0x400E1214U) /**< (PIOC) Output Disable Register */
+#define REG_PIOC_OSR            (*(__I  uint32_t*)0x400E1218U) /**< (PIOC) Output Status Register */
+#define REG_PIOC_IFER           (*(__O  uint32_t*)0x400E1220U) /**< (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR           (*(__O  uint32_t*)0x400E1224U) /**< (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR           (*(__I  uint32_t*)0x400E1228U) /**< (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR           (*(__O  uint32_t*)0x400E1230U) /**< (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR           (*(__O  uint32_t*)0x400E1234U) /**< (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR           (*(__IO uint32_t*)0x400E1238U) /**< (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR           (*(__I  uint32_t*)0x400E123CU) /**< (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER            (*(__O  uint32_t*)0x400E1240U) /**< (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR            (*(__O  uint32_t*)0x400E1244U) /**< (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR            (*(__I  uint32_t*)0x400E1248U) /**< (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR            (*(__I  uint32_t*)0x400E124CU) /**< (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER           (*(__O  uint32_t*)0x400E1250U) /**< (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR           (*(__O  uint32_t*)0x400E1254U) /**< (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR           (*(__I  uint32_t*)0x400E1258U) /**< (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR           (*(__O  uint32_t*)0x400E1260U) /**< (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER           (*(__O  uint32_t*)0x400E1264U) /**< (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR           (*(__I  uint32_t*)0x400E1268U) /**< (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR         (*(__IO uint32_t*)0x400E1270U) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR0        (*(__IO uint32_t*)0x400E1270U) /**< (PIOC) Peripheral ABCD Select Register 0 */
+#define REG_PIOC_ABCDSR1        (*(__IO uint32_t*)0x400E1274U) /**< (PIOC) Peripheral ABCD Select Register 1 */
+#define REG_PIOC_IFSCDR         (*(__O  uint32_t*)0x400E1280U) /**< (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER         (*(__O  uint32_t*)0x400E1284U) /**< (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR         (*(__I  uint32_t*)0x400E1288U) /**< (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR           (*(__IO uint32_t*)0x400E128CU) /**< (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR          (*(__O  uint32_t*)0x400E1290U) /**< (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER          (*(__O  uint32_t*)0x400E1294U) /**< (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR          (*(__I  uint32_t*)0x400E1298U) /**< (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER           (*(__O  uint32_t*)0x400E12A0U) /**< (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR           (*(__O  uint32_t*)0x400E12A4U) /**< (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR           (*(__I  uint32_t*)0x400E12A8U) /**< (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER          (*(__O  uint32_t*)0x400E12B0U) /**< (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR          (*(__O  uint32_t*)0x400E12B4U) /**< (PIOC) Additional Interrupt Modes Disable Register */
+#define REG_PIOC_AIMMR          (*(__I  uint32_t*)0x400E12B8U) /**< (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR            (*(__O  uint32_t*)0x400E12C0U) /**< (PIOC) Edge Select Register */
+#define REG_PIOC_LSR            (*(__O  uint32_t*)0x400E12C4U) /**< (PIOC) Level Select Register */
+#define REG_PIOC_ELSR           (*(__I  uint32_t*)0x400E12C8U) /**< (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR         (*(__O  uint32_t*)0x400E12D0U) /**< (PIOC) Falling Edge/Low-Level Select Register */
+#define REG_PIOC_REHLSR         (*(__O  uint32_t*)0x400E12D4U) /**< (PIOC) Rising Edge/High-Level Select Register */
+#define REG_PIOC_FRLHSR         (*(__I  uint32_t*)0x400E12D8U) /**< (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR         (*(__I  uint32_t*)0x400E12E0U) /**< (PIOC) Lock Status */
+#define REG_PIOC_WPMR           (*(__IO uint32_t*)0x400E12E4U) /**< (PIOC) Write Protection Mode Register */
+#define REG_PIOC_WPSR           (*(__I  uint32_t*)0x400E12E8U) /**< (PIOC) Write Protection Status Register */
+#define REG_PIOC_SCHMITT        (*(__IO uint32_t*)0x400E1300U) /**< (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DRIVER         (*(__IO uint32_t*)0x400E1318U) /**< (PIOC) I/O Drive Register */
+#define REG_PIOC_PCMR           (*(__IO uint32_t*)0x400E1350U) /**< (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER          (*(__O  uint32_t*)0x400E1354U) /**< (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR          (*(__O  uint32_t*)0x400E1358U) /**< (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR          (*(__I  uint32_t*)0x400E135CU) /**< (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR          (*(__I  uint32_t*)0x400E1360U) /**< (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR          (*(__I  uint32_t*)0x400E1364U) /**< (PIOC) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOC peripheral ========== */
+#define PIOC_INSTANCE_ID                         12         
+#define PIOC_CLOCK_ID                            12         
+
+#endif /* _SAMV71_PIOC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/piod.h
+++ b/asf/sam/include/samv71b/instance/piod.h
@@ -1,0 +1,159 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOD
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIOD_INSTANCE_H_
+#define _SAMV71_PIOD_INSTANCE_H_
+
+/* ========== Register definition for PIOD peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOD_PER            (0x400E1400) /**< (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR            (0x400E1404) /**< (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR            (0x400E1408) /**< (PIOD) PIO Status Register */
+#define REG_PIOD_OER            (0x400E1410) /**< (PIOD) Output Enable Register */
+#define REG_PIOD_ODR            (0x400E1414) /**< (PIOD) Output Disable Register */
+#define REG_PIOD_OSR            (0x400E1418) /**< (PIOD) Output Status Register */
+#define REG_PIOD_IFER           (0x400E1420) /**< (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR           (0x400E1424) /**< (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR           (0x400E1428) /**< (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR           (0x400E1430) /**< (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR           (0x400E1434) /**< (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR           (0x400E1438) /**< (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR           (0x400E143C) /**< (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER            (0x400E1440) /**< (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR            (0x400E1444) /**< (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR            (0x400E1448) /**< (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR            (0x400E144C) /**< (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER           (0x400E1450) /**< (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR           (0x400E1454) /**< (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR           (0x400E1458) /**< (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR           (0x400E1460) /**< (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER           (0x400E1464) /**< (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR           (0x400E1468) /**< (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR         (0x400E1470) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR0        (0x400E1470) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR1        (0x400E1474) /**< (PIOD) Peripheral ABCD Select Register 1 */
+#define REG_PIOD_IFSCDR         (0x400E1480) /**< (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER         (0x400E1484) /**< (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR         (0x400E1488) /**< (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR           (0x400E148C) /**< (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR          (0x400E1490) /**< (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER          (0x400E1494) /**< (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR          (0x400E1498) /**< (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER           (0x400E14A0) /**< (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR           (0x400E14A4) /**< (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR           (0x400E14A8) /**< (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER          (0x400E14B0) /**< (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR          (0x400E14B4) /**< (PIOD) Additional Interrupt Modes Disable Register */
+#define REG_PIOD_AIMMR          (0x400E14B8) /**< (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR            (0x400E14C0) /**< (PIOD) Edge Select Register */
+#define REG_PIOD_LSR            (0x400E14C4) /**< (PIOD) Level Select Register */
+#define REG_PIOD_ELSR           (0x400E14C8) /**< (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR         (0x400E14D0) /**< (PIOD) Falling Edge/Low-Level Select Register */
+#define REG_PIOD_REHLSR         (0x400E14D4) /**< (PIOD) Rising Edge/High-Level Select Register */
+#define REG_PIOD_FRLHSR         (0x400E14D8) /**< (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR         (0x400E14E0) /**< (PIOD) Lock Status */
+#define REG_PIOD_WPMR           (0x400E14E4) /**< (PIOD) Write Protection Mode Register */
+#define REG_PIOD_WPSR           (0x400E14E8) /**< (PIOD) Write Protection Status Register */
+#define REG_PIOD_SCHMITT        (0x400E1500) /**< (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DRIVER         (0x400E1518) /**< (PIOD) I/O Drive Register */
+#define REG_PIOD_PCMR           (0x400E1550) /**< (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER          (0x400E1554) /**< (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR          (0x400E1558) /**< (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR          (0x400E155C) /**< (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR          (0x400E1560) /**< (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR          (0x400E1564) /**< (PIOD) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOD_PER            (*(__O  uint32_t*)0x400E1400U) /**< (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR            (*(__O  uint32_t*)0x400E1404U) /**< (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR            (*(__I  uint32_t*)0x400E1408U) /**< (PIOD) PIO Status Register */
+#define REG_PIOD_OER            (*(__O  uint32_t*)0x400E1410U) /**< (PIOD) Output Enable Register */
+#define REG_PIOD_ODR            (*(__O  uint32_t*)0x400E1414U) /**< (PIOD) Output Disable Register */
+#define REG_PIOD_OSR            (*(__I  uint32_t*)0x400E1418U) /**< (PIOD) Output Status Register */
+#define REG_PIOD_IFER           (*(__O  uint32_t*)0x400E1420U) /**< (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR           (*(__O  uint32_t*)0x400E1424U) /**< (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR           (*(__I  uint32_t*)0x400E1428U) /**< (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR           (*(__O  uint32_t*)0x400E1430U) /**< (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR           (*(__O  uint32_t*)0x400E1434U) /**< (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR           (*(__IO uint32_t*)0x400E1438U) /**< (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR           (*(__I  uint32_t*)0x400E143CU) /**< (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER            (*(__O  uint32_t*)0x400E1440U) /**< (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR            (*(__O  uint32_t*)0x400E1444U) /**< (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR            (*(__I  uint32_t*)0x400E1448U) /**< (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR            (*(__I  uint32_t*)0x400E144CU) /**< (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER           (*(__O  uint32_t*)0x400E1450U) /**< (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR           (*(__O  uint32_t*)0x400E1454U) /**< (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR           (*(__I  uint32_t*)0x400E1458U) /**< (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR           (*(__O  uint32_t*)0x400E1460U) /**< (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER           (*(__O  uint32_t*)0x400E1464U) /**< (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR           (*(__I  uint32_t*)0x400E1468U) /**< (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR         (*(__IO uint32_t*)0x400E1470U) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR0        (*(__IO uint32_t*)0x400E1470U) /**< (PIOD) Peripheral ABCD Select Register 0 */
+#define REG_PIOD_ABCDSR1        (*(__IO uint32_t*)0x400E1474U) /**< (PIOD) Peripheral ABCD Select Register 1 */
+#define REG_PIOD_IFSCDR         (*(__O  uint32_t*)0x400E1480U) /**< (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER         (*(__O  uint32_t*)0x400E1484U) /**< (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR         (*(__I  uint32_t*)0x400E1488U) /**< (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR           (*(__IO uint32_t*)0x400E148CU) /**< (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR          (*(__O  uint32_t*)0x400E1490U) /**< (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER          (*(__O  uint32_t*)0x400E1494U) /**< (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR          (*(__I  uint32_t*)0x400E1498U) /**< (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER           (*(__O  uint32_t*)0x400E14A0U) /**< (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR           (*(__O  uint32_t*)0x400E14A4U) /**< (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR           (*(__I  uint32_t*)0x400E14A8U) /**< (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER          (*(__O  uint32_t*)0x400E14B0U) /**< (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR          (*(__O  uint32_t*)0x400E14B4U) /**< (PIOD) Additional Interrupt Modes Disable Register */
+#define REG_PIOD_AIMMR          (*(__I  uint32_t*)0x400E14B8U) /**< (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR            (*(__O  uint32_t*)0x400E14C0U) /**< (PIOD) Edge Select Register */
+#define REG_PIOD_LSR            (*(__O  uint32_t*)0x400E14C4U) /**< (PIOD) Level Select Register */
+#define REG_PIOD_ELSR           (*(__I  uint32_t*)0x400E14C8U) /**< (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR         (*(__O  uint32_t*)0x400E14D0U) /**< (PIOD) Falling Edge/Low-Level Select Register */
+#define REG_PIOD_REHLSR         (*(__O  uint32_t*)0x400E14D4U) /**< (PIOD) Rising Edge/High-Level Select Register */
+#define REG_PIOD_FRLHSR         (*(__I  uint32_t*)0x400E14D8U) /**< (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR         (*(__I  uint32_t*)0x400E14E0U) /**< (PIOD) Lock Status */
+#define REG_PIOD_WPMR           (*(__IO uint32_t*)0x400E14E4U) /**< (PIOD) Write Protection Mode Register */
+#define REG_PIOD_WPSR           (*(__I  uint32_t*)0x400E14E8U) /**< (PIOD) Write Protection Status Register */
+#define REG_PIOD_SCHMITT        (*(__IO uint32_t*)0x400E1500U) /**< (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DRIVER         (*(__IO uint32_t*)0x400E1518U) /**< (PIOD) I/O Drive Register */
+#define REG_PIOD_PCMR           (*(__IO uint32_t*)0x400E1550U) /**< (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER          (*(__O  uint32_t*)0x400E1554U) /**< (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR          (*(__O  uint32_t*)0x400E1558U) /**< (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR          (*(__I  uint32_t*)0x400E155CU) /**< (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR          (*(__I  uint32_t*)0x400E1560U) /**< (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR          (*(__I  uint32_t*)0x400E1564U) /**< (PIOD) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOD peripheral ========== */
+#define PIOD_INSTANCE_ID                         16         
+#define PIOD_CLOCK_ID                            16         
+
+#endif /* _SAMV71_PIOD_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pioe.h
+++ b/asf/sam/include/samv71b/instance/pioe.h
@@ -1,0 +1,159 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PIOE
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PIOE_INSTANCE_H_
+#define _SAMV71_PIOE_INSTANCE_H_
+
+/* ========== Register definition for PIOE peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PIOE_PER            (0x400E1600) /**< (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR            (0x400E1604) /**< (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR            (0x400E1608) /**< (PIOE) PIO Status Register */
+#define REG_PIOE_OER            (0x400E1610) /**< (PIOE) Output Enable Register */
+#define REG_PIOE_ODR            (0x400E1614) /**< (PIOE) Output Disable Register */
+#define REG_PIOE_OSR            (0x400E1618) /**< (PIOE) Output Status Register */
+#define REG_PIOE_IFER           (0x400E1620) /**< (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR           (0x400E1624) /**< (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR           (0x400E1628) /**< (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR           (0x400E1630) /**< (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR           (0x400E1634) /**< (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR           (0x400E1638) /**< (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR           (0x400E163C) /**< (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER            (0x400E1640) /**< (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR            (0x400E1644) /**< (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR            (0x400E1648) /**< (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR            (0x400E164C) /**< (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER           (0x400E1650) /**< (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR           (0x400E1654) /**< (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR           (0x400E1658) /**< (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR           (0x400E1660) /**< (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER           (0x400E1664) /**< (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR           (0x400E1668) /**< (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR         (0x400E1670) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR0        (0x400E1670) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR1        (0x400E1674) /**< (PIOE) Peripheral ABCD Select Register 1 */
+#define REG_PIOE_IFSCDR         (0x400E1680) /**< (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER         (0x400E1684) /**< (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR         (0x400E1688) /**< (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR           (0x400E168C) /**< (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR          (0x400E1690) /**< (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER          (0x400E1694) /**< (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR          (0x400E1698) /**< (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER           (0x400E16A0) /**< (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR           (0x400E16A4) /**< (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR           (0x400E16A8) /**< (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER          (0x400E16B0) /**< (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR          (0x400E16B4) /**< (PIOE) Additional Interrupt Modes Disable Register */
+#define REG_PIOE_AIMMR          (0x400E16B8) /**< (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR            (0x400E16C0) /**< (PIOE) Edge Select Register */
+#define REG_PIOE_LSR            (0x400E16C4) /**< (PIOE) Level Select Register */
+#define REG_PIOE_ELSR           (0x400E16C8) /**< (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR         (0x400E16D0) /**< (PIOE) Falling Edge/Low-Level Select Register */
+#define REG_PIOE_REHLSR         (0x400E16D4) /**< (PIOE) Rising Edge/High-Level Select Register */
+#define REG_PIOE_FRLHSR         (0x400E16D8) /**< (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR         (0x400E16E0) /**< (PIOE) Lock Status */
+#define REG_PIOE_WPMR           (0x400E16E4) /**< (PIOE) Write Protection Mode Register */
+#define REG_PIOE_WPSR           (0x400E16E8) /**< (PIOE) Write Protection Status Register */
+#define REG_PIOE_SCHMITT        (0x400E1700) /**< (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DRIVER         (0x400E1718) /**< (PIOE) I/O Drive Register */
+#define REG_PIOE_PCMR           (0x400E1750) /**< (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER          (0x400E1754) /**< (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR          (0x400E1758) /**< (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR          (0x400E175C) /**< (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR          (0x400E1760) /**< (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR          (0x400E1764) /**< (PIOE) Parallel Capture Reception Holding Register */
+
+#else
+
+#define REG_PIOE_PER            (*(__O  uint32_t*)0x400E1600U) /**< (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR            (*(__O  uint32_t*)0x400E1604U) /**< (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR            (*(__I  uint32_t*)0x400E1608U) /**< (PIOE) PIO Status Register */
+#define REG_PIOE_OER            (*(__O  uint32_t*)0x400E1610U) /**< (PIOE) Output Enable Register */
+#define REG_PIOE_ODR            (*(__O  uint32_t*)0x400E1614U) /**< (PIOE) Output Disable Register */
+#define REG_PIOE_OSR            (*(__I  uint32_t*)0x400E1618U) /**< (PIOE) Output Status Register */
+#define REG_PIOE_IFER           (*(__O  uint32_t*)0x400E1620U) /**< (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR           (*(__O  uint32_t*)0x400E1624U) /**< (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR           (*(__I  uint32_t*)0x400E1628U) /**< (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR           (*(__O  uint32_t*)0x400E1630U) /**< (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR           (*(__O  uint32_t*)0x400E1634U) /**< (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR           (*(__IO uint32_t*)0x400E1638U) /**< (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR           (*(__I  uint32_t*)0x400E163CU) /**< (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER            (*(__O  uint32_t*)0x400E1640U) /**< (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR            (*(__O  uint32_t*)0x400E1644U) /**< (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR            (*(__I  uint32_t*)0x400E1648U) /**< (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR            (*(__I  uint32_t*)0x400E164CU) /**< (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER           (*(__O  uint32_t*)0x400E1650U) /**< (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR           (*(__O  uint32_t*)0x400E1654U) /**< (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR           (*(__I  uint32_t*)0x400E1658U) /**< (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR           (*(__O  uint32_t*)0x400E1660U) /**< (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER           (*(__O  uint32_t*)0x400E1664U) /**< (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR           (*(__I  uint32_t*)0x400E1668U) /**< (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR         (*(__IO uint32_t*)0x400E1670U) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR0        (*(__IO uint32_t*)0x400E1670U) /**< (PIOE) Peripheral ABCD Select Register 0 */
+#define REG_PIOE_ABCDSR1        (*(__IO uint32_t*)0x400E1674U) /**< (PIOE) Peripheral ABCD Select Register 1 */
+#define REG_PIOE_IFSCDR         (*(__O  uint32_t*)0x400E1680U) /**< (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER         (*(__O  uint32_t*)0x400E1684U) /**< (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR         (*(__I  uint32_t*)0x400E1688U) /**< (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR           (*(__IO uint32_t*)0x400E168CU) /**< (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR          (*(__O  uint32_t*)0x400E1690U) /**< (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER          (*(__O  uint32_t*)0x400E1694U) /**< (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR          (*(__I  uint32_t*)0x400E1698U) /**< (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER           (*(__O  uint32_t*)0x400E16A0U) /**< (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR           (*(__O  uint32_t*)0x400E16A4U) /**< (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR           (*(__I  uint32_t*)0x400E16A8U) /**< (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER          (*(__O  uint32_t*)0x400E16B0U) /**< (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR          (*(__O  uint32_t*)0x400E16B4U) /**< (PIOE) Additional Interrupt Modes Disable Register */
+#define REG_PIOE_AIMMR          (*(__I  uint32_t*)0x400E16B8U) /**< (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR            (*(__O  uint32_t*)0x400E16C0U) /**< (PIOE) Edge Select Register */
+#define REG_PIOE_LSR            (*(__O  uint32_t*)0x400E16C4U) /**< (PIOE) Level Select Register */
+#define REG_PIOE_ELSR           (*(__I  uint32_t*)0x400E16C8U) /**< (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR         (*(__O  uint32_t*)0x400E16D0U) /**< (PIOE) Falling Edge/Low-Level Select Register */
+#define REG_PIOE_REHLSR         (*(__O  uint32_t*)0x400E16D4U) /**< (PIOE) Rising Edge/High-Level Select Register */
+#define REG_PIOE_FRLHSR         (*(__I  uint32_t*)0x400E16D8U) /**< (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR         (*(__I  uint32_t*)0x400E16E0U) /**< (PIOE) Lock Status */
+#define REG_PIOE_WPMR           (*(__IO uint32_t*)0x400E16E4U) /**< (PIOE) Write Protection Mode Register */
+#define REG_PIOE_WPSR           (*(__I  uint32_t*)0x400E16E8U) /**< (PIOE) Write Protection Status Register */
+#define REG_PIOE_SCHMITT        (*(__IO uint32_t*)0x400E1700U) /**< (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DRIVER         (*(__IO uint32_t*)0x400E1718U) /**< (PIOE) I/O Drive Register */
+#define REG_PIOE_PCMR           (*(__IO uint32_t*)0x400E1750U) /**< (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER          (*(__O  uint32_t*)0x400E1754U) /**< (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR          (*(__O  uint32_t*)0x400E1758U) /**< (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR          (*(__I  uint32_t*)0x400E175CU) /**< (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR          (*(__I  uint32_t*)0x400E1760U) /**< (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR          (*(__I  uint32_t*)0x400E1764U) /**< (PIOE) Parallel Capture Reception Holding Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PIOE peripheral ========== */
+#define PIOE_INSTANCE_ID                         17         
+#define PIOE_CLOCK_ID                            17         
+
+#endif /* _SAMV71_PIOE_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pmc.h
+++ b/asf/sam/include/samv71b/instance/pmc.h
@@ -1,0 +1,136 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PMC_INSTANCE_H_
+#define _SAMV71_PMC_INSTANCE_H_
+
+/* ========== Register definition for PMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PMC_SCER            (0x400E0600) /**< (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR            (0x400E0604) /**< (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR            (0x400E0608) /**< (PMC) System Clock Status Register */
+#define REG_PMC_PCER0           (0x400E0610) /**< (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0           (0x400E0614) /**< (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0           (0x400E0618) /**< (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_UCKR           (0x400E061C) /**< (PMC) UTMI Clock Register */
+#define REG_CKGR_MOR            (0x400E0620) /**< (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR           (0x400E0624) /**< (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR          (0x400E0628) /**< (PMC) PLLA Register */
+#define REG_PMC_MCKR            (0x400E0630) /**< (PMC) Master Clock Register */
+#define REG_PMC_USB             (0x400E0638) /**< (PMC) USB Clock Register */
+#define REG_PMC_PCK             (0x400E0640) /**< (PMC) Programmable Clock Register */
+#define REG_PMC_PCK0            (0x400E0640) /**< (PMC) Programmable Clock Register 0 */
+#define REG_PMC_PCK1            (0x400E0644) /**< (PMC) Programmable Clock Register 1 */
+#define REG_PMC_PCK2            (0x400E0648) /**< (PMC) Programmable Clock Register 2 */
+#define REG_PMC_PCK3            (0x400E064C) /**< (PMC) Programmable Clock Register 3 */
+#define REG_PMC_PCK4            (0x400E0650) /**< (PMC) Programmable Clock Register 4 */
+#define REG_PMC_PCK5            (0x400E0654) /**< (PMC) Programmable Clock Register 5 */
+#define REG_PMC_PCK6            (0x400E0658) /**< (PMC) Programmable Clock Register 6 */
+#define REG_PMC_PCK7            (0x400E065C) /**< (PMC) Programmable Clock Register 7 */
+#define REG_PMC_IER             (0x400E0660) /**< (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR             (0x400E0664) /**< (PMC) Interrupt Disable Register */
+#define REG_PMC_SR              (0x400E0668) /**< (PMC) Status Register */
+#define REG_PMC_IMR             (0x400E066C) /**< (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR            (0x400E0670) /**< (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR            (0x400E0674) /**< (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR            (0x400E0678) /**< (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR            (0x400E06E4) /**< (PMC) Write Protection Mode Register */
+#define REG_PMC_WPSR            (0x400E06E8) /**< (PMC) Write Protection Status Register */
+#define REG_PMC_PCER1           (0x400E0700) /**< (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1           (0x400E0704) /**< (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1           (0x400E0708) /**< (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_PCR             (0x400E070C) /**< (PMC) Peripheral Control Register */
+#define REG_PMC_OCR             (0x400E0710) /**< (PMC) Oscillator Calibration Register */
+#define REG_PMC_SLPWK_ER0       (0x400E0714) /**< (PMC) SleepWalking Enable Register 0 */
+#define REG_PMC_SLPWK_DR0       (0x400E0718) /**< (PMC) SleepWalking Disable Register 0 */
+#define REG_PMC_SLPWK_SR0       (0x400E071C) /**< (PMC) SleepWalking Status Register 0 */
+#define REG_PMC_SLPWK_ASR0      (0x400E0720) /**< (PMC) SleepWalking Activity Status Register 0 */
+#define REG_PMC_PMMR            (0x400E0730) /**< (PMC) PLL Maximum Multiplier Value Register */
+#define REG_PMC_SLPWK_ER1       (0x400E0734) /**< (PMC) SleepWalking Enable Register 1 */
+#define REG_PMC_SLPWK_DR1       (0x400E0738) /**< (PMC) SleepWalking Disable Register 1 */
+#define REG_PMC_SLPWK_SR1       (0x400E073C) /**< (PMC) SleepWalking Status Register 1 */
+#define REG_PMC_SLPWK_ASR1      (0x400E0740) /**< (PMC) SleepWalking Activity Status Register 1 */
+#define REG_PMC_SLPWK_AIPR      (0x400E0744) /**< (PMC) SleepWalking Activity In Progress Register */
+
+#else
+
+#define REG_PMC_SCER            (*(__O  uint32_t*)0x400E0600U) /**< (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR            (*(__O  uint32_t*)0x400E0604U) /**< (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR            (*(__I  uint32_t*)0x400E0608U) /**< (PMC) System Clock Status Register */
+#define REG_PMC_PCER0           (*(__O  uint32_t*)0x400E0610U) /**< (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0           (*(__O  uint32_t*)0x400E0614U) /**< (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0           (*(__I  uint32_t*)0x400E0618U) /**< (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_UCKR           (*(__IO uint32_t*)0x400E061CU) /**< (PMC) UTMI Clock Register */
+#define REG_CKGR_MOR            (*(__IO uint32_t*)0x400E0620U) /**< (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR           (*(__IO uint32_t*)0x400E0624U) /**< (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR          (*(__IO uint32_t*)0x400E0628U) /**< (PMC) PLLA Register */
+#define REG_PMC_MCKR            (*(__IO uint32_t*)0x400E0630U) /**< (PMC) Master Clock Register */
+#define REG_PMC_USB             (*(__IO uint32_t*)0x400E0638U) /**< (PMC) USB Clock Register */
+#define REG_PMC_PCK             (*(__IO uint32_t*)0x400E0640U) /**< (PMC) Programmable Clock Register */
+#define REG_PMC_PCK0            (*(__IO uint32_t*)0x400E0640U) /**< (PMC) Programmable Clock Register 0 */
+#define REG_PMC_PCK1            (*(__IO uint32_t*)0x400E0644U) /**< (PMC) Programmable Clock Register 1 */
+#define REG_PMC_PCK2            (*(__IO uint32_t*)0x400E0648U) /**< (PMC) Programmable Clock Register 2 */
+#define REG_PMC_PCK3            (*(__IO uint32_t*)0x400E064CU) /**< (PMC) Programmable Clock Register 3 */
+#define REG_PMC_PCK4            (*(__IO uint32_t*)0x400E0650U) /**< (PMC) Programmable Clock Register 4 */
+#define REG_PMC_PCK5            (*(__IO uint32_t*)0x400E0654U) /**< (PMC) Programmable Clock Register 5 */
+#define REG_PMC_PCK6            (*(__IO uint32_t*)0x400E0658U) /**< (PMC) Programmable Clock Register 6 */
+#define REG_PMC_PCK7            (*(__IO uint32_t*)0x400E065CU) /**< (PMC) Programmable Clock Register 7 */
+#define REG_PMC_IER             (*(__O  uint32_t*)0x400E0660U) /**< (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR             (*(__O  uint32_t*)0x400E0664U) /**< (PMC) Interrupt Disable Register */
+#define REG_PMC_SR              (*(__I  uint32_t*)0x400E0668U) /**< (PMC) Status Register */
+#define REG_PMC_IMR             (*(__I  uint32_t*)0x400E066CU) /**< (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR            (*(__IO uint32_t*)0x400E0670U) /**< (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR            (*(__IO uint32_t*)0x400E0674U) /**< (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR            (*(__O  uint32_t*)0x400E0678U) /**< (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR            (*(__IO uint32_t*)0x400E06E4U) /**< (PMC) Write Protection Mode Register */
+#define REG_PMC_WPSR            (*(__I  uint32_t*)0x400E06E8U) /**< (PMC) Write Protection Status Register */
+#define REG_PMC_PCER1           (*(__O  uint32_t*)0x400E0700U) /**< (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1           (*(__O  uint32_t*)0x400E0704U) /**< (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1           (*(__I  uint32_t*)0x400E0708U) /**< (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_PCR             (*(__IO uint32_t*)0x400E070CU) /**< (PMC) Peripheral Control Register */
+#define REG_PMC_OCR             (*(__IO uint32_t*)0x400E0710U) /**< (PMC) Oscillator Calibration Register */
+#define REG_PMC_SLPWK_ER0       (*(__O  uint32_t*)0x400E0714U) /**< (PMC) SleepWalking Enable Register 0 */
+#define REG_PMC_SLPWK_DR0       (*(__O  uint32_t*)0x400E0718U) /**< (PMC) SleepWalking Disable Register 0 */
+#define REG_PMC_SLPWK_SR0       (*(__I  uint32_t*)0x400E071CU) /**< (PMC) SleepWalking Status Register 0 */
+#define REG_PMC_SLPWK_ASR0      (*(__I  uint32_t*)0x400E0720U) /**< (PMC) SleepWalking Activity Status Register 0 */
+#define REG_PMC_PMMR            (*(__IO uint32_t*)0x400E0730U) /**< (PMC) PLL Maximum Multiplier Value Register */
+#define REG_PMC_SLPWK_ER1       (*(__O  uint32_t*)0x400E0734U) /**< (PMC) SleepWalking Enable Register 1 */
+#define REG_PMC_SLPWK_DR1       (*(__O  uint32_t*)0x400E0738U) /**< (PMC) SleepWalking Disable Register 1 */
+#define REG_PMC_SLPWK_SR1       (*(__I  uint32_t*)0x400E073CU) /**< (PMC) SleepWalking Status Register 1 */
+#define REG_PMC_SLPWK_ASR1      (*(__I  uint32_t*)0x400E0740U) /**< (PMC) SleepWalking Activity Status Register 1 */
+#define REG_PMC_SLPWK_AIPR      (*(__I  uint32_t*)0x400E0744U) /**< (PMC) SleepWalking Activity In Progress Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PMC peripheral ========== */
+#define PMC_INSTANCE_ID                          5          
+
+#endif /* _SAMV71_PMC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pwm0.h
+++ b/asf/sam/include/samv71b/instance/pwm0.h
@@ -1,0 +1,274 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PWM0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PWM0_INSTANCE_H_
+#define _SAMV71_PWM0_INSTANCE_H_
+
+/* ========== Register definition for PWM0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PWM0_CMPV0          (0x40020130) /**< (PWM0) PWM Comparison 0 Value Register 0 */
+#define REG_PWM0_CMPVUPD0       (0x40020134) /**< (PWM0) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM0_CMPM0          (0x40020138) /**< (PWM0) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM0_CMPMUPD0       (0x4002013C) /**< (PWM0) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM0_CMPV1          (0x40020140) /**< (PWM0) PWM Comparison 0 Value Register 1 */
+#define REG_PWM0_CMPVUPD1       (0x40020144) /**< (PWM0) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM0_CMPM1          (0x40020148) /**< (PWM0) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM0_CMPMUPD1       (0x4002014C) /**< (PWM0) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM0_CMPV2          (0x40020150) /**< (PWM0) PWM Comparison 0 Value Register 2 */
+#define REG_PWM0_CMPVUPD2       (0x40020154) /**< (PWM0) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM0_CMPM2          (0x40020158) /**< (PWM0) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM0_CMPMUPD2       (0x4002015C) /**< (PWM0) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM0_CMPV3          (0x40020160) /**< (PWM0) PWM Comparison 0 Value Register 3 */
+#define REG_PWM0_CMPVUPD3       (0x40020164) /**< (PWM0) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM0_CMPM3          (0x40020168) /**< (PWM0) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM0_CMPMUPD3       (0x4002016C) /**< (PWM0) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM0_CMPV4          (0x40020170) /**< (PWM0) PWM Comparison 0 Value Register 4 */
+#define REG_PWM0_CMPVUPD4       (0x40020174) /**< (PWM0) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM0_CMPM4          (0x40020178) /**< (PWM0) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM0_CMPMUPD4       (0x4002017C) /**< (PWM0) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM0_CMPV5          (0x40020180) /**< (PWM0) PWM Comparison 0 Value Register 5 */
+#define REG_PWM0_CMPVUPD5       (0x40020184) /**< (PWM0) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM0_CMPM5          (0x40020188) /**< (PWM0) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM0_CMPMUPD5       (0x4002018C) /**< (PWM0) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM0_CMPV6          (0x40020190) /**< (PWM0) PWM Comparison 0 Value Register 6 */
+#define REG_PWM0_CMPVUPD6       (0x40020194) /**< (PWM0) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM0_CMPM6          (0x40020198) /**< (PWM0) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM0_CMPMUPD6       (0x4002019C) /**< (PWM0) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM0_CMPV7          (0x400201A0) /**< (PWM0) PWM Comparison 0 Value Register 7 */
+#define REG_PWM0_CMPVUPD7       (0x400201A4) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM0_CMPM7          (0x400201A8) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM0_CMPMUPD7       (0x400201AC) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM0_CMR0           (0x40020200) /**< (PWM0) PWM Channel Mode Register 0 */
+#define REG_PWM0_CDTY0          (0x40020204) /**< (PWM0) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM0_CDTYUPD0       (0x40020208) /**< (PWM0) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM0_CPRD0          (0x4002020C) /**< (PWM0) PWM Channel Period Register 0 */
+#define REG_PWM0_CPRDUPD0       (0x40020210) /**< (PWM0) PWM Channel Period Update Register 0 */
+#define REG_PWM0_CCNT0          (0x40020214) /**< (PWM0) PWM Channel Counter Register 0 */
+#define REG_PWM0_DT0            (0x40020218) /**< (PWM0) PWM Channel Dead Time Register 0 */
+#define REG_PWM0_DTUPD0         (0x4002021C) /**< (PWM0) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM0_CMR1           (0x40020220) /**< (PWM0) PWM Channel Mode Register 1 */
+#define REG_PWM0_CDTY1          (0x40020224) /**< (PWM0) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM0_CDTYUPD1       (0x40020228) /**< (PWM0) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM0_CPRD1          (0x4002022C) /**< (PWM0) PWM Channel Period Register 1 */
+#define REG_PWM0_CPRDUPD1       (0x40020230) /**< (PWM0) PWM Channel Period Update Register 1 */
+#define REG_PWM0_CCNT1          (0x40020234) /**< (PWM0) PWM Channel Counter Register 1 */
+#define REG_PWM0_DT1            (0x40020238) /**< (PWM0) PWM Channel Dead Time Register 1 */
+#define REG_PWM0_DTUPD1         (0x4002023C) /**< (PWM0) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM0_CMR2           (0x40020240) /**< (PWM0) PWM Channel Mode Register 2 */
+#define REG_PWM0_CDTY2          (0x40020244) /**< (PWM0) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM0_CDTYUPD2       (0x40020248) /**< (PWM0) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM0_CPRD2          (0x4002024C) /**< (PWM0) PWM Channel Period Register 2 */
+#define REG_PWM0_CPRDUPD2       (0x40020250) /**< (PWM0) PWM Channel Period Update Register 2 */
+#define REG_PWM0_CCNT2          (0x40020254) /**< (PWM0) PWM Channel Counter Register 2 */
+#define REG_PWM0_DT2            (0x40020258) /**< (PWM0) PWM Channel Dead Time Register 2 */
+#define REG_PWM0_DTUPD2         (0x4002025C) /**< (PWM0) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM0_CMR3           (0x40020260) /**< (PWM0) PWM Channel Mode Register 3 */
+#define REG_PWM0_CDTY3          (0x40020264) /**< (PWM0) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM0_CDTYUPD3       (0x40020268) /**< (PWM0) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM0_CPRD3          (0x4002026C) /**< (PWM0) PWM Channel Period Register 3 */
+#define REG_PWM0_CPRDUPD3       (0x40020270) /**< (PWM0) PWM Channel Period Update Register 3 */
+#define REG_PWM0_CCNT3          (0x40020274) /**< (PWM0) PWM Channel Counter Register 3 */
+#define REG_PWM0_DT3            (0x40020278) /**< (PWM0) PWM Channel Dead Time Register 3 */
+#define REG_PWM0_DTUPD3         (0x4002027C) /**< (PWM0) PWM Channel Dead Time Update Register 3 */
+#define REG_PWM0_CLK            (0x40020000) /**< (PWM0) PWM Clock Register */
+#define REG_PWM0_ENA            (0x40020004) /**< (PWM0) PWM Enable Register */
+#define REG_PWM0_DIS            (0x40020008) /**< (PWM0) PWM Disable Register */
+#define REG_PWM0_SR             (0x4002000C) /**< (PWM0) PWM Status Register */
+#define REG_PWM0_IER1           (0x40020010) /**< (PWM0) PWM Interrupt Enable Register 1 */
+#define REG_PWM0_IDR1           (0x40020014) /**< (PWM0) PWM Interrupt Disable Register 1 */
+#define REG_PWM0_IMR1           (0x40020018) /**< (PWM0) PWM Interrupt Mask Register 1 */
+#define REG_PWM0_ISR1           (0x4002001C) /**< (PWM0) PWM Interrupt Status Register 1 */
+#define REG_PWM0_SCM            (0x40020020) /**< (PWM0) PWM Sync Channels Mode Register */
+#define REG_PWM0_DMAR           (0x40020024) /**< (PWM0) PWM DMA Register */
+#define REG_PWM0_SCUC           (0x40020028) /**< (PWM0) PWM Sync Channels Update Control Register */
+#define REG_PWM0_SCUP           (0x4002002C) /**< (PWM0) PWM Sync Channels Update Period Register */
+#define REG_PWM0_SCUPUPD        (0x40020030) /**< (PWM0) PWM Sync Channels Update Period Update Register */
+#define REG_PWM0_IER2           (0x40020034) /**< (PWM0) PWM Interrupt Enable Register 2 */
+#define REG_PWM0_IDR2           (0x40020038) /**< (PWM0) PWM Interrupt Disable Register 2 */
+#define REG_PWM0_IMR2           (0x4002003C) /**< (PWM0) PWM Interrupt Mask Register 2 */
+#define REG_PWM0_ISR2           (0x40020040) /**< (PWM0) PWM Interrupt Status Register 2 */
+#define REG_PWM0_OOV            (0x40020044) /**< (PWM0) PWM Output Override Value Register */
+#define REG_PWM0_OS             (0x40020048) /**< (PWM0) PWM Output Selection Register */
+#define REG_PWM0_OSS            (0x4002004C) /**< (PWM0) PWM Output Selection Set Register */
+#define REG_PWM0_OSC            (0x40020050) /**< (PWM0) PWM Output Selection Clear Register */
+#define REG_PWM0_OSSUPD         (0x40020054) /**< (PWM0) PWM Output Selection Set Update Register */
+#define REG_PWM0_OSCUPD         (0x40020058) /**< (PWM0) PWM Output Selection Clear Update Register */
+#define REG_PWM0_FMR            (0x4002005C) /**< (PWM0) PWM Fault Mode Register */
+#define REG_PWM0_FSR            (0x40020060) /**< (PWM0) PWM Fault Status Register */
+#define REG_PWM0_FCR            (0x40020064) /**< (PWM0) PWM Fault Clear Register */
+#define REG_PWM0_FPV1           (0x40020068) /**< (PWM0) PWM Fault Protection Value Register 1 */
+#define REG_PWM0_FPE            (0x4002006C) /**< (PWM0) PWM Fault Protection Enable Register */
+#define REG_PWM0_ELMR           (0x4002007C) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR0          (0x4002007C) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR1          (0x40020080) /**< (PWM0) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM0_SSPR           (0x400200A0) /**< (PWM0) PWM Spread Spectrum Register */
+#define REG_PWM0_SSPUP          (0x400200A4) /**< (PWM0) PWM Spread Spectrum Update Register */
+#define REG_PWM0_SMMR           (0x400200B0) /**< (PWM0) PWM Stepper Motor Mode Register */
+#define REG_PWM0_FPV2           (0x400200C0) /**< (PWM0) PWM Fault Protection Value 2 Register */
+#define REG_PWM0_WPCR           (0x400200E4) /**< (PWM0) PWM Write Protection Control Register */
+#define REG_PWM0_WPSR           (0x400200E8) /**< (PWM0) PWM Write Protection Status Register */
+#define REG_PWM0_CMUPD0         (0x40020400) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM0_CMUPD1         (0x40020420) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM0_ETRG1          (0x4002042C) /**< (PWM0) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM0_LEBR1          (0x40020430) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM0_CMUPD2         (0x40020440) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM0_ETRG2          (0x4002044C) /**< (PWM0) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM0_LEBR2          (0x40020450) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM0_CMUPD3         (0x40020460) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 3) */
+
+#else
+
+#define REG_PWM0_CMPV0          (*(__IO uint32_t*)0x40020130U) /**< (PWM0) PWM Comparison 0 Value Register 0 */
+#define REG_PWM0_CMPVUPD0       (*(__O  uint32_t*)0x40020134U) /**< (PWM0) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM0_CMPM0          (*(__IO uint32_t*)0x40020138U) /**< (PWM0) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM0_CMPMUPD0       (*(__O  uint32_t*)0x4002013CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM0_CMPV1          (*(__IO uint32_t*)0x40020140U) /**< (PWM0) PWM Comparison 0 Value Register 1 */
+#define REG_PWM0_CMPVUPD1       (*(__O  uint32_t*)0x40020144U) /**< (PWM0) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM0_CMPM1          (*(__IO uint32_t*)0x40020148U) /**< (PWM0) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM0_CMPMUPD1       (*(__O  uint32_t*)0x4002014CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM0_CMPV2          (*(__IO uint32_t*)0x40020150U) /**< (PWM0) PWM Comparison 0 Value Register 2 */
+#define REG_PWM0_CMPVUPD2       (*(__O  uint32_t*)0x40020154U) /**< (PWM0) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM0_CMPM2          (*(__IO uint32_t*)0x40020158U) /**< (PWM0) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM0_CMPMUPD2       (*(__O  uint32_t*)0x4002015CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM0_CMPV3          (*(__IO uint32_t*)0x40020160U) /**< (PWM0) PWM Comparison 0 Value Register 3 */
+#define REG_PWM0_CMPVUPD3       (*(__O  uint32_t*)0x40020164U) /**< (PWM0) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM0_CMPM3          (*(__IO uint32_t*)0x40020168U) /**< (PWM0) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM0_CMPMUPD3       (*(__O  uint32_t*)0x4002016CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM0_CMPV4          (*(__IO uint32_t*)0x40020170U) /**< (PWM0) PWM Comparison 0 Value Register 4 */
+#define REG_PWM0_CMPVUPD4       (*(__O  uint32_t*)0x40020174U) /**< (PWM0) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM0_CMPM4          (*(__IO uint32_t*)0x40020178U) /**< (PWM0) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM0_CMPMUPD4       (*(__O  uint32_t*)0x4002017CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM0_CMPV5          (*(__IO uint32_t*)0x40020180U) /**< (PWM0) PWM Comparison 0 Value Register 5 */
+#define REG_PWM0_CMPVUPD5       (*(__O  uint32_t*)0x40020184U) /**< (PWM0) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM0_CMPM5          (*(__IO uint32_t*)0x40020188U) /**< (PWM0) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM0_CMPMUPD5       (*(__O  uint32_t*)0x4002018CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM0_CMPV6          (*(__IO uint32_t*)0x40020190U) /**< (PWM0) PWM Comparison 0 Value Register 6 */
+#define REG_PWM0_CMPVUPD6       (*(__O  uint32_t*)0x40020194U) /**< (PWM0) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM0_CMPM6          (*(__IO uint32_t*)0x40020198U) /**< (PWM0) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM0_CMPMUPD6       (*(__O  uint32_t*)0x4002019CU) /**< (PWM0) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM0_CMPV7          (*(__IO uint32_t*)0x400201A0U) /**< (PWM0) PWM Comparison 0 Value Register 7 */
+#define REG_PWM0_CMPVUPD7       (*(__O  uint32_t*)0x400201A4U) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM0_CMPM7          (*(__IO uint32_t*)0x400201A8U) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM0_CMPMUPD7       (*(__O  uint32_t*)0x400201ACU) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM0_CMR0           (*(__IO uint32_t*)0x40020200U) /**< (PWM0) PWM Channel Mode Register 0 */
+#define REG_PWM0_CDTY0          (*(__IO uint32_t*)0x40020204U) /**< (PWM0) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM0_CDTYUPD0       (*(__O  uint32_t*)0x40020208U) /**< (PWM0) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM0_CPRD0          (*(__IO uint32_t*)0x4002020CU) /**< (PWM0) PWM Channel Period Register 0 */
+#define REG_PWM0_CPRDUPD0       (*(__O  uint32_t*)0x40020210U) /**< (PWM0) PWM Channel Period Update Register 0 */
+#define REG_PWM0_CCNT0          (*(__I  uint32_t*)0x40020214U) /**< (PWM0) PWM Channel Counter Register 0 */
+#define REG_PWM0_DT0            (*(__IO uint32_t*)0x40020218U) /**< (PWM0) PWM Channel Dead Time Register 0 */
+#define REG_PWM0_DTUPD0         (*(__O  uint32_t*)0x4002021CU) /**< (PWM0) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM0_CMR1           (*(__IO uint32_t*)0x40020220U) /**< (PWM0) PWM Channel Mode Register 1 */
+#define REG_PWM0_CDTY1          (*(__IO uint32_t*)0x40020224U) /**< (PWM0) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM0_CDTYUPD1       (*(__O  uint32_t*)0x40020228U) /**< (PWM0) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM0_CPRD1          (*(__IO uint32_t*)0x4002022CU) /**< (PWM0) PWM Channel Period Register 1 */
+#define REG_PWM0_CPRDUPD1       (*(__O  uint32_t*)0x40020230U) /**< (PWM0) PWM Channel Period Update Register 1 */
+#define REG_PWM0_CCNT1          (*(__I  uint32_t*)0x40020234U) /**< (PWM0) PWM Channel Counter Register 1 */
+#define REG_PWM0_DT1            (*(__IO uint32_t*)0x40020238U) /**< (PWM0) PWM Channel Dead Time Register 1 */
+#define REG_PWM0_DTUPD1         (*(__O  uint32_t*)0x4002023CU) /**< (PWM0) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM0_CMR2           (*(__IO uint32_t*)0x40020240U) /**< (PWM0) PWM Channel Mode Register 2 */
+#define REG_PWM0_CDTY2          (*(__IO uint32_t*)0x40020244U) /**< (PWM0) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM0_CDTYUPD2       (*(__O  uint32_t*)0x40020248U) /**< (PWM0) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM0_CPRD2          (*(__IO uint32_t*)0x4002024CU) /**< (PWM0) PWM Channel Period Register 2 */
+#define REG_PWM0_CPRDUPD2       (*(__O  uint32_t*)0x40020250U) /**< (PWM0) PWM Channel Period Update Register 2 */
+#define REG_PWM0_CCNT2          (*(__I  uint32_t*)0x40020254U) /**< (PWM0) PWM Channel Counter Register 2 */
+#define REG_PWM0_DT2            (*(__IO uint32_t*)0x40020258U) /**< (PWM0) PWM Channel Dead Time Register 2 */
+#define REG_PWM0_DTUPD2         (*(__O  uint32_t*)0x4002025CU) /**< (PWM0) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM0_CMR3           (*(__IO uint32_t*)0x40020260U) /**< (PWM0) PWM Channel Mode Register 3 */
+#define REG_PWM0_CDTY3          (*(__IO uint32_t*)0x40020264U) /**< (PWM0) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM0_CDTYUPD3       (*(__O  uint32_t*)0x40020268U) /**< (PWM0) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM0_CPRD3          (*(__IO uint32_t*)0x4002026CU) /**< (PWM0) PWM Channel Period Register 3 */
+#define REG_PWM0_CPRDUPD3       (*(__O  uint32_t*)0x40020270U) /**< (PWM0) PWM Channel Period Update Register 3 */
+#define REG_PWM0_CCNT3          (*(__I  uint32_t*)0x40020274U) /**< (PWM0) PWM Channel Counter Register 3 */
+#define REG_PWM0_DT3            (*(__IO uint32_t*)0x40020278U) /**< (PWM0) PWM Channel Dead Time Register 3 */
+#define REG_PWM0_DTUPD3         (*(__O  uint32_t*)0x4002027CU) /**< (PWM0) PWM Channel Dead Time Update Register 3 */
+#define REG_PWM0_CLK            (*(__IO uint32_t*)0x40020000U) /**< (PWM0) PWM Clock Register */
+#define REG_PWM0_ENA            (*(__O  uint32_t*)0x40020004U) /**< (PWM0) PWM Enable Register */
+#define REG_PWM0_DIS            (*(__O  uint32_t*)0x40020008U) /**< (PWM0) PWM Disable Register */
+#define REG_PWM0_SR             (*(__I  uint32_t*)0x4002000CU) /**< (PWM0) PWM Status Register */
+#define REG_PWM0_IER1           (*(__O  uint32_t*)0x40020010U) /**< (PWM0) PWM Interrupt Enable Register 1 */
+#define REG_PWM0_IDR1           (*(__O  uint32_t*)0x40020014U) /**< (PWM0) PWM Interrupt Disable Register 1 */
+#define REG_PWM0_IMR1           (*(__I  uint32_t*)0x40020018U) /**< (PWM0) PWM Interrupt Mask Register 1 */
+#define REG_PWM0_ISR1           (*(__I  uint32_t*)0x4002001CU) /**< (PWM0) PWM Interrupt Status Register 1 */
+#define REG_PWM0_SCM            (*(__IO uint32_t*)0x40020020U) /**< (PWM0) PWM Sync Channels Mode Register */
+#define REG_PWM0_DMAR           (*(__O  uint32_t*)0x40020024U) /**< (PWM0) PWM DMA Register */
+#define REG_PWM0_SCUC           (*(__IO uint32_t*)0x40020028U) /**< (PWM0) PWM Sync Channels Update Control Register */
+#define REG_PWM0_SCUP           (*(__IO uint32_t*)0x4002002CU) /**< (PWM0) PWM Sync Channels Update Period Register */
+#define REG_PWM0_SCUPUPD        (*(__O  uint32_t*)0x40020030U) /**< (PWM0) PWM Sync Channels Update Period Update Register */
+#define REG_PWM0_IER2           (*(__O  uint32_t*)0x40020034U) /**< (PWM0) PWM Interrupt Enable Register 2 */
+#define REG_PWM0_IDR2           (*(__O  uint32_t*)0x40020038U) /**< (PWM0) PWM Interrupt Disable Register 2 */
+#define REG_PWM0_IMR2           (*(__I  uint32_t*)0x4002003CU) /**< (PWM0) PWM Interrupt Mask Register 2 */
+#define REG_PWM0_ISR2           (*(__I  uint32_t*)0x40020040U) /**< (PWM0) PWM Interrupt Status Register 2 */
+#define REG_PWM0_OOV            (*(__IO uint32_t*)0x40020044U) /**< (PWM0) PWM Output Override Value Register */
+#define REG_PWM0_OS             (*(__IO uint32_t*)0x40020048U) /**< (PWM0) PWM Output Selection Register */
+#define REG_PWM0_OSS            (*(__O  uint32_t*)0x4002004CU) /**< (PWM0) PWM Output Selection Set Register */
+#define REG_PWM0_OSC            (*(__O  uint32_t*)0x40020050U) /**< (PWM0) PWM Output Selection Clear Register */
+#define REG_PWM0_OSSUPD         (*(__O  uint32_t*)0x40020054U) /**< (PWM0) PWM Output Selection Set Update Register */
+#define REG_PWM0_OSCUPD         (*(__O  uint32_t*)0x40020058U) /**< (PWM0) PWM Output Selection Clear Update Register */
+#define REG_PWM0_FMR            (*(__IO uint32_t*)0x4002005CU) /**< (PWM0) PWM Fault Mode Register */
+#define REG_PWM0_FSR            (*(__I  uint32_t*)0x40020060U) /**< (PWM0) PWM Fault Status Register */
+#define REG_PWM0_FCR            (*(__O  uint32_t*)0x40020064U) /**< (PWM0) PWM Fault Clear Register */
+#define REG_PWM0_FPV1           (*(__IO uint32_t*)0x40020068U) /**< (PWM0) PWM Fault Protection Value Register 1 */
+#define REG_PWM0_FPE            (*(__IO uint32_t*)0x4002006CU) /**< (PWM0) PWM Fault Protection Enable Register */
+#define REG_PWM0_ELMR           (*(__IO uint32_t*)0x4002007CU) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR0          (*(__IO uint32_t*)0x4002007CU) /**< (PWM0) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM0_ELMR1          (*(__IO uint32_t*)0x40020080U) /**< (PWM0) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM0_SSPR           (*(__IO uint32_t*)0x400200A0U) /**< (PWM0) PWM Spread Spectrum Register */
+#define REG_PWM0_SSPUP          (*(__O  uint32_t*)0x400200A4U) /**< (PWM0) PWM Spread Spectrum Update Register */
+#define REG_PWM0_SMMR           (*(__IO uint32_t*)0x400200B0U) /**< (PWM0) PWM Stepper Motor Mode Register */
+#define REG_PWM0_FPV2           (*(__IO uint32_t*)0x400200C0U) /**< (PWM0) PWM Fault Protection Value 2 Register */
+#define REG_PWM0_WPCR           (*(__O  uint32_t*)0x400200E4U) /**< (PWM0) PWM Write Protection Control Register */
+#define REG_PWM0_WPSR           (*(__I  uint32_t*)0x400200E8U) /**< (PWM0) PWM Write Protection Status Register */
+#define REG_PWM0_CMUPD0         (*(__O  uint32_t*)0x40020400U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM0_CMUPD1         (*(__O  uint32_t*)0x40020420U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM0_ETRG1          (*(__IO uint32_t*)0x4002042CU) /**< (PWM0) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM0_LEBR1          (*(__IO uint32_t*)0x40020430U) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM0_CMUPD2         (*(__O  uint32_t*)0x40020440U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM0_ETRG2          (*(__IO uint32_t*)0x4002044CU) /**< (PWM0) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM0_LEBR2          (*(__IO uint32_t*)0x40020450U) /**< (PWM0) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM0_CMUPD3         (*(__O  uint32_t*)0x40020460U) /**< (PWM0) PWM Channel Mode Update Register (ch_num = 3) */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PWM0 peripheral ========== */
+#define PWM0_DMAC_ID_TX                          13         
+#define PWM0_INSTANCE_ID                         31         
+#define PWM0_CLOCK_ID                            31         
+#define PWM0_FAULT_PWM_ID0                       0x0        /* Fault 0 - PWM0_PWMFI0 Input pin */
+#define PWM0_FAULT_PWM_ID1                       0x1        /* Fault 1 - PWM0_PWMFI1 Input pin */
+#define PWM0_FAULT_PWM_ID2                       0x2        /* Fault 2 - PWM0_PWMFI2 Input pin */
+#define PWM0_FAULT_PWM_ID3                       0x3        /* Fault 3 - MAIN_OSC_PMC */
+#define PWM0_FAULT_PWM_ID4                       0x4        /* Fault 4 - AFEC0 */
+#define PWM0_FAULT_PWM_ID5                       0x5        /* Fault 5 - AFEC1 */
+#define PWM0_FAULT_PWM_ID6                       0x6        /* Fault 6 - ACC */
+#define PWM0_FAULT_PWM_ID7                       0x7        /* Fault 7 - TC0 */
+
+#endif /* _SAMV71_PWM0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/pwm1.h
+++ b/asf/sam/include/samv71b/instance/pwm1.h
@@ -1,0 +1,274 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PWM1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_PWM1_INSTANCE_H_
+#define _SAMV71_PWM1_INSTANCE_H_
+
+/* ========== Register definition for PWM1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_PWM1_CMPV0          (0x4005C130) /**< (PWM1) PWM Comparison 0 Value Register 0 */
+#define REG_PWM1_CMPVUPD0       (0x4005C134) /**< (PWM1) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM1_CMPM0          (0x4005C138) /**< (PWM1) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM1_CMPMUPD0       (0x4005C13C) /**< (PWM1) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM1_CMPV1          (0x4005C140) /**< (PWM1) PWM Comparison 0 Value Register 1 */
+#define REG_PWM1_CMPVUPD1       (0x4005C144) /**< (PWM1) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM1_CMPM1          (0x4005C148) /**< (PWM1) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM1_CMPMUPD1       (0x4005C14C) /**< (PWM1) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM1_CMPV2          (0x4005C150) /**< (PWM1) PWM Comparison 0 Value Register 2 */
+#define REG_PWM1_CMPVUPD2       (0x4005C154) /**< (PWM1) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM1_CMPM2          (0x4005C158) /**< (PWM1) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM1_CMPMUPD2       (0x4005C15C) /**< (PWM1) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM1_CMPV3          (0x4005C160) /**< (PWM1) PWM Comparison 0 Value Register 3 */
+#define REG_PWM1_CMPVUPD3       (0x4005C164) /**< (PWM1) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM1_CMPM3          (0x4005C168) /**< (PWM1) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM1_CMPMUPD3       (0x4005C16C) /**< (PWM1) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM1_CMPV4          (0x4005C170) /**< (PWM1) PWM Comparison 0 Value Register 4 */
+#define REG_PWM1_CMPVUPD4       (0x4005C174) /**< (PWM1) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM1_CMPM4          (0x4005C178) /**< (PWM1) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM1_CMPMUPD4       (0x4005C17C) /**< (PWM1) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM1_CMPV5          (0x4005C180) /**< (PWM1) PWM Comparison 0 Value Register 5 */
+#define REG_PWM1_CMPVUPD5       (0x4005C184) /**< (PWM1) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM1_CMPM5          (0x4005C188) /**< (PWM1) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM1_CMPMUPD5       (0x4005C18C) /**< (PWM1) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM1_CMPV6          (0x4005C190) /**< (PWM1) PWM Comparison 0 Value Register 6 */
+#define REG_PWM1_CMPVUPD6       (0x4005C194) /**< (PWM1) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM1_CMPM6          (0x4005C198) /**< (PWM1) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM1_CMPMUPD6       (0x4005C19C) /**< (PWM1) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM1_CMPV7          (0x4005C1A0) /**< (PWM1) PWM Comparison 0 Value Register 7 */
+#define REG_PWM1_CMPVUPD7       (0x4005C1A4) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM1_CMPM7          (0x4005C1A8) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM1_CMPMUPD7       (0x4005C1AC) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM1_CMR0           (0x4005C200) /**< (PWM1) PWM Channel Mode Register 0 */
+#define REG_PWM1_CDTY0          (0x4005C204) /**< (PWM1) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM1_CDTYUPD0       (0x4005C208) /**< (PWM1) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM1_CPRD0          (0x4005C20C) /**< (PWM1) PWM Channel Period Register 0 */
+#define REG_PWM1_CPRDUPD0       (0x4005C210) /**< (PWM1) PWM Channel Period Update Register 0 */
+#define REG_PWM1_CCNT0          (0x4005C214) /**< (PWM1) PWM Channel Counter Register 0 */
+#define REG_PWM1_DT0            (0x4005C218) /**< (PWM1) PWM Channel Dead Time Register 0 */
+#define REG_PWM1_DTUPD0         (0x4005C21C) /**< (PWM1) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM1_CMR1           (0x4005C220) /**< (PWM1) PWM Channel Mode Register 1 */
+#define REG_PWM1_CDTY1          (0x4005C224) /**< (PWM1) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM1_CDTYUPD1       (0x4005C228) /**< (PWM1) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM1_CPRD1          (0x4005C22C) /**< (PWM1) PWM Channel Period Register 1 */
+#define REG_PWM1_CPRDUPD1       (0x4005C230) /**< (PWM1) PWM Channel Period Update Register 1 */
+#define REG_PWM1_CCNT1          (0x4005C234) /**< (PWM1) PWM Channel Counter Register 1 */
+#define REG_PWM1_DT1            (0x4005C238) /**< (PWM1) PWM Channel Dead Time Register 1 */
+#define REG_PWM1_DTUPD1         (0x4005C23C) /**< (PWM1) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM1_CMR2           (0x4005C240) /**< (PWM1) PWM Channel Mode Register 2 */
+#define REG_PWM1_CDTY2          (0x4005C244) /**< (PWM1) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM1_CDTYUPD2       (0x4005C248) /**< (PWM1) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM1_CPRD2          (0x4005C24C) /**< (PWM1) PWM Channel Period Register 2 */
+#define REG_PWM1_CPRDUPD2       (0x4005C250) /**< (PWM1) PWM Channel Period Update Register 2 */
+#define REG_PWM1_CCNT2          (0x4005C254) /**< (PWM1) PWM Channel Counter Register 2 */
+#define REG_PWM1_DT2            (0x4005C258) /**< (PWM1) PWM Channel Dead Time Register 2 */
+#define REG_PWM1_DTUPD2         (0x4005C25C) /**< (PWM1) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM1_CMR3           (0x4005C260) /**< (PWM1) PWM Channel Mode Register 3 */
+#define REG_PWM1_CDTY3          (0x4005C264) /**< (PWM1) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM1_CDTYUPD3       (0x4005C268) /**< (PWM1) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM1_CPRD3          (0x4005C26C) /**< (PWM1) PWM Channel Period Register 3 */
+#define REG_PWM1_CPRDUPD3       (0x4005C270) /**< (PWM1) PWM Channel Period Update Register 3 */
+#define REG_PWM1_CCNT3          (0x4005C274) /**< (PWM1) PWM Channel Counter Register 3 */
+#define REG_PWM1_DT3            (0x4005C278) /**< (PWM1) PWM Channel Dead Time Register 3 */
+#define REG_PWM1_DTUPD3         (0x4005C27C) /**< (PWM1) PWM Channel Dead Time Update Register 3 */
+#define REG_PWM1_CLK            (0x4005C000) /**< (PWM1) PWM Clock Register */
+#define REG_PWM1_ENA            (0x4005C004) /**< (PWM1) PWM Enable Register */
+#define REG_PWM1_DIS            (0x4005C008) /**< (PWM1) PWM Disable Register */
+#define REG_PWM1_SR             (0x4005C00C) /**< (PWM1) PWM Status Register */
+#define REG_PWM1_IER1           (0x4005C010) /**< (PWM1) PWM Interrupt Enable Register 1 */
+#define REG_PWM1_IDR1           (0x4005C014) /**< (PWM1) PWM Interrupt Disable Register 1 */
+#define REG_PWM1_IMR1           (0x4005C018) /**< (PWM1) PWM Interrupt Mask Register 1 */
+#define REG_PWM1_ISR1           (0x4005C01C) /**< (PWM1) PWM Interrupt Status Register 1 */
+#define REG_PWM1_SCM            (0x4005C020) /**< (PWM1) PWM Sync Channels Mode Register */
+#define REG_PWM1_DMAR           (0x4005C024) /**< (PWM1) PWM DMA Register */
+#define REG_PWM1_SCUC           (0x4005C028) /**< (PWM1) PWM Sync Channels Update Control Register */
+#define REG_PWM1_SCUP           (0x4005C02C) /**< (PWM1) PWM Sync Channels Update Period Register */
+#define REG_PWM1_SCUPUPD        (0x4005C030) /**< (PWM1) PWM Sync Channels Update Period Update Register */
+#define REG_PWM1_IER2           (0x4005C034) /**< (PWM1) PWM Interrupt Enable Register 2 */
+#define REG_PWM1_IDR2           (0x4005C038) /**< (PWM1) PWM Interrupt Disable Register 2 */
+#define REG_PWM1_IMR2           (0x4005C03C) /**< (PWM1) PWM Interrupt Mask Register 2 */
+#define REG_PWM1_ISR2           (0x4005C040) /**< (PWM1) PWM Interrupt Status Register 2 */
+#define REG_PWM1_OOV            (0x4005C044) /**< (PWM1) PWM Output Override Value Register */
+#define REG_PWM1_OS             (0x4005C048) /**< (PWM1) PWM Output Selection Register */
+#define REG_PWM1_OSS            (0x4005C04C) /**< (PWM1) PWM Output Selection Set Register */
+#define REG_PWM1_OSC            (0x4005C050) /**< (PWM1) PWM Output Selection Clear Register */
+#define REG_PWM1_OSSUPD         (0x4005C054) /**< (PWM1) PWM Output Selection Set Update Register */
+#define REG_PWM1_OSCUPD         (0x4005C058) /**< (PWM1) PWM Output Selection Clear Update Register */
+#define REG_PWM1_FMR            (0x4005C05C) /**< (PWM1) PWM Fault Mode Register */
+#define REG_PWM1_FSR            (0x4005C060) /**< (PWM1) PWM Fault Status Register */
+#define REG_PWM1_FCR            (0x4005C064) /**< (PWM1) PWM Fault Clear Register */
+#define REG_PWM1_FPV1           (0x4005C068) /**< (PWM1) PWM Fault Protection Value Register 1 */
+#define REG_PWM1_FPE            (0x4005C06C) /**< (PWM1) PWM Fault Protection Enable Register */
+#define REG_PWM1_ELMR           (0x4005C07C) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR0          (0x4005C07C) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR1          (0x4005C080) /**< (PWM1) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM1_SSPR           (0x4005C0A0) /**< (PWM1) PWM Spread Spectrum Register */
+#define REG_PWM1_SSPUP          (0x4005C0A4) /**< (PWM1) PWM Spread Spectrum Update Register */
+#define REG_PWM1_SMMR           (0x4005C0B0) /**< (PWM1) PWM Stepper Motor Mode Register */
+#define REG_PWM1_FPV2           (0x4005C0C0) /**< (PWM1) PWM Fault Protection Value 2 Register */
+#define REG_PWM1_WPCR           (0x4005C0E4) /**< (PWM1) PWM Write Protection Control Register */
+#define REG_PWM1_WPSR           (0x4005C0E8) /**< (PWM1) PWM Write Protection Status Register */
+#define REG_PWM1_CMUPD0         (0x4005C400) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM1_CMUPD1         (0x4005C420) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM1_ETRG1          (0x4005C42C) /**< (PWM1) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM1_LEBR1          (0x4005C430) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM1_CMUPD2         (0x4005C440) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM1_ETRG2          (0x4005C44C) /**< (PWM1) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM1_LEBR2          (0x4005C450) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM1_CMUPD3         (0x4005C460) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 3) */
+
+#else
+
+#define REG_PWM1_CMPV0          (*(__IO uint32_t*)0x4005C130U) /**< (PWM1) PWM Comparison 0 Value Register 0 */
+#define REG_PWM1_CMPVUPD0       (*(__O  uint32_t*)0x4005C134U) /**< (PWM1) PWM Comparison 0 Value Update Register 0 */
+#define REG_PWM1_CMPM0          (*(__IO uint32_t*)0x4005C138U) /**< (PWM1) PWM Comparison 0 Mode Register 0 */
+#define REG_PWM1_CMPMUPD0       (*(__O  uint32_t*)0x4005C13CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 0 */
+#define REG_PWM1_CMPV1          (*(__IO uint32_t*)0x4005C140U) /**< (PWM1) PWM Comparison 0 Value Register 1 */
+#define REG_PWM1_CMPVUPD1       (*(__O  uint32_t*)0x4005C144U) /**< (PWM1) PWM Comparison 0 Value Update Register 1 */
+#define REG_PWM1_CMPM1          (*(__IO uint32_t*)0x4005C148U) /**< (PWM1) PWM Comparison 0 Mode Register 1 */
+#define REG_PWM1_CMPMUPD1       (*(__O  uint32_t*)0x4005C14CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 1 */
+#define REG_PWM1_CMPV2          (*(__IO uint32_t*)0x4005C150U) /**< (PWM1) PWM Comparison 0 Value Register 2 */
+#define REG_PWM1_CMPVUPD2       (*(__O  uint32_t*)0x4005C154U) /**< (PWM1) PWM Comparison 0 Value Update Register 2 */
+#define REG_PWM1_CMPM2          (*(__IO uint32_t*)0x4005C158U) /**< (PWM1) PWM Comparison 0 Mode Register 2 */
+#define REG_PWM1_CMPMUPD2       (*(__O  uint32_t*)0x4005C15CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 2 */
+#define REG_PWM1_CMPV3          (*(__IO uint32_t*)0x4005C160U) /**< (PWM1) PWM Comparison 0 Value Register 3 */
+#define REG_PWM1_CMPVUPD3       (*(__O  uint32_t*)0x4005C164U) /**< (PWM1) PWM Comparison 0 Value Update Register 3 */
+#define REG_PWM1_CMPM3          (*(__IO uint32_t*)0x4005C168U) /**< (PWM1) PWM Comparison 0 Mode Register 3 */
+#define REG_PWM1_CMPMUPD3       (*(__O  uint32_t*)0x4005C16CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 3 */
+#define REG_PWM1_CMPV4          (*(__IO uint32_t*)0x4005C170U) /**< (PWM1) PWM Comparison 0 Value Register 4 */
+#define REG_PWM1_CMPVUPD4       (*(__O  uint32_t*)0x4005C174U) /**< (PWM1) PWM Comparison 0 Value Update Register 4 */
+#define REG_PWM1_CMPM4          (*(__IO uint32_t*)0x4005C178U) /**< (PWM1) PWM Comparison 0 Mode Register 4 */
+#define REG_PWM1_CMPMUPD4       (*(__O  uint32_t*)0x4005C17CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 4 */
+#define REG_PWM1_CMPV5          (*(__IO uint32_t*)0x4005C180U) /**< (PWM1) PWM Comparison 0 Value Register 5 */
+#define REG_PWM1_CMPVUPD5       (*(__O  uint32_t*)0x4005C184U) /**< (PWM1) PWM Comparison 0 Value Update Register 5 */
+#define REG_PWM1_CMPM5          (*(__IO uint32_t*)0x4005C188U) /**< (PWM1) PWM Comparison 0 Mode Register 5 */
+#define REG_PWM1_CMPMUPD5       (*(__O  uint32_t*)0x4005C18CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 5 */
+#define REG_PWM1_CMPV6          (*(__IO uint32_t*)0x4005C190U) /**< (PWM1) PWM Comparison 0 Value Register 6 */
+#define REG_PWM1_CMPVUPD6       (*(__O  uint32_t*)0x4005C194U) /**< (PWM1) PWM Comparison 0 Value Update Register 6 */
+#define REG_PWM1_CMPM6          (*(__IO uint32_t*)0x4005C198U) /**< (PWM1) PWM Comparison 0 Mode Register 6 */
+#define REG_PWM1_CMPMUPD6       (*(__O  uint32_t*)0x4005C19CU) /**< (PWM1) PWM Comparison 0 Mode Update Register 6 */
+#define REG_PWM1_CMPV7          (*(__IO uint32_t*)0x4005C1A0U) /**< (PWM1) PWM Comparison 0 Value Register 7 */
+#define REG_PWM1_CMPVUPD7       (*(__O  uint32_t*)0x4005C1A4U) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
+#define REG_PWM1_CMPM7          (*(__IO uint32_t*)0x4005C1A8U) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
+#define REG_PWM1_CMPMUPD7       (*(__O  uint32_t*)0x4005C1ACU) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
+#define REG_PWM1_CMR0           (*(__IO uint32_t*)0x4005C200U) /**< (PWM1) PWM Channel Mode Register 0 */
+#define REG_PWM1_CDTY0          (*(__IO uint32_t*)0x4005C204U) /**< (PWM1) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM1_CDTYUPD0       (*(__O  uint32_t*)0x4005C208U) /**< (PWM1) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM1_CPRD0          (*(__IO uint32_t*)0x4005C20CU) /**< (PWM1) PWM Channel Period Register 0 */
+#define REG_PWM1_CPRDUPD0       (*(__O  uint32_t*)0x4005C210U) /**< (PWM1) PWM Channel Period Update Register 0 */
+#define REG_PWM1_CCNT0          (*(__I  uint32_t*)0x4005C214U) /**< (PWM1) PWM Channel Counter Register 0 */
+#define REG_PWM1_DT0            (*(__IO uint32_t*)0x4005C218U) /**< (PWM1) PWM Channel Dead Time Register 0 */
+#define REG_PWM1_DTUPD0         (*(__O  uint32_t*)0x4005C21CU) /**< (PWM1) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM1_CMR1           (*(__IO uint32_t*)0x4005C220U) /**< (PWM1) PWM Channel Mode Register 1 */
+#define REG_PWM1_CDTY1          (*(__IO uint32_t*)0x4005C224U) /**< (PWM1) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM1_CDTYUPD1       (*(__O  uint32_t*)0x4005C228U) /**< (PWM1) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM1_CPRD1          (*(__IO uint32_t*)0x4005C22CU) /**< (PWM1) PWM Channel Period Register 1 */
+#define REG_PWM1_CPRDUPD1       (*(__O  uint32_t*)0x4005C230U) /**< (PWM1) PWM Channel Period Update Register 1 */
+#define REG_PWM1_CCNT1          (*(__I  uint32_t*)0x4005C234U) /**< (PWM1) PWM Channel Counter Register 1 */
+#define REG_PWM1_DT1            (*(__IO uint32_t*)0x4005C238U) /**< (PWM1) PWM Channel Dead Time Register 1 */
+#define REG_PWM1_DTUPD1         (*(__O  uint32_t*)0x4005C23CU) /**< (PWM1) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM1_CMR2           (*(__IO uint32_t*)0x4005C240U) /**< (PWM1) PWM Channel Mode Register 2 */
+#define REG_PWM1_CDTY2          (*(__IO uint32_t*)0x4005C244U) /**< (PWM1) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM1_CDTYUPD2       (*(__O  uint32_t*)0x4005C248U) /**< (PWM1) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM1_CPRD2          (*(__IO uint32_t*)0x4005C24CU) /**< (PWM1) PWM Channel Period Register 2 */
+#define REG_PWM1_CPRDUPD2       (*(__O  uint32_t*)0x4005C250U) /**< (PWM1) PWM Channel Period Update Register 2 */
+#define REG_PWM1_CCNT2          (*(__I  uint32_t*)0x4005C254U) /**< (PWM1) PWM Channel Counter Register 2 */
+#define REG_PWM1_DT2            (*(__IO uint32_t*)0x4005C258U) /**< (PWM1) PWM Channel Dead Time Register 2 */
+#define REG_PWM1_DTUPD2         (*(__O  uint32_t*)0x4005C25CU) /**< (PWM1) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM1_CMR3           (*(__IO uint32_t*)0x4005C260U) /**< (PWM1) PWM Channel Mode Register 3 */
+#define REG_PWM1_CDTY3          (*(__IO uint32_t*)0x4005C264U) /**< (PWM1) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM1_CDTYUPD3       (*(__O  uint32_t*)0x4005C268U) /**< (PWM1) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM1_CPRD3          (*(__IO uint32_t*)0x4005C26CU) /**< (PWM1) PWM Channel Period Register 3 */
+#define REG_PWM1_CPRDUPD3       (*(__O  uint32_t*)0x4005C270U) /**< (PWM1) PWM Channel Period Update Register 3 */
+#define REG_PWM1_CCNT3          (*(__I  uint32_t*)0x4005C274U) /**< (PWM1) PWM Channel Counter Register 3 */
+#define REG_PWM1_DT3            (*(__IO uint32_t*)0x4005C278U) /**< (PWM1) PWM Channel Dead Time Register 3 */
+#define REG_PWM1_DTUPD3         (*(__O  uint32_t*)0x4005C27CU) /**< (PWM1) PWM Channel Dead Time Update Register 3 */
+#define REG_PWM1_CLK            (*(__IO uint32_t*)0x4005C000U) /**< (PWM1) PWM Clock Register */
+#define REG_PWM1_ENA            (*(__O  uint32_t*)0x4005C004U) /**< (PWM1) PWM Enable Register */
+#define REG_PWM1_DIS            (*(__O  uint32_t*)0x4005C008U) /**< (PWM1) PWM Disable Register */
+#define REG_PWM1_SR             (*(__I  uint32_t*)0x4005C00CU) /**< (PWM1) PWM Status Register */
+#define REG_PWM1_IER1           (*(__O  uint32_t*)0x4005C010U) /**< (PWM1) PWM Interrupt Enable Register 1 */
+#define REG_PWM1_IDR1           (*(__O  uint32_t*)0x4005C014U) /**< (PWM1) PWM Interrupt Disable Register 1 */
+#define REG_PWM1_IMR1           (*(__I  uint32_t*)0x4005C018U) /**< (PWM1) PWM Interrupt Mask Register 1 */
+#define REG_PWM1_ISR1           (*(__I  uint32_t*)0x4005C01CU) /**< (PWM1) PWM Interrupt Status Register 1 */
+#define REG_PWM1_SCM            (*(__IO uint32_t*)0x4005C020U) /**< (PWM1) PWM Sync Channels Mode Register */
+#define REG_PWM1_DMAR           (*(__O  uint32_t*)0x4005C024U) /**< (PWM1) PWM DMA Register */
+#define REG_PWM1_SCUC           (*(__IO uint32_t*)0x4005C028U) /**< (PWM1) PWM Sync Channels Update Control Register */
+#define REG_PWM1_SCUP           (*(__IO uint32_t*)0x4005C02CU) /**< (PWM1) PWM Sync Channels Update Period Register */
+#define REG_PWM1_SCUPUPD        (*(__O  uint32_t*)0x4005C030U) /**< (PWM1) PWM Sync Channels Update Period Update Register */
+#define REG_PWM1_IER2           (*(__O  uint32_t*)0x4005C034U) /**< (PWM1) PWM Interrupt Enable Register 2 */
+#define REG_PWM1_IDR2           (*(__O  uint32_t*)0x4005C038U) /**< (PWM1) PWM Interrupt Disable Register 2 */
+#define REG_PWM1_IMR2           (*(__I  uint32_t*)0x4005C03CU) /**< (PWM1) PWM Interrupt Mask Register 2 */
+#define REG_PWM1_ISR2           (*(__I  uint32_t*)0x4005C040U) /**< (PWM1) PWM Interrupt Status Register 2 */
+#define REG_PWM1_OOV            (*(__IO uint32_t*)0x4005C044U) /**< (PWM1) PWM Output Override Value Register */
+#define REG_PWM1_OS             (*(__IO uint32_t*)0x4005C048U) /**< (PWM1) PWM Output Selection Register */
+#define REG_PWM1_OSS            (*(__O  uint32_t*)0x4005C04CU) /**< (PWM1) PWM Output Selection Set Register */
+#define REG_PWM1_OSC            (*(__O  uint32_t*)0x4005C050U) /**< (PWM1) PWM Output Selection Clear Register */
+#define REG_PWM1_OSSUPD         (*(__O  uint32_t*)0x4005C054U) /**< (PWM1) PWM Output Selection Set Update Register */
+#define REG_PWM1_OSCUPD         (*(__O  uint32_t*)0x4005C058U) /**< (PWM1) PWM Output Selection Clear Update Register */
+#define REG_PWM1_FMR            (*(__IO uint32_t*)0x4005C05CU) /**< (PWM1) PWM Fault Mode Register */
+#define REG_PWM1_FSR            (*(__I  uint32_t*)0x4005C060U) /**< (PWM1) PWM Fault Status Register */
+#define REG_PWM1_FCR            (*(__O  uint32_t*)0x4005C064U) /**< (PWM1) PWM Fault Clear Register */
+#define REG_PWM1_FPV1           (*(__IO uint32_t*)0x4005C068U) /**< (PWM1) PWM Fault Protection Value Register 1 */
+#define REG_PWM1_FPE            (*(__IO uint32_t*)0x4005C06CU) /**< (PWM1) PWM Fault Protection Enable Register */
+#define REG_PWM1_ELMR           (*(__IO uint32_t*)0x4005C07CU) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR0          (*(__IO uint32_t*)0x4005C07CU) /**< (PWM1) PWM Event Line 0 Mode Register 0 */
+#define REG_PWM1_ELMR1          (*(__IO uint32_t*)0x4005C080U) /**< (PWM1) PWM Event Line 0 Mode Register 1 */
+#define REG_PWM1_SSPR           (*(__IO uint32_t*)0x4005C0A0U) /**< (PWM1) PWM Spread Spectrum Register */
+#define REG_PWM1_SSPUP          (*(__O  uint32_t*)0x4005C0A4U) /**< (PWM1) PWM Spread Spectrum Update Register */
+#define REG_PWM1_SMMR           (*(__IO uint32_t*)0x4005C0B0U) /**< (PWM1) PWM Stepper Motor Mode Register */
+#define REG_PWM1_FPV2           (*(__IO uint32_t*)0x4005C0C0U) /**< (PWM1) PWM Fault Protection Value 2 Register */
+#define REG_PWM1_WPCR           (*(__O  uint32_t*)0x4005C0E4U) /**< (PWM1) PWM Write Protection Control Register */
+#define REG_PWM1_WPSR           (*(__I  uint32_t*)0x4005C0E8U) /**< (PWM1) PWM Write Protection Status Register */
+#define REG_PWM1_CMUPD0         (*(__O  uint32_t*)0x4005C400U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM1_CMUPD1         (*(__O  uint32_t*)0x4005C420U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM1_ETRG1          (*(__IO uint32_t*)0x4005C42CU) /**< (PWM1) PWM External Trigger Register (trg_num = 1) */
+#define REG_PWM1_LEBR1          (*(__IO uint32_t*)0x4005C430U) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 1) */
+#define REG_PWM1_CMUPD2         (*(__O  uint32_t*)0x4005C440U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM1_ETRG2          (*(__IO uint32_t*)0x4005C44CU) /**< (PWM1) PWM External Trigger Register (trg_num = 2) */
+#define REG_PWM1_LEBR2          (*(__IO uint32_t*)0x4005C450U) /**< (PWM1) PWM Leading-Edge Blanking Register (trg_num = 2) */
+#define REG_PWM1_CMUPD3         (*(__O  uint32_t*)0x4005C460U) /**< (PWM1) PWM Channel Mode Update Register (ch_num = 3) */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for PWM1 peripheral ========== */
+#define PWM1_DMAC_ID_TX                          39         
+#define PWM1_INSTANCE_ID                         60         
+#define PWM1_CLOCK_ID                            60         
+#define PWM1_FAULT_PWM_ID0                       0x0        /* Fault 0 - PWM0_PWMFI0 Input pin */
+#define PWM1_FAULT_PWM_ID1                       0x1        /* Fault 1 - PWM0_PWMFI1 Input pin */
+#define PWM1_FAULT_PWM_ID2                       0x2        /* Fault 2 - PWM0_PWMFI2 Input pin */
+#define PWM1_FAULT_PWM_ID3                       0x3        /* Fault 3 - MAIN_OSC_PMC */
+#define PWM1_FAULT_PWM_ID4                       0x4        /* Fault 4 - AFEC0 */
+#define PWM1_FAULT_PWM_ID5                       0x5        /* Fault 5 - AFEC1 */
+#define PWM1_FAULT_PWM_ID6                       0x6        /* Fault 6 - ACC */
+#define PWM1_FAULT_PWM_ID7                       0x7        /* Fault 7 - TC1 */
+
+#endif /* _SAMV71_PWM1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/qspi.h
+++ b/asf/sam/include/samv71b/instance/qspi.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Instance description for QSPI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_QSPI_INSTANCE_H_
+#define _SAMV71_QSPI_INSTANCE_H_
+
+/* ========== Register definition for QSPI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_QSPI_CR             (0x4007C000) /**< (QSPI) Control Register */
+#define REG_QSPI_MR             (0x4007C004) /**< (QSPI) Mode Register */
+#define REG_QSPI_RDR            (0x4007C008) /**< (QSPI) Receive Data Register */
+#define REG_QSPI_TDR            (0x4007C00C) /**< (QSPI) Transmit Data Register */
+#define REG_QSPI_SR             (0x4007C010) /**< (QSPI) Status Register */
+#define REG_QSPI_IER            (0x4007C014) /**< (QSPI) Interrupt Enable Register */
+#define REG_QSPI_IDR            (0x4007C018) /**< (QSPI) Interrupt Disable Register */
+#define REG_QSPI_IMR            (0x4007C01C) /**< (QSPI) Interrupt Mask Register */
+#define REG_QSPI_SCR            (0x4007C020) /**< (QSPI) Serial Clock Register */
+#define REG_QSPI_IAR            (0x4007C030) /**< (QSPI) Instruction Address Register */
+#define REG_QSPI_ICR            (0x4007C034) /**< (QSPI) Instruction Code Register */
+#define REG_QSPI_IFR            (0x4007C038) /**< (QSPI) Instruction Frame Register */
+#define REG_QSPI_SMR            (0x4007C040) /**< (QSPI) Scrambling Mode Register */
+#define REG_QSPI_SKR            (0x4007C044) /**< (QSPI) Scrambling Key Register */
+#define REG_QSPI_WPMR           (0x4007C0E4) /**< (QSPI) Write Protection Mode Register */
+#define REG_QSPI_WPSR           (0x4007C0E8) /**< (QSPI) Write Protection Status Register */
+
+#else
+
+#define REG_QSPI_CR             (*(__O  uint32_t*)0x4007C000U) /**< (QSPI) Control Register */
+#define REG_QSPI_MR             (*(__IO uint32_t*)0x4007C004U) /**< (QSPI) Mode Register */
+#define REG_QSPI_RDR            (*(__I  uint32_t*)0x4007C008U) /**< (QSPI) Receive Data Register */
+#define REG_QSPI_TDR            (*(__O  uint32_t*)0x4007C00CU) /**< (QSPI) Transmit Data Register */
+#define REG_QSPI_SR             (*(__I  uint32_t*)0x4007C010U) /**< (QSPI) Status Register */
+#define REG_QSPI_IER            (*(__O  uint32_t*)0x4007C014U) /**< (QSPI) Interrupt Enable Register */
+#define REG_QSPI_IDR            (*(__O  uint32_t*)0x4007C018U) /**< (QSPI) Interrupt Disable Register */
+#define REG_QSPI_IMR            (*(__I  uint32_t*)0x4007C01CU) /**< (QSPI) Interrupt Mask Register */
+#define REG_QSPI_SCR            (*(__IO uint32_t*)0x4007C020U) /**< (QSPI) Serial Clock Register */
+#define REG_QSPI_IAR            (*(__IO uint32_t*)0x4007C030U) /**< (QSPI) Instruction Address Register */
+#define REG_QSPI_ICR            (*(__IO uint32_t*)0x4007C034U) /**< (QSPI) Instruction Code Register */
+#define REG_QSPI_IFR            (*(__IO uint32_t*)0x4007C038U) /**< (QSPI) Instruction Frame Register */
+#define REG_QSPI_SMR            (*(__IO uint32_t*)0x4007C040U) /**< (QSPI) Scrambling Mode Register */
+#define REG_QSPI_SKR            (*(__O  uint32_t*)0x4007C044U) /**< (QSPI) Scrambling Key Register */
+#define REG_QSPI_WPMR           (*(__IO uint32_t*)0x4007C0E4U) /**< (QSPI) Write Protection Mode Register */
+#define REG_QSPI_WPSR           (*(__I  uint32_t*)0x4007C0E8U) /**< (QSPI) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for QSPI peripheral ========== */
+#define QSPI_DMAC_ID_RX                          6          
+#define QSPI_DMAC_ID_TX                          5          
+#define QSPI_INSTANCE_ID                         43         
+#define QSPI_CLOCK_ID                            43         
+
+#endif /* _SAMV71_QSPI_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/rstc.h
+++ b/asf/sam/include/samv71b/instance/rstc.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RSTC_INSTANCE_H_
+#define _SAMV71_RSTC_INSTANCE_H_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSTC_CR             (0x400E1800) /**< (RSTC) Control Register */
+#define REG_RSTC_SR             (0x400E1804) /**< (RSTC) Status Register */
+#define REG_RSTC_MR             (0x400E1808) /**< (RSTC) Mode Register */
+
+#else
+
+#define REG_RSTC_CR             (*(__O  uint32_t*)0x400E1800U) /**< (RSTC) Control Register */
+#define REG_RSTC_SR             (*(__I  uint32_t*)0x400E1804U) /**< (RSTC) Status Register */
+#define REG_RSTC_MR             (*(__IO uint32_t*)0x400E1808U) /**< (RSTC) Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSTC peripheral ========== */
+#define RSTC_INSTANCE_ID                         1          
+
+#endif /* _SAMV71_RSTC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/rswdt.h
+++ b/asf/sam/include/samv71b/instance/rswdt.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSWDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RSWDT_INSTANCE_H_
+#define _SAMV71_RSWDT_INSTANCE_H_
+
+/* ========== Register definition for RSWDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RSWDT_CR            (0x400E1900) /**< (RSWDT) Control Register */
+#define REG_RSWDT_MR            (0x400E1904) /**< (RSWDT) Mode Register */
+#define REG_RSWDT_SR            (0x400E1908) /**< (RSWDT) Status Register */
+
+#else
+
+#define REG_RSWDT_CR            (*(__O  uint32_t*)0x400E1900U) /**< (RSWDT) Control Register */
+#define REG_RSWDT_MR            (*(__IO uint32_t*)0x400E1904U) /**< (RSWDT) Mode Register */
+#define REG_RSWDT_SR            (*(__I  uint32_t*)0x400E1908U) /**< (RSWDT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RSWDT peripheral ========== */
+#define RSWDT_INSTANCE_ID                        63         
+
+#endif /* _SAMV71_RSWDT_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/rtc.h
+++ b/asf/sam/include/samv71b/instance/rtc.h
@@ -1,0 +1,70 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RTC_INSTANCE_H_
+#define _SAMV71_RTC_INSTANCE_H_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTC_CR              (0x400E1860) /**< (RTC) Control Register */
+#define REG_RTC_MR              (0x400E1864) /**< (RTC) Mode Register */
+#define REG_RTC_TIMR            (0x400E1868) /**< (RTC) Time Register */
+#define REG_RTC_CALR            (0x400E186C) /**< (RTC) Calendar Register */
+#define REG_RTC_TIMALR          (0x400E1870) /**< (RTC) Time Alarm Register */
+#define REG_RTC_CALALR          (0x400E1874) /**< (RTC) Calendar Alarm Register */
+#define REG_RTC_SR              (0x400E1878) /**< (RTC) Status Register */
+#define REG_RTC_SCCR            (0x400E187C) /**< (RTC) Status Clear Command Register */
+#define REG_RTC_IER             (0x400E1880) /**< (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
+#define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
+
+#else
+
+#define REG_RTC_CR              (*(__IO uint32_t*)0x400E1860U) /**< (RTC) Control Register */
+#define REG_RTC_MR              (*(__IO uint32_t*)0x400E1864U) /**< (RTC) Mode Register */
+#define REG_RTC_TIMR            (*(__IO uint32_t*)0x400E1868U) /**< (RTC) Time Register */
+#define REG_RTC_CALR            (*(__IO uint32_t*)0x400E186CU) /**< (RTC) Calendar Register */
+#define REG_RTC_TIMALR          (*(__IO uint32_t*)0x400E1870U) /**< (RTC) Time Alarm Register */
+#define REG_RTC_CALALR          (*(__IO uint32_t*)0x400E1874U) /**< (RTC) Calendar Alarm Register */
+#define REG_RTC_SR              (*(__I  uint32_t*)0x400E1878U) /**< (RTC) Status Register */
+#define REG_RTC_SCCR            (*(__O  uint32_t*)0x400E187CU) /**< (RTC) Status Clear Command Register */
+#define REG_RTC_IER             (*(__O  uint32_t*)0x400E1880U) /**< (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
+#define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTC peripheral ========== */
+#define RTC_INSTANCE_ID                          2          
+
+#endif /* _SAMV71_RTC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/rtt.h
+++ b/asf/sam/include/samv71b/instance/rtt.h
@@ -1,0 +1,54 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_RTT_INSTANCE_H_
+#define _SAMV71_RTT_INSTANCE_H_
+
+/* ========== Register definition for RTT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_RTT_MR              (0x400E1830) /**< (RTT) Mode Register */
+#define REG_RTT_AR              (0x400E1834) /**< (RTT) Alarm Register */
+#define REG_RTT_VR              (0x400E1838) /**< (RTT) Value Register */
+#define REG_RTT_SR              (0x400E183C) /**< (RTT) Status Register */
+
+#else
+
+#define REG_RTT_MR              (*(__IO uint32_t*)0x400E1830U) /**< (RTT) Mode Register */
+#define REG_RTT_AR              (*(__IO uint32_t*)0x400E1834U) /**< (RTT) Alarm Register */
+#define REG_RTT_VR              (*(__I  uint32_t*)0x400E1838U) /**< (RTT) Value Register */
+#define REG_RTT_SR              (*(__I  uint32_t*)0x400E183CU) /**< (RTT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for RTT peripheral ========== */
+#define RTT_INSTANCE_ID                          3          
+
+#endif /* _SAMV71_RTT_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/sdramc.h
+++ b/asf/sam/include/samv71b/instance/sdramc.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SDRAMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SDRAMC_INSTANCE_H_
+#define _SAMV71_SDRAMC_INSTANCE_H_
+
+/* ========== Register definition for SDRAMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SDRAMC_MR           (0x40084000) /**< (SDRAMC) SDRAMC Mode Register */
+#define REG_SDRAMC_TR           (0x40084004) /**< (SDRAMC) SDRAMC Refresh Timer Register */
+#define REG_SDRAMC_CR           (0x40084008) /**< (SDRAMC) SDRAMC Configuration Register */
+#define REG_SDRAMC_LPR          (0x40084010) /**< (SDRAMC) SDRAMC Low Power Register */
+#define REG_SDRAMC_IER          (0x40084014) /**< (SDRAMC) SDRAMC Interrupt Enable Register */
+#define REG_SDRAMC_IDR          (0x40084018) /**< (SDRAMC) SDRAMC Interrupt Disable Register */
+#define REG_SDRAMC_IMR          (0x4008401C) /**< (SDRAMC) SDRAMC Interrupt Mask Register */
+#define REG_SDRAMC_ISR          (0x40084020) /**< (SDRAMC) SDRAMC Interrupt Status Register */
+#define REG_SDRAMC_MDR          (0x40084024) /**< (SDRAMC) SDRAMC Memory Device Register */
+#define REG_SDRAMC_CFR1         (0x40084028) /**< (SDRAMC) SDRAMC Configuration Register 1 */
+#define REG_SDRAMC_OCMS         (0x4008402C) /**< (SDRAMC) SDRAMC OCMS Register */
+#define REG_SDRAMC_OCMS_KEY1    (0x40084030) /**< (SDRAMC) SDRAMC OCMS KEY1 Register */
+#define REG_SDRAMC_OCMS_KEY2    (0x40084034) /**< (SDRAMC) SDRAMC OCMS KEY2 Register */
+
+#else
+
+#define REG_SDRAMC_MR           (*(__IO uint32_t*)0x40084000U) /**< (SDRAMC) SDRAMC Mode Register */
+#define REG_SDRAMC_TR           (*(__IO uint32_t*)0x40084004U) /**< (SDRAMC) SDRAMC Refresh Timer Register */
+#define REG_SDRAMC_CR           (*(__IO uint32_t*)0x40084008U) /**< (SDRAMC) SDRAMC Configuration Register */
+#define REG_SDRAMC_LPR          (*(__IO uint32_t*)0x40084010U) /**< (SDRAMC) SDRAMC Low Power Register */
+#define REG_SDRAMC_IER          (*(__O  uint32_t*)0x40084014U) /**< (SDRAMC) SDRAMC Interrupt Enable Register */
+#define REG_SDRAMC_IDR          (*(__O  uint32_t*)0x40084018U) /**< (SDRAMC) SDRAMC Interrupt Disable Register */
+#define REG_SDRAMC_IMR          (*(__I  uint32_t*)0x4008401CU) /**< (SDRAMC) SDRAMC Interrupt Mask Register */
+#define REG_SDRAMC_ISR          (*(__I  uint32_t*)0x40084020U) /**< (SDRAMC) SDRAMC Interrupt Status Register */
+#define REG_SDRAMC_MDR          (*(__IO uint32_t*)0x40084024U) /**< (SDRAMC) SDRAMC Memory Device Register */
+#define REG_SDRAMC_CFR1         (*(__IO uint32_t*)0x40084028U) /**< (SDRAMC) SDRAMC Configuration Register 1 */
+#define REG_SDRAMC_OCMS         (*(__IO uint32_t*)0x4008402CU) /**< (SDRAMC) SDRAMC OCMS Register */
+#define REG_SDRAMC_OCMS_KEY1    (*(__O  uint32_t*)0x40084030U) /**< (SDRAMC) SDRAMC OCMS KEY1 Register */
+#define REG_SDRAMC_OCMS_KEY2    (*(__O  uint32_t*)0x40084034U) /**< (SDRAMC) SDRAMC OCMS KEY2 Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SDRAMC peripheral ========== */
+#define SDRAMC_INSTANCE_ID                       62         
+#define SDRAMC_CLOCK_ID                          62         
+
+#endif /* _SAMV71_SDRAMC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/smc.h
+++ b/asf/sam/include/samv71b/instance/smc.h
@@ -1,0 +1,89 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SMC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SMC_INSTANCE_H_
+#define _SAMV71_SMC_INSTANCE_H_
+
+/* ========== Register definition for SMC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SMC_SETUP0          (0x40080000) /**< (SMC) SMC Setup Register 0 */
+#define REG_SMC_PULSE0          (0x40080004) /**< (SMC) SMC Pulse Register 0 */
+#define REG_SMC_CYCLE0          (0x40080008) /**< (SMC) SMC Cycle Register 0 */
+#define REG_SMC_MODE0           (0x4008000C) /**< (SMC) SMC Mode Register 0 */
+#define REG_SMC_SETUP1          (0x40080010) /**< (SMC) SMC Setup Register 1 */
+#define REG_SMC_PULSE1          (0x40080014) /**< (SMC) SMC Pulse Register 1 */
+#define REG_SMC_CYCLE1          (0x40080018) /**< (SMC) SMC Cycle Register 1 */
+#define REG_SMC_MODE1           (0x4008001C) /**< (SMC) SMC Mode Register 1 */
+#define REG_SMC_SETUP2          (0x40080020) /**< (SMC) SMC Setup Register 2 */
+#define REG_SMC_PULSE2          (0x40080024) /**< (SMC) SMC Pulse Register 2 */
+#define REG_SMC_CYCLE2          (0x40080028) /**< (SMC) SMC Cycle Register 2 */
+#define REG_SMC_MODE2           (0x4008002C) /**< (SMC) SMC Mode Register 2 */
+#define REG_SMC_SETUP3          (0x40080030) /**< (SMC) SMC Setup Register 3 */
+#define REG_SMC_PULSE3          (0x40080034) /**< (SMC) SMC Pulse Register 3 */
+#define REG_SMC_CYCLE3          (0x40080038) /**< (SMC) SMC Cycle Register 3 */
+#define REG_SMC_MODE3           (0x4008003C) /**< (SMC) SMC Mode Register 3 */
+#define REG_SMC_OCMS            (0x40080080) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (0x40080084) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (0x40080088) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
+#define REG_SMC_WPMR            (0x400800E4) /**< (SMC) SMC Write Protection Mode Register */
+#define REG_SMC_WPSR            (0x400800E8) /**< (SMC) SMC Write Protection Status Register */
+
+#else
+
+#define REG_SMC_SETUP0          (*(__IO uint32_t*)0x40080000U) /**< (SMC) SMC Setup Register 0 */
+#define REG_SMC_PULSE0          (*(__IO uint32_t*)0x40080004U) /**< (SMC) SMC Pulse Register 0 */
+#define REG_SMC_CYCLE0          (*(__IO uint32_t*)0x40080008U) /**< (SMC) SMC Cycle Register 0 */
+#define REG_SMC_MODE0           (*(__IO uint32_t*)0x4008000CU) /**< (SMC) SMC Mode Register 0 */
+#define REG_SMC_SETUP1          (*(__IO uint32_t*)0x40080010U) /**< (SMC) SMC Setup Register 1 */
+#define REG_SMC_PULSE1          (*(__IO uint32_t*)0x40080014U) /**< (SMC) SMC Pulse Register 1 */
+#define REG_SMC_CYCLE1          (*(__IO uint32_t*)0x40080018U) /**< (SMC) SMC Cycle Register 1 */
+#define REG_SMC_MODE1           (*(__IO uint32_t*)0x4008001CU) /**< (SMC) SMC Mode Register 1 */
+#define REG_SMC_SETUP2          (*(__IO uint32_t*)0x40080020U) /**< (SMC) SMC Setup Register 2 */
+#define REG_SMC_PULSE2          (*(__IO uint32_t*)0x40080024U) /**< (SMC) SMC Pulse Register 2 */
+#define REG_SMC_CYCLE2          (*(__IO uint32_t*)0x40080028U) /**< (SMC) SMC Cycle Register 2 */
+#define REG_SMC_MODE2           (*(__IO uint32_t*)0x4008002CU) /**< (SMC) SMC Mode Register 2 */
+#define REG_SMC_SETUP3          (*(__IO uint32_t*)0x40080030U) /**< (SMC) SMC Setup Register 3 */
+#define REG_SMC_PULSE3          (*(__IO uint32_t*)0x40080034U) /**< (SMC) SMC Pulse Register 3 */
+#define REG_SMC_CYCLE3          (*(__IO uint32_t*)0x40080038U) /**< (SMC) SMC Cycle Register 3 */
+#define REG_SMC_MODE3           (*(__IO uint32_t*)0x4008003CU) /**< (SMC) SMC Mode Register 3 */
+#define REG_SMC_OCMS            (*(__IO uint32_t*)0x40080080U) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (*(__O  uint32_t*)0x40080084U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (*(__O  uint32_t*)0x40080088U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
+#define REG_SMC_WPMR            (*(__IO uint32_t*)0x400800E4U) /**< (SMC) SMC Write Protection Mode Register */
+#define REG_SMC_WPSR            (*(__I  uint32_t*)0x400800E8U) /**< (SMC) SMC Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SMC peripheral ========== */
+#define SMC_INSTANCE_ID                          9          
+#define SMC_CLOCK_ID                             9          
+
+#endif /* _SAMV71_SMC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/spi0.h
+++ b/asf/sam/include/samv71b/instance/spi0.h
@@ -1,0 +1,79 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SPI0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SPI0_INSTANCE_H_
+#define _SAMV71_SPI0_INSTANCE_H_
+
+/* ========== Register definition for SPI0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SPI0_CR             (0x40008000) /**< (SPI0) Control Register */
+#define REG_SPI0_MR             (0x40008004) /**< (SPI0) Mode Register */
+#define REG_SPI0_RDR            (0x40008008) /**< (SPI0) Receive Data Register */
+#define REG_SPI0_TDR            (0x4000800C) /**< (SPI0) Transmit Data Register */
+#define REG_SPI0_SR             (0x40008010) /**< (SPI0) Status Register */
+#define REG_SPI0_IER            (0x40008014) /**< (SPI0) Interrupt Enable Register */
+#define REG_SPI0_IDR            (0x40008018) /**< (SPI0) Interrupt Disable Register */
+#define REG_SPI0_IMR            (0x4000801C) /**< (SPI0) Interrupt Mask Register */
+#define REG_SPI0_CSR            (0x40008030) /**< (SPI0) Chip Select Register */
+#define REG_SPI0_CSR0           (0x40008030) /**< (SPI0) Chip Select Register 0 */
+#define REG_SPI0_CSR1           (0x40008034) /**< (SPI0) Chip Select Register 1 */
+#define REG_SPI0_CSR2           (0x40008038) /**< (SPI0) Chip Select Register 2 */
+#define REG_SPI0_CSR3           (0x4000803C) /**< (SPI0) Chip Select Register 3 */
+#define REG_SPI0_WPMR           (0x400080E4) /**< (SPI0) Write Protection Mode Register */
+#define REG_SPI0_WPSR           (0x400080E8) /**< (SPI0) Write Protection Status Register */
+
+#else
+
+#define REG_SPI0_CR             (*(__O  uint32_t*)0x40008000U) /**< (SPI0) Control Register */
+#define REG_SPI0_MR             (*(__IO uint32_t*)0x40008004U) /**< (SPI0) Mode Register */
+#define REG_SPI0_RDR            (*(__I  uint32_t*)0x40008008U) /**< (SPI0) Receive Data Register */
+#define REG_SPI0_TDR            (*(__O  uint32_t*)0x4000800CU) /**< (SPI0) Transmit Data Register */
+#define REG_SPI0_SR             (*(__I  uint32_t*)0x40008010U) /**< (SPI0) Status Register */
+#define REG_SPI0_IER            (*(__O  uint32_t*)0x40008014U) /**< (SPI0) Interrupt Enable Register */
+#define REG_SPI0_IDR            (*(__O  uint32_t*)0x40008018U) /**< (SPI0) Interrupt Disable Register */
+#define REG_SPI0_IMR            (*(__I  uint32_t*)0x4000801CU) /**< (SPI0) Interrupt Mask Register */
+#define REG_SPI0_CSR            (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register */
+#define REG_SPI0_CSR0           (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register 0 */
+#define REG_SPI0_CSR1           (*(__IO uint32_t*)0x40008034U) /**< (SPI0) Chip Select Register 1 */
+#define REG_SPI0_CSR2           (*(__IO uint32_t*)0x40008038U) /**< (SPI0) Chip Select Register 2 */
+#define REG_SPI0_CSR3           (*(__IO uint32_t*)0x4000803CU) /**< (SPI0) Chip Select Register 3 */
+#define REG_SPI0_WPMR           (*(__IO uint32_t*)0x400080E4U) /**< (SPI0) Write Protection Mode Register */
+#define REG_SPI0_WPSR           (*(__I  uint32_t*)0x400080E8U) /**< (SPI0) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SPI0 peripheral ========== */
+#define SPI0_DMAC_ID_RX                          2          
+#define SPI0_DMAC_ID_TX                          1          
+#define SPI0_INSTANCE_ID                         21         
+#define SPI0_CLOCK_ID                            21         
+
+#endif /* _SAMV71_SPI0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/spi1.h
+++ b/asf/sam/include/samv71b/instance/spi1.h
@@ -1,0 +1,79 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SPI1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SPI1_INSTANCE_H_
+#define _SAMV71_SPI1_INSTANCE_H_
+
+/* ========== Register definition for SPI1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SPI1_CR             (0x40058000) /**< (SPI1) Control Register */
+#define REG_SPI1_MR             (0x40058004) /**< (SPI1) Mode Register */
+#define REG_SPI1_RDR            (0x40058008) /**< (SPI1) Receive Data Register */
+#define REG_SPI1_TDR            (0x4005800C) /**< (SPI1) Transmit Data Register */
+#define REG_SPI1_SR             (0x40058010) /**< (SPI1) Status Register */
+#define REG_SPI1_IER            (0x40058014) /**< (SPI1) Interrupt Enable Register */
+#define REG_SPI1_IDR            (0x40058018) /**< (SPI1) Interrupt Disable Register */
+#define REG_SPI1_IMR            (0x4005801C) /**< (SPI1) Interrupt Mask Register */
+#define REG_SPI1_CSR            (0x40058030) /**< (SPI1) Chip Select Register */
+#define REG_SPI1_CSR0           (0x40058030) /**< (SPI1) Chip Select Register 0 */
+#define REG_SPI1_CSR1           (0x40058034) /**< (SPI1) Chip Select Register 1 */
+#define REG_SPI1_CSR2           (0x40058038) /**< (SPI1) Chip Select Register 2 */
+#define REG_SPI1_CSR3           (0x4005803C) /**< (SPI1) Chip Select Register 3 */
+#define REG_SPI1_WPMR           (0x400580E4) /**< (SPI1) Write Protection Mode Register */
+#define REG_SPI1_WPSR           (0x400580E8) /**< (SPI1) Write Protection Status Register */
+
+#else
+
+#define REG_SPI1_CR             (*(__O  uint32_t*)0x40058000U) /**< (SPI1) Control Register */
+#define REG_SPI1_MR             (*(__IO uint32_t*)0x40058004U) /**< (SPI1) Mode Register */
+#define REG_SPI1_RDR            (*(__I  uint32_t*)0x40058008U) /**< (SPI1) Receive Data Register */
+#define REG_SPI1_TDR            (*(__O  uint32_t*)0x4005800CU) /**< (SPI1) Transmit Data Register */
+#define REG_SPI1_SR             (*(__I  uint32_t*)0x40058010U) /**< (SPI1) Status Register */
+#define REG_SPI1_IER            (*(__O  uint32_t*)0x40058014U) /**< (SPI1) Interrupt Enable Register */
+#define REG_SPI1_IDR            (*(__O  uint32_t*)0x40058018U) /**< (SPI1) Interrupt Disable Register */
+#define REG_SPI1_IMR            (*(__I  uint32_t*)0x4005801CU) /**< (SPI1) Interrupt Mask Register */
+#define REG_SPI1_CSR            (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register */
+#define REG_SPI1_CSR0           (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register 0 */
+#define REG_SPI1_CSR1           (*(__IO uint32_t*)0x40058034U) /**< (SPI1) Chip Select Register 1 */
+#define REG_SPI1_CSR2           (*(__IO uint32_t*)0x40058038U) /**< (SPI1) Chip Select Register 2 */
+#define REG_SPI1_CSR3           (*(__IO uint32_t*)0x4005803CU) /**< (SPI1) Chip Select Register 3 */
+#define REG_SPI1_WPMR           (*(__IO uint32_t*)0x400580E4U) /**< (SPI1) Write Protection Mode Register */
+#define REG_SPI1_WPSR           (*(__I  uint32_t*)0x400580E8U) /**< (SPI1) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SPI1 peripheral ========== */
+#define SPI1_DMAC_ID_RX                          4          
+#define SPI1_DMAC_ID_TX                          3          
+#define SPI1_INSTANCE_ID                         42         
+#define SPI1_CLOCK_ID                            42         
+
+#endif /* _SAMV71_SPI1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/ssc.h
+++ b/asf/sam/include/samv71b/instance/ssc.h
@@ -1,0 +1,85 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SSC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SSC_INSTANCE_H_
+#define _SAMV71_SSC_INSTANCE_H_
+
+/* ========== Register definition for SSC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SSC_CR              (0x40004000) /**< (SSC) Control Register */
+#define REG_SSC_CMR             (0x40004004) /**< (SSC) Clock Mode Register */
+#define REG_SSC_RCMR            (0x40004010) /**< (SSC) Receive Clock Mode Register */
+#define REG_SSC_RFMR            (0x40004014) /**< (SSC) Receive Frame Mode Register */
+#define REG_SSC_TCMR            (0x40004018) /**< (SSC) Transmit Clock Mode Register */
+#define REG_SSC_TFMR            (0x4000401C) /**< (SSC) Transmit Frame Mode Register */
+#define REG_SSC_RHR             (0x40004020) /**< (SSC) Receive Holding Register */
+#define REG_SSC_THR             (0x40004024) /**< (SSC) Transmit Holding Register */
+#define REG_SSC_RSHR            (0x40004030) /**< (SSC) Receive Sync. Holding Register */
+#define REG_SSC_TSHR            (0x40004034) /**< (SSC) Transmit Sync. Holding Register */
+#define REG_SSC_RC0R            (0x40004038) /**< (SSC) Receive Compare 0 Register */
+#define REG_SSC_RC1R            (0x4000403C) /**< (SSC) Receive Compare 1 Register */
+#define REG_SSC_SR              (0x40004040) /**< (SSC) Status Register */
+#define REG_SSC_IER             (0x40004044) /**< (SSC) Interrupt Enable Register */
+#define REG_SSC_IDR             (0x40004048) /**< (SSC) Interrupt Disable Register */
+#define REG_SSC_IMR             (0x4000404C) /**< (SSC) Interrupt Mask Register */
+#define REG_SSC_WPMR            (0x400040E4) /**< (SSC) Write Protection Mode Register */
+#define REG_SSC_WPSR            (0x400040E8) /**< (SSC) Write Protection Status Register */
+
+#else
+
+#define REG_SSC_CR              (*(__O  uint32_t*)0x40004000U) /**< (SSC) Control Register */
+#define REG_SSC_CMR             (*(__IO uint32_t*)0x40004004U) /**< (SSC) Clock Mode Register */
+#define REG_SSC_RCMR            (*(__IO uint32_t*)0x40004010U) /**< (SSC) Receive Clock Mode Register */
+#define REG_SSC_RFMR            (*(__IO uint32_t*)0x40004014U) /**< (SSC) Receive Frame Mode Register */
+#define REG_SSC_TCMR            (*(__IO uint32_t*)0x40004018U) /**< (SSC) Transmit Clock Mode Register */
+#define REG_SSC_TFMR            (*(__IO uint32_t*)0x4000401CU) /**< (SSC) Transmit Frame Mode Register */
+#define REG_SSC_RHR             (*(__I  uint32_t*)0x40004020U) /**< (SSC) Receive Holding Register */
+#define REG_SSC_THR             (*(__O  uint32_t*)0x40004024U) /**< (SSC) Transmit Holding Register */
+#define REG_SSC_RSHR            (*(__I  uint32_t*)0x40004030U) /**< (SSC) Receive Sync. Holding Register */
+#define REG_SSC_TSHR            (*(__IO uint32_t*)0x40004034U) /**< (SSC) Transmit Sync. Holding Register */
+#define REG_SSC_RC0R            (*(__IO uint32_t*)0x40004038U) /**< (SSC) Receive Compare 0 Register */
+#define REG_SSC_RC1R            (*(__IO uint32_t*)0x4000403CU) /**< (SSC) Receive Compare 1 Register */
+#define REG_SSC_SR              (*(__I  uint32_t*)0x40004040U) /**< (SSC) Status Register */
+#define REG_SSC_IER             (*(__O  uint32_t*)0x40004044U) /**< (SSC) Interrupt Enable Register */
+#define REG_SSC_IDR             (*(__O  uint32_t*)0x40004048U) /**< (SSC) Interrupt Disable Register */
+#define REG_SSC_IMR             (*(__I  uint32_t*)0x4000404CU) /**< (SSC) Interrupt Mask Register */
+#define REG_SSC_WPMR            (*(__IO uint32_t*)0x400040E4U) /**< (SSC) Write Protection Mode Register */
+#define REG_SSC_WPSR            (*(__I  uint32_t*)0x400040E8U) /**< (SSC) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SSC peripheral ========== */
+#define SSC_DMAC_ID_RX                           33         
+#define SSC_DMAC_ID_TX                           32         
+#define SSC_INSTANCE_ID                          22         
+#define SSC_CLOCK_ID                             22         
+
+#endif /* _SAMV71_SSC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/supc.h
+++ b/asf/sam/include/samv71b/instance/supc.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SUPC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_SUPC_INSTANCE_H_
+#define _SAMV71_SUPC_INSTANCE_H_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_SUPC_CR             (0x400E1810) /**< (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR           (0x400E1814) /**< (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR             (0x400E1818) /**< (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR           (0x400E181C) /**< (SUPC) Supply Controller Wake-up Mode Register */
+#define REG_SUPC_WUIR           (0x400E1820) /**< (SUPC) Supply Controller Wake-up Inputs Register */
+#define REG_SUPC_SR             (0x400E1824) /**< (SUPC) Supply Controller Status Register */
+
+#else
+
+#define REG_SUPC_CR             (*(__O  uint32_t*)0x400E1810U) /**< (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR           (*(__IO uint32_t*)0x400E1814U) /**< (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR             (*(__IO uint32_t*)0x400E1818U) /**< (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR           (*(__IO uint32_t*)0x400E181CU) /**< (SUPC) Supply Controller Wake-up Mode Register */
+#define REG_SUPC_WUIR           (*(__IO uint32_t*)0x400E1820U) /**< (SUPC) Supply Controller Wake-up Inputs Register */
+#define REG_SUPC_SR             (*(__I  uint32_t*)0x400E1824U) /**< (SUPC) Supply Controller Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for SUPC peripheral ========== */
+#define SUPC_INSTANCE_ID                         0          
+
+#endif /* _SAMV71_SUPC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/tc0.h
+++ b/asf/sam/include/samv71b/instance/tc0.h
@@ -1,0 +1,157 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TC0_INSTANCE_H_
+#define _SAMV71_TC0_INSTANCE_H_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC0_CCR0            (0x4000C000) /**< (TC0) Channel Control Register (channel = 0) 0 */
+#define REG_TC0_CMR0            (0x4000C004) /**< (TC0) Channel Mode Register (channel = 0) 0 */
+#define REG_TC0_SMMR0           (0x4000C008) /**< (TC0) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC0_RAB0            (0x4000C00C) /**< (TC0) Register AB (channel = 0) 0 */
+#define REG_TC0_CV0             (0x4000C010) /**< (TC0) Counter Value (channel = 0) 0 */
+#define REG_TC0_RA0             (0x4000C014) /**< (TC0) Register A (channel = 0) 0 */
+#define REG_TC0_RB0             (0x4000C018) /**< (TC0) Register B (channel = 0) 0 */
+#define REG_TC0_RC0             (0x4000C01C) /**< (TC0) Register C (channel = 0) 0 */
+#define REG_TC0_SR0             (0x4000C020) /**< (TC0) Status Register (channel = 0) 0 */
+#define REG_TC0_IER0            (0x4000C024) /**< (TC0) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC0_IDR0            (0x4000C028) /**< (TC0) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC0_IMR0            (0x4000C02C) /**< (TC0) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC0_EMR0            (0x4000C030) /**< (TC0) Extended Mode Register (channel = 0) 0 */
+#define REG_TC0_CCR1            (0x4000C040) /**< (TC0) Channel Control Register (channel = 0) 1 */
+#define REG_TC0_CMR1            (0x4000C044) /**< (TC0) Channel Mode Register (channel = 0) 1 */
+#define REG_TC0_SMMR1           (0x4000C048) /**< (TC0) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC0_RAB1            (0x4000C04C) /**< (TC0) Register AB (channel = 0) 1 */
+#define REG_TC0_CV1             (0x4000C050) /**< (TC0) Counter Value (channel = 0) 1 */
+#define REG_TC0_RA1             (0x4000C054) /**< (TC0) Register A (channel = 0) 1 */
+#define REG_TC0_RB1             (0x4000C058) /**< (TC0) Register B (channel = 0) 1 */
+#define REG_TC0_RC1             (0x4000C05C) /**< (TC0) Register C (channel = 0) 1 */
+#define REG_TC0_SR1             (0x4000C060) /**< (TC0) Status Register (channel = 0) 1 */
+#define REG_TC0_IER1            (0x4000C064) /**< (TC0) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC0_IDR1            (0x4000C068) /**< (TC0) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC0_IMR1            (0x4000C06C) /**< (TC0) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC0_EMR1            (0x4000C070) /**< (TC0) Extended Mode Register (channel = 0) 1 */
+#define REG_TC0_CCR2            (0x4000C080) /**< (TC0) Channel Control Register (channel = 0) 2 */
+#define REG_TC0_CMR2            (0x4000C084) /**< (TC0) Channel Mode Register (channel = 0) 2 */
+#define REG_TC0_SMMR2           (0x4000C088) /**< (TC0) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC0_RAB2            (0x4000C08C) /**< (TC0) Register AB (channel = 0) 2 */
+#define REG_TC0_CV2             (0x4000C090) /**< (TC0) Counter Value (channel = 0) 2 */
+#define REG_TC0_RA2             (0x4000C094) /**< (TC0) Register A (channel = 0) 2 */
+#define REG_TC0_RB2             (0x4000C098) /**< (TC0) Register B (channel = 0) 2 */
+#define REG_TC0_RC2             (0x4000C09C) /**< (TC0) Register C (channel = 0) 2 */
+#define REG_TC0_SR2             (0x4000C0A0) /**< (TC0) Status Register (channel = 0) 2 */
+#define REG_TC0_IER2            (0x4000C0A4) /**< (TC0) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC0_IDR2            (0x4000C0A8) /**< (TC0) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC0_IMR2            (0x4000C0AC) /**< (TC0) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC0_EMR2            (0x4000C0B0) /**< (TC0) Extended Mode Register (channel = 0) 2 */
+#define REG_TC0_BCR             (0x4000C0C0) /**< (TC0) Block Control Register */
+#define REG_TC0_BMR             (0x4000C0C4) /**< (TC0) Block Mode Register */
+#define REG_TC0_QIER            (0x4000C0C8) /**< (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR            (0x4000C0CC) /**< (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR            (0x4000C0D0) /**< (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR            (0x4000C0D4) /**< (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR             (0x4000C0D8) /**< (TC0) Fault Mode Register */
+#define REG_TC0_WPMR            (0x4000C0E4) /**< (TC0) Write Protection Mode Register */
+
+#else
+
+#define REG_TC0_CCR0            (*(__O  uint32_t*)0x4000C000U) /**< (TC0) Channel Control Register (channel = 0) 0 */
+#define REG_TC0_CMR0            (*(__IO uint32_t*)0x4000C004U) /**< (TC0) Channel Mode Register (channel = 0) 0 */
+#define REG_TC0_SMMR0           (*(__IO uint32_t*)0x4000C008U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC0_RAB0            (*(__I  uint32_t*)0x4000C00CU) /**< (TC0) Register AB (channel = 0) 0 */
+#define REG_TC0_CV0             (*(__I  uint32_t*)0x4000C010U) /**< (TC0) Counter Value (channel = 0) 0 */
+#define REG_TC0_RA0             (*(__IO uint32_t*)0x4000C014U) /**< (TC0) Register A (channel = 0) 0 */
+#define REG_TC0_RB0             (*(__IO uint32_t*)0x4000C018U) /**< (TC0) Register B (channel = 0) 0 */
+#define REG_TC0_RC0             (*(__IO uint32_t*)0x4000C01CU) /**< (TC0) Register C (channel = 0) 0 */
+#define REG_TC0_SR0             (*(__I  uint32_t*)0x4000C020U) /**< (TC0) Status Register (channel = 0) 0 */
+#define REG_TC0_IER0            (*(__O  uint32_t*)0x4000C024U) /**< (TC0) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC0_IDR0            (*(__O  uint32_t*)0x4000C028U) /**< (TC0) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC0_IMR0            (*(__I  uint32_t*)0x4000C02CU) /**< (TC0) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC0_EMR0            (*(__IO uint32_t*)0x4000C030U) /**< (TC0) Extended Mode Register (channel = 0) 0 */
+#define REG_TC0_CCR1            (*(__O  uint32_t*)0x4000C040U) /**< (TC0) Channel Control Register (channel = 0) 1 */
+#define REG_TC0_CMR1            (*(__IO uint32_t*)0x4000C044U) /**< (TC0) Channel Mode Register (channel = 0) 1 */
+#define REG_TC0_SMMR1           (*(__IO uint32_t*)0x4000C048U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC0_RAB1            (*(__I  uint32_t*)0x4000C04CU) /**< (TC0) Register AB (channel = 0) 1 */
+#define REG_TC0_CV1             (*(__I  uint32_t*)0x4000C050U) /**< (TC0) Counter Value (channel = 0) 1 */
+#define REG_TC0_RA1             (*(__IO uint32_t*)0x4000C054U) /**< (TC0) Register A (channel = 0) 1 */
+#define REG_TC0_RB1             (*(__IO uint32_t*)0x4000C058U) /**< (TC0) Register B (channel = 0) 1 */
+#define REG_TC0_RC1             (*(__IO uint32_t*)0x4000C05CU) /**< (TC0) Register C (channel = 0) 1 */
+#define REG_TC0_SR1             (*(__I  uint32_t*)0x4000C060U) /**< (TC0) Status Register (channel = 0) 1 */
+#define REG_TC0_IER1            (*(__O  uint32_t*)0x4000C064U) /**< (TC0) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC0_IDR1            (*(__O  uint32_t*)0x4000C068U) /**< (TC0) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC0_IMR1            (*(__I  uint32_t*)0x4000C06CU) /**< (TC0) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC0_EMR1            (*(__IO uint32_t*)0x4000C070U) /**< (TC0) Extended Mode Register (channel = 0) 1 */
+#define REG_TC0_CCR2            (*(__O  uint32_t*)0x4000C080U) /**< (TC0) Channel Control Register (channel = 0) 2 */
+#define REG_TC0_CMR2            (*(__IO uint32_t*)0x4000C084U) /**< (TC0) Channel Mode Register (channel = 0) 2 */
+#define REG_TC0_SMMR2           (*(__IO uint32_t*)0x4000C088U) /**< (TC0) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC0_RAB2            (*(__I  uint32_t*)0x4000C08CU) /**< (TC0) Register AB (channel = 0) 2 */
+#define REG_TC0_CV2             (*(__I  uint32_t*)0x4000C090U) /**< (TC0) Counter Value (channel = 0) 2 */
+#define REG_TC0_RA2             (*(__IO uint32_t*)0x4000C094U) /**< (TC0) Register A (channel = 0) 2 */
+#define REG_TC0_RB2             (*(__IO uint32_t*)0x4000C098U) /**< (TC0) Register B (channel = 0) 2 */
+#define REG_TC0_RC2             (*(__IO uint32_t*)0x4000C09CU) /**< (TC0) Register C (channel = 0) 2 */
+#define REG_TC0_SR2             (*(__I  uint32_t*)0x4000C0A0U) /**< (TC0) Status Register (channel = 0) 2 */
+#define REG_TC0_IER2            (*(__O  uint32_t*)0x4000C0A4U) /**< (TC0) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC0_IDR2            (*(__O  uint32_t*)0x4000C0A8U) /**< (TC0) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC0_IMR2            (*(__I  uint32_t*)0x4000C0ACU) /**< (TC0) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC0_EMR2            (*(__IO uint32_t*)0x4000C0B0U) /**< (TC0) Extended Mode Register (channel = 0) 2 */
+#define REG_TC0_BCR             (*(__O  uint32_t*)0x4000C0C0U) /**< (TC0) Block Control Register */
+#define REG_TC0_BMR             (*(__IO uint32_t*)0x4000C0C4U) /**< (TC0) Block Mode Register */
+#define REG_TC0_QIER            (*(__O  uint32_t*)0x4000C0C8U) /**< (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR            (*(__O  uint32_t*)0x4000C0CCU) /**< (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR            (*(__I  uint32_t*)0x4000C0D0U) /**< (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR            (*(__I  uint32_t*)0x4000C0D4U) /**< (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR             (*(__IO uint32_t*)0x4000C0D8U) /**< (TC0) Fault Mode Register */
+#define REG_TC0_WPMR            (*(__IO uint32_t*)0x4000C0E4U) /**< (TC0) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC0 peripheral ========== */
+#define TC0_DMAC_ID_RX                           40         
+#define TC0_INSTANCE_ID_CHANNEL0                 23         
+#define TC0_INSTANCE_ID_CHANNEL1                 24         
+#define TC0_INSTANCE_ID_CHANNEL2                 25         
+#define TC0_CLOCK_ID_CHANNEL0                    23         
+#define TC0_CLOCK_ID_CHANNEL1                    24         
+#define TC0_CLOCK_ID_CHANNEL2                    25         
+#define TC0_TCCLKS_                              0          /* MCK */
+#define TC0_TCCLKS_TIMER_CLOCK1                  1          /* PCK */
+#define TC0_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC0_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC0_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC0_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC0_TCCLKS_XC0                           6          /* XC0 */
+#define TC0_TCCLKS_XC1                           7          /* XC1 */
+#define TC0_TCCLKS_XC2                           8          /* XC2 */
+#define TC0_NUM_INTERRUPT_LINES                  3          
+#define TC0_TIMER_WIDTH                          16         
+
+#endif /* _SAMV71_TC0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/tc1.h
+++ b/asf/sam/include/samv71b/instance/tc1.h
@@ -1,0 +1,157 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TC1_INSTANCE_H_
+#define _SAMV71_TC1_INSTANCE_H_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC1_CCR0            (0x40010000) /**< (TC1) Channel Control Register (channel = 0) 0 */
+#define REG_TC1_CMR0            (0x40010004) /**< (TC1) Channel Mode Register (channel = 0) 0 */
+#define REG_TC1_SMMR0           (0x40010008) /**< (TC1) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC1_RAB0            (0x4001000C) /**< (TC1) Register AB (channel = 0) 0 */
+#define REG_TC1_CV0             (0x40010010) /**< (TC1) Counter Value (channel = 0) 0 */
+#define REG_TC1_RA0             (0x40010014) /**< (TC1) Register A (channel = 0) 0 */
+#define REG_TC1_RB0             (0x40010018) /**< (TC1) Register B (channel = 0) 0 */
+#define REG_TC1_RC0             (0x4001001C) /**< (TC1) Register C (channel = 0) 0 */
+#define REG_TC1_SR0             (0x40010020) /**< (TC1) Status Register (channel = 0) 0 */
+#define REG_TC1_IER0            (0x40010024) /**< (TC1) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC1_IDR0            (0x40010028) /**< (TC1) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC1_IMR0            (0x4001002C) /**< (TC1) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC1_EMR0            (0x40010030) /**< (TC1) Extended Mode Register (channel = 0) 0 */
+#define REG_TC1_CCR1            (0x40010040) /**< (TC1) Channel Control Register (channel = 0) 1 */
+#define REG_TC1_CMR1            (0x40010044) /**< (TC1) Channel Mode Register (channel = 0) 1 */
+#define REG_TC1_SMMR1           (0x40010048) /**< (TC1) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC1_RAB1            (0x4001004C) /**< (TC1) Register AB (channel = 0) 1 */
+#define REG_TC1_CV1             (0x40010050) /**< (TC1) Counter Value (channel = 0) 1 */
+#define REG_TC1_RA1             (0x40010054) /**< (TC1) Register A (channel = 0) 1 */
+#define REG_TC1_RB1             (0x40010058) /**< (TC1) Register B (channel = 0) 1 */
+#define REG_TC1_RC1             (0x4001005C) /**< (TC1) Register C (channel = 0) 1 */
+#define REG_TC1_SR1             (0x40010060) /**< (TC1) Status Register (channel = 0) 1 */
+#define REG_TC1_IER1            (0x40010064) /**< (TC1) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC1_IDR1            (0x40010068) /**< (TC1) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC1_IMR1            (0x4001006C) /**< (TC1) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC1_EMR1            (0x40010070) /**< (TC1) Extended Mode Register (channel = 0) 1 */
+#define REG_TC1_CCR2            (0x40010080) /**< (TC1) Channel Control Register (channel = 0) 2 */
+#define REG_TC1_CMR2            (0x40010084) /**< (TC1) Channel Mode Register (channel = 0) 2 */
+#define REG_TC1_SMMR2           (0x40010088) /**< (TC1) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC1_RAB2            (0x4001008C) /**< (TC1) Register AB (channel = 0) 2 */
+#define REG_TC1_CV2             (0x40010090) /**< (TC1) Counter Value (channel = 0) 2 */
+#define REG_TC1_RA2             (0x40010094) /**< (TC1) Register A (channel = 0) 2 */
+#define REG_TC1_RB2             (0x40010098) /**< (TC1) Register B (channel = 0) 2 */
+#define REG_TC1_RC2             (0x4001009C) /**< (TC1) Register C (channel = 0) 2 */
+#define REG_TC1_SR2             (0x400100A0) /**< (TC1) Status Register (channel = 0) 2 */
+#define REG_TC1_IER2            (0x400100A4) /**< (TC1) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC1_IDR2            (0x400100A8) /**< (TC1) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC1_IMR2            (0x400100AC) /**< (TC1) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC1_EMR2            (0x400100B0) /**< (TC1) Extended Mode Register (channel = 0) 2 */
+#define REG_TC1_BCR             (0x400100C0) /**< (TC1) Block Control Register */
+#define REG_TC1_BMR             (0x400100C4) /**< (TC1) Block Mode Register */
+#define REG_TC1_QIER            (0x400100C8) /**< (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR            (0x400100CC) /**< (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR            (0x400100D0) /**< (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR            (0x400100D4) /**< (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR             (0x400100D8) /**< (TC1) Fault Mode Register */
+#define REG_TC1_WPMR            (0x400100E4) /**< (TC1) Write Protection Mode Register */
+
+#else
+
+#define REG_TC1_CCR0            (*(__O  uint32_t*)0x40010000U) /**< (TC1) Channel Control Register (channel = 0) 0 */
+#define REG_TC1_CMR0            (*(__IO uint32_t*)0x40010004U) /**< (TC1) Channel Mode Register (channel = 0) 0 */
+#define REG_TC1_SMMR0           (*(__IO uint32_t*)0x40010008U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC1_RAB0            (*(__I  uint32_t*)0x4001000CU) /**< (TC1) Register AB (channel = 0) 0 */
+#define REG_TC1_CV0             (*(__I  uint32_t*)0x40010010U) /**< (TC1) Counter Value (channel = 0) 0 */
+#define REG_TC1_RA0             (*(__IO uint32_t*)0x40010014U) /**< (TC1) Register A (channel = 0) 0 */
+#define REG_TC1_RB0             (*(__IO uint32_t*)0x40010018U) /**< (TC1) Register B (channel = 0) 0 */
+#define REG_TC1_RC0             (*(__IO uint32_t*)0x4001001CU) /**< (TC1) Register C (channel = 0) 0 */
+#define REG_TC1_SR0             (*(__I  uint32_t*)0x40010020U) /**< (TC1) Status Register (channel = 0) 0 */
+#define REG_TC1_IER0            (*(__O  uint32_t*)0x40010024U) /**< (TC1) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC1_IDR0            (*(__O  uint32_t*)0x40010028U) /**< (TC1) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC1_IMR0            (*(__I  uint32_t*)0x4001002CU) /**< (TC1) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC1_EMR0            (*(__IO uint32_t*)0x40010030U) /**< (TC1) Extended Mode Register (channel = 0) 0 */
+#define REG_TC1_CCR1            (*(__O  uint32_t*)0x40010040U) /**< (TC1) Channel Control Register (channel = 0) 1 */
+#define REG_TC1_CMR1            (*(__IO uint32_t*)0x40010044U) /**< (TC1) Channel Mode Register (channel = 0) 1 */
+#define REG_TC1_SMMR1           (*(__IO uint32_t*)0x40010048U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC1_RAB1            (*(__I  uint32_t*)0x4001004CU) /**< (TC1) Register AB (channel = 0) 1 */
+#define REG_TC1_CV1             (*(__I  uint32_t*)0x40010050U) /**< (TC1) Counter Value (channel = 0) 1 */
+#define REG_TC1_RA1             (*(__IO uint32_t*)0x40010054U) /**< (TC1) Register A (channel = 0) 1 */
+#define REG_TC1_RB1             (*(__IO uint32_t*)0x40010058U) /**< (TC1) Register B (channel = 0) 1 */
+#define REG_TC1_RC1             (*(__IO uint32_t*)0x4001005CU) /**< (TC1) Register C (channel = 0) 1 */
+#define REG_TC1_SR1             (*(__I  uint32_t*)0x40010060U) /**< (TC1) Status Register (channel = 0) 1 */
+#define REG_TC1_IER1            (*(__O  uint32_t*)0x40010064U) /**< (TC1) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC1_IDR1            (*(__O  uint32_t*)0x40010068U) /**< (TC1) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC1_IMR1            (*(__I  uint32_t*)0x4001006CU) /**< (TC1) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC1_EMR1            (*(__IO uint32_t*)0x40010070U) /**< (TC1) Extended Mode Register (channel = 0) 1 */
+#define REG_TC1_CCR2            (*(__O  uint32_t*)0x40010080U) /**< (TC1) Channel Control Register (channel = 0) 2 */
+#define REG_TC1_CMR2            (*(__IO uint32_t*)0x40010084U) /**< (TC1) Channel Mode Register (channel = 0) 2 */
+#define REG_TC1_SMMR2           (*(__IO uint32_t*)0x40010088U) /**< (TC1) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC1_RAB2            (*(__I  uint32_t*)0x4001008CU) /**< (TC1) Register AB (channel = 0) 2 */
+#define REG_TC1_CV2             (*(__I  uint32_t*)0x40010090U) /**< (TC1) Counter Value (channel = 0) 2 */
+#define REG_TC1_RA2             (*(__IO uint32_t*)0x40010094U) /**< (TC1) Register A (channel = 0) 2 */
+#define REG_TC1_RB2             (*(__IO uint32_t*)0x40010098U) /**< (TC1) Register B (channel = 0) 2 */
+#define REG_TC1_RC2             (*(__IO uint32_t*)0x4001009CU) /**< (TC1) Register C (channel = 0) 2 */
+#define REG_TC1_SR2             (*(__I  uint32_t*)0x400100A0U) /**< (TC1) Status Register (channel = 0) 2 */
+#define REG_TC1_IER2            (*(__O  uint32_t*)0x400100A4U) /**< (TC1) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC1_IDR2            (*(__O  uint32_t*)0x400100A8U) /**< (TC1) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC1_IMR2            (*(__I  uint32_t*)0x400100ACU) /**< (TC1) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC1_EMR2            (*(__IO uint32_t*)0x400100B0U) /**< (TC1) Extended Mode Register (channel = 0) 2 */
+#define REG_TC1_BCR             (*(__O  uint32_t*)0x400100C0U) /**< (TC1) Block Control Register */
+#define REG_TC1_BMR             (*(__IO uint32_t*)0x400100C4U) /**< (TC1) Block Mode Register */
+#define REG_TC1_QIER            (*(__O  uint32_t*)0x400100C8U) /**< (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR            (*(__O  uint32_t*)0x400100CCU) /**< (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR            (*(__I  uint32_t*)0x400100D0U) /**< (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR            (*(__I  uint32_t*)0x400100D4U) /**< (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR             (*(__IO uint32_t*)0x400100D8U) /**< (TC1) Fault Mode Register */
+#define REG_TC1_WPMR            (*(__IO uint32_t*)0x400100E4U) /**< (TC1) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC1 peripheral ========== */
+#define TC1_DMAC_ID_RX                           41         
+#define TC1_INSTANCE_ID_CHANNEL0                 26         
+#define TC1_INSTANCE_ID_CHANNEL1                 27         
+#define TC1_INSTANCE_ID_CHANNEL2                 28         
+#define TC1_CLOCK_ID_CHANNEL0                    26         
+#define TC1_CLOCK_ID_CHANNEL1                    27         
+#define TC1_CLOCK_ID_CHANNEL2                    28         
+#define TC1_TCCLKS_                              0          /* MCK */
+#define TC1_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC1_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC1_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC1_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC1_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC1_TCCLKS_XC0                           6          /* XC0 */
+#define TC1_TCCLKS_XC1                           7          /* XC1 */
+#define TC1_TCCLKS_XC2                           8          /* XC2 */
+#define TC1_NUM_INTERRUPT_LINES                  3          
+#define TC1_TIMER_WIDTH                          16         
+
+#endif /* _SAMV71_TC1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/tc2.h
+++ b/asf/sam/include/samv71b/instance/tc2.h
@@ -1,0 +1,157 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TC2_INSTANCE_H_
+#define _SAMV71_TC2_INSTANCE_H_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC2_CCR0            (0x40014000) /**< (TC2) Channel Control Register (channel = 0) 0 */
+#define REG_TC2_CMR0            (0x40014004) /**< (TC2) Channel Mode Register (channel = 0) 0 */
+#define REG_TC2_SMMR0           (0x40014008) /**< (TC2) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC2_RAB0            (0x4001400C) /**< (TC2) Register AB (channel = 0) 0 */
+#define REG_TC2_CV0             (0x40014010) /**< (TC2) Counter Value (channel = 0) 0 */
+#define REG_TC2_RA0             (0x40014014) /**< (TC2) Register A (channel = 0) 0 */
+#define REG_TC2_RB0             (0x40014018) /**< (TC2) Register B (channel = 0) 0 */
+#define REG_TC2_RC0             (0x4001401C) /**< (TC2) Register C (channel = 0) 0 */
+#define REG_TC2_SR0             (0x40014020) /**< (TC2) Status Register (channel = 0) 0 */
+#define REG_TC2_IER0            (0x40014024) /**< (TC2) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC2_IDR0            (0x40014028) /**< (TC2) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC2_IMR0            (0x4001402C) /**< (TC2) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC2_EMR0            (0x40014030) /**< (TC2) Extended Mode Register (channel = 0) 0 */
+#define REG_TC2_CCR1            (0x40014040) /**< (TC2) Channel Control Register (channel = 0) 1 */
+#define REG_TC2_CMR1            (0x40014044) /**< (TC2) Channel Mode Register (channel = 0) 1 */
+#define REG_TC2_SMMR1           (0x40014048) /**< (TC2) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC2_RAB1            (0x4001404C) /**< (TC2) Register AB (channel = 0) 1 */
+#define REG_TC2_CV1             (0x40014050) /**< (TC2) Counter Value (channel = 0) 1 */
+#define REG_TC2_RA1             (0x40014054) /**< (TC2) Register A (channel = 0) 1 */
+#define REG_TC2_RB1             (0x40014058) /**< (TC2) Register B (channel = 0) 1 */
+#define REG_TC2_RC1             (0x4001405C) /**< (TC2) Register C (channel = 0) 1 */
+#define REG_TC2_SR1             (0x40014060) /**< (TC2) Status Register (channel = 0) 1 */
+#define REG_TC2_IER1            (0x40014064) /**< (TC2) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC2_IDR1            (0x40014068) /**< (TC2) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC2_IMR1            (0x4001406C) /**< (TC2) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC2_EMR1            (0x40014070) /**< (TC2) Extended Mode Register (channel = 0) 1 */
+#define REG_TC2_CCR2            (0x40014080) /**< (TC2) Channel Control Register (channel = 0) 2 */
+#define REG_TC2_CMR2            (0x40014084) /**< (TC2) Channel Mode Register (channel = 0) 2 */
+#define REG_TC2_SMMR2           (0x40014088) /**< (TC2) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC2_RAB2            (0x4001408C) /**< (TC2) Register AB (channel = 0) 2 */
+#define REG_TC2_CV2             (0x40014090) /**< (TC2) Counter Value (channel = 0) 2 */
+#define REG_TC2_RA2             (0x40014094) /**< (TC2) Register A (channel = 0) 2 */
+#define REG_TC2_RB2             (0x40014098) /**< (TC2) Register B (channel = 0) 2 */
+#define REG_TC2_RC2             (0x4001409C) /**< (TC2) Register C (channel = 0) 2 */
+#define REG_TC2_SR2             (0x400140A0) /**< (TC2) Status Register (channel = 0) 2 */
+#define REG_TC2_IER2            (0x400140A4) /**< (TC2) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC2_IDR2            (0x400140A8) /**< (TC2) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC2_IMR2            (0x400140AC) /**< (TC2) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC2_EMR2            (0x400140B0) /**< (TC2) Extended Mode Register (channel = 0) 2 */
+#define REG_TC2_BCR             (0x400140C0) /**< (TC2) Block Control Register */
+#define REG_TC2_BMR             (0x400140C4) /**< (TC2) Block Mode Register */
+#define REG_TC2_QIER            (0x400140C8) /**< (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR            (0x400140CC) /**< (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR            (0x400140D0) /**< (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR            (0x400140D4) /**< (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR             (0x400140D8) /**< (TC2) Fault Mode Register */
+#define REG_TC2_WPMR            (0x400140E4) /**< (TC2) Write Protection Mode Register */
+
+#else
+
+#define REG_TC2_CCR0            (*(__O  uint32_t*)0x40014000U) /**< (TC2) Channel Control Register (channel = 0) 0 */
+#define REG_TC2_CMR0            (*(__IO uint32_t*)0x40014004U) /**< (TC2) Channel Mode Register (channel = 0) 0 */
+#define REG_TC2_SMMR0           (*(__IO uint32_t*)0x40014008U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC2_RAB0            (*(__I  uint32_t*)0x4001400CU) /**< (TC2) Register AB (channel = 0) 0 */
+#define REG_TC2_CV0             (*(__I  uint32_t*)0x40014010U) /**< (TC2) Counter Value (channel = 0) 0 */
+#define REG_TC2_RA0             (*(__IO uint32_t*)0x40014014U) /**< (TC2) Register A (channel = 0) 0 */
+#define REG_TC2_RB0             (*(__IO uint32_t*)0x40014018U) /**< (TC2) Register B (channel = 0) 0 */
+#define REG_TC2_RC0             (*(__IO uint32_t*)0x4001401CU) /**< (TC2) Register C (channel = 0) 0 */
+#define REG_TC2_SR0             (*(__I  uint32_t*)0x40014020U) /**< (TC2) Status Register (channel = 0) 0 */
+#define REG_TC2_IER0            (*(__O  uint32_t*)0x40014024U) /**< (TC2) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC2_IDR0            (*(__O  uint32_t*)0x40014028U) /**< (TC2) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC2_IMR0            (*(__I  uint32_t*)0x4001402CU) /**< (TC2) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC2_EMR0            (*(__IO uint32_t*)0x40014030U) /**< (TC2) Extended Mode Register (channel = 0) 0 */
+#define REG_TC2_CCR1            (*(__O  uint32_t*)0x40014040U) /**< (TC2) Channel Control Register (channel = 0) 1 */
+#define REG_TC2_CMR1            (*(__IO uint32_t*)0x40014044U) /**< (TC2) Channel Mode Register (channel = 0) 1 */
+#define REG_TC2_SMMR1           (*(__IO uint32_t*)0x40014048U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC2_RAB1            (*(__I  uint32_t*)0x4001404CU) /**< (TC2) Register AB (channel = 0) 1 */
+#define REG_TC2_CV1             (*(__I  uint32_t*)0x40014050U) /**< (TC2) Counter Value (channel = 0) 1 */
+#define REG_TC2_RA1             (*(__IO uint32_t*)0x40014054U) /**< (TC2) Register A (channel = 0) 1 */
+#define REG_TC2_RB1             (*(__IO uint32_t*)0x40014058U) /**< (TC2) Register B (channel = 0) 1 */
+#define REG_TC2_RC1             (*(__IO uint32_t*)0x4001405CU) /**< (TC2) Register C (channel = 0) 1 */
+#define REG_TC2_SR1             (*(__I  uint32_t*)0x40014060U) /**< (TC2) Status Register (channel = 0) 1 */
+#define REG_TC2_IER1            (*(__O  uint32_t*)0x40014064U) /**< (TC2) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC2_IDR1            (*(__O  uint32_t*)0x40014068U) /**< (TC2) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC2_IMR1            (*(__I  uint32_t*)0x4001406CU) /**< (TC2) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC2_EMR1            (*(__IO uint32_t*)0x40014070U) /**< (TC2) Extended Mode Register (channel = 0) 1 */
+#define REG_TC2_CCR2            (*(__O  uint32_t*)0x40014080U) /**< (TC2) Channel Control Register (channel = 0) 2 */
+#define REG_TC2_CMR2            (*(__IO uint32_t*)0x40014084U) /**< (TC2) Channel Mode Register (channel = 0) 2 */
+#define REG_TC2_SMMR2           (*(__IO uint32_t*)0x40014088U) /**< (TC2) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC2_RAB2            (*(__I  uint32_t*)0x4001408CU) /**< (TC2) Register AB (channel = 0) 2 */
+#define REG_TC2_CV2             (*(__I  uint32_t*)0x40014090U) /**< (TC2) Counter Value (channel = 0) 2 */
+#define REG_TC2_RA2             (*(__IO uint32_t*)0x40014094U) /**< (TC2) Register A (channel = 0) 2 */
+#define REG_TC2_RB2             (*(__IO uint32_t*)0x40014098U) /**< (TC2) Register B (channel = 0) 2 */
+#define REG_TC2_RC2             (*(__IO uint32_t*)0x4001409CU) /**< (TC2) Register C (channel = 0) 2 */
+#define REG_TC2_SR2             (*(__I  uint32_t*)0x400140A0U) /**< (TC2) Status Register (channel = 0) 2 */
+#define REG_TC2_IER2            (*(__O  uint32_t*)0x400140A4U) /**< (TC2) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC2_IDR2            (*(__O  uint32_t*)0x400140A8U) /**< (TC2) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC2_IMR2            (*(__I  uint32_t*)0x400140ACU) /**< (TC2) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC2_EMR2            (*(__IO uint32_t*)0x400140B0U) /**< (TC2) Extended Mode Register (channel = 0) 2 */
+#define REG_TC2_BCR             (*(__O  uint32_t*)0x400140C0U) /**< (TC2) Block Control Register */
+#define REG_TC2_BMR             (*(__IO uint32_t*)0x400140C4U) /**< (TC2) Block Mode Register */
+#define REG_TC2_QIER            (*(__O  uint32_t*)0x400140C8U) /**< (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR            (*(__O  uint32_t*)0x400140CCU) /**< (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR            (*(__I  uint32_t*)0x400140D0U) /**< (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR            (*(__I  uint32_t*)0x400140D4U) /**< (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR             (*(__IO uint32_t*)0x400140D8U) /**< (TC2) Fault Mode Register */
+#define REG_TC2_WPMR            (*(__IO uint32_t*)0x400140E4U) /**< (TC2) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC2 peripheral ========== */
+#define TC2_DMAC_ID_RX                           42         
+#define TC2_INSTANCE_ID_CHANNEL0                 47         
+#define TC2_INSTANCE_ID_CHANNEL1                 48         
+#define TC2_INSTANCE_ID_CHANNEL2                 49         
+#define TC2_CLOCK_ID_CHANNEL0                    47         
+#define TC2_CLOCK_ID_CHANNEL1                    48         
+#define TC2_CLOCK_ID_CHANNEL2                    49         
+#define TC2_TCCLKS_                              0          /* MCK */
+#define TC2_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC2_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC2_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC2_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC2_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC2_TCCLKS_XC0                           6          /* XC0 */
+#define TC2_TCCLKS_XC1                           7          /* XC1 */
+#define TC2_TCCLKS_XC2                           8          /* XC2 */
+#define TC2_NUM_INTERRUPT_LINES                  3          
+#define TC2_TIMER_WIDTH                          16         
+
+#endif /* _SAMV71_TC2_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/tc3.h
+++ b/asf/sam/include/samv71b/instance/tc3.h
@@ -1,0 +1,157 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC3
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TC3_INSTANCE_H_
+#define _SAMV71_TC3_INSTANCE_H_
+
+/* ========== Register definition for TC3 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TC3_CCR0            (0x40054000) /**< (TC3) Channel Control Register (channel = 0) 0 */
+#define REG_TC3_CMR0            (0x40054004) /**< (TC3) Channel Mode Register (channel = 0) 0 */
+#define REG_TC3_SMMR0           (0x40054008) /**< (TC3) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC3_RAB0            (0x4005400C) /**< (TC3) Register AB (channel = 0) 0 */
+#define REG_TC3_CV0             (0x40054010) /**< (TC3) Counter Value (channel = 0) 0 */
+#define REG_TC3_RA0             (0x40054014) /**< (TC3) Register A (channel = 0) 0 */
+#define REG_TC3_RB0             (0x40054018) /**< (TC3) Register B (channel = 0) 0 */
+#define REG_TC3_RC0             (0x4005401C) /**< (TC3) Register C (channel = 0) 0 */
+#define REG_TC3_SR0             (0x40054020) /**< (TC3) Status Register (channel = 0) 0 */
+#define REG_TC3_IER0            (0x40054024) /**< (TC3) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC3_IDR0            (0x40054028) /**< (TC3) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC3_IMR0            (0x4005402C) /**< (TC3) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC3_EMR0            (0x40054030) /**< (TC3) Extended Mode Register (channel = 0) 0 */
+#define REG_TC3_CCR1            (0x40054040) /**< (TC3) Channel Control Register (channel = 0) 1 */
+#define REG_TC3_CMR1            (0x40054044) /**< (TC3) Channel Mode Register (channel = 0) 1 */
+#define REG_TC3_SMMR1           (0x40054048) /**< (TC3) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC3_RAB1            (0x4005404C) /**< (TC3) Register AB (channel = 0) 1 */
+#define REG_TC3_CV1             (0x40054050) /**< (TC3) Counter Value (channel = 0) 1 */
+#define REG_TC3_RA1             (0x40054054) /**< (TC3) Register A (channel = 0) 1 */
+#define REG_TC3_RB1             (0x40054058) /**< (TC3) Register B (channel = 0) 1 */
+#define REG_TC3_RC1             (0x4005405C) /**< (TC3) Register C (channel = 0) 1 */
+#define REG_TC3_SR1             (0x40054060) /**< (TC3) Status Register (channel = 0) 1 */
+#define REG_TC3_IER1            (0x40054064) /**< (TC3) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC3_IDR1            (0x40054068) /**< (TC3) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC3_IMR1            (0x4005406C) /**< (TC3) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC3_EMR1            (0x40054070) /**< (TC3) Extended Mode Register (channel = 0) 1 */
+#define REG_TC3_CCR2            (0x40054080) /**< (TC3) Channel Control Register (channel = 0) 2 */
+#define REG_TC3_CMR2            (0x40054084) /**< (TC3) Channel Mode Register (channel = 0) 2 */
+#define REG_TC3_SMMR2           (0x40054088) /**< (TC3) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC3_RAB2            (0x4005408C) /**< (TC3) Register AB (channel = 0) 2 */
+#define REG_TC3_CV2             (0x40054090) /**< (TC3) Counter Value (channel = 0) 2 */
+#define REG_TC3_RA2             (0x40054094) /**< (TC3) Register A (channel = 0) 2 */
+#define REG_TC3_RB2             (0x40054098) /**< (TC3) Register B (channel = 0) 2 */
+#define REG_TC3_RC2             (0x4005409C) /**< (TC3) Register C (channel = 0) 2 */
+#define REG_TC3_SR2             (0x400540A0) /**< (TC3) Status Register (channel = 0) 2 */
+#define REG_TC3_IER2            (0x400540A4) /**< (TC3) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC3_IDR2            (0x400540A8) /**< (TC3) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC3_IMR2            (0x400540AC) /**< (TC3) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC3_EMR2            (0x400540B0) /**< (TC3) Extended Mode Register (channel = 0) 2 */
+#define REG_TC3_BCR             (0x400540C0) /**< (TC3) Block Control Register */
+#define REG_TC3_BMR             (0x400540C4) /**< (TC3) Block Mode Register */
+#define REG_TC3_QIER            (0x400540C8) /**< (TC3) QDEC Interrupt Enable Register */
+#define REG_TC3_QIDR            (0x400540CC) /**< (TC3) QDEC Interrupt Disable Register */
+#define REG_TC3_QIMR            (0x400540D0) /**< (TC3) QDEC Interrupt Mask Register */
+#define REG_TC3_QISR            (0x400540D4) /**< (TC3) QDEC Interrupt Status Register */
+#define REG_TC3_FMR             (0x400540D8) /**< (TC3) Fault Mode Register */
+#define REG_TC3_WPMR            (0x400540E4) /**< (TC3) Write Protection Mode Register */
+
+#else
+
+#define REG_TC3_CCR0            (*(__O  uint32_t*)0x40054000U) /**< (TC3) Channel Control Register (channel = 0) 0 */
+#define REG_TC3_CMR0            (*(__IO uint32_t*)0x40054004U) /**< (TC3) Channel Mode Register (channel = 0) 0 */
+#define REG_TC3_SMMR0           (*(__IO uint32_t*)0x40054008U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 0 */
+#define REG_TC3_RAB0            (*(__I  uint32_t*)0x4005400CU) /**< (TC3) Register AB (channel = 0) 0 */
+#define REG_TC3_CV0             (*(__I  uint32_t*)0x40054010U) /**< (TC3) Counter Value (channel = 0) 0 */
+#define REG_TC3_RA0             (*(__IO uint32_t*)0x40054014U) /**< (TC3) Register A (channel = 0) 0 */
+#define REG_TC3_RB0             (*(__IO uint32_t*)0x40054018U) /**< (TC3) Register B (channel = 0) 0 */
+#define REG_TC3_RC0             (*(__IO uint32_t*)0x4005401CU) /**< (TC3) Register C (channel = 0) 0 */
+#define REG_TC3_SR0             (*(__I  uint32_t*)0x40054020U) /**< (TC3) Status Register (channel = 0) 0 */
+#define REG_TC3_IER0            (*(__O  uint32_t*)0x40054024U) /**< (TC3) Interrupt Enable Register (channel = 0) 0 */
+#define REG_TC3_IDR0            (*(__O  uint32_t*)0x40054028U) /**< (TC3) Interrupt Disable Register (channel = 0) 0 */
+#define REG_TC3_IMR0            (*(__I  uint32_t*)0x4005402CU) /**< (TC3) Interrupt Mask Register (channel = 0) 0 */
+#define REG_TC3_EMR0            (*(__IO uint32_t*)0x40054030U) /**< (TC3) Extended Mode Register (channel = 0) 0 */
+#define REG_TC3_CCR1            (*(__O  uint32_t*)0x40054040U) /**< (TC3) Channel Control Register (channel = 0) 1 */
+#define REG_TC3_CMR1            (*(__IO uint32_t*)0x40054044U) /**< (TC3) Channel Mode Register (channel = 0) 1 */
+#define REG_TC3_SMMR1           (*(__IO uint32_t*)0x40054048U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 1 */
+#define REG_TC3_RAB1            (*(__I  uint32_t*)0x4005404CU) /**< (TC3) Register AB (channel = 0) 1 */
+#define REG_TC3_CV1             (*(__I  uint32_t*)0x40054050U) /**< (TC3) Counter Value (channel = 0) 1 */
+#define REG_TC3_RA1             (*(__IO uint32_t*)0x40054054U) /**< (TC3) Register A (channel = 0) 1 */
+#define REG_TC3_RB1             (*(__IO uint32_t*)0x40054058U) /**< (TC3) Register B (channel = 0) 1 */
+#define REG_TC3_RC1             (*(__IO uint32_t*)0x4005405CU) /**< (TC3) Register C (channel = 0) 1 */
+#define REG_TC3_SR1             (*(__I  uint32_t*)0x40054060U) /**< (TC3) Status Register (channel = 0) 1 */
+#define REG_TC3_IER1            (*(__O  uint32_t*)0x40054064U) /**< (TC3) Interrupt Enable Register (channel = 0) 1 */
+#define REG_TC3_IDR1            (*(__O  uint32_t*)0x40054068U) /**< (TC3) Interrupt Disable Register (channel = 0) 1 */
+#define REG_TC3_IMR1            (*(__I  uint32_t*)0x4005406CU) /**< (TC3) Interrupt Mask Register (channel = 0) 1 */
+#define REG_TC3_EMR1            (*(__IO uint32_t*)0x40054070U) /**< (TC3) Extended Mode Register (channel = 0) 1 */
+#define REG_TC3_CCR2            (*(__O  uint32_t*)0x40054080U) /**< (TC3) Channel Control Register (channel = 0) 2 */
+#define REG_TC3_CMR2            (*(__IO uint32_t*)0x40054084U) /**< (TC3) Channel Mode Register (channel = 0) 2 */
+#define REG_TC3_SMMR2           (*(__IO uint32_t*)0x40054088U) /**< (TC3) Stepper Motor Mode Register (channel = 0) 2 */
+#define REG_TC3_RAB2            (*(__I  uint32_t*)0x4005408CU) /**< (TC3) Register AB (channel = 0) 2 */
+#define REG_TC3_CV2             (*(__I  uint32_t*)0x40054090U) /**< (TC3) Counter Value (channel = 0) 2 */
+#define REG_TC3_RA2             (*(__IO uint32_t*)0x40054094U) /**< (TC3) Register A (channel = 0) 2 */
+#define REG_TC3_RB2             (*(__IO uint32_t*)0x40054098U) /**< (TC3) Register B (channel = 0) 2 */
+#define REG_TC3_RC2             (*(__IO uint32_t*)0x4005409CU) /**< (TC3) Register C (channel = 0) 2 */
+#define REG_TC3_SR2             (*(__I  uint32_t*)0x400540A0U) /**< (TC3) Status Register (channel = 0) 2 */
+#define REG_TC3_IER2            (*(__O  uint32_t*)0x400540A4U) /**< (TC3) Interrupt Enable Register (channel = 0) 2 */
+#define REG_TC3_IDR2            (*(__O  uint32_t*)0x400540A8U) /**< (TC3) Interrupt Disable Register (channel = 0) 2 */
+#define REG_TC3_IMR2            (*(__I  uint32_t*)0x400540ACU) /**< (TC3) Interrupt Mask Register (channel = 0) 2 */
+#define REG_TC3_EMR2            (*(__IO uint32_t*)0x400540B0U) /**< (TC3) Extended Mode Register (channel = 0) 2 */
+#define REG_TC3_BCR             (*(__O  uint32_t*)0x400540C0U) /**< (TC3) Block Control Register */
+#define REG_TC3_BMR             (*(__IO uint32_t*)0x400540C4U) /**< (TC3) Block Mode Register */
+#define REG_TC3_QIER            (*(__O  uint32_t*)0x400540C8U) /**< (TC3) QDEC Interrupt Enable Register */
+#define REG_TC3_QIDR            (*(__O  uint32_t*)0x400540CCU) /**< (TC3) QDEC Interrupt Disable Register */
+#define REG_TC3_QIMR            (*(__I  uint32_t*)0x400540D0U) /**< (TC3) QDEC Interrupt Mask Register */
+#define REG_TC3_QISR            (*(__I  uint32_t*)0x400540D4U) /**< (TC3) QDEC Interrupt Status Register */
+#define REG_TC3_FMR             (*(__IO uint32_t*)0x400540D8U) /**< (TC3) Fault Mode Register */
+#define REG_TC3_WPMR            (*(__IO uint32_t*)0x400540E4U) /**< (TC3) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TC3 peripheral ========== */
+#define TC3_DMAC_ID_RX                           43         
+#define TC3_INSTANCE_ID_CHANNEL0                 50         
+#define TC3_INSTANCE_ID_CHANNEL1                 51         
+#define TC3_INSTANCE_ID_CHANNEL2                 52         
+#define TC3_CLOCK_ID_CHANNEL0                    50         
+#define TC3_CLOCK_ID_CHANNEL1                    51         
+#define TC3_CLOCK_ID_CHANNEL2                    52         
+#define TC3_TCCLKS_                              0          /* MCK */
+#define TC3_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC3_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC3_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC3_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC3_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC3_TCCLKS_XC0                           6          /* XC0 */
+#define TC3_TCCLKS_XC1                           7          /* XC1 */
+#define TC3_TCCLKS_XC2                           8          /* XC2 */
+#define TC3_NUM_INTERRUPT_LINES                  3          
+#define TC3_TIMER_WIDTH                          16         
+
+#endif /* _SAMV71_TC3_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/trng.h
+++ b/asf/sam/include/samv71b/instance/trng.h
@@ -1,0 +1,59 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TRNG_INSTANCE_H_
+#define _SAMV71_TRNG_INSTANCE_H_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TRNG_CR             (0x40070000) /**< (TRNG) Control Register */
+#define REG_TRNG_IER            (0x40070010) /**< (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR            (0x40070014) /**< (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR            (0x40070018) /**< (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR            (0x4007001C) /**< (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA          (0x40070050) /**< (TRNG) Output Data Register */
+
+#else
+
+#define REG_TRNG_CR             (*(__O  uint32_t*)0x40070000U) /**< (TRNG) Control Register */
+#define REG_TRNG_IER            (*(__O  uint32_t*)0x40070010U) /**< (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR            (*(__O  uint32_t*)0x40070014U) /**< (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR            (*(__I  uint32_t*)0x40070018U) /**< (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR            (*(__I  uint32_t*)0x4007001CU) /**< (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA          (*(__I  uint32_t*)0x40070050U) /**< (TRNG) Output Data Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TRNG peripheral ========== */
+#define TRNG_INSTANCE_ID                         57         
+#define TRNG_CLOCK_ID                            57         
+
+#endif /* _SAMV71_TRNG_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/twihs0.h
+++ b/asf/sam/include/samv71b/instance/twihs0.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TWIHS0_INSTANCE_H_
+#define _SAMV71_TWIHS0_INSTANCE_H_
+
+/* ========== Register definition for TWIHS0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS0_CR           (0x40018000) /**< (TWIHS0) Control Register */
+#define REG_TWIHS0_MMR          (0x40018004) /**< (TWIHS0) Master Mode Register */
+#define REG_TWIHS0_SMR          (0x40018008) /**< (TWIHS0) Slave Mode Register */
+#define REG_TWIHS0_IADR         (0x4001800C) /**< (TWIHS0) Internal Address Register */
+#define REG_TWIHS0_CWGR         (0x40018010) /**< (TWIHS0) Clock Waveform Generator Register */
+#define REG_TWIHS0_SR           (0x40018020) /**< (TWIHS0) Status Register */
+#define REG_TWIHS0_IER          (0x40018024) /**< (TWIHS0) Interrupt Enable Register */
+#define REG_TWIHS0_IDR          (0x40018028) /**< (TWIHS0) Interrupt Disable Register */
+#define REG_TWIHS0_IMR          (0x4001802C) /**< (TWIHS0) Interrupt Mask Register */
+#define REG_TWIHS0_RHR          (0x40018030) /**< (TWIHS0) Receive Holding Register */
+#define REG_TWIHS0_THR          (0x40018034) /**< (TWIHS0) Transmit Holding Register */
+#define REG_TWIHS0_SMBTR        (0x40018038) /**< (TWIHS0) SMBus Timing Register */
+#define REG_TWIHS0_FILTR        (0x40018044) /**< (TWIHS0) Filter Register */
+#define REG_TWIHS0_SWMR         (0x4001804C) /**< (TWIHS0) SleepWalking Matching Register */
+#define REG_TWIHS0_WPMR         (0x400180E4) /**< (TWIHS0) Write Protection Mode Register */
+#define REG_TWIHS0_WPSR         (0x400180E8) /**< (TWIHS0) Write Protection Status Register */
+
+#else
+
+#define REG_TWIHS0_CR           (*(__O  uint32_t*)0x40018000U) /**< (TWIHS0) Control Register */
+#define REG_TWIHS0_MMR          (*(__IO uint32_t*)0x40018004U) /**< (TWIHS0) Master Mode Register */
+#define REG_TWIHS0_SMR          (*(__IO uint32_t*)0x40018008U) /**< (TWIHS0) Slave Mode Register */
+#define REG_TWIHS0_IADR         (*(__IO uint32_t*)0x4001800CU) /**< (TWIHS0) Internal Address Register */
+#define REG_TWIHS0_CWGR         (*(__IO uint32_t*)0x40018010U) /**< (TWIHS0) Clock Waveform Generator Register */
+#define REG_TWIHS0_SR           (*(__I  uint32_t*)0x40018020U) /**< (TWIHS0) Status Register */
+#define REG_TWIHS0_IER          (*(__O  uint32_t*)0x40018024U) /**< (TWIHS0) Interrupt Enable Register */
+#define REG_TWIHS0_IDR          (*(__O  uint32_t*)0x40018028U) /**< (TWIHS0) Interrupt Disable Register */
+#define REG_TWIHS0_IMR          (*(__I  uint32_t*)0x4001802CU) /**< (TWIHS0) Interrupt Mask Register */
+#define REG_TWIHS0_RHR          (*(__I  uint32_t*)0x40018030U) /**< (TWIHS0) Receive Holding Register */
+#define REG_TWIHS0_THR          (*(__O  uint32_t*)0x40018034U) /**< (TWIHS0) Transmit Holding Register */
+#define REG_TWIHS0_SMBTR        (*(__IO uint32_t*)0x40018038U) /**< (TWIHS0) SMBus Timing Register */
+#define REG_TWIHS0_FILTR        (*(__IO uint32_t*)0x40018044U) /**< (TWIHS0) Filter Register */
+#define REG_TWIHS0_SWMR         (*(__IO uint32_t*)0x4001804CU) /**< (TWIHS0) SleepWalking Matching Register */
+#define REG_TWIHS0_WPMR         (*(__IO uint32_t*)0x400180E4U) /**< (TWIHS0) Write Protection Mode Register */
+#define REG_TWIHS0_WPSR         (*(__I  uint32_t*)0x400180E8U) /**< (TWIHS0) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS0 peripheral ========== */
+#define TWIHS0_DMAC_ID_RX                        15         
+#define TWIHS0_DMAC_ID_TX                        14         
+#define TWIHS0_INSTANCE_ID                       19         
+#define TWIHS0_CLOCK_ID                          19         
+
+#endif /* _SAMV71_TWIHS0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/twihs1.h
+++ b/asf/sam/include/samv71b/instance/twihs1.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TWIHS1_INSTANCE_H_
+#define _SAMV71_TWIHS1_INSTANCE_H_
+
+/* ========== Register definition for TWIHS1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS1_CR           (0x4001C000) /**< (TWIHS1) Control Register */
+#define REG_TWIHS1_MMR          (0x4001C004) /**< (TWIHS1) Master Mode Register */
+#define REG_TWIHS1_SMR          (0x4001C008) /**< (TWIHS1) Slave Mode Register */
+#define REG_TWIHS1_IADR         (0x4001C00C) /**< (TWIHS1) Internal Address Register */
+#define REG_TWIHS1_CWGR         (0x4001C010) /**< (TWIHS1) Clock Waveform Generator Register */
+#define REG_TWIHS1_SR           (0x4001C020) /**< (TWIHS1) Status Register */
+#define REG_TWIHS1_IER          (0x4001C024) /**< (TWIHS1) Interrupt Enable Register */
+#define REG_TWIHS1_IDR          (0x4001C028) /**< (TWIHS1) Interrupt Disable Register */
+#define REG_TWIHS1_IMR          (0x4001C02C) /**< (TWIHS1) Interrupt Mask Register */
+#define REG_TWIHS1_RHR          (0x4001C030) /**< (TWIHS1) Receive Holding Register */
+#define REG_TWIHS1_THR          (0x4001C034) /**< (TWIHS1) Transmit Holding Register */
+#define REG_TWIHS1_SMBTR        (0x4001C038) /**< (TWIHS1) SMBus Timing Register */
+#define REG_TWIHS1_FILTR        (0x4001C044) /**< (TWIHS1) Filter Register */
+#define REG_TWIHS1_SWMR         (0x4001C04C) /**< (TWIHS1) SleepWalking Matching Register */
+#define REG_TWIHS1_WPMR         (0x4001C0E4) /**< (TWIHS1) Write Protection Mode Register */
+#define REG_TWIHS1_WPSR         (0x4001C0E8) /**< (TWIHS1) Write Protection Status Register */
+
+#else
+
+#define REG_TWIHS1_CR           (*(__O  uint32_t*)0x4001C000U) /**< (TWIHS1) Control Register */
+#define REG_TWIHS1_MMR          (*(__IO uint32_t*)0x4001C004U) /**< (TWIHS1) Master Mode Register */
+#define REG_TWIHS1_SMR          (*(__IO uint32_t*)0x4001C008U) /**< (TWIHS1) Slave Mode Register */
+#define REG_TWIHS1_IADR         (*(__IO uint32_t*)0x4001C00CU) /**< (TWIHS1) Internal Address Register */
+#define REG_TWIHS1_CWGR         (*(__IO uint32_t*)0x4001C010U) /**< (TWIHS1) Clock Waveform Generator Register */
+#define REG_TWIHS1_SR           (*(__I  uint32_t*)0x4001C020U) /**< (TWIHS1) Status Register */
+#define REG_TWIHS1_IER          (*(__O  uint32_t*)0x4001C024U) /**< (TWIHS1) Interrupt Enable Register */
+#define REG_TWIHS1_IDR          (*(__O  uint32_t*)0x4001C028U) /**< (TWIHS1) Interrupt Disable Register */
+#define REG_TWIHS1_IMR          (*(__I  uint32_t*)0x4001C02CU) /**< (TWIHS1) Interrupt Mask Register */
+#define REG_TWIHS1_RHR          (*(__I  uint32_t*)0x4001C030U) /**< (TWIHS1) Receive Holding Register */
+#define REG_TWIHS1_THR          (*(__O  uint32_t*)0x4001C034U) /**< (TWIHS1) Transmit Holding Register */
+#define REG_TWIHS1_SMBTR        (*(__IO uint32_t*)0x4001C038U) /**< (TWIHS1) SMBus Timing Register */
+#define REG_TWIHS1_FILTR        (*(__IO uint32_t*)0x4001C044U) /**< (TWIHS1) Filter Register */
+#define REG_TWIHS1_SWMR         (*(__IO uint32_t*)0x4001C04CU) /**< (TWIHS1) SleepWalking Matching Register */
+#define REG_TWIHS1_WPMR         (*(__IO uint32_t*)0x4001C0E4U) /**< (TWIHS1) Write Protection Mode Register */
+#define REG_TWIHS1_WPSR         (*(__I  uint32_t*)0x4001C0E8U) /**< (TWIHS1) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS1 peripheral ========== */
+#define TWIHS1_DMAC_ID_RX                        17         
+#define TWIHS1_DMAC_ID_TX                        16         
+#define TWIHS1_INSTANCE_ID                       20         
+#define TWIHS1_CLOCK_ID                          20         
+
+#endif /* _SAMV71_TWIHS1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/twihs2.h
+++ b/asf/sam/include/samv71b/instance/twihs2.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIHS2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_TWIHS2_INSTANCE_H_
+#define _SAMV71_TWIHS2_INSTANCE_H_
+
+/* ========== Register definition for TWIHS2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_TWIHS2_CR           (0x40060000) /**< (TWIHS2) Control Register */
+#define REG_TWIHS2_MMR          (0x40060004) /**< (TWIHS2) Master Mode Register */
+#define REG_TWIHS2_SMR          (0x40060008) /**< (TWIHS2) Slave Mode Register */
+#define REG_TWIHS2_IADR         (0x4006000C) /**< (TWIHS2) Internal Address Register */
+#define REG_TWIHS2_CWGR         (0x40060010) /**< (TWIHS2) Clock Waveform Generator Register */
+#define REG_TWIHS2_SR           (0x40060020) /**< (TWIHS2) Status Register */
+#define REG_TWIHS2_IER          (0x40060024) /**< (TWIHS2) Interrupt Enable Register */
+#define REG_TWIHS2_IDR          (0x40060028) /**< (TWIHS2) Interrupt Disable Register */
+#define REG_TWIHS2_IMR          (0x4006002C) /**< (TWIHS2) Interrupt Mask Register */
+#define REG_TWIHS2_RHR          (0x40060030) /**< (TWIHS2) Receive Holding Register */
+#define REG_TWIHS2_THR          (0x40060034) /**< (TWIHS2) Transmit Holding Register */
+#define REG_TWIHS2_SMBTR        (0x40060038) /**< (TWIHS2) SMBus Timing Register */
+#define REG_TWIHS2_FILTR        (0x40060044) /**< (TWIHS2) Filter Register */
+#define REG_TWIHS2_SWMR         (0x4006004C) /**< (TWIHS2) SleepWalking Matching Register */
+#define REG_TWIHS2_WPMR         (0x400600E4) /**< (TWIHS2) Write Protection Mode Register */
+#define REG_TWIHS2_WPSR         (0x400600E8) /**< (TWIHS2) Write Protection Status Register */
+
+#else
+
+#define REG_TWIHS2_CR           (*(__O  uint32_t*)0x40060000U) /**< (TWIHS2) Control Register */
+#define REG_TWIHS2_MMR          (*(__IO uint32_t*)0x40060004U) /**< (TWIHS2) Master Mode Register */
+#define REG_TWIHS2_SMR          (*(__IO uint32_t*)0x40060008U) /**< (TWIHS2) Slave Mode Register */
+#define REG_TWIHS2_IADR         (*(__IO uint32_t*)0x4006000CU) /**< (TWIHS2) Internal Address Register */
+#define REG_TWIHS2_CWGR         (*(__IO uint32_t*)0x40060010U) /**< (TWIHS2) Clock Waveform Generator Register */
+#define REG_TWIHS2_SR           (*(__I  uint32_t*)0x40060020U) /**< (TWIHS2) Status Register */
+#define REG_TWIHS2_IER          (*(__O  uint32_t*)0x40060024U) /**< (TWIHS2) Interrupt Enable Register */
+#define REG_TWIHS2_IDR          (*(__O  uint32_t*)0x40060028U) /**< (TWIHS2) Interrupt Disable Register */
+#define REG_TWIHS2_IMR          (*(__I  uint32_t*)0x4006002CU) /**< (TWIHS2) Interrupt Mask Register */
+#define REG_TWIHS2_RHR          (*(__I  uint32_t*)0x40060030U) /**< (TWIHS2) Receive Holding Register */
+#define REG_TWIHS2_THR          (*(__O  uint32_t*)0x40060034U) /**< (TWIHS2) Transmit Holding Register */
+#define REG_TWIHS2_SMBTR        (*(__IO uint32_t*)0x40060038U) /**< (TWIHS2) SMBus Timing Register */
+#define REG_TWIHS2_FILTR        (*(__IO uint32_t*)0x40060044U) /**< (TWIHS2) Filter Register */
+#define REG_TWIHS2_SWMR         (*(__IO uint32_t*)0x4006004CU) /**< (TWIHS2) SleepWalking Matching Register */
+#define REG_TWIHS2_WPMR         (*(__IO uint32_t*)0x400600E4U) /**< (TWIHS2) Write Protection Mode Register */
+#define REG_TWIHS2_WPSR         (*(__I  uint32_t*)0x400600E8U) /**< (TWIHS2) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for TWIHS2 peripheral ========== */
+#define TWIHS2_DMAC_ID_RX                        19         
+#define TWIHS2_DMAC_ID_TX                        18         
+#define TWIHS2_INSTANCE_ID                       41         
+#define TWIHS2_CLOCK_ID                          41         
+
+#endif /* _SAMV71_TWIHS2_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/uart0.h
+++ b/asf/sam/include/samv71b/instance/uart0.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART0_INSTANCE_H_
+#define _SAMV71_UART0_INSTANCE_H_
+
+/* ========== Register definition for UART0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART0_CR            (0x400E0800) /**< (UART0) Control Register */
+#define REG_UART0_MR            (0x400E0804) /**< (UART0) Mode Register */
+#define REG_UART0_IER           (0x400E0808) /**< (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR           (0x400E080C) /**< (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR           (0x400E0810) /**< (UART0) Interrupt Mask Register */
+#define REG_UART0_SR            (0x400E0814) /**< (UART0) Status Register */
+#define REG_UART0_RHR           (0x400E0818) /**< (UART0) Receive Holding Register */
+#define REG_UART0_THR           (0x400E081C) /**< (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR          (0x400E0820) /**< (UART0) Baud Rate Generator Register */
+#define REG_UART0_CMPR          (0x400E0824) /**< (UART0) Comparison Register */
+#define REG_UART0_WPMR          (0x400E08E4) /**< (UART0) Write Protection Mode Register */
+
+#else
+
+#define REG_UART0_CR            (*(__O  uint32_t*)0x400E0800U) /**< (UART0) Control Register */
+#define REG_UART0_MR            (*(__IO uint32_t*)0x400E0804U) /**< (UART0) Mode Register */
+#define REG_UART0_IER           (*(__O  uint32_t*)0x400E0808U) /**< (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR           (*(__O  uint32_t*)0x400E080CU) /**< (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR           (*(__I  uint32_t*)0x400E0810U) /**< (UART0) Interrupt Mask Register */
+#define REG_UART0_SR            (*(__I  uint32_t*)0x400E0814U) /**< (UART0) Status Register */
+#define REG_UART0_RHR           (*(__I  uint32_t*)0x400E0818U) /**< (UART0) Receive Holding Register */
+#define REG_UART0_THR           (*(__O  uint32_t*)0x400E081CU) /**< (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR          (*(__IO uint32_t*)0x400E0820U) /**< (UART0) Baud Rate Generator Register */
+#define REG_UART0_CMPR          (*(__IO uint32_t*)0x400E0824U) /**< (UART0) Comparison Register */
+#define REG_UART0_WPMR          (*(__IO uint32_t*)0x400E08E4U) /**< (UART0) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART0 peripheral ========== */
+#define UART0_DMAC_ID_RX                         21         
+#define UART0_DMAC_ID_TX                         20         
+#define UART0_INSTANCE_ID                        7          
+#define UART0_CLOCK_ID                           7          
+#define UART0_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART0_BRSRCCK_PMC_PCK                    0          /* PCK4 */
+
+#endif /* _SAMV71_UART0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/uart1.h
+++ b/asf/sam/include/samv71b/instance/uart1.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART1_INSTANCE_H_
+#define _SAMV71_UART1_INSTANCE_H_
+
+/* ========== Register definition for UART1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART1_CR            (0x400E0A00) /**< (UART1) Control Register */
+#define REG_UART1_MR            (0x400E0A04) /**< (UART1) Mode Register */
+#define REG_UART1_IER           (0x400E0A08) /**< (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR           (0x400E0A0C) /**< (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR           (0x400E0A10) /**< (UART1) Interrupt Mask Register */
+#define REG_UART1_SR            (0x400E0A14) /**< (UART1) Status Register */
+#define REG_UART1_RHR           (0x400E0A18) /**< (UART1) Receive Holding Register */
+#define REG_UART1_THR           (0x400E0A1C) /**< (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR          (0x400E0A20) /**< (UART1) Baud Rate Generator Register */
+#define REG_UART1_CMPR          (0x400E0A24) /**< (UART1) Comparison Register */
+#define REG_UART1_WPMR          (0x400E0AE4) /**< (UART1) Write Protection Mode Register */
+
+#else
+
+#define REG_UART1_CR            (*(__O  uint32_t*)0x400E0A00U) /**< (UART1) Control Register */
+#define REG_UART1_MR            (*(__IO uint32_t*)0x400E0A04U) /**< (UART1) Mode Register */
+#define REG_UART1_IER           (*(__O  uint32_t*)0x400E0A08U) /**< (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR           (*(__O  uint32_t*)0x400E0A0CU) /**< (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR           (*(__I  uint32_t*)0x400E0A10U) /**< (UART1) Interrupt Mask Register */
+#define REG_UART1_SR            (*(__I  uint32_t*)0x400E0A14U) /**< (UART1) Status Register */
+#define REG_UART1_RHR           (*(__I  uint32_t*)0x400E0A18U) /**< (UART1) Receive Holding Register */
+#define REG_UART1_THR           (*(__O  uint32_t*)0x400E0A1CU) /**< (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR          (*(__IO uint32_t*)0x400E0A20U) /**< (UART1) Baud Rate Generator Register */
+#define REG_UART1_CMPR          (*(__IO uint32_t*)0x400E0A24U) /**< (UART1) Comparison Register */
+#define REG_UART1_WPMR          (*(__IO uint32_t*)0x400E0AE4U) /**< (UART1) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART1 peripheral ========== */
+#define UART1_DMAC_ID_RX                         23         
+#define UART1_DMAC_ID_TX                         22         
+#define UART1_INSTANCE_ID                        8          
+#define UART1_CLOCK_ID                           8          
+#define UART1_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART1_BRSRCCK_PMC_PCK                    0          /* PCK4 */
+
+#endif /* _SAMV71_UART1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/uart2.h
+++ b/asf/sam/include/samv71b/instance/uart2.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART2_INSTANCE_H_
+#define _SAMV71_UART2_INSTANCE_H_
+
+/* ========== Register definition for UART2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART2_CR            (0x400E1A00) /**< (UART2) Control Register */
+#define REG_UART2_MR            (0x400E1A04) /**< (UART2) Mode Register */
+#define REG_UART2_IER           (0x400E1A08) /**< (UART2) Interrupt Enable Register */
+#define REG_UART2_IDR           (0x400E1A0C) /**< (UART2) Interrupt Disable Register */
+#define REG_UART2_IMR           (0x400E1A10) /**< (UART2) Interrupt Mask Register */
+#define REG_UART2_SR            (0x400E1A14) /**< (UART2) Status Register */
+#define REG_UART2_RHR           (0x400E1A18) /**< (UART2) Receive Holding Register */
+#define REG_UART2_THR           (0x400E1A1C) /**< (UART2) Transmit Holding Register */
+#define REG_UART2_BRGR          (0x400E1A20) /**< (UART2) Baud Rate Generator Register */
+#define REG_UART2_CMPR          (0x400E1A24) /**< (UART2) Comparison Register */
+#define REG_UART2_WPMR          (0x400E1AE4) /**< (UART2) Write Protection Mode Register */
+
+#else
+
+#define REG_UART2_CR            (*(__O  uint32_t*)0x400E1A00U) /**< (UART2) Control Register */
+#define REG_UART2_MR            (*(__IO uint32_t*)0x400E1A04U) /**< (UART2) Mode Register */
+#define REG_UART2_IER           (*(__O  uint32_t*)0x400E1A08U) /**< (UART2) Interrupt Enable Register */
+#define REG_UART2_IDR           (*(__O  uint32_t*)0x400E1A0CU) /**< (UART2) Interrupt Disable Register */
+#define REG_UART2_IMR           (*(__I  uint32_t*)0x400E1A10U) /**< (UART2) Interrupt Mask Register */
+#define REG_UART2_SR            (*(__I  uint32_t*)0x400E1A14U) /**< (UART2) Status Register */
+#define REG_UART2_RHR           (*(__I  uint32_t*)0x400E1A18U) /**< (UART2) Receive Holding Register */
+#define REG_UART2_THR           (*(__O  uint32_t*)0x400E1A1CU) /**< (UART2) Transmit Holding Register */
+#define REG_UART2_BRGR          (*(__IO uint32_t*)0x400E1A20U) /**< (UART2) Baud Rate Generator Register */
+#define REG_UART2_CMPR          (*(__IO uint32_t*)0x400E1A24U) /**< (UART2) Comparison Register */
+#define REG_UART2_WPMR          (*(__IO uint32_t*)0x400E1AE4U) /**< (UART2) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART2 peripheral ========== */
+#define UART2_DMAC_ID_RX                         25         
+#define UART2_DMAC_ID_TX                         24         
+#define UART2_INSTANCE_ID                        44         
+#define UART2_CLOCK_ID                           44         
+#define UART2_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART2_BRSRCCK_PMC_PCK                    0          /* PCK4 */
+
+#endif /* _SAMV71_UART2_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/uart3.h
+++ b/asf/sam/include/samv71b/instance/uart3.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART3
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART3_INSTANCE_H_
+#define _SAMV71_UART3_INSTANCE_H_
+
+/* ========== Register definition for UART3 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART3_CR            (0x400E1C00) /**< (UART3) Control Register */
+#define REG_UART3_MR            (0x400E1C04) /**< (UART3) Mode Register */
+#define REG_UART3_IER           (0x400E1C08) /**< (UART3) Interrupt Enable Register */
+#define REG_UART3_IDR           (0x400E1C0C) /**< (UART3) Interrupt Disable Register */
+#define REG_UART3_IMR           (0x400E1C10) /**< (UART3) Interrupt Mask Register */
+#define REG_UART3_SR            (0x400E1C14) /**< (UART3) Status Register */
+#define REG_UART3_RHR           (0x400E1C18) /**< (UART3) Receive Holding Register */
+#define REG_UART3_THR           (0x400E1C1C) /**< (UART3) Transmit Holding Register */
+#define REG_UART3_BRGR          (0x400E1C20) /**< (UART3) Baud Rate Generator Register */
+#define REG_UART3_CMPR          (0x400E1C24) /**< (UART3) Comparison Register */
+#define REG_UART3_WPMR          (0x400E1CE4) /**< (UART3) Write Protection Mode Register */
+
+#else
+
+#define REG_UART3_CR            (*(__O  uint32_t*)0x400E1C00U) /**< (UART3) Control Register */
+#define REG_UART3_MR            (*(__IO uint32_t*)0x400E1C04U) /**< (UART3) Mode Register */
+#define REG_UART3_IER           (*(__O  uint32_t*)0x400E1C08U) /**< (UART3) Interrupt Enable Register */
+#define REG_UART3_IDR           (*(__O  uint32_t*)0x400E1C0CU) /**< (UART3) Interrupt Disable Register */
+#define REG_UART3_IMR           (*(__I  uint32_t*)0x400E1C10U) /**< (UART3) Interrupt Mask Register */
+#define REG_UART3_SR            (*(__I  uint32_t*)0x400E1C14U) /**< (UART3) Status Register */
+#define REG_UART3_RHR           (*(__I  uint32_t*)0x400E1C18U) /**< (UART3) Receive Holding Register */
+#define REG_UART3_THR           (*(__O  uint32_t*)0x400E1C1CU) /**< (UART3) Transmit Holding Register */
+#define REG_UART3_BRGR          (*(__IO uint32_t*)0x400E1C20U) /**< (UART3) Baud Rate Generator Register */
+#define REG_UART3_CMPR          (*(__IO uint32_t*)0x400E1C24U) /**< (UART3) Comparison Register */
+#define REG_UART3_WPMR          (*(__IO uint32_t*)0x400E1CE4U) /**< (UART3) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART3 peripheral ========== */
+#define UART3_DMAC_ID_RX                         27         
+#define UART3_DMAC_ID_TX                         26         
+#define UART3_INSTANCE_ID                        45         
+#define UART3_CLOCK_ID                           45         
+#define UART3_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART3_BRSRCCK_PMC_PCK                    0          /* PCK4 */
+
+#endif /* _SAMV71_UART3_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/uart4.h
+++ b/asf/sam/include/samv71b/instance/uart4.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UART4
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UART4_INSTANCE_H_
+#define _SAMV71_UART4_INSTANCE_H_
+
+/* ========== Register definition for UART4 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UART4_CR            (0x400E1E00) /**< (UART4) Control Register */
+#define REG_UART4_MR            (0x400E1E04) /**< (UART4) Mode Register */
+#define REG_UART4_IER           (0x400E1E08) /**< (UART4) Interrupt Enable Register */
+#define REG_UART4_IDR           (0x400E1E0C) /**< (UART4) Interrupt Disable Register */
+#define REG_UART4_IMR           (0x400E1E10) /**< (UART4) Interrupt Mask Register */
+#define REG_UART4_SR            (0x400E1E14) /**< (UART4) Status Register */
+#define REG_UART4_RHR           (0x400E1E18) /**< (UART4) Receive Holding Register */
+#define REG_UART4_THR           (0x400E1E1C) /**< (UART4) Transmit Holding Register */
+#define REG_UART4_BRGR          (0x400E1E20) /**< (UART4) Baud Rate Generator Register */
+#define REG_UART4_CMPR          (0x400E1E24) /**< (UART4) Comparison Register */
+#define REG_UART4_WPMR          (0x400E1EE4) /**< (UART4) Write Protection Mode Register */
+
+#else
+
+#define REG_UART4_CR            (*(__O  uint32_t*)0x400E1E00U) /**< (UART4) Control Register */
+#define REG_UART4_MR            (*(__IO uint32_t*)0x400E1E04U) /**< (UART4) Mode Register */
+#define REG_UART4_IER           (*(__O  uint32_t*)0x400E1E08U) /**< (UART4) Interrupt Enable Register */
+#define REG_UART4_IDR           (*(__O  uint32_t*)0x400E1E0CU) /**< (UART4) Interrupt Disable Register */
+#define REG_UART4_IMR           (*(__I  uint32_t*)0x400E1E10U) /**< (UART4) Interrupt Mask Register */
+#define REG_UART4_SR            (*(__I  uint32_t*)0x400E1E14U) /**< (UART4) Status Register */
+#define REG_UART4_RHR           (*(__I  uint32_t*)0x400E1E18U) /**< (UART4) Receive Holding Register */
+#define REG_UART4_THR           (*(__O  uint32_t*)0x400E1E1CU) /**< (UART4) Transmit Holding Register */
+#define REG_UART4_BRGR          (*(__IO uint32_t*)0x400E1E20U) /**< (UART4) Baud Rate Generator Register */
+#define REG_UART4_CMPR          (*(__IO uint32_t*)0x400E1E24U) /**< (UART4) Comparison Register */
+#define REG_UART4_WPMR          (*(__IO uint32_t*)0x400E1EE4U) /**< (UART4) Write Protection Mode Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for UART4 peripheral ========== */
+#define UART4_DMAC_ID_RX                         29         
+#define UART4_DMAC_ID_TX                         28         
+#define UART4_INSTANCE_ID                        46         
+#define UART4_CLOCK_ID                           46         
+#define UART4_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART4_BRSRCCK_PMC_PCK                    0          /* PCK4 */
+
+#endif /* _SAMV71_UART4_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/usart0.h
+++ b/asf/sam/include/samv71b/instance/usart0.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART0
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USART0_INSTANCE_H_
+#define _SAMV71_USART0_INSTANCE_H_
+
+/* ========== Register definition for USART0 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART0_US_CR        (0x40024000) /**< (USART0) Control Register */
+#define REG_USART0_US_MR        (0x40024004) /**< (USART0) Mode Register */
+#define REG_USART0_US_IER       (0x40024008) /**< (USART0) Interrupt Enable Register */
+#define REG_USART0_US_IDR       (0x4002400C) /**< (USART0) Interrupt Disable Register */
+#define REG_USART0_US_IMR       (0x40024010) /**< (USART0) Interrupt Mask Register */
+#define REG_USART0_US_CSR       (0x40024014) /**< (USART0) Channel Status Register */
+#define REG_USART0_US_RHR       (0x40024018) /**< (USART0) Receive Holding Register */
+#define REG_USART0_US_THR       (0x4002401C) /**< (USART0) Transmit Holding Register */
+#define REG_USART0_US_BRGR      (0x40024020) /**< (USART0) Baud Rate Generator Register */
+#define REG_USART0_US_RTOR      (0x40024024) /**< (USART0) Receiver Timeout Register */
+#define REG_USART0_US_TTGR      (0x40024028) /**< (USART0) Transmitter Timeguard Register */
+#define REG_USART0_US_FIDI      (0x40024040) /**< (USART0) FI DI Ratio Register */
+#define REG_USART0_US_NER       (0x40024044) /**< (USART0) Number of Errors Register */
+#define REG_USART0_US_IF        (0x4002404C) /**< (USART0) IrDA Filter Register */
+#define REG_USART0_US_MAN       (0x40024050) /**< (USART0) Manchester Configuration Register */
+#define REG_USART0_US_LINMR     (0x40024054) /**< (USART0) LIN Mode Register */
+#define REG_USART0_US_LINIR     (0x40024058) /**< (USART0) LIN Identifier Register */
+#define REG_USART0_US_LINBRR    (0x4002405C) /**< (USART0) LIN Baud Rate Register */
+#define REG_USART0_US_LONMR     (0x40024060) /**< (USART0) LON Mode Register */
+#define REG_USART0_US_LONPR     (0x40024064) /**< (USART0) LON Preamble Register */
+#define REG_USART0_US_LONDL     (0x40024068) /**< (USART0) LON Data Length Register */
+#define REG_USART0_US_LONL2HDR  (0x4002406C) /**< (USART0) LON L2HDR Register */
+#define REG_USART0_US_LONBL     (0x40024070) /**< (USART0) LON Backlog Register */
+#define REG_USART0_US_LONB1TX   (0x40024074) /**< (USART0) LON Beta1 Tx Register */
+#define REG_USART0_US_LONB1RX   (0x40024078) /**< (USART0) LON Beta1 Rx Register */
+#define REG_USART0_US_LONPRIO   (0x4002407C) /**< (USART0) LON Priority Register */
+#define REG_USART0_US_IDTTX     (0x40024080) /**< (USART0) LON IDT Tx Register */
+#define REG_USART0_US_IDTRX     (0x40024084) /**< (USART0) LON IDT Rx Register */
+#define REG_USART0_US_ICDIFF    (0x40024088) /**< (USART0) IC DIFF Register */
+#define REG_USART0_US_WPMR      (0x400240E4) /**< (USART0) Write Protection Mode Register */
+#define REG_USART0_US_WPSR      (0x400240E8) /**< (USART0) Write Protection Status Register */
+
+#else
+
+#define REG_USART0_US_CR        (*(__O  uint32_t*)0x40024000U) /**< (USART0) Control Register */
+#define REG_USART0_US_MR        (*(__IO uint32_t*)0x40024004U) /**< (USART0) Mode Register */
+#define REG_USART0_US_IER       (*(__O  uint32_t*)0x40024008U) /**< (USART0) Interrupt Enable Register */
+#define REG_USART0_US_IDR       (*(__O  uint32_t*)0x4002400CU) /**< (USART0) Interrupt Disable Register */
+#define REG_USART0_US_IMR       (*(__I  uint32_t*)0x40024010U) /**< (USART0) Interrupt Mask Register */
+#define REG_USART0_US_CSR       (*(__I  uint32_t*)0x40024014U) /**< (USART0) Channel Status Register */
+#define REG_USART0_US_RHR       (*(__I  uint32_t*)0x40024018U) /**< (USART0) Receive Holding Register */
+#define REG_USART0_US_THR       (*(__O  uint32_t*)0x4002401CU) /**< (USART0) Transmit Holding Register */
+#define REG_USART0_US_BRGR      (*(__IO uint32_t*)0x40024020U) /**< (USART0) Baud Rate Generator Register */
+#define REG_USART0_US_RTOR      (*(__IO uint32_t*)0x40024024U) /**< (USART0) Receiver Timeout Register */
+#define REG_USART0_US_TTGR      (*(__IO uint32_t*)0x40024028U) /**< (USART0) Transmitter Timeguard Register */
+#define REG_USART0_US_FIDI      (*(__IO uint32_t*)0x40024040U) /**< (USART0) FI DI Ratio Register */
+#define REG_USART0_US_NER       (*(__I  uint32_t*)0x40024044U) /**< (USART0) Number of Errors Register */
+#define REG_USART0_US_IF        (*(__IO uint32_t*)0x4002404CU) /**< (USART0) IrDA Filter Register */
+#define REG_USART0_US_MAN       (*(__IO uint32_t*)0x40024050U) /**< (USART0) Manchester Configuration Register */
+#define REG_USART0_US_LINMR     (*(__IO uint32_t*)0x40024054U) /**< (USART0) LIN Mode Register */
+#define REG_USART0_US_LINIR     (*(__IO uint32_t*)0x40024058U) /**< (USART0) LIN Identifier Register */
+#define REG_USART0_US_LINBRR    (*(__I  uint32_t*)0x4002405CU) /**< (USART0) LIN Baud Rate Register */
+#define REG_USART0_US_LONMR     (*(__IO uint32_t*)0x40024060U) /**< (USART0) LON Mode Register */
+#define REG_USART0_US_LONPR     (*(__IO uint32_t*)0x40024064U) /**< (USART0) LON Preamble Register */
+#define REG_USART0_US_LONDL     (*(__IO uint32_t*)0x40024068U) /**< (USART0) LON Data Length Register */
+#define REG_USART0_US_LONL2HDR  (*(__IO uint32_t*)0x4002406CU) /**< (USART0) LON L2HDR Register */
+#define REG_USART0_US_LONBL     (*(__I  uint32_t*)0x40024070U) /**< (USART0) LON Backlog Register */
+#define REG_USART0_US_LONB1TX   (*(__IO uint32_t*)0x40024074U) /**< (USART0) LON Beta1 Tx Register */
+#define REG_USART0_US_LONB1RX   (*(__IO uint32_t*)0x40024078U) /**< (USART0) LON Beta1 Rx Register */
+#define REG_USART0_US_LONPRIO   (*(__IO uint32_t*)0x4002407CU) /**< (USART0) LON Priority Register */
+#define REG_USART0_US_IDTTX     (*(__IO uint32_t*)0x40024080U) /**< (USART0) LON IDT Tx Register */
+#define REG_USART0_US_IDTRX     (*(__IO uint32_t*)0x40024084U) /**< (USART0) LON IDT Rx Register */
+#define REG_USART0_US_ICDIFF    (*(__IO uint32_t*)0x40024088U) /**< (USART0) IC DIFF Register */
+#define REG_USART0_US_WPMR      (*(__IO uint32_t*)0x400240E4U) /**< (USART0) Write Protection Mode Register */
+#define REG_USART0_US_WPSR      (*(__I  uint32_t*)0x400240E8U) /**< (USART0) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART0 peripheral ========== */
+#define USART0_DMAC_ID_RX                        8          
+#define USART0_DMAC_ID_TX                        7          
+#define USART0_INSTANCE_ID                       13         
+#define USART0_CLOCK_ID                          13         
+#define USART0_USCLKS_MCK                        0          /* MCK */
+#define USART0_USCLKS_DIV                        1          /* MCK/8 */
+#define USART0_USCLKS_PCK                        2          /* PCK4 */
+#define USART0_USCLKS_SCK                        3          /* SCK */
+
+#endif /* _SAMV71_USART0_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/usart1.h
+++ b/asf/sam/include/samv71b/instance/usart1.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART1
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USART1_INSTANCE_H_
+#define _SAMV71_USART1_INSTANCE_H_
+
+/* ========== Register definition for USART1 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART1_US_CR        (0x40028000) /**< (USART1) Control Register */
+#define REG_USART1_US_MR        (0x40028004) /**< (USART1) Mode Register */
+#define REG_USART1_US_IER       (0x40028008) /**< (USART1) Interrupt Enable Register */
+#define REG_USART1_US_IDR       (0x4002800C) /**< (USART1) Interrupt Disable Register */
+#define REG_USART1_US_IMR       (0x40028010) /**< (USART1) Interrupt Mask Register */
+#define REG_USART1_US_CSR       (0x40028014) /**< (USART1) Channel Status Register */
+#define REG_USART1_US_RHR       (0x40028018) /**< (USART1) Receive Holding Register */
+#define REG_USART1_US_THR       (0x4002801C) /**< (USART1) Transmit Holding Register */
+#define REG_USART1_US_BRGR      (0x40028020) /**< (USART1) Baud Rate Generator Register */
+#define REG_USART1_US_RTOR      (0x40028024) /**< (USART1) Receiver Timeout Register */
+#define REG_USART1_US_TTGR      (0x40028028) /**< (USART1) Transmitter Timeguard Register */
+#define REG_USART1_US_FIDI      (0x40028040) /**< (USART1) FI DI Ratio Register */
+#define REG_USART1_US_NER       (0x40028044) /**< (USART1) Number of Errors Register */
+#define REG_USART1_US_IF        (0x4002804C) /**< (USART1) IrDA Filter Register */
+#define REG_USART1_US_MAN       (0x40028050) /**< (USART1) Manchester Configuration Register */
+#define REG_USART1_US_LINMR     (0x40028054) /**< (USART1) LIN Mode Register */
+#define REG_USART1_US_LINIR     (0x40028058) /**< (USART1) LIN Identifier Register */
+#define REG_USART1_US_LINBRR    (0x4002805C) /**< (USART1) LIN Baud Rate Register */
+#define REG_USART1_US_LONMR     (0x40028060) /**< (USART1) LON Mode Register */
+#define REG_USART1_US_LONPR     (0x40028064) /**< (USART1) LON Preamble Register */
+#define REG_USART1_US_LONDL     (0x40028068) /**< (USART1) LON Data Length Register */
+#define REG_USART1_US_LONL2HDR  (0x4002806C) /**< (USART1) LON L2HDR Register */
+#define REG_USART1_US_LONBL     (0x40028070) /**< (USART1) LON Backlog Register */
+#define REG_USART1_US_LONB1TX   (0x40028074) /**< (USART1) LON Beta1 Tx Register */
+#define REG_USART1_US_LONB1RX   (0x40028078) /**< (USART1) LON Beta1 Rx Register */
+#define REG_USART1_US_LONPRIO   (0x4002807C) /**< (USART1) LON Priority Register */
+#define REG_USART1_US_IDTTX     (0x40028080) /**< (USART1) LON IDT Tx Register */
+#define REG_USART1_US_IDTRX     (0x40028084) /**< (USART1) LON IDT Rx Register */
+#define REG_USART1_US_ICDIFF    (0x40028088) /**< (USART1) IC DIFF Register */
+#define REG_USART1_US_WPMR      (0x400280E4) /**< (USART1) Write Protection Mode Register */
+#define REG_USART1_US_WPSR      (0x400280E8) /**< (USART1) Write Protection Status Register */
+
+#else
+
+#define REG_USART1_US_CR        (*(__O  uint32_t*)0x40028000U) /**< (USART1) Control Register */
+#define REG_USART1_US_MR        (*(__IO uint32_t*)0x40028004U) /**< (USART1) Mode Register */
+#define REG_USART1_US_IER       (*(__O  uint32_t*)0x40028008U) /**< (USART1) Interrupt Enable Register */
+#define REG_USART1_US_IDR       (*(__O  uint32_t*)0x4002800CU) /**< (USART1) Interrupt Disable Register */
+#define REG_USART1_US_IMR       (*(__I  uint32_t*)0x40028010U) /**< (USART1) Interrupt Mask Register */
+#define REG_USART1_US_CSR       (*(__I  uint32_t*)0x40028014U) /**< (USART1) Channel Status Register */
+#define REG_USART1_US_RHR       (*(__I  uint32_t*)0x40028018U) /**< (USART1) Receive Holding Register */
+#define REG_USART1_US_THR       (*(__O  uint32_t*)0x4002801CU) /**< (USART1) Transmit Holding Register */
+#define REG_USART1_US_BRGR      (*(__IO uint32_t*)0x40028020U) /**< (USART1) Baud Rate Generator Register */
+#define REG_USART1_US_RTOR      (*(__IO uint32_t*)0x40028024U) /**< (USART1) Receiver Timeout Register */
+#define REG_USART1_US_TTGR      (*(__IO uint32_t*)0x40028028U) /**< (USART1) Transmitter Timeguard Register */
+#define REG_USART1_US_FIDI      (*(__IO uint32_t*)0x40028040U) /**< (USART1) FI DI Ratio Register */
+#define REG_USART1_US_NER       (*(__I  uint32_t*)0x40028044U) /**< (USART1) Number of Errors Register */
+#define REG_USART1_US_IF        (*(__IO uint32_t*)0x4002804CU) /**< (USART1) IrDA Filter Register */
+#define REG_USART1_US_MAN       (*(__IO uint32_t*)0x40028050U) /**< (USART1) Manchester Configuration Register */
+#define REG_USART1_US_LINMR     (*(__IO uint32_t*)0x40028054U) /**< (USART1) LIN Mode Register */
+#define REG_USART1_US_LINIR     (*(__IO uint32_t*)0x40028058U) /**< (USART1) LIN Identifier Register */
+#define REG_USART1_US_LINBRR    (*(__I  uint32_t*)0x4002805CU) /**< (USART1) LIN Baud Rate Register */
+#define REG_USART1_US_LONMR     (*(__IO uint32_t*)0x40028060U) /**< (USART1) LON Mode Register */
+#define REG_USART1_US_LONPR     (*(__IO uint32_t*)0x40028064U) /**< (USART1) LON Preamble Register */
+#define REG_USART1_US_LONDL     (*(__IO uint32_t*)0x40028068U) /**< (USART1) LON Data Length Register */
+#define REG_USART1_US_LONL2HDR  (*(__IO uint32_t*)0x4002806CU) /**< (USART1) LON L2HDR Register */
+#define REG_USART1_US_LONBL     (*(__I  uint32_t*)0x40028070U) /**< (USART1) LON Backlog Register */
+#define REG_USART1_US_LONB1TX   (*(__IO uint32_t*)0x40028074U) /**< (USART1) LON Beta1 Tx Register */
+#define REG_USART1_US_LONB1RX   (*(__IO uint32_t*)0x40028078U) /**< (USART1) LON Beta1 Rx Register */
+#define REG_USART1_US_LONPRIO   (*(__IO uint32_t*)0x4002807CU) /**< (USART1) LON Priority Register */
+#define REG_USART1_US_IDTTX     (*(__IO uint32_t*)0x40028080U) /**< (USART1) LON IDT Tx Register */
+#define REG_USART1_US_IDTRX     (*(__IO uint32_t*)0x40028084U) /**< (USART1) LON IDT Rx Register */
+#define REG_USART1_US_ICDIFF    (*(__IO uint32_t*)0x40028088U) /**< (USART1) IC DIFF Register */
+#define REG_USART1_US_WPMR      (*(__IO uint32_t*)0x400280E4U) /**< (USART1) Write Protection Mode Register */
+#define REG_USART1_US_WPSR      (*(__I  uint32_t*)0x400280E8U) /**< (USART1) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART1 peripheral ========== */
+#define USART1_DMAC_ID_RX                        10         
+#define USART1_DMAC_ID_TX                        9          
+#define USART1_INSTANCE_ID                       14         
+#define USART1_CLOCK_ID                          14         
+#define USART1_USCLKS_MCK                        0          /* MCK */
+#define USART1_USCLKS_DIV                        1          /* MCK/8 */
+#define USART1_USCLKS_PCK                        2          /* PCK4 */
+#define USART1_USCLKS_SCK                        3          /* SCK */
+
+#endif /* _SAMV71_USART1_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/usart2.h
+++ b/asf/sam/include/samv71b/instance/usart2.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART2
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USART2_INSTANCE_H_
+#define _SAMV71_USART2_INSTANCE_H_
+
+/* ========== Register definition for USART2 peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USART2_US_CR        (0x4002C000) /**< (USART2) Control Register */
+#define REG_USART2_US_MR        (0x4002C004) /**< (USART2) Mode Register */
+#define REG_USART2_US_IER       (0x4002C008) /**< (USART2) Interrupt Enable Register */
+#define REG_USART2_US_IDR       (0x4002C00C) /**< (USART2) Interrupt Disable Register */
+#define REG_USART2_US_IMR       (0x4002C010) /**< (USART2) Interrupt Mask Register */
+#define REG_USART2_US_CSR       (0x4002C014) /**< (USART2) Channel Status Register */
+#define REG_USART2_US_RHR       (0x4002C018) /**< (USART2) Receive Holding Register */
+#define REG_USART2_US_THR       (0x4002C01C) /**< (USART2) Transmit Holding Register */
+#define REG_USART2_US_BRGR      (0x4002C020) /**< (USART2) Baud Rate Generator Register */
+#define REG_USART2_US_RTOR      (0x4002C024) /**< (USART2) Receiver Timeout Register */
+#define REG_USART2_US_TTGR      (0x4002C028) /**< (USART2) Transmitter Timeguard Register */
+#define REG_USART2_US_FIDI      (0x4002C040) /**< (USART2) FI DI Ratio Register */
+#define REG_USART2_US_NER       (0x4002C044) /**< (USART2) Number of Errors Register */
+#define REG_USART2_US_IF        (0x4002C04C) /**< (USART2) IrDA Filter Register */
+#define REG_USART2_US_MAN       (0x4002C050) /**< (USART2) Manchester Configuration Register */
+#define REG_USART2_US_LINMR     (0x4002C054) /**< (USART2) LIN Mode Register */
+#define REG_USART2_US_LINIR     (0x4002C058) /**< (USART2) LIN Identifier Register */
+#define REG_USART2_US_LINBRR    (0x4002C05C) /**< (USART2) LIN Baud Rate Register */
+#define REG_USART2_US_LONMR     (0x4002C060) /**< (USART2) LON Mode Register */
+#define REG_USART2_US_LONPR     (0x4002C064) /**< (USART2) LON Preamble Register */
+#define REG_USART2_US_LONDL     (0x4002C068) /**< (USART2) LON Data Length Register */
+#define REG_USART2_US_LONL2HDR  (0x4002C06C) /**< (USART2) LON L2HDR Register */
+#define REG_USART2_US_LONBL     (0x4002C070) /**< (USART2) LON Backlog Register */
+#define REG_USART2_US_LONB1TX   (0x4002C074) /**< (USART2) LON Beta1 Tx Register */
+#define REG_USART2_US_LONB1RX   (0x4002C078) /**< (USART2) LON Beta1 Rx Register */
+#define REG_USART2_US_LONPRIO   (0x4002C07C) /**< (USART2) LON Priority Register */
+#define REG_USART2_US_IDTTX     (0x4002C080) /**< (USART2) LON IDT Tx Register */
+#define REG_USART2_US_IDTRX     (0x4002C084) /**< (USART2) LON IDT Rx Register */
+#define REG_USART2_US_ICDIFF    (0x4002C088) /**< (USART2) IC DIFF Register */
+#define REG_USART2_US_WPMR      (0x4002C0E4) /**< (USART2) Write Protection Mode Register */
+#define REG_USART2_US_WPSR      (0x4002C0E8) /**< (USART2) Write Protection Status Register */
+
+#else
+
+#define REG_USART2_US_CR        (*(__O  uint32_t*)0x4002C000U) /**< (USART2) Control Register */
+#define REG_USART2_US_MR        (*(__IO uint32_t*)0x4002C004U) /**< (USART2) Mode Register */
+#define REG_USART2_US_IER       (*(__O  uint32_t*)0x4002C008U) /**< (USART2) Interrupt Enable Register */
+#define REG_USART2_US_IDR       (*(__O  uint32_t*)0x4002C00CU) /**< (USART2) Interrupt Disable Register */
+#define REG_USART2_US_IMR       (*(__I  uint32_t*)0x4002C010U) /**< (USART2) Interrupt Mask Register */
+#define REG_USART2_US_CSR       (*(__I  uint32_t*)0x4002C014U) /**< (USART2) Channel Status Register */
+#define REG_USART2_US_RHR       (*(__I  uint32_t*)0x4002C018U) /**< (USART2) Receive Holding Register */
+#define REG_USART2_US_THR       (*(__O  uint32_t*)0x4002C01CU) /**< (USART2) Transmit Holding Register */
+#define REG_USART2_US_BRGR      (*(__IO uint32_t*)0x4002C020U) /**< (USART2) Baud Rate Generator Register */
+#define REG_USART2_US_RTOR      (*(__IO uint32_t*)0x4002C024U) /**< (USART2) Receiver Timeout Register */
+#define REG_USART2_US_TTGR      (*(__IO uint32_t*)0x4002C028U) /**< (USART2) Transmitter Timeguard Register */
+#define REG_USART2_US_FIDI      (*(__IO uint32_t*)0x4002C040U) /**< (USART2) FI DI Ratio Register */
+#define REG_USART2_US_NER       (*(__I  uint32_t*)0x4002C044U) /**< (USART2) Number of Errors Register */
+#define REG_USART2_US_IF        (*(__IO uint32_t*)0x4002C04CU) /**< (USART2) IrDA Filter Register */
+#define REG_USART2_US_MAN       (*(__IO uint32_t*)0x4002C050U) /**< (USART2) Manchester Configuration Register */
+#define REG_USART2_US_LINMR     (*(__IO uint32_t*)0x4002C054U) /**< (USART2) LIN Mode Register */
+#define REG_USART2_US_LINIR     (*(__IO uint32_t*)0x4002C058U) /**< (USART2) LIN Identifier Register */
+#define REG_USART2_US_LINBRR    (*(__I  uint32_t*)0x4002C05CU) /**< (USART2) LIN Baud Rate Register */
+#define REG_USART2_US_LONMR     (*(__IO uint32_t*)0x4002C060U) /**< (USART2) LON Mode Register */
+#define REG_USART2_US_LONPR     (*(__IO uint32_t*)0x4002C064U) /**< (USART2) LON Preamble Register */
+#define REG_USART2_US_LONDL     (*(__IO uint32_t*)0x4002C068U) /**< (USART2) LON Data Length Register */
+#define REG_USART2_US_LONL2HDR  (*(__IO uint32_t*)0x4002C06CU) /**< (USART2) LON L2HDR Register */
+#define REG_USART2_US_LONBL     (*(__I  uint32_t*)0x4002C070U) /**< (USART2) LON Backlog Register */
+#define REG_USART2_US_LONB1TX   (*(__IO uint32_t*)0x4002C074U) /**< (USART2) LON Beta1 Tx Register */
+#define REG_USART2_US_LONB1RX   (*(__IO uint32_t*)0x4002C078U) /**< (USART2) LON Beta1 Rx Register */
+#define REG_USART2_US_LONPRIO   (*(__IO uint32_t*)0x4002C07CU) /**< (USART2) LON Priority Register */
+#define REG_USART2_US_IDTTX     (*(__IO uint32_t*)0x4002C080U) /**< (USART2) LON IDT Tx Register */
+#define REG_USART2_US_IDTRX     (*(__IO uint32_t*)0x4002C084U) /**< (USART2) LON IDT Rx Register */
+#define REG_USART2_US_ICDIFF    (*(__IO uint32_t*)0x4002C088U) /**< (USART2) IC DIFF Register */
+#define REG_USART2_US_WPMR      (*(__IO uint32_t*)0x4002C0E4U) /**< (USART2) Write Protection Mode Register */
+#define REG_USART2_US_WPSR      (*(__I  uint32_t*)0x4002C0E8U) /**< (USART2) Write Protection Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USART2 peripheral ========== */
+#define USART2_DMAC_ID_RX                        12         
+#define USART2_DMAC_ID_TX                        11         
+#define USART2_INSTANCE_ID                       15         
+#define USART2_CLOCK_ID                          15         
+#define USART2_USCLKS_MCK                        0          /* MCK */
+#define USART2_USCLKS_DIV                        1          /* MCK/8 */
+#define USART2_USCLKS_PCK                        2          /* PCK4 */
+#define USART2_USCLKS_SCK                        3          /* SCK */
+
+#endif /* _SAMV71_USART2_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/usbhs.h
+++ b/asf/sam/include/samv71b/instance/usbhs.h
@@ -1,0 +1,561 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USBHS
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_USBHS_INSTANCE_H_
+#define _SAMV71_USBHS_INSTANCE_H_
+
+/* ========== Register definition for USBHS peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_USBHS_DEVDMANXTDSC0 (0x40038310) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (0x40038314) /**< (USBHS) Device DMA Channel Address Register 0 */
+#define REG_USBHS_DEVDMACONTROL0 (0x40038318) /**< (USBHS) Device DMA Channel Control Register 0 */
+#define REG_USBHS_DEVDMASTATUS0 (0x4003831C) /**< (USBHS) Device DMA Channel Status Register 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (0x40038320) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (0x40038324) /**< (USBHS) Device DMA Channel Address Register 1 */
+#define REG_USBHS_DEVDMACONTROL1 (0x40038328) /**< (USBHS) Device DMA Channel Control Register 1 */
+#define REG_USBHS_DEVDMASTATUS1 (0x4003832C) /**< (USBHS) Device DMA Channel Status Register 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (0x40038330) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (0x40038334) /**< (USBHS) Device DMA Channel Address Register 2 */
+#define REG_USBHS_DEVDMACONTROL2 (0x40038338) /**< (USBHS) Device DMA Channel Control Register 2 */
+#define REG_USBHS_DEVDMASTATUS2 (0x4003833C) /**< (USBHS) Device DMA Channel Status Register 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (0x40038340) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (0x40038344) /**< (USBHS) Device DMA Channel Address Register 3 */
+#define REG_USBHS_DEVDMACONTROL3 (0x40038348) /**< (USBHS) Device DMA Channel Control Register 3 */
+#define REG_USBHS_DEVDMASTATUS3 (0x4003834C) /**< (USBHS) Device DMA Channel Status Register 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (0x40038350) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (0x40038354) /**< (USBHS) Device DMA Channel Address Register 4 */
+#define REG_USBHS_DEVDMACONTROL4 (0x40038358) /**< (USBHS) Device DMA Channel Control Register 4 */
+#define REG_USBHS_DEVDMASTATUS4 (0x4003835C) /**< (USBHS) Device DMA Channel Status Register 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (0x40038360) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (0x40038364) /**< (USBHS) Device DMA Channel Address Register 5 */
+#define REG_USBHS_DEVDMACONTROL5 (0x40038368) /**< (USBHS) Device DMA Channel Control Register 5 */
+#define REG_USBHS_DEVDMASTATUS5 (0x4003836C) /**< (USBHS) Device DMA Channel Status Register 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (0x40038370) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (0x40038374) /**< (USBHS) Device DMA Channel Address Register 6 */
+#define REG_USBHS_DEVDMACONTROL6 (0x40038378) /**< (USBHS) Device DMA Channel Control Register 6 */
+#define REG_USBHS_DEVDMASTATUS6 (0x4003837C) /**< (USBHS) Device DMA Channel Status Register 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (0x40038710) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (0x40038714) /**< (USBHS) Host DMA Channel Address Register 0 */
+#define REG_USBHS_HSTDMACONTROL0 (0x40038718) /**< (USBHS) Host DMA Channel Control Register 0 */
+#define REG_USBHS_HSTDMASTATUS0 (0x4003871C) /**< (USBHS) Host DMA Channel Status Register 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (0x40038720) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (0x40038724) /**< (USBHS) Host DMA Channel Address Register 1 */
+#define REG_USBHS_HSTDMACONTROL1 (0x40038728) /**< (USBHS) Host DMA Channel Control Register 1 */
+#define REG_USBHS_HSTDMASTATUS1 (0x4003872C) /**< (USBHS) Host DMA Channel Status Register 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (0x40038730) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (0x40038734) /**< (USBHS) Host DMA Channel Address Register 2 */
+#define REG_USBHS_HSTDMACONTROL2 (0x40038738) /**< (USBHS) Host DMA Channel Control Register 2 */
+#define REG_USBHS_HSTDMASTATUS2 (0x4003873C) /**< (USBHS) Host DMA Channel Status Register 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (0x40038740) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (0x40038744) /**< (USBHS) Host DMA Channel Address Register 3 */
+#define REG_USBHS_HSTDMACONTROL3 (0x40038748) /**< (USBHS) Host DMA Channel Control Register 3 */
+#define REG_USBHS_HSTDMASTATUS3 (0x4003874C) /**< (USBHS) Host DMA Channel Status Register 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (0x40038750) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (0x40038754) /**< (USBHS) Host DMA Channel Address Register 4 */
+#define REG_USBHS_HSTDMACONTROL4 (0x40038758) /**< (USBHS) Host DMA Channel Control Register 4 */
+#define REG_USBHS_HSTDMASTATUS4 (0x4003875C) /**< (USBHS) Host DMA Channel Status Register 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (0x40038760) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (0x40038764) /**< (USBHS) Host DMA Channel Address Register 5 */
+#define REG_USBHS_HSTDMACONTROL5 (0x40038768) /**< (USBHS) Host DMA Channel Control Register 5 */
+#define REG_USBHS_HSTDMASTATUS5 (0x4003876C) /**< (USBHS) Host DMA Channel Status Register 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (0x40038770) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (0x40038774) /**< (USBHS) Host DMA Channel Address Register 6 */
+#define REG_USBHS_HSTDMACONTROL6 (0x40038778) /**< (USBHS) Host DMA Channel Control Register 6 */
+#define REG_USBHS_HSTDMASTATUS6 (0x4003877C) /**< (USBHS) Host DMA Channel Status Register 6 */
+#define REG_USBHS_DEVCTRL       (0x40038000) /**< (USBHS) Device General Control Register */
+#define REG_USBHS_DEVISR        (0x40038004) /**< (USBHS) Device Global Interrupt Status Register */
+#define REG_USBHS_DEVICR        (0x40038008) /**< (USBHS) Device Global Interrupt Clear Register */
+#define REG_USBHS_DEVIFR        (0x4003800C) /**< (USBHS) Device Global Interrupt Set Register */
+#define REG_USBHS_DEVIMR        (0x40038010) /**< (USBHS) Device Global Interrupt Mask Register */
+#define REG_USBHS_DEVIDR        (0x40038014) /**< (USBHS) Device Global Interrupt Disable Register */
+#define REG_USBHS_DEVIER        (0x40038018) /**< (USBHS) Device Global Interrupt Enable Register */
+#define REG_USBHS_DEVEPT        (0x4003801C) /**< (USBHS) Device Endpoint Register */
+#define REG_USBHS_DEVFNUM       (0x40038020) /**< (USBHS) Device Frame Number Register */
+#define REG_USBHS_DEVEPTCFG     (0x40038100) /**< (USBHS) Device Endpoint Configuration Register */
+#define REG_USBHS_DEVEPTCFG0    (0x40038100) /**< (USBHS) Device Endpoint Configuration Register 0 */
+#define REG_USBHS_DEVEPTCFG1    (0x40038104) /**< (USBHS) Device Endpoint Configuration Register 1 */
+#define REG_USBHS_DEVEPTCFG2    (0x40038108) /**< (USBHS) Device Endpoint Configuration Register 2 */
+#define REG_USBHS_DEVEPTCFG3    (0x4003810C) /**< (USBHS) Device Endpoint Configuration Register 3 */
+#define REG_USBHS_DEVEPTCFG4    (0x40038110) /**< (USBHS) Device Endpoint Configuration Register 4 */
+#define REG_USBHS_DEVEPTCFG5    (0x40038114) /**< (USBHS) Device Endpoint Configuration Register 5 */
+#define REG_USBHS_DEVEPTCFG6    (0x40038118) /**< (USBHS) Device Endpoint Configuration Register 6 */
+#define REG_USBHS_DEVEPTCFG7    (0x4003811C) /**< (USBHS) Device Endpoint Configuration Register 7 */
+#define REG_USBHS_DEVEPTCFG8    (0x40038120) /**< (USBHS) Device Endpoint Configuration Register 8 */
+#define REG_USBHS_DEVEPTCFG9    (0x40038124) /**< (USBHS) Device Endpoint Configuration Register 9 */
+#define REG_USBHS_DEVEPTISR     (0x40038130) /**< (USBHS) Device Endpoint Interrupt Status Register */
+#define REG_USBHS_DEVEPTISR0    (0x40038130) /**< (USBHS) Device Endpoint Interrupt Status Register 0 */
+#define REG_USBHS_DEVEPTISR1    (0x40038134) /**< (USBHS) Device Endpoint Interrupt Status Register 1 */
+#define REG_USBHS_DEVEPTISR2    (0x40038138) /**< (USBHS) Device Endpoint Interrupt Status Register 2 */
+#define REG_USBHS_DEVEPTISR3    (0x4003813C) /**< (USBHS) Device Endpoint Interrupt Status Register 3 */
+#define REG_USBHS_DEVEPTISR4    (0x40038140) /**< (USBHS) Device Endpoint Interrupt Status Register 4 */
+#define REG_USBHS_DEVEPTISR5    (0x40038144) /**< (USBHS) Device Endpoint Interrupt Status Register 5 */
+#define REG_USBHS_DEVEPTISR6    (0x40038148) /**< (USBHS) Device Endpoint Interrupt Status Register 6 */
+#define REG_USBHS_DEVEPTISR7    (0x4003814C) /**< (USBHS) Device Endpoint Interrupt Status Register 7 */
+#define REG_USBHS_DEVEPTISR8    (0x40038150) /**< (USBHS) Device Endpoint Interrupt Status Register 8 */
+#define REG_USBHS_DEVEPTISR9    (0x40038154) /**< (USBHS) Device Endpoint Interrupt Status Register 9 */
+#define REG_USBHS_DEVEPTICR     (0x40038160) /**< (USBHS) Device Endpoint Interrupt Clear Register */
+#define REG_USBHS_DEVEPTICR0    (0x40038160) /**< (USBHS) Device Endpoint Interrupt Clear Register 0 */
+#define REG_USBHS_DEVEPTICR1    (0x40038164) /**< (USBHS) Device Endpoint Interrupt Clear Register 1 */
+#define REG_USBHS_DEVEPTICR2    (0x40038168) /**< (USBHS) Device Endpoint Interrupt Clear Register 2 */
+#define REG_USBHS_DEVEPTICR3    (0x4003816C) /**< (USBHS) Device Endpoint Interrupt Clear Register 3 */
+#define REG_USBHS_DEVEPTICR4    (0x40038170) /**< (USBHS) Device Endpoint Interrupt Clear Register 4 */
+#define REG_USBHS_DEVEPTICR5    (0x40038174) /**< (USBHS) Device Endpoint Interrupt Clear Register 5 */
+#define REG_USBHS_DEVEPTICR6    (0x40038178) /**< (USBHS) Device Endpoint Interrupt Clear Register 6 */
+#define REG_USBHS_DEVEPTICR7    (0x4003817C) /**< (USBHS) Device Endpoint Interrupt Clear Register 7 */
+#define REG_USBHS_DEVEPTICR8    (0x40038180) /**< (USBHS) Device Endpoint Interrupt Clear Register 8 */
+#define REG_USBHS_DEVEPTICR9    (0x40038184) /**< (USBHS) Device Endpoint Interrupt Clear Register 9 */
+#define REG_USBHS_DEVEPTIFR     (0x40038190) /**< (USBHS) Device Endpoint Interrupt Set Register */
+#define REG_USBHS_DEVEPTIFR0    (0x40038190) /**< (USBHS) Device Endpoint Interrupt Set Register 0 */
+#define REG_USBHS_DEVEPTIFR1    (0x40038194) /**< (USBHS) Device Endpoint Interrupt Set Register 1 */
+#define REG_USBHS_DEVEPTIFR2    (0x40038198) /**< (USBHS) Device Endpoint Interrupt Set Register 2 */
+#define REG_USBHS_DEVEPTIFR3    (0x4003819C) /**< (USBHS) Device Endpoint Interrupt Set Register 3 */
+#define REG_USBHS_DEVEPTIFR4    (0x400381A0) /**< (USBHS) Device Endpoint Interrupt Set Register 4 */
+#define REG_USBHS_DEVEPTIFR5    (0x400381A4) /**< (USBHS) Device Endpoint Interrupt Set Register 5 */
+#define REG_USBHS_DEVEPTIFR6    (0x400381A8) /**< (USBHS) Device Endpoint Interrupt Set Register 6 */
+#define REG_USBHS_DEVEPTIFR7    (0x400381AC) /**< (USBHS) Device Endpoint Interrupt Set Register 7 */
+#define REG_USBHS_DEVEPTIFR8    (0x400381B0) /**< (USBHS) Device Endpoint Interrupt Set Register 8 */
+#define REG_USBHS_DEVEPTIFR9    (0x400381B4) /**< (USBHS) Device Endpoint Interrupt Set Register 9 */
+#define REG_USBHS_DEVEPTIMR     (0x400381C0) /**< (USBHS) Device Endpoint Interrupt Mask Register */
+#define REG_USBHS_DEVEPTIMR0    (0x400381C0) /**< (USBHS) Device Endpoint Interrupt Mask Register 0 */
+#define REG_USBHS_DEVEPTIMR1    (0x400381C4) /**< (USBHS) Device Endpoint Interrupt Mask Register 1 */
+#define REG_USBHS_DEVEPTIMR2    (0x400381C8) /**< (USBHS) Device Endpoint Interrupt Mask Register 2 */
+#define REG_USBHS_DEVEPTIMR3    (0x400381CC) /**< (USBHS) Device Endpoint Interrupt Mask Register 3 */
+#define REG_USBHS_DEVEPTIMR4    (0x400381D0) /**< (USBHS) Device Endpoint Interrupt Mask Register 4 */
+#define REG_USBHS_DEVEPTIMR5    (0x400381D4) /**< (USBHS) Device Endpoint Interrupt Mask Register 5 */
+#define REG_USBHS_DEVEPTIMR6    (0x400381D8) /**< (USBHS) Device Endpoint Interrupt Mask Register 6 */
+#define REG_USBHS_DEVEPTIMR7    (0x400381DC) /**< (USBHS) Device Endpoint Interrupt Mask Register 7 */
+#define REG_USBHS_DEVEPTIMR8    (0x400381E0) /**< (USBHS) Device Endpoint Interrupt Mask Register 8 */
+#define REG_USBHS_DEVEPTIMR9    (0x400381E4) /**< (USBHS) Device Endpoint Interrupt Mask Register 9 */
+#define REG_USBHS_DEVEPTIER     (0x400381F0) /**< (USBHS) Device Endpoint Interrupt Enable Register */
+#define REG_USBHS_DEVEPTIER0    (0x400381F0) /**< (USBHS) Device Endpoint Interrupt Enable Register 0 */
+#define REG_USBHS_DEVEPTIER1    (0x400381F4) /**< (USBHS) Device Endpoint Interrupt Enable Register 1 */
+#define REG_USBHS_DEVEPTIER2    (0x400381F8) /**< (USBHS) Device Endpoint Interrupt Enable Register 2 */
+#define REG_USBHS_DEVEPTIER3    (0x400381FC) /**< (USBHS) Device Endpoint Interrupt Enable Register 3 */
+#define REG_USBHS_DEVEPTIER4    (0x40038200) /**< (USBHS) Device Endpoint Interrupt Enable Register 4 */
+#define REG_USBHS_DEVEPTIER5    (0x40038204) /**< (USBHS) Device Endpoint Interrupt Enable Register 5 */
+#define REG_USBHS_DEVEPTIER6    (0x40038208) /**< (USBHS) Device Endpoint Interrupt Enable Register 6 */
+#define REG_USBHS_DEVEPTIER7    (0x4003820C) /**< (USBHS) Device Endpoint Interrupt Enable Register 7 */
+#define REG_USBHS_DEVEPTIER8    (0x40038210) /**< (USBHS) Device Endpoint Interrupt Enable Register 8 */
+#define REG_USBHS_DEVEPTIER9    (0x40038214) /**< (USBHS) Device Endpoint Interrupt Enable Register 9 */
+#define REG_USBHS_DEVEPTIDR     (0x40038220) /**< (USBHS) Device Endpoint Interrupt Disable Register */
+#define REG_USBHS_DEVEPTIDR0    (0x40038220) /**< (USBHS) Device Endpoint Interrupt Disable Register 0 */
+#define REG_USBHS_DEVEPTIDR1    (0x40038224) /**< (USBHS) Device Endpoint Interrupt Disable Register 1 */
+#define REG_USBHS_DEVEPTIDR2    (0x40038228) /**< (USBHS) Device Endpoint Interrupt Disable Register 2 */
+#define REG_USBHS_DEVEPTIDR3    (0x4003822C) /**< (USBHS) Device Endpoint Interrupt Disable Register 3 */
+#define REG_USBHS_DEVEPTIDR4    (0x40038230) /**< (USBHS) Device Endpoint Interrupt Disable Register 4 */
+#define REG_USBHS_DEVEPTIDR5    (0x40038234) /**< (USBHS) Device Endpoint Interrupt Disable Register 5 */
+#define REG_USBHS_DEVEPTIDR6    (0x40038238) /**< (USBHS) Device Endpoint Interrupt Disable Register 6 */
+#define REG_USBHS_DEVEPTIDR7    (0x4003823C) /**< (USBHS) Device Endpoint Interrupt Disable Register 7 */
+#define REG_USBHS_DEVEPTIDR8    (0x40038240) /**< (USBHS) Device Endpoint Interrupt Disable Register 8 */
+#define REG_USBHS_DEVEPTIDR9    (0x40038244) /**< (USBHS) Device Endpoint Interrupt Disable Register 9 */
+#define REG_USBHS_HSTCTRL       (0x40038400) /**< (USBHS) Host General Control Register */
+#define REG_USBHS_HSTISR        (0x40038404) /**< (USBHS) Host Global Interrupt Status Register */
+#define REG_USBHS_HSTICR        (0x40038408) /**< (USBHS) Host Global Interrupt Clear Register */
+#define REG_USBHS_HSTIFR        (0x4003840C) /**< (USBHS) Host Global Interrupt Set Register */
+#define REG_USBHS_HSTIMR        (0x40038410) /**< (USBHS) Host Global Interrupt Mask Register */
+#define REG_USBHS_HSTIDR        (0x40038414) /**< (USBHS) Host Global Interrupt Disable Register */
+#define REG_USBHS_HSTIER        (0x40038418) /**< (USBHS) Host Global Interrupt Enable Register */
+#define REG_USBHS_HSTPIP        (0x4003841C) /**< (USBHS) Host Pipe Register */
+#define REG_USBHS_HSTFNUM       (0x40038420) /**< (USBHS) Host Frame Number Register */
+#define REG_USBHS_HSTADDR1      (0x40038424) /**< (USBHS) Host Address 1 Register */
+#define REG_USBHS_HSTADDR2      (0x40038428) /**< (USBHS) Host Address 2 Register */
+#define REG_USBHS_HSTADDR3      (0x4003842C) /**< (USBHS) Host Address 3 Register */
+#define REG_USBHS_HSTPIPCFG     (0x40038500) /**< (USBHS) Host Pipe Configuration Register */
+#define REG_USBHS_HSTPIPCFG0    (0x40038500) /**< (USBHS) Host Pipe Configuration Register 0 */
+#define REG_USBHS_HSTPIPCFG1    (0x40038504) /**< (USBHS) Host Pipe Configuration Register 1 */
+#define REG_USBHS_HSTPIPCFG2    (0x40038508) /**< (USBHS) Host Pipe Configuration Register 2 */
+#define REG_USBHS_HSTPIPCFG3    (0x4003850C) /**< (USBHS) Host Pipe Configuration Register 3 */
+#define REG_USBHS_HSTPIPCFG4    (0x40038510) /**< (USBHS) Host Pipe Configuration Register 4 */
+#define REG_USBHS_HSTPIPCFG5    (0x40038514) /**< (USBHS) Host Pipe Configuration Register 5 */
+#define REG_USBHS_HSTPIPCFG6    (0x40038518) /**< (USBHS) Host Pipe Configuration Register 6 */
+#define REG_USBHS_HSTPIPCFG7    (0x4003851C) /**< (USBHS) Host Pipe Configuration Register 7 */
+#define REG_USBHS_HSTPIPCFG8    (0x40038520) /**< (USBHS) Host Pipe Configuration Register 8 */
+#define REG_USBHS_HSTPIPCFG9    (0x40038524) /**< (USBHS) Host Pipe Configuration Register 9 */
+#define REG_USBHS_HSTPIPISR     (0x40038530) /**< (USBHS) Host Pipe Status Register */
+#define REG_USBHS_HSTPIPISR0    (0x40038530) /**< (USBHS) Host Pipe Status Register 0 */
+#define REG_USBHS_HSTPIPISR1    (0x40038534) /**< (USBHS) Host Pipe Status Register 1 */
+#define REG_USBHS_HSTPIPISR2    (0x40038538) /**< (USBHS) Host Pipe Status Register 2 */
+#define REG_USBHS_HSTPIPISR3    (0x4003853C) /**< (USBHS) Host Pipe Status Register 3 */
+#define REG_USBHS_HSTPIPISR4    (0x40038540) /**< (USBHS) Host Pipe Status Register 4 */
+#define REG_USBHS_HSTPIPISR5    (0x40038544) /**< (USBHS) Host Pipe Status Register 5 */
+#define REG_USBHS_HSTPIPISR6    (0x40038548) /**< (USBHS) Host Pipe Status Register 6 */
+#define REG_USBHS_HSTPIPISR7    (0x4003854C) /**< (USBHS) Host Pipe Status Register 7 */
+#define REG_USBHS_HSTPIPISR8    (0x40038550) /**< (USBHS) Host Pipe Status Register 8 */
+#define REG_USBHS_HSTPIPISR9    (0x40038554) /**< (USBHS) Host Pipe Status Register 9 */
+#define REG_USBHS_HSTPIPICR     (0x40038560) /**< (USBHS) Host Pipe Clear Register */
+#define REG_USBHS_HSTPIPICR0    (0x40038560) /**< (USBHS) Host Pipe Clear Register 0 */
+#define REG_USBHS_HSTPIPICR1    (0x40038564) /**< (USBHS) Host Pipe Clear Register 1 */
+#define REG_USBHS_HSTPIPICR2    (0x40038568) /**< (USBHS) Host Pipe Clear Register 2 */
+#define REG_USBHS_HSTPIPICR3    (0x4003856C) /**< (USBHS) Host Pipe Clear Register 3 */
+#define REG_USBHS_HSTPIPICR4    (0x40038570) /**< (USBHS) Host Pipe Clear Register 4 */
+#define REG_USBHS_HSTPIPICR5    (0x40038574) /**< (USBHS) Host Pipe Clear Register 5 */
+#define REG_USBHS_HSTPIPICR6    (0x40038578) /**< (USBHS) Host Pipe Clear Register 6 */
+#define REG_USBHS_HSTPIPICR7    (0x4003857C) /**< (USBHS) Host Pipe Clear Register 7 */
+#define REG_USBHS_HSTPIPICR8    (0x40038580) /**< (USBHS) Host Pipe Clear Register 8 */
+#define REG_USBHS_HSTPIPICR9    (0x40038584) /**< (USBHS) Host Pipe Clear Register 9 */
+#define REG_USBHS_HSTPIPIFR     (0x40038590) /**< (USBHS) Host Pipe Set Register */
+#define REG_USBHS_HSTPIPIFR0    (0x40038590) /**< (USBHS) Host Pipe Set Register 0 */
+#define REG_USBHS_HSTPIPIFR1    (0x40038594) /**< (USBHS) Host Pipe Set Register 1 */
+#define REG_USBHS_HSTPIPIFR2    (0x40038598) /**< (USBHS) Host Pipe Set Register 2 */
+#define REG_USBHS_HSTPIPIFR3    (0x4003859C) /**< (USBHS) Host Pipe Set Register 3 */
+#define REG_USBHS_HSTPIPIFR4    (0x400385A0) /**< (USBHS) Host Pipe Set Register 4 */
+#define REG_USBHS_HSTPIPIFR5    (0x400385A4) /**< (USBHS) Host Pipe Set Register 5 */
+#define REG_USBHS_HSTPIPIFR6    (0x400385A8) /**< (USBHS) Host Pipe Set Register 6 */
+#define REG_USBHS_HSTPIPIFR7    (0x400385AC) /**< (USBHS) Host Pipe Set Register 7 */
+#define REG_USBHS_HSTPIPIFR8    (0x400385B0) /**< (USBHS) Host Pipe Set Register 8 */
+#define REG_USBHS_HSTPIPIFR9    (0x400385B4) /**< (USBHS) Host Pipe Set Register 9 */
+#define REG_USBHS_HSTPIPIMR     (0x400385C0) /**< (USBHS) Host Pipe Mask Register */
+#define REG_USBHS_HSTPIPIMR0    (0x400385C0) /**< (USBHS) Host Pipe Mask Register 0 */
+#define REG_USBHS_HSTPIPIMR1    (0x400385C4) /**< (USBHS) Host Pipe Mask Register 1 */
+#define REG_USBHS_HSTPIPIMR2    (0x400385C8) /**< (USBHS) Host Pipe Mask Register 2 */
+#define REG_USBHS_HSTPIPIMR3    (0x400385CC) /**< (USBHS) Host Pipe Mask Register 3 */
+#define REG_USBHS_HSTPIPIMR4    (0x400385D0) /**< (USBHS) Host Pipe Mask Register 4 */
+#define REG_USBHS_HSTPIPIMR5    (0x400385D4) /**< (USBHS) Host Pipe Mask Register 5 */
+#define REG_USBHS_HSTPIPIMR6    (0x400385D8) /**< (USBHS) Host Pipe Mask Register 6 */
+#define REG_USBHS_HSTPIPIMR7    (0x400385DC) /**< (USBHS) Host Pipe Mask Register 7 */
+#define REG_USBHS_HSTPIPIMR8    (0x400385E0) /**< (USBHS) Host Pipe Mask Register 8 */
+#define REG_USBHS_HSTPIPIMR9    (0x400385E4) /**< (USBHS) Host Pipe Mask Register 9 */
+#define REG_USBHS_HSTPIPIER     (0x400385F0) /**< (USBHS) Host Pipe Enable Register */
+#define REG_USBHS_HSTPIPIER0    (0x400385F0) /**< (USBHS) Host Pipe Enable Register 0 */
+#define REG_USBHS_HSTPIPIER1    (0x400385F4) /**< (USBHS) Host Pipe Enable Register 1 */
+#define REG_USBHS_HSTPIPIER2    (0x400385F8) /**< (USBHS) Host Pipe Enable Register 2 */
+#define REG_USBHS_HSTPIPIER3    (0x400385FC) /**< (USBHS) Host Pipe Enable Register 3 */
+#define REG_USBHS_HSTPIPIER4    (0x40038600) /**< (USBHS) Host Pipe Enable Register 4 */
+#define REG_USBHS_HSTPIPIER5    (0x40038604) /**< (USBHS) Host Pipe Enable Register 5 */
+#define REG_USBHS_HSTPIPIER6    (0x40038608) /**< (USBHS) Host Pipe Enable Register 6 */
+#define REG_USBHS_HSTPIPIER7    (0x4003860C) /**< (USBHS) Host Pipe Enable Register 7 */
+#define REG_USBHS_HSTPIPIER8    (0x40038610) /**< (USBHS) Host Pipe Enable Register 8 */
+#define REG_USBHS_HSTPIPIER9    (0x40038614) /**< (USBHS) Host Pipe Enable Register 9 */
+#define REG_USBHS_HSTPIPIDR     (0x40038620) /**< (USBHS) Host Pipe Disable Register */
+#define REG_USBHS_HSTPIPIDR0    (0x40038620) /**< (USBHS) Host Pipe Disable Register 0 */
+#define REG_USBHS_HSTPIPIDR1    (0x40038624) /**< (USBHS) Host Pipe Disable Register 1 */
+#define REG_USBHS_HSTPIPIDR2    (0x40038628) /**< (USBHS) Host Pipe Disable Register 2 */
+#define REG_USBHS_HSTPIPIDR3    (0x4003862C) /**< (USBHS) Host Pipe Disable Register 3 */
+#define REG_USBHS_HSTPIPIDR4    (0x40038630) /**< (USBHS) Host Pipe Disable Register 4 */
+#define REG_USBHS_HSTPIPIDR5    (0x40038634) /**< (USBHS) Host Pipe Disable Register 5 */
+#define REG_USBHS_HSTPIPIDR6    (0x40038638) /**< (USBHS) Host Pipe Disable Register 6 */
+#define REG_USBHS_HSTPIPIDR7    (0x4003863C) /**< (USBHS) Host Pipe Disable Register 7 */
+#define REG_USBHS_HSTPIPIDR8    (0x40038640) /**< (USBHS) Host Pipe Disable Register 8 */
+#define REG_USBHS_HSTPIPIDR9    (0x40038644) /**< (USBHS) Host Pipe Disable Register 9 */
+#define REG_USBHS_HSTPIPINRQ    (0x40038650) /**< (USBHS) Host Pipe IN Request Register */
+#define REG_USBHS_HSTPIPINRQ0   (0x40038650) /**< (USBHS) Host Pipe IN Request Register 0 */
+#define REG_USBHS_HSTPIPINRQ1   (0x40038654) /**< (USBHS) Host Pipe IN Request Register 1 */
+#define REG_USBHS_HSTPIPINRQ2   (0x40038658) /**< (USBHS) Host Pipe IN Request Register 2 */
+#define REG_USBHS_HSTPIPINRQ3   (0x4003865C) /**< (USBHS) Host Pipe IN Request Register 3 */
+#define REG_USBHS_HSTPIPINRQ4   (0x40038660) /**< (USBHS) Host Pipe IN Request Register 4 */
+#define REG_USBHS_HSTPIPINRQ5   (0x40038664) /**< (USBHS) Host Pipe IN Request Register 5 */
+#define REG_USBHS_HSTPIPINRQ6   (0x40038668) /**< (USBHS) Host Pipe IN Request Register 6 */
+#define REG_USBHS_HSTPIPINRQ7   (0x4003866C) /**< (USBHS) Host Pipe IN Request Register 7 */
+#define REG_USBHS_HSTPIPINRQ8   (0x40038670) /**< (USBHS) Host Pipe IN Request Register 8 */
+#define REG_USBHS_HSTPIPINRQ9   (0x40038674) /**< (USBHS) Host Pipe IN Request Register 9 */
+#define REG_USBHS_HSTPIPERR     (0x40038680) /**< (USBHS) Host Pipe Error Register */
+#define REG_USBHS_HSTPIPERR0    (0x40038680) /**< (USBHS) Host Pipe Error Register 0 */
+#define REG_USBHS_HSTPIPERR1    (0x40038684) /**< (USBHS) Host Pipe Error Register 1 */
+#define REG_USBHS_HSTPIPERR2    (0x40038688) /**< (USBHS) Host Pipe Error Register 2 */
+#define REG_USBHS_HSTPIPERR3    (0x4003868C) /**< (USBHS) Host Pipe Error Register 3 */
+#define REG_USBHS_HSTPIPERR4    (0x40038690) /**< (USBHS) Host Pipe Error Register 4 */
+#define REG_USBHS_HSTPIPERR5    (0x40038694) /**< (USBHS) Host Pipe Error Register 5 */
+#define REG_USBHS_HSTPIPERR6    (0x40038698) /**< (USBHS) Host Pipe Error Register 6 */
+#define REG_USBHS_HSTPIPERR7    (0x4003869C) /**< (USBHS) Host Pipe Error Register 7 */
+#define REG_USBHS_HSTPIPERR8    (0x400386A0) /**< (USBHS) Host Pipe Error Register 8 */
+#define REG_USBHS_HSTPIPERR9    (0x400386A4) /**< (USBHS) Host Pipe Error Register 9 */
+#define REG_USBHS_CTRL          (0x40038800) /**< (USBHS) General Control Register */
+#define REG_USBHS_SR            (0x40038804) /**< (USBHS) General Status Register */
+#define REG_USBHS_SCR           (0x40038808) /**< (USBHS) General Status Clear Register */
+#define REG_USBHS_SFR           (0x4003880C) /**< (USBHS) General Status Set Register */
+
+#else
+
+#define REG_USBHS_DEVDMANXTDSC0 (*(__IO uint32_t*)0x40038310U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (*(__IO uint32_t*)0x40038314U) /**< (USBHS) Device DMA Channel Address Register 0 */
+#define REG_USBHS_DEVDMACONTROL0 (*(__IO uint32_t*)0x40038318U) /**< (USBHS) Device DMA Channel Control Register 0 */
+#define REG_USBHS_DEVDMASTATUS0 (*(__IO uint32_t*)0x4003831CU) /**< (USBHS) Device DMA Channel Status Register 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (*(__IO uint32_t*)0x40038320U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (*(__IO uint32_t*)0x40038324U) /**< (USBHS) Device DMA Channel Address Register 1 */
+#define REG_USBHS_DEVDMACONTROL1 (*(__IO uint32_t*)0x40038328U) /**< (USBHS) Device DMA Channel Control Register 1 */
+#define REG_USBHS_DEVDMASTATUS1 (*(__IO uint32_t*)0x4003832CU) /**< (USBHS) Device DMA Channel Status Register 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (*(__IO uint32_t*)0x40038330U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (*(__IO uint32_t*)0x40038334U) /**< (USBHS) Device DMA Channel Address Register 2 */
+#define REG_USBHS_DEVDMACONTROL2 (*(__IO uint32_t*)0x40038338U) /**< (USBHS) Device DMA Channel Control Register 2 */
+#define REG_USBHS_DEVDMASTATUS2 (*(__IO uint32_t*)0x4003833CU) /**< (USBHS) Device DMA Channel Status Register 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (*(__IO uint32_t*)0x40038340U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (*(__IO uint32_t*)0x40038344U) /**< (USBHS) Device DMA Channel Address Register 3 */
+#define REG_USBHS_DEVDMACONTROL3 (*(__IO uint32_t*)0x40038348U) /**< (USBHS) Device DMA Channel Control Register 3 */
+#define REG_USBHS_DEVDMASTATUS3 (*(__IO uint32_t*)0x4003834CU) /**< (USBHS) Device DMA Channel Status Register 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (*(__IO uint32_t*)0x40038350U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (*(__IO uint32_t*)0x40038354U) /**< (USBHS) Device DMA Channel Address Register 4 */
+#define REG_USBHS_DEVDMACONTROL4 (*(__IO uint32_t*)0x40038358U) /**< (USBHS) Device DMA Channel Control Register 4 */
+#define REG_USBHS_DEVDMASTATUS4 (*(__IO uint32_t*)0x4003835CU) /**< (USBHS) Device DMA Channel Status Register 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (*(__IO uint32_t*)0x40038360U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (*(__IO uint32_t*)0x40038364U) /**< (USBHS) Device DMA Channel Address Register 5 */
+#define REG_USBHS_DEVDMACONTROL5 (*(__IO uint32_t*)0x40038368U) /**< (USBHS) Device DMA Channel Control Register 5 */
+#define REG_USBHS_DEVDMASTATUS5 (*(__IO uint32_t*)0x4003836CU) /**< (USBHS) Device DMA Channel Status Register 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (*(__IO uint32_t*)0x40038370U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (*(__IO uint32_t*)0x40038374U) /**< (USBHS) Device DMA Channel Address Register 6 */
+#define REG_USBHS_DEVDMACONTROL6 (*(__IO uint32_t*)0x40038378U) /**< (USBHS) Device DMA Channel Control Register 6 */
+#define REG_USBHS_DEVDMASTATUS6 (*(__IO uint32_t*)0x4003837CU) /**< (USBHS) Device DMA Channel Status Register 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (*(__IO uint32_t*)0x40038710U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (*(__IO uint32_t*)0x40038714U) /**< (USBHS) Host DMA Channel Address Register 0 */
+#define REG_USBHS_HSTDMACONTROL0 (*(__IO uint32_t*)0x40038718U) /**< (USBHS) Host DMA Channel Control Register 0 */
+#define REG_USBHS_HSTDMASTATUS0 (*(__IO uint32_t*)0x4003871CU) /**< (USBHS) Host DMA Channel Status Register 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (*(__IO uint32_t*)0x40038720U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (*(__IO uint32_t*)0x40038724U) /**< (USBHS) Host DMA Channel Address Register 1 */
+#define REG_USBHS_HSTDMACONTROL1 (*(__IO uint32_t*)0x40038728U) /**< (USBHS) Host DMA Channel Control Register 1 */
+#define REG_USBHS_HSTDMASTATUS1 (*(__IO uint32_t*)0x4003872CU) /**< (USBHS) Host DMA Channel Status Register 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (*(__IO uint32_t*)0x40038730U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (*(__IO uint32_t*)0x40038734U) /**< (USBHS) Host DMA Channel Address Register 2 */
+#define REG_USBHS_HSTDMACONTROL2 (*(__IO uint32_t*)0x40038738U) /**< (USBHS) Host DMA Channel Control Register 2 */
+#define REG_USBHS_HSTDMASTATUS2 (*(__IO uint32_t*)0x4003873CU) /**< (USBHS) Host DMA Channel Status Register 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (*(__IO uint32_t*)0x40038740U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (*(__IO uint32_t*)0x40038744U) /**< (USBHS) Host DMA Channel Address Register 3 */
+#define REG_USBHS_HSTDMACONTROL3 (*(__IO uint32_t*)0x40038748U) /**< (USBHS) Host DMA Channel Control Register 3 */
+#define REG_USBHS_HSTDMASTATUS3 (*(__IO uint32_t*)0x4003874CU) /**< (USBHS) Host DMA Channel Status Register 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (*(__IO uint32_t*)0x40038750U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (*(__IO uint32_t*)0x40038754U) /**< (USBHS) Host DMA Channel Address Register 4 */
+#define REG_USBHS_HSTDMACONTROL4 (*(__IO uint32_t*)0x40038758U) /**< (USBHS) Host DMA Channel Control Register 4 */
+#define REG_USBHS_HSTDMASTATUS4 (*(__IO uint32_t*)0x4003875CU) /**< (USBHS) Host DMA Channel Status Register 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (*(__IO uint32_t*)0x40038760U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (*(__IO uint32_t*)0x40038764U) /**< (USBHS) Host DMA Channel Address Register 5 */
+#define REG_USBHS_HSTDMACONTROL5 (*(__IO uint32_t*)0x40038768U) /**< (USBHS) Host DMA Channel Control Register 5 */
+#define REG_USBHS_HSTDMASTATUS5 (*(__IO uint32_t*)0x4003876CU) /**< (USBHS) Host DMA Channel Status Register 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (*(__IO uint32_t*)0x40038770U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (*(__IO uint32_t*)0x40038774U) /**< (USBHS) Host DMA Channel Address Register 6 */
+#define REG_USBHS_HSTDMACONTROL6 (*(__IO uint32_t*)0x40038778U) /**< (USBHS) Host DMA Channel Control Register 6 */
+#define REG_USBHS_HSTDMASTATUS6 (*(__IO uint32_t*)0x4003877CU) /**< (USBHS) Host DMA Channel Status Register 6 */
+#define REG_USBHS_DEVCTRL       (*(__IO uint32_t*)0x40038000U) /**< (USBHS) Device General Control Register */
+#define REG_USBHS_DEVISR        (*(__I  uint32_t*)0x40038004U) /**< (USBHS) Device Global Interrupt Status Register */
+#define REG_USBHS_DEVICR        (*(__O  uint32_t*)0x40038008U) /**< (USBHS) Device Global Interrupt Clear Register */
+#define REG_USBHS_DEVIFR        (*(__O  uint32_t*)0x4003800CU) /**< (USBHS) Device Global Interrupt Set Register */
+#define REG_USBHS_DEVIMR        (*(__I  uint32_t*)0x40038010U) /**< (USBHS) Device Global Interrupt Mask Register */
+#define REG_USBHS_DEVIDR        (*(__O  uint32_t*)0x40038014U) /**< (USBHS) Device Global Interrupt Disable Register */
+#define REG_USBHS_DEVIER        (*(__O  uint32_t*)0x40038018U) /**< (USBHS) Device Global Interrupt Enable Register */
+#define REG_USBHS_DEVEPT        (*(__IO uint32_t*)0x4003801CU) /**< (USBHS) Device Endpoint Register */
+#define REG_USBHS_DEVFNUM       (*(__I  uint32_t*)0x40038020U) /**< (USBHS) Device Frame Number Register */
+#define REG_USBHS_DEVEPTCFG     (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register */
+#define REG_USBHS_DEVEPTCFG0    (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register 0 */
+#define REG_USBHS_DEVEPTCFG1    (*(__IO uint32_t*)0x40038104U) /**< (USBHS) Device Endpoint Configuration Register 1 */
+#define REG_USBHS_DEVEPTCFG2    (*(__IO uint32_t*)0x40038108U) /**< (USBHS) Device Endpoint Configuration Register 2 */
+#define REG_USBHS_DEVEPTCFG3    (*(__IO uint32_t*)0x4003810CU) /**< (USBHS) Device Endpoint Configuration Register 3 */
+#define REG_USBHS_DEVEPTCFG4    (*(__IO uint32_t*)0x40038110U) /**< (USBHS) Device Endpoint Configuration Register 4 */
+#define REG_USBHS_DEVEPTCFG5    (*(__IO uint32_t*)0x40038114U) /**< (USBHS) Device Endpoint Configuration Register 5 */
+#define REG_USBHS_DEVEPTCFG6    (*(__IO uint32_t*)0x40038118U) /**< (USBHS) Device Endpoint Configuration Register 6 */
+#define REG_USBHS_DEVEPTCFG7    (*(__IO uint32_t*)0x4003811CU) /**< (USBHS) Device Endpoint Configuration Register 7 */
+#define REG_USBHS_DEVEPTCFG8    (*(__IO uint32_t*)0x40038120U) /**< (USBHS) Device Endpoint Configuration Register 8 */
+#define REG_USBHS_DEVEPTCFG9    (*(__IO uint32_t*)0x40038124U) /**< (USBHS) Device Endpoint Configuration Register 9 */
+#define REG_USBHS_DEVEPTISR     (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Interrupt Status Register */
+#define REG_USBHS_DEVEPTISR0    (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Interrupt Status Register 0 */
+#define REG_USBHS_DEVEPTISR1    (*(__I  uint32_t*)0x40038134U) /**< (USBHS) Device Endpoint Interrupt Status Register 1 */
+#define REG_USBHS_DEVEPTISR2    (*(__I  uint32_t*)0x40038138U) /**< (USBHS) Device Endpoint Interrupt Status Register 2 */
+#define REG_USBHS_DEVEPTISR3    (*(__I  uint32_t*)0x4003813CU) /**< (USBHS) Device Endpoint Interrupt Status Register 3 */
+#define REG_USBHS_DEVEPTISR4    (*(__I  uint32_t*)0x40038140U) /**< (USBHS) Device Endpoint Interrupt Status Register 4 */
+#define REG_USBHS_DEVEPTISR5    (*(__I  uint32_t*)0x40038144U) /**< (USBHS) Device Endpoint Interrupt Status Register 5 */
+#define REG_USBHS_DEVEPTISR6    (*(__I  uint32_t*)0x40038148U) /**< (USBHS) Device Endpoint Interrupt Status Register 6 */
+#define REG_USBHS_DEVEPTISR7    (*(__I  uint32_t*)0x4003814CU) /**< (USBHS) Device Endpoint Interrupt Status Register 7 */
+#define REG_USBHS_DEVEPTISR8    (*(__I  uint32_t*)0x40038150U) /**< (USBHS) Device Endpoint Interrupt Status Register 8 */
+#define REG_USBHS_DEVEPTISR9    (*(__I  uint32_t*)0x40038154U) /**< (USBHS) Device Endpoint Interrupt Status Register 9 */
+#define REG_USBHS_DEVEPTICR     (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Interrupt Clear Register */
+#define REG_USBHS_DEVEPTICR0    (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Interrupt Clear Register 0 */
+#define REG_USBHS_DEVEPTICR1    (*(__O  uint32_t*)0x40038164U) /**< (USBHS) Device Endpoint Interrupt Clear Register 1 */
+#define REG_USBHS_DEVEPTICR2    (*(__O  uint32_t*)0x40038168U) /**< (USBHS) Device Endpoint Interrupt Clear Register 2 */
+#define REG_USBHS_DEVEPTICR3    (*(__O  uint32_t*)0x4003816CU) /**< (USBHS) Device Endpoint Interrupt Clear Register 3 */
+#define REG_USBHS_DEVEPTICR4    (*(__O  uint32_t*)0x40038170U) /**< (USBHS) Device Endpoint Interrupt Clear Register 4 */
+#define REG_USBHS_DEVEPTICR5    (*(__O  uint32_t*)0x40038174U) /**< (USBHS) Device Endpoint Interrupt Clear Register 5 */
+#define REG_USBHS_DEVEPTICR6    (*(__O  uint32_t*)0x40038178U) /**< (USBHS) Device Endpoint Interrupt Clear Register 6 */
+#define REG_USBHS_DEVEPTICR7    (*(__O  uint32_t*)0x4003817CU) /**< (USBHS) Device Endpoint Interrupt Clear Register 7 */
+#define REG_USBHS_DEVEPTICR8    (*(__O  uint32_t*)0x40038180U) /**< (USBHS) Device Endpoint Interrupt Clear Register 8 */
+#define REG_USBHS_DEVEPTICR9    (*(__O  uint32_t*)0x40038184U) /**< (USBHS) Device Endpoint Interrupt Clear Register 9 */
+#define REG_USBHS_DEVEPTIFR     (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Interrupt Set Register */
+#define REG_USBHS_DEVEPTIFR0    (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Interrupt Set Register 0 */
+#define REG_USBHS_DEVEPTIFR1    (*(__O  uint32_t*)0x40038194U) /**< (USBHS) Device Endpoint Interrupt Set Register 1 */
+#define REG_USBHS_DEVEPTIFR2    (*(__O  uint32_t*)0x40038198U) /**< (USBHS) Device Endpoint Interrupt Set Register 2 */
+#define REG_USBHS_DEVEPTIFR3    (*(__O  uint32_t*)0x4003819CU) /**< (USBHS) Device Endpoint Interrupt Set Register 3 */
+#define REG_USBHS_DEVEPTIFR4    (*(__O  uint32_t*)0x400381A0U) /**< (USBHS) Device Endpoint Interrupt Set Register 4 */
+#define REG_USBHS_DEVEPTIFR5    (*(__O  uint32_t*)0x400381A4U) /**< (USBHS) Device Endpoint Interrupt Set Register 5 */
+#define REG_USBHS_DEVEPTIFR6    (*(__O  uint32_t*)0x400381A8U) /**< (USBHS) Device Endpoint Interrupt Set Register 6 */
+#define REG_USBHS_DEVEPTIFR7    (*(__O  uint32_t*)0x400381ACU) /**< (USBHS) Device Endpoint Interrupt Set Register 7 */
+#define REG_USBHS_DEVEPTIFR8    (*(__O  uint32_t*)0x400381B0U) /**< (USBHS) Device Endpoint Interrupt Set Register 8 */
+#define REG_USBHS_DEVEPTIFR9    (*(__O  uint32_t*)0x400381B4U) /**< (USBHS) Device Endpoint Interrupt Set Register 9 */
+#define REG_USBHS_DEVEPTIMR     (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Interrupt Mask Register */
+#define REG_USBHS_DEVEPTIMR0    (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 0 */
+#define REG_USBHS_DEVEPTIMR1    (*(__I  uint32_t*)0x400381C4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 1 */
+#define REG_USBHS_DEVEPTIMR2    (*(__I  uint32_t*)0x400381C8U) /**< (USBHS) Device Endpoint Interrupt Mask Register 2 */
+#define REG_USBHS_DEVEPTIMR3    (*(__I  uint32_t*)0x400381CCU) /**< (USBHS) Device Endpoint Interrupt Mask Register 3 */
+#define REG_USBHS_DEVEPTIMR4    (*(__I  uint32_t*)0x400381D0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 4 */
+#define REG_USBHS_DEVEPTIMR5    (*(__I  uint32_t*)0x400381D4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 5 */
+#define REG_USBHS_DEVEPTIMR6    (*(__I  uint32_t*)0x400381D8U) /**< (USBHS) Device Endpoint Interrupt Mask Register 6 */
+#define REG_USBHS_DEVEPTIMR7    (*(__I  uint32_t*)0x400381DCU) /**< (USBHS) Device Endpoint Interrupt Mask Register 7 */
+#define REG_USBHS_DEVEPTIMR8    (*(__I  uint32_t*)0x400381E0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 8 */
+#define REG_USBHS_DEVEPTIMR9    (*(__I  uint32_t*)0x400381E4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 9 */
+#define REG_USBHS_DEVEPTIER     (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Interrupt Enable Register */
+#define REG_USBHS_DEVEPTIER0    (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Interrupt Enable Register 0 */
+#define REG_USBHS_DEVEPTIER1    (*(__O  uint32_t*)0x400381F4U) /**< (USBHS) Device Endpoint Interrupt Enable Register 1 */
+#define REG_USBHS_DEVEPTIER2    (*(__O  uint32_t*)0x400381F8U) /**< (USBHS) Device Endpoint Interrupt Enable Register 2 */
+#define REG_USBHS_DEVEPTIER3    (*(__O  uint32_t*)0x400381FCU) /**< (USBHS) Device Endpoint Interrupt Enable Register 3 */
+#define REG_USBHS_DEVEPTIER4    (*(__O  uint32_t*)0x40038200U) /**< (USBHS) Device Endpoint Interrupt Enable Register 4 */
+#define REG_USBHS_DEVEPTIER5    (*(__O  uint32_t*)0x40038204U) /**< (USBHS) Device Endpoint Interrupt Enable Register 5 */
+#define REG_USBHS_DEVEPTIER6    (*(__O  uint32_t*)0x40038208U) /**< (USBHS) Device Endpoint Interrupt Enable Register 6 */
+#define REG_USBHS_DEVEPTIER7    (*(__O  uint32_t*)0x4003820CU) /**< (USBHS) Device Endpoint Interrupt Enable Register 7 */
+#define REG_USBHS_DEVEPTIER8    (*(__O  uint32_t*)0x40038210U) /**< (USBHS) Device Endpoint Interrupt Enable Register 8 */
+#define REG_USBHS_DEVEPTIER9    (*(__O  uint32_t*)0x40038214U) /**< (USBHS) Device Endpoint Interrupt Enable Register 9 */
+#define REG_USBHS_DEVEPTIDR     (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Interrupt Disable Register */
+#define REG_USBHS_DEVEPTIDR0    (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Interrupt Disable Register 0 */
+#define REG_USBHS_DEVEPTIDR1    (*(__O  uint32_t*)0x40038224U) /**< (USBHS) Device Endpoint Interrupt Disable Register 1 */
+#define REG_USBHS_DEVEPTIDR2    (*(__O  uint32_t*)0x40038228U) /**< (USBHS) Device Endpoint Interrupt Disable Register 2 */
+#define REG_USBHS_DEVEPTIDR3    (*(__O  uint32_t*)0x4003822CU) /**< (USBHS) Device Endpoint Interrupt Disable Register 3 */
+#define REG_USBHS_DEVEPTIDR4    (*(__O  uint32_t*)0x40038230U) /**< (USBHS) Device Endpoint Interrupt Disable Register 4 */
+#define REG_USBHS_DEVEPTIDR5    (*(__O  uint32_t*)0x40038234U) /**< (USBHS) Device Endpoint Interrupt Disable Register 5 */
+#define REG_USBHS_DEVEPTIDR6    (*(__O  uint32_t*)0x40038238U) /**< (USBHS) Device Endpoint Interrupt Disable Register 6 */
+#define REG_USBHS_DEVEPTIDR7    (*(__O  uint32_t*)0x4003823CU) /**< (USBHS) Device Endpoint Interrupt Disable Register 7 */
+#define REG_USBHS_DEVEPTIDR8    (*(__O  uint32_t*)0x40038240U) /**< (USBHS) Device Endpoint Interrupt Disable Register 8 */
+#define REG_USBHS_DEVEPTIDR9    (*(__O  uint32_t*)0x40038244U) /**< (USBHS) Device Endpoint Interrupt Disable Register 9 */
+#define REG_USBHS_HSTCTRL       (*(__IO uint32_t*)0x40038400U) /**< (USBHS) Host General Control Register */
+#define REG_USBHS_HSTISR        (*(__I  uint32_t*)0x40038404U) /**< (USBHS) Host Global Interrupt Status Register */
+#define REG_USBHS_HSTICR        (*(__O  uint32_t*)0x40038408U) /**< (USBHS) Host Global Interrupt Clear Register */
+#define REG_USBHS_HSTIFR        (*(__O  uint32_t*)0x4003840CU) /**< (USBHS) Host Global Interrupt Set Register */
+#define REG_USBHS_HSTIMR        (*(__I  uint32_t*)0x40038410U) /**< (USBHS) Host Global Interrupt Mask Register */
+#define REG_USBHS_HSTIDR        (*(__O  uint32_t*)0x40038414U) /**< (USBHS) Host Global Interrupt Disable Register */
+#define REG_USBHS_HSTIER        (*(__O  uint32_t*)0x40038418U) /**< (USBHS) Host Global Interrupt Enable Register */
+#define REG_USBHS_HSTPIP        (*(__IO uint32_t*)0x4003841CU) /**< (USBHS) Host Pipe Register */
+#define REG_USBHS_HSTFNUM       (*(__IO uint32_t*)0x40038420U) /**< (USBHS) Host Frame Number Register */
+#define REG_USBHS_HSTADDR1      (*(__IO uint32_t*)0x40038424U) /**< (USBHS) Host Address 1 Register */
+#define REG_USBHS_HSTADDR2      (*(__IO uint32_t*)0x40038428U) /**< (USBHS) Host Address 2 Register */
+#define REG_USBHS_HSTADDR3      (*(__IO uint32_t*)0x4003842CU) /**< (USBHS) Host Address 3 Register */
+#define REG_USBHS_HSTPIPCFG     (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register */
+#define REG_USBHS_HSTPIPCFG0    (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register 0 */
+#define REG_USBHS_HSTPIPCFG1    (*(__IO uint32_t*)0x40038504U) /**< (USBHS) Host Pipe Configuration Register 1 */
+#define REG_USBHS_HSTPIPCFG2    (*(__IO uint32_t*)0x40038508U) /**< (USBHS) Host Pipe Configuration Register 2 */
+#define REG_USBHS_HSTPIPCFG3    (*(__IO uint32_t*)0x4003850CU) /**< (USBHS) Host Pipe Configuration Register 3 */
+#define REG_USBHS_HSTPIPCFG4    (*(__IO uint32_t*)0x40038510U) /**< (USBHS) Host Pipe Configuration Register 4 */
+#define REG_USBHS_HSTPIPCFG5    (*(__IO uint32_t*)0x40038514U) /**< (USBHS) Host Pipe Configuration Register 5 */
+#define REG_USBHS_HSTPIPCFG6    (*(__IO uint32_t*)0x40038518U) /**< (USBHS) Host Pipe Configuration Register 6 */
+#define REG_USBHS_HSTPIPCFG7    (*(__IO uint32_t*)0x4003851CU) /**< (USBHS) Host Pipe Configuration Register 7 */
+#define REG_USBHS_HSTPIPCFG8    (*(__IO uint32_t*)0x40038520U) /**< (USBHS) Host Pipe Configuration Register 8 */
+#define REG_USBHS_HSTPIPCFG9    (*(__IO uint32_t*)0x40038524U) /**< (USBHS) Host Pipe Configuration Register 9 */
+#define REG_USBHS_HSTPIPISR     (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register */
+#define REG_USBHS_HSTPIPISR0    (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register 0 */
+#define REG_USBHS_HSTPIPISR1    (*(__I  uint32_t*)0x40038534U) /**< (USBHS) Host Pipe Status Register 1 */
+#define REG_USBHS_HSTPIPISR2    (*(__I  uint32_t*)0x40038538U) /**< (USBHS) Host Pipe Status Register 2 */
+#define REG_USBHS_HSTPIPISR3    (*(__I  uint32_t*)0x4003853CU) /**< (USBHS) Host Pipe Status Register 3 */
+#define REG_USBHS_HSTPIPISR4    (*(__I  uint32_t*)0x40038540U) /**< (USBHS) Host Pipe Status Register 4 */
+#define REG_USBHS_HSTPIPISR5    (*(__I  uint32_t*)0x40038544U) /**< (USBHS) Host Pipe Status Register 5 */
+#define REG_USBHS_HSTPIPISR6    (*(__I  uint32_t*)0x40038548U) /**< (USBHS) Host Pipe Status Register 6 */
+#define REG_USBHS_HSTPIPISR7    (*(__I  uint32_t*)0x4003854CU) /**< (USBHS) Host Pipe Status Register 7 */
+#define REG_USBHS_HSTPIPISR8    (*(__I  uint32_t*)0x40038550U) /**< (USBHS) Host Pipe Status Register 8 */
+#define REG_USBHS_HSTPIPISR9    (*(__I  uint32_t*)0x40038554U) /**< (USBHS) Host Pipe Status Register 9 */
+#define REG_USBHS_HSTPIPICR     (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register */
+#define REG_USBHS_HSTPIPICR0    (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register 0 */
+#define REG_USBHS_HSTPIPICR1    (*(__O  uint32_t*)0x40038564U) /**< (USBHS) Host Pipe Clear Register 1 */
+#define REG_USBHS_HSTPIPICR2    (*(__O  uint32_t*)0x40038568U) /**< (USBHS) Host Pipe Clear Register 2 */
+#define REG_USBHS_HSTPIPICR3    (*(__O  uint32_t*)0x4003856CU) /**< (USBHS) Host Pipe Clear Register 3 */
+#define REG_USBHS_HSTPIPICR4    (*(__O  uint32_t*)0x40038570U) /**< (USBHS) Host Pipe Clear Register 4 */
+#define REG_USBHS_HSTPIPICR5    (*(__O  uint32_t*)0x40038574U) /**< (USBHS) Host Pipe Clear Register 5 */
+#define REG_USBHS_HSTPIPICR6    (*(__O  uint32_t*)0x40038578U) /**< (USBHS) Host Pipe Clear Register 6 */
+#define REG_USBHS_HSTPIPICR7    (*(__O  uint32_t*)0x4003857CU) /**< (USBHS) Host Pipe Clear Register 7 */
+#define REG_USBHS_HSTPIPICR8    (*(__O  uint32_t*)0x40038580U) /**< (USBHS) Host Pipe Clear Register 8 */
+#define REG_USBHS_HSTPIPICR9    (*(__O  uint32_t*)0x40038584U) /**< (USBHS) Host Pipe Clear Register 9 */
+#define REG_USBHS_HSTPIPIFR     (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register */
+#define REG_USBHS_HSTPIPIFR0    (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register 0 */
+#define REG_USBHS_HSTPIPIFR1    (*(__O  uint32_t*)0x40038594U) /**< (USBHS) Host Pipe Set Register 1 */
+#define REG_USBHS_HSTPIPIFR2    (*(__O  uint32_t*)0x40038598U) /**< (USBHS) Host Pipe Set Register 2 */
+#define REG_USBHS_HSTPIPIFR3    (*(__O  uint32_t*)0x4003859CU) /**< (USBHS) Host Pipe Set Register 3 */
+#define REG_USBHS_HSTPIPIFR4    (*(__O  uint32_t*)0x400385A0U) /**< (USBHS) Host Pipe Set Register 4 */
+#define REG_USBHS_HSTPIPIFR5    (*(__O  uint32_t*)0x400385A4U) /**< (USBHS) Host Pipe Set Register 5 */
+#define REG_USBHS_HSTPIPIFR6    (*(__O  uint32_t*)0x400385A8U) /**< (USBHS) Host Pipe Set Register 6 */
+#define REG_USBHS_HSTPIPIFR7    (*(__O  uint32_t*)0x400385ACU) /**< (USBHS) Host Pipe Set Register 7 */
+#define REG_USBHS_HSTPIPIFR8    (*(__O  uint32_t*)0x400385B0U) /**< (USBHS) Host Pipe Set Register 8 */
+#define REG_USBHS_HSTPIPIFR9    (*(__O  uint32_t*)0x400385B4U) /**< (USBHS) Host Pipe Set Register 9 */
+#define REG_USBHS_HSTPIPIMR     (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register */
+#define REG_USBHS_HSTPIPIMR0    (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register 0 */
+#define REG_USBHS_HSTPIPIMR1    (*(__I  uint32_t*)0x400385C4U) /**< (USBHS) Host Pipe Mask Register 1 */
+#define REG_USBHS_HSTPIPIMR2    (*(__I  uint32_t*)0x400385C8U) /**< (USBHS) Host Pipe Mask Register 2 */
+#define REG_USBHS_HSTPIPIMR3    (*(__I  uint32_t*)0x400385CCU) /**< (USBHS) Host Pipe Mask Register 3 */
+#define REG_USBHS_HSTPIPIMR4    (*(__I  uint32_t*)0x400385D0U) /**< (USBHS) Host Pipe Mask Register 4 */
+#define REG_USBHS_HSTPIPIMR5    (*(__I  uint32_t*)0x400385D4U) /**< (USBHS) Host Pipe Mask Register 5 */
+#define REG_USBHS_HSTPIPIMR6    (*(__I  uint32_t*)0x400385D8U) /**< (USBHS) Host Pipe Mask Register 6 */
+#define REG_USBHS_HSTPIPIMR7    (*(__I  uint32_t*)0x400385DCU) /**< (USBHS) Host Pipe Mask Register 7 */
+#define REG_USBHS_HSTPIPIMR8    (*(__I  uint32_t*)0x400385E0U) /**< (USBHS) Host Pipe Mask Register 8 */
+#define REG_USBHS_HSTPIPIMR9    (*(__I  uint32_t*)0x400385E4U) /**< (USBHS) Host Pipe Mask Register 9 */
+#define REG_USBHS_HSTPIPIER     (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register */
+#define REG_USBHS_HSTPIPIER0    (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register 0 */
+#define REG_USBHS_HSTPIPIER1    (*(__O  uint32_t*)0x400385F4U) /**< (USBHS) Host Pipe Enable Register 1 */
+#define REG_USBHS_HSTPIPIER2    (*(__O  uint32_t*)0x400385F8U) /**< (USBHS) Host Pipe Enable Register 2 */
+#define REG_USBHS_HSTPIPIER3    (*(__O  uint32_t*)0x400385FCU) /**< (USBHS) Host Pipe Enable Register 3 */
+#define REG_USBHS_HSTPIPIER4    (*(__O  uint32_t*)0x40038600U) /**< (USBHS) Host Pipe Enable Register 4 */
+#define REG_USBHS_HSTPIPIER5    (*(__O  uint32_t*)0x40038604U) /**< (USBHS) Host Pipe Enable Register 5 */
+#define REG_USBHS_HSTPIPIER6    (*(__O  uint32_t*)0x40038608U) /**< (USBHS) Host Pipe Enable Register 6 */
+#define REG_USBHS_HSTPIPIER7    (*(__O  uint32_t*)0x4003860CU) /**< (USBHS) Host Pipe Enable Register 7 */
+#define REG_USBHS_HSTPIPIER8    (*(__O  uint32_t*)0x40038610U) /**< (USBHS) Host Pipe Enable Register 8 */
+#define REG_USBHS_HSTPIPIER9    (*(__O  uint32_t*)0x40038614U) /**< (USBHS) Host Pipe Enable Register 9 */
+#define REG_USBHS_HSTPIPIDR     (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register */
+#define REG_USBHS_HSTPIPIDR0    (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register 0 */
+#define REG_USBHS_HSTPIPIDR1    (*(__O  uint32_t*)0x40038624U) /**< (USBHS) Host Pipe Disable Register 1 */
+#define REG_USBHS_HSTPIPIDR2    (*(__O  uint32_t*)0x40038628U) /**< (USBHS) Host Pipe Disable Register 2 */
+#define REG_USBHS_HSTPIPIDR3    (*(__O  uint32_t*)0x4003862CU) /**< (USBHS) Host Pipe Disable Register 3 */
+#define REG_USBHS_HSTPIPIDR4    (*(__O  uint32_t*)0x40038630U) /**< (USBHS) Host Pipe Disable Register 4 */
+#define REG_USBHS_HSTPIPIDR5    (*(__O  uint32_t*)0x40038634U) /**< (USBHS) Host Pipe Disable Register 5 */
+#define REG_USBHS_HSTPIPIDR6    (*(__O  uint32_t*)0x40038638U) /**< (USBHS) Host Pipe Disable Register 6 */
+#define REG_USBHS_HSTPIPIDR7    (*(__O  uint32_t*)0x4003863CU) /**< (USBHS) Host Pipe Disable Register 7 */
+#define REG_USBHS_HSTPIPIDR8    (*(__O  uint32_t*)0x40038640U) /**< (USBHS) Host Pipe Disable Register 8 */
+#define REG_USBHS_HSTPIPIDR9    (*(__O  uint32_t*)0x40038644U) /**< (USBHS) Host Pipe Disable Register 9 */
+#define REG_USBHS_HSTPIPINRQ    (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register */
+#define REG_USBHS_HSTPIPINRQ0   (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register 0 */
+#define REG_USBHS_HSTPIPINRQ1   (*(__IO uint32_t*)0x40038654U) /**< (USBHS) Host Pipe IN Request Register 1 */
+#define REG_USBHS_HSTPIPINRQ2   (*(__IO uint32_t*)0x40038658U) /**< (USBHS) Host Pipe IN Request Register 2 */
+#define REG_USBHS_HSTPIPINRQ3   (*(__IO uint32_t*)0x4003865CU) /**< (USBHS) Host Pipe IN Request Register 3 */
+#define REG_USBHS_HSTPIPINRQ4   (*(__IO uint32_t*)0x40038660U) /**< (USBHS) Host Pipe IN Request Register 4 */
+#define REG_USBHS_HSTPIPINRQ5   (*(__IO uint32_t*)0x40038664U) /**< (USBHS) Host Pipe IN Request Register 5 */
+#define REG_USBHS_HSTPIPINRQ6   (*(__IO uint32_t*)0x40038668U) /**< (USBHS) Host Pipe IN Request Register 6 */
+#define REG_USBHS_HSTPIPINRQ7   (*(__IO uint32_t*)0x4003866CU) /**< (USBHS) Host Pipe IN Request Register 7 */
+#define REG_USBHS_HSTPIPINRQ8   (*(__IO uint32_t*)0x40038670U) /**< (USBHS) Host Pipe IN Request Register 8 */
+#define REG_USBHS_HSTPIPINRQ9   (*(__IO uint32_t*)0x40038674U) /**< (USBHS) Host Pipe IN Request Register 9 */
+#define REG_USBHS_HSTPIPERR     (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register */
+#define REG_USBHS_HSTPIPERR0    (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register 0 */
+#define REG_USBHS_HSTPIPERR1    (*(__IO uint32_t*)0x40038684U) /**< (USBHS) Host Pipe Error Register 1 */
+#define REG_USBHS_HSTPIPERR2    (*(__IO uint32_t*)0x40038688U) /**< (USBHS) Host Pipe Error Register 2 */
+#define REG_USBHS_HSTPIPERR3    (*(__IO uint32_t*)0x4003868CU) /**< (USBHS) Host Pipe Error Register 3 */
+#define REG_USBHS_HSTPIPERR4    (*(__IO uint32_t*)0x40038690U) /**< (USBHS) Host Pipe Error Register 4 */
+#define REG_USBHS_HSTPIPERR5    (*(__IO uint32_t*)0x40038694U) /**< (USBHS) Host Pipe Error Register 5 */
+#define REG_USBHS_HSTPIPERR6    (*(__IO uint32_t*)0x40038698U) /**< (USBHS) Host Pipe Error Register 6 */
+#define REG_USBHS_HSTPIPERR7    (*(__IO uint32_t*)0x4003869CU) /**< (USBHS) Host Pipe Error Register 7 */
+#define REG_USBHS_HSTPIPERR8    (*(__IO uint32_t*)0x400386A0U) /**< (USBHS) Host Pipe Error Register 8 */
+#define REG_USBHS_HSTPIPERR9    (*(__IO uint32_t*)0x400386A4U) /**< (USBHS) Host Pipe Error Register 9 */
+#define REG_USBHS_CTRL          (*(__IO uint32_t*)0x40038800U) /**< (USBHS) General Control Register */
+#define REG_USBHS_SR            (*(__I  uint32_t*)0x40038804U) /**< (USBHS) General Status Register */
+#define REG_USBHS_SCR           (*(__O  uint32_t*)0x40038808U) /**< (USBHS) General Status Clear Register */
+#define REG_USBHS_SFR           (*(__O  uint32_t*)0x4003880CU) /**< (USBHS) General Status Set Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for USBHS peripheral ========== */
+#define USBHS_INSTANCE_ID                        34         
+#define USBHS_CLOCK_ID                           34         
+
+#endif /* _SAMV71_USBHS_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/utmi.h
+++ b/asf/sam/include/samv71b/instance/utmi.h
@@ -1,0 +1,46 @@
+/**
+ * \file
+ *
+ * \brief Instance description for UTMI
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_UTMI_INSTANCE_H_
+#define _SAMV71_UTMI_INSTANCE_H_
+
+/* ========== Register definition for UTMI peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_UTMI_OHCIICR        (0x400E0410) /**< (UTMI) OHCI Interrupt Configuration Register */
+#define REG_UTMI_CKTRIM         (0x400E0430) /**< (UTMI) UTMI Clock Trimming Register */
+
+#else
+
+#define REG_UTMI_OHCIICR        (*(__IO uint32_t*)0x400E0410U) /**< (UTMI) OHCI Interrupt Configuration Register */
+#define REG_UTMI_CKTRIM         (*(__IO uint32_t*)0x400E0430U) /**< (UTMI) UTMI Clock Trimming Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* _SAMV71_UTMI_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/wdt.h
+++ b/asf/sam/include/samv71b/instance/wdt.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_WDT_INSTANCE_H_
+#define _SAMV71_WDT_INSTANCE_H_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_WDT_CR              (0x400E1850) /**< (WDT) Control Register */
+#define REG_WDT_MR              (0x400E1854) /**< (WDT) Mode Register */
+#define REG_WDT_SR              (0x400E1858) /**< (WDT) Status Register */
+
+#else
+
+#define REG_WDT_CR              (*(__O  uint32_t*)0x400E1850U) /**< (WDT) Control Register */
+#define REG_WDT_MR              (*(__IO uint32_t*)0x400E1854U) /**< (WDT) Mode Register */
+#define REG_WDT_SR              (*(__I  uint32_t*)0x400E1858U) /**< (WDT) Status Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for WDT peripheral ========== */
+#define WDT_INSTANCE_ID                          4          
+
+#endif /* _SAMV71_WDT_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/xdmac.h
+++ b/asf/sam/include/samv71b/instance/xdmac.h
@@ -1,0 +1,753 @@
+/**
+ * \file
+ *
+ * \brief Instance description for XDMAC
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71_XDMAC_INSTANCE_H_
+#define _SAMV71_XDMAC_INSTANCE_H_
+
+/* ========== Register definition for XDMAC peripheral ========== */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+
+#define REG_XDMAC_CIE0          (0x40078050) /**< (XDMAC) Channel Interrupt Enable Register 0 */
+#define REG_XDMAC_CID0          (0x40078054) /**< (XDMAC) Channel Interrupt Disable Register 0 */
+#define REG_XDMAC_CIM0          (0x40078058) /**< (XDMAC) Channel Interrupt Mask Register 0 */
+#define REG_XDMAC_CIS0          (0x4007805C) /**< (XDMAC) Channel Interrupt Status Register 0 */
+#define REG_XDMAC_CSA0          (0x40078060) /**< (XDMAC) Channel Source Address Register 0 */
+#define REG_XDMAC_CDA0          (0x40078064) /**< (XDMAC) Channel Destination Address Register 0 */
+#define REG_XDMAC_CNDA0         (0x40078068) /**< (XDMAC) Channel Next Descriptor Address Register 0 */
+#define REG_XDMAC_CNDC0         (0x4007806C) /**< (XDMAC) Channel Next Descriptor Control Register 0 */
+#define REG_XDMAC_CUBC0         (0x40078070) /**< (XDMAC) Channel Microblock Control Register 0 */
+#define REG_XDMAC_CBC0          (0x40078074) /**< (XDMAC) Channel Block Control Register 0 */
+#define REG_XDMAC_CC0           (0x40078078) /**< (XDMAC) Channel Configuration Register 0 */
+#define REG_XDMAC_CDS_MSP0      (0x4007807C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 0 */
+#define REG_XDMAC_CSUS0         (0x40078080) /**< (XDMAC) Channel Source Microblock Stride 0 */
+#define REG_XDMAC_CDUS0         (0x40078084) /**< (XDMAC) Channel Destination Microblock Stride 0 */
+#define REG_XDMAC_CIE1          (0x40078090) /**< (XDMAC) Channel Interrupt Enable Register 1 */
+#define REG_XDMAC_CID1          (0x40078094) /**< (XDMAC) Channel Interrupt Disable Register 1 */
+#define REG_XDMAC_CIM1          (0x40078098) /**< (XDMAC) Channel Interrupt Mask Register 1 */
+#define REG_XDMAC_CIS1          (0x4007809C) /**< (XDMAC) Channel Interrupt Status Register 1 */
+#define REG_XDMAC_CSA1          (0x400780A0) /**< (XDMAC) Channel Source Address Register 1 */
+#define REG_XDMAC_CDA1          (0x400780A4) /**< (XDMAC) Channel Destination Address Register 1 */
+#define REG_XDMAC_CNDA1         (0x400780A8) /**< (XDMAC) Channel Next Descriptor Address Register 1 */
+#define REG_XDMAC_CNDC1         (0x400780AC) /**< (XDMAC) Channel Next Descriptor Control Register 1 */
+#define REG_XDMAC_CUBC1         (0x400780B0) /**< (XDMAC) Channel Microblock Control Register 1 */
+#define REG_XDMAC_CBC1          (0x400780B4) /**< (XDMAC) Channel Block Control Register 1 */
+#define REG_XDMAC_CC1           (0x400780B8) /**< (XDMAC) Channel Configuration Register 1 */
+#define REG_XDMAC_CDS_MSP1      (0x400780BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 1 */
+#define REG_XDMAC_CSUS1         (0x400780C0) /**< (XDMAC) Channel Source Microblock Stride 1 */
+#define REG_XDMAC_CDUS1         (0x400780C4) /**< (XDMAC) Channel Destination Microblock Stride 1 */
+#define REG_XDMAC_CIE2          (0x400780D0) /**< (XDMAC) Channel Interrupt Enable Register 2 */
+#define REG_XDMAC_CID2          (0x400780D4) /**< (XDMAC) Channel Interrupt Disable Register 2 */
+#define REG_XDMAC_CIM2          (0x400780D8) /**< (XDMAC) Channel Interrupt Mask Register 2 */
+#define REG_XDMAC_CIS2          (0x400780DC) /**< (XDMAC) Channel Interrupt Status Register 2 */
+#define REG_XDMAC_CSA2          (0x400780E0) /**< (XDMAC) Channel Source Address Register 2 */
+#define REG_XDMAC_CDA2          (0x400780E4) /**< (XDMAC) Channel Destination Address Register 2 */
+#define REG_XDMAC_CNDA2         (0x400780E8) /**< (XDMAC) Channel Next Descriptor Address Register 2 */
+#define REG_XDMAC_CNDC2         (0x400780EC) /**< (XDMAC) Channel Next Descriptor Control Register 2 */
+#define REG_XDMAC_CUBC2         (0x400780F0) /**< (XDMAC) Channel Microblock Control Register 2 */
+#define REG_XDMAC_CBC2          (0x400780F4) /**< (XDMAC) Channel Block Control Register 2 */
+#define REG_XDMAC_CC2           (0x400780F8) /**< (XDMAC) Channel Configuration Register 2 */
+#define REG_XDMAC_CDS_MSP2      (0x400780FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 2 */
+#define REG_XDMAC_CSUS2         (0x40078100) /**< (XDMAC) Channel Source Microblock Stride 2 */
+#define REG_XDMAC_CDUS2         (0x40078104) /**< (XDMAC) Channel Destination Microblock Stride 2 */
+#define REG_XDMAC_CIE3          (0x40078110) /**< (XDMAC) Channel Interrupt Enable Register 3 */
+#define REG_XDMAC_CID3          (0x40078114) /**< (XDMAC) Channel Interrupt Disable Register 3 */
+#define REG_XDMAC_CIM3          (0x40078118) /**< (XDMAC) Channel Interrupt Mask Register 3 */
+#define REG_XDMAC_CIS3          (0x4007811C) /**< (XDMAC) Channel Interrupt Status Register 3 */
+#define REG_XDMAC_CSA3          (0x40078120) /**< (XDMAC) Channel Source Address Register 3 */
+#define REG_XDMAC_CDA3          (0x40078124) /**< (XDMAC) Channel Destination Address Register 3 */
+#define REG_XDMAC_CNDA3         (0x40078128) /**< (XDMAC) Channel Next Descriptor Address Register 3 */
+#define REG_XDMAC_CNDC3         (0x4007812C) /**< (XDMAC) Channel Next Descriptor Control Register 3 */
+#define REG_XDMAC_CUBC3         (0x40078130) /**< (XDMAC) Channel Microblock Control Register 3 */
+#define REG_XDMAC_CBC3          (0x40078134) /**< (XDMAC) Channel Block Control Register 3 */
+#define REG_XDMAC_CC3           (0x40078138) /**< (XDMAC) Channel Configuration Register 3 */
+#define REG_XDMAC_CDS_MSP3      (0x4007813C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 3 */
+#define REG_XDMAC_CSUS3         (0x40078140) /**< (XDMAC) Channel Source Microblock Stride 3 */
+#define REG_XDMAC_CDUS3         (0x40078144) /**< (XDMAC) Channel Destination Microblock Stride 3 */
+#define REG_XDMAC_CIE4          (0x40078150) /**< (XDMAC) Channel Interrupt Enable Register 4 */
+#define REG_XDMAC_CID4          (0x40078154) /**< (XDMAC) Channel Interrupt Disable Register 4 */
+#define REG_XDMAC_CIM4          (0x40078158) /**< (XDMAC) Channel Interrupt Mask Register 4 */
+#define REG_XDMAC_CIS4          (0x4007815C) /**< (XDMAC) Channel Interrupt Status Register 4 */
+#define REG_XDMAC_CSA4          (0x40078160) /**< (XDMAC) Channel Source Address Register 4 */
+#define REG_XDMAC_CDA4          (0x40078164) /**< (XDMAC) Channel Destination Address Register 4 */
+#define REG_XDMAC_CNDA4         (0x40078168) /**< (XDMAC) Channel Next Descriptor Address Register 4 */
+#define REG_XDMAC_CNDC4         (0x4007816C) /**< (XDMAC) Channel Next Descriptor Control Register 4 */
+#define REG_XDMAC_CUBC4         (0x40078170) /**< (XDMAC) Channel Microblock Control Register 4 */
+#define REG_XDMAC_CBC4          (0x40078174) /**< (XDMAC) Channel Block Control Register 4 */
+#define REG_XDMAC_CC4           (0x40078178) /**< (XDMAC) Channel Configuration Register 4 */
+#define REG_XDMAC_CDS_MSP4      (0x4007817C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 4 */
+#define REG_XDMAC_CSUS4         (0x40078180) /**< (XDMAC) Channel Source Microblock Stride 4 */
+#define REG_XDMAC_CDUS4         (0x40078184) /**< (XDMAC) Channel Destination Microblock Stride 4 */
+#define REG_XDMAC_CIE5          (0x40078190) /**< (XDMAC) Channel Interrupt Enable Register 5 */
+#define REG_XDMAC_CID5          (0x40078194) /**< (XDMAC) Channel Interrupt Disable Register 5 */
+#define REG_XDMAC_CIM5          (0x40078198) /**< (XDMAC) Channel Interrupt Mask Register 5 */
+#define REG_XDMAC_CIS5          (0x4007819C) /**< (XDMAC) Channel Interrupt Status Register 5 */
+#define REG_XDMAC_CSA5          (0x400781A0) /**< (XDMAC) Channel Source Address Register 5 */
+#define REG_XDMAC_CDA5          (0x400781A4) /**< (XDMAC) Channel Destination Address Register 5 */
+#define REG_XDMAC_CNDA5         (0x400781A8) /**< (XDMAC) Channel Next Descriptor Address Register 5 */
+#define REG_XDMAC_CNDC5         (0x400781AC) /**< (XDMAC) Channel Next Descriptor Control Register 5 */
+#define REG_XDMAC_CUBC5         (0x400781B0) /**< (XDMAC) Channel Microblock Control Register 5 */
+#define REG_XDMAC_CBC5          (0x400781B4) /**< (XDMAC) Channel Block Control Register 5 */
+#define REG_XDMAC_CC5           (0x400781B8) /**< (XDMAC) Channel Configuration Register 5 */
+#define REG_XDMAC_CDS_MSP5      (0x400781BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 5 */
+#define REG_XDMAC_CSUS5         (0x400781C0) /**< (XDMAC) Channel Source Microblock Stride 5 */
+#define REG_XDMAC_CDUS5         (0x400781C4) /**< (XDMAC) Channel Destination Microblock Stride 5 */
+#define REG_XDMAC_CIE6          (0x400781D0) /**< (XDMAC) Channel Interrupt Enable Register 6 */
+#define REG_XDMAC_CID6          (0x400781D4) /**< (XDMAC) Channel Interrupt Disable Register 6 */
+#define REG_XDMAC_CIM6          (0x400781D8) /**< (XDMAC) Channel Interrupt Mask Register 6 */
+#define REG_XDMAC_CIS6          (0x400781DC) /**< (XDMAC) Channel Interrupt Status Register 6 */
+#define REG_XDMAC_CSA6          (0x400781E0) /**< (XDMAC) Channel Source Address Register 6 */
+#define REG_XDMAC_CDA6          (0x400781E4) /**< (XDMAC) Channel Destination Address Register 6 */
+#define REG_XDMAC_CNDA6         (0x400781E8) /**< (XDMAC) Channel Next Descriptor Address Register 6 */
+#define REG_XDMAC_CNDC6         (0x400781EC) /**< (XDMAC) Channel Next Descriptor Control Register 6 */
+#define REG_XDMAC_CUBC6         (0x400781F0) /**< (XDMAC) Channel Microblock Control Register 6 */
+#define REG_XDMAC_CBC6          (0x400781F4) /**< (XDMAC) Channel Block Control Register 6 */
+#define REG_XDMAC_CC6           (0x400781F8) /**< (XDMAC) Channel Configuration Register 6 */
+#define REG_XDMAC_CDS_MSP6      (0x400781FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 6 */
+#define REG_XDMAC_CSUS6         (0x40078200) /**< (XDMAC) Channel Source Microblock Stride 6 */
+#define REG_XDMAC_CDUS6         (0x40078204) /**< (XDMAC) Channel Destination Microblock Stride 6 */
+#define REG_XDMAC_CIE7          (0x40078210) /**< (XDMAC) Channel Interrupt Enable Register 7 */
+#define REG_XDMAC_CID7          (0x40078214) /**< (XDMAC) Channel Interrupt Disable Register 7 */
+#define REG_XDMAC_CIM7          (0x40078218) /**< (XDMAC) Channel Interrupt Mask Register 7 */
+#define REG_XDMAC_CIS7          (0x4007821C) /**< (XDMAC) Channel Interrupt Status Register 7 */
+#define REG_XDMAC_CSA7          (0x40078220) /**< (XDMAC) Channel Source Address Register 7 */
+#define REG_XDMAC_CDA7          (0x40078224) /**< (XDMAC) Channel Destination Address Register 7 */
+#define REG_XDMAC_CNDA7         (0x40078228) /**< (XDMAC) Channel Next Descriptor Address Register 7 */
+#define REG_XDMAC_CNDC7         (0x4007822C) /**< (XDMAC) Channel Next Descriptor Control Register 7 */
+#define REG_XDMAC_CUBC7         (0x40078230) /**< (XDMAC) Channel Microblock Control Register 7 */
+#define REG_XDMAC_CBC7          (0x40078234) /**< (XDMAC) Channel Block Control Register 7 */
+#define REG_XDMAC_CC7           (0x40078238) /**< (XDMAC) Channel Configuration Register 7 */
+#define REG_XDMAC_CDS_MSP7      (0x4007823C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 7 */
+#define REG_XDMAC_CSUS7         (0x40078240) /**< (XDMAC) Channel Source Microblock Stride 7 */
+#define REG_XDMAC_CDUS7         (0x40078244) /**< (XDMAC) Channel Destination Microblock Stride 7 */
+#define REG_XDMAC_CIE8          (0x40078250) /**< (XDMAC) Channel Interrupt Enable Register 8 */
+#define REG_XDMAC_CID8          (0x40078254) /**< (XDMAC) Channel Interrupt Disable Register 8 */
+#define REG_XDMAC_CIM8          (0x40078258) /**< (XDMAC) Channel Interrupt Mask Register 8 */
+#define REG_XDMAC_CIS8          (0x4007825C) /**< (XDMAC) Channel Interrupt Status Register 8 */
+#define REG_XDMAC_CSA8          (0x40078260) /**< (XDMAC) Channel Source Address Register 8 */
+#define REG_XDMAC_CDA8          (0x40078264) /**< (XDMAC) Channel Destination Address Register 8 */
+#define REG_XDMAC_CNDA8         (0x40078268) /**< (XDMAC) Channel Next Descriptor Address Register 8 */
+#define REG_XDMAC_CNDC8         (0x4007826C) /**< (XDMAC) Channel Next Descriptor Control Register 8 */
+#define REG_XDMAC_CUBC8         (0x40078270) /**< (XDMAC) Channel Microblock Control Register 8 */
+#define REG_XDMAC_CBC8          (0x40078274) /**< (XDMAC) Channel Block Control Register 8 */
+#define REG_XDMAC_CC8           (0x40078278) /**< (XDMAC) Channel Configuration Register 8 */
+#define REG_XDMAC_CDS_MSP8      (0x4007827C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 8 */
+#define REG_XDMAC_CSUS8         (0x40078280) /**< (XDMAC) Channel Source Microblock Stride 8 */
+#define REG_XDMAC_CDUS8         (0x40078284) /**< (XDMAC) Channel Destination Microblock Stride 8 */
+#define REG_XDMAC_CIE9          (0x40078290) /**< (XDMAC) Channel Interrupt Enable Register 9 */
+#define REG_XDMAC_CID9          (0x40078294) /**< (XDMAC) Channel Interrupt Disable Register 9 */
+#define REG_XDMAC_CIM9          (0x40078298) /**< (XDMAC) Channel Interrupt Mask Register 9 */
+#define REG_XDMAC_CIS9          (0x4007829C) /**< (XDMAC) Channel Interrupt Status Register 9 */
+#define REG_XDMAC_CSA9          (0x400782A0) /**< (XDMAC) Channel Source Address Register 9 */
+#define REG_XDMAC_CDA9          (0x400782A4) /**< (XDMAC) Channel Destination Address Register 9 */
+#define REG_XDMAC_CNDA9         (0x400782A8) /**< (XDMAC) Channel Next Descriptor Address Register 9 */
+#define REG_XDMAC_CNDC9         (0x400782AC) /**< (XDMAC) Channel Next Descriptor Control Register 9 */
+#define REG_XDMAC_CUBC9         (0x400782B0) /**< (XDMAC) Channel Microblock Control Register 9 */
+#define REG_XDMAC_CBC9          (0x400782B4) /**< (XDMAC) Channel Block Control Register 9 */
+#define REG_XDMAC_CC9           (0x400782B8) /**< (XDMAC) Channel Configuration Register 9 */
+#define REG_XDMAC_CDS_MSP9      (0x400782BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 9 */
+#define REG_XDMAC_CSUS9         (0x400782C0) /**< (XDMAC) Channel Source Microblock Stride 9 */
+#define REG_XDMAC_CDUS9         (0x400782C4) /**< (XDMAC) Channel Destination Microblock Stride 9 */
+#define REG_XDMAC_CIE10         (0x400782D0) /**< (XDMAC) Channel Interrupt Enable Register 10 */
+#define REG_XDMAC_CID10         (0x400782D4) /**< (XDMAC) Channel Interrupt Disable Register 10 */
+#define REG_XDMAC_CIM10         (0x400782D8) /**< (XDMAC) Channel Interrupt Mask Register 10 */
+#define REG_XDMAC_CIS10         (0x400782DC) /**< (XDMAC) Channel Interrupt Status Register 10 */
+#define REG_XDMAC_CSA10         (0x400782E0) /**< (XDMAC) Channel Source Address Register 10 */
+#define REG_XDMAC_CDA10         (0x400782E4) /**< (XDMAC) Channel Destination Address Register 10 */
+#define REG_XDMAC_CNDA10        (0x400782E8) /**< (XDMAC) Channel Next Descriptor Address Register 10 */
+#define REG_XDMAC_CNDC10        (0x400782EC) /**< (XDMAC) Channel Next Descriptor Control Register 10 */
+#define REG_XDMAC_CUBC10        (0x400782F0) /**< (XDMAC) Channel Microblock Control Register 10 */
+#define REG_XDMAC_CBC10         (0x400782F4) /**< (XDMAC) Channel Block Control Register 10 */
+#define REG_XDMAC_CC10          (0x400782F8) /**< (XDMAC) Channel Configuration Register 10 */
+#define REG_XDMAC_CDS_MSP10     (0x400782FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 10 */
+#define REG_XDMAC_CSUS10        (0x40078300) /**< (XDMAC) Channel Source Microblock Stride 10 */
+#define REG_XDMAC_CDUS10        (0x40078304) /**< (XDMAC) Channel Destination Microblock Stride 10 */
+#define REG_XDMAC_CIE11         (0x40078310) /**< (XDMAC) Channel Interrupt Enable Register 11 */
+#define REG_XDMAC_CID11         (0x40078314) /**< (XDMAC) Channel Interrupt Disable Register 11 */
+#define REG_XDMAC_CIM11         (0x40078318) /**< (XDMAC) Channel Interrupt Mask Register 11 */
+#define REG_XDMAC_CIS11         (0x4007831C) /**< (XDMAC) Channel Interrupt Status Register 11 */
+#define REG_XDMAC_CSA11         (0x40078320) /**< (XDMAC) Channel Source Address Register 11 */
+#define REG_XDMAC_CDA11         (0x40078324) /**< (XDMAC) Channel Destination Address Register 11 */
+#define REG_XDMAC_CNDA11        (0x40078328) /**< (XDMAC) Channel Next Descriptor Address Register 11 */
+#define REG_XDMAC_CNDC11        (0x4007832C) /**< (XDMAC) Channel Next Descriptor Control Register 11 */
+#define REG_XDMAC_CUBC11        (0x40078330) /**< (XDMAC) Channel Microblock Control Register 11 */
+#define REG_XDMAC_CBC11         (0x40078334) /**< (XDMAC) Channel Block Control Register 11 */
+#define REG_XDMAC_CC11          (0x40078338) /**< (XDMAC) Channel Configuration Register 11 */
+#define REG_XDMAC_CDS_MSP11     (0x4007833C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 11 */
+#define REG_XDMAC_CSUS11        (0x40078340) /**< (XDMAC) Channel Source Microblock Stride 11 */
+#define REG_XDMAC_CDUS11        (0x40078344) /**< (XDMAC) Channel Destination Microblock Stride 11 */
+#define REG_XDMAC_CIE12         (0x40078350) /**< (XDMAC) Channel Interrupt Enable Register 12 */
+#define REG_XDMAC_CID12         (0x40078354) /**< (XDMAC) Channel Interrupt Disable Register 12 */
+#define REG_XDMAC_CIM12         (0x40078358) /**< (XDMAC) Channel Interrupt Mask Register 12 */
+#define REG_XDMAC_CIS12         (0x4007835C) /**< (XDMAC) Channel Interrupt Status Register 12 */
+#define REG_XDMAC_CSA12         (0x40078360) /**< (XDMAC) Channel Source Address Register 12 */
+#define REG_XDMAC_CDA12         (0x40078364) /**< (XDMAC) Channel Destination Address Register 12 */
+#define REG_XDMAC_CNDA12        (0x40078368) /**< (XDMAC) Channel Next Descriptor Address Register 12 */
+#define REG_XDMAC_CNDC12        (0x4007836C) /**< (XDMAC) Channel Next Descriptor Control Register 12 */
+#define REG_XDMAC_CUBC12        (0x40078370) /**< (XDMAC) Channel Microblock Control Register 12 */
+#define REG_XDMAC_CBC12         (0x40078374) /**< (XDMAC) Channel Block Control Register 12 */
+#define REG_XDMAC_CC12          (0x40078378) /**< (XDMAC) Channel Configuration Register 12 */
+#define REG_XDMAC_CDS_MSP12     (0x4007837C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 12 */
+#define REG_XDMAC_CSUS12        (0x40078380) /**< (XDMAC) Channel Source Microblock Stride 12 */
+#define REG_XDMAC_CDUS12        (0x40078384) /**< (XDMAC) Channel Destination Microblock Stride 12 */
+#define REG_XDMAC_CIE13         (0x40078390) /**< (XDMAC) Channel Interrupt Enable Register 13 */
+#define REG_XDMAC_CID13         (0x40078394) /**< (XDMAC) Channel Interrupt Disable Register 13 */
+#define REG_XDMAC_CIM13         (0x40078398) /**< (XDMAC) Channel Interrupt Mask Register 13 */
+#define REG_XDMAC_CIS13         (0x4007839C) /**< (XDMAC) Channel Interrupt Status Register 13 */
+#define REG_XDMAC_CSA13         (0x400783A0) /**< (XDMAC) Channel Source Address Register 13 */
+#define REG_XDMAC_CDA13         (0x400783A4) /**< (XDMAC) Channel Destination Address Register 13 */
+#define REG_XDMAC_CNDA13        (0x400783A8) /**< (XDMAC) Channel Next Descriptor Address Register 13 */
+#define REG_XDMAC_CNDC13        (0x400783AC) /**< (XDMAC) Channel Next Descriptor Control Register 13 */
+#define REG_XDMAC_CUBC13        (0x400783B0) /**< (XDMAC) Channel Microblock Control Register 13 */
+#define REG_XDMAC_CBC13         (0x400783B4) /**< (XDMAC) Channel Block Control Register 13 */
+#define REG_XDMAC_CC13          (0x400783B8) /**< (XDMAC) Channel Configuration Register 13 */
+#define REG_XDMAC_CDS_MSP13     (0x400783BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 13 */
+#define REG_XDMAC_CSUS13        (0x400783C0) /**< (XDMAC) Channel Source Microblock Stride 13 */
+#define REG_XDMAC_CDUS13        (0x400783C4) /**< (XDMAC) Channel Destination Microblock Stride 13 */
+#define REG_XDMAC_CIE14         (0x400783D0) /**< (XDMAC) Channel Interrupt Enable Register 14 */
+#define REG_XDMAC_CID14         (0x400783D4) /**< (XDMAC) Channel Interrupt Disable Register 14 */
+#define REG_XDMAC_CIM14         (0x400783D8) /**< (XDMAC) Channel Interrupt Mask Register 14 */
+#define REG_XDMAC_CIS14         (0x400783DC) /**< (XDMAC) Channel Interrupt Status Register 14 */
+#define REG_XDMAC_CSA14         (0x400783E0) /**< (XDMAC) Channel Source Address Register 14 */
+#define REG_XDMAC_CDA14         (0x400783E4) /**< (XDMAC) Channel Destination Address Register 14 */
+#define REG_XDMAC_CNDA14        (0x400783E8) /**< (XDMAC) Channel Next Descriptor Address Register 14 */
+#define REG_XDMAC_CNDC14        (0x400783EC) /**< (XDMAC) Channel Next Descriptor Control Register 14 */
+#define REG_XDMAC_CUBC14        (0x400783F0) /**< (XDMAC) Channel Microblock Control Register 14 */
+#define REG_XDMAC_CBC14         (0x400783F4) /**< (XDMAC) Channel Block Control Register 14 */
+#define REG_XDMAC_CC14          (0x400783F8) /**< (XDMAC) Channel Configuration Register 14 */
+#define REG_XDMAC_CDS_MSP14     (0x400783FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 14 */
+#define REG_XDMAC_CSUS14        (0x40078400) /**< (XDMAC) Channel Source Microblock Stride 14 */
+#define REG_XDMAC_CDUS14        (0x40078404) /**< (XDMAC) Channel Destination Microblock Stride 14 */
+#define REG_XDMAC_CIE15         (0x40078410) /**< (XDMAC) Channel Interrupt Enable Register 15 */
+#define REG_XDMAC_CID15         (0x40078414) /**< (XDMAC) Channel Interrupt Disable Register 15 */
+#define REG_XDMAC_CIM15         (0x40078418) /**< (XDMAC) Channel Interrupt Mask Register 15 */
+#define REG_XDMAC_CIS15         (0x4007841C) /**< (XDMAC) Channel Interrupt Status Register 15 */
+#define REG_XDMAC_CSA15         (0x40078420) /**< (XDMAC) Channel Source Address Register 15 */
+#define REG_XDMAC_CDA15         (0x40078424) /**< (XDMAC) Channel Destination Address Register 15 */
+#define REG_XDMAC_CNDA15        (0x40078428) /**< (XDMAC) Channel Next Descriptor Address Register 15 */
+#define REG_XDMAC_CNDC15        (0x4007842C) /**< (XDMAC) Channel Next Descriptor Control Register 15 */
+#define REG_XDMAC_CUBC15        (0x40078430) /**< (XDMAC) Channel Microblock Control Register 15 */
+#define REG_XDMAC_CBC15         (0x40078434) /**< (XDMAC) Channel Block Control Register 15 */
+#define REG_XDMAC_CC15          (0x40078438) /**< (XDMAC) Channel Configuration Register 15 */
+#define REG_XDMAC_CDS_MSP15     (0x4007843C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 15 */
+#define REG_XDMAC_CSUS15        (0x40078440) /**< (XDMAC) Channel Source Microblock Stride 15 */
+#define REG_XDMAC_CDUS15        (0x40078444) /**< (XDMAC) Channel Destination Microblock Stride 15 */
+#define REG_XDMAC_CIE16         (0x40078450) /**< (XDMAC) Channel Interrupt Enable Register 16 */
+#define REG_XDMAC_CID16         (0x40078454) /**< (XDMAC) Channel Interrupt Disable Register 16 */
+#define REG_XDMAC_CIM16         (0x40078458) /**< (XDMAC) Channel Interrupt Mask Register 16 */
+#define REG_XDMAC_CIS16         (0x4007845C) /**< (XDMAC) Channel Interrupt Status Register 16 */
+#define REG_XDMAC_CSA16         (0x40078460) /**< (XDMAC) Channel Source Address Register 16 */
+#define REG_XDMAC_CDA16         (0x40078464) /**< (XDMAC) Channel Destination Address Register 16 */
+#define REG_XDMAC_CNDA16        (0x40078468) /**< (XDMAC) Channel Next Descriptor Address Register 16 */
+#define REG_XDMAC_CNDC16        (0x4007846C) /**< (XDMAC) Channel Next Descriptor Control Register 16 */
+#define REG_XDMAC_CUBC16        (0x40078470) /**< (XDMAC) Channel Microblock Control Register 16 */
+#define REG_XDMAC_CBC16         (0x40078474) /**< (XDMAC) Channel Block Control Register 16 */
+#define REG_XDMAC_CC16          (0x40078478) /**< (XDMAC) Channel Configuration Register 16 */
+#define REG_XDMAC_CDS_MSP16     (0x4007847C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 16 */
+#define REG_XDMAC_CSUS16        (0x40078480) /**< (XDMAC) Channel Source Microblock Stride 16 */
+#define REG_XDMAC_CDUS16        (0x40078484) /**< (XDMAC) Channel Destination Microblock Stride 16 */
+#define REG_XDMAC_CIE17         (0x40078490) /**< (XDMAC) Channel Interrupt Enable Register 17 */
+#define REG_XDMAC_CID17         (0x40078494) /**< (XDMAC) Channel Interrupt Disable Register 17 */
+#define REG_XDMAC_CIM17         (0x40078498) /**< (XDMAC) Channel Interrupt Mask Register 17 */
+#define REG_XDMAC_CIS17         (0x4007849C) /**< (XDMAC) Channel Interrupt Status Register 17 */
+#define REG_XDMAC_CSA17         (0x400784A0) /**< (XDMAC) Channel Source Address Register 17 */
+#define REG_XDMAC_CDA17         (0x400784A4) /**< (XDMAC) Channel Destination Address Register 17 */
+#define REG_XDMAC_CNDA17        (0x400784A8) /**< (XDMAC) Channel Next Descriptor Address Register 17 */
+#define REG_XDMAC_CNDC17        (0x400784AC) /**< (XDMAC) Channel Next Descriptor Control Register 17 */
+#define REG_XDMAC_CUBC17        (0x400784B0) /**< (XDMAC) Channel Microblock Control Register 17 */
+#define REG_XDMAC_CBC17         (0x400784B4) /**< (XDMAC) Channel Block Control Register 17 */
+#define REG_XDMAC_CC17          (0x400784B8) /**< (XDMAC) Channel Configuration Register 17 */
+#define REG_XDMAC_CDS_MSP17     (0x400784BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 17 */
+#define REG_XDMAC_CSUS17        (0x400784C0) /**< (XDMAC) Channel Source Microblock Stride 17 */
+#define REG_XDMAC_CDUS17        (0x400784C4) /**< (XDMAC) Channel Destination Microblock Stride 17 */
+#define REG_XDMAC_CIE18         (0x400784D0) /**< (XDMAC) Channel Interrupt Enable Register 18 */
+#define REG_XDMAC_CID18         (0x400784D4) /**< (XDMAC) Channel Interrupt Disable Register 18 */
+#define REG_XDMAC_CIM18         (0x400784D8) /**< (XDMAC) Channel Interrupt Mask Register 18 */
+#define REG_XDMAC_CIS18         (0x400784DC) /**< (XDMAC) Channel Interrupt Status Register 18 */
+#define REG_XDMAC_CSA18         (0x400784E0) /**< (XDMAC) Channel Source Address Register 18 */
+#define REG_XDMAC_CDA18         (0x400784E4) /**< (XDMAC) Channel Destination Address Register 18 */
+#define REG_XDMAC_CNDA18        (0x400784E8) /**< (XDMAC) Channel Next Descriptor Address Register 18 */
+#define REG_XDMAC_CNDC18        (0x400784EC) /**< (XDMAC) Channel Next Descriptor Control Register 18 */
+#define REG_XDMAC_CUBC18        (0x400784F0) /**< (XDMAC) Channel Microblock Control Register 18 */
+#define REG_XDMAC_CBC18         (0x400784F4) /**< (XDMAC) Channel Block Control Register 18 */
+#define REG_XDMAC_CC18          (0x400784F8) /**< (XDMAC) Channel Configuration Register 18 */
+#define REG_XDMAC_CDS_MSP18     (0x400784FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 18 */
+#define REG_XDMAC_CSUS18        (0x40078500) /**< (XDMAC) Channel Source Microblock Stride 18 */
+#define REG_XDMAC_CDUS18        (0x40078504) /**< (XDMAC) Channel Destination Microblock Stride 18 */
+#define REG_XDMAC_CIE19         (0x40078510) /**< (XDMAC) Channel Interrupt Enable Register 19 */
+#define REG_XDMAC_CID19         (0x40078514) /**< (XDMAC) Channel Interrupt Disable Register 19 */
+#define REG_XDMAC_CIM19         (0x40078518) /**< (XDMAC) Channel Interrupt Mask Register 19 */
+#define REG_XDMAC_CIS19         (0x4007851C) /**< (XDMAC) Channel Interrupt Status Register 19 */
+#define REG_XDMAC_CSA19         (0x40078520) /**< (XDMAC) Channel Source Address Register 19 */
+#define REG_XDMAC_CDA19         (0x40078524) /**< (XDMAC) Channel Destination Address Register 19 */
+#define REG_XDMAC_CNDA19        (0x40078528) /**< (XDMAC) Channel Next Descriptor Address Register 19 */
+#define REG_XDMAC_CNDC19        (0x4007852C) /**< (XDMAC) Channel Next Descriptor Control Register 19 */
+#define REG_XDMAC_CUBC19        (0x40078530) /**< (XDMAC) Channel Microblock Control Register 19 */
+#define REG_XDMAC_CBC19         (0x40078534) /**< (XDMAC) Channel Block Control Register 19 */
+#define REG_XDMAC_CC19          (0x40078538) /**< (XDMAC) Channel Configuration Register 19 */
+#define REG_XDMAC_CDS_MSP19     (0x4007853C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 19 */
+#define REG_XDMAC_CSUS19        (0x40078540) /**< (XDMAC) Channel Source Microblock Stride 19 */
+#define REG_XDMAC_CDUS19        (0x40078544) /**< (XDMAC) Channel Destination Microblock Stride 19 */
+#define REG_XDMAC_CIE20         (0x40078550) /**< (XDMAC) Channel Interrupt Enable Register 20 */
+#define REG_XDMAC_CID20         (0x40078554) /**< (XDMAC) Channel Interrupt Disable Register 20 */
+#define REG_XDMAC_CIM20         (0x40078558) /**< (XDMAC) Channel Interrupt Mask Register 20 */
+#define REG_XDMAC_CIS20         (0x4007855C) /**< (XDMAC) Channel Interrupt Status Register 20 */
+#define REG_XDMAC_CSA20         (0x40078560) /**< (XDMAC) Channel Source Address Register 20 */
+#define REG_XDMAC_CDA20         (0x40078564) /**< (XDMAC) Channel Destination Address Register 20 */
+#define REG_XDMAC_CNDA20        (0x40078568) /**< (XDMAC) Channel Next Descriptor Address Register 20 */
+#define REG_XDMAC_CNDC20        (0x4007856C) /**< (XDMAC) Channel Next Descriptor Control Register 20 */
+#define REG_XDMAC_CUBC20        (0x40078570) /**< (XDMAC) Channel Microblock Control Register 20 */
+#define REG_XDMAC_CBC20         (0x40078574) /**< (XDMAC) Channel Block Control Register 20 */
+#define REG_XDMAC_CC20          (0x40078578) /**< (XDMAC) Channel Configuration Register 20 */
+#define REG_XDMAC_CDS_MSP20     (0x4007857C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 20 */
+#define REG_XDMAC_CSUS20        (0x40078580) /**< (XDMAC) Channel Source Microblock Stride 20 */
+#define REG_XDMAC_CDUS20        (0x40078584) /**< (XDMAC) Channel Destination Microblock Stride 20 */
+#define REG_XDMAC_CIE21         (0x40078590) /**< (XDMAC) Channel Interrupt Enable Register 21 */
+#define REG_XDMAC_CID21         (0x40078594) /**< (XDMAC) Channel Interrupt Disable Register 21 */
+#define REG_XDMAC_CIM21         (0x40078598) /**< (XDMAC) Channel Interrupt Mask Register 21 */
+#define REG_XDMAC_CIS21         (0x4007859C) /**< (XDMAC) Channel Interrupt Status Register 21 */
+#define REG_XDMAC_CSA21         (0x400785A0) /**< (XDMAC) Channel Source Address Register 21 */
+#define REG_XDMAC_CDA21         (0x400785A4) /**< (XDMAC) Channel Destination Address Register 21 */
+#define REG_XDMAC_CNDA21        (0x400785A8) /**< (XDMAC) Channel Next Descriptor Address Register 21 */
+#define REG_XDMAC_CNDC21        (0x400785AC) /**< (XDMAC) Channel Next Descriptor Control Register 21 */
+#define REG_XDMAC_CUBC21        (0x400785B0) /**< (XDMAC) Channel Microblock Control Register 21 */
+#define REG_XDMAC_CBC21         (0x400785B4) /**< (XDMAC) Channel Block Control Register 21 */
+#define REG_XDMAC_CC21          (0x400785B8) /**< (XDMAC) Channel Configuration Register 21 */
+#define REG_XDMAC_CDS_MSP21     (0x400785BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 21 */
+#define REG_XDMAC_CSUS21        (0x400785C0) /**< (XDMAC) Channel Source Microblock Stride 21 */
+#define REG_XDMAC_CDUS21        (0x400785C4) /**< (XDMAC) Channel Destination Microblock Stride 21 */
+#define REG_XDMAC_CIE22         (0x400785D0) /**< (XDMAC) Channel Interrupt Enable Register 22 */
+#define REG_XDMAC_CID22         (0x400785D4) /**< (XDMAC) Channel Interrupt Disable Register 22 */
+#define REG_XDMAC_CIM22         (0x400785D8) /**< (XDMAC) Channel Interrupt Mask Register 22 */
+#define REG_XDMAC_CIS22         (0x400785DC) /**< (XDMAC) Channel Interrupt Status Register 22 */
+#define REG_XDMAC_CSA22         (0x400785E0) /**< (XDMAC) Channel Source Address Register 22 */
+#define REG_XDMAC_CDA22         (0x400785E4) /**< (XDMAC) Channel Destination Address Register 22 */
+#define REG_XDMAC_CNDA22        (0x400785E8) /**< (XDMAC) Channel Next Descriptor Address Register 22 */
+#define REG_XDMAC_CNDC22        (0x400785EC) /**< (XDMAC) Channel Next Descriptor Control Register 22 */
+#define REG_XDMAC_CUBC22        (0x400785F0) /**< (XDMAC) Channel Microblock Control Register 22 */
+#define REG_XDMAC_CBC22         (0x400785F4) /**< (XDMAC) Channel Block Control Register 22 */
+#define REG_XDMAC_CC22          (0x400785F8) /**< (XDMAC) Channel Configuration Register 22 */
+#define REG_XDMAC_CDS_MSP22     (0x400785FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 22 */
+#define REG_XDMAC_CSUS22        (0x40078600) /**< (XDMAC) Channel Source Microblock Stride 22 */
+#define REG_XDMAC_CDUS22        (0x40078604) /**< (XDMAC) Channel Destination Microblock Stride 22 */
+#define REG_XDMAC_CIE23         (0x40078610) /**< (XDMAC) Channel Interrupt Enable Register 23 */
+#define REG_XDMAC_CID23         (0x40078614) /**< (XDMAC) Channel Interrupt Disable Register 23 */
+#define REG_XDMAC_CIM23         (0x40078618) /**< (XDMAC) Channel Interrupt Mask Register 23 */
+#define REG_XDMAC_CIS23         (0x4007861C) /**< (XDMAC) Channel Interrupt Status Register 23 */
+#define REG_XDMAC_CSA23         (0x40078620) /**< (XDMAC) Channel Source Address Register 23 */
+#define REG_XDMAC_CDA23         (0x40078624) /**< (XDMAC) Channel Destination Address Register 23 */
+#define REG_XDMAC_CNDA23        (0x40078628) /**< (XDMAC) Channel Next Descriptor Address Register 23 */
+#define REG_XDMAC_CNDC23        (0x4007862C) /**< (XDMAC) Channel Next Descriptor Control Register 23 */
+#define REG_XDMAC_CUBC23        (0x40078630) /**< (XDMAC) Channel Microblock Control Register 23 */
+#define REG_XDMAC_CBC23         (0x40078634) /**< (XDMAC) Channel Block Control Register 23 */
+#define REG_XDMAC_CC23          (0x40078638) /**< (XDMAC) Channel Configuration Register 23 */
+#define REG_XDMAC_CDS_MSP23     (0x4007863C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 23 */
+#define REG_XDMAC_CSUS23        (0x40078640) /**< (XDMAC) Channel Source Microblock Stride 23 */
+#define REG_XDMAC_CDUS23        (0x40078644) /**< (XDMAC) Channel Destination Microblock Stride 23 */
+#define REG_XDMAC_GTYPE         (0x40078000) /**< (XDMAC) Global Type Register */
+#define REG_XDMAC_GCFG          (0x40078004) /**< (XDMAC) Global Configuration Register */
+#define REG_XDMAC_GWAC          (0x40078008) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
+#define REG_XDMAC_GIE           (0x4007800C) /**< (XDMAC) Global Interrupt Enable Register */
+#define REG_XDMAC_GID           (0x40078010) /**< (XDMAC) Global Interrupt Disable Register */
+#define REG_XDMAC_GIM           (0x40078014) /**< (XDMAC) Global Interrupt Mask Register */
+#define REG_XDMAC_GIS           (0x40078018) /**< (XDMAC) Global Interrupt Status Register */
+#define REG_XDMAC_GE            (0x4007801C) /**< (XDMAC) Global Channel Enable Register */
+#define REG_XDMAC_GD            (0x40078020) /**< (XDMAC) Global Channel Disable Register */
+#define REG_XDMAC_GS            (0x40078024) /**< (XDMAC) Global Channel Status Register */
+#define REG_XDMAC_GRS           (0x40078028) /**< (XDMAC) Global Channel Read Suspend Register */
+#define REG_XDMAC_GWS           (0x4007802C) /**< (XDMAC) Global Channel Write Suspend Register */
+#define REG_XDMAC_GRWS          (0x40078030) /**< (XDMAC) Global Channel Read Write Suspend Register */
+#define REG_XDMAC_GRWR          (0x40078034) /**< (XDMAC) Global Channel Read Write Resume Register */
+#define REG_XDMAC_GSWR          (0x40078038) /**< (XDMAC) Global Channel Software Request Register */
+#define REG_XDMAC_GSWS          (0x4007803C) /**< (XDMAC) Global Channel Software Request Status Register */
+#define REG_XDMAC_GSWF          (0x40078040) /**< (XDMAC) Global Channel Software Flush Request Register */
+
+#else
+
+#define REG_XDMAC_CIE0          (*(__O  uint32_t*)0x40078050U) /**< (XDMAC) Channel Interrupt Enable Register 0 */
+#define REG_XDMAC_CID0          (*(__O  uint32_t*)0x40078054U) /**< (XDMAC) Channel Interrupt Disable Register 0 */
+#define REG_XDMAC_CIM0          (*(__I  uint32_t*)0x40078058U) /**< (XDMAC) Channel Interrupt Mask Register 0 */
+#define REG_XDMAC_CIS0          (*(__I  uint32_t*)0x4007805CU) /**< (XDMAC) Channel Interrupt Status Register 0 */
+#define REG_XDMAC_CSA0          (*(__IO uint32_t*)0x40078060U) /**< (XDMAC) Channel Source Address Register 0 */
+#define REG_XDMAC_CDA0          (*(__IO uint32_t*)0x40078064U) /**< (XDMAC) Channel Destination Address Register 0 */
+#define REG_XDMAC_CNDA0         (*(__IO uint32_t*)0x40078068U) /**< (XDMAC) Channel Next Descriptor Address Register 0 */
+#define REG_XDMAC_CNDC0         (*(__IO uint32_t*)0x4007806CU) /**< (XDMAC) Channel Next Descriptor Control Register 0 */
+#define REG_XDMAC_CUBC0         (*(__IO uint32_t*)0x40078070U) /**< (XDMAC) Channel Microblock Control Register 0 */
+#define REG_XDMAC_CBC0          (*(__IO uint32_t*)0x40078074U) /**< (XDMAC) Channel Block Control Register 0 */
+#define REG_XDMAC_CC0           (*(__IO uint32_t*)0x40078078U) /**< (XDMAC) Channel Configuration Register 0 */
+#define REG_XDMAC_CDS_MSP0      (*(__IO uint32_t*)0x4007807CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 0 */
+#define REG_XDMAC_CSUS0         (*(__IO uint32_t*)0x40078080U) /**< (XDMAC) Channel Source Microblock Stride 0 */
+#define REG_XDMAC_CDUS0         (*(__IO uint32_t*)0x40078084U) /**< (XDMAC) Channel Destination Microblock Stride 0 */
+#define REG_XDMAC_CIE1          (*(__O  uint32_t*)0x40078090U) /**< (XDMAC) Channel Interrupt Enable Register 1 */
+#define REG_XDMAC_CID1          (*(__O  uint32_t*)0x40078094U) /**< (XDMAC) Channel Interrupt Disable Register 1 */
+#define REG_XDMAC_CIM1          (*(__I  uint32_t*)0x40078098U) /**< (XDMAC) Channel Interrupt Mask Register 1 */
+#define REG_XDMAC_CIS1          (*(__I  uint32_t*)0x4007809CU) /**< (XDMAC) Channel Interrupt Status Register 1 */
+#define REG_XDMAC_CSA1          (*(__IO uint32_t*)0x400780A0U) /**< (XDMAC) Channel Source Address Register 1 */
+#define REG_XDMAC_CDA1          (*(__IO uint32_t*)0x400780A4U) /**< (XDMAC) Channel Destination Address Register 1 */
+#define REG_XDMAC_CNDA1         (*(__IO uint32_t*)0x400780A8U) /**< (XDMAC) Channel Next Descriptor Address Register 1 */
+#define REG_XDMAC_CNDC1         (*(__IO uint32_t*)0x400780ACU) /**< (XDMAC) Channel Next Descriptor Control Register 1 */
+#define REG_XDMAC_CUBC1         (*(__IO uint32_t*)0x400780B0U) /**< (XDMAC) Channel Microblock Control Register 1 */
+#define REG_XDMAC_CBC1          (*(__IO uint32_t*)0x400780B4U) /**< (XDMAC) Channel Block Control Register 1 */
+#define REG_XDMAC_CC1           (*(__IO uint32_t*)0x400780B8U) /**< (XDMAC) Channel Configuration Register 1 */
+#define REG_XDMAC_CDS_MSP1      (*(__IO uint32_t*)0x400780BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 1 */
+#define REG_XDMAC_CSUS1         (*(__IO uint32_t*)0x400780C0U) /**< (XDMAC) Channel Source Microblock Stride 1 */
+#define REG_XDMAC_CDUS1         (*(__IO uint32_t*)0x400780C4U) /**< (XDMAC) Channel Destination Microblock Stride 1 */
+#define REG_XDMAC_CIE2          (*(__O  uint32_t*)0x400780D0U) /**< (XDMAC) Channel Interrupt Enable Register 2 */
+#define REG_XDMAC_CID2          (*(__O  uint32_t*)0x400780D4U) /**< (XDMAC) Channel Interrupt Disable Register 2 */
+#define REG_XDMAC_CIM2          (*(__I  uint32_t*)0x400780D8U) /**< (XDMAC) Channel Interrupt Mask Register 2 */
+#define REG_XDMAC_CIS2          (*(__I  uint32_t*)0x400780DCU) /**< (XDMAC) Channel Interrupt Status Register 2 */
+#define REG_XDMAC_CSA2          (*(__IO uint32_t*)0x400780E0U) /**< (XDMAC) Channel Source Address Register 2 */
+#define REG_XDMAC_CDA2          (*(__IO uint32_t*)0x400780E4U) /**< (XDMAC) Channel Destination Address Register 2 */
+#define REG_XDMAC_CNDA2         (*(__IO uint32_t*)0x400780E8U) /**< (XDMAC) Channel Next Descriptor Address Register 2 */
+#define REG_XDMAC_CNDC2         (*(__IO uint32_t*)0x400780ECU) /**< (XDMAC) Channel Next Descriptor Control Register 2 */
+#define REG_XDMAC_CUBC2         (*(__IO uint32_t*)0x400780F0U) /**< (XDMAC) Channel Microblock Control Register 2 */
+#define REG_XDMAC_CBC2          (*(__IO uint32_t*)0x400780F4U) /**< (XDMAC) Channel Block Control Register 2 */
+#define REG_XDMAC_CC2           (*(__IO uint32_t*)0x400780F8U) /**< (XDMAC) Channel Configuration Register 2 */
+#define REG_XDMAC_CDS_MSP2      (*(__IO uint32_t*)0x400780FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 2 */
+#define REG_XDMAC_CSUS2         (*(__IO uint32_t*)0x40078100U) /**< (XDMAC) Channel Source Microblock Stride 2 */
+#define REG_XDMAC_CDUS2         (*(__IO uint32_t*)0x40078104U) /**< (XDMAC) Channel Destination Microblock Stride 2 */
+#define REG_XDMAC_CIE3          (*(__O  uint32_t*)0x40078110U) /**< (XDMAC) Channel Interrupt Enable Register 3 */
+#define REG_XDMAC_CID3          (*(__O  uint32_t*)0x40078114U) /**< (XDMAC) Channel Interrupt Disable Register 3 */
+#define REG_XDMAC_CIM3          (*(__I  uint32_t*)0x40078118U) /**< (XDMAC) Channel Interrupt Mask Register 3 */
+#define REG_XDMAC_CIS3          (*(__I  uint32_t*)0x4007811CU) /**< (XDMAC) Channel Interrupt Status Register 3 */
+#define REG_XDMAC_CSA3          (*(__IO uint32_t*)0x40078120U) /**< (XDMAC) Channel Source Address Register 3 */
+#define REG_XDMAC_CDA3          (*(__IO uint32_t*)0x40078124U) /**< (XDMAC) Channel Destination Address Register 3 */
+#define REG_XDMAC_CNDA3         (*(__IO uint32_t*)0x40078128U) /**< (XDMAC) Channel Next Descriptor Address Register 3 */
+#define REG_XDMAC_CNDC3         (*(__IO uint32_t*)0x4007812CU) /**< (XDMAC) Channel Next Descriptor Control Register 3 */
+#define REG_XDMAC_CUBC3         (*(__IO uint32_t*)0x40078130U) /**< (XDMAC) Channel Microblock Control Register 3 */
+#define REG_XDMAC_CBC3          (*(__IO uint32_t*)0x40078134U) /**< (XDMAC) Channel Block Control Register 3 */
+#define REG_XDMAC_CC3           (*(__IO uint32_t*)0x40078138U) /**< (XDMAC) Channel Configuration Register 3 */
+#define REG_XDMAC_CDS_MSP3      (*(__IO uint32_t*)0x4007813CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 3 */
+#define REG_XDMAC_CSUS3         (*(__IO uint32_t*)0x40078140U) /**< (XDMAC) Channel Source Microblock Stride 3 */
+#define REG_XDMAC_CDUS3         (*(__IO uint32_t*)0x40078144U) /**< (XDMAC) Channel Destination Microblock Stride 3 */
+#define REG_XDMAC_CIE4          (*(__O  uint32_t*)0x40078150U) /**< (XDMAC) Channel Interrupt Enable Register 4 */
+#define REG_XDMAC_CID4          (*(__O  uint32_t*)0x40078154U) /**< (XDMAC) Channel Interrupt Disable Register 4 */
+#define REG_XDMAC_CIM4          (*(__I  uint32_t*)0x40078158U) /**< (XDMAC) Channel Interrupt Mask Register 4 */
+#define REG_XDMAC_CIS4          (*(__I  uint32_t*)0x4007815CU) /**< (XDMAC) Channel Interrupt Status Register 4 */
+#define REG_XDMAC_CSA4          (*(__IO uint32_t*)0x40078160U) /**< (XDMAC) Channel Source Address Register 4 */
+#define REG_XDMAC_CDA4          (*(__IO uint32_t*)0x40078164U) /**< (XDMAC) Channel Destination Address Register 4 */
+#define REG_XDMAC_CNDA4         (*(__IO uint32_t*)0x40078168U) /**< (XDMAC) Channel Next Descriptor Address Register 4 */
+#define REG_XDMAC_CNDC4         (*(__IO uint32_t*)0x4007816CU) /**< (XDMAC) Channel Next Descriptor Control Register 4 */
+#define REG_XDMAC_CUBC4         (*(__IO uint32_t*)0x40078170U) /**< (XDMAC) Channel Microblock Control Register 4 */
+#define REG_XDMAC_CBC4          (*(__IO uint32_t*)0x40078174U) /**< (XDMAC) Channel Block Control Register 4 */
+#define REG_XDMAC_CC4           (*(__IO uint32_t*)0x40078178U) /**< (XDMAC) Channel Configuration Register 4 */
+#define REG_XDMAC_CDS_MSP4      (*(__IO uint32_t*)0x4007817CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 4 */
+#define REG_XDMAC_CSUS4         (*(__IO uint32_t*)0x40078180U) /**< (XDMAC) Channel Source Microblock Stride 4 */
+#define REG_XDMAC_CDUS4         (*(__IO uint32_t*)0x40078184U) /**< (XDMAC) Channel Destination Microblock Stride 4 */
+#define REG_XDMAC_CIE5          (*(__O  uint32_t*)0x40078190U) /**< (XDMAC) Channel Interrupt Enable Register 5 */
+#define REG_XDMAC_CID5          (*(__O  uint32_t*)0x40078194U) /**< (XDMAC) Channel Interrupt Disable Register 5 */
+#define REG_XDMAC_CIM5          (*(__I  uint32_t*)0x40078198U) /**< (XDMAC) Channel Interrupt Mask Register 5 */
+#define REG_XDMAC_CIS5          (*(__I  uint32_t*)0x4007819CU) /**< (XDMAC) Channel Interrupt Status Register 5 */
+#define REG_XDMAC_CSA5          (*(__IO uint32_t*)0x400781A0U) /**< (XDMAC) Channel Source Address Register 5 */
+#define REG_XDMAC_CDA5          (*(__IO uint32_t*)0x400781A4U) /**< (XDMAC) Channel Destination Address Register 5 */
+#define REG_XDMAC_CNDA5         (*(__IO uint32_t*)0x400781A8U) /**< (XDMAC) Channel Next Descriptor Address Register 5 */
+#define REG_XDMAC_CNDC5         (*(__IO uint32_t*)0x400781ACU) /**< (XDMAC) Channel Next Descriptor Control Register 5 */
+#define REG_XDMAC_CUBC5         (*(__IO uint32_t*)0x400781B0U) /**< (XDMAC) Channel Microblock Control Register 5 */
+#define REG_XDMAC_CBC5          (*(__IO uint32_t*)0x400781B4U) /**< (XDMAC) Channel Block Control Register 5 */
+#define REG_XDMAC_CC5           (*(__IO uint32_t*)0x400781B8U) /**< (XDMAC) Channel Configuration Register 5 */
+#define REG_XDMAC_CDS_MSP5      (*(__IO uint32_t*)0x400781BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 5 */
+#define REG_XDMAC_CSUS5         (*(__IO uint32_t*)0x400781C0U) /**< (XDMAC) Channel Source Microblock Stride 5 */
+#define REG_XDMAC_CDUS5         (*(__IO uint32_t*)0x400781C4U) /**< (XDMAC) Channel Destination Microblock Stride 5 */
+#define REG_XDMAC_CIE6          (*(__O  uint32_t*)0x400781D0U) /**< (XDMAC) Channel Interrupt Enable Register 6 */
+#define REG_XDMAC_CID6          (*(__O  uint32_t*)0x400781D4U) /**< (XDMAC) Channel Interrupt Disable Register 6 */
+#define REG_XDMAC_CIM6          (*(__I  uint32_t*)0x400781D8U) /**< (XDMAC) Channel Interrupt Mask Register 6 */
+#define REG_XDMAC_CIS6          (*(__I  uint32_t*)0x400781DCU) /**< (XDMAC) Channel Interrupt Status Register 6 */
+#define REG_XDMAC_CSA6          (*(__IO uint32_t*)0x400781E0U) /**< (XDMAC) Channel Source Address Register 6 */
+#define REG_XDMAC_CDA6          (*(__IO uint32_t*)0x400781E4U) /**< (XDMAC) Channel Destination Address Register 6 */
+#define REG_XDMAC_CNDA6         (*(__IO uint32_t*)0x400781E8U) /**< (XDMAC) Channel Next Descriptor Address Register 6 */
+#define REG_XDMAC_CNDC6         (*(__IO uint32_t*)0x400781ECU) /**< (XDMAC) Channel Next Descriptor Control Register 6 */
+#define REG_XDMAC_CUBC6         (*(__IO uint32_t*)0x400781F0U) /**< (XDMAC) Channel Microblock Control Register 6 */
+#define REG_XDMAC_CBC6          (*(__IO uint32_t*)0x400781F4U) /**< (XDMAC) Channel Block Control Register 6 */
+#define REG_XDMAC_CC6           (*(__IO uint32_t*)0x400781F8U) /**< (XDMAC) Channel Configuration Register 6 */
+#define REG_XDMAC_CDS_MSP6      (*(__IO uint32_t*)0x400781FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 6 */
+#define REG_XDMAC_CSUS6         (*(__IO uint32_t*)0x40078200U) /**< (XDMAC) Channel Source Microblock Stride 6 */
+#define REG_XDMAC_CDUS6         (*(__IO uint32_t*)0x40078204U) /**< (XDMAC) Channel Destination Microblock Stride 6 */
+#define REG_XDMAC_CIE7          (*(__O  uint32_t*)0x40078210U) /**< (XDMAC) Channel Interrupt Enable Register 7 */
+#define REG_XDMAC_CID7          (*(__O  uint32_t*)0x40078214U) /**< (XDMAC) Channel Interrupt Disable Register 7 */
+#define REG_XDMAC_CIM7          (*(__I  uint32_t*)0x40078218U) /**< (XDMAC) Channel Interrupt Mask Register 7 */
+#define REG_XDMAC_CIS7          (*(__I  uint32_t*)0x4007821CU) /**< (XDMAC) Channel Interrupt Status Register 7 */
+#define REG_XDMAC_CSA7          (*(__IO uint32_t*)0x40078220U) /**< (XDMAC) Channel Source Address Register 7 */
+#define REG_XDMAC_CDA7          (*(__IO uint32_t*)0x40078224U) /**< (XDMAC) Channel Destination Address Register 7 */
+#define REG_XDMAC_CNDA7         (*(__IO uint32_t*)0x40078228U) /**< (XDMAC) Channel Next Descriptor Address Register 7 */
+#define REG_XDMAC_CNDC7         (*(__IO uint32_t*)0x4007822CU) /**< (XDMAC) Channel Next Descriptor Control Register 7 */
+#define REG_XDMAC_CUBC7         (*(__IO uint32_t*)0x40078230U) /**< (XDMAC) Channel Microblock Control Register 7 */
+#define REG_XDMAC_CBC7          (*(__IO uint32_t*)0x40078234U) /**< (XDMAC) Channel Block Control Register 7 */
+#define REG_XDMAC_CC7           (*(__IO uint32_t*)0x40078238U) /**< (XDMAC) Channel Configuration Register 7 */
+#define REG_XDMAC_CDS_MSP7      (*(__IO uint32_t*)0x4007823CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 7 */
+#define REG_XDMAC_CSUS7         (*(__IO uint32_t*)0x40078240U) /**< (XDMAC) Channel Source Microblock Stride 7 */
+#define REG_XDMAC_CDUS7         (*(__IO uint32_t*)0x40078244U) /**< (XDMAC) Channel Destination Microblock Stride 7 */
+#define REG_XDMAC_CIE8          (*(__O  uint32_t*)0x40078250U) /**< (XDMAC) Channel Interrupt Enable Register 8 */
+#define REG_XDMAC_CID8          (*(__O  uint32_t*)0x40078254U) /**< (XDMAC) Channel Interrupt Disable Register 8 */
+#define REG_XDMAC_CIM8          (*(__I  uint32_t*)0x40078258U) /**< (XDMAC) Channel Interrupt Mask Register 8 */
+#define REG_XDMAC_CIS8          (*(__I  uint32_t*)0x4007825CU) /**< (XDMAC) Channel Interrupt Status Register 8 */
+#define REG_XDMAC_CSA8          (*(__IO uint32_t*)0x40078260U) /**< (XDMAC) Channel Source Address Register 8 */
+#define REG_XDMAC_CDA8          (*(__IO uint32_t*)0x40078264U) /**< (XDMAC) Channel Destination Address Register 8 */
+#define REG_XDMAC_CNDA8         (*(__IO uint32_t*)0x40078268U) /**< (XDMAC) Channel Next Descriptor Address Register 8 */
+#define REG_XDMAC_CNDC8         (*(__IO uint32_t*)0x4007826CU) /**< (XDMAC) Channel Next Descriptor Control Register 8 */
+#define REG_XDMAC_CUBC8         (*(__IO uint32_t*)0x40078270U) /**< (XDMAC) Channel Microblock Control Register 8 */
+#define REG_XDMAC_CBC8          (*(__IO uint32_t*)0x40078274U) /**< (XDMAC) Channel Block Control Register 8 */
+#define REG_XDMAC_CC8           (*(__IO uint32_t*)0x40078278U) /**< (XDMAC) Channel Configuration Register 8 */
+#define REG_XDMAC_CDS_MSP8      (*(__IO uint32_t*)0x4007827CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 8 */
+#define REG_XDMAC_CSUS8         (*(__IO uint32_t*)0x40078280U) /**< (XDMAC) Channel Source Microblock Stride 8 */
+#define REG_XDMAC_CDUS8         (*(__IO uint32_t*)0x40078284U) /**< (XDMAC) Channel Destination Microblock Stride 8 */
+#define REG_XDMAC_CIE9          (*(__O  uint32_t*)0x40078290U) /**< (XDMAC) Channel Interrupt Enable Register 9 */
+#define REG_XDMAC_CID9          (*(__O  uint32_t*)0x40078294U) /**< (XDMAC) Channel Interrupt Disable Register 9 */
+#define REG_XDMAC_CIM9          (*(__I  uint32_t*)0x40078298U) /**< (XDMAC) Channel Interrupt Mask Register 9 */
+#define REG_XDMAC_CIS9          (*(__I  uint32_t*)0x4007829CU) /**< (XDMAC) Channel Interrupt Status Register 9 */
+#define REG_XDMAC_CSA9          (*(__IO uint32_t*)0x400782A0U) /**< (XDMAC) Channel Source Address Register 9 */
+#define REG_XDMAC_CDA9          (*(__IO uint32_t*)0x400782A4U) /**< (XDMAC) Channel Destination Address Register 9 */
+#define REG_XDMAC_CNDA9         (*(__IO uint32_t*)0x400782A8U) /**< (XDMAC) Channel Next Descriptor Address Register 9 */
+#define REG_XDMAC_CNDC9         (*(__IO uint32_t*)0x400782ACU) /**< (XDMAC) Channel Next Descriptor Control Register 9 */
+#define REG_XDMAC_CUBC9         (*(__IO uint32_t*)0x400782B0U) /**< (XDMAC) Channel Microblock Control Register 9 */
+#define REG_XDMAC_CBC9          (*(__IO uint32_t*)0x400782B4U) /**< (XDMAC) Channel Block Control Register 9 */
+#define REG_XDMAC_CC9           (*(__IO uint32_t*)0x400782B8U) /**< (XDMAC) Channel Configuration Register 9 */
+#define REG_XDMAC_CDS_MSP9      (*(__IO uint32_t*)0x400782BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 9 */
+#define REG_XDMAC_CSUS9         (*(__IO uint32_t*)0x400782C0U) /**< (XDMAC) Channel Source Microblock Stride 9 */
+#define REG_XDMAC_CDUS9         (*(__IO uint32_t*)0x400782C4U) /**< (XDMAC) Channel Destination Microblock Stride 9 */
+#define REG_XDMAC_CIE10         (*(__O  uint32_t*)0x400782D0U) /**< (XDMAC) Channel Interrupt Enable Register 10 */
+#define REG_XDMAC_CID10         (*(__O  uint32_t*)0x400782D4U) /**< (XDMAC) Channel Interrupt Disable Register 10 */
+#define REG_XDMAC_CIM10         (*(__I  uint32_t*)0x400782D8U) /**< (XDMAC) Channel Interrupt Mask Register 10 */
+#define REG_XDMAC_CIS10         (*(__I  uint32_t*)0x400782DCU) /**< (XDMAC) Channel Interrupt Status Register 10 */
+#define REG_XDMAC_CSA10         (*(__IO uint32_t*)0x400782E0U) /**< (XDMAC) Channel Source Address Register 10 */
+#define REG_XDMAC_CDA10         (*(__IO uint32_t*)0x400782E4U) /**< (XDMAC) Channel Destination Address Register 10 */
+#define REG_XDMAC_CNDA10        (*(__IO uint32_t*)0x400782E8U) /**< (XDMAC) Channel Next Descriptor Address Register 10 */
+#define REG_XDMAC_CNDC10        (*(__IO uint32_t*)0x400782ECU) /**< (XDMAC) Channel Next Descriptor Control Register 10 */
+#define REG_XDMAC_CUBC10        (*(__IO uint32_t*)0x400782F0U) /**< (XDMAC) Channel Microblock Control Register 10 */
+#define REG_XDMAC_CBC10         (*(__IO uint32_t*)0x400782F4U) /**< (XDMAC) Channel Block Control Register 10 */
+#define REG_XDMAC_CC10          (*(__IO uint32_t*)0x400782F8U) /**< (XDMAC) Channel Configuration Register 10 */
+#define REG_XDMAC_CDS_MSP10     (*(__IO uint32_t*)0x400782FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 10 */
+#define REG_XDMAC_CSUS10        (*(__IO uint32_t*)0x40078300U) /**< (XDMAC) Channel Source Microblock Stride 10 */
+#define REG_XDMAC_CDUS10        (*(__IO uint32_t*)0x40078304U) /**< (XDMAC) Channel Destination Microblock Stride 10 */
+#define REG_XDMAC_CIE11         (*(__O  uint32_t*)0x40078310U) /**< (XDMAC) Channel Interrupt Enable Register 11 */
+#define REG_XDMAC_CID11         (*(__O  uint32_t*)0x40078314U) /**< (XDMAC) Channel Interrupt Disable Register 11 */
+#define REG_XDMAC_CIM11         (*(__I  uint32_t*)0x40078318U) /**< (XDMAC) Channel Interrupt Mask Register 11 */
+#define REG_XDMAC_CIS11         (*(__I  uint32_t*)0x4007831CU) /**< (XDMAC) Channel Interrupt Status Register 11 */
+#define REG_XDMAC_CSA11         (*(__IO uint32_t*)0x40078320U) /**< (XDMAC) Channel Source Address Register 11 */
+#define REG_XDMAC_CDA11         (*(__IO uint32_t*)0x40078324U) /**< (XDMAC) Channel Destination Address Register 11 */
+#define REG_XDMAC_CNDA11        (*(__IO uint32_t*)0x40078328U) /**< (XDMAC) Channel Next Descriptor Address Register 11 */
+#define REG_XDMAC_CNDC11        (*(__IO uint32_t*)0x4007832CU) /**< (XDMAC) Channel Next Descriptor Control Register 11 */
+#define REG_XDMAC_CUBC11        (*(__IO uint32_t*)0x40078330U) /**< (XDMAC) Channel Microblock Control Register 11 */
+#define REG_XDMAC_CBC11         (*(__IO uint32_t*)0x40078334U) /**< (XDMAC) Channel Block Control Register 11 */
+#define REG_XDMAC_CC11          (*(__IO uint32_t*)0x40078338U) /**< (XDMAC) Channel Configuration Register 11 */
+#define REG_XDMAC_CDS_MSP11     (*(__IO uint32_t*)0x4007833CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 11 */
+#define REG_XDMAC_CSUS11        (*(__IO uint32_t*)0x40078340U) /**< (XDMAC) Channel Source Microblock Stride 11 */
+#define REG_XDMAC_CDUS11        (*(__IO uint32_t*)0x40078344U) /**< (XDMAC) Channel Destination Microblock Stride 11 */
+#define REG_XDMAC_CIE12         (*(__O  uint32_t*)0x40078350U) /**< (XDMAC) Channel Interrupt Enable Register 12 */
+#define REG_XDMAC_CID12         (*(__O  uint32_t*)0x40078354U) /**< (XDMAC) Channel Interrupt Disable Register 12 */
+#define REG_XDMAC_CIM12         (*(__I  uint32_t*)0x40078358U) /**< (XDMAC) Channel Interrupt Mask Register 12 */
+#define REG_XDMAC_CIS12         (*(__I  uint32_t*)0x4007835CU) /**< (XDMAC) Channel Interrupt Status Register 12 */
+#define REG_XDMAC_CSA12         (*(__IO uint32_t*)0x40078360U) /**< (XDMAC) Channel Source Address Register 12 */
+#define REG_XDMAC_CDA12         (*(__IO uint32_t*)0x40078364U) /**< (XDMAC) Channel Destination Address Register 12 */
+#define REG_XDMAC_CNDA12        (*(__IO uint32_t*)0x40078368U) /**< (XDMAC) Channel Next Descriptor Address Register 12 */
+#define REG_XDMAC_CNDC12        (*(__IO uint32_t*)0x4007836CU) /**< (XDMAC) Channel Next Descriptor Control Register 12 */
+#define REG_XDMAC_CUBC12        (*(__IO uint32_t*)0x40078370U) /**< (XDMAC) Channel Microblock Control Register 12 */
+#define REG_XDMAC_CBC12         (*(__IO uint32_t*)0x40078374U) /**< (XDMAC) Channel Block Control Register 12 */
+#define REG_XDMAC_CC12          (*(__IO uint32_t*)0x40078378U) /**< (XDMAC) Channel Configuration Register 12 */
+#define REG_XDMAC_CDS_MSP12     (*(__IO uint32_t*)0x4007837CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 12 */
+#define REG_XDMAC_CSUS12        (*(__IO uint32_t*)0x40078380U) /**< (XDMAC) Channel Source Microblock Stride 12 */
+#define REG_XDMAC_CDUS12        (*(__IO uint32_t*)0x40078384U) /**< (XDMAC) Channel Destination Microblock Stride 12 */
+#define REG_XDMAC_CIE13         (*(__O  uint32_t*)0x40078390U) /**< (XDMAC) Channel Interrupt Enable Register 13 */
+#define REG_XDMAC_CID13         (*(__O  uint32_t*)0x40078394U) /**< (XDMAC) Channel Interrupt Disable Register 13 */
+#define REG_XDMAC_CIM13         (*(__I  uint32_t*)0x40078398U) /**< (XDMAC) Channel Interrupt Mask Register 13 */
+#define REG_XDMAC_CIS13         (*(__I  uint32_t*)0x4007839CU) /**< (XDMAC) Channel Interrupt Status Register 13 */
+#define REG_XDMAC_CSA13         (*(__IO uint32_t*)0x400783A0U) /**< (XDMAC) Channel Source Address Register 13 */
+#define REG_XDMAC_CDA13         (*(__IO uint32_t*)0x400783A4U) /**< (XDMAC) Channel Destination Address Register 13 */
+#define REG_XDMAC_CNDA13        (*(__IO uint32_t*)0x400783A8U) /**< (XDMAC) Channel Next Descriptor Address Register 13 */
+#define REG_XDMAC_CNDC13        (*(__IO uint32_t*)0x400783ACU) /**< (XDMAC) Channel Next Descriptor Control Register 13 */
+#define REG_XDMAC_CUBC13        (*(__IO uint32_t*)0x400783B0U) /**< (XDMAC) Channel Microblock Control Register 13 */
+#define REG_XDMAC_CBC13         (*(__IO uint32_t*)0x400783B4U) /**< (XDMAC) Channel Block Control Register 13 */
+#define REG_XDMAC_CC13          (*(__IO uint32_t*)0x400783B8U) /**< (XDMAC) Channel Configuration Register 13 */
+#define REG_XDMAC_CDS_MSP13     (*(__IO uint32_t*)0x400783BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 13 */
+#define REG_XDMAC_CSUS13        (*(__IO uint32_t*)0x400783C0U) /**< (XDMAC) Channel Source Microblock Stride 13 */
+#define REG_XDMAC_CDUS13        (*(__IO uint32_t*)0x400783C4U) /**< (XDMAC) Channel Destination Microblock Stride 13 */
+#define REG_XDMAC_CIE14         (*(__O  uint32_t*)0x400783D0U) /**< (XDMAC) Channel Interrupt Enable Register 14 */
+#define REG_XDMAC_CID14         (*(__O  uint32_t*)0x400783D4U) /**< (XDMAC) Channel Interrupt Disable Register 14 */
+#define REG_XDMAC_CIM14         (*(__I  uint32_t*)0x400783D8U) /**< (XDMAC) Channel Interrupt Mask Register 14 */
+#define REG_XDMAC_CIS14         (*(__I  uint32_t*)0x400783DCU) /**< (XDMAC) Channel Interrupt Status Register 14 */
+#define REG_XDMAC_CSA14         (*(__IO uint32_t*)0x400783E0U) /**< (XDMAC) Channel Source Address Register 14 */
+#define REG_XDMAC_CDA14         (*(__IO uint32_t*)0x400783E4U) /**< (XDMAC) Channel Destination Address Register 14 */
+#define REG_XDMAC_CNDA14        (*(__IO uint32_t*)0x400783E8U) /**< (XDMAC) Channel Next Descriptor Address Register 14 */
+#define REG_XDMAC_CNDC14        (*(__IO uint32_t*)0x400783ECU) /**< (XDMAC) Channel Next Descriptor Control Register 14 */
+#define REG_XDMAC_CUBC14        (*(__IO uint32_t*)0x400783F0U) /**< (XDMAC) Channel Microblock Control Register 14 */
+#define REG_XDMAC_CBC14         (*(__IO uint32_t*)0x400783F4U) /**< (XDMAC) Channel Block Control Register 14 */
+#define REG_XDMAC_CC14          (*(__IO uint32_t*)0x400783F8U) /**< (XDMAC) Channel Configuration Register 14 */
+#define REG_XDMAC_CDS_MSP14     (*(__IO uint32_t*)0x400783FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 14 */
+#define REG_XDMAC_CSUS14        (*(__IO uint32_t*)0x40078400U) /**< (XDMAC) Channel Source Microblock Stride 14 */
+#define REG_XDMAC_CDUS14        (*(__IO uint32_t*)0x40078404U) /**< (XDMAC) Channel Destination Microblock Stride 14 */
+#define REG_XDMAC_CIE15         (*(__O  uint32_t*)0x40078410U) /**< (XDMAC) Channel Interrupt Enable Register 15 */
+#define REG_XDMAC_CID15         (*(__O  uint32_t*)0x40078414U) /**< (XDMAC) Channel Interrupt Disable Register 15 */
+#define REG_XDMAC_CIM15         (*(__I  uint32_t*)0x40078418U) /**< (XDMAC) Channel Interrupt Mask Register 15 */
+#define REG_XDMAC_CIS15         (*(__I  uint32_t*)0x4007841CU) /**< (XDMAC) Channel Interrupt Status Register 15 */
+#define REG_XDMAC_CSA15         (*(__IO uint32_t*)0x40078420U) /**< (XDMAC) Channel Source Address Register 15 */
+#define REG_XDMAC_CDA15         (*(__IO uint32_t*)0x40078424U) /**< (XDMAC) Channel Destination Address Register 15 */
+#define REG_XDMAC_CNDA15        (*(__IO uint32_t*)0x40078428U) /**< (XDMAC) Channel Next Descriptor Address Register 15 */
+#define REG_XDMAC_CNDC15        (*(__IO uint32_t*)0x4007842CU) /**< (XDMAC) Channel Next Descriptor Control Register 15 */
+#define REG_XDMAC_CUBC15        (*(__IO uint32_t*)0x40078430U) /**< (XDMAC) Channel Microblock Control Register 15 */
+#define REG_XDMAC_CBC15         (*(__IO uint32_t*)0x40078434U) /**< (XDMAC) Channel Block Control Register 15 */
+#define REG_XDMAC_CC15          (*(__IO uint32_t*)0x40078438U) /**< (XDMAC) Channel Configuration Register 15 */
+#define REG_XDMAC_CDS_MSP15     (*(__IO uint32_t*)0x4007843CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 15 */
+#define REG_XDMAC_CSUS15        (*(__IO uint32_t*)0x40078440U) /**< (XDMAC) Channel Source Microblock Stride 15 */
+#define REG_XDMAC_CDUS15        (*(__IO uint32_t*)0x40078444U) /**< (XDMAC) Channel Destination Microblock Stride 15 */
+#define REG_XDMAC_CIE16         (*(__O  uint32_t*)0x40078450U) /**< (XDMAC) Channel Interrupt Enable Register 16 */
+#define REG_XDMAC_CID16         (*(__O  uint32_t*)0x40078454U) /**< (XDMAC) Channel Interrupt Disable Register 16 */
+#define REG_XDMAC_CIM16         (*(__I  uint32_t*)0x40078458U) /**< (XDMAC) Channel Interrupt Mask Register 16 */
+#define REG_XDMAC_CIS16         (*(__I  uint32_t*)0x4007845CU) /**< (XDMAC) Channel Interrupt Status Register 16 */
+#define REG_XDMAC_CSA16         (*(__IO uint32_t*)0x40078460U) /**< (XDMAC) Channel Source Address Register 16 */
+#define REG_XDMAC_CDA16         (*(__IO uint32_t*)0x40078464U) /**< (XDMAC) Channel Destination Address Register 16 */
+#define REG_XDMAC_CNDA16        (*(__IO uint32_t*)0x40078468U) /**< (XDMAC) Channel Next Descriptor Address Register 16 */
+#define REG_XDMAC_CNDC16        (*(__IO uint32_t*)0x4007846CU) /**< (XDMAC) Channel Next Descriptor Control Register 16 */
+#define REG_XDMAC_CUBC16        (*(__IO uint32_t*)0x40078470U) /**< (XDMAC) Channel Microblock Control Register 16 */
+#define REG_XDMAC_CBC16         (*(__IO uint32_t*)0x40078474U) /**< (XDMAC) Channel Block Control Register 16 */
+#define REG_XDMAC_CC16          (*(__IO uint32_t*)0x40078478U) /**< (XDMAC) Channel Configuration Register 16 */
+#define REG_XDMAC_CDS_MSP16     (*(__IO uint32_t*)0x4007847CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 16 */
+#define REG_XDMAC_CSUS16        (*(__IO uint32_t*)0x40078480U) /**< (XDMAC) Channel Source Microblock Stride 16 */
+#define REG_XDMAC_CDUS16        (*(__IO uint32_t*)0x40078484U) /**< (XDMAC) Channel Destination Microblock Stride 16 */
+#define REG_XDMAC_CIE17         (*(__O  uint32_t*)0x40078490U) /**< (XDMAC) Channel Interrupt Enable Register 17 */
+#define REG_XDMAC_CID17         (*(__O  uint32_t*)0x40078494U) /**< (XDMAC) Channel Interrupt Disable Register 17 */
+#define REG_XDMAC_CIM17         (*(__I  uint32_t*)0x40078498U) /**< (XDMAC) Channel Interrupt Mask Register 17 */
+#define REG_XDMAC_CIS17         (*(__I  uint32_t*)0x4007849CU) /**< (XDMAC) Channel Interrupt Status Register 17 */
+#define REG_XDMAC_CSA17         (*(__IO uint32_t*)0x400784A0U) /**< (XDMAC) Channel Source Address Register 17 */
+#define REG_XDMAC_CDA17         (*(__IO uint32_t*)0x400784A4U) /**< (XDMAC) Channel Destination Address Register 17 */
+#define REG_XDMAC_CNDA17        (*(__IO uint32_t*)0x400784A8U) /**< (XDMAC) Channel Next Descriptor Address Register 17 */
+#define REG_XDMAC_CNDC17        (*(__IO uint32_t*)0x400784ACU) /**< (XDMAC) Channel Next Descriptor Control Register 17 */
+#define REG_XDMAC_CUBC17        (*(__IO uint32_t*)0x400784B0U) /**< (XDMAC) Channel Microblock Control Register 17 */
+#define REG_XDMAC_CBC17         (*(__IO uint32_t*)0x400784B4U) /**< (XDMAC) Channel Block Control Register 17 */
+#define REG_XDMAC_CC17          (*(__IO uint32_t*)0x400784B8U) /**< (XDMAC) Channel Configuration Register 17 */
+#define REG_XDMAC_CDS_MSP17     (*(__IO uint32_t*)0x400784BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 17 */
+#define REG_XDMAC_CSUS17        (*(__IO uint32_t*)0x400784C0U) /**< (XDMAC) Channel Source Microblock Stride 17 */
+#define REG_XDMAC_CDUS17        (*(__IO uint32_t*)0x400784C4U) /**< (XDMAC) Channel Destination Microblock Stride 17 */
+#define REG_XDMAC_CIE18         (*(__O  uint32_t*)0x400784D0U) /**< (XDMAC) Channel Interrupt Enable Register 18 */
+#define REG_XDMAC_CID18         (*(__O  uint32_t*)0x400784D4U) /**< (XDMAC) Channel Interrupt Disable Register 18 */
+#define REG_XDMAC_CIM18         (*(__I  uint32_t*)0x400784D8U) /**< (XDMAC) Channel Interrupt Mask Register 18 */
+#define REG_XDMAC_CIS18         (*(__I  uint32_t*)0x400784DCU) /**< (XDMAC) Channel Interrupt Status Register 18 */
+#define REG_XDMAC_CSA18         (*(__IO uint32_t*)0x400784E0U) /**< (XDMAC) Channel Source Address Register 18 */
+#define REG_XDMAC_CDA18         (*(__IO uint32_t*)0x400784E4U) /**< (XDMAC) Channel Destination Address Register 18 */
+#define REG_XDMAC_CNDA18        (*(__IO uint32_t*)0x400784E8U) /**< (XDMAC) Channel Next Descriptor Address Register 18 */
+#define REG_XDMAC_CNDC18        (*(__IO uint32_t*)0x400784ECU) /**< (XDMAC) Channel Next Descriptor Control Register 18 */
+#define REG_XDMAC_CUBC18        (*(__IO uint32_t*)0x400784F0U) /**< (XDMAC) Channel Microblock Control Register 18 */
+#define REG_XDMAC_CBC18         (*(__IO uint32_t*)0x400784F4U) /**< (XDMAC) Channel Block Control Register 18 */
+#define REG_XDMAC_CC18          (*(__IO uint32_t*)0x400784F8U) /**< (XDMAC) Channel Configuration Register 18 */
+#define REG_XDMAC_CDS_MSP18     (*(__IO uint32_t*)0x400784FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 18 */
+#define REG_XDMAC_CSUS18        (*(__IO uint32_t*)0x40078500U) /**< (XDMAC) Channel Source Microblock Stride 18 */
+#define REG_XDMAC_CDUS18        (*(__IO uint32_t*)0x40078504U) /**< (XDMAC) Channel Destination Microblock Stride 18 */
+#define REG_XDMAC_CIE19         (*(__O  uint32_t*)0x40078510U) /**< (XDMAC) Channel Interrupt Enable Register 19 */
+#define REG_XDMAC_CID19         (*(__O  uint32_t*)0x40078514U) /**< (XDMAC) Channel Interrupt Disable Register 19 */
+#define REG_XDMAC_CIM19         (*(__I  uint32_t*)0x40078518U) /**< (XDMAC) Channel Interrupt Mask Register 19 */
+#define REG_XDMAC_CIS19         (*(__I  uint32_t*)0x4007851CU) /**< (XDMAC) Channel Interrupt Status Register 19 */
+#define REG_XDMAC_CSA19         (*(__IO uint32_t*)0x40078520U) /**< (XDMAC) Channel Source Address Register 19 */
+#define REG_XDMAC_CDA19         (*(__IO uint32_t*)0x40078524U) /**< (XDMAC) Channel Destination Address Register 19 */
+#define REG_XDMAC_CNDA19        (*(__IO uint32_t*)0x40078528U) /**< (XDMAC) Channel Next Descriptor Address Register 19 */
+#define REG_XDMAC_CNDC19        (*(__IO uint32_t*)0x4007852CU) /**< (XDMAC) Channel Next Descriptor Control Register 19 */
+#define REG_XDMAC_CUBC19        (*(__IO uint32_t*)0x40078530U) /**< (XDMAC) Channel Microblock Control Register 19 */
+#define REG_XDMAC_CBC19         (*(__IO uint32_t*)0x40078534U) /**< (XDMAC) Channel Block Control Register 19 */
+#define REG_XDMAC_CC19          (*(__IO uint32_t*)0x40078538U) /**< (XDMAC) Channel Configuration Register 19 */
+#define REG_XDMAC_CDS_MSP19     (*(__IO uint32_t*)0x4007853CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 19 */
+#define REG_XDMAC_CSUS19        (*(__IO uint32_t*)0x40078540U) /**< (XDMAC) Channel Source Microblock Stride 19 */
+#define REG_XDMAC_CDUS19        (*(__IO uint32_t*)0x40078544U) /**< (XDMAC) Channel Destination Microblock Stride 19 */
+#define REG_XDMAC_CIE20         (*(__O  uint32_t*)0x40078550U) /**< (XDMAC) Channel Interrupt Enable Register 20 */
+#define REG_XDMAC_CID20         (*(__O  uint32_t*)0x40078554U) /**< (XDMAC) Channel Interrupt Disable Register 20 */
+#define REG_XDMAC_CIM20         (*(__I  uint32_t*)0x40078558U) /**< (XDMAC) Channel Interrupt Mask Register 20 */
+#define REG_XDMAC_CIS20         (*(__I  uint32_t*)0x4007855CU) /**< (XDMAC) Channel Interrupt Status Register 20 */
+#define REG_XDMAC_CSA20         (*(__IO uint32_t*)0x40078560U) /**< (XDMAC) Channel Source Address Register 20 */
+#define REG_XDMAC_CDA20         (*(__IO uint32_t*)0x40078564U) /**< (XDMAC) Channel Destination Address Register 20 */
+#define REG_XDMAC_CNDA20        (*(__IO uint32_t*)0x40078568U) /**< (XDMAC) Channel Next Descriptor Address Register 20 */
+#define REG_XDMAC_CNDC20        (*(__IO uint32_t*)0x4007856CU) /**< (XDMAC) Channel Next Descriptor Control Register 20 */
+#define REG_XDMAC_CUBC20        (*(__IO uint32_t*)0x40078570U) /**< (XDMAC) Channel Microblock Control Register 20 */
+#define REG_XDMAC_CBC20         (*(__IO uint32_t*)0x40078574U) /**< (XDMAC) Channel Block Control Register 20 */
+#define REG_XDMAC_CC20          (*(__IO uint32_t*)0x40078578U) /**< (XDMAC) Channel Configuration Register 20 */
+#define REG_XDMAC_CDS_MSP20     (*(__IO uint32_t*)0x4007857CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 20 */
+#define REG_XDMAC_CSUS20        (*(__IO uint32_t*)0x40078580U) /**< (XDMAC) Channel Source Microblock Stride 20 */
+#define REG_XDMAC_CDUS20        (*(__IO uint32_t*)0x40078584U) /**< (XDMAC) Channel Destination Microblock Stride 20 */
+#define REG_XDMAC_CIE21         (*(__O  uint32_t*)0x40078590U) /**< (XDMAC) Channel Interrupt Enable Register 21 */
+#define REG_XDMAC_CID21         (*(__O  uint32_t*)0x40078594U) /**< (XDMAC) Channel Interrupt Disable Register 21 */
+#define REG_XDMAC_CIM21         (*(__I  uint32_t*)0x40078598U) /**< (XDMAC) Channel Interrupt Mask Register 21 */
+#define REG_XDMAC_CIS21         (*(__I  uint32_t*)0x4007859CU) /**< (XDMAC) Channel Interrupt Status Register 21 */
+#define REG_XDMAC_CSA21         (*(__IO uint32_t*)0x400785A0U) /**< (XDMAC) Channel Source Address Register 21 */
+#define REG_XDMAC_CDA21         (*(__IO uint32_t*)0x400785A4U) /**< (XDMAC) Channel Destination Address Register 21 */
+#define REG_XDMAC_CNDA21        (*(__IO uint32_t*)0x400785A8U) /**< (XDMAC) Channel Next Descriptor Address Register 21 */
+#define REG_XDMAC_CNDC21        (*(__IO uint32_t*)0x400785ACU) /**< (XDMAC) Channel Next Descriptor Control Register 21 */
+#define REG_XDMAC_CUBC21        (*(__IO uint32_t*)0x400785B0U) /**< (XDMAC) Channel Microblock Control Register 21 */
+#define REG_XDMAC_CBC21         (*(__IO uint32_t*)0x400785B4U) /**< (XDMAC) Channel Block Control Register 21 */
+#define REG_XDMAC_CC21          (*(__IO uint32_t*)0x400785B8U) /**< (XDMAC) Channel Configuration Register 21 */
+#define REG_XDMAC_CDS_MSP21     (*(__IO uint32_t*)0x400785BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 21 */
+#define REG_XDMAC_CSUS21        (*(__IO uint32_t*)0x400785C0U) /**< (XDMAC) Channel Source Microblock Stride 21 */
+#define REG_XDMAC_CDUS21        (*(__IO uint32_t*)0x400785C4U) /**< (XDMAC) Channel Destination Microblock Stride 21 */
+#define REG_XDMAC_CIE22         (*(__O  uint32_t*)0x400785D0U) /**< (XDMAC) Channel Interrupt Enable Register 22 */
+#define REG_XDMAC_CID22         (*(__O  uint32_t*)0x400785D4U) /**< (XDMAC) Channel Interrupt Disable Register 22 */
+#define REG_XDMAC_CIM22         (*(__I  uint32_t*)0x400785D8U) /**< (XDMAC) Channel Interrupt Mask Register 22 */
+#define REG_XDMAC_CIS22         (*(__I  uint32_t*)0x400785DCU) /**< (XDMAC) Channel Interrupt Status Register 22 */
+#define REG_XDMAC_CSA22         (*(__IO uint32_t*)0x400785E0U) /**< (XDMAC) Channel Source Address Register 22 */
+#define REG_XDMAC_CDA22         (*(__IO uint32_t*)0x400785E4U) /**< (XDMAC) Channel Destination Address Register 22 */
+#define REG_XDMAC_CNDA22        (*(__IO uint32_t*)0x400785E8U) /**< (XDMAC) Channel Next Descriptor Address Register 22 */
+#define REG_XDMAC_CNDC22        (*(__IO uint32_t*)0x400785ECU) /**< (XDMAC) Channel Next Descriptor Control Register 22 */
+#define REG_XDMAC_CUBC22        (*(__IO uint32_t*)0x400785F0U) /**< (XDMAC) Channel Microblock Control Register 22 */
+#define REG_XDMAC_CBC22         (*(__IO uint32_t*)0x400785F4U) /**< (XDMAC) Channel Block Control Register 22 */
+#define REG_XDMAC_CC22          (*(__IO uint32_t*)0x400785F8U) /**< (XDMAC) Channel Configuration Register 22 */
+#define REG_XDMAC_CDS_MSP22     (*(__IO uint32_t*)0x400785FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 22 */
+#define REG_XDMAC_CSUS22        (*(__IO uint32_t*)0x40078600U) /**< (XDMAC) Channel Source Microblock Stride 22 */
+#define REG_XDMAC_CDUS22        (*(__IO uint32_t*)0x40078604U) /**< (XDMAC) Channel Destination Microblock Stride 22 */
+#define REG_XDMAC_CIE23         (*(__O  uint32_t*)0x40078610U) /**< (XDMAC) Channel Interrupt Enable Register 23 */
+#define REG_XDMAC_CID23         (*(__O  uint32_t*)0x40078614U) /**< (XDMAC) Channel Interrupt Disable Register 23 */
+#define REG_XDMAC_CIM23         (*(__I  uint32_t*)0x40078618U) /**< (XDMAC) Channel Interrupt Mask Register 23 */
+#define REG_XDMAC_CIS23         (*(__I  uint32_t*)0x4007861CU) /**< (XDMAC) Channel Interrupt Status Register 23 */
+#define REG_XDMAC_CSA23         (*(__IO uint32_t*)0x40078620U) /**< (XDMAC) Channel Source Address Register 23 */
+#define REG_XDMAC_CDA23         (*(__IO uint32_t*)0x40078624U) /**< (XDMAC) Channel Destination Address Register 23 */
+#define REG_XDMAC_CNDA23        (*(__IO uint32_t*)0x40078628U) /**< (XDMAC) Channel Next Descriptor Address Register 23 */
+#define REG_XDMAC_CNDC23        (*(__IO uint32_t*)0x4007862CU) /**< (XDMAC) Channel Next Descriptor Control Register 23 */
+#define REG_XDMAC_CUBC23        (*(__IO uint32_t*)0x40078630U) /**< (XDMAC) Channel Microblock Control Register 23 */
+#define REG_XDMAC_CBC23         (*(__IO uint32_t*)0x40078634U) /**< (XDMAC) Channel Block Control Register 23 */
+#define REG_XDMAC_CC23          (*(__IO uint32_t*)0x40078638U) /**< (XDMAC) Channel Configuration Register 23 */
+#define REG_XDMAC_CDS_MSP23     (*(__IO uint32_t*)0x4007863CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 23 */
+#define REG_XDMAC_CSUS23        (*(__IO uint32_t*)0x40078640U) /**< (XDMAC) Channel Source Microblock Stride 23 */
+#define REG_XDMAC_CDUS23        (*(__IO uint32_t*)0x40078644U) /**< (XDMAC) Channel Destination Microblock Stride 23 */
+#define REG_XDMAC_GTYPE         (*(__I  uint32_t*)0x40078000U) /**< (XDMAC) Global Type Register */
+#define REG_XDMAC_GCFG          (*(__IO uint32_t*)0x40078004U) /**< (XDMAC) Global Configuration Register */
+#define REG_XDMAC_GWAC          (*(__IO uint32_t*)0x40078008U) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
+#define REG_XDMAC_GIE           (*(__O  uint32_t*)0x4007800CU) /**< (XDMAC) Global Interrupt Enable Register */
+#define REG_XDMAC_GID           (*(__O  uint32_t*)0x40078010U) /**< (XDMAC) Global Interrupt Disable Register */
+#define REG_XDMAC_GIM           (*(__I  uint32_t*)0x40078014U) /**< (XDMAC) Global Interrupt Mask Register */
+#define REG_XDMAC_GIS           (*(__I  uint32_t*)0x40078018U) /**< (XDMAC) Global Interrupt Status Register */
+#define REG_XDMAC_GE            (*(__O  uint32_t*)0x4007801CU) /**< (XDMAC) Global Channel Enable Register */
+#define REG_XDMAC_GD            (*(__O  uint32_t*)0x40078020U) /**< (XDMAC) Global Channel Disable Register */
+#define REG_XDMAC_GS            (*(__I  uint32_t*)0x40078024U) /**< (XDMAC) Global Channel Status Register */
+#define REG_XDMAC_GRS           (*(__IO uint32_t*)0x40078028U) /**< (XDMAC) Global Channel Read Suspend Register */
+#define REG_XDMAC_GWS           (*(__IO uint32_t*)0x4007802CU) /**< (XDMAC) Global Channel Write Suspend Register */
+#define REG_XDMAC_GRWS          (*(__O  uint32_t*)0x40078030U) /**< (XDMAC) Global Channel Read Write Suspend Register */
+#define REG_XDMAC_GRWR          (*(__O  uint32_t*)0x40078034U) /**< (XDMAC) Global Channel Read Write Resume Register */
+#define REG_XDMAC_GSWR          (*(__O  uint32_t*)0x40078038U) /**< (XDMAC) Global Channel Software Request Register */
+#define REG_XDMAC_GSWS          (*(__I  uint32_t*)0x4007803CU) /**< (XDMAC) Global Channel Software Request Status Register */
+#define REG_XDMAC_GSWF          (*(__O  uint32_t*)0x40078040U) /**< (XDMAC) Global Channel Software Flush Request Register */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance Parameter definitions for XDMAC peripheral ========== */
+#define XDMAC_INSTANCE_ID                        58         
+#define XDMAC_CLOCK_ID                           58         
+
+#endif /* _SAMV71_XDMAC_INSTANCE_ */

--- a/asf/sam/include/samv71b/pio/samv71j19b.h
+++ b/asf/sam/include/samv71b/pio/samv71j19b.h
@@ -1,0 +1,1121 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:20:53Z */
+#ifndef _SAMV71J19B_PIO_H_
+#define _SAMV71J19B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71J19B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71j20b.h
+++ b/asf/sam/include/samv71b/pio/samv71j20b.h
@@ -1,0 +1,1121 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:20:58Z */
+#ifndef _SAMV71J20B_PIO_H_
+#define _SAMV71J20B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71J20B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71j21b.h
+++ b/asf/sam/include/samv71b/pio/samv71j21b.h
@@ -1,0 +1,1121 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71J21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:02Z */
+#ifndef _SAMV71J21B_PIO_H_
+#define _SAMV71J21B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71J21B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71n19b.h
+++ b/asf/sam/include/samv71b/pio/samv71n19b.h
@@ -1,0 +1,1281 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:04Z */
+#ifndef _SAMV71N19B_PIO_H_
+#define _SAMV71N19B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71N19B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71n20b.h
+++ b/asf/sam/include/samv71b/pio/samv71n20b.h
@@ -1,0 +1,1281 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:07Z */
+#ifndef _SAMV71N20B_PIO_H_
+#define _SAMV71N20B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71N20B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71n21b.h
+++ b/asf/sam/include/samv71b/pio/samv71n21b.h
@@ -1,0 +1,1281 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71N21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:09Z */
+#ifndef _SAMV71N21B_PIO_H_
+#define _SAMV71N21B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
+#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71N21B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71q19b.h
+++ b/asf/sam/include/samv71b/pio/samv71q19b.h
@@ -1,0 +1,1975 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:11Z */
+#ifndef _SAMV71Q19B_PIO_H_
+#define _SAMV71Q19B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for I2SC1 peripheral ========== */
+#define PIN_PA20D_I2SC1_CK                         _L_(20)      /**< I2SC1 signal: CK on PA20 mux D*/
+#define MUX_PA20D_I2SC1_CK                         _L_(3)       /**< I2SC1 signal line function value: CK */
+#define PIO_PA20D_I2SC1_CK                         (_UL_(1) << 20)
+
+#define PIN_PE2C_I2SC1_DI0                         _L_(130)     /**< I2SC1 signal: DI0 on PE2 mux C*/
+#define MUX_PE2C_I2SC1_DI0                         _L_(2)       /**< I2SC1 signal line function value: DI0 */
+#define PIO_PE2C_I2SC1_DI0                         (_UL_(1) << 2)
+
+#define PIN_PE1C_I2SC1_DO0                         _L_(129)     /**< I2SC1 signal: DO0 on PE1 mux C*/
+#define MUX_PE1C_I2SC1_DO0                         _L_(2)       /**< I2SC1 signal line function value: DO0 */
+#define PIO_PE1C_I2SC1_DO0                         (_UL_(1) << 1)
+
+#define PIN_PA19D_I2SC1_MCK                        _L_(19)      /**< I2SC1 signal: MCK on PA19 mux D*/
+#define MUX_PA19D_I2SC1_MCK                        _L_(3)       /**< I2SC1 signal line function value: MCK */
+#define PIO_PA19D_I2SC1_MCK                        (_UL_(1) << 19)
+
+#define PIN_PE0C_I2SC1_WS                          _L_(128)     /**< I2SC1 signal: WS on PE0 mux C*/
+#define MUX_PE0C_I2SC1_WS                          _L_(2)       /**< I2SC1 signal line function value: WS */
+#define PIO_PE0C_I2SC1_WS                          (_UL_(1) << 0)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71Q19B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71q20b.h
+++ b/asf/sam/include/samv71b/pio/samv71q20b.h
@@ -1,0 +1,1975 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:13Z */
+#ifndef _SAMV71Q20B_PIO_H_
+#define _SAMV71Q20B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for I2SC1 peripheral ========== */
+#define PIN_PA20D_I2SC1_CK                         _L_(20)      /**< I2SC1 signal: CK on PA20 mux D*/
+#define MUX_PA20D_I2SC1_CK                         _L_(3)       /**< I2SC1 signal line function value: CK */
+#define PIO_PA20D_I2SC1_CK                         (_UL_(1) << 20)
+
+#define PIN_PE2C_I2SC1_DI0                         _L_(130)     /**< I2SC1 signal: DI0 on PE2 mux C*/
+#define MUX_PE2C_I2SC1_DI0                         _L_(2)       /**< I2SC1 signal line function value: DI0 */
+#define PIO_PE2C_I2SC1_DI0                         (_UL_(1) << 2)
+
+#define PIN_PE1C_I2SC1_DO0                         _L_(129)     /**< I2SC1 signal: DO0 on PE1 mux C*/
+#define MUX_PE1C_I2SC1_DO0                         _L_(2)       /**< I2SC1 signal line function value: DO0 */
+#define PIO_PE1C_I2SC1_DO0                         (_UL_(1) << 1)
+
+#define PIN_PA19D_I2SC1_MCK                        _L_(19)      /**< I2SC1 signal: MCK on PA19 mux D*/
+#define MUX_PA19D_I2SC1_MCK                        _L_(3)       /**< I2SC1 signal line function value: MCK */
+#define PIO_PA19D_I2SC1_MCK                        (_UL_(1) << 19)
+
+#define PIN_PE0C_I2SC1_WS                          _L_(128)     /**< I2SC1 signal: WS on PE0 mux C*/
+#define MUX_PE0C_I2SC1_WS                          _L_(2)       /**< I2SC1 signal line function value: WS */
+#define PIO_PE0C_I2SC1_WS                          (_UL_(1) << 0)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71Q20B_PIO_H_ */

--- a/asf/sam/include/samv71b/pio/samv71q21b.h
+++ b/asf/sam/include/samv71b/pio/samv71q21b.h
@@ -1,0 +1,1975 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMV71Q21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71Q21B_PIO_H_
+#define _SAMV71Q21B_PIO_H_
+
+/* ========== Peripheral I/O pin numbers ========== */
+#define PIN_PA0                     (  0)  /**< Pin Number for PA0 */
+#define PIN_PA1                     (  1)  /**< Pin Number for PA1 */
+#define PIN_PA2                     (  2)  /**< Pin Number for PA2 */
+#define PIN_PA3                     (  3)  /**< Pin Number for PA3 */
+#define PIN_PA4                     (  4)  /**< Pin Number for PA4 */
+#define PIN_PA5                     (  5)  /**< Pin Number for PA5 */
+#define PIN_PA6                     (  6)  /**< Pin Number for PA6 */
+#define PIN_PA7                     (  7)  /**< Pin Number for PA7 */
+#define PIN_PA8                     (  8)  /**< Pin Number for PA8 */
+#define PIN_PA9                     (  9)  /**< Pin Number for PA9 */
+#define PIN_PA10                    ( 10)  /**< Pin Number for PA10 */
+#define PIN_PA11                    ( 11)  /**< Pin Number for PA11 */
+#define PIN_PA12                    ( 12)  /**< Pin Number for PA12 */
+#define PIN_PA13                    ( 13)  /**< Pin Number for PA13 */
+#define PIN_PA14                    ( 14)  /**< Pin Number for PA14 */
+#define PIN_PA15                    ( 15)  /**< Pin Number for PA15 */
+#define PIN_PA16                    ( 16)  /**< Pin Number for PA16 */
+#define PIN_PA17                    ( 17)  /**< Pin Number for PA17 */
+#define PIN_PA18                    ( 18)  /**< Pin Number for PA18 */
+#define PIN_PA19                    ( 19)  /**< Pin Number for PA19 */
+#define PIN_PA20                    ( 20)  /**< Pin Number for PA20 */
+#define PIN_PA21                    ( 21)  /**< Pin Number for PA21 */
+#define PIN_PA22                    ( 22)  /**< Pin Number for PA22 */
+#define PIN_PA23                    ( 23)  /**< Pin Number for PA23 */
+#define PIN_PA24                    ( 24)  /**< Pin Number for PA24 */
+#define PIN_PA25                    ( 25)  /**< Pin Number for PA25 */
+#define PIN_PA26                    ( 26)  /**< Pin Number for PA26 */
+#define PIN_PA27                    ( 27)  /**< Pin Number for PA27 */
+#define PIN_PA28                    ( 28)  /**< Pin Number for PA28 */
+#define PIN_PA29                    ( 29)  /**< Pin Number for PA29 */
+#define PIN_PA30                    ( 30)  /**< Pin Number for PA30 */
+#define PIN_PA31                    ( 31)  /**< Pin Number for PA31 */
+#define PIN_PB0                     ( 32)  /**< Pin Number for PB0 */
+#define PIN_PB1                     ( 33)  /**< Pin Number for PB1 */
+#define PIN_PB2                     ( 34)  /**< Pin Number for PB2 */
+#define PIN_PB3                     ( 35)  /**< Pin Number for PB3 */
+#define PIN_PB4                     ( 36)  /**< Pin Number for PB4 */
+#define PIN_PB5                     ( 37)  /**< Pin Number for PB5 */
+#define PIN_PB6                     ( 38)  /**< Pin Number for PB6 */
+#define PIN_PB7                     ( 39)  /**< Pin Number for PB7 */
+#define PIN_PB8                     ( 40)  /**< Pin Number for PB8 */
+#define PIN_PB9                     ( 41)  /**< Pin Number for PB9 */
+#define PIN_PB12                    ( 44)  /**< Pin Number for PB12 */
+#define PIN_PB13                    ( 45)  /**< Pin Number for PB13 */
+#define PIN_PC0                     ( 64)  /**< Pin Number for PC0 */
+#define PIN_PC1                     ( 65)  /**< Pin Number for PC1 */
+#define PIN_PC2                     ( 66)  /**< Pin Number for PC2 */
+#define PIN_PC3                     ( 67)  /**< Pin Number for PC3 */
+#define PIN_PC4                     ( 68)  /**< Pin Number for PC4 */
+#define PIN_PC5                     ( 69)  /**< Pin Number for PC5 */
+#define PIN_PC6                     ( 70)  /**< Pin Number for PC6 */
+#define PIN_PC7                     ( 71)  /**< Pin Number for PC7 */
+#define PIN_PC8                     ( 72)  /**< Pin Number for PC8 */
+#define PIN_PC9                     ( 73)  /**< Pin Number for PC9 */
+#define PIN_PC10                    ( 74)  /**< Pin Number for PC10 */
+#define PIN_PC11                    ( 75)  /**< Pin Number for PC11 */
+#define PIN_PC12                    ( 76)  /**< Pin Number for PC12 */
+#define PIN_PC13                    ( 77)  /**< Pin Number for PC13 */
+#define PIN_PC14                    ( 78)  /**< Pin Number for PC14 */
+#define PIN_PC15                    ( 79)  /**< Pin Number for PC15 */
+#define PIN_PC16                    ( 80)  /**< Pin Number for PC16 */
+#define PIN_PC17                    ( 81)  /**< Pin Number for PC17 */
+#define PIN_PC18                    ( 82)  /**< Pin Number for PC18 */
+#define PIN_PC19                    ( 83)  /**< Pin Number for PC19 */
+#define PIN_PC20                    ( 84)  /**< Pin Number for PC20 */
+#define PIN_PC21                    ( 85)  /**< Pin Number for PC21 */
+#define PIN_PC22                    ( 86)  /**< Pin Number for PC22 */
+#define PIN_PC23                    ( 87)  /**< Pin Number for PC23 */
+#define PIN_PC24                    ( 88)  /**< Pin Number for PC24 */
+#define PIN_PC25                    ( 89)  /**< Pin Number for PC25 */
+#define PIN_PC26                    ( 90)  /**< Pin Number for PC26 */
+#define PIN_PC27                    ( 91)  /**< Pin Number for PC27 */
+#define PIN_PC28                    ( 92)  /**< Pin Number for PC28 */
+#define PIN_PC29                    ( 93)  /**< Pin Number for PC29 */
+#define PIN_PC30                    ( 94)  /**< Pin Number for PC30 */
+#define PIN_PC31                    ( 95)  /**< Pin Number for PC31 */
+#define PIN_PD0                     ( 96)  /**< Pin Number for PD0 */
+#define PIN_PD1                     ( 97)  /**< Pin Number for PD1 */
+#define PIN_PD2                     ( 98)  /**< Pin Number for PD2 */
+#define PIN_PD3                     ( 99)  /**< Pin Number for PD3 */
+#define PIN_PD4                     (100)  /**< Pin Number for PD4 */
+#define PIN_PD5                     (101)  /**< Pin Number for PD5 */
+#define PIN_PD6                     (102)  /**< Pin Number for PD6 */
+#define PIN_PD7                     (103)  /**< Pin Number for PD7 */
+#define PIN_PD8                     (104)  /**< Pin Number for PD8 */
+#define PIN_PD9                     (105)  /**< Pin Number for PD9 */
+#define PIN_PD10                    (106)  /**< Pin Number for PD10 */
+#define PIN_PD11                    (107)  /**< Pin Number for PD11 */
+#define PIN_PD12                    (108)  /**< Pin Number for PD12 */
+#define PIN_PD13                    (109)  /**< Pin Number for PD13 */
+#define PIN_PD14                    (110)  /**< Pin Number for PD14 */
+#define PIN_PD15                    (111)  /**< Pin Number for PD15 */
+#define PIN_PD16                    (112)  /**< Pin Number for PD16 */
+#define PIN_PD17                    (113)  /**< Pin Number for PD17 */
+#define PIN_PD18                    (114)  /**< Pin Number for PD18 */
+#define PIN_PD19                    (115)  /**< Pin Number for PD19 */
+#define PIN_PD20                    (116)  /**< Pin Number for PD20 */
+#define PIN_PD21                    (117)  /**< Pin Number for PD21 */
+#define PIN_PD22                    (118)  /**< Pin Number for PD22 */
+#define PIN_PD23                    (119)  /**< Pin Number for PD23 */
+#define PIN_PD24                    (120)  /**< Pin Number for PD24 */
+#define PIN_PD25                    (121)  /**< Pin Number for PD25 */
+#define PIN_PD26                    (122)  /**< Pin Number for PD26 */
+#define PIN_PD27                    (123)  /**< Pin Number for PD27 */
+#define PIN_PD28                    (124)  /**< Pin Number for PD28 */
+#define PIN_PD29                    (125)  /**< Pin Number for PD29 */
+#define PIN_PD30                    (126)  /**< Pin Number for PD30 */
+#define PIN_PD31                    (127)  /**< Pin Number for PD31 */
+#define PIN_PE0                     (128)  /**< Pin Number for PE0 */
+#define PIN_PE1                     (129)  /**< Pin Number for PE1 */
+#define PIN_PE2                     (130)  /**< Pin Number for PE2 */
+#define PIN_PE3                     (131)  /**< Pin Number for PE3 */
+#define PIN_PE4                     (132)  /**< Pin Number for PE4 */
+#define PIN_PE5                     (133)  /**< Pin Number for PE5 */
+
+
+/* ========== Peripheral I/O masks ========== */
+#define PIO_PA0                     (_U_(1) << 0) /**< PIO Mask for PA0 */
+#define PIO_PA1                     (_U_(1) << 1) /**< PIO Mask for PA1 */
+#define PIO_PA2                     (_U_(1) << 2) /**< PIO Mask for PA2 */
+#define PIO_PA3                     (_U_(1) << 3) /**< PIO Mask for PA3 */
+#define PIO_PA4                     (_U_(1) << 4) /**< PIO Mask for PA4 */
+#define PIO_PA5                     (_U_(1) << 5) /**< PIO Mask for PA5 */
+#define PIO_PA6                     (_U_(1) << 6) /**< PIO Mask for PA6 */
+#define PIO_PA7                     (_U_(1) << 7) /**< PIO Mask for PA7 */
+#define PIO_PA8                     (_U_(1) << 8) /**< PIO Mask for PA8 */
+#define PIO_PA9                     (_U_(1) << 9) /**< PIO Mask for PA9 */
+#define PIO_PA10                    (_U_(1) << 10) /**< PIO Mask for PA10 */
+#define PIO_PA11                    (_U_(1) << 11) /**< PIO Mask for PA11 */
+#define PIO_PA12                    (_U_(1) << 12) /**< PIO Mask for PA12 */
+#define PIO_PA13                    (_U_(1) << 13) /**< PIO Mask for PA13 */
+#define PIO_PA14                    (_U_(1) << 14) /**< PIO Mask for PA14 */
+#define PIO_PA15                    (_U_(1) << 15) /**< PIO Mask for PA15 */
+#define PIO_PA16                    (_U_(1) << 16) /**< PIO Mask for PA16 */
+#define PIO_PA17                    (_U_(1) << 17) /**< PIO Mask for PA17 */
+#define PIO_PA18                    (_U_(1) << 18) /**< PIO Mask for PA18 */
+#define PIO_PA19                    (_U_(1) << 19) /**< PIO Mask for PA19 */
+#define PIO_PA20                    (_U_(1) << 20) /**< PIO Mask for PA20 */
+#define PIO_PA21                    (_U_(1) << 21) /**< PIO Mask for PA21 */
+#define PIO_PA22                    (_U_(1) << 22) /**< PIO Mask for PA22 */
+#define PIO_PA23                    (_U_(1) << 23) /**< PIO Mask for PA23 */
+#define PIO_PA24                    (_U_(1) << 24) /**< PIO Mask for PA24 */
+#define PIO_PA25                    (_U_(1) << 25) /**< PIO Mask for PA25 */
+#define PIO_PA26                    (_U_(1) << 26) /**< PIO Mask for PA26 */
+#define PIO_PA27                    (_U_(1) << 27) /**< PIO Mask for PA27 */
+#define PIO_PA28                    (_U_(1) << 28) /**< PIO Mask for PA28 */
+#define PIO_PA29                    (_U_(1) << 29) /**< PIO Mask for PA29 */
+#define PIO_PA30                    (_U_(1) << 30) /**< PIO Mask for PA30 */
+#define PIO_PA31                    (_U_(1) << 31) /**< PIO Mask for PA31 */
+#define PIO_PB0                     (_U_(1) << 0) /**< PIO Mask for PB0 */
+#define PIO_PB1                     (_U_(1) << 1) /**< PIO Mask for PB1 */
+#define PIO_PB2                     (_U_(1) << 2) /**< PIO Mask for PB2 */
+#define PIO_PB3                     (_U_(1) << 3) /**< PIO Mask for PB3 */
+#define PIO_PB4                     (_U_(1) << 4) /**< PIO Mask for PB4 */
+#define PIO_PB5                     (_U_(1) << 5) /**< PIO Mask for PB5 */
+#define PIO_PB6                     (_U_(1) << 6) /**< PIO Mask for PB6 */
+#define PIO_PB7                     (_U_(1) << 7) /**< PIO Mask for PB7 */
+#define PIO_PB8                     (_U_(1) << 8) /**< PIO Mask for PB8 */
+#define PIO_PB9                     (_U_(1) << 9) /**< PIO Mask for PB9 */
+#define PIO_PB12                    (_U_(1) << 12) /**< PIO Mask for PB12 */
+#define PIO_PB13                    (_U_(1) << 13) /**< PIO Mask for PB13 */
+#define PIO_PC0                     (_U_(1) << 0) /**< PIO Mask for PC0 */
+#define PIO_PC1                     (_U_(1) << 1) /**< PIO Mask for PC1 */
+#define PIO_PC2                     (_U_(1) << 2) /**< PIO Mask for PC2 */
+#define PIO_PC3                     (_U_(1) << 3) /**< PIO Mask for PC3 */
+#define PIO_PC4                     (_U_(1) << 4) /**< PIO Mask for PC4 */
+#define PIO_PC5                     (_U_(1) << 5) /**< PIO Mask for PC5 */
+#define PIO_PC6                     (_U_(1) << 6) /**< PIO Mask for PC6 */
+#define PIO_PC7                     (_U_(1) << 7) /**< PIO Mask for PC7 */
+#define PIO_PC8                     (_U_(1) << 8) /**< PIO Mask for PC8 */
+#define PIO_PC9                     (_U_(1) << 9) /**< PIO Mask for PC9 */
+#define PIO_PC10                    (_U_(1) << 10) /**< PIO Mask for PC10 */
+#define PIO_PC11                    (_U_(1) << 11) /**< PIO Mask for PC11 */
+#define PIO_PC12                    (_U_(1) << 12) /**< PIO Mask for PC12 */
+#define PIO_PC13                    (_U_(1) << 13) /**< PIO Mask for PC13 */
+#define PIO_PC14                    (_U_(1) << 14) /**< PIO Mask for PC14 */
+#define PIO_PC15                    (_U_(1) << 15) /**< PIO Mask for PC15 */
+#define PIO_PC16                    (_U_(1) << 16) /**< PIO Mask for PC16 */
+#define PIO_PC17                    (_U_(1) << 17) /**< PIO Mask for PC17 */
+#define PIO_PC18                    (_U_(1) << 18) /**< PIO Mask for PC18 */
+#define PIO_PC19                    (_U_(1) << 19) /**< PIO Mask for PC19 */
+#define PIO_PC20                    (_U_(1) << 20) /**< PIO Mask for PC20 */
+#define PIO_PC21                    (_U_(1) << 21) /**< PIO Mask for PC21 */
+#define PIO_PC22                    (_U_(1) << 22) /**< PIO Mask for PC22 */
+#define PIO_PC23                    (_U_(1) << 23) /**< PIO Mask for PC23 */
+#define PIO_PC24                    (_U_(1) << 24) /**< PIO Mask for PC24 */
+#define PIO_PC25                    (_U_(1) << 25) /**< PIO Mask for PC25 */
+#define PIO_PC26                    (_U_(1) << 26) /**< PIO Mask for PC26 */
+#define PIO_PC27                    (_U_(1) << 27) /**< PIO Mask for PC27 */
+#define PIO_PC28                    (_U_(1) << 28) /**< PIO Mask for PC28 */
+#define PIO_PC29                    (_U_(1) << 29) /**< PIO Mask for PC29 */
+#define PIO_PC30                    (_U_(1) << 30) /**< PIO Mask for PC30 */
+#define PIO_PC31                    (_U_(1) << 31) /**< PIO Mask for PC31 */
+#define PIO_PD0                     (_U_(1) << 0) /**< PIO Mask for PD0 */
+#define PIO_PD1                     (_U_(1) << 1) /**< PIO Mask for PD1 */
+#define PIO_PD2                     (_U_(1) << 2) /**< PIO Mask for PD2 */
+#define PIO_PD3                     (_U_(1) << 3) /**< PIO Mask for PD3 */
+#define PIO_PD4                     (_U_(1) << 4) /**< PIO Mask for PD4 */
+#define PIO_PD5                     (_U_(1) << 5) /**< PIO Mask for PD5 */
+#define PIO_PD6                     (_U_(1) << 6) /**< PIO Mask for PD6 */
+#define PIO_PD7                     (_U_(1) << 7) /**< PIO Mask for PD7 */
+#define PIO_PD8                     (_U_(1) << 8) /**< PIO Mask for PD8 */
+#define PIO_PD9                     (_U_(1) << 9) /**< PIO Mask for PD9 */
+#define PIO_PD10                    (_U_(1) << 10) /**< PIO Mask for PD10 */
+#define PIO_PD11                    (_U_(1) << 11) /**< PIO Mask for PD11 */
+#define PIO_PD12                    (_U_(1) << 12) /**< PIO Mask for PD12 */
+#define PIO_PD13                    (_U_(1) << 13) /**< PIO Mask for PD13 */
+#define PIO_PD14                    (_U_(1) << 14) /**< PIO Mask for PD14 */
+#define PIO_PD15                    (_U_(1) << 15) /**< PIO Mask for PD15 */
+#define PIO_PD16                    (_U_(1) << 16) /**< PIO Mask for PD16 */
+#define PIO_PD17                    (_U_(1) << 17) /**< PIO Mask for PD17 */
+#define PIO_PD18                    (_U_(1) << 18) /**< PIO Mask for PD18 */
+#define PIO_PD19                    (_U_(1) << 19) /**< PIO Mask for PD19 */
+#define PIO_PD20                    (_U_(1) << 20) /**< PIO Mask for PD20 */
+#define PIO_PD21                    (_U_(1) << 21) /**< PIO Mask for PD21 */
+#define PIO_PD22                    (_U_(1) << 22) /**< PIO Mask for PD22 */
+#define PIO_PD23                    (_U_(1) << 23) /**< PIO Mask for PD23 */
+#define PIO_PD24                    (_U_(1) << 24) /**< PIO Mask for PD24 */
+#define PIO_PD25                    (_U_(1) << 25) /**< PIO Mask for PD25 */
+#define PIO_PD26                    (_U_(1) << 26) /**< PIO Mask for PD26 */
+#define PIO_PD27                    (_U_(1) << 27) /**< PIO Mask for PD27 */
+#define PIO_PD28                    (_U_(1) << 28) /**< PIO Mask for PD28 */
+#define PIO_PD29                    (_U_(1) << 29) /**< PIO Mask for PD29 */
+#define PIO_PD30                    (_U_(1) << 30) /**< PIO Mask for PD30 */
+#define PIO_PD31                    (_U_(1) << 31) /**< PIO Mask for PD31 */
+#define PIO_PE0                     (_U_(1) << 0) /**< PIO Mask for PE0 */
+#define PIO_PE1                     (_U_(1) << 1) /**< PIO Mask for PE1 */
+#define PIO_PE2                     (_U_(1) << 2) /**< PIO Mask for PE2 */
+#define PIO_PE3                     (_U_(1) << 3) /**< PIO Mask for PE3 */
+#define PIO_PE4                     (_U_(1) << 4) /**< PIO Mask for PE4 */
+#define PIO_PE5                     (_U_(1) << 5) /**< PIO Mask for PE5 */
+
+
+/* ========== Peripheral I/O indexes ========== */
+#define PIO_PA0_IDX                 (  0)  /**< PIO Index Number for PA0 */
+#define PIO_PA1_IDX                 (  1)  /**< PIO Index Number for PA1 */
+#define PIO_PA2_IDX                 (  2)  /**< PIO Index Number for PA2 */
+#define PIO_PA3_IDX                 (  3)  /**< PIO Index Number for PA3 */
+#define PIO_PA4_IDX                 (  4)  /**< PIO Index Number for PA4 */
+#define PIO_PA5_IDX                 (  5)  /**< PIO Index Number for PA5 */
+#define PIO_PA6_IDX                 (  6)  /**< PIO Index Number for PA6 */
+#define PIO_PA7_IDX                 (  7)  /**< PIO Index Number for PA7 */
+#define PIO_PA8_IDX                 (  8)  /**< PIO Index Number for PA8 */
+#define PIO_PA9_IDX                 (  9)  /**< PIO Index Number for PA9 */
+#define PIO_PA10_IDX                ( 10)  /**< PIO Index Number for PA10 */
+#define PIO_PA11_IDX                ( 11)  /**< PIO Index Number for PA11 */
+#define PIO_PA12_IDX                ( 12)  /**< PIO Index Number for PA12 */
+#define PIO_PA13_IDX                ( 13)  /**< PIO Index Number for PA13 */
+#define PIO_PA14_IDX                ( 14)  /**< PIO Index Number for PA14 */
+#define PIO_PA15_IDX                ( 15)  /**< PIO Index Number for PA15 */
+#define PIO_PA16_IDX                ( 16)  /**< PIO Index Number for PA16 */
+#define PIO_PA17_IDX                ( 17)  /**< PIO Index Number for PA17 */
+#define PIO_PA18_IDX                ( 18)  /**< PIO Index Number for PA18 */
+#define PIO_PA19_IDX                ( 19)  /**< PIO Index Number for PA19 */
+#define PIO_PA20_IDX                ( 20)  /**< PIO Index Number for PA20 */
+#define PIO_PA21_IDX                ( 21)  /**< PIO Index Number for PA21 */
+#define PIO_PA22_IDX                ( 22)  /**< PIO Index Number for PA22 */
+#define PIO_PA23_IDX                ( 23)  /**< PIO Index Number for PA23 */
+#define PIO_PA24_IDX                ( 24)  /**< PIO Index Number for PA24 */
+#define PIO_PA25_IDX                ( 25)  /**< PIO Index Number for PA25 */
+#define PIO_PA26_IDX                ( 26)  /**< PIO Index Number for PA26 */
+#define PIO_PA27_IDX                ( 27)  /**< PIO Index Number for PA27 */
+#define PIO_PA28_IDX                ( 28)  /**< PIO Index Number for PA28 */
+#define PIO_PA29_IDX                ( 29)  /**< PIO Index Number for PA29 */
+#define PIO_PA30_IDX                ( 30)  /**< PIO Index Number for PA30 */
+#define PIO_PA31_IDX                ( 31)  /**< PIO Index Number for PA31 */
+#define PIO_PB0_IDX                 ( 32)  /**< PIO Index Number for PB0 */
+#define PIO_PB1_IDX                 ( 33)  /**< PIO Index Number for PB1 */
+#define PIO_PB2_IDX                 ( 34)  /**< PIO Index Number for PB2 */
+#define PIO_PB3_IDX                 ( 35)  /**< PIO Index Number for PB3 */
+#define PIO_PB4_IDX                 ( 36)  /**< PIO Index Number for PB4 */
+#define PIO_PB5_IDX                 ( 37)  /**< PIO Index Number for PB5 */
+#define PIO_PB6_IDX                 ( 38)  /**< PIO Index Number for PB6 */
+#define PIO_PB7_IDX                 ( 39)  /**< PIO Index Number for PB7 */
+#define PIO_PB8_IDX                 ( 40)  /**< PIO Index Number for PB8 */
+#define PIO_PB9_IDX                 ( 41)  /**< PIO Index Number for PB9 */
+#define PIO_PB12_IDX                ( 44)  /**< PIO Index Number for PB12 */
+#define PIO_PB13_IDX                ( 45)  /**< PIO Index Number for PB13 */
+#define PIO_PC0_IDX                 ( 64)  /**< PIO Index Number for PC0 */
+#define PIO_PC1_IDX                 ( 65)  /**< PIO Index Number for PC1 */
+#define PIO_PC2_IDX                 ( 66)  /**< PIO Index Number for PC2 */
+#define PIO_PC3_IDX                 ( 67)  /**< PIO Index Number for PC3 */
+#define PIO_PC4_IDX                 ( 68)  /**< PIO Index Number for PC4 */
+#define PIO_PC5_IDX                 ( 69)  /**< PIO Index Number for PC5 */
+#define PIO_PC6_IDX                 ( 70)  /**< PIO Index Number for PC6 */
+#define PIO_PC7_IDX                 ( 71)  /**< PIO Index Number for PC7 */
+#define PIO_PC8_IDX                 ( 72)  /**< PIO Index Number for PC8 */
+#define PIO_PC9_IDX                 ( 73)  /**< PIO Index Number for PC9 */
+#define PIO_PC10_IDX                ( 74)  /**< PIO Index Number for PC10 */
+#define PIO_PC11_IDX                ( 75)  /**< PIO Index Number for PC11 */
+#define PIO_PC12_IDX                ( 76)  /**< PIO Index Number for PC12 */
+#define PIO_PC13_IDX                ( 77)  /**< PIO Index Number for PC13 */
+#define PIO_PC14_IDX                ( 78)  /**< PIO Index Number for PC14 */
+#define PIO_PC15_IDX                ( 79)  /**< PIO Index Number for PC15 */
+#define PIO_PC16_IDX                ( 80)  /**< PIO Index Number for PC16 */
+#define PIO_PC17_IDX                ( 81)  /**< PIO Index Number for PC17 */
+#define PIO_PC18_IDX                ( 82)  /**< PIO Index Number for PC18 */
+#define PIO_PC19_IDX                ( 83)  /**< PIO Index Number for PC19 */
+#define PIO_PC20_IDX                ( 84)  /**< PIO Index Number for PC20 */
+#define PIO_PC21_IDX                ( 85)  /**< PIO Index Number for PC21 */
+#define PIO_PC22_IDX                ( 86)  /**< PIO Index Number for PC22 */
+#define PIO_PC23_IDX                ( 87)  /**< PIO Index Number for PC23 */
+#define PIO_PC24_IDX                ( 88)  /**< PIO Index Number for PC24 */
+#define PIO_PC25_IDX                ( 89)  /**< PIO Index Number for PC25 */
+#define PIO_PC26_IDX                ( 90)  /**< PIO Index Number for PC26 */
+#define PIO_PC27_IDX                ( 91)  /**< PIO Index Number for PC27 */
+#define PIO_PC28_IDX                ( 92)  /**< PIO Index Number for PC28 */
+#define PIO_PC29_IDX                ( 93)  /**< PIO Index Number for PC29 */
+#define PIO_PC30_IDX                ( 94)  /**< PIO Index Number for PC30 */
+#define PIO_PC31_IDX                ( 95)  /**< PIO Index Number for PC31 */
+#define PIO_PD0_IDX                 ( 96)  /**< PIO Index Number for PD0 */
+#define PIO_PD1_IDX                 ( 97)  /**< PIO Index Number for PD1 */
+#define PIO_PD2_IDX                 ( 98)  /**< PIO Index Number for PD2 */
+#define PIO_PD3_IDX                 ( 99)  /**< PIO Index Number for PD3 */
+#define PIO_PD4_IDX                 (100)  /**< PIO Index Number for PD4 */
+#define PIO_PD5_IDX                 (101)  /**< PIO Index Number for PD5 */
+#define PIO_PD6_IDX                 (102)  /**< PIO Index Number for PD6 */
+#define PIO_PD7_IDX                 (103)  /**< PIO Index Number for PD7 */
+#define PIO_PD8_IDX                 (104)  /**< PIO Index Number for PD8 */
+#define PIO_PD9_IDX                 (105)  /**< PIO Index Number for PD9 */
+#define PIO_PD10_IDX                (106)  /**< PIO Index Number for PD10 */
+#define PIO_PD11_IDX                (107)  /**< PIO Index Number for PD11 */
+#define PIO_PD12_IDX                (108)  /**< PIO Index Number for PD12 */
+#define PIO_PD13_IDX                (109)  /**< PIO Index Number for PD13 */
+#define PIO_PD14_IDX                (110)  /**< PIO Index Number for PD14 */
+#define PIO_PD15_IDX                (111)  /**< PIO Index Number for PD15 */
+#define PIO_PD16_IDX                (112)  /**< PIO Index Number for PD16 */
+#define PIO_PD17_IDX                (113)  /**< PIO Index Number for PD17 */
+#define PIO_PD18_IDX                (114)  /**< PIO Index Number for PD18 */
+#define PIO_PD19_IDX                (115)  /**< PIO Index Number for PD19 */
+#define PIO_PD20_IDX                (116)  /**< PIO Index Number for PD20 */
+#define PIO_PD21_IDX                (117)  /**< PIO Index Number for PD21 */
+#define PIO_PD22_IDX                (118)  /**< PIO Index Number for PD22 */
+#define PIO_PD23_IDX                (119)  /**< PIO Index Number for PD23 */
+#define PIO_PD24_IDX                (120)  /**< PIO Index Number for PD24 */
+#define PIO_PD25_IDX                (121)  /**< PIO Index Number for PD25 */
+#define PIO_PD26_IDX                (122)  /**< PIO Index Number for PD26 */
+#define PIO_PD27_IDX                (123)  /**< PIO Index Number for PD27 */
+#define PIO_PD28_IDX                (124)  /**< PIO Index Number for PD28 */
+#define PIO_PD29_IDX                (125)  /**< PIO Index Number for PD29 */
+#define PIO_PD30_IDX                (126)  /**< PIO Index Number for PD30 */
+#define PIO_PD31_IDX                (127)  /**< PIO Index Number for PD31 */
+#define PIO_PE0_IDX                 (128)  /**< PIO Index Number for PE0 */
+#define PIO_PE1_IDX                 (129)  /**< PIO Index Number for PE1 */
+#define PIO_PE2_IDX                 (130)  /**< PIO Index Number for PE2 */
+#define PIO_PE3_IDX                 (131)  /**< PIO Index Number for PE3 */
+#define PIO_PE4_IDX                 (132)  /**< PIO Index Number for PE4 */
+#define PIO_PE5_IDX                 (133)  /**< PIO Index Number for PE5 */
+
+/* ========== PIO definition for AFEC0 peripheral ========== */
+#define PIN_PA8B_AFEC0_ADTRG                       _L_(8)       /**< AFEC0 signal: ADTRG on PA8 mux B*/
+#define MUX_PA8B_AFEC0_ADTRG                       _L_(1)       /**< AFEC0 signal line function value: ADTRG */
+#define PIO_PA8B_AFEC0_ADTRG                       (_UL_(1) << 8)
+
+#define PIN_PD30X1_AFEC0_AD0                       _L_(126)     /**< AFEC0 signal: AD0 on PD30 mux X1*/
+#define PIO_PD30X1_AFEC0_AD0                       (_UL_(1) << 30)
+
+#define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
+#define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
+
+#define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
+#define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
+
+#define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
+#define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
+
+#define PIN_PE4X1_AFEC0_AD4                        _L_(132)     /**< AFEC0 signal: AD4 on PE4 mux X1*/
+#define PIO_PE4X1_AFEC0_AD4                        (_UL_(1) << 4)
+
+#define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
+#define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
+
+#define PIN_PA17X1_AFEC0_AD6                       _L_(17)      /**< AFEC0 signal: AD6 on PA17 mux X1*/
+#define PIO_PA17X1_AFEC0_AD6                       (_UL_(1) << 17)
+
+#define PIN_PA18X1_AFEC0_AD7                       _L_(18)      /**< AFEC0 signal: AD7 on PA18 mux X1*/
+#define PIO_PA18X1_AFEC0_AD7                       (_UL_(1) << 18)
+
+#define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
+#define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
+
+#define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
+#define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
+
+#define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
+#define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
+
+/* ========== PIO definition for AFEC1 peripheral ========== */
+#define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
+#define MUX_PD9C_AFEC1_ADTRG                       _L_(2)       /**< AFEC1 signal line function value: ADTRG */
+#define PIO_PD9C_AFEC1_ADTRG                       (_UL_(1) << 9)
+
+#define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
+#define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
+
+#define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
+#define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
+
+#define PIN_PC15X1_AFEC1_AD2                       _L_(79)      /**< AFEC1 signal: AD2 on PC15 mux X1*/
+#define PIO_PC15X1_AFEC1_AD2                       (_UL_(1) << 15)
+
+#define PIN_PC12X1_AFEC1_AD3                       _L_(76)      /**< AFEC1 signal: AD3 on PC12 mux X1*/
+#define PIO_PC12X1_AFEC1_AD3                       (_UL_(1) << 12)
+
+#define PIN_PC29X1_AFEC1_AD4                       _L_(93)      /**< AFEC1 signal: AD4 on PC29 mux X1*/
+#define PIO_PC29X1_AFEC1_AD4                       (_UL_(1) << 29)
+
+#define PIN_PC30X1_AFEC1_AD5                       _L_(94)      /**< AFEC1 signal: AD5 on PC30 mux X1*/
+#define PIO_PC30X1_AFEC1_AD5                       (_UL_(1) << 30)
+
+#define PIN_PC31X1_AFEC1_AD6                       _L_(95)      /**< AFEC1 signal: AD6 on PC31 mux X1*/
+#define PIO_PC31X1_AFEC1_AD6                       (_UL_(1) << 31)
+
+#define PIN_PC26X1_AFEC1_AD7                       _L_(90)      /**< AFEC1 signal: AD7 on PC26 mux X1*/
+#define PIO_PC26X1_AFEC1_AD7                       (_UL_(1) << 26)
+
+#define PIN_PC27X1_AFEC1_AD8                       _L_(91)      /**< AFEC1 signal: AD8 on PC27 mux X1*/
+#define PIO_PC27X1_AFEC1_AD8                       (_UL_(1) << 27)
+
+#define PIN_PC0X1_AFEC1_AD9                        _L_(64)      /**< AFEC1 signal: AD9 on PC0 mux X1*/
+#define PIO_PC0X1_AFEC1_AD9                        (_UL_(1) << 0)
+
+#define PIN_PE3X1_AFEC1_AD10                       _L_(131)     /**< AFEC1 signal: AD10 on PE3 mux X1*/
+#define PIO_PE3X1_AFEC1_AD10                       (_UL_(1) << 3)
+
+#define PIN_PE0X1_AFEC1_AD11                       _L_(128)     /**< AFEC1 signal: AD11 on PE0 mux X1*/
+#define PIO_PE0X1_AFEC1_AD11                       (_UL_(1) << 0)
+
+/* ========== PIO definition for DACC peripheral ========== */
+#define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
+#define PIO_PB13X1_DACC_DAC0                       (_UL_(1) << 13)
+
+#define PIN_PD0X1_DACC_DAC1                        _L_(96)      /**< DACC signal: DAC1 on PD0 mux X1*/
+#define PIO_PD0X1_DACC_DAC1                        (_UL_(1) << 0)
+
+#define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
+#define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
+#define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
+
+/* ========== PIO definition for GMAC peripheral ========== */
+#define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
+#define MUX_PD13A_GMAC_GCOL                        _L_(0)       /**< GMAC signal line function value: GCOL */
+#define PIO_PD13A_GMAC_GCOL                        (_UL_(1) << 13)
+
+#define PIN_PD10A_GMAC_GCRS                        _L_(106)     /**< GMAC signal: GCRS on PD10 mux A*/
+#define MUX_PD10A_GMAC_GCRS                        _L_(0)       /**< GMAC signal line function value: GCRS */
+#define PIO_PD10A_GMAC_GCRS                        (_UL_(1) << 10)
+
+#define PIN_PD8A_GMAC_GMDC                         _L_(104)     /**< GMAC signal: GMDC on PD8 mux A*/
+#define MUX_PD8A_GMAC_GMDC                         _L_(0)       /**< GMAC signal line function value: GMDC */
+#define PIO_PD8A_GMAC_GMDC                         (_UL_(1) << 8)
+
+#define PIN_PD9A_GMAC_GMDIO                        _L_(105)     /**< GMAC signal: GMDIO on PD9 mux A*/
+#define MUX_PD9A_GMAC_GMDIO                        _L_(0)       /**< GMAC signal line function value: GMDIO */
+#define PIO_PD9A_GMAC_GMDIO                        (_UL_(1) << 9)
+
+#define PIN_PD14A_GMAC_GRXCK                       _L_(110)     /**< GMAC signal: GRXCK on PD14 mux A*/
+#define MUX_PD14A_GMAC_GRXCK                       _L_(0)       /**< GMAC signal line function value: GRXCK */
+#define PIO_PD14A_GMAC_GRXCK                       (_UL_(1) << 14)
+
+#define PIN_PD4A_GMAC_GRXDV                        _L_(100)     /**< GMAC signal: GRXDV on PD4 mux A*/
+#define MUX_PD4A_GMAC_GRXDV                        _L_(0)       /**< GMAC signal line function value: GRXDV */
+#define PIO_PD4A_GMAC_GRXDV                        (_UL_(1) << 4)
+
+#define PIN_PD7A_GMAC_GRXER                        _L_(103)     /**< GMAC signal: GRXER on PD7 mux A*/
+#define MUX_PD7A_GMAC_GRXER                        _L_(0)       /**< GMAC signal line function value: GRXER */
+#define PIO_PD7A_GMAC_GRXER                        (_UL_(1) << 7)
+
+#define PIN_PD5A_GMAC_GRX0                         _L_(101)     /**< GMAC signal: GRX0 on PD5 mux A*/
+#define MUX_PD5A_GMAC_GRX0                         _L_(0)       /**< GMAC signal line function value: GRX0 */
+#define PIO_PD5A_GMAC_GRX0                         (_UL_(1) << 5)
+
+#define PIN_PD6A_GMAC_GRX1                         _L_(102)     /**< GMAC signal: GRX1 on PD6 mux A*/
+#define MUX_PD6A_GMAC_GRX1                         _L_(0)       /**< GMAC signal line function value: GRX1 */
+#define PIO_PD6A_GMAC_GRX1                         (_UL_(1) << 6)
+
+#define PIN_PD11A_GMAC_GRX2                        _L_(107)     /**< GMAC signal: GRX2 on PD11 mux A*/
+#define MUX_PD11A_GMAC_GRX2                        _L_(0)       /**< GMAC signal line function value: GRX2 */
+#define PIO_PD11A_GMAC_GRX2                        (_UL_(1) << 11)
+
+#define PIN_PD12A_GMAC_GRX3                        _L_(108)     /**< GMAC signal: GRX3 on PD12 mux A*/
+#define MUX_PD12A_GMAC_GRX3                        _L_(0)       /**< GMAC signal line function value: GRX3 */
+#define PIO_PD12A_GMAC_GRX3                        (_UL_(1) << 12)
+
+#define PIN_PB1B_GMAC_GTSUCOMP                     _L_(33)      /**< GMAC signal: GTSUCOMP on PB1 mux B*/
+#define MUX_PB1B_GMAC_GTSUCOMP                     _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB1B_GMAC_GTSUCOMP                     (_UL_(1) << 1)
+
+#define PIN_PB12B_GMAC_GTSUCOMP                    _L_(44)      /**< GMAC signal: GTSUCOMP on PB12 mux B*/
+#define MUX_PB12B_GMAC_GTSUCOMP                    _L_(1)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PB12B_GMAC_GTSUCOMP                    (_UL_(1) << 12)
+
+#define PIN_PD11C_GMAC_GTSUCOMP                    _L_(107)     /**< GMAC signal: GTSUCOMP on PD11 mux C*/
+#define MUX_PD11C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD11C_GMAC_GTSUCOMP                    (_UL_(1) << 11)
+
+#define PIN_PD20C_GMAC_GTSUCOMP                    _L_(116)     /**< GMAC signal: GTSUCOMP on PD20 mux C*/
+#define MUX_PD20C_GMAC_GTSUCOMP                    _L_(2)       /**< GMAC signal line function value: GTSUCOMP */
+#define PIO_PD20C_GMAC_GTSUCOMP                    (_UL_(1) << 20)
+
+#define PIN_PD0A_GMAC_GTXCK                        _L_(96)      /**< GMAC signal: GTXCK on PD0 mux A*/
+#define MUX_PD0A_GMAC_GTXCK                        _L_(0)       /**< GMAC signal line function value: GTXCK */
+#define PIO_PD0A_GMAC_GTXCK                        (_UL_(1) << 0)
+
+#define PIN_PD1A_GMAC_GTXEN                        _L_(97)      /**< GMAC signal: GTXEN on PD1 mux A*/
+#define MUX_PD1A_GMAC_GTXEN                        _L_(0)       /**< GMAC signal line function value: GTXEN */
+#define PIO_PD1A_GMAC_GTXEN                        (_UL_(1) << 1)
+
+#define PIN_PD17A_GMAC_GTXER                       _L_(113)     /**< GMAC signal: GTXER on PD17 mux A*/
+#define MUX_PD17A_GMAC_GTXER                       _L_(0)       /**< GMAC signal line function value: GTXER */
+#define PIO_PD17A_GMAC_GTXER                       (_UL_(1) << 17)
+
+#define PIN_PD2A_GMAC_GTX0                         _L_(98)      /**< GMAC signal: GTX0 on PD2 mux A*/
+#define MUX_PD2A_GMAC_GTX0                         _L_(0)       /**< GMAC signal line function value: GTX0 */
+#define PIO_PD2A_GMAC_GTX0                         (_UL_(1) << 2)
+
+#define PIN_PD3A_GMAC_GTX1                         _L_(99)      /**< GMAC signal: GTX1 on PD3 mux A*/
+#define MUX_PD3A_GMAC_GTX1                         _L_(0)       /**< GMAC signal line function value: GTX1 */
+#define PIO_PD3A_GMAC_GTX1                         (_UL_(1) << 3)
+
+#define PIN_PD15A_GMAC_GTX2                        _L_(111)     /**< GMAC signal: GTX2 on PD15 mux A*/
+#define MUX_PD15A_GMAC_GTX2                        _L_(0)       /**< GMAC signal line function value: GTX2 */
+#define PIO_PD15A_GMAC_GTX2                        (_UL_(1) << 15)
+
+#define PIN_PD16A_GMAC_GTX3                        _L_(112)     /**< GMAC signal: GTX3 on PD16 mux A*/
+#define MUX_PD16A_GMAC_GTX3                        _L_(0)       /**< GMAC signal line function value: GTX3 */
+#define PIO_PD16A_GMAC_GTX3                        (_UL_(1) << 16)
+
+/* ========== PIO definition for HSMCI peripheral ========== */
+#define PIN_PA28C_HSMCI_MCCDA                      _L_(28)      /**< HSMCI signal: MCCDA on PA28 mux C*/
+#define MUX_PA28C_HSMCI_MCCDA                      _L_(2)       /**< HSMCI signal line function value: MCCDA */
+#define PIO_PA28C_HSMCI_MCCDA                      (_UL_(1) << 28)
+
+#define PIN_PA25D_HSMCI_MCCK                       _L_(25)      /**< HSMCI signal: MCCK on PA25 mux D*/
+#define MUX_PA25D_HSMCI_MCCK                       _L_(3)       /**< HSMCI signal line function value: MCCK */
+#define PIO_PA25D_HSMCI_MCCK                       (_UL_(1) << 25)
+
+#define PIN_PA30C_HSMCI_MCDA0                      _L_(30)      /**< HSMCI signal: MCDA0 on PA30 mux C*/
+#define MUX_PA30C_HSMCI_MCDA0                      _L_(2)       /**< HSMCI signal line function value: MCDA0 */
+#define PIO_PA30C_HSMCI_MCDA0                      (_UL_(1) << 30)
+
+#define PIN_PA31C_HSMCI_MCDA1                      _L_(31)      /**< HSMCI signal: MCDA1 on PA31 mux C*/
+#define MUX_PA31C_HSMCI_MCDA1                      _L_(2)       /**< HSMCI signal line function value: MCDA1 */
+#define PIO_PA31C_HSMCI_MCDA1                      (_UL_(1) << 31)
+
+#define PIN_PA26C_HSMCI_MCDA2                      _L_(26)      /**< HSMCI signal: MCDA2 on PA26 mux C*/
+#define MUX_PA26C_HSMCI_MCDA2                      _L_(2)       /**< HSMCI signal line function value: MCDA2 */
+#define PIO_PA26C_HSMCI_MCDA2                      (_UL_(1) << 26)
+
+#define PIN_PA27C_HSMCI_MCDA3                      _L_(27)      /**< HSMCI signal: MCDA3 on PA27 mux C*/
+#define MUX_PA27C_HSMCI_MCDA3                      _L_(2)       /**< HSMCI signal line function value: MCDA3 */
+#define PIO_PA27C_HSMCI_MCDA3                      (_UL_(1) << 27)
+
+/* ========== PIO definition for I2SC0 peripheral ========== */
+#define PIN_PA1D_I2SC0_CK                          _L_(1)       /**< I2SC0 signal: CK on PA1 mux D*/
+#define MUX_PA1D_I2SC0_CK                          _L_(3)       /**< I2SC0 signal line function value: CK */
+#define PIO_PA1D_I2SC0_CK                          (_UL_(1) << 1)
+
+#define PIN_PA16D_I2SC0_DI0                        _L_(16)      /**< I2SC0 signal: DI0 on PA16 mux D*/
+#define MUX_PA16D_I2SC0_DI0                        _L_(3)       /**< I2SC0 signal line function value: DI0 */
+#define PIO_PA16D_I2SC0_DI0                        (_UL_(1) << 16)
+
+#define PIN_PA30D_I2SC0_DO0                        _L_(30)      /**< I2SC0 signal: DO0 on PA30 mux D*/
+#define MUX_PA30D_I2SC0_DO0                        _L_(3)       /**< I2SC0 signal line function value: DO0 */
+#define PIO_PA30D_I2SC0_DO0                        (_UL_(1) << 30)
+
+#define PIN_PA0D_I2SC0_MCK                         _L_(0)       /**< I2SC0 signal: MCK on PA0 mux D*/
+#define MUX_PA0D_I2SC0_MCK                         _L_(3)       /**< I2SC0 signal line function value: MCK */
+#define PIO_PA0D_I2SC0_MCK                         (_UL_(1) << 0)
+
+#define PIN_PA15D_I2SC0_WS                         _L_(15)      /**< I2SC0 signal: WS on PA15 mux D*/
+#define MUX_PA15D_I2SC0_WS                         _L_(3)       /**< I2SC0 signal line function value: WS */
+#define PIO_PA15D_I2SC0_WS                         (_UL_(1) << 15)
+
+/* ========== PIO definition for I2SC1 peripheral ========== */
+#define PIN_PA20D_I2SC1_CK                         _L_(20)      /**< I2SC1 signal: CK on PA20 mux D*/
+#define MUX_PA20D_I2SC1_CK                         _L_(3)       /**< I2SC1 signal line function value: CK */
+#define PIO_PA20D_I2SC1_CK                         (_UL_(1) << 20)
+
+#define PIN_PE2C_I2SC1_DI0                         _L_(130)     /**< I2SC1 signal: DI0 on PE2 mux C*/
+#define MUX_PE2C_I2SC1_DI0                         _L_(2)       /**< I2SC1 signal line function value: DI0 */
+#define PIO_PE2C_I2SC1_DI0                         (_UL_(1) << 2)
+
+#define PIN_PE1C_I2SC1_DO0                         _L_(129)     /**< I2SC1 signal: DO0 on PE1 mux C*/
+#define MUX_PE1C_I2SC1_DO0                         _L_(2)       /**< I2SC1 signal line function value: DO0 */
+#define PIO_PE1C_I2SC1_DO0                         (_UL_(1) << 1)
+
+#define PIN_PA19D_I2SC1_MCK                        _L_(19)      /**< I2SC1 signal: MCK on PA19 mux D*/
+#define MUX_PA19D_I2SC1_MCK                        _L_(3)       /**< I2SC1 signal line function value: MCK */
+#define PIO_PA19D_I2SC1_MCK                        (_UL_(1) << 19)
+
+#define PIN_PE0C_I2SC1_WS                          _L_(128)     /**< I2SC1 signal: WS on PE0 mux C*/
+#define MUX_PE0C_I2SC1_WS                          _L_(2)       /**< I2SC1 signal line function value: WS */
+#define PIO_PE0C_I2SC1_WS                          (_UL_(1) << 0)
+
+/* ========== PIO definition for ISI peripheral ========== */
+#define PIN_PD22D_ISI_D0                           _L_(118)     /**< ISI signal: D0 on PD22 mux D*/
+#define MUX_PD22D_ISI_D0                           _L_(3)       /**< ISI signal line function value: D0 */
+#define PIO_PD22D_ISI_D0                           (_UL_(1) << 22)
+
+#define PIN_PD21D_ISI_D1                           _L_(117)     /**< ISI signal: D1 on PD21 mux D*/
+#define MUX_PD21D_ISI_D1                           _L_(3)       /**< ISI signal line function value: D1 */
+#define PIO_PD21D_ISI_D1                           (_UL_(1) << 21)
+
+#define PIN_PB3D_ISI_D2                            _L_(35)      /**< ISI signal: D2 on PB3 mux D*/
+#define MUX_PB3D_ISI_D2                            _L_(3)       /**< ISI signal line function value: D2 */
+#define PIO_PB3D_ISI_D2                            (_UL_(1) << 3)
+
+#define PIN_PA9B_ISI_D3                            _L_(9)       /**< ISI signal: D3 on PA9 mux B*/
+#define MUX_PA9B_ISI_D3                            _L_(1)       /**< ISI signal line function value: D3 */
+#define PIO_PA9B_ISI_D3                            (_UL_(1) << 9)
+
+#define PIN_PA5B_ISI_D4                            _L_(5)       /**< ISI signal: D4 on PA5 mux B*/
+#define MUX_PA5B_ISI_D4                            _L_(1)       /**< ISI signal line function value: D4 */
+#define PIO_PA5B_ISI_D4                            (_UL_(1) << 5)
+
+#define PIN_PD11D_ISI_D5                           _L_(107)     /**< ISI signal: D5 on PD11 mux D*/
+#define MUX_PD11D_ISI_D5                           _L_(3)       /**< ISI signal line function value: D5 */
+#define PIO_PD11D_ISI_D5                           (_UL_(1) << 11)
+
+#define PIN_PD12D_ISI_D6                           _L_(108)     /**< ISI signal: D6 on PD12 mux D*/
+#define MUX_PD12D_ISI_D6                           _L_(3)       /**< ISI signal line function value: D6 */
+#define PIO_PD12D_ISI_D6                           (_UL_(1) << 12)
+
+#define PIN_PA27D_ISI_D7                           _L_(27)      /**< ISI signal: D7 on PA27 mux D*/
+#define MUX_PA27D_ISI_D7                           _L_(3)       /**< ISI signal line function value: D7 */
+#define PIO_PA27D_ISI_D7                           (_UL_(1) << 27)
+
+#define PIN_PD27D_ISI_D8                           _L_(123)     /**< ISI signal: D8 on PD27 mux D*/
+#define MUX_PD27D_ISI_D8                           _L_(3)       /**< ISI signal line function value: D8 */
+#define PIO_PD27D_ISI_D8                           (_UL_(1) << 27)
+
+#define PIN_PD28D_ISI_D9                           _L_(124)     /**< ISI signal: D9 on PD28 mux D*/
+#define MUX_PD28D_ISI_D9                           _L_(3)       /**< ISI signal line function value: D9 */
+#define PIO_PD28D_ISI_D9                           (_UL_(1) << 28)
+
+#define PIN_PD30D_ISI_D10                          _L_(126)     /**< ISI signal: D10 on PD30 mux D*/
+#define MUX_PD30D_ISI_D10                          _L_(3)       /**< ISI signal line function value: D10 */
+#define PIO_PD30D_ISI_D10                          (_UL_(1) << 30)
+
+#define PIN_PD31D_ISI_D11                          _L_(127)     /**< ISI signal: D11 on PD31 mux D*/
+#define MUX_PD31D_ISI_D11                          _L_(3)       /**< ISI signal line function value: D11 */
+#define PIO_PD31D_ISI_D11                          (_UL_(1) << 31)
+
+#define PIN_PD24D_ISI_HSYNC                        _L_(120)     /**< ISI signal: HSYNC on PD24 mux D*/
+#define MUX_PD24D_ISI_HSYNC                        _L_(3)       /**< ISI signal line function value: HSYNC */
+#define PIO_PD24D_ISI_HSYNC                        (_UL_(1) << 24)
+
+#define PIN_PA24D_ISI_PCK                          _L_(24)      /**< ISI signal: PCK on PA24 mux D*/
+#define MUX_PA24D_ISI_PCK                          _L_(3)       /**< ISI signal line function value: PCK */
+#define PIO_PA24D_ISI_PCK                          (_UL_(1) << 24)
+
+#define PIN_PD25D_ISI_VSYNC                        _L_(121)     /**< ISI signal: VSYNC on PD25 mux D*/
+#define MUX_PD25D_ISI_VSYNC                        _L_(3)       /**< ISI signal line function value: VSYNC */
+#define PIO_PD25D_ISI_VSYNC                        (_UL_(1) << 25)
+
+/* ========== PIO definition for MCAN0 peripheral ========== */
+#define PIN_PB3A_MCAN0_CANRX0                      _L_(35)      /**< MCAN0 signal: CANRX0 on PB3 mux A*/
+#define MUX_PB3A_MCAN0_CANRX0                      _L_(0)       /**< MCAN0 signal line function value: CANRX0 */
+#define PIO_PB3A_MCAN0_CANRX0                      (_UL_(1) << 3)
+
+#define PIN_PB2A_MCAN0_CANTX0                      _L_(34)      /**< MCAN0 signal: CANTX0 on PB2 mux A*/
+#define MUX_PB2A_MCAN0_CANTX0                      _L_(0)       /**< MCAN0 signal line function value: CANTX0 */
+#define PIO_PB2A_MCAN0_CANTX0                      (_UL_(1) << 2)
+
+/* ========== PIO definition for MCAN1 peripheral ========== */
+#define PIN_PC12C_MCAN1_CANRX1                     _L_(76)      /**< MCAN1 signal: CANRX1 on PC12 mux C*/
+#define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
+#define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
+
+#define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
+#define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
+
+#define PIN_PD12B_MCAN1_CANTX1                     _L_(108)     /**< MCAN1 signal: CANTX1 on PD12 mux B*/
+#define MUX_PD12B_MCAN1_CANTX1                     _L_(1)       /**< MCAN1 signal line function value: CANTX1 */
+#define PIO_PD12B_MCAN1_CANTX1                     (_UL_(1) << 12)
+
+/* ========== PIO definition for MLB peripheral ========== */
+#define PIN_PB4C_MLB_MLBCLK                        _L_(36)      /**< MLB signal: MLBCLK on PB4 mux C*/
+#define MUX_PB4C_MLB_MLBCLK                        _L_(2)       /**< MLB signal line function value: MLBCLK */
+#define PIO_PB4C_MLB_MLBCLK                        (_UL_(1) << 4)
+
+#define PIN_PB5C_MLB_MLBDAT                        _L_(37)      /**< MLB signal: MLBDAT on PB5 mux C*/
+#define MUX_PB5C_MLB_MLBDAT                        _L_(2)       /**< MLB signal line function value: MLBDAT */
+#define PIO_PB5C_MLB_MLBDAT                        (_UL_(1) << 5)
+
+#define PIN_PD10D_MLB_MLBSIG                       _L_(106)     /**< MLB signal: MLBSIG on PD10 mux D*/
+#define MUX_PD10D_MLB_MLBSIG                       _L_(3)       /**< MLB signal line function value: MLBSIG */
+#define PIO_PD10D_MLB_MLBSIG                       (_UL_(1) << 10)
+
+/* ========== PIO definition for PMC peripheral ========== */
+#define PIN_PA6B_PMC_PCK0                          _L_(6)       /**< PMC signal: PCK0 on PA6 mux B*/
+#define MUX_PA6B_PMC_PCK0                          _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PA6B_PMC_PCK0                          (_UL_(1) << 6)
+
+#define PIN_PB12D_PMC_PCK0                         _L_(44)      /**< PMC signal: PCK0 on PB12 mux D*/
+#define MUX_PB12D_PMC_PCK0                         _L_(3)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB12D_PMC_PCK0                         (_UL_(1) << 12)
+
+#define PIN_PB13B_PMC_PCK0                         _L_(45)      /**< PMC signal: PCK0 on PB13 mux B*/
+#define MUX_PB13B_PMC_PCK0                         _L_(1)       /**< PMC signal line function value: PCK0 */
+#define PIO_PB13B_PMC_PCK0                         (_UL_(1) << 13)
+
+#define PIN_PA17B_PMC_PCK1                         _L_(17)      /**< PMC signal: PCK1 on PA17 mux B*/
+#define MUX_PA17B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA17B_PMC_PCK1                         (_UL_(1) << 17)
+
+#define PIN_PA21B_PMC_PCK1                         _L_(21)      /**< PMC signal: PCK1 on PA21 mux B*/
+#define MUX_PA21B_PMC_PCK1                         _L_(1)       /**< PMC signal line function value: PCK1 */
+#define PIO_PA21B_PMC_PCK1                         (_UL_(1) << 21)
+
+#define PIN_PA3C_PMC_PCK2                          _L_(3)       /**< PMC signal: PCK2 on PA3 mux C*/
+#define MUX_PA3C_PMC_PCK2                          _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA3C_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PA18B_PMC_PCK2                         _L_(18)      /**< PMC signal: PCK2 on PA18 mux B*/
+#define MUX_PA18B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA18B_PMC_PCK2                         (_UL_(1) << 18)
+
+#define PIN_PA31B_PMC_PCK2                         _L_(31)      /**< PMC signal: PCK2 on PA31 mux B*/
+#define MUX_PA31B_PMC_PCK2                         _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PA31B_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB3B_PMC_PCK2                          _L_(35)      /**< PMC signal: PCK2 on PB3 mux B*/
+#define MUX_PB3B_PMC_PCK2                          _L_(1)       /**< PMC signal line function value: PCK2 */
+#define PIO_PB3B_PMC_PCK2                          (_UL_(1) << 3)
+
+#define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
+#define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
+#define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
+
+/* ========== PIO definition for PWM0 peripheral ========== */
+#define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
+#define MUX_PA10B_PWM0_PWMEXTRG0                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG0 */
+#define PIO_PA10B_PWM0_PWMEXTRG0                   (_UL_(1) << 10)
+
+#define PIN_PA22B_PWM0_PWMEXTRG1                   _L_(22)      /**< PWM0 signal: PWMEXTRG1 on PA22 mux B*/
+#define MUX_PA22B_PWM0_PWMEXTRG1                   _L_(1)       /**< PWM0 signal line function value: PWMEXTRG1 */
+#define PIO_PA22B_PWM0_PWMEXTRG1                   (_UL_(1) << 22)
+
+#define PIN_PA9C_PWM0_PWMFI0                       _L_(9)       /**< PWM0 signal: PWMFI0 on PA9 mux C*/
+#define MUX_PA9C_PWM0_PWMFI0                       _L_(2)       /**< PWM0 signal line function value: PWMFI0 */
+#define PIO_PA9C_PWM0_PWMFI0                       (_UL_(1) << 9)
+
+#define PIN_PD8B_PWM0_PWMFI1                       _L_(104)     /**< PWM0 signal: PWMFI1 on PD8 mux B*/
+#define MUX_PD8B_PWM0_PWMFI1                       _L_(1)       /**< PWM0 signal line function value: PWMFI1 */
+#define PIO_PD8B_PWM0_PWMFI1                       (_UL_(1) << 8)
+
+#define PIN_PD9B_PWM0_PWMFI2                       _L_(105)     /**< PWM0 signal: PWMFI2 on PD9 mux B*/
+#define MUX_PD9B_PWM0_PWMFI2                       _L_(1)       /**< PWM0 signal line function value: PWMFI2 */
+#define PIO_PD9B_PWM0_PWMFI2                       (_UL_(1) << 9)
+
+#define PIN_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal: PWMH0 on PA0 mux A*/
+#define MUX_PA0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PA11B_PWM0_PWMH0                       _L_(11)      /**< PWM0 signal: PWMH0 on PA11 mux B*/
+#define MUX_PA11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PA23B_PWM0_PWMH0                       _L_(23)      /**< PWM0 signal: PWMH0 on PA23 mux B*/
+#define MUX_PA23B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PA23B_PWM0_PWMH0                       (_UL_(1) << 23)
+
+#define PIN_PB0A_PWM0_PWMH0                        _L_(32)      /**< PWM0 signal: PWMH0 on PB0 mux A*/
+#define MUX_PB0A_PWM0_PWMH0                        _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PB0A_PWM0_PWMH0                        (_UL_(1) << 0)
+
+#define PIN_PD11B_PWM0_PWMH0                       _L_(107)     /**< PWM0 signal: PWMH0 on PD11 mux B*/
+#define MUX_PD11B_PWM0_PWMH0                       _L_(1)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD11B_PWM0_PWMH0                       (_UL_(1) << 11)
+
+#define PIN_PD20A_PWM0_PWMH0                       _L_(116)     /**< PWM0 signal: PWMH0 on PD20 mux A*/
+#define MUX_PD20A_PWM0_PWMH0                       _L_(0)       /**< PWM0 signal line function value: PWMH0 */
+#define PIO_PD20A_PWM0_PWMH0                       (_UL_(1) << 20)
+
+#define PIN_PA2A_PWM0_PWMH1                        _L_(2)       /**< PWM0 signal: PWMH1 on PA2 mux A*/
+#define MUX_PA2A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA2A_PWM0_PWMH1                        (_UL_(1) << 2)
+
+#define PIN_PA12B_PWM0_PWMH1                       _L_(12)      /**< PWM0 signal: PWMH1 on PA12 mux B*/
+#define MUX_PA12B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA12B_PWM0_PWMH1                       (_UL_(1) << 12)
+
+#define PIN_PA24B_PWM0_PWMH1                       _L_(24)      /**< PWM0 signal: PWMH1 on PA24 mux B*/
+#define MUX_PA24B_PWM0_PWMH1                       _L_(1)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PA24B_PWM0_PWMH1                       (_UL_(1) << 24)
+
+#define PIN_PB1A_PWM0_PWMH1                        _L_(33)      /**< PWM0 signal: PWMH1 on PB1 mux A*/
+#define MUX_PB1A_PWM0_PWMH1                        _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PB1A_PWM0_PWMH1                        (_UL_(1) << 1)
+
+#define PIN_PD21A_PWM0_PWMH1                       _L_(117)     /**< PWM0 signal: PWMH1 on PD21 mux A*/
+#define MUX_PD21A_PWM0_PWMH1                       _L_(0)       /**< PWM0 signal line function value: PWMH1 */
+#define PIO_PD21A_PWM0_PWMH1                       (_UL_(1) << 21)
+
+#define PIN_PA13B_PWM0_PWMH2                       _L_(13)      /**< PWM0 signal: PWMH2 on PA13 mux B*/
+#define MUX_PA13B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA13B_PWM0_PWMH2                       (_UL_(1) << 13)
+
+#define PIN_PA25B_PWM0_PWMH2                       _L_(25)      /**< PWM0 signal: PWMH2 on PA25 mux B*/
+#define MUX_PA25B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PA25B_PWM0_PWMH2                       (_UL_(1) << 25)
+
+#define PIN_PB4B_PWM0_PWMH2                        _L_(36)      /**< PWM0 signal: PWMH2 on PB4 mux B*/
+#define MUX_PB4B_PWM0_PWMH2                        _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PB4B_PWM0_PWMH2                        (_UL_(1) << 4)
+
+#define PIN_PC19B_PWM0_PWMH2                       _L_(83)      /**< PWM0 signal: PWMH2 on PC19 mux B*/
+#define MUX_PC19B_PWM0_PWMH2                       _L_(1)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PC19B_PWM0_PWMH2                       (_UL_(1) << 19)
+
+#define PIN_PD22A_PWM0_PWMH2                       _L_(118)     /**< PWM0 signal: PWMH2 on PD22 mux A*/
+#define MUX_PD22A_PWM0_PWMH2                       _L_(0)       /**< PWM0 signal line function value: PWMH2 */
+#define PIO_PD22A_PWM0_PWMH2                       (_UL_(1) << 22)
+
+#define PIN_PA7B_PWM0_PWMH3                        _L_(7)       /**< PWM0 signal: PWMH3 on PA7 mux B*/
+#define MUX_PA7B_PWM0_PWMH3                        _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA7B_PWM0_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA14B_PWM0_PWMH3                       _L_(14)      /**< PWM0 signal: PWMH3 on PA14 mux B*/
+#define MUX_PA14B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA14B_PWM0_PWMH3                       (_UL_(1) << 14)
+
+#define PIN_PA17C_PWM0_PWMH3                       _L_(17)      /**< PWM0 signal: PWMH3 on PA17 mux C*/
+#define MUX_PA17C_PWM0_PWMH3                       _L_(2)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PA17C_PWM0_PWMH3                       (_UL_(1) << 17)
+
+#define PIN_PC13B_PWM0_PWMH3                       _L_(77)      /**< PWM0 signal: PWMH3 on PC13 mux B*/
+#define MUX_PC13B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC13B_PWM0_PWMH3                       (_UL_(1) << 13)
+
+#define PIN_PC21B_PWM0_PWMH3                       _L_(85)      /**< PWM0 signal: PWMH3 on PC21 mux B*/
+#define MUX_PC21B_PWM0_PWMH3                       _L_(1)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PC21B_PWM0_PWMH3                       (_UL_(1) << 21)
+
+#define PIN_PD23A_PWM0_PWMH3                       _L_(119)     /**< PWM0 signal: PWMH3 on PD23 mux A*/
+#define MUX_PD23A_PWM0_PWMH3                       _L_(0)       /**< PWM0 signal line function value: PWMH3 */
+#define PIO_PD23A_PWM0_PWMH3                       (_UL_(1) << 23)
+
+#define PIN_PA1A_PWM0_PWML0                        _L_(1)       /**< PWM0 signal: PWML0 on PA1 mux A*/
+#define MUX_PA1A_PWM0_PWML0                        _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA1A_PWM0_PWML0                        (_UL_(1) << 1)
+
+#define PIN_PA19B_PWM0_PWML0                       _L_(19)      /**< PWM0 signal: PWML0 on PA19 mux B*/
+#define MUX_PA19B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PA19B_PWM0_PWML0                       (_UL_(1) << 19)
+
+#define PIN_PB5B_PWM0_PWML0                        _L_(37)      /**< PWM0 signal: PWML0 on PB5 mux B*/
+#define MUX_PB5B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PB5B_PWM0_PWML0                        (_UL_(1) << 5)
+
+#define PIN_PC0B_PWM0_PWML0                        _L_(64)      /**< PWM0 signal: PWML0 on PC0 mux B*/
+#define MUX_PC0B_PWM0_PWML0                        _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PC0B_PWM0_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PD10B_PWM0_PWML0                       _L_(106)     /**< PWM0 signal: PWML0 on PD10 mux B*/
+#define MUX_PD10B_PWM0_PWML0                       _L_(1)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD10B_PWM0_PWML0                       (_UL_(1) << 10)
+
+#define PIN_PD24A_PWM0_PWML0                       _L_(120)     /**< PWM0 signal: PWML0 on PD24 mux A*/
+#define MUX_PD24A_PWM0_PWML0                       _L_(0)       /**< PWM0 signal line function value: PWML0 */
+#define PIO_PD24A_PWM0_PWML0                       (_UL_(1) << 24)
+
+#define PIN_PA20B_PWM0_PWML1                       _L_(20)      /**< PWM0 signal: PWML1 on PA20 mux B*/
+#define MUX_PA20B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PA20B_PWM0_PWML1                       (_UL_(1) << 20)
+
+#define PIN_PB12A_PWM0_PWML1                       _L_(44)      /**< PWM0 signal: PWML1 on PB12 mux A*/
+#define MUX_PB12A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PB12A_PWM0_PWML1                       (_UL_(1) << 12)
+
+#define PIN_PC1B_PWM0_PWML1                        _L_(65)      /**< PWM0 signal: PWML1 on PC1 mux B*/
+#define MUX_PC1B_PWM0_PWML1                        _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC1B_PWM0_PWML1                        (_UL_(1) << 1)
+
+#define PIN_PC18B_PWM0_PWML1                       _L_(82)      /**< PWM0 signal: PWML1 on PC18 mux B*/
+#define MUX_PC18B_PWM0_PWML1                       _L_(1)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PC18B_PWM0_PWML1                       (_UL_(1) << 18)
+
+#define PIN_PD25A_PWM0_PWML1                       _L_(121)     /**< PWM0 signal: PWML1 on PD25 mux A*/
+#define MUX_PD25A_PWM0_PWML1                       _L_(0)       /**< PWM0 signal line function value: PWML1 */
+#define PIO_PD25A_PWM0_PWML1                       (_UL_(1) << 25)
+
+#define PIN_PA16C_PWM0_PWML2                       _L_(16)      /**< PWM0 signal: PWML2 on PA16 mux C*/
+#define MUX_PA16C_PWM0_PWML2                       _L_(2)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA16C_PWM0_PWML2                       (_UL_(1) << 16)
+
+#define PIN_PA30A_PWM0_PWML2                       _L_(30)      /**< PWM0 signal: PWML2 on PA30 mux A*/
+#define MUX_PA30A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PA30A_PWM0_PWML2                       (_UL_(1) << 30)
+
+#define PIN_PB13A_PWM0_PWML2                       _L_(45)      /**< PWM0 signal: PWML2 on PB13 mux A*/
+#define MUX_PB13A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PB13A_PWM0_PWML2                       (_UL_(1) << 13)
+
+#define PIN_PC2B_PWM0_PWML2                        _L_(66)      /**< PWM0 signal: PWML2 on PC2 mux B*/
+#define MUX_PC2B_PWM0_PWML2                        _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC2B_PWM0_PWML2                        (_UL_(1) << 2)
+
+#define PIN_PC20B_PWM0_PWML2                       _L_(84)      /**< PWM0 signal: PWML2 on PC20 mux B*/
+#define MUX_PC20B_PWM0_PWML2                       _L_(1)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PC20B_PWM0_PWML2                       (_UL_(1) << 20)
+
+#define PIN_PD26A_PWM0_PWML2                       _L_(122)     /**< PWM0 signal: PWML2 on PD26 mux A*/
+#define MUX_PD26A_PWM0_PWML2                       _L_(0)       /**< PWM0 signal line function value: PWML2 */
+#define PIO_PD26A_PWM0_PWML2                       (_UL_(1) << 26)
+
+#define PIN_PA15C_PWM0_PWML3                       _L_(15)      /**< PWM0 signal: PWML3 on PA15 mux C*/
+#define MUX_PA15C_PWM0_PWML3                       _L_(2)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PA15C_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC3B_PWM0_PWML3                        _L_(67)      /**< PWM0 signal: PWML3 on PC3 mux B*/
+#define MUX_PC3B_PWM0_PWML3                        _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC3B_PWM0_PWML3                        (_UL_(1) << 3)
+
+#define PIN_PC15B_PWM0_PWML3                       _L_(79)      /**< PWM0 signal: PWML3 on PC15 mux B*/
+#define MUX_PC15B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC15B_PWM0_PWML3                       (_UL_(1) << 15)
+
+#define PIN_PC22B_PWM0_PWML3                       _L_(86)      /**< PWM0 signal: PWML3 on PC22 mux B*/
+#define MUX_PC22B_PWM0_PWML3                       _L_(1)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PC22B_PWM0_PWML3                       (_UL_(1) << 22)
+
+#define PIN_PD27A_PWM0_PWML3                       _L_(123)     /**< PWM0 signal: PWML3 on PD27 mux A*/
+#define MUX_PD27A_PWM0_PWML3                       _L_(0)       /**< PWM0 signal line function value: PWML3 */
+#define PIO_PD27A_PWM0_PWML3                       (_UL_(1) << 27)
+
+/* ========== PIO definition for PWM1 peripheral ========== */
+#define PIN_PA30B_PWM1_PWMEXTRG0                   _L_(30)      /**< PWM1 signal: PWMEXTRG0 on PA30 mux B*/
+#define MUX_PA30B_PWM1_PWMEXTRG0                   _L_(1)       /**< PWM1 signal line function value: PWMEXTRG0 */
+#define PIO_PA30B_PWM1_PWMEXTRG0                   (_UL_(1) << 30)
+
+#define PIN_PA18A_PWM1_PWMEXTRG1                   _L_(18)      /**< PWM1 signal: PWMEXTRG1 on PA18 mux A*/
+#define MUX_PA18A_PWM1_PWMEXTRG1                   _L_(0)       /**< PWM1 signal line function value: PWMEXTRG1 */
+#define PIO_PA18A_PWM1_PWMEXTRG1                   (_UL_(1) << 18)
+
+#define PIN_PA21C_PWM1_PWMFI0                      _L_(21)      /**< PWM1 signal: PWMFI0 on PA21 mux C*/
+#define MUX_PA21C_PWM1_PWMFI0                      _L_(2)       /**< PWM1 signal line function value: PWMFI0 */
+#define PIO_PA21C_PWM1_PWMFI0                      (_UL_(1) << 21)
+
+#define PIN_PA26D_PWM1_PWMFI1                      _L_(26)      /**< PWM1 signal: PWMFI1 on PA26 mux D*/
+#define MUX_PA26D_PWM1_PWMFI1                      _L_(3)       /**< PWM1 signal line function value: PWMFI1 */
+#define PIO_PA26D_PWM1_PWMFI1                      (_UL_(1) << 26)
+
+#define PIN_PA28D_PWM1_PWMFI2                      _L_(28)      /**< PWM1 signal: PWMFI2 on PA28 mux D*/
+#define MUX_PA28D_PWM1_PWMFI2                      _L_(3)       /**< PWM1 signal line function value: PWMFI2 */
+#define PIO_PA28D_PWM1_PWMFI2                      (_UL_(1) << 28)
+
+#define PIN_PA12C_PWM1_PWMH0                       _L_(12)      /**< PWM1 signal: PWMH0 on PA12 mux C*/
+#define MUX_PA12C_PWM1_PWMH0                       _L_(2)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PA12C_PWM1_PWMH0                       (_UL_(1) << 12)
+
+#define PIN_PD1B_PWM1_PWMH0                        _L_(97)      /**< PWM1 signal: PWMH0 on PD1 mux B*/
+#define MUX_PD1B_PWM1_PWMH0                        _L_(1)       /**< PWM1 signal line function value: PWMH0 */
+#define PIO_PD1B_PWM1_PWMH0                        (_UL_(1) << 1)
+
+#define PIN_PA14C_PWM1_PWMH1                       _L_(14)      /**< PWM1 signal: PWMH1 on PA14 mux C*/
+#define MUX_PA14C_PWM1_PWMH1                       _L_(2)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PA14C_PWM1_PWMH1                       (_UL_(1) << 14)
+
+#define PIN_PD3B_PWM1_PWMH1                        _L_(99)      /**< PWM1 signal: PWMH1 on PD3 mux B*/
+#define MUX_PD3B_PWM1_PWMH1                        _L_(1)       /**< PWM1 signal line function value: PWMH1 */
+#define PIO_PD3B_PWM1_PWMH1                        (_UL_(1) << 3)
+
+#define PIN_PA31D_PWM1_PWMH2                       _L_(31)      /**< PWM1 signal: PWMH2 on PA31 mux D*/
+#define MUX_PA31D_PWM1_PWMH2                       _L_(3)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PA31D_PWM1_PWMH2                       (_UL_(1) << 31)
+
+#define PIN_PD5B_PWM1_PWMH2                        _L_(101)     /**< PWM1 signal: PWMH2 on PD5 mux B*/
+#define MUX_PD5B_PWM1_PWMH2                        _L_(1)       /**< PWM1 signal line function value: PWMH2 */
+#define PIO_PD5B_PWM1_PWMH2                        (_UL_(1) << 5)
+
+#define PIN_PA8A_PWM1_PWMH3                        _L_(8)       /**< PWM1 signal: PWMH3 on PA8 mux A*/
+#define MUX_PA8A_PWM1_PWMH3                        _L_(0)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PA8A_PWM1_PWMH3                        (_UL_(1) << 8)
+
+#define PIN_PD7B_PWM1_PWMH3                        _L_(103)     /**< PWM1 signal: PWMH3 on PD7 mux B*/
+#define MUX_PD7B_PWM1_PWMH3                        _L_(1)       /**< PWM1 signal line function value: PWMH3 */
+#define PIO_PD7B_PWM1_PWMH3                        (_UL_(1) << 7)
+
+#define PIN_PA11C_PWM1_PWML0                       _L_(11)      /**< PWM1 signal: PWML0 on PA11 mux C*/
+#define MUX_PA11C_PWM1_PWML0                       _L_(2)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PA11C_PWM1_PWML0                       (_UL_(1) << 11)
+
+#define PIN_PD0B_PWM1_PWML0                        _L_(96)      /**< PWM1 signal: PWML0 on PD0 mux B*/
+#define MUX_PD0B_PWM1_PWML0                        _L_(1)       /**< PWM1 signal line function value: PWML0 */
+#define PIO_PD0B_PWM1_PWML0                        (_UL_(1) << 0)
+
+#define PIN_PA13C_PWM1_PWML1                       _L_(13)      /**< PWM1 signal: PWML1 on PA13 mux C*/
+#define MUX_PA13C_PWM1_PWML1                       _L_(2)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PA13C_PWM1_PWML1                       (_UL_(1) << 13)
+
+#define PIN_PD2B_PWM1_PWML1                        _L_(98)      /**< PWM1 signal: PWML1 on PD2 mux B*/
+#define MUX_PD2B_PWM1_PWML1                        _L_(1)       /**< PWM1 signal line function value: PWML1 */
+#define PIO_PD2B_PWM1_PWML1                        (_UL_(1) << 2)
+
+#define PIN_PA23D_PWM1_PWML2                       _L_(23)      /**< PWM1 signal: PWML2 on PA23 mux D*/
+#define MUX_PA23D_PWM1_PWML2                       _L_(3)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PA23D_PWM1_PWML2                       (_UL_(1) << 23)
+
+#define PIN_PD4B_PWM1_PWML2                        _L_(100)     /**< PWM1 signal: PWML2 on PD4 mux B*/
+#define MUX_PD4B_PWM1_PWML2                        _L_(1)       /**< PWM1 signal line function value: PWML2 */
+#define PIO_PD4B_PWM1_PWML2                        (_UL_(1) << 4)
+
+#define PIN_PA5A_PWM1_PWML3                        _L_(5)       /**< PWM1 signal: PWML3 on PA5 mux A*/
+#define MUX_PA5A_PWM1_PWML3                        _L_(0)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PA5A_PWM1_PWML3                        (_UL_(1) << 5)
+
+#define PIN_PD6B_PWM1_PWML3                        _L_(102)     /**< PWM1 signal: PWML3 on PD6 mux B*/
+#define MUX_PD6B_PWM1_PWML3                        _L_(1)       /**< PWM1 signal line function value: PWML3 */
+#define PIO_PD6B_PWM1_PWML3                        (_UL_(1) << 6)
+
+/* ========== PIO definition for QSPI peripheral ========== */
+#define PIN_PA11A_QSPI_QCS                         _L_(11)      /**< QSPI signal: QCS on PA11 mux A*/
+#define MUX_PA11A_QSPI_QCS                         _L_(0)       /**< QSPI signal line function value: QCS */
+#define PIO_PA11A_QSPI_QCS                         (_UL_(1) << 11)
+
+#define PIN_PA13A_QSPI_QIO0                        _L_(13)      /**< QSPI signal: QIO0 on PA13 mux A*/
+#define MUX_PA13A_QSPI_QIO0                        _L_(0)       /**< QSPI signal line function value: QIO0 */
+#define PIO_PA13A_QSPI_QIO0                        (_UL_(1) << 13)
+
+#define PIN_PA12A_QSPI_QIO1                        _L_(12)      /**< QSPI signal: QIO1 on PA12 mux A*/
+#define MUX_PA12A_QSPI_QIO1                        _L_(0)       /**< QSPI signal line function value: QIO1 */
+#define PIO_PA12A_QSPI_QIO1                        (_UL_(1) << 12)
+
+#define PIN_PA17A_QSPI_QIO2                        _L_(17)      /**< QSPI signal: QIO2 on PA17 mux A*/
+#define MUX_PA17A_QSPI_QIO2                        _L_(0)       /**< QSPI signal line function value: QIO2 */
+#define PIO_PA17A_QSPI_QIO2                        (_UL_(1) << 17)
+
+#define PIN_PD31A_QSPI_QIO3                        _L_(127)     /**< QSPI signal: QIO3 on PD31 mux A*/
+#define MUX_PD31A_QSPI_QIO3                        _L_(0)       /**< QSPI signal line function value: QIO3 */
+#define PIO_PD31A_QSPI_QIO3                        (_UL_(1) << 31)
+
+#define PIN_PA14A_QSPI_QSCK                        _L_(14)      /**< QSPI signal: QSCK on PA14 mux A*/
+#define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
+#define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
+
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
+/* ========== PIO definition for SPI0 peripheral ========== */
+#define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
+#define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
+#define PIO_PD20B_SPI0_MISO                        (_UL_(1) << 20)
+
+#define PIN_PD21B_SPI0_MOSI                        _L_(117)     /**< SPI0 signal: MOSI on PD21 mux B*/
+#define MUX_PD21B_SPI0_MOSI                        _L_(1)       /**< SPI0 signal line function value: MOSI */
+#define PIO_PD21B_SPI0_MOSI                        (_UL_(1) << 21)
+
+#define PIN_PB2D_SPI0_NPCS0                        _L_(34)      /**< SPI0 signal: NPCS0 on PB2 mux D*/
+#define MUX_PB2D_SPI0_NPCS0                        _L_(3)       /**< SPI0 signal line function value: NPCS0 */
+#define PIO_PB2D_SPI0_NPCS0                        (_UL_(1) << 2)
+
+#define PIN_PA31A_SPI0_NPCS1                       _L_(31)      /**< SPI0 signal: NPCS1 on PA31 mux A*/
+#define MUX_PA31A_SPI0_NPCS1                       _L_(0)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PA31A_SPI0_NPCS1                       (_UL_(1) << 31)
+
+#define PIN_PD25B_SPI0_NPCS1                       _L_(121)     /**< SPI0 signal: NPCS1 on PD25 mux B*/
+#define MUX_PD25B_SPI0_NPCS1                       _L_(1)       /**< SPI0 signal line function value: NPCS1 */
+#define PIO_PD25B_SPI0_NPCS1                       (_UL_(1) << 25)
+
+#define PIN_PD12C_SPI0_NPCS2                       _L_(108)     /**< SPI0 signal: NPCS2 on PD12 mux C*/
+#define MUX_PD12C_SPI0_NPCS2                       _L_(2)       /**< SPI0 signal line function value: NPCS2 */
+#define PIO_PD12C_SPI0_NPCS2                       (_UL_(1) << 12)
+
+#define PIN_PD27B_SPI0_NPCS3                       _L_(123)     /**< SPI0 signal: NPCS3 on PD27 mux B*/
+#define MUX_PD27B_SPI0_NPCS3                       _L_(1)       /**< SPI0 signal line function value: NPCS3 */
+#define PIO_PD27B_SPI0_NPCS3                       (_UL_(1) << 27)
+
+#define PIN_PD22B_SPI0_SPCK                        _L_(118)     /**< SPI0 signal: SPCK on PD22 mux B*/
+#define MUX_PD22B_SPI0_SPCK                        _L_(1)       /**< SPI0 signal line function value: SPCK */
+#define PIO_PD22B_SPI0_SPCK                        (_UL_(1) << 22)
+
+/* ========== PIO definition for SPI1 peripheral ========== */
+#define PIN_PC26C_SPI1_MISO                        _L_(90)      /**< SPI1 signal: MISO on PC26 mux C*/
+#define MUX_PC26C_SPI1_MISO                        _L_(2)       /**< SPI1 signal line function value: MISO */
+#define PIO_PC26C_SPI1_MISO                        (_UL_(1) << 26)
+
+#define PIN_PC27C_SPI1_MOSI                        _L_(91)      /**< SPI1 signal: MOSI on PC27 mux C*/
+#define MUX_PC27C_SPI1_MOSI                        _L_(2)       /**< SPI1 signal line function value: MOSI */
+#define PIO_PC27C_SPI1_MOSI                        (_UL_(1) << 27)
+
+#define PIN_PC25C_SPI1_NPCS0                       _L_(89)      /**< SPI1 signal: NPCS0 on PC25 mux C*/
+#define MUX_PC25C_SPI1_NPCS0                       _L_(2)       /**< SPI1 signal line function value: NPCS0 */
+#define PIO_PC25C_SPI1_NPCS0                       (_UL_(1) << 25)
+
+#define PIN_PC28C_SPI1_NPCS1                       _L_(92)      /**< SPI1 signal: NPCS1 on PC28 mux C*/
+#define MUX_PC28C_SPI1_NPCS1                       _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PC28C_SPI1_NPCS1                       (_UL_(1) << 28)
+
+#define PIN_PD0C_SPI1_NPCS1                        _L_(96)      /**< SPI1 signal: NPCS1 on PD0 mux C*/
+#define MUX_PD0C_SPI1_NPCS1                        _L_(2)       /**< SPI1 signal line function value: NPCS1 */
+#define PIO_PD0C_SPI1_NPCS1                        (_UL_(1) << 0)
+
+#define PIN_PC29C_SPI1_NPCS2                       _L_(93)      /**< SPI1 signal: NPCS2 on PC29 mux C*/
+#define MUX_PC29C_SPI1_NPCS2                       _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PC29C_SPI1_NPCS2                       (_UL_(1) << 29)
+
+#define PIN_PD1C_SPI1_NPCS2                        _L_(97)      /**< SPI1 signal: NPCS2 on PD1 mux C*/
+#define MUX_PD1C_SPI1_NPCS2                        _L_(2)       /**< SPI1 signal line function value: NPCS2 */
+#define PIO_PD1C_SPI1_NPCS2                        (_UL_(1) << 1)
+
+#define PIN_PC30C_SPI1_NPCS3                       _L_(94)      /**< SPI1 signal: NPCS3 on PC30 mux C*/
+#define MUX_PC30C_SPI1_NPCS3                       _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PC30C_SPI1_NPCS3                       (_UL_(1) << 30)
+
+#define PIN_PD2C_SPI1_NPCS3                        _L_(98)      /**< SPI1 signal: NPCS3 on PD2 mux C*/
+#define MUX_PD2C_SPI1_NPCS3                        _L_(2)       /**< SPI1 signal line function value: NPCS3 */
+#define PIO_PD2C_SPI1_NPCS3                        (_UL_(1) << 2)
+
+#define PIN_PC24C_SPI1_SPCK                        _L_(88)      /**< SPI1 signal: SPCK on PC24 mux C*/
+#define MUX_PC24C_SPI1_SPCK                        _L_(2)       /**< SPI1 signal line function value: SPCK */
+#define PIO_PC24C_SPI1_SPCK                        (_UL_(1) << 24)
+
+/* ========== PIO definition for SSC peripheral ========== */
+#define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
+#define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
+#define PIO_PA10C_SSC_RD                           (_UL_(1) << 10)
+
+#define PIN_PD24B_SSC_RF                           _L_(120)     /**< SSC signal: RF on PD24 mux B*/
+#define MUX_PD24B_SSC_RF                           _L_(1)       /**< SSC signal line function value: RF */
+#define PIO_PD24B_SSC_RF                           (_UL_(1) << 24)
+
+#define PIN_PA22A_SSC_RK                           _L_(22)      /**< SSC signal: RK on PA22 mux A*/
+#define MUX_PA22A_SSC_RK                           _L_(0)       /**< SSC signal line function value: RK */
+#define PIO_PA22A_SSC_RK                           (_UL_(1) << 22)
+
+#define PIN_PB5D_SSC_TD                            _L_(37)      /**< SSC signal: TD on PB5 mux D*/
+#define MUX_PB5D_SSC_TD                            _L_(3)       /**< SSC signal line function value: TD */
+#define PIO_PB5D_SSC_TD                            (_UL_(1) << 5)
+
+#define PIN_PD10C_SSC_TD                           _L_(106)     /**< SSC signal: TD on PD10 mux C*/
+#define MUX_PD10C_SSC_TD                           _L_(2)       /**< SSC signal line function value: TD */
+#define PIO_PD10C_SSC_TD                           (_UL_(1) << 10)
+
+#define PIN_PD26B_SSC_TD                           _L_(122)     /**< SSC signal: TD on PD26 mux B*/
+#define MUX_PD26B_SSC_TD                           _L_(1)       /**< SSC signal line function value: TD */
+#define PIO_PD26B_SSC_TD                           (_UL_(1) << 26)
+
+#define PIN_PB0D_SSC_TF                            _L_(32)      /**< SSC signal: TF on PB0 mux D*/
+#define MUX_PB0D_SSC_TF                            _L_(3)       /**< SSC signal line function value: TF */
+#define PIO_PB0D_SSC_TF                            (_UL_(1) << 0)
+
+#define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
+#define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
+#define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
+
+/* ========== PIO definition for TC0 peripheral ========== */
+#define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
+#define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
+#define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
+
+#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
+#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
+#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
+
+#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
+#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
+#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
+
+#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
+#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
+#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
+
+#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
+#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
+#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
+
+#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
+#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
+#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
+
+#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
+#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
+#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
+
+#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
+#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
+#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
+
+#define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
+#define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */
+#define PIO_PA27B_TC0_TIOB2                        (_UL_(1) << 27)
+
+/* ========== PIO definition for TC1 peripheral ========== */
+#define PIN_PC25B_TC1_TCLK3                        _L_(89)      /**< TC1 signal: TCLK3 on PC25 mux B*/
+#define MUX_PC25B_TC1_TCLK3                        _L_(1)       /**< TC1 signal line function value: TCLK3 */
+#define PIO_PC25B_TC1_TCLK3                        (_UL_(1) << 25)
+
+#define PIN_PC28B_TC1_TCLK4                        _L_(92)      /**< TC1 signal: TCLK4 on PC28 mux B*/
+#define MUX_PC28B_TC1_TCLK4                        _L_(1)       /**< TC1 signal line function value: TCLK4 */
+#define PIO_PC28B_TC1_TCLK4                        (_UL_(1) << 28)
+
+#define PIN_PC31B_TC1_TCLK5                        _L_(95)      /**< TC1 signal: TCLK5 on PC31 mux B*/
+#define MUX_PC31B_TC1_TCLK5                        _L_(1)       /**< TC1 signal line function value: TCLK5 */
+#define PIO_PC31B_TC1_TCLK5                        (_UL_(1) << 31)
+
+#define PIN_PC23B_TC1_TIOA3                        _L_(87)      /**< TC1 signal: TIOA3 on PC23 mux B*/
+#define MUX_PC23B_TC1_TIOA3                        _L_(1)       /**< TC1 signal line function value: TIOA3 */
+#define PIO_PC23B_TC1_TIOA3                        (_UL_(1) << 23)
+
+#define PIN_PC26B_TC1_TIOA4                        _L_(90)      /**< TC1 signal: TIOA4 on PC26 mux B*/
+#define MUX_PC26B_TC1_TIOA4                        _L_(1)       /**< TC1 signal line function value: TIOA4 */
+#define PIO_PC26B_TC1_TIOA4                        (_UL_(1) << 26)
+
+#define PIN_PC29B_TC1_TIOA5                        _L_(93)      /**< TC1 signal: TIOA5 on PC29 mux B*/
+#define MUX_PC29B_TC1_TIOA5                        _L_(1)       /**< TC1 signal line function value: TIOA5 */
+#define PIO_PC29B_TC1_TIOA5                        (_UL_(1) << 29)
+
+#define PIN_PC24B_TC1_TIOB3                        _L_(88)      /**< TC1 signal: TIOB3 on PC24 mux B*/
+#define MUX_PC24B_TC1_TIOB3                        _L_(1)       /**< TC1 signal line function value: TIOB3 */
+#define PIO_PC24B_TC1_TIOB3                        (_UL_(1) << 24)
+
+#define PIN_PC27B_TC1_TIOB4                        _L_(91)      /**< TC1 signal: TIOB4 on PC27 mux B*/
+#define MUX_PC27B_TC1_TIOB4                        _L_(1)       /**< TC1 signal line function value: TIOB4 */
+#define PIO_PC27B_TC1_TIOB4                        (_UL_(1) << 27)
+
+#define PIN_PC30B_TC1_TIOB5                        _L_(94)      /**< TC1 signal: TIOB5 on PC30 mux B*/
+#define MUX_PC30B_TC1_TIOB5                        _L_(1)       /**< TC1 signal line function value: TIOB5 */
+#define PIO_PC30B_TC1_TIOB5                        (_UL_(1) << 30)
+
+/* ========== PIO definition for TC2 peripheral ========== */
+#define PIN_PC7B_TC2_TCLK6                         _L_(71)      /**< TC2 signal: TCLK6 on PC7 mux B*/
+#define MUX_PC7B_TC2_TCLK6                         _L_(1)       /**< TC2 signal line function value: TCLK6 */
+#define PIO_PC7B_TC2_TCLK6                         (_UL_(1) << 7)
+
+#define PIN_PC10B_TC2_TCLK7                        _L_(74)      /**< TC2 signal: TCLK7 on PC10 mux B*/
+#define MUX_PC10B_TC2_TCLK7                        _L_(1)       /**< TC2 signal line function value: TCLK7 */
+#define PIO_PC10B_TC2_TCLK7                        (_UL_(1) << 10)
+
+#define PIN_PC14B_TC2_TCLK8                        _L_(78)      /**< TC2 signal: TCLK8 on PC14 mux B*/
+#define MUX_PC14B_TC2_TCLK8                        _L_(1)       /**< TC2 signal line function value: TCLK8 */
+#define PIO_PC14B_TC2_TCLK8                        (_UL_(1) << 14)
+
+#define PIN_PC5B_TC2_TIOA6                         _L_(69)      /**< TC2 signal: TIOA6 on PC5 mux B*/
+#define MUX_PC5B_TC2_TIOA6                         _L_(1)       /**< TC2 signal line function value: TIOA6 */
+#define PIO_PC5B_TC2_TIOA6                         (_UL_(1) << 5)
+
+#define PIN_PC8B_TC2_TIOA7                         _L_(72)      /**< TC2 signal: TIOA7 on PC8 mux B*/
+#define MUX_PC8B_TC2_TIOA7                         _L_(1)       /**< TC2 signal line function value: TIOA7 */
+#define PIO_PC8B_TC2_TIOA7                         (_UL_(1) << 8)
+
+#define PIN_PC11B_TC2_TIOA8                        _L_(75)      /**< TC2 signal: TIOA8 on PC11 mux B*/
+#define MUX_PC11B_TC2_TIOA8                        _L_(1)       /**< TC2 signal line function value: TIOA8 */
+#define PIO_PC11B_TC2_TIOA8                        (_UL_(1) << 11)
+
+#define PIN_PC6B_TC2_TIOB6                         _L_(70)      /**< TC2 signal: TIOB6 on PC6 mux B*/
+#define MUX_PC6B_TC2_TIOB6                         _L_(1)       /**< TC2 signal line function value: TIOB6 */
+#define PIO_PC6B_TC2_TIOB6                         (_UL_(1) << 6)
+
+#define PIN_PC9B_TC2_TIOB7                         _L_(73)      /**< TC2 signal: TIOB7 on PC9 mux B*/
+#define MUX_PC9B_TC2_TIOB7                         _L_(1)       /**< TC2 signal line function value: TIOB7 */
+#define PIO_PC9B_TC2_TIOB7                         (_UL_(1) << 9)
+
+#define PIN_PC12B_TC2_TIOB8                        _L_(76)      /**< TC2 signal: TIOB8 on PC12 mux B*/
+#define MUX_PC12B_TC2_TIOB8                        _L_(1)       /**< TC2 signal line function value: TIOB8 */
+#define PIO_PC12B_TC2_TIOB8                        (_UL_(1) << 12)
+
+/* ========== PIO definition for TC3 peripheral ========== */
+#define PIN_PE2B_TC3_TCLK9                         _L_(130)     /**< TC3 signal: TCLK9 on PE2 mux B*/
+#define MUX_PE2B_TC3_TCLK9                         _L_(1)       /**< TC3 signal line function value: TCLK9 */
+#define PIO_PE2B_TC3_TCLK9                         (_UL_(1) << 2)
+
+#define PIN_PE5B_TC3_TCLK10                        _L_(133)     /**< TC3 signal: TCLK10 on PE5 mux B*/
+#define MUX_PE5B_TC3_TCLK10                        _L_(1)       /**< TC3 signal line function value: TCLK10 */
+#define PIO_PE5B_TC3_TCLK10                        (_UL_(1) << 5)
+
+#define PIN_PD24C_TC3_TCLK11                       _L_(120)     /**< TC3 signal: TCLK11 on PD24 mux C*/
+#define MUX_PD24C_TC3_TCLK11                       _L_(2)       /**< TC3 signal line function value: TCLK11 */
+#define PIO_PD24C_TC3_TCLK11                       (_UL_(1) << 24)
+
+#define PIN_PE0B_TC3_TIOA9                         _L_(128)     /**< TC3 signal: TIOA9 on PE0 mux B*/
+#define MUX_PE0B_TC3_TIOA9                         _L_(1)       /**< TC3 signal line function value: TIOA9 */
+#define PIO_PE0B_TC3_TIOA9                         (_UL_(1) << 0)
+
+#define PIN_PE3B_TC3_TIOA10                        _L_(131)     /**< TC3 signal: TIOA10 on PE3 mux B*/
+#define MUX_PE3B_TC3_TIOA10                        _L_(1)       /**< TC3 signal line function value: TIOA10 */
+#define PIO_PE3B_TC3_TIOA10                        (_UL_(1) << 3)
+
+#define PIN_PD21C_TC3_TIOA11                       _L_(117)     /**< TC3 signal: TIOA11 on PD21 mux C*/
+#define MUX_PD21C_TC3_TIOA11                       _L_(2)       /**< TC3 signal line function value: TIOA11 */
+#define PIO_PD21C_TC3_TIOA11                       (_UL_(1) << 21)
+
+#define PIN_PE1B_TC3_TIOB9                         _L_(129)     /**< TC3 signal: TIOB9 on PE1 mux B*/
+#define MUX_PE1B_TC3_TIOB9                         _L_(1)       /**< TC3 signal line function value: TIOB9 */
+#define PIO_PE1B_TC3_TIOB9                         (_UL_(1) << 1)
+
+#define PIN_PE4B_TC3_TIOB10                        _L_(132)     /**< TC3 signal: TIOB10 on PE4 mux B*/
+#define MUX_PE4B_TC3_TIOB10                        _L_(1)       /**< TC3 signal line function value: TIOB10 */
+#define PIO_PE4B_TC3_TIOB10                        (_UL_(1) << 4)
+
+#define PIN_PD22C_TC3_TIOB11                       _L_(118)     /**< TC3 signal: TIOB11 on PD22 mux C*/
+#define MUX_PD22C_TC3_TIOB11                       _L_(2)       /**< TC3 signal line function value: TIOB11 */
+#define PIO_PD22C_TC3_TIOB11                       (_UL_(1) << 22)
+
+/* ========== PIO definition for TWIHS0 peripheral ========== */
+#define PIN_PA4A_TWIHS0_TWCK0                      _L_(4)       /**< TWIHS0 signal: TWCK0 on PA4 mux A*/
+#define MUX_PA4A_TWIHS0_TWCK0                      _L_(0)       /**< TWIHS0 signal line function value: TWCK0 */
+#define PIO_PA4A_TWIHS0_TWCK0                      (_UL_(1) << 4)
+
+#define PIN_PA3A_TWIHS0_TWD0                       _L_(3)       /**< TWIHS0 signal: TWD0 on PA3 mux A*/
+#define MUX_PA3A_TWIHS0_TWD0                       _L_(0)       /**< TWIHS0 signal line function value: TWD0 */
+#define PIO_PA3A_TWIHS0_TWD0                       (_UL_(1) << 3)
+
+/* ========== PIO definition for TWIHS1 peripheral ========== */
+#define PIN_PB5A_TWIHS1_TWCK1                      _L_(37)      /**< TWIHS1 signal: TWCK1 on PB5 mux A*/
+#define MUX_PB5A_TWIHS1_TWCK1                      _L_(0)       /**< TWIHS1 signal line function value: TWCK1 */
+#define PIO_PB5A_TWIHS1_TWCK1                      (_UL_(1) << 5)
+
+#define PIN_PB4A_TWIHS1_TWD1                       _L_(36)      /**< TWIHS1 signal: TWD1 on PB4 mux A*/
+#define MUX_PB4A_TWIHS1_TWD1                       _L_(0)       /**< TWIHS1 signal line function value: TWD1 */
+#define PIO_PB4A_TWIHS1_TWD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for TWIHS2 peripheral ========== */
+#define PIN_PD28C_TWIHS2_TWCK2                     _L_(124)     /**< TWIHS2 signal: TWCK2 on PD28 mux C*/
+#define MUX_PD28C_TWIHS2_TWCK2                     _L_(2)       /**< TWIHS2 signal line function value: TWCK2 */
+#define PIO_PD28C_TWIHS2_TWCK2                     (_UL_(1) << 28)
+
+#define PIN_PD27C_TWIHS2_TWD2                      _L_(123)     /**< TWIHS2 signal: TWD2 on PD27 mux C*/
+#define MUX_PD27C_TWIHS2_TWD2                      _L_(2)       /**< TWIHS2 signal line function value: TWD2 */
+#define PIO_PD27C_TWIHS2_TWD2                      (_UL_(1) << 27)
+
+/* ========== PIO definition for UART0 peripheral ========== */
+#define PIN_PA9A_UART0_URXD0                       _L_(9)       /**< UART0 signal: URXD0 on PA9 mux A*/
+#define MUX_PA9A_UART0_URXD0                       _L_(0)       /**< UART0 signal line function value: URXD0 */
+#define PIO_PA9A_UART0_URXD0                       (_UL_(1) << 9)
+
+#define PIN_PA10A_UART0_UTXD0                      _L_(10)      /**< UART0 signal: UTXD0 on PA10 mux A*/
+#define MUX_PA10A_UART0_UTXD0                      _L_(0)       /**< UART0 signal line function value: UTXD0 */
+#define PIO_PA10A_UART0_UTXD0                      (_UL_(1) << 10)
+
+/* ========== PIO definition for UART1 peripheral ========== */
+#define PIN_PA5C_UART1_URXD1                       _L_(5)       /**< UART1 signal: URXD1 on PA5 mux C*/
+#define MUX_PA5C_UART1_URXD1                       _L_(2)       /**< UART1 signal line function value: URXD1 */
+#define PIO_PA5C_UART1_URXD1                       (_UL_(1) << 5)
+
+#define PIN_PA4C_UART1_UTXD1                       _L_(4)       /**< UART1 signal: UTXD1 on PA4 mux C*/
+#define MUX_PA4C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA4C_UART1_UTXD1                       (_UL_(1) << 4)
+
+#define PIN_PA6C_UART1_UTXD1                       _L_(6)       /**< UART1 signal: UTXD1 on PA6 mux C*/
+#define MUX_PA6C_UART1_UTXD1                       _L_(2)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PA6C_UART1_UTXD1                       (_UL_(1) << 6)
+
+#define PIN_PD26D_UART1_UTXD1                      _L_(122)     /**< UART1 signal: UTXD1 on PD26 mux D*/
+#define MUX_PD26D_UART1_UTXD1                      _L_(3)       /**< UART1 signal line function value: UTXD1 */
+#define PIO_PD26D_UART1_UTXD1                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART2 peripheral ========== */
+#define PIN_PD25C_UART2_URXD2                      _L_(121)     /**< UART2 signal: URXD2 on PD25 mux C*/
+#define MUX_PD25C_UART2_URXD2                      _L_(2)       /**< UART2 signal line function value: URXD2 */
+#define PIO_PD25C_UART2_URXD2                      (_UL_(1) << 25)
+
+#define PIN_PD26C_UART2_UTXD2                      _L_(122)     /**< UART2 signal: UTXD2 on PD26 mux C*/
+#define MUX_PD26C_UART2_UTXD2                      _L_(2)       /**< UART2 signal line function value: UTXD2 */
+#define PIO_PD26C_UART2_UTXD2                      (_UL_(1) << 26)
+
+/* ========== PIO definition for UART3 peripheral ========== */
+#define PIN_PD28A_UART3_URXD3                      _L_(124)     /**< UART3 signal: URXD3 on PD28 mux A*/
+#define MUX_PD28A_UART3_URXD3                      _L_(0)       /**< UART3 signal line function value: URXD3 */
+#define PIO_PD28A_UART3_URXD3                      (_UL_(1) << 28)
+
+#define PIN_PD30A_UART3_UTXD3                      _L_(126)     /**< UART3 signal: UTXD3 on PD30 mux A*/
+#define MUX_PD30A_UART3_UTXD3                      _L_(0)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD30A_UART3_UTXD3                      (_UL_(1) << 30)
+
+#define PIN_PD31B_UART3_UTXD3                      _L_(127)     /**< UART3 signal: UTXD3 on PD31 mux B*/
+#define MUX_PD31B_UART3_UTXD3                      _L_(1)       /**< UART3 signal line function value: UTXD3 */
+#define PIO_PD31B_UART3_UTXD3                      (_UL_(1) << 31)
+
+/* ========== PIO definition for UART4 peripheral ========== */
+#define PIN_PD18C_UART4_URXD4                      _L_(114)     /**< UART4 signal: URXD4 on PD18 mux C*/
+#define MUX_PD18C_UART4_URXD4                      _L_(2)       /**< UART4 signal line function value: URXD4 */
+#define PIO_PD18C_UART4_URXD4                      (_UL_(1) << 18)
+
+#define PIN_PD3C_UART4_UTXD4                       _L_(99)      /**< UART4 signal: UTXD4 on PD3 mux C*/
+#define MUX_PD3C_UART4_UTXD4                       _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD3C_UART4_UTXD4                       (_UL_(1) << 3)
+
+#define PIN_PD19C_UART4_UTXD4                      _L_(115)     /**< UART4 signal: UTXD4 on PD19 mux C*/
+#define MUX_PD19C_UART4_UTXD4                      _L_(2)       /**< UART4 signal line function value: UTXD4 */
+#define PIO_PD19C_UART4_UTXD4                      (_UL_(1) << 19)
+
+/* ========== PIO definition for USART0 peripheral ========== */
+#define PIN_PB2C_USART0_CTS0                       _L_(34)      /**< USART0 signal: CTS0 on PB2 mux C*/
+#define MUX_PB2C_USART0_CTS0                       _L_(2)       /**< USART0 signal line function value: CTS0 */
+#define PIO_PB2C_USART0_CTS0                       (_UL_(1) << 2)
+
+#define PIN_PD0D_USART0_DCD0                       _L_(96)      /**< USART0 signal: DCD0 on PD0 mux D*/
+#define MUX_PD0D_USART0_DCD0                       _L_(3)       /**< USART0 signal line function value: DCD0 */
+#define PIO_PD0D_USART0_DCD0                       (_UL_(1) << 0)
+
+#define PIN_PD2D_USART0_DSR0                       _L_(98)      /**< USART0 signal: DSR0 on PD2 mux D*/
+#define MUX_PD2D_USART0_DSR0                       _L_(3)       /**< USART0 signal line function value: DSR0 */
+#define PIO_PD2D_USART0_DSR0                       (_UL_(1) << 2)
+
+#define PIN_PD1D_USART0_DTR0                       _L_(97)      /**< USART0 signal: DTR0 on PD1 mux D*/
+#define MUX_PD1D_USART0_DTR0                       _L_(3)       /**< USART0 signal line function value: DTR0 */
+#define PIO_PD1D_USART0_DTR0                       (_UL_(1) << 1)
+
+#define PIN_PD3D_USART0_RI0                        _L_(99)      /**< USART0 signal: RI0 on PD3 mux D*/
+#define MUX_PD3D_USART0_RI0                        _L_(3)       /**< USART0 signal line function value: RI0 */
+#define PIO_PD3D_USART0_RI0                        (_UL_(1) << 3)
+
+#define PIN_PB3C_USART0_RTS0                       _L_(35)      /**< USART0 signal: RTS0 on PB3 mux C*/
+#define MUX_PB3C_USART0_RTS0                       _L_(2)       /**< USART0 signal line function value: RTS0 */
+#define PIO_PB3C_USART0_RTS0                       (_UL_(1) << 3)
+
+#define PIN_PB0C_USART0_RXD0                       _L_(32)      /**< USART0 signal: RXD0 on PB0 mux C*/
+#define MUX_PB0C_USART0_RXD0                       _L_(2)       /**< USART0 signal line function value: RXD0 */
+#define PIO_PB0C_USART0_RXD0                       (_UL_(1) << 0)
+
+#define PIN_PB13C_USART0_SCK0                      _L_(45)      /**< USART0 signal: SCK0 on PB13 mux C*/
+#define MUX_PB13C_USART0_SCK0                      _L_(2)       /**< USART0 signal line function value: SCK0 */
+#define PIO_PB13C_USART0_SCK0                      (_UL_(1) << 13)
+
+#define PIN_PB1C_USART0_TXD0                       _L_(33)      /**< USART0 signal: TXD0 on PB1 mux C*/
+#define MUX_PB1C_USART0_TXD0                       _L_(2)       /**< USART0 signal line function value: TXD0 */
+#define PIO_PB1C_USART0_TXD0                       (_UL_(1) << 1)
+
+/* ========== PIO definition for USART1 peripheral ========== */
+#define PIN_PA25A_USART1_CTS1                      _L_(25)      /**< USART1 signal: CTS1 on PA25 mux A*/
+#define MUX_PA25A_USART1_CTS1                      _L_(0)       /**< USART1 signal line function value: CTS1 */
+#define PIO_PA25A_USART1_CTS1                      (_UL_(1) << 25)
+
+#define PIN_PA26A_USART1_DCD1                      _L_(26)      /**< USART1 signal: DCD1 on PA26 mux A*/
+#define MUX_PA26A_USART1_DCD1                      _L_(0)       /**< USART1 signal line function value: DCD1 */
+#define PIO_PA26A_USART1_DCD1                      (_UL_(1) << 26)
+
+#define PIN_PA28A_USART1_DSR1                      _L_(28)      /**< USART1 signal: DSR1 on PA28 mux A*/
+#define MUX_PA28A_USART1_DSR1                      _L_(0)       /**< USART1 signal line function value: DSR1 */
+#define PIO_PA28A_USART1_DSR1                      (_UL_(1) << 28)
+
+#define PIN_PA27A_USART1_DTR1                      _L_(27)      /**< USART1 signal: DTR1 on PA27 mux A*/
+#define MUX_PA27A_USART1_DTR1                      _L_(0)       /**< USART1 signal line function value: DTR1 */
+#define PIO_PA27A_USART1_DTR1                      (_UL_(1) << 27)
+
+#define PIN_PA3B_USART1_LONCOL1                    _L_(3)       /**< USART1 signal: LONCOL1 on PA3 mux B*/
+#define MUX_PA3B_USART1_LONCOL1                    _L_(1)       /**< USART1 signal line function value: LONCOL1 */
+#define PIO_PA3B_USART1_LONCOL1                    (_UL_(1) << 3)
+
+#define PIN_PA29A_USART1_RI1                       _L_(29)      /**< USART1 signal: RI1 on PA29 mux A*/
+#define MUX_PA29A_USART1_RI1                       _L_(0)       /**< USART1 signal line function value: RI1 */
+#define PIO_PA29A_USART1_RI1                       (_UL_(1) << 29)
+
+#define PIN_PA24A_USART1_RTS1                      _L_(24)      /**< USART1 signal: RTS1 on PA24 mux A*/
+#define MUX_PA24A_USART1_RTS1                      _L_(0)       /**< USART1 signal line function value: RTS1 */
+#define PIO_PA24A_USART1_RTS1                      (_UL_(1) << 24)
+
+#define PIN_PA21A_USART1_RXD1                      _L_(21)      /**< USART1 signal: RXD1 on PA21 mux A*/
+#define MUX_PA21A_USART1_RXD1                      _L_(0)       /**< USART1 signal line function value: RXD1 */
+#define PIO_PA21A_USART1_RXD1                      (_UL_(1) << 21)
+
+#define PIN_PA23A_USART1_SCK1                      _L_(23)      /**< USART1 signal: SCK1 on PA23 mux A*/
+#define MUX_PA23A_USART1_SCK1                      _L_(0)       /**< USART1 signal line function value: SCK1 */
+#define PIO_PA23A_USART1_SCK1                      (_UL_(1) << 23)
+
+#define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
+#define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
+#define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for USART2 peripheral ========== */
+#define PIN_PD19B_USART2_CTS2                      _L_(115)     /**< USART2 signal: CTS2 on PD19 mux B*/
+#define MUX_PD19B_USART2_CTS2                      _L_(1)       /**< USART2 signal line function value: CTS2 */
+#define PIO_PD19B_USART2_CTS2                      (_UL_(1) << 19)
+
+#define PIN_PD4D_USART2_DCD2                       _L_(100)     /**< USART2 signal: DCD2 on PD4 mux D*/
+#define MUX_PD4D_USART2_DCD2                       _L_(3)       /**< USART2 signal line function value: DCD2 */
+#define PIO_PD4D_USART2_DCD2                       (_UL_(1) << 4)
+
+#define PIN_PD6D_USART2_DSR2                       _L_(102)     /**< USART2 signal: DSR2 on PD6 mux D*/
+#define MUX_PD6D_USART2_DSR2                       _L_(3)       /**< USART2 signal line function value: DSR2 */
+#define PIO_PD6D_USART2_DSR2                       (_UL_(1) << 6)
+
+#define PIN_PD5D_USART2_DTR2                       _L_(101)     /**< USART2 signal: DTR2 on PD5 mux D*/
+#define MUX_PD5D_USART2_DTR2                       _L_(3)       /**< USART2 signal line function value: DTR2 */
+#define PIO_PD5D_USART2_DTR2                       (_UL_(1) << 5)
+
+#define PIN_PD7D_USART2_RI2                        _L_(103)     /**< USART2 signal: RI2 on PD7 mux D*/
+#define MUX_PD7D_USART2_RI2                        _L_(3)       /**< USART2 signal line function value: RI2 */
+#define PIO_PD7D_USART2_RI2                        (_UL_(1) << 7)
+
+#define PIN_PD18B_USART2_RTS2                      _L_(114)     /**< USART2 signal: RTS2 on PD18 mux B*/
+#define MUX_PD18B_USART2_RTS2                      _L_(1)       /**< USART2 signal line function value: RTS2 */
+#define PIO_PD18B_USART2_RTS2                      (_UL_(1) << 18)
+
+#define PIN_PD15B_USART2_RXD2                      _L_(111)     /**< USART2 signal: RXD2 on PD15 mux B*/
+#define MUX_PD15B_USART2_RXD2                      _L_(1)       /**< USART2 signal line function value: RXD2 */
+#define PIO_PD15B_USART2_RXD2                      (_UL_(1) << 15)
+
+#define PIN_PD17B_USART2_SCK2                      _L_(113)     /**< USART2 signal: SCK2 on PD17 mux B*/
+#define MUX_PD17B_USART2_SCK2                      _L_(1)       /**< USART2 signal line function value: SCK2 */
+#define PIO_PD17B_USART2_SCK2                      (_UL_(1) << 17)
+
+#define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
+#define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
+#define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
+
+
+#endif /* _SAMV71Q21B_PIO_H_ */

--- a/asf/sam/include/samv71b/samv71j19b.h
+++ b/asf/sam/include/samv71b/samv71j19b.h
@@ -1,0 +1,863 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:20:53Z */
+#ifndef _SAMV71J19B_H_
+#define _SAMV71J19B_H_
+
+/** \addtogroup SAMV71J19B_definitions SAMV71J19B definitions
+  This file defines all structures and symbols for SAMV71J19B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J19B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J19B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J19B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J19B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J19B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J19B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J19B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J19B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J19B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J19B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J19B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J19B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J19B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J19B Parallel Input/Output Controller (PIOD) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J19B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J19B Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J19B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J19B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J19B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J19B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J19B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J19B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J19B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J19B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71J19B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J19B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J19B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J19B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J19B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J19B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J19B Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J19B Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J19B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J19B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J19B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J19B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J19B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J19B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J19B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J19B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J19B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J19B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J19B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J19B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J19B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J19B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J19B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J19B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71J19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71J19B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J19B Floating Point Unit (FPU) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J19B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J19B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J19B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J19B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J19B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J19B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J19B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J19B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J19B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J19B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J19B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J19B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pvReserved18;
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J19B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J19B Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J19B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J19B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J19B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J19B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J19B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J19B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J19B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J19B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71J19B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J19B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J19B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J19B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J19B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J19B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J19B Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J19B Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J19B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J19B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J19B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J19B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J19B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J19B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J19B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J19B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J19B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J19B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J19B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J19B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J19B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J19B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J19B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J19B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71J19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71J19B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J19B Floating Point Unit (FPU) */
+  void* pvReserved69;
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71J19B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J19B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J19B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J19B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J19B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J19B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J19B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J19B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J19B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J19B*/
+/* ************************************************************************** */
+#include "pio/samv71j19b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J19B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J19B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J19B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J19B definitions */
+
+
+#endif /* _SAMV71J19B_H_ */

--- a/asf/sam/include/samv71b/samv71j20b.h
+++ b/asf/sam/include/samv71b/samv71j20b.h
@@ -1,0 +1,863 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:20:58Z */
+#ifndef _SAMV71J20B_H_
+#define _SAMV71J20B_H_
+
+/** \addtogroup SAMV71J20B_definitions SAMV71J20B definitions
+  This file defines all structures and symbols for SAMV71J20B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J20B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J20B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J20B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J20B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J20B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J20B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J20B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J20B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J20B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J20B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J20B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J20B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J20B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J20B Parallel Input/Output Controller (PIOD) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J20B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J20B Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J20B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J20B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J20B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J20B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J20B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J20B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J20B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J20B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71J20B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J20B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J20B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J20B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J20B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J20B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J20B Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J20B Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J20B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J20B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J20B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J20B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J20B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J20B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J20B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J20B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J20B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J20B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J20B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J20B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J20B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J20B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J20B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J20B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71J20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71J20B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J20B Floating Point Unit (FPU) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J20B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J20B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J20B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J20B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J20B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J20B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J20B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J20B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J20B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J20B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J20B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J20B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pvReserved18;
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J20B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J20B Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J20B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J20B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J20B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J20B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J20B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J20B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J20B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J20B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71J20B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J20B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J20B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J20B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J20B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J20B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J20B Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J20B Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J20B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J20B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J20B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J20B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J20B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J20B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J20B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J20B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J20B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J20B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J20B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J20B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J20B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J20B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J20B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J20B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71J20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71J20B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J20B Floating Point Unit (FPU) */
+  void* pvReserved69;
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71J20B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J20B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J20B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J20B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J20B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J20B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J20B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J20B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J20B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J20B*/
+/* ************************************************************************** */
+#include "pio/samv71j20b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J20B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J20B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J20B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J20B definitions */
+
+
+#endif /* _SAMV71J20B_H_ */

--- a/asf/sam/include/samv71b/samv71j21b.h
+++ b/asf/sam/include/samv71b/samv71j21b.h
@@ -1,0 +1,863 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71J21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:02Z */
+#ifndef _SAMV71J21B_H_
+#define _SAMV71J21B_H_
+
+/** \addtogroup SAMV71J21B_definitions SAMV71J21B definitions
+  This file defines all structures and symbols for SAMV71J21B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71J21B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71J21B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71J21B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71J21B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71J21B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71J21B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71J21B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71J21B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71J21B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71J21B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71J21B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71J21B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71J21B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71J21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71J21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71J21B Parallel Input/Output Controller (PIOD) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71J21B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71J21B Two-wire Interface High Speed (TWIHS1) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71J21B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71J21B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71J21B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71J21B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71J21B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71J21B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71J21B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71J21B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71J21B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71J21B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71J21B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71J21B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71J21B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71J21B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71J21B Controller Area Network (MCAN0) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71J21B Analog Front-End Controller (AFEC1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71J21B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71J21B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71J21B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71J21B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71J21B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71J21B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71J21B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71J21B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71J21B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71J21B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71J21B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71J21B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71J21B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71J21B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71J21B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71J21B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71J21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71J21B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71J21B Floating Point Unit (FPU) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71J21B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71J21B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71J21B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71J21B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71J21B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71J21B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71J21B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71J21B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71J21B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71J21B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71J21B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71J21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71J21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pvReserved15;
+  void* pfnPIOD_Handler;                         /* 16  SAMV71J21B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pvReserved18;
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71J21B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71J21B Two-wire Interface High Speed (TWIHS1) */
+  void* pvReserved21;
+  void* pfnSSC_Handler;                          /* 22  SAMV71J21B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71J21B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71J21B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71J21B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71J21B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71J21B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71J21B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71J21B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71J21B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71J21B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71J21B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71J21B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71J21B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71J21B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71J21B Controller Area Network (MCAN0) */
+  void* pvReserved37;
+  void* pvReserved38;
+  void* pfnGMAC_Handler;                         /* 39  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71J21B Analog Front-End Controller (AFEC1) */
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71J21B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71J21B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pvReserved45;
+  void* pvReserved46;
+  void* pfnTC6_Handler;                          /* 47  SAMV71J21B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71J21B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71J21B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71J21B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71J21B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71J21B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71J21B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71J21B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71J21B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71J21B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71J21B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71J21B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71J21B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71J21B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71J21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71J21B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71J21B Floating Point Unit (FPU) */
+  void* pvReserved69;
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71J21B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71J21B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71J21B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71J21B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71J21B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71J21B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+
+#define ID_PERIPH_COUNT ( 64) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71J21B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71J21B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN_INST_NUM          1                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0 }                      /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS_INST_NUM         2                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1 }             /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART_INST_NUM          3                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2 }        /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART_INST_NUM         2                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1 }             /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71J21B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71J21B*/
+/* ************************************************************************** */
+#include "pio/samv71j21b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71J21B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71J21B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000000)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71J21B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71J21B definitions */
+
+
+#endif /* _SAMV71J21B_H_ */

--- a/asf/sam/include/samv71b/samv71n19b.h
+++ b/asf/sam/include/samv71b/samv71n19b.h
@@ -1,0 +1,925 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:04Z */
+#ifndef _SAMV71N19B_H_
+#define _SAMV71N19B_H_
+
+/** \addtogroup SAMV71N19B_definitions SAMV71N19B definitions
+  This file defines all structures and symbols for SAMV71N19B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N19B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N19B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N19B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N19B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N19B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N19B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N19B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N19B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N19B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N19B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N19B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N19B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N19B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N19B Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N19B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N19B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N19B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N19B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N19B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N19B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N19B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N19B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N19B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N19B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N19B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N19B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71N19B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N19B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N19B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N19B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N19B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N19B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N19B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N19B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N19B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N19B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N19B Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N19B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N19B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N19B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N19B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N19B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N19B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N19B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N19B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N19B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N19B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N19B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N19B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N19B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N19B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N19B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71N19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71N19B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N19B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71N19B Inter-IC Sound Controller (I2SC0) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N19B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N19B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N19B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N19B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N19B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N19B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N19B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N19B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N19B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N19B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N19B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N19B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N19B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N19B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N19B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N19B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N19B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N19B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N19B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N19B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N19B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N19B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N19B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N19B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N19B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71N19B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N19B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N19B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N19B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N19B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N19B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N19B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N19B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N19B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N19B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N19B Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N19B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N19B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N19B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N19B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N19B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N19B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N19B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N19B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N19B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N19B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N19B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N19B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N19B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N19B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N19B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N19B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71N19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71N19B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N19B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71N19B Inter-IC Sound Controller (I2SC0) */
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71N19B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N19B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N19B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N19B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N19B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N19B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+
+#define ID_PERIPH_COUNT ( 70) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N19B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N19B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC_INST_NUM          1                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0 }                      /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N19B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N19B*/
+/* ************************************************************************** */
+#include "pio/samv71n19b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N19B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N19B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N19B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N19B definitions */
+
+
+#endif /* _SAMV71N19B_H_ */

--- a/asf/sam/include/samv71b/samv71n20b.h
+++ b/asf/sam/include/samv71b/samv71n20b.h
@@ -1,0 +1,925 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:07Z */
+#ifndef _SAMV71N20B_H_
+#define _SAMV71N20B_H_
+
+/** \addtogroup SAMV71N20B_definitions SAMV71N20B definitions
+  This file defines all structures and symbols for SAMV71N20B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N20B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N20B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N20B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N20B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N20B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N20B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N20B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N20B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N20B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N20B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N20B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N20B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N20B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N20B Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N20B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N20B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N20B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N20B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N20B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N20B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N20B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N20B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N20B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N20B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N20B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N20B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71N20B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N20B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N20B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N20B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N20B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N20B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N20B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N20B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N20B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N20B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N20B Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N20B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N20B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N20B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N20B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N20B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N20B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N20B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N20B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N20B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N20B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N20B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N20B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N20B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N20B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N20B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71N20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71N20B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N20B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71N20B Inter-IC Sound Controller (I2SC0) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N20B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N20B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N20B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N20B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N20B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N20B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N20B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N20B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N20B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N20B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N20B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N20B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N20B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N20B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N20B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N20B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N20B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N20B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N20B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N20B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N20B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N20B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N20B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N20B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N20B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71N20B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N20B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N20B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N20B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N20B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N20B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N20B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N20B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N20B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N20B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N20B Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N20B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N20B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N20B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N20B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N20B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N20B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N20B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N20B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N20B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N20B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N20B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N20B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N20B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N20B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N20B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N20B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71N20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71N20B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N20B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71N20B Inter-IC Sound Controller (I2SC0) */
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71N20B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N20B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N20B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N20B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N20B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N20B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+
+#define ID_PERIPH_COUNT ( 70) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N20B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N20B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC_INST_NUM          1                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0 }                      /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N20B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N20B*/
+/* ************************************************************************** */
+#include "pio/samv71n20b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N20B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N20B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N20B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N20B definitions */
+
+
+#endif /* _SAMV71N20B_H_ */

--- a/asf/sam/include/samv71b/samv71n21b.h
+++ b/asf/sam/include/samv71b/samv71n21b.h
@@ -1,0 +1,925 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71N21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:09Z */
+#ifndef _SAMV71N21B_H_
+#define _SAMV71N21B_H_
+
+/** \addtogroup SAMV71N21B_definitions SAMV71N21B definitions
+  This file defines all structures and symbols for SAMV71N21B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71N21B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71N21B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71N21B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71N21B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71N21B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71N21B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71N21B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71N21B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71N21B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71N21B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71N21B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71N21B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71N21B Parallel Input/Output Controller (PIOB) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71N21B Parallel Input/Output Controller (PIOD) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71N21B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71N21B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71N21B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71N21B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71N21B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71N21B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71N21B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71N21B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71N21B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71N21B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71N21B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71N21B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71N21B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71N21B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71N21B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71N21B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71N21B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71N21B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71N21B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71N21B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71N21B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71N21B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71N21B Two-wire Interface High Speed (TWIHS2) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71N21B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71N21B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71N21B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71N21B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71N21B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71N21B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71N21B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71N21B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71N21B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71N21B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71N21B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71N21B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71N21B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71N21B Floating Point Unit (FPU) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71N21B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71N21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71N21B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71N21B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71N21B Inter-IC Sound Controller (I2SC0) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71N21B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71N21B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71N21B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71N21B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71N21B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71N21B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71N21B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71N21B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71N21B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71N21B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71N21B Parallel Input/Output Controller (PIOB) */
+  void* pvReserved12;
+  void* pfnUSART0_Handler;                       /* 13  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71N21B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71N21B Parallel Input/Output Controller (PIOD) */
+  void* pvReserved17;
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71N21B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71N21B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71N21B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71N21B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71N21B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71N21B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71N21B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71N21B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71N21B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71N21B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71N21B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71N21B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71N21B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71N21B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71N21B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71N21B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71N21B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71N21B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71N21B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71N21B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71N21B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71N21B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71N21B Two-wire Interface High Speed (TWIHS2) */
+  void* pvReserved42;
+  void* pfnQSPI_Handler;                         /* 43  SAMV71N21B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71N21B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71N21B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71N21B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71N21B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71N21B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71N21B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71N21B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71N21B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71N21B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71N21B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71N21B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71N21B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71N21B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71N21B Floating Point Unit (FPU) */
+  void* pvReserved62;
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71N21B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71N21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71N21B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71N21B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71N21B Inter-IC Sound Controller (I2SC0) */
+  void* pvReserved70;
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71N21B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SPI0_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71N21B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71N21B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71N21B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71N21B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/piod.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/spi0.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71N21B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+
+#define ID_PERIPH_COUNT ( 70) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71N21B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71N21B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC_INST_NUM          1                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0 }                      /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIO_INST_NUM           3                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOD }           /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI_INST_NUM           1                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0 }                       /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71N21B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71N21B*/
+/* ************************************************************************** */
+#include "pio/samv71n21b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71N21B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71N21B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000001)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71N21B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71N21B definitions */
+
+
+#endif /* _SAMV71N21B_H_ */

--- a/asf/sam/include/samv71b/samv71q19b.h
+++ b/asf/sam/include/samv71b/samv71q19b.h
@@ -1,0 +1,977 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q19B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:11Z */
+#ifndef _SAMV71Q19B_H_
+#define _SAMV71Q19B_H_
+
+/** \addtogroup SAMV71Q19B_definitions SAMV71Q19B definitions
+  This file defines all structures and symbols for SAMV71Q19B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q19B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q19B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q19B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q19B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q19B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q19B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q19B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q19B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q19B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q19B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q19B Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q19B Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q19B Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q19B Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q19B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q19B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q19B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q19B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q19B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q19B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q19B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q19B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q19B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q19B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q19B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q19B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q19B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q19B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q19B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q19B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q19B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q19B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q19B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q19B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q19B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q19B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q19B Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q19B Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q19B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q19B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q19B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q19B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q19B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q19B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q19B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q19B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q19B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q19B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q19B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q19B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q19B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q19B Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q19B SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q19B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71Q19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71Q19B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q19B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71Q19B Inter-IC Sound Controller (I2SC0) */
+  I2SC1_IRQn                = 70 , /**< 70  SAMV71Q19B Inter-IC Sound Controller (I2SC1) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q19B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q19B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q19B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q19B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q19B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q19B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q19B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q19B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q19B Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q19B Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q19B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q19B Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q19B Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q19B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q19B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q19B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q19B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q19B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q19B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q19B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q19B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q19B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q19B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q19B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q19B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q19B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q19B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q19B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q19B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q19B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q19B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q19B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q19B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q19B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q19B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q19B Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q19B Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q19B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q19B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q19B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q19B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q19B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q19B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q19B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q19B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q19B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q19B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q19B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q19B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q19B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q19B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q19B Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q19B SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q19B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71Q19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71Q19B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q19B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71Q19B Inter-IC Sound Controller (I2SC0) */
+  void* pfnI2SC1_Handler;                        /* 70  SAMV71Q19B Inter-IC Sound Controller (I2SC1) */
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71Q19B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void I2SC1_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q19B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q19B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q19B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q19B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/i2sc1.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q19B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+#define ID_I2SC1        ( 70) /**< \brief Inter-IC Sound Controller (I2SC1) */
+
+#define ID_PERIPH_COUNT ( 71) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q19B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q19B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  (0x40090000)                   /**< \brief (I2SC1     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  ((I2sc *)0x40090000U)          /**< \brief (I2SC1     ) Base Address */
+#define I2SC_INST_NUM          2                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0, I2SC1 }               /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q19B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q19B*/
+/* ************************************************************************** */
+#include "pio/samv71q19b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q19B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00080000)       /*  512kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      1024)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q19B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q19B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q19B definitions */
+
+
+#endif /* _SAMV71Q19B_H_ */

--- a/asf/sam/include/samv71b/samv71q20b.h
+++ b/asf/sam/include/samv71b/samv71q20b.h
@@ -1,0 +1,977 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q20B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:13Z */
+#ifndef _SAMV71Q20B_H_
+#define _SAMV71Q20B_H_
+
+/** \addtogroup SAMV71Q20B_definitions SAMV71Q20B definitions
+  This file defines all structures and symbols for SAMV71Q20B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q20B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q20B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q20B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q20B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q20B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q20B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q20B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q20B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q20B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q20B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q20B Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q20B Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q20B Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q20B Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q20B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q20B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q20B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q20B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q20B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q20B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q20B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q20B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q20B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q20B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q20B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q20B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q20B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q20B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q20B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q20B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q20B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q20B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q20B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q20B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q20B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q20B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q20B Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q20B Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q20B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q20B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q20B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q20B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q20B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q20B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q20B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q20B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q20B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q20B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q20B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q20B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q20B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q20B Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q20B SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q20B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71Q20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71Q20B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q20B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71Q20B Inter-IC Sound Controller (I2SC0) */
+  I2SC1_IRQn                = 70 , /**< 70  SAMV71Q20B Inter-IC Sound Controller (I2SC1) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q20B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q20B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q20B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q20B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q20B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q20B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q20B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q20B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q20B Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q20B Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q20B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q20B Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q20B Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q20B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q20B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q20B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q20B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q20B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q20B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q20B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q20B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q20B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q20B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q20B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q20B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q20B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q20B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q20B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q20B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q20B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q20B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q20B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q20B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q20B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q20B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q20B Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q20B Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q20B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q20B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q20B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q20B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q20B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q20B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q20B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q20B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q20B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q20B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q20B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q20B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q20B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q20B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q20B Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q20B SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q20B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71Q20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71Q20B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q20B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71Q20B Inter-IC Sound Controller (I2SC0) */
+  void* pfnI2SC1_Handler;                        /* 70  SAMV71Q20B Inter-IC Sound Controller (I2SC1) */
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71Q20B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void I2SC1_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q20B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q20B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q20B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q20B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/i2sc1.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q20B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+#define ID_I2SC1        ( 70) /**< \brief Inter-IC Sound Controller (I2SC1) */
+
+#define ID_PERIPH_COUNT ( 71) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q20B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q20B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  (0x40090000)                   /**< \brief (I2SC1     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  ((I2sc *)0x40090000U)          /**< \brief (I2SC1     ) Base Address */
+#define I2SC_INST_NUM          2                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0, I2SC1 }               /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q20B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q20B*/
+/* ************************************************************************** */
+#include "pio/samv71q20b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q20B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00100000)       /* 1024kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      2048)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q20B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q20B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q20B definitions */
+
+
+#endif /* _SAMV71Q20B_H_ */

--- a/asf/sam/include/samv71b/samv71q21b.h
+++ b/asf/sam/include/samv71b/samv71q21b.h
@@ -1,0 +1,977 @@
+/**
+ * \file
+ *
+ * \brief Header file for ATSAMV71Q21B
+ *
+ * Copyright (c) 2019 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+/* file generated from device description version 2019-01-18T21:21:15Z */
+#ifndef _SAMV71Q21B_H_
+#define _SAMV71Q21B_H_
+
+/** \addtogroup SAMV71Q21B_definitions SAMV71Q21B definitions
+  This file defines all structures and symbols for SAMV71Q21B:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+ *  @{
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \defgroup Atmel_glob_defs Atmel Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+
+    \remark
+    CMSIS core has a syntax that differs from this using i.e. __I, __O, or __IO followed by 'uint<size>_t' respective types.
+    Default the header files will follow the CMSIS core syntax.
+ *  @{
+ */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+
+#define CAST(type, value) ((type *)(value)) /**< Pointer Type Conversion Macro for C/C++ */
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else /* Assembler */
+#define CAST(type, value) (value) /**< Pointer Type Conversion Macro for Assembler */
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !defined(SKIP_INTEGER_LITERALS)
+
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x) x ## U    /**< C code: Unsigned integer literal constant value */
+#define _L_(x) x ## L    /**< C code: Long integer literal constant value */
+#define _UL_(x) x ## UL  /**< C code: Unsigned Long integer literal constant value */
+
+#else /* Assembler */
+
+#define _U_(x) x    /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x) x    /**< Assembler: Long integer literal constant value */
+#define _UL_(x) x   /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* SKIP_INTEGER_LITERALS */
+/** @}  end of Atmel Global Defines */
+
+/** \addtogroup SAMV71Q21B_cmsis CMSIS Definitions
+ *  @{
+ */
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  CORTEX-M7 Processor Exceptions Numbers ******************************/
+  Reset_IRQn                = -15, /**< 1   Reset Vector, invoked on Power up and warm reset  */
+  NonMaskableInt_IRQn       = -14, /**< 2   Non maskable Interrupt, cannot be stopped or preempted  */
+  HardFault_IRQn            = -13, /**< 3   Hard Fault, all classes of Fault     */
+  MemoryManagement_IRQn     = -12, /**< 4   Memory Management, MPU mismatch, including Access Violation and No Match  */
+  BusFault_IRQn             = -11, /**< 5   Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  UsageFault_IRQn           = -10, /**< 6   Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  SVCall_IRQn               = -5 , /**< 11  System Service Call via SVC instruction  */
+  DebugMonitor_IRQn         = -4 , /**< 12  Debug Monitor                        */
+  PendSV_IRQn               = -2 , /**< 14  Pendable request for system service  */
+  SysTick_IRQn              = -1 , /**< 15  System Tick Timer                    */
+/******  SAMV71Q21B specific Interrupt Numbers ***********************************/
+  SUPC_IRQn                 = 0  , /**< 0   SAMV71Q21B Supply Controller (SUPC) */
+  RSTC_IRQn                 = 1  , /**< 1   SAMV71Q21B Reset Controller (RSTC)  */
+  RTC_IRQn                  = 2  , /**< 2   SAMV71Q21B Real-time Clock (RTC)    */
+  RTT_IRQn                  = 3  , /**< 3   SAMV71Q21B Real-time Timer (RTT)    */
+  WDT_IRQn                  = 4  , /**< 4   SAMV71Q21B Watchdog Timer (WDT)     */
+  PMC_IRQn                  = 5  , /**< 5   SAMV71Q21B Power Management Controller (PMC) */
+  EFC_IRQn                  = 6  , /**< 6   SAMV71Q21B Embedded Flash Controller (EFC) */
+  UART0_IRQn                = 7  , /**< 7   SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART0) */
+  UART1_IRQn                = 8  , /**< 8   SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART1) */
+  PIOA_IRQn                 = 10 , /**< 10  SAMV71Q21B Parallel Input/Output Controller (PIOA) */
+  PIOB_IRQn                 = 11 , /**< 11  SAMV71Q21B Parallel Input/Output Controller (PIOB) */
+  PIOC_IRQn                 = 12 , /**< 12  SAMV71Q21B Parallel Input/Output Controller (PIOC) */
+  USART0_IRQn               = 13 , /**< 13  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  USART1_IRQn               = 14 , /**< 14  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  USART2_IRQn               = 15 , /**< 15  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  PIOD_IRQn                 = 16 , /**< 16  SAMV71Q21B Parallel Input/Output Controller (PIOD) */
+  PIOE_IRQn                 = 17 , /**< 17  SAMV71Q21B Parallel Input/Output Controller (PIOE) */
+  HSMCI_IRQn                = 18 , /**< 18  SAMV71Q21B High Speed MultiMedia Card Interface (HSMCI) */
+  TWIHS0_IRQn               = 19 , /**< 19  SAMV71Q21B Two-wire Interface High Speed (TWIHS0) */
+  TWIHS1_IRQn               = 20 , /**< 20  SAMV71Q21B Two-wire Interface High Speed (TWIHS1) */
+  SPI0_IRQn                 = 21 , /**< 21  SAMV71Q21B Serial Peripheral Interface (SPI0) */
+  SSC_IRQn                  = 22 , /**< 22  SAMV71Q21B Synchronous Serial Controller (SSC) */
+  TC0_IRQn                  = 23 , /**< 23  SAMV71Q21B Timer Counter (TC0)      */
+  TC1_IRQn                  = 24 , /**< 24  SAMV71Q21B Timer Counter (TC0)      */
+  TC2_IRQn                  = 25 , /**< 25  SAMV71Q21B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAMV71Q21B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAMV71Q21B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAMV71Q21B Timer Counter (TC1)      */
+  AFEC0_IRQn                = 29 , /**< 29  SAMV71Q21B Analog Front-End Controller (AFEC0) */
+  DACC_IRQn                 = 30 , /**< 30  SAMV71Q21B Digital-to-Analog Converter Controller (DACC) */
+  PWM0_IRQn                 = 31 , /**< 31  SAMV71Q21B Pulse Width Modulation Controller (PWM0) */
+  ICM_IRQn                  = 32 , /**< 32  SAMV71Q21B Integrity Check Monitor (ICM) */
+  ACC_IRQn                  = 33 , /**< 33  SAMV71Q21B Analog Comparator Controller (ACC) */
+  USBHS_IRQn                = 34 , /**< 34  SAMV71Q21B USB High-Speed Interface (USBHS) */
+  MCAN0_INT0_IRQn           = 35 , /**< 35  SAMV71Q21B Controller Area Network (MCAN0) */
+  MCAN0_INT1_IRQn           = 36 , /**< 36  SAMV71Q21B Controller Area Network (MCAN0) */
+  MCAN1_INT0_IRQn           = 37 , /**< 37  SAMV71Q21B Controller Area Network (MCAN1) */
+  MCAN1_INT1_IRQn           = 38 , /**< 38  SAMV71Q21B Controller Area Network (MCAN1) */
+  GMAC_IRQn                 = 39 , /**< 39  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  AFEC1_IRQn                = 40 , /**< 40  SAMV71Q21B Analog Front-End Controller (AFEC1) */
+  TWIHS2_IRQn               = 41 , /**< 41  SAMV71Q21B Two-wire Interface High Speed (TWIHS2) */
+  SPI1_IRQn                 = 42 , /**< 42  SAMV71Q21B Serial Peripheral Interface (SPI1) */
+  QSPI_IRQn                 = 43 , /**< 43  SAMV71Q21B Quad Serial Peripheral Interface (QSPI) */
+  UART2_IRQn                = 44 , /**< 44  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART2) */
+  UART3_IRQn                = 45 , /**< 45  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART3) */
+  UART4_IRQn                = 46 , /**< 46  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAMV71Q21B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAMV71Q21B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAMV71Q21B Timer Counter (TC2)      */
+  TC9_IRQn                  = 50 , /**< 50  SAMV71Q21B Timer Counter (TC3)      */
+  TC10_IRQn                 = 51 , /**< 51  SAMV71Q21B Timer Counter (TC3)      */
+  TC11_IRQn                 = 52 , /**< 52  SAMV71Q21B Timer Counter (TC3)      */
+  MLB_IRQn                  = 53 , /**< 53  SAMV71Q21B MediaLB (MLB)            */
+  AES_IRQn                  = 56 , /**< 56  SAMV71Q21B Advanced Encryption Standard (AES) */
+  TRNG_IRQn                 = 57 , /**< 57  SAMV71Q21B True Random Number Generator (TRNG) */
+  XDMAC_IRQn                = 58 , /**< 58  SAMV71Q21B Extensible DMA Controller (XDMAC) */
+  ISI_IRQn                  = 59 , /**< 59  SAMV71Q21B Image Sensor Interface (ISI) */
+  PWM1_IRQn                 = 60 , /**< 60  SAMV71Q21B Pulse Width Modulation Controller (PWM1) */
+  FPU_IRQn                  = 61 , /**< 61  SAMV71Q21B Floating Point Unit (FPU) */
+  SDRAMC_IRQn               = 62 , /**< 62  SAMV71Q21B SDRAM Controller (SDRAMC) */
+  RSWDT_IRQn                = 63 , /**< 63  SAMV71Q21B Reinforced Safety Watchdog Timer (RSWDT) */
+  CCW_IRQn                  = 64 , /**< 64  SAMV71Q21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAMV71Q21B System Control Block (SCB) */
+  GMAC_Q1_IRQn              = 66 , /**< 66  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q2_IRQn              = 67 , /**< 67  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  IXC_IRQn                  = 68 , /**< 68  SAMV71Q21B Floating Point Unit (FPU) */
+  I2SC0_IRQn                = 69 , /**< 69  SAMV71Q21B Inter-IC Sound Controller (I2SC0) */
+  I2SC1_IRQn                = 70 , /**< 70  SAMV71Q21B Inter-IC Sound Controller (I2SC1) */
+  GMAC_Q3_IRQn              = 71 , /**< 71  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q4_IRQn              = 72 , /**< 72  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  GMAC_Q5_IRQn              = 73 , /**< 73  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+
+  PERIPH_COUNT_IRQn        = 74  /**< Number of peripheral IDs */
+} IRQn_Type;
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;                        /* -15 Reset Vector, invoked on Power up and warm reset  */
+  void* pfnNonMaskableInt_Handler;               /* -14 Non maskable Interrupt, cannot be stopped or preempted  */
+  void* pfnHardFault_Handler;                    /* -13 Hard Fault, all classes of Fault     */
+  void* pfnMemoryManagement_Handler;             /* -12 Memory Management, MPU mismatch, including Access Violation and No Match  */
+  void* pfnBusFault_Handler;                     /* -11 Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault  */
+  void* pfnUsageFault_Handler;                   /* -10 Usage Fault, i.e. Undef Instruction, Illegal State Transition  */
+  void* pvReservedC9;
+  void* pvReservedC8;
+  void* pvReservedC7;
+  void* pvReservedC6;
+  void* pfnSVCall_Handler;                       /*  -5 System Service Call via SVC instruction  */
+  void* pfnDebugMonitor_Handler;                 /*  -4 Debug Monitor                        */
+  void* pvReservedC3;
+  void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
+  void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;                         /* 0   SAMV71Q21B Supply Controller (SUPC) */
+  void* pfnRSTC_Handler;                         /* 1   SAMV71Q21B Reset Controller (RSTC) */
+  void* pfnRTC_Handler;                          /* 2   SAMV71Q21B Real-time Clock (RTC) */
+  void* pfnRTT_Handler;                          /* 3   SAMV71Q21B Real-time Timer (RTT) */
+  void* pfnWDT_Handler;                          /* 4   SAMV71Q21B Watchdog Timer (WDT) */
+  void* pfnPMC_Handler;                          /* 5   SAMV71Q21B Power Management Controller (PMC) */
+  void* pfnEFC_Handler;                          /* 6   SAMV71Q21B Embedded Flash Controller (EFC) */
+  void* pfnUART0_Handler;                        /* 7   SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART0) */
+  void* pfnUART1_Handler;                        /* 8   SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART1) */
+  void* pvReserved9;
+  void* pfnPIOA_Handler;                         /* 10  SAMV71Q21B Parallel Input/Output Controller (PIOA) */
+  void* pfnPIOB_Handler;                         /* 11  SAMV71Q21B Parallel Input/Output Controller (PIOB) */
+  void* pfnPIOC_Handler;                         /* 12  SAMV71Q21B Parallel Input/Output Controller (PIOC) */
+  void* pfnUSART0_Handler;                       /* 13  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+  void* pfnUSART1_Handler;                       /* 14  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+  void* pfnUSART2_Handler;                       /* 15  SAMV71Q21B Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+  void* pfnPIOD_Handler;                         /* 16  SAMV71Q21B Parallel Input/Output Controller (PIOD) */
+  void* pfnPIOE_Handler;                         /* 17  SAMV71Q21B Parallel Input/Output Controller (PIOE) */
+  void* pfnHSMCI_Handler;                        /* 18  SAMV71Q21B High Speed MultiMedia Card Interface (HSMCI) */
+  void* pfnTWIHS0_Handler;                       /* 19  SAMV71Q21B Two-wire Interface High Speed (TWIHS0) */
+  void* pfnTWIHS1_Handler;                       /* 20  SAMV71Q21B Two-wire Interface High Speed (TWIHS1) */
+  void* pfnSPI0_Handler;                         /* 21  SAMV71Q21B Serial Peripheral Interface (SPI0) */
+  void* pfnSSC_Handler;                          /* 22  SAMV71Q21B Synchronous Serial Controller (SSC) */
+  void* pfnTC0_Handler;                          /* 23  SAMV71Q21B Timer Counter (TC0) */
+  void* pfnTC1_Handler;                          /* 24  SAMV71Q21B Timer Counter (TC0) */
+  void* pfnTC2_Handler;                          /* 25  SAMV71Q21B Timer Counter (TC0) */
+  void* pfnTC3_Handler;                          /* 26  SAMV71Q21B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAMV71Q21B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAMV71Q21B Timer Counter (TC1) */
+  void* pfnAFEC0_Handler;                        /* 29  SAMV71Q21B Analog Front-End Controller (AFEC0) */
+  void* pfnDACC_Handler;                         /* 30  SAMV71Q21B Digital-to-Analog Converter Controller (DACC) */
+  void* pfnPWM0_Handler;                         /* 31  SAMV71Q21B Pulse Width Modulation Controller (PWM0) */
+  void* pfnICM_Handler;                          /* 32  SAMV71Q21B Integrity Check Monitor (ICM) */
+  void* pfnACC_Handler;                          /* 33  SAMV71Q21B Analog Comparator Controller (ACC) */
+  void* pfnUSBHS_Handler;                        /* 34  SAMV71Q21B USB High-Speed Interface (USBHS) */
+  void* pfnMCAN0_INT0_Handler;                   /* 35  SAMV71Q21B Controller Area Network (MCAN0) */
+  void* pfnMCAN0_INT1_Handler;                   /* 36  SAMV71Q21B Controller Area Network (MCAN0) */
+  void* pfnMCAN1_INT0_Handler;                   /* 37  SAMV71Q21B Controller Area Network (MCAN1) */
+  void* pfnMCAN1_INT1_Handler;                   /* 38  SAMV71Q21B Controller Area Network (MCAN1) */
+  void* pfnGMAC_Handler;                         /* 39  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnAFEC1_Handler;                        /* 40  SAMV71Q21B Analog Front-End Controller (AFEC1) */
+  void* pfnTWIHS2_Handler;                       /* 41  SAMV71Q21B Two-wire Interface High Speed (TWIHS2) */
+  void* pfnSPI1_Handler;                         /* 42  SAMV71Q21B Serial Peripheral Interface (SPI1) */
+  void* pfnQSPI_Handler;                         /* 43  SAMV71Q21B Quad Serial Peripheral Interface (QSPI) */
+  void* pfnUART2_Handler;                        /* 44  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART2) */
+  void* pfnUART3_Handler;                        /* 45  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART3) */
+  void* pfnUART4_Handler;                        /* 46  SAMV71Q21B Universal Asynchronous Receiver Transmitter (UART4) */
+  void* pfnTC6_Handler;                          /* 47  SAMV71Q21B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAMV71Q21B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAMV71Q21B Timer Counter (TC2) */
+  void* pfnTC9_Handler;                          /* 50  SAMV71Q21B Timer Counter (TC3) */
+  void* pfnTC10_Handler;                         /* 51  SAMV71Q21B Timer Counter (TC3) */
+  void* pfnTC11_Handler;                         /* 52  SAMV71Q21B Timer Counter (TC3) */
+  void* pfnMLB_Handler;                          /* 53  SAMV71Q21B MediaLB (MLB)       */
+  void* pvReserved54;
+  void* pvReserved55;
+  void* pfnAES_Handler;                          /* 56  SAMV71Q21B Advanced Encryption Standard (AES) */
+  void* pfnTRNG_Handler;                         /* 57  SAMV71Q21B True Random Number Generator (TRNG) */
+  void* pfnXDMAC_Handler;                        /* 58  SAMV71Q21B Extensible DMA Controller (XDMAC) */
+  void* pfnISI_Handler;                          /* 59  SAMV71Q21B Image Sensor Interface (ISI) */
+  void* pfnPWM1_Handler;                         /* 60  SAMV71Q21B Pulse Width Modulation Controller (PWM1) */
+  void* pfnFPU_Handler;                          /* 61  SAMV71Q21B Floating Point Unit (FPU) */
+  void* pfnSDRAMC_Handler;                       /* 62  SAMV71Q21B SDRAM Controller (SDRAMC) */
+  void* pfnRSWDT_Handler;                        /* 63  SAMV71Q21B Reinforced Safety Watchdog Timer (RSWDT) */
+  void* pfnCCW_Handler;                          /* 64  SAMV71Q21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAMV71Q21B System Control Block (SCB) */
+  void* pfnGMAC_Q1_Handler;                      /* 66  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q2_Handler;                      /* 67  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnIXC_Handler;                          /* 68  SAMV71Q21B Floating Point Unit (FPU) */
+  void* pfnI2SC0_Handler;                        /* 69  SAMV71Q21B Inter-IC Sound Controller (I2SC0) */
+  void* pfnI2SC1_Handler;                        /* 70  SAMV71Q21B Inter-IC Sound Controller (I2SC1) */
+  void* pfnGMAC_Q3_Handler;                      /* 71  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q4_Handler;                      /* 72  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+  void* pfnGMAC_Q5_Handler;                      /* 73  SAMV71Q21B Gigabit Ethernet MAC (GMAC) */
+} DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if !defined DONT_USE_PREDEFINED_CORE_HANDLERS
+
+/* CORTEX-M7 core handlers */
+void Reset_Handler                 ( void );
+void NonMaskableInt_Handler        ( void );
+void HardFault_Handler             ( void );
+void MemoryManagement_Handler      ( void );
+void BusFault_Handler              ( void );
+void UsageFault_Handler            ( void );
+void SVCall_Handler                ( void );
+void DebugMonitor_Handler          ( void );
+void PendSV_Handler                ( void );
+void SysTick_Handler               ( void );
+#endif /* DONT_USE_PREDEFINED_CORE_HANDLERS */
+
+#if !defined DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+
+/* Peripherals handlers */
+void ACC_Handler                   ( void );
+void AES_Handler                   ( void );
+void AFEC0_Handler                 ( void );
+void AFEC1_Handler                 ( void );
+void CCF_Handler                   ( void );
+void CCW_Handler                   ( void );
+void DACC_Handler                  ( void );
+void EFC_Handler                   ( void );
+void FPU_Handler                   ( void );
+void GMAC_Handler                  ( void );
+void GMAC_Q1_Handler               ( void );
+void GMAC_Q2_Handler               ( void );
+void GMAC_Q3_Handler               ( void );
+void GMAC_Q4_Handler               ( void );
+void GMAC_Q5_Handler               ( void );
+void HSMCI_Handler                 ( void );
+void I2SC0_Handler                 ( void );
+void I2SC1_Handler                 ( void );
+void ICM_Handler                   ( void );
+void ISI_Handler                   ( void );
+void IXC_Handler                   ( void );
+void MCAN0_INT0_Handler            ( void );
+void MCAN0_INT1_Handler            ( void );
+void MCAN1_INT0_Handler            ( void );
+void MCAN1_INT1_Handler            ( void );
+void MLB_Handler                   ( void );
+void PIOA_Handler                  ( void );
+void PIOB_Handler                  ( void );
+void PIOC_Handler                  ( void );
+void PIOD_Handler                  ( void );
+void PIOE_Handler                  ( void );
+void PMC_Handler                   ( void );
+void PWM0_Handler                  ( void );
+void PWM1_Handler                  ( void );
+void QSPI_Handler                  ( void );
+void RSTC_Handler                  ( void );
+void RSWDT_Handler                 ( void );
+void RTC_Handler                   ( void );
+void RTT_Handler                   ( void );
+void SDRAMC_Handler                ( void );
+void SPI0_Handler                  ( void );
+void SPI1_Handler                  ( void );
+void SSC_Handler                   ( void );
+void SUPC_Handler                  ( void );
+void TC0_Handler                   ( void );
+void TC10_Handler                  ( void );
+void TC11_Handler                  ( void );
+void TC1_Handler                   ( void );
+void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
+void TC9_Handler                   ( void );
+void TRNG_Handler                  ( void );
+void TWIHS0_Handler                ( void );
+void TWIHS1_Handler                ( void );
+void TWIHS2_Handler                ( void );
+void UART0_Handler                 ( void );
+void UART1_Handler                 ( void );
+void UART2_Handler                 ( void );
+void UART3_Handler                 ( void );
+void UART4_Handler                 ( void );
+void USART0_Handler                ( void );
+void USART1_Handler                ( void );
+void USART2_Handler                ( void );
+void USBHS_Handler                 ( void );
+void WDT_Handler                   ( void );
+void XDMAC_Handler                 ( void );
+#endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+/*
+ * \brief Configuration of the CORTEX-M7 Processor and Core Peripherals
+ */
+
+#define __CM7_REV                 0x0101 /**< CM7 Core Revision                                                         */
+#define __NVIC_PRIO_BITS               3 /**< Number of Bits used for Priority Levels                                   */
+#define __Vendor_SysTickConfig         0 /**< Set to 1 if different SysTick Config is used                              */
+#define __MPU_PRESENT                  1 /**< MPU present or not                                                        */
+#define __VTOR_PRESENT                 1 /**< Vector Table Offset Register present or not                               */
+#define __FPU_PRESENT                  1 /**< FPU present or not                                                        */
+#define __FPU_DP                       1 /**< Double Precision FPU                                                      */
+#define __ICACHE_PRESENT               1 /**< Instruction Cache present                                                 */
+#define __DCACHE_PRESENT               1 /**< Data Cache present                                                        */
+#define __ITCM_PRESENT                 1 /**< Instruction TCM present                                                   */
+#define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
+#define __DEBUG_LVL                    1
+#define __TRACE_LVL                    1
+#define __LITTLE_ENDIAN                1
+#define __ARCH_ARM                     1
+#define __ARCH_ARM_CORTEX_M            1
+#define __DEVICE_IS_SAM                1
+
+/*
+ * \brief CMSIS includes
+ */
+#include <core_cm7.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samv71.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/** @}  end of SAMV71Q21B_cmsis CMSIS Definitions */
+
+/** \defgroup SAMV71Q21B_api Peripheral Software API
+ *  @{
+ */
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMV71Q21B */
+/* ************************************************************************** */
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/chipid.h"
+#include "component/dacc.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/i2sc.h"
+#include "component/icm.h"
+#include "component/isi.h"
+#include "component/matrix.h"
+#include "component/mcan.h"
+#include "component/mlb.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/qspi.h"
+#include "component/rstc.h"
+#include "component/rswdt.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/sdramc.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/ssc.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twihs.h"
+#include "component/uart.h"
+#include "component/usart.h"
+#include "component/usbhs.h"
+#include "component/utmi.h"
+#include "component/wdt.h"
+#include "component/xdmac.h"
+/** @}  end of Peripheral Software API */
+
+/** \defgroup SAMV71Q21B_reg Registers Access Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#include "instance/acc.h"
+#include "instance/aes.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/chipid.h"
+#include "instance/dacc.h"
+#include "instance/efc.h"
+#include "instance/gmac.h"
+#include "instance/gpbr.h"
+#include "instance/hsmci.h"
+#include "instance/i2sc0.h"
+#include "instance/i2sc1.h"
+#include "instance/icm.h"
+#include "instance/isi.h"
+#include "instance/matrix.h"
+#include "instance/mcan0.h"
+#include "instance/mcan1.h"
+#include "instance/mlb.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/pmc.h"
+#include "instance/pwm0.h"
+#include "instance/pwm1.h"
+#include "instance/qspi.h"
+#include "instance/rstc.h"
+#include "instance/rswdt.h"
+#include "instance/rtc.h"
+#include "instance/rtt.h"
+#include "instance/sdramc.h"
+#include "instance/smc.h"
+#include "instance/spi0.h"
+#include "instance/spi1.h"
+#include "instance/ssc.h"
+#include "instance/supc.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/trng.h"
+#include "instance/twihs0.h"
+#include "instance/twihs1.h"
+#include "instance/twihs2.h"
+#include "instance/uart0.h"
+#include "instance/uart1.h"
+#include "instance/uart2.h"
+#include "instance/uart3.h"
+#include "instance/uart4.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usbhs.h"
+#include "instance/utmi.h"
+#include "instance/wdt.h"
+#include "instance/xdmac.h"
+/** @}  end of Registers Access Definitions */
+
+/** \addtogroup SAMV71Q21B_id Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  PERIPHERAL ID DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#define ID_SUPC         (  0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC         (  1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC          (  2) /**< \brief Real-time Clock (RTC) */
+#define ID_RTT          (  3) /**< \brief Real-time Timer (RTT) */
+#define ID_WDT          (  4) /**< \brief Watchdog Timer (WDT) */
+#define ID_PMC          (  5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC          (  6) /**< \brief Embedded Flash Controller (EFC) */
+#define ID_UART0        (  7) /**< \brief Universal Asynchronous Receiver Transmitter (UART0) */
+#define ID_UART1        (  8) /**< \brief Universal Asynchronous Receiver Transmitter (UART1) */
+#define ID_SMC          (  9) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA         ( 10) /**< \brief Parallel Input/Output Controller (PIOA) */
+#define ID_PIOB         ( 11) /**< \brief Parallel Input/Output Controller (PIOB) */
+#define ID_PIOC         ( 12) /**< \brief Parallel Input/Output Controller (PIOC) */
+#define ID_USART0       ( 13) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART0) */
+#define ID_USART1       ( 14) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART1) */
+#define ID_USART2       ( 15) /**< \brief Universal Synchronous Asynchronous Receiver Transmitter (USART2) */
+#define ID_PIOD         ( 16) /**< \brief Parallel Input/Output Controller (PIOD) */
+#define ID_PIOE         ( 17) /**< \brief Parallel Input/Output Controller (PIOE) */
+#define ID_HSMCI        ( 18) /**< \brief High Speed MultiMedia Card Interface (HSMCI) */
+#define ID_TWIHS0       ( 19) /**< \brief Two-wire Interface High Speed (TWIHS0) */
+#define ID_TWIHS1       ( 20) /**< \brief Two-wire Interface High Speed (TWIHS1) */
+#define ID_SPI0         ( 21) /**< \brief Serial Peripheral Interface (SPI0) */
+#define ID_SSC          ( 22) /**< \brief Synchronous Serial Controller (SSC) */
+#define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
+#define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
+#define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
+#define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
+#define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
+#define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
+#define ID_ICM          ( 32) /**< \brief Integrity Check Monitor (ICM) */
+#define ID_ACC          ( 33) /**< \brief Analog Comparator Controller (ACC) */
+#define ID_USBHS        ( 34) /**< \brief USB High-Speed Interface (USBHS) */
+#define ID_MCAN0        ( 35) /**< \brief Controller Area Network (MCAN0) */
+#define ID_MCAN1        ( 37) /**< \brief Controller Area Network (MCAN1) */
+#define ID_GMAC         ( 39) /**< \brief Gigabit Ethernet MAC (GMAC) */
+#define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
+#define ID_TWIHS2       ( 41) /**< \brief Two-wire Interface High Speed (TWIHS2) */
+#define ID_SPI1         ( 42) /**< \brief Serial Peripheral Interface (SPI1) */
+#define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
+#define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
+#define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
+#define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
+#define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
+#define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
+#define ID_MLB          ( 53) /**< \brief MediaLB (MLB) */
+#define ID_AES          ( 56) /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG         ( 57) /**< \brief True Random Number Generator (TRNG) */
+#define ID_XDMAC        ( 58) /**< \brief Extensible DMA Controller (XDMAC) */
+#define ID_ISI          ( 59) /**< \brief Image Sensor Interface (ISI) */
+#define ID_PWM1         ( 60) /**< \brief Pulse Width Modulation Controller (PWM1) */
+#define ID_SDRAMC       ( 62) /**< \brief SDRAM Controller (SDRAMC) */
+#define ID_RSWDT        ( 63) /**< \brief Reinforced Safety Watchdog Timer (RSWDT) */
+#define ID_I2SC0        ( 69) /**< \brief Inter-IC Sound Controller (I2SC0) */
+#define ID_I2SC1        ( 70) /**< \brief Inter-IC Sound Controller (I2SC1) */
+
+#define ID_PERIPH_COUNT ( 71) /**< \brief Number of peripheral IDs */
+/** @}  end of Peripheral Ids Definitions */
+
+/** \addtogroup legacy_SAMV71Q21B_id Legacy Peripheral Ids Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
+/** @}  end of Legacy Peripheral Ids Definitions */
+
+/** \addtogroup SAMV71Q21B_base Peripheral Base Address Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#define ACC                    (0x40044000)                   /**< \brief (ACC       ) Base Address */
+#define AES                    (0x4006C000)                   /**< \brief (AES       ) Base Address */
+#define AFEC0                  (0x4003C000)                   /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  (0x40064000)                   /**< \brief (AFEC1     ) Base Address */
+#define CHIPID                 (0x400E0940)                   /**< \brief (CHIPID    ) Base Address */
+#define DACC                   (0x40040000)                   /**< \brief (DACC      ) Base Address */
+#define EFC                    (0x400E0C00)                   /**< \brief (EFC       ) Base Address */
+#define GMAC                   (0x40050000)                   /**< \brief (GMAC      ) Base Address */
+#define GPBR                   (0x400E1890)                   /**< \brief (GPBR      ) Base Address */
+#define HSMCI                  (0x40000000)                   /**< \brief (HSMCI     ) Base Address */
+#define I2SC0                  (0x4008C000)                   /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  (0x40090000)                   /**< \brief (I2SC1     ) Base Address */
+#define ICM                    (0x40048000)                   /**< \brief (ICM       ) Base Address */
+#define ISI                    (0x4004C000)                   /**< \brief (ISI       ) Base Address */
+#define MATRIX                 (0x40088000)                   /**< \brief (MATRIX    ) Base Address */
+#define MCAN0                  (0x40030000)                   /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  (0x40034000)                   /**< \brief (MCAN1     ) Base Address */
+#define MLB                    (0x40068000)                   /**< \brief (MLB       ) Base Address */
+#define PIOA                   (0x400E0E00)                   /**< \brief (PIOA      ) Base Address */
+#define PIOB                   (0x400E1000)                   /**< \brief (PIOB      ) Base Address */
+#define PIOC                   (0x400E1200)                   /**< \brief (PIOC      ) Base Address */
+#define PIOD                   (0x400E1400)                   /**< \brief (PIOD      ) Base Address */
+#define PIOE                   (0x400E1600)                   /**< \brief (PIOE      ) Base Address */
+#define PMC                    (0x400E0600)                   /**< \brief (PMC       ) Base Address */
+#define PWM0                   (0x40020000)                   /**< \brief (PWM0      ) Base Address */
+#define PWM1                   (0x4005C000)                   /**< \brief (PWM1      ) Base Address */
+#define QSPI                   (0x4007C000)                   /**< \brief (QSPI      ) Base Address */
+#define RSTC                   (0x400E1800)                   /**< \brief (RSTC      ) Base Address */
+#define RSWDT                  (0x400E1900)                   /**< \brief (RSWDT     ) Base Address */
+#define RTC                    (0x400E1860)                   /**< \brief (RTC       ) Base Address */
+#define RTT                    (0x400E1830)                   /**< \brief (RTT       ) Base Address */
+#define SDRAMC                 (0x40084000)                   /**< \brief (SDRAMC    ) Base Address */
+#define SMC                    (0x40080000)                   /**< \brief (SMC       ) Base Address */
+#define SPI0                   (0x40008000)                   /**< \brief (SPI0      ) Base Address */
+#define SPI1                   (0x40058000)                   /**< \brief (SPI1      ) Base Address */
+#define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
+#define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
+#define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
+#define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
+#define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
+#define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 (0x4001C000)                   /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 (0x40060000)                   /**< \brief (TWIHS2    ) Base Address */
+#define UART0                  (0x400E0800)                   /**< \brief (UART0     ) Base Address */
+#define UART1                  (0x400E0A00)                   /**< \brief (UART1     ) Base Address */
+#define UART2                  (0x400E1A00)                   /**< \brief (UART2     ) Base Address */
+#define UART3                  (0x400E1C00)                   /**< \brief (UART3     ) Base Address */
+#define UART4                  (0x400E1E00)                   /**< \brief (UART4     ) Base Address */
+#define USART0                 (0x40024000)                   /**< \brief (USART0    ) Base Address */
+#define USART1                 (0x40028000)                   /**< \brief (USART1    ) Base Address */
+#define USART2                 (0x4002C000)                   /**< \brief (USART2    ) Base Address */
+#define USBHS                  (0x40038000)                   /**< \brief (USBHS     ) Base Address */
+#define UTMI                   (0x400E0400)                   /**< \brief (UTMI      ) Base Address */
+#define WDT                    (0x400E1850)                   /**< \brief (WDT       ) Base Address */
+#define XDMAC                  (0x40078000)                   /**< \brief (XDMAC     ) Base Address */
+
+#else /* For C/C++ compiler */
+
+#define ACC                    ((Acc *)0x40044000U)           /**< \brief (ACC       ) Base Address */
+#define ACC_INST_NUM           1                              /**< \brief (ACC       ) Number of instances */
+#define ACC_INSTS              { ACC }                        /**< \brief (ACC       ) Instances List */
+
+#define AES                    ((Aes *)0x4006C000U)           /**< \brief (AES       ) Base Address */
+#define AES_INST_NUM           1                              /**< \brief (AES       ) Number of instances */
+#define AES_INSTS              { AES }                        /**< \brief (AES       ) Instances List */
+
+#define AFEC0                  ((Afec *)0x4003C000U)          /**< \brief (AFEC0     ) Base Address */
+#define AFEC1                  ((Afec *)0x40064000U)          /**< \brief (AFEC1     ) Base Address */
+#define AFEC_INST_NUM          2                              /**< \brief (AFEC      ) Number of instances */
+#define AFEC_INSTS             { AFEC0, AFEC1 }               /**< \brief (AFEC      ) Instances List */
+
+#define CHIPID                 ((Chipid *)0x400E0940U)        /**< \brief (CHIPID    ) Base Address */
+#define CHIPID_INST_NUM        1                              /**< \brief (CHIPID    ) Number of instances */
+#define CHIPID_INSTS           { CHIPID }                     /**< \brief (CHIPID    ) Instances List */
+
+#define DACC                   ((Dacc *)0x40040000U)          /**< \brief (DACC      ) Base Address */
+#define DACC_INST_NUM          1                              /**< \brief (DACC      ) Number of instances */
+#define DACC_INSTS             { DACC }                       /**< \brief (DACC      ) Instances List */
+
+#define EFC                    ((Efc *)0x400E0C00U)           /**< \brief (EFC       ) Base Address */
+#define EFC_INST_NUM           1                              /**< \brief (EFC       ) Number of instances */
+#define EFC_INSTS              { EFC }                        /**< \brief (EFC       ) Instances List */
+
+#define GMAC                   ((Gmac *)0x40050000U)          /**< \brief (GMAC      ) Base Address */
+#define GMAC_INST_NUM          1                              /**< \brief (GMAC      ) Number of instances */
+#define GMAC_INSTS             { GMAC }                       /**< \brief (GMAC      ) Instances List */
+
+#define GPBR                   ((Gpbr *)0x400E1890U)          /**< \brief (GPBR      ) Base Address */
+#define GPBR_INST_NUM          1                              /**< \brief (GPBR      ) Number of instances */
+#define GPBR_INSTS             { GPBR }                       /**< \brief (GPBR      ) Instances List */
+
+#define HSMCI                  ((Hsmci *)0x40000000U)         /**< \brief (HSMCI     ) Base Address */
+#define HSMCI_INST_NUM         1                              /**< \brief (HSMCI     ) Number of instances */
+#define HSMCI_INSTS            { HSMCI }                      /**< \brief (HSMCI     ) Instances List */
+
+#define I2SC0                  ((I2sc *)0x4008C000U)          /**< \brief (I2SC0     ) Base Address */
+#define I2SC1                  ((I2sc *)0x40090000U)          /**< \brief (I2SC1     ) Base Address */
+#define I2SC_INST_NUM          2                              /**< \brief (I2SC      ) Number of instances */
+#define I2SC_INSTS             { I2SC0, I2SC1 }               /**< \brief (I2SC      ) Instances List */
+
+#define ICM                    ((Icm *)0x40048000U)           /**< \brief (ICM       ) Base Address */
+#define ICM_INST_NUM           1                              /**< \brief (ICM       ) Number of instances */
+#define ICM_INSTS              { ICM }                        /**< \brief (ICM       ) Instances List */
+
+#define ISI                    ((Isi *)0x4004C000U)           /**< \brief (ISI       ) Base Address */
+#define ISI_INST_NUM           1                              /**< \brief (ISI       ) Number of instances */
+#define ISI_INSTS              { ISI }                        /**< \brief (ISI       ) Instances List */
+
+#define MATRIX                 ((Matrix *)0x40088000U)        /**< \brief (MATRIX    ) Base Address */
+#define MATRIX_INST_NUM        1                              /**< \brief (MATRIX    ) Number of instances */
+#define MATRIX_INSTS           { MATRIX }                     /**< \brief (MATRIX    ) Instances List */
+
+#define MCAN0                  ((Mcan *)0x40030000U)          /**< \brief (MCAN0     ) Base Address */
+#define MCAN1                  ((Mcan *)0x40034000U)          /**< \brief (MCAN1     ) Base Address */
+#define MCAN_INST_NUM          2                              /**< \brief (MCAN      ) Number of instances */
+#define MCAN_INSTS             { MCAN0, MCAN1 }               /**< \brief (MCAN      ) Instances List */
+
+#define MLB                    ((Mlb *)0x40068000U)           /**< \brief (MLB       ) Base Address */
+#define MLB_INST_NUM           1                              /**< \brief (MLB       ) Number of instances */
+#define MLB_INSTS              { MLB }                        /**< \brief (MLB       ) Instances List */
+
+#define PIOA                   ((Pio *)0x400E0E00U)           /**< \brief (PIOA      ) Base Address */
+#define PIOB                   ((Pio *)0x400E1000U)           /**< \brief (PIOB      ) Base Address */
+#define PIOC                   ((Pio *)0x400E1200U)           /**< \brief (PIOC      ) Base Address */
+#define PIOD                   ((Pio *)0x400E1400U)           /**< \brief (PIOD      ) Base Address */
+#define PIOE                   ((Pio *)0x400E1600U)           /**< \brief (PIOE      ) Base Address */
+#define PIO_INST_NUM           5                              /**< \brief (PIO       ) Number of instances */
+#define PIO_INSTS              { PIOA, PIOB, PIOC, PIOD, PIOE } /**< \brief (PIO       ) Instances List */
+
+#define PMC                    ((Pmc *)0x400E0600U)           /**< \brief (PMC       ) Base Address */
+#define PMC_INST_NUM           1                              /**< \brief (PMC       ) Number of instances */
+#define PMC_INSTS              { PMC }                        /**< \brief (PMC       ) Instances List */
+
+#define PWM0                   ((Pwm *)0x40020000U)           /**< \brief (PWM0      ) Base Address */
+#define PWM1                   ((Pwm *)0x4005C000U)           /**< \brief (PWM1      ) Base Address */
+#define PWM_INST_NUM           2                              /**< \brief (PWM       ) Number of instances */
+#define PWM_INSTS              { PWM0, PWM1 }                 /**< \brief (PWM       ) Instances List */
+
+#define QSPI                   ((Qspi *)0x4007C000U)          /**< \brief (QSPI      ) Base Address */
+#define QSPI_INST_NUM          1                              /**< \brief (QSPI      ) Number of instances */
+#define QSPI_INSTS             { QSPI }                       /**< \brief (QSPI      ) Instances List */
+
+#define RSTC                   ((Rstc *)0x400E1800U)          /**< \brief (RSTC      ) Base Address */
+#define RSTC_INST_NUM          1                              /**< \brief (RSTC      ) Number of instances */
+#define RSTC_INSTS             { RSTC }                       /**< \brief (RSTC      ) Instances List */
+
+#define RSWDT                  ((Rswdt *)0x400E1900U)         /**< \brief (RSWDT     ) Base Address */
+#define RSWDT_INST_NUM         1                              /**< \brief (RSWDT     ) Number of instances */
+#define RSWDT_INSTS            { RSWDT }                      /**< \brief (RSWDT     ) Instances List */
+
+#define RTC                    ((Rtc *)0x400E1860U)           /**< \brief (RTC       ) Base Address */
+#define RTC_INST_NUM           1                              /**< \brief (RTC       ) Number of instances */
+#define RTC_INSTS              { RTC }                        /**< \brief (RTC       ) Instances List */
+
+#define RTT                    ((Rtt *)0x400E1830U)           /**< \brief (RTT       ) Base Address */
+#define RTT_INST_NUM           1                              /**< \brief (RTT       ) Number of instances */
+#define RTT_INSTS              { RTT }                        /**< \brief (RTT       ) Instances List */
+
+#define SDRAMC                 ((Sdramc *)0x40084000U)        /**< \brief (SDRAMC    ) Base Address */
+#define SDRAMC_INST_NUM        1                              /**< \brief (SDRAMC    ) Number of instances */
+#define SDRAMC_INSTS           { SDRAMC }                     /**< \brief (SDRAMC    ) Instances List */
+
+#define SMC                    ((Smc *)0x40080000U)           /**< \brief (SMC       ) Base Address */
+#define SMC_INST_NUM           1                              /**< \brief (SMC       ) Number of instances */
+#define SMC_INSTS              { SMC }                        /**< \brief (SMC       ) Instances List */
+
+#define SPI0                   ((Spi *)0x40008000U)           /**< \brief (SPI0      ) Base Address */
+#define SPI1                   ((Spi *)0x40058000U)           /**< \brief (SPI1      ) Base Address */
+#define SPI_INST_NUM           2                              /**< \brief (SPI       ) Number of instances */
+#define SPI_INSTS              { SPI0, SPI1 }                 /**< \brief (SPI       ) Instances List */
+
+#define SSC                    ((Ssc *)0x40004000U)           /**< \brief (SSC       ) Base Address */
+#define SSC_INST_NUM           1                              /**< \brief (SSC       ) Number of instances */
+#define SSC_INSTS              { SSC }                        /**< \brief (SSC       ) Instances List */
+
+#define SUPC                   ((Supc *)0x400E1810U)          /**< \brief (SUPC      ) Base Address */
+#define SUPC_INST_NUM          1                              /**< \brief (SUPC      ) Number of instances */
+#define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
+
+#define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
+#define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
+
+#define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
+#define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
+#define TRNG_INSTS             { TRNG }                       /**< \brief (TRNG      ) Instances List */
+
+#define TWIHS0                 ((Twihs *)0x40018000U)         /**< \brief (TWIHS0    ) Base Address */
+#define TWIHS1                 ((Twihs *)0x4001C000U)         /**< \brief (TWIHS1    ) Base Address */
+#define TWIHS2                 ((Twihs *)0x40060000U)         /**< \brief (TWIHS2    ) Base Address */
+#define TWIHS_INST_NUM         3                              /**< \brief (TWIHS     ) Number of instances */
+#define TWIHS_INSTS            { TWIHS0, TWIHS1, TWIHS2 }     /**< \brief (TWIHS     ) Instances List */
+
+#define UART0                  ((Uart *)0x400E0800U)          /**< \brief (UART0     ) Base Address */
+#define UART1                  ((Uart *)0x400E0A00U)          /**< \brief (UART1     ) Base Address */
+#define UART2                  ((Uart *)0x400E1A00U)          /**< \brief (UART2     ) Base Address */
+#define UART3                  ((Uart *)0x400E1C00U)          /**< \brief (UART3     ) Base Address */
+#define UART4                  ((Uart *)0x400E1E00U)          /**< \brief (UART4     ) Base Address */
+#define UART_INST_NUM          5                              /**< \brief (UART      ) Number of instances */
+#define UART_INSTS             { UART0, UART1, UART2, UART3, UART4 } /**< \brief (UART      ) Instances List */
+
+#define USART0                 ((Usart *)0x40024000U)         /**< \brief (USART0    ) Base Address */
+#define USART1                 ((Usart *)0x40028000U)         /**< \brief (USART1    ) Base Address */
+#define USART2                 ((Usart *)0x4002C000U)         /**< \brief (USART2    ) Base Address */
+#define USART_INST_NUM         3                              /**< \brief (USART     ) Number of instances */
+#define USART_INSTS            { USART0, USART1, USART2 }     /**< \brief (USART     ) Instances List */
+
+#define USBHS                  ((Usbhs *)0x40038000U)         /**< \brief (USBHS     ) Base Address */
+#define USBHS_INST_NUM         1                              /**< \brief (USBHS     ) Number of instances */
+#define USBHS_INSTS            { USBHS }                      /**< \brief (USBHS     ) Instances List */
+
+#define UTMI                   ((Utmi *)0x400E0400U)          /**< \brief (UTMI      ) Base Address */
+#define UTMI_INST_NUM          1                              /**< \brief (UTMI      ) Number of instances */
+#define UTMI_INSTS             { UTMI }                       /**< \brief (UTMI      ) Instances List */
+
+#define WDT                    ((Wdt *)0x400E1850U)           /**< \brief (WDT       ) Base Address */
+#define WDT_INST_NUM           1                              /**< \brief (WDT       ) Number of instances */
+#define WDT_INSTS              { WDT }                        /**< \brief (WDT       ) Instances List */
+
+#define XDMAC                  ((Xdmac *)0x40078000U)         /**< \brief (XDMAC     ) Base Address */
+#define XDMAC_INST_NUM         1                              /**< \brief (XDMAC     ) Number of instances */
+#define XDMAC_INSTS            { XDMAC }                      /**< \brief (XDMAC     ) Instances List */
+
+#endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+/** @}  end of Peripheral Base Address Definitions */
+
+/** \addtogroup SAMV71Q21B_pio Peripheral Pio Definitions
+ *  @{
+ */
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAMV71Q21B*/
+/* ************************************************************************** */
+#include "pio/samv71q21b.h"
+/** @}  end of Peripheral Pio Definitions */
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAMV71Q21B*/
+/* ************************************************************************** */
+
+#define PERIPHERALS_SIZE         _U_(0x20000000)       /* 524288kB Memory segment type: io */
+#define SYSTEM_SIZE              _U_(0x10000000)       /* 262144kB Memory segment type: io */
+#define QSPIMEM_SIZE             _U_(0x20000000)       /* 524288kB Memory segment type: other */
+#define AXIMX_SIZE               _U_(0x00100000)       /* 1024kB Memory segment type: other */
+#define ITCM_SIZE                _U_(0x00200000)       /* 2048kB Memory segment type: other */
+#define IFLASH_SIZE              _U_(0x00200000)       /* 2048kB Memory segment type: flash */
+#define IFLASH_PAGE_SIZE         _U_(       512)
+#define IFLASH_NB_OF_PAGES       _U_(      4096)
+
+#define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
+#define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
+#define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
+#define EBI_CS0_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS1_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS2_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define EBI_CS3_SIZE             _U_(0x01000000)       /* 16384kB Memory segment type: other */
+#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
+
+#define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
+#define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
+#define QSPIMEM_ADDR             _U_(0x80000000)       /**< QSPIMEM base address (type: other)*/
+#define AXIMX_ADDR               _U_(0xa0000000)       /**< AXIMX base address (type: other)*/
+#define ITCM_ADDR                _U_(0x00000000)       /**< ITCM base address (type: other)*/
+#define IFLASH_ADDR              _U_(0x00400000)       /**< IFLASH base address (type: flash)*/
+#define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
+#define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
+#define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
+#define EBI_CS0_ADDR             _U_(0x60000000)       /**< EBI_CS0 base address (type: other)*/
+#define EBI_CS1_ADDR             _U_(0x61000000)       /**< EBI_CS1 base address (type: other)*/
+#define EBI_CS2_ADDR             _U_(0x62000000)       /**< EBI_CS2 base address (type: other)*/
+#define EBI_CS3_ADDR             _U_(0x63000000)       /**< EBI_CS3 base address (type: other)*/
+#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
+
+/* ************************************************************************** */
+/**  DEVICE SIGNATURES FOR SAMV71Q21B */
+/* ************************************************************************** */
+#define JTAGID                   _UL_(0X05B3D03F)
+#define CHIP_JTAGID              _UL_(0X05B3D03F)
+#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_EXID                _UL_(0X00000002)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMV71Q21B */
+/* ************************************************************************** */
+#define CHIP_FREQ_SLCK_RC_MIN          _UL_(20000)     
+#define CHIP_FREQ_SLCK_RC              _UL_(32000)     /**< \brief Typical Slow Clock Internal RC frequency*/
+#define CHIP_FREQ_SLCK_RC_MAX          _UL_(44000)     
+#define CHIP_FREQ_MAINCK_RC_4MHZ       _UL_(4000000)   
+#define CHIP_FREQ_MAINCK_RC_8MHZ       _UL_(8000000)   
+#define CHIP_FREQ_MAINCK_RC_12MHZ      _UL_(12000000)  
+#define CHIP_FREQ_CPU_MAX              _UL_(300000000) 
+#define CHIP_FREQ_XTAL_32K             _UL_(32768)     
+#define CHIP_FREQ_XTAL_12M             _UL_(12000000)  
+#define CHIP_FREQ_FWS_0                _UL_(23000000)  /**< \brief Maximum operating frequency when FWS is 0*/
+#define CHIP_FREQ_FWS_1                _UL_(46000000)  /**< \brief Maximum operating frequency when FWS is 1*/
+#define CHIP_FREQ_FWS_2                _UL_(69000000)  /**< \brief Maximum operating frequency when FWS is 2*/
+#define CHIP_FREQ_FWS_3                _UL_(92000000)  /**< \brief Maximum operating frequency when FWS is 3*/
+#define CHIP_FREQ_FWS_4                _UL_(115000000) /**< \brief Maximum operating frequency when FWS is 4*/
+#define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
+#define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
+#define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @}  end of SAMV71Q21B definitions */
+
+
+#endif /* _SAMV71Q21B_H_ */


### PR DESCRIPTION
Origin: Atmel SAMV71(b) Series Device Support (2.4.182)
License: Apache-2.0
URL: http://packs.download.atmel.com/Atmel.SAMV71_DFP.2.4.182.atpack
Purpose: Introduction of ASF for the SAMV71 series.
Maintained-by: External
Signed-off-by: Gerson Fernando Budke nandojve@gmail.com